### PR TITLE
Add TUS creation-with-upload support

### DIFF
--- a/apps/files/src/mixins.js
+++ b/apps/files/src/mixins.js
@@ -446,7 +446,16 @@ export default {
         relativePath = pathUtil.join(basePath, relativePath)
         // FIXME: this might break if relativePath is not the currentFolder
         // and is a mount point that has no chunk support
-        if (this.browserSupportsChunked && this.currentFolder.isChunkedUploadSupported) {
+        if (this.browserSupportsChunked && this.currentFolder.chunkUploadSupport) {
+          const extraOptions = {}
+          // enable direct upload if enabled and supported
+          // instead of create + upload in two requests
+          if (
+            this.configuration.uploadChunkDirect &&
+            this.currentFolder.chunkUploadSupport.extension.includes('creation-with-upload')
+          ) {
+            extraOptions.uploadDataDuringCreation = true
+          }
           let chunkSize = this.configuration.uploadChunkSize
           if (this.capabilities.files.tus_support.max_chunk_size > 0) {
             if (
@@ -463,7 +472,8 @@ export default {
               overridePatchMethod: !!this.capabilities.files.tus_support.http_method_override,
               emitProgress: progress => {
                 this.$_ocUpload_onProgress(progress, file)
-              }
+              },
+              ...extraOptions
             })
           })
         } else {

--- a/apps/files/src/store/actions.js
+++ b/apps/files/src/store/actions.js
@@ -94,7 +94,7 @@ function _buildFile(file) {
     isReceivedShare: function() {
       return this.permissions.indexOf('S') >= 0
     },
-    isChunkedUploadSupported: !!(file.getTusSupport && file.getTusSupport())
+    chunkUploadSupport: !!file.getTusSupport && file.getTusSupport()
   }
 }
 

--- a/src/plugins/upload.js
+++ b/src/plugins/upload.js
@@ -27,6 +27,7 @@ export default {
               removeFingerprintOnSuccess: true,
               overridePatchMethod: !!options.overridePatchMethod,
               retryDelays: [0, 3000, 5000, 10000, 20000],
+              uploadDataDuringCreation: options.uploadDataDuringCreation || false,
               metadata: {
                 filename: file.name,
                 filetype: file.type,

--- a/src/store/config.js
+++ b/src/store/config.js
@@ -48,6 +48,7 @@ const mutations = {
     state.openIdConnect = config.openIdConnect
     state.rootFolder = config.rootFolder === undefined ? '/' : config.rootFolder
     state.uploadChunkSize = config.uploadChunkSize === undefined ? Infinity : config.uploadChunkSize
+    state.uploadChunkDirect = config.uploadChunkDirect !== false // defaults to true if undefined
     state.state = config.state === undefined ? 'working' : config.state
     state.applications = config.applications === undefined ? [] : config.applications
     if (config.corrupted) state.corrupted = config.corrupted


### PR DESCRIPTION
## Description
Whenever the server advertised the capability for creation-with-upload,
use it automatically for chunked uploads.

It is possible to override this and disable it by setting
uploadChunkDirect=false in config.json

## Related Issue
None

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual test with latest reva

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] debug ocis/reva issue
- [ ] add changelog