### PR TITLE
Feature/copy move in same location

### DIFF
--- a/apps/files/src/components/LocationPicker/LocationPicker.vue
+++ b/apps/files/src/components/LocationPicker/LocationPicker.vue
@@ -9,20 +9,15 @@
       <oc-button @click.native="leaveLocationPicker(originalLocation)">
         <translate>Cancel</translate>
       </oc-button>
-      <span v-if="!canConfirm" :uk-tooltip="sameLocationToolTip">
-        <oc-button id="location-picker-btn-confirm" disabled>
-          <span v-text="confirmBtnText" />
-        </oc-button>
-      </span>
-      <span v-else>
-        <oc-button
-          id="location-picker-btn-confirm"
-          variation="primary"
-          @click.native="confirmAction"
-        >
-          <span v-text="confirmBtnText" />
-        </oc-button>
-      </span>
+      <oc-button
+        id="location-picker-btn-confirm"
+        variation="primary"
+        :uk-tooltip="sameLocationToolTip"
+        :disabled="!canConfirm"
+        @click.native="confirmAction"
+      >
+        <span v-text="confirmBtnText" />
+      </oc-button>
     </div>
     <file-list
       id="location-picker-files-list"

--- a/apps/files/src/components/LocationPicker/LocationPicker.vue
+++ b/apps/files/src/components/LocationPicker/LocationPicker.vue
@@ -9,14 +9,20 @@
       <oc-button @click.native="leaveLocationPicker(originalLocation)">
         <translate>Cancel</translate>
       </oc-button>
-      <oc-button
-        id="location-picker-btn-confirm"
-        variation="primary"
-        :disabled="!canConfirm"
-        @click.native="confirmAction"
-      >
-        <span v-text="confirmBtnText" />
-      </oc-button>
+      <span v-if="!canConfirm" :uk-tooltip="sameLocationToolTip">
+        <oc-button disabled id="location-picker-btn-confirm">
+          <span v-text="confirmBtnText" />
+        </oc-button>
+      </span>
+      <span v-else >
+        <oc-button
+          id="location-picker-btn-confirm"
+          variation="primary"
+          @click.native="confirmAction"
+        >
+          <span v-text="confirmBtnText" />
+        </oc-button>
+      </span>
     </div>
     <file-list
       id="location-picker-files-list"
@@ -113,6 +119,8 @@ import FileItem from '../FileItem.vue'
 import SortableColumnHeader from '../FilesLists/SortableColumnHeader.vue'
 import NoContentMessage from '../NoContentMessage.vue'
 import CopySidebarMainContent from './CopySidebarMainContent.vue'
+import pathUtil from 'path'
+
 
 export default {
   name: 'LocationPicker',
@@ -213,6 +221,12 @@ export default {
     },
 
     canConfirm() {
+      if (!this.currentFolder) {
+        return false
+      }
+      if (this.currentFolder.path === '/' + this.originalLocation) {
+        return false
+      }
       return this.currentFolder && this.currentFolder.canCreate()
     },
 
@@ -245,6 +259,17 @@ export default {
       }
 
       return this.$gettext('Confirm')
+    },
+
+    sameLocationToolTip() {
+      if (!this.canConfirm) {
+        if (this.currentAction === 'move') {
+          return this.$gettext('You cannot move into the original location.')
+        } else if (this.currentAction === 'copy') {
+          return this.$gettext('You cannot copy into the original location.')
+        }
+      }
+      return null
     }
   },
 

--- a/changelog/unreleased/copy-move-same-location.md
+++ b/changelog/unreleased/copy-move-same-location.md
@@ -1,0 +1,6 @@
+Change: Handle copy and move into the source destination
+
+Move into the same location is not allowed and the move button is disabled.
+Copy in contrary will append a postfix to the target.
+
+https://github.com/owncloud/phoenix/pull/3847


### PR DESCRIPTION
## Description
In case of move it is not allowed to move resources into the source destination. The action button will be disabled
When copying to the same location a postfix will be applied. 

## Related Issue
- Fixes https://github.com/owncloud/phoenix/issues/3751

## How Has This Been Tested?
: :hand: 

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...