### PR TITLE
[tests-only] Bump OCIS commit id for tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -330,7 +330,7 @@ config = {
 	'defaults': {
 		'acceptance': {
 			'ocisBranch': 'master',
-			'ocisCommit': '76fefa325594c3d58560ca06e0e5311298104832',
+			'ocisCommit': '74c1c1fb0e6b45c0c1c2a0359462c3b739112a43',
 		}
 	},
 


### PR DESCRIPTION
The updated commit-id has nothing interesting/new, but the CI against core uses `daily-master-qa` and I want to make sure that the tests pass with that. So this is an easy way to get a full drone CI result.