### PR TITLE
[CI ONLY] bump hugo version

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1123,7 +1123,7 @@ def website(ctx):
 			},
 			{
 				'name': 'test',
-				'image': 'webhippie/hugo:latest',
+				'image': 'owncloudci/hugo:0.71.0',
 				'commands': [
 					'cd hugo',
 				'	hugo',


### PR DESCRIPTION
## Description
Change from webhippie to ownCloud CI image.

## Related Issue
- Pipeline fails: https://drone.owncloud.com/owncloud/web/12153/3/3

```
1 | latest: Pulling from webhippie/hugo
-- | --
2 | Digest: sha256:d720aa7a4149cecb8ad2f602ac23c3ff54e51fd36fd8411a57ea3e97801b0b0c
3 | Status: Downloaded newer image for webhippie/hugo:latest
4 | + cd hugo
5 | + \thugo
6 | ERROR 2020/12/11 08:09:14 HUGO-GEEKDOC theme does not support Hugo version 0.55.5. Minimum version required is 0.65.0
7 | Building sites … Total in 61 ms
8 | Error: Error building site: logged 1 error(s)
```

## Motivation and Context
Fix Pipeline

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

## Checklist:

## Open tasks:
