### PR TITLE
[docs-only] add collapse section in docs

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -5,6 +5,7 @@ weight: -15
 geekdocRepo: https://github.com/owncloud/phoenix
 geekdocEditPath: edit/master/docs
 geekdocFilePath: _index.md
+geekdocCollapseSection: true
 ---
 
 This is the next generation ownCloud frontend.

--- a/docs/deployments/_index.md
+++ b/docs/deployments/_index.md
@@ -5,6 +5,7 @@ weight: 55
 geekdocRepo: https://github.com/owncloud/phoenix
 geekdocEditPath: edit/master/docs/deployments
 geekdocFilePath: _index.md
+geekdocCollapseSection: true
 ---
 
 Showcases of different scenarios of deploying ownCloud Web.


### PR DESCRIPTION
## Description
This makes the Phoenix section and the Phoenix/Deployments sections collapseable in the docs https://owncloud.github.io/.

## Related Issue
- was already done for oCIS https://github.com/owncloud/ocis/pull/1046

## Motivation and Context
- make docs more nice

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

## Checklist:

## Open tasks:
