### PR TITLE
[tests-only] add legacy dist target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,21 @@ core: dist/core/core.bundle.js
 
 .PHONY: clean-core
 clean-core:
-	rm -rf $(DIST) $(HUGO)
+	rm -rf $(DIST) $(HUGO) $(CURDIR)/release $(CURDIR)/build/dist
 	rm -rf node_modules
 
+#
+# Release
+# make this app compatible with the ownCloud
+# default build tools
+#
+.PHONY: dist
+dist:
+	make -f Makefile.release
+	mkdir -p $(CURDIR)/build/dist
+	cp $(CURDIR)/release/web-app.tar.gz $(CURDIR)/build/dist/
+
+#
 #
 # Apps
 #

--- a/Makefile.release
+++ b/Makefile.release
@@ -64,7 +64,7 @@ package-plain:
 	cd $(dist_dir) && tar -czf $(CURDIR)/release/$(app_name).tar.gz -C $(dist_dir) * .htaccess
 
 .PHONY: package-ocx
-package-ocx: sign ocx-app-config ocx-app-bundle
+package-ocx: ocx-app-config sign ocx-app-bundle
 
 .PHONY: sign
 sign:


### PR DESCRIPTION
# Description

To keep the web app compatible with our default build and signing process
https://gitea.owncloud.services/devops/releasescripts
BTW: @jnweiger you need to update that and recreate your build container. ownCloud web needs node 12

- We need to add a `dist` target on the default makefile.

