### PR TITLE
[tests-only] Change more phoenix to web now that owncloud/ocis has web extension

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -330,7 +330,7 @@ config = {
 	'defaults': {
 		'acceptance': {
 			'ocisBranch': 'master',
-			'ocisCommit': '76fefa325594c3d58560ca06e0e5311298104832',
+			'ocisCommit': 'ee7b3213b39ec8e76b4a176ed85cbf2588009554',
 		}
 	},
 
@@ -1400,8 +1400,8 @@ def ocisService():
 			'STORAGE_DATAGATEWAY_PUBLIC_URL': 'https://ocis:9200/data',
 			'STORAGE_USERS_DATA_SERVER_URL': 'http://ocis:9158/data',
 			'STORAGE_FRONTEND_PUBLIC_URL': 'https://ocis:9200',
-			'PHOENIX_WEB_CONFIG': '/srv/config/drone/ocis-config.json',
-			'PHOENIX_ASSET_PATH': '/var/www/owncloud/web/dist',
+			'WEB_UI_CONFIG': '/srv/config/drone/ocis-config.json',
+			'WEB_ASSET_PATH': '/var/www/owncloud/web/dist',
 			'KONNECTD_IDENTIFIER_REGISTRATION_CONF': '/srv/config/drone/identifier-registration.yml',
 			'KONNECTD_ISS': 'https://ocis:9200',
 			'KONNECTD_TLS': 'true',
@@ -1430,9 +1430,9 @@ def buildOcisWeb():
 		'pull': 'always',
 		'commands': [
 			'cd $GOPATH/src/github.com/owncloud/ocis',
-			'cd ocis-phoenix',
+			'cd web',
 			'make build',
-			'cp bin/ocis-phoenix /var/www/owncloud'
+			'cp bin/web /var/www/owncloud/ocis-web'
 		],
 		'volumes': [{
 			'name': 'gopath',
@@ -1451,13 +1451,13 @@ def ocisWebService():
 		'pull': 'always',
 		'detach': True,
 		'environment' : {
-			'PHOENIX_WEB_CONFIG': '/srv/config/drone/config.json',
-			'PHOENIX_ASSET_PATH': '/var/www/owncloud/web/dist',
-			'PHOENIX_OIDC_CLIENT_ID': 'phoenix'
+			'WEB_UI_CONFIG': '/srv/config/drone/config.json',
+			'WEB_ASSET_PATH': '/var/www/owncloud/web/dist',
+			'WEB_OIDC_CLIENT_ID': 'phoenix'
 		},
 		'commands': [
 			'cd /var/www/owncloud',
-			'./ocis-phoenix --log-level debug server',
+			'./ocis-web --log-level debug server',
 		],
 		'volumes': [{
 			'name': 'gopath',

--- a/tests/acceptance/features/webUIFavorites/favoritesFile.feature
+++ b/tests/acceptance/features/webUIFavorites/favoritesFile.feature
@@ -1,4 +1,4 @@
-@skipOnOCIS @ocis-reva-issue-39 @skipOnIphoneResolution @ocis-web=issue-3968
+@skipOnOCIS @ocis-reva-issue-39 @skipOnIphoneResolution @ocis-web-issue-3968
 Feature: Mark file as favorite
 
   As a user

--- a/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
+++ b/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
@@ -1,4 +1,4 @@
-@skipOnOCIS @ocis-reva-issue-39 @skipOnIphoneResolution @ocis-web=issue-3968
+@skipOnOCIS @ocis-reva-issue-39 @skipOnIphoneResolution @ocis-web-issue-3968
 Feature: Unmark file/folder as favorite
 
   As a user

--- a/tests/acceptance/ocis-mac-config.json
+++ b/tests/acceptance/ocis-mac-config.json
@@ -12,7 +12,6 @@
   "apps": [
     "files",
     "draw-io",
-    "pdf-viewer",
     "markdown-editor",
     "media-viewer"
   ]

--- a/tests/drone/config.json
+++ b/tests/drone/config.json
@@ -5,7 +5,7 @@
   "openIdConnect": {
     "metadata_url": "https://konnectd:9130/.well-known/openid-configuration",
     "authority": "https://konnectd:9130",
-    "client_id": "phoenix",
+    "client_id": "web",
     "response_type": "code",
     "scope": "openid profile email"
   },

--- a/tests/drone/config.json
+++ b/tests/drone/config.json
@@ -12,7 +12,6 @@
   "apps": [
     "files",
     "draw-io",
-    "pdf-viewer",
     "markdown-editor",
     "media-viewer"
   ]

--- a/tests/drone/identifier-registration-oc10.yml
+++ b/tests/drone/identifier-registration-oc10.yml
@@ -2,7 +2,7 @@
 
 # OpenID Connect client registry.
 clients:
-  - id: phoenix
+  - id: web
     name: OCIS
     application_type: web
     insecure: yes

--- a/tests/drone/identifier-registration.yml
+++ b/tests/drone/identifier-registration.yml
@@ -2,7 +2,7 @@
 
 # OpenID Connect client registry.
 clients:
-  - id: phoenix
+  - id: web
     name: OCIS
     application_type: web
     insecure: yes

--- a/tests/drone/ocis-config.json
+++ b/tests/drone/ocis-config.json
@@ -5,7 +5,7 @@
   "openIdConnect": {
     "metadata_url": "https://ocis:9200/.well-known/openid-configuration",
     "authority": "https://ocis:9200",
-    "client_id": "phoenix",
+    "client_id": "web",
     "response_type": "code",
     "scope": "openid profile email"
   },

--- a/tests/drone/ocis-config.json
+++ b/tests/drone/ocis-config.json
@@ -12,7 +12,6 @@
   "apps": [
     "files",
     "draw-io",
-    "pdf-viewer",
     "markdown-editor",
     "media-viewer"
   ]


### PR DESCRIPTION
## Description
PR https://github.com/owncloud/ocis/pull/1041 switched `owncloud/ocis` to having a `web` extension, rather than `ocis-phoenix`

Adjust CI here so that it understands the changes in `owncloud/ocis`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
