### PR TITLE
Add media viewer and draw-io to default apps

### DIFF
--- a/changelog/unreleased/default-apps
+++ b/changelog/unreleased/default-apps
@@ -1,0 +1,6 @@
+Enhancement: Extend default apps
+
+When release tarballs are created, we are copying the config.json.dist into them as a default config.
+In that file were so far only "files" app enabled. This adds also "media viewer" and "draw-io" into apps enabled by default.
+
+https://github.com/owncloud/web/pull/4493

--- a/config.json.dist
+++ b/config.json.dist
@@ -8,7 +8,9 @@
     "authUrl": ""
   },
   "apps" : [
-    "files"
+    "files",
+    "media-viewer",
+    "draw-io"
   ],
   "applications" : []
 }


### PR DESCRIPTION
When release tarballs are created, we are copying the config.json.dist into them as a default config. This file had so far only "files" app enabled. This adds also "media viewer" and "draw-io" into apps enabled by default.