### PR TITLE
[tests-only] Remove WEB_OIDC_CLIENT_ID phoenix from .drone.star - not used

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1453,7 +1453,6 @@ def ocisWebService():
 		'environment' : {
 			'WEB_UI_CONFIG': '/srv/config/drone/config.json',
 			'WEB_ASSET_PATH': '/var/www/owncloud/web/dist',
-			'WEB_OIDC_CLIENT_ID': 'phoenix'
 		},
 		'commands': [
 			'cd /var/www/owncloud',


### PR DESCRIPTION
## Description
Remove the last mention of `phoenix` from `.drone.star` - it seems to be an accidental leftover.

IMO `WEB_OIDC_CLIENT_ID` is not used in the drone test environment of oC10 and in OCIS it defaults to "web" nowadays. So we should not need to mention it at all.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...