### PR TITLE
Fix opening editors in new tab

### DIFF
--- a/apps/files/src/mixins/fileActions.js
+++ b/apps/files/src/mixins/fileActions.js
@@ -84,9 +84,8 @@ export default {
           name: editor.routeName,
           params: { filePath: filePath }
         }).href
-        const url = window.location.origin + '/' + path
         const target = `${editor.routeName}-${filePath}`
-        const win = window.open(url, target)
+        const win = window.open(path, target)
         // in case popup is blocked win will be null
         if (win) {
           win.focus()
@@ -94,7 +93,7 @@ export default {
         return
       }
 
-      const routeName = editor.routeName ? editor.app + '/' + editor.routeName : editor.app
+      const routeName = editor.routeName || editor.app
       const params = {
         filePath,
         contextRouteName: this.$route.name

--- a/apps/media-viewer/src/app.js
+++ b/apps/media-viewer/src/app.js
@@ -21,7 +21,7 @@ const appInfo = {
   extensions: [
     {
       extension: 'png',
-      routeName: 'media',
+      routeName: 'mediaviewer/media',
       routes: [
         'files-list',
         'files-favorites',
@@ -32,7 +32,7 @@ const appInfo = {
     },
     {
       extension: 'jpg',
-      routeName: 'media',
+      routeName: 'mediaviewer/media',
       routes: [
         'files-list',
         'files-favorites',
@@ -43,7 +43,7 @@ const appInfo = {
     },
     {
       extension: 'jpeg',
-      routeName: 'media',
+      routeName: 'mediaviewer/media',
       routes: [
         'files-list',
         'files-favorites',
@@ -54,7 +54,7 @@ const appInfo = {
     },
     {
       extension: 'gif',
-      routeName: 'media',
+      routeName: 'mediaviewer/media',
       routes: [
         'files-list',
         'files-favorites',
@@ -65,7 +65,7 @@ const appInfo = {
     },
     {
       extension: 'mp4',
-      routeName: 'media',
+      routeName: 'mediaviewer/media',
       routes: [
         'files-list',
         'files-favorites',
@@ -76,7 +76,7 @@ const appInfo = {
     },
     {
       extension: 'webm',
-      routeName: 'media',
+      routeName: 'mediaviewer/media',
       routes: [
         'files-list',
         'files-favorites',
@@ -87,7 +87,7 @@ const appInfo = {
     },
     {
       extension: 'ogg',
-      routeName: 'media',
+      routeName: 'mediaviewer/media',
       routes: [
         'files-list',
         'files-favorites',

--- a/changelog/unreleased/editors-new-tab
+++ b/changelog/unreleased/editors-new-tab
@@ -1,0 +1,5 @@
+Bugfix: Do not use origin location to open editors
+
+When opening the editors view in a new tab, we were using the origin of location. This would break in case we have Web deployed to a different path than root e.g. `http://owncloud/apps/web`.
+
+https://github.com/owncloud/web/pull/4500


### PR DESCRIPTION
When opening the editors view in a new tab, we were using the origin of location. This would break in case we have Web deployed to a different path than root e.g. `http://owncloud/apps/web`.