### PR TITLE
[tests-only] Support an EXPECTED_FAILURES_FILE

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -88,7 +88,8 @@ config = {
 			},
 			'extraEnvironment': {
 				'OPENID_LOGIN': 'true',
-				'WEB_UI_CONFIG': '/srv/config/drone/config.json'
+				'WEB_UI_CONFIG': '/srv/config/drone/config.json',
+				'EXPECTED_FAILURES_FILE': '/var/www/owncloud/web/tests/acceptance/expected-failures-with-oc10-server.txt'
 			}
 		},
 		'webUIFederation': {
@@ -98,7 +99,8 @@ config = {
 			},
 			'extraEnvironment': {
 				'OPENID_LOGIN': 'true',
-				'REMOTE_BACKEND_HOST': 'http://federated'
+				'REMOTE_BACKEND_HOST': 'http://federated',
+				'EXPECTED_FAILURES_FILE': '/var/www/owncloud/web/tests/acceptance/expected-failures-with-oc10-server.txt'
 			},
 			'federatedServerNeeded': True,
 			'federatedServerVersion': 'daily-master-qa'
@@ -169,7 +171,8 @@ config = {
 			},
 			'extraEnvironment': {
 				'OPENID_LOGIN': 'true',
-				'SCREEN_RESOLUTION': '768x1024'
+				'SCREEN_RESOLUTION': '768x1024',
+				'EXPECTED_FAILURES_FILE': '/var/www/owncloud/web/tests/acceptance/expected-failures-with-oc10-server.txt'
 			},
 			'filterTags': '@smokeTest and not @skipOnXGAPortraitResolution and not @skip and not @skipOnOC10'
 		},
@@ -231,7 +234,8 @@ config = {
 			},
 			'extraEnvironment': {
 				'OPENID_LOGIN': 'true',
-				'SCREEN_RESOLUTION': '375x812'
+				'SCREEN_RESOLUTION': '375x812',
+				'EXPECTED_FAILURES_FILE': '/var/www/owncloud/web/tests/acceptance/expected-failures-with-oc10-server.txt'
 			},
 			'filterTags': '@smokeTest and not @skipOnIphoneResolution and not @skip and not @skipOnOC10'
 		},
@@ -320,7 +324,8 @@ config = {
 				'RUN_ON_OCIS': 'true',
 				'OCIS_SKELETON_DIR': '/srv/app/testing/data/webUISkeleton',
 				'OCIS_REVA_DATA_ROOT': '/srv/app/tmp/ocis/owncloud/data/',
-				'WEB_UI_CONFIG': '/srv/config/drone/ocis-config.json'
+				'WEB_UI_CONFIG': '/srv/config/drone/ocis-config.json',
+				'EXPECTED_FAILURES_FILE': '/var/www/owncloud/web/tests/acceptance/expected-failures-with-ocis-server-owncloud-storage.txt'
 			},
 			'runningOnOCIS': True,
 			'filterTags': 'not @skip and not @skipOnOCIS',
@@ -1601,7 +1606,7 @@ def runWebuiAcceptanceTests(suite, alternateSuiteName, filterTags, extraEnvironm
 		'environment': environment,
 		'commands': [
 			'cd /var/www/owncloud/web',
-			'yarn run acceptance-tests-drone',
+			'./tests/acceptance/run.sh',
 		],
 		'volumes': [{
 			'name': 'gopath',

--- a/tests/acceptance/expected-failures-with-oc10-server.txt
+++ b/tests/acceptance/expected-failures-with-oc10-server.txt
@@ -1,0 +1,1 @@
+# this file contains the scenarios from web tests that are currently expected to fail on oC10

--- a/tests/acceptance/expected-failures-with-ocis-server-owncloud-storage.txt
+++ b/tests/acceptance/expected-failures-with-ocis-server-owncloud-storage.txt
@@ -1,0 +1,1 @@
+# this file contains the scenarios from phoenix tests that are currently expected to fail on OCIS with owncloud storage

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+
+echo 'run.sh: running acceptance-tests-drone'
+
+# An array of the suites that were run. Each entry is a string like:
+# webUILogin
+# webUIPrivateLinks
+declare -a SUITES_IN_THIS_RUN
+
+# An array of the scenarios that failed. Each entry is a string like:
+# webUILogin/login.feature:50
+# webUIPrivateLinks/accessingPrivateLinks.feature:8
+declare -a FAILED_SCENARIO_PATHS
+
+# An array of the scenarios that failed, and were not in the expected failures file.
+# Each entry is a string like:
+# webUILogin/login.feature:50
+# webUIPrivateLinks/accessingPrivateLinks.feature:8
+declare -a UNEXPECTED_FAILED_SCENARIOS
+
+# An array of the scenarios that were in the expected failures file but did not fail
+# Each entry is a string like:
+# webUILogin/login.feature:50
+# webUIPrivateLinks/accessingPrivateLinks.feature:8
+declare -a UNEXPECTED_PASSED_SCENARIOS
+
+UNEXPECTED_NIGHTWATCH_CRASH=false
+
+yarn run acceptance-tests-drone | tee -a 'logfile.txt'
+ACCEPTANCE_TESTS_EXIT_STATUS=${PIPESTATUS[0]}
+if [ "${ACCEPTANCE_TESTS_EXIT_STATUS}" -ne 0 ]; then
+  echo "The acceptance tests exited with error status ${ACCEPTANCE_TESTS_EXIT_STATUS}"
+
+  FAILED_SCENARIOS="$(grep -F ') Scenario:' logfile.txt)"
+  for FAILED_SCENARIO in ${FAILED_SCENARIOS}; do
+    if [[ $FAILED_SCENARIO =~ "tests/acceptance/features/" ]]; then
+      SUITE_PATH=$(dirname "${FAILED_SCENARIO}")
+      SUITE=$(basename "${SUITE_PATH}")
+      SCENARIO=$(basename "${FAILED_SCENARIO}")
+      SUITE_SCENARIO="${SUITE}/${SCENARIO}"
+      FAILED_SCENARIO_PATHS+=("${SUITE_SCENARIO}")
+    fi
+  done
+
+  if [ ${#FAILED_SCENARIO_PATHS[@]} -eq 0 ]
+  then
+    # Nightwatch had some problem but there were no failed scenarios reported
+    # So the problem is something else.
+    # Possibly there were missing step definitions. Or Nightwatch crashed badly, or...
+    UNEXPECTED_NIGHTWATCH_CRASH=true
+  fi
+fi
+
+if [ ${#FAILED_SCENARIO_PATHS[@]} -ne 0 ]
+then
+  echo "The following scenarios failed:"
+  echo "-------------------------------"
+  echo "${FAILED_SCENARIO_PATHS[@]}"
+  echo "-------------------------------"
+fi
+
+# Work out which suites were run.
+# TEST_PATHS = "tests/acceptance/features/webUILogin tests/acceptance/features/webUINotifications"
+# or
+# TEST_CONTEXT = "webUIFavorites"
+if [ -n "${TEST_PATHS}" ]; then
+  for TEST_PATH in ${TEST_PATHS}; do
+    SUITE=$(basename "${TEST_PATH}")
+    SUITES_IN_THIS_RUN+=("${SUITE}")
+  done
+fi
+
+if [ -n "${TEST_CONTEXT}" ]; then
+  SUITES_IN_THIS_RUN+=("${TEST_CONTEXT}")
+fi
+
+if [ -n "${EXPECTED_FAILURES_FILE}" ]; then
+  echo "Checking expected failures in ${EXPECTED_FAILURES_FILE}"
+
+  # Check that every failed scenario is in the list of expected failures
+  for FAILED_SCENARIO_PATH in "${FAILED_SCENARIO_PATHS[@]}"; do
+    grep -x "${FAILED_SCENARIO_PATH}" "${EXPECTED_FAILURES_FILE}" >/dev/null
+    if [ $? -ne 0 ]; then
+      echo "Error: Scenario ${FAILED_SCENARIO_PATH} failed but was not expected to fail."
+      UNEXPECTED_FAILED_SCENARIOS+=("${FAILED_SCENARIO_PATH}")
+    fi
+  done
+
+  # Check that every relevant scenario in the expected failures file did fail
+  while IFS= read -r LINE; do
+    # Ignore comment lines (starting with hash) or the empty lines
+    if [[ ("${LINE}" =~ ^#) || (-z "${LINE}") ]]; then
+      continue
+    fi
+
+    # This should be a suite name (string) like "webUILogin"
+    EXPECTED_FAILURE_SUITE=$(dirname "${LINE}")
+
+    for SUITE_IN_THIS_RUN in "${SUITES_IN_THIS_RUN[@]}"; do
+      if [ "${SUITE_IN_THIS_RUN}" == "${EXPECTED_FAILURE_SUITE}" ]
+      then
+        # This line in the expected failures file is for a suite that has been run.
+        # So we expect that the scenario in LINE has run and failed.
+        # Look for it in FAILED_SCENARIO_PATHS
+        # The string that is echoed is space-separated. A space is added at the end also.
+        # Then we look for the line from the expected failures file followed by a space.
+        # That ensures that when looking for a specific line number like xyz.feature:12
+        # we do not accidentally match xyz.feature:12 that is in xyz.feature:123
+        echo "${FAILED_SCENARIO_PATHS[@]} " | grep "${LINE} " > /dev/null
+        if [ $? -ne 0 ]
+        then
+          echo "Info: Scenario ${LINE} was expected to fail but did not fail."
+          UNEXPECTED_PASSED_SCENARIOS+=("${LINE}")
+        fi
+      fi
+    done
+  done < "${EXPECTED_FAILURES_FILE}"
+fi
+
+if [ ${#UNEXPECTED_FAILED_SCENARIOS[@]} -gt 0 ]; then
+  UNEXPECTED_FAILURE=true
+else
+  UNEXPECTED_FAILURE=false
+fi
+
+if [ ${#UNEXPECTED_PASSED_SCENARIOS[@]} -gt 0 ]; then
+  UNEXPECTED_SUCCESS=true
+else
+  UNEXPECTED_SUCCESS=false
+fi
+
+if [ "${UNEXPECTED_FAILURE}" = false ] && [ "${UNEXPECTED_SUCCESS}" = false ] && [ "${UNEXPECTED_NIGHTWATCH_CRASH}" = false ]; then
+  FINAL_EXIT_STATUS=0
+else
+  FINAL_EXIT_STATUS=1
+fi
+
+if [ "${UNEXPECTED_FAILURE}" = true ]
+then
+  tput setaf 3; echo "runsh: Total unexpected failed scenarios throughout the test run:"
+  tput setaf 1; printf "%s\n" "${UNEXPECTED_FAILED_SCENARIOS[@]}"
+else
+  tput setaf 2; echo "runsh: There were no unexpected failures."
+fi
+
+if [ "${UNEXPECTED_SUCCESS}" = true ]
+then
+  tput setaf 3; echo "runsh: Total unexpected passed scenarios throughout the test run:"
+  tput setaf 1; printf "%s\n" "${UNEXPECTED_PASSED_SCENARIOS[@]}"
+else
+  tput setaf 2; echo "runsh: There were no unexpected success."
+fi
+
+if [ "${UNEXPECTED_NIGHTWATCH_CRASH}" = true ]
+then
+  tput setaf 3; echo "Unexpected failure or crash of the nightwatch test run"
+fi
+
+echo "runsh: Exit code: ${FINAL_EXIT_STATUS}"
+
+exit ${FINAL_EXIT_STATUS}


### PR DESCRIPTION
## Description
If `EXPECTED_FAILURES_FILE` env var is defined, then read a list of expected-failing test scenarios from that file.

drone runs the script `tests/acceptance/run.sh` That runs the test scenarios, and then parses the output to find the scenarios that failed. It then compares that to the expected-failures. It reports both:
- scenarios that failed but are not in expected-failures. These are unexpected failures.
- scenarios that are in expected-failures but did not fail. These are unexpected passes.

Empty expected-failures files are provided for when running the tests against oC10 and against OCIS with owncloud storage.

After this code is merged, we can unskip the test scenarios that are skipped on OCIS, and add the ones that fail to the expected-failures file for OCIS.

We can also do similar if there are good scenarios that are skipped on oC10.

## How Has This Been Tested?
PR #4510 demonstrates that this code can report unexpected failures and passes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
