### PR TITLE
Be more forgiving with the server url

### DIFF
--- a/changelog/unreleased/server-url
+++ b/changelog/unreleased/server-url
@@ -1,0 +1,5 @@
+Bugfix: Allow server URL without trailing slash
+
+The server URL in the config was leading to issues resolving resources when it had no trailing slash. We are now checking if the trailing slash is missing and add it upon applying the config if needed.
+
+https://github.com/owncloud/web/pull/4536

--- a/src/store/config.js
+++ b/src/store/config.js
@@ -69,7 +69,7 @@ const actions = {
 
 const mutations = {
   LOAD_CONFIG(state, config) {
-    state.server = config.server
+    state.server = config.server.endsWith('/') ? config.server : config.server + '/'
     state.auth = config.auth
     state.openIdConnect = config.openIdConnect
     state.uploadChunkSize = config.uploadChunkSize === undefined ? Infinity : config.uploadChunkSize


### PR DESCRIPTION


## Description
This PR adds a check upon loading the config, if the server url has a trailing slash and adds it if missing. This was leading to wrong paths and therefor unresolved resources before (see screenshot).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- manually

## Screenshots (if appropriate):
<img width="615" alt="Screenshot 2020-12-17 at 12 17 24" src="https://user-images.githubusercontent.com/3532843/102482932-472d7200-4064-11eb-8335-6ecd313c9250.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
