### PR TITLE
Set up a php oc10 controller for reading the config.json from the config folder

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -42,7 +42,7 @@ copy-configs: copy-web-config copy-htaccess
 
 .PHONY: copy-web-config
 copy-web-config:
-	cp config.json.dist $(dist_dir)/config.json
+	cp config.json.dist $(dist_dir)/config.json.dist
 
 .Phony: copy-htaccess
 copy-htaccess:

--- a/Makefile.release
+++ b/Makefile.release
@@ -78,6 +78,7 @@ endif
 ocx-app-config:
 	cp -R appinfo $(dist_dir)
 	cp -R img $(dist_dir)
+	cp -R lib $(dist_dir)
 	rm $(dist_dir)/.htaccess # .htaccess is not needed/read in ocx app deployment scenarios
 
 .PHONY: ocx-app-bundle

--- a/Makefile.release
+++ b/Makefile.release
@@ -42,11 +42,11 @@ copy-configs: copy-web-config copy-htaccess
 
 .PHONY: copy-web-config
 copy-web-config:
-	cp config.json.dist $(dist_dir)/config.json.dist
+	cp config.json.dist $(dist_dir)/
 
 .Phony: copy-htaccess
 copy-htaccess:
-	cp .htaccess $(dist_dir)
+	cp .htaccess $(dist_dir)/
 
 .PHONY: package
 package: create-release-folder create-packages
@@ -78,6 +78,7 @@ endif
 ocx-app-config:
 	cp -R appinfo $(dist_dir)
 	cp -R img $(dist_dir)
+	rm $(dist_dir)/.htaccess # .htaccess is not needed/read in ocx app deployment scenarios
 
 .PHONY: ocx-app-bundle
 ocx-app-bundle:

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -19,6 +19,4 @@
  *
  */
 
-use OCA\Web\Application;
-
 $app = new OCA\Web\Application();

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @author Benedikt Kulmann <bkulmann@owncloud.com>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+use OCA\Web\Application;
+
+$app = new Application();

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -21,4 +21,4 @@
 
 use OCA\Web\Application;
 
-$app = new Application();
+$app = new OCA\Web\Application();

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @author Benedikt Kulmann <bkulmann@owncloud.com>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Web;
+
+$application = new Application();
+$application->registerRoutes(
+	$this,
+	[
+		'routes' => [
+			['name' => 'Config#getConfig', 'url' => '/config']
+		]
+	]
+);

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -19,8 +19,14 @@
  *
  */
 
-return [
-    'routes' => [
-        ['name' => 'Config#getConfig', 'url' => '/config', 'verb' => 'GET']
+use OCA\Web\Application;
+
+$app = new Application();
+$app->registerRoutes(
+    $this,
+    [
+        'routes' => [
+            ['name' => 'Config#getConfig', 'url' => '/config', 'verb' => 'GET']
+        ]
     ]
-];
+);

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -19,14 +19,8 @@
  *
  */
 
-namespace OCA\Web;
-
-$application = new Application();
-$application->registerRoutes(
-	$this,
-	[
-		'routes' => [
-			['name' => 'Config#getConfig', 'url' => '/config']
-		]
-	]
-);
+return [
+    'routes' => [
+        ['name' => 'Config#getConfig', 'url' => '/config', 'verb' => 'GET']
+    ]
+];

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -26,7 +26,14 @@ $app->registerRoutes(
     $this,
     [
         'routes' => [
-            ['name' => 'Config#getConfig', 'url' => '/config', 'verb' => 'GET']
+			['name' => 'Config#getConfig', 'url' => '/config.json', 'verb' => 'GET'],
+            [
+            	'name' => 'Files#getFile',
+				'url' => '/{path}',
+				'verb' => 'GET',
+				'requirements' => ['path' => '.+'],
+				'defaults' => ['path' => 'index.html']
+			]
         ]
     ]
 );

--- a/changelog/unreleased/oc10-app-config-endpoint
+++ b/changelog/unreleased/oc10-app-config-endpoint
@@ -1,0 +1,5 @@
+Change: Add config endpoint for oc10 app deployment
+
+We added a config endpoint for when ownCloud Web is deployed as ownCloud 10 app. The config.json file must not be placed in the apps folder because it would cause the app integrity check to fail.
+
+https://github.com/owncloud/web/pull/4537

--- a/changelog/unreleased/oc10-app-controllers
+++ b/changelog/unreleased/oc10-app-controllers
@@ -1,5 +1,6 @@
-Change: Add config endpoint for oc10 app deployment
+Change: Add controllers for oc10 app deployment
 
 We added a config endpoint for when ownCloud Web is deployed as ownCloud 10 app. The config.json file must not be placed in the apps folder because it would cause the app integrity check to fail.
+In addition to the config endpoint we added a wildcard endpoint for serving static assets (js bundles, css, etc) of the ownCloud Web javascript application by their paths.
 
 https://github.com/owncloud/web/pull/4537

--- a/docs/deployments/oc10-app.md
+++ b/docs/deployments/oc10-app.md
@@ -24,7 +24,7 @@ Depending on your setup, the name of `apps-external` folder can vary. It is impo
 Download [ownCloud Web app](https://marketplace.owncloud.com/apps/web) from the marketplace and enable it.
 
 ## Configure oauth2
-In the `Admin` of ownCloud 10, head into `User Authentication` and add a new client with arbitrary name and redirection URL `https://<your-owncloud-server>/apps-external/web/oidc-callback.html`.
+Within the `Admin` page of ownCloud 10, head into `User Authentication` and add a new client with arbitrary name (e.g. `ownCloud Web`) and redirection URL `https://<your-owncloud-server>/apps-external/web/oidc-callback.html`.
 
 {{< figure src="/clients/web/static/oauth2.jpg" alt="Example OAuth2 entry" >}}
 
@@ -35,7 +35,7 @@ To display ownCloud Web in the app switcher and to redirect all private and publ
 'web.baseUrl' => 'https://<your-owncloud-server>/apps-external/web',
 ```
 ## Configure ownCloud Web
-There are a few config values which need to be set in order for ownCloud Web to work correctly. Navigate into `apps-external/web` and adjust `config.json` according to the following example:
+There are a few config values which need to be set in order for ownCloud Web to work correctly. Please copy `apps-external/web/config.json.dist` into `config/config.json` and adjust it according to the following example:
 
 ```json
 {
@@ -73,6 +73,10 @@ There are a few config values which need to be set in order for ownCloud Web to 
   ]
 }
 ```
+
+{{< hint info >}}
+It is important that you don't edit or place the `config.json` within the app folder. If you do, the integrity check of the app will fail and raise warnings.
+{{< /hint >}}
 
 ## Accessing ownCloud Web
 After following all the steps, you should see a new entry in the application switcher called `New Design` which points to the ownCloud web.

--- a/docs/deployments/oc10-app.md
+++ b/docs/deployments/oc10-app.md
@@ -10,11 +10,7 @@ geekdocFilePath: oc10-app.md
 {{< toc >}}
 
 The ownCloud Web is being deployed as an app to [ownCloud marketplace](https://market.owncloud.com) to enable easy early integration into existing ownCloud 10 instances.
-After completing this setup, ownCloud Web will be available on `https://<your-owncloud-server>/apps-external/web`.
-
-{{< hint info >}}
-Depending on your setup, the name of `apps-external` folder can vary. It is important to use the correct name in all of the mentioned URLs.
-{{< /hint >}}
+After completing this setup, ownCloud Web will be available on `https://<your-owncloud-server>/index.php/apps/web`.
 
 ## Prerequisites
 - Running [ownCloud 10 server](https://owncloud.com/download-server/) with version 10.6
@@ -24,7 +20,7 @@ Depending on your setup, the name of `apps-external` folder can vary. It is impo
 Download [ownCloud Web app](https://marketplace.owncloud.com/apps/web) from the marketplace and enable it.
 
 ## Configure oauth2
-Within the `Admin` page of ownCloud 10, head into `User Authentication` and add a new client with arbitrary name (e.g. `ownCloud Web`) and redirection URL `https://<your-owncloud-server>/apps-external/web/oidc-callback.html`.
+Within the `Admin` page of ownCloud 10, head into `User Authentication` and add a new client with arbitrary name (e.g. `ownCloud Web`) and redirection URL `https://<your-owncloud-server>/index.php/apps/web/oidc-callback.html`.
 
 {{< figure src="/clients/web/static/oauth2.jpg" alt="Example OAuth2 entry" >}}
 
@@ -32,26 +28,26 @@ Within the `Admin` page of ownCloud 10, head into `User Authentication` and add 
 To display ownCloud Web in the app switcher and to redirect all private and public links to the new WebUI, add the following config into `config/config.php`:
 
 ```php
-'web.baseUrl' => 'https://<your-owncloud-server>/apps-external/web',
+'web.baseUrl' => 'https://<your-owncloud-server>/index.php/apps/web',
 ```
 ## Configure ownCloud Web
-There are a few config values which need to be set in order for ownCloud Web to work correctly. Please copy `apps-external/web/config.json.dist` into `config/config.json` and adjust it according to the following example:
+There are a few config values which need to be set in order for ownCloud Web to work correctly. Please copy `config.json.dist` from the web app directory into `config/config.json` and adjust it according to the following example:
 
 ```json
 {
-  "server" : "https://<your-owncloud-server>", // ownCloud 10 server address
-  "theme": "owncloud", // Theme to be used in ownCloud Web pointing to a json file inside of `themes` folder
+  "server" : "https://<your-owncloud-server>",
+  "theme": "owncloud",
   "auth": {
-    "clientId": "<client-id-from-oauth2>", // Client ID received when adding ownCloud Web in the `User Authentication` section in `Admin`
+    "clientId": "<client-id-from-oauth2>",
     "url": "https://<your-owncloud-server>/index.php/apps/oauth2/api/v1/token",
     "authUrl": "https://<your-owncloud-server>/index.php/apps/oauth2/authorize"
   },
-  "apps" : [ // List of extensions to be loaded
+  "apps" : [
     "files"
   ],
-  "applications" : [ // Apps to be displayed in the application switcher or in the user menu
+  "applications" : [
     {
-      "title": { // Item in apps switcher pointing to the old ownCloud UI
+      "title": {
         "en": "Classic Design",
         "de": "Dateien",
         "fr": "Fichiers",
@@ -60,7 +56,7 @@ There are a few config values which need to be set in order for ownCloud Web to 
       "icon": "switch_ui",
       "url": "http://<your-owncloud-server>/index.php/apps/files"
     },
-    { // Item in user menu pointing to user settings in the old ownCloud UI
+    {
       "icon": "application",
       "menu": "user",
       "target": "_self",
@@ -73,6 +69,16 @@ There are a few config values which need to be set in order for ownCloud Web to 
   ]
 }
 ```
+
+|config parameter|explanation|
+|---|---|
+|server|ownCloud 10 server address|
+|theme|Theme to be used in ownCloud Web pointing to a json file inside of `themes` folder|
+|auth.clientId|Client ID received when adding ownCloud Web in the `User Authentication` section in `Admin`|
+|apps|List of internal extensions to be loaded|
+|applications|Additional apps and links to be displayed in the application switcher or in the user menu|
+|applications[0].title|Visible title in the application switcher or user menu, localizable|
+|applications[1].menu|Use `user` to move the menu item into the user menu. Defaults to app switcher|
 
 {{< hint info >}}
 It is important that you don't edit or place the `config.json` within the app folder. If you do, the integrity check of the app will fail and raise warnings.

--- a/lib/Application.php
+++ b/lib/Application.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @author Benedikt Kulmann <bkulmann@owncloud.com>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Web;
+
+use OCP\AppFramework\App;
+
+class Application extends App {
+
+    const APPID = 'web';
+
+	/**
+	 * @param array $urlParams
+	 */
+	public function __construct(array $urlParams = []) {
+		parent::__construct(Application::APPID, $urlParams);
+	}
+}

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -63,10 +63,11 @@ class ConfigController extends Controller {
         try {
             $configFile = \OC::$SERVERROOT . '/config/config.json';
             $configJSON = file_get_contents($configFile);
-            return new DataResponse($configJSON);
+            $decoded = \json_decode($configJSON, true);
+            return new DataResponse($decoded);
         } catch(\Exception $e) {
             $this->logger->logException($e, ['app' => 'web']);
-            return new DataResponse([$e->getMessage()], Http::STATUS_NOT_FOUND);
+            return new DataResponse(["message" => $e->getMessage()], Http::STATUS_NOT_FOUND);
         }
     }
 }

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @author Benedikt Kulmann <bkulmann@owncloud.com>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Web\Controller;
+
+use OC\AppFramework\Http;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\ILogger;
+use OCP\IRequest;
+
+/**
+ * Class ConfigController
+ *
+ * @package OCA\Web\Controller
+ */
+class ConfigController extends Controller {
+
+    /**
+     * @var ILogger
+     */
+    private $logger;
+
+    /**
+     * ConfigController constructor.
+     *
+     * @param string $appName
+     * @param IRequest $request
+     * @param ILogger $logger
+     */
+    public function __construct(string $appName, IRequest $request, ILogger $logger) {
+        parent::__construct($appName, $request);
+        $this->logger = $logger;
+    }
+
+    /**
+     * Loads the config json file for ownCloud Web
+     *
+     * @PublicPage
+     * @NoCSRFRequired
+     *
+     * @return DataResponse
+     */
+    public function getConfig(): DataResponse {
+        try {
+            $configFile = \OC::$SERVERROOT . '/config/config.json';
+            $configJSON = file_get_contents($configFile);
+            return new DataResponse($configJSON);
+        } catch(\Exception $e) {
+            $this->logger->logException($e, ['app' => 'web']);
+            return new DataResponse([$e->getMessage()], Http::STATUS_NOT_FOUND);
+        }
+    }
+}

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -63,8 +63,8 @@ class ConfigController extends Controller {
         try {
             $configFile = \OC::$SERVERROOT . '/config/config.json';
             $configContent = \file_get_contents($configFile);
-            $configJSON = \json_decode($configContent, true);
-            return new JSONResponse($configJSON);
+            $configAssoc = \json_decode($configContent, true);
+            return new JSONResponse($configAssoc);
         } catch(\Exception $e) {
             $this->logger->logException($e, ['app' => 'web']);
             return new JSONResponse(["message" => $e->getMessage()], Http::STATUS_NOT_FOUND);

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -23,7 +23,7 @@ namespace OCA\Web\Controller;
 
 use OC\AppFramework\Http;
 use OCP\AppFramework\Controller;
-use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\JSONResponse;
 use OCP\ILogger;
 use OCP\IRequest;
 
@@ -57,17 +57,17 @@ class ConfigController extends Controller {
      * @PublicPage
      * @NoCSRFRequired
      *
-     * @return DataResponse
+     * @return JSONResponse
      */
-    public function getConfig(): DataResponse {
+    public function getConfig(): JSONResponse {
         try {
             $configFile = \OC::$SERVERROOT . '/config/config.json';
-            $configJSON = file_get_contents($configFile);
-            $decoded = \json_decode($configJSON, true);
-            return new DataResponse($decoded);
+            $configContent = \file_get_contents($configFile);
+            $configJSON = \json_decode($configContent, true);
+            return new JSONResponse($configJSON);
         } catch(\Exception $e) {
             $this->logger->logException($e, ['app' => 'web']);
-            return new DataResponse(["message" => $e->getMessage()], Http::STATUS_NOT_FOUND);
+            return new JSONResponse(["message" => $e->getMessage()], Http::STATUS_NOT_FOUND);
         }
     }
 }

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -54,7 +54,7 @@ class ConfigController extends Controller {
     /**
      * Loads the config json file for ownCloud Web
      *
-	 * @NoAdminRequired
+	 * @PublicPage
 	 * @NoCSRFRequired
      *
      * @return JSONResponse

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -54,8 +54,8 @@ class ConfigController extends Controller {
     /**
      * Loads the config json file for ownCloud Web
      *
-     * @NoAdminRequired
-     * @NoCSRFRequired
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
      *
      * @return JSONResponse
      */
@@ -64,7 +64,12 @@ class ConfigController extends Controller {
             $configFile = \OC::$SERVERROOT . '/config/config.json';
             $configContent = \file_get_contents($configFile);
             $configAssoc = \json_decode($configContent, true);
-            return new JSONResponse($configAssoc);
+            $response = new JSONResponse($configAssoc);
+			$response->addHeader('Cache-Control', 'max-age=0, no-cache, no-store, must-revalidate');
+			$response->addHeader('Pragma', 'no-cache');
+			$response->addHeader('Expires', 'Wed, 11 Jan 1984 05:00:00 GMT');
+			$response->addHeader('X-Frame-Options', 'DENY');
+			return $response;
         } catch(\Exception $e) {
             $this->logger->logException($e, ['app' => 'web']);
             return new JSONResponse(["message" => $e->getMessage()], Http::STATUS_NOT_FOUND);

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -54,7 +54,7 @@ class ConfigController extends Controller {
     /**
      * Loads the config json file for ownCloud Web
      *
-     * @PublicPage
+     * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -95,12 +95,17 @@ class FilesController extends Controller {
 		$response = new DataDisplayResponse(\file_get_contents($absolutePath), Http::STATUS_OK, [
 			'Content-Type' => $this->getMimeType($absolutePath),
 			'Content-Length' => \filesize($absolutePath),
+			'Cache-Control' => 'max-age=0, no-cache, no-store, must-revalidate',
+			'Pragma' => 'no-cache',
+			'Expires' => 'Wed, 11 Jan 1984 05:00:00 GMT',
+			'X-Frame-Options' => 'DENY'
 		]);
 		if (\strpos($path, "oidc-callback.html") === 0 || \strpos($path, "oidc-silent-redirect.html") === 0) {
 			$csp = new ContentSecurityPolicy();
 			$csp->allowInlineScript(true);
 			$response->setContentSecurityPolicy($csp);
 		}
+
 		return $response;
 	}
 

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -58,7 +58,7 @@ class FilesController extends Controller {
 	/**
 	 * Tries to load a file by the given $path.
 	 *
-	 * @NoAdminRequired
+	 * @PublicPage
 	 * @NoCSRFRequired
 	 *
 	 * @param $path string

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -83,12 +83,16 @@ class FilesController extends Controller {
 			return new DataResponse(['error' => 'resource not found'], Http::STATUS_NOT_FOUND);
 		}
 
-		// check if path resolves to a file
+		// check if path resolves to an actual file
 		if (\is_dir($path)) {
 			return new DataResponse(['error' => 'resource not found'], Http::STATUS_NOT_FOUND);
 		}
-		$absolutePath = \dirname(__FILE__, 3) . '/' . $path;
-		if (!($realPath = \realpath($absolutePath))) {
+		$basePath = \dirname(__DIR__,2);
+		$absolutePath = \realpath( $basePath . '/' . $path);
+		if ($absolutePath === false) {
+			return new DataResponse(['error' => 'resource not found'], Http::STATUS_NOT_FOUND);
+		}
+		if (\strpos($absolutePath, $basePath) !== 0) {
 			return new DataResponse(['error' => 'resource not found'], Http::STATUS_NOT_FOUND);
 		}
 

--- a/lib/Controller/FilesController.php
+++ b/lib/Controller/FilesController.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * @author Benedikt Kulmann <bkulmann@owncloud.com>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Web\Controller;
+
+use GuzzleHttp\Mimetypes;
+use OC\AppFramework\Http;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\ContentSecurityPolicy;
+use OCP\AppFramework\Http\DataDisplayResponse;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\Response;
+use OCP\ILogger;
+use OCP\IRequest;
+
+/**
+ * Class FilesController
+ *
+ * @package OCA\Web\Controller
+ */
+class FilesController extends Controller {
+
+	/**
+	 * @var ILogger
+	 */
+	private $logger;
+
+	/**
+	 * FilesController constructor.
+	 *
+	 * @param string $appName
+	 * @param IRequest $request
+	 * @param ILogger $logger
+	 */
+	public function __construct(string $appName, IRequest $request, ILogger $logger) {
+		parent::__construct($appName, $request);
+		$this->logger = $logger;
+	}
+
+	/**
+	 * Tries to load a file by the given $path.
+	 *
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 *
+	 * @param $path string
+	 * @return DataResponse
+	 */
+	public function getFile(string $path): Response {
+		// don't allow directory traversal to parents
+		if (\strpos($path, "..") !== false) {
+			return new DataResponse(['error' => 'resource not found'], Http::STATUS_NOT_FOUND);
+		}
+
+		// check if path permitted
+		$permittedPaths = ["apps", "core", "css", "img", "node_modules", "themes", "index.html", "oidc-callback.html", "oidc-silent-redirect.html"];
+		$found = false;
+		foreach ($permittedPaths as $p) {
+			if (\strpos($path, $p) === 0) {
+				$found = true;
+				break;
+			}
+		}
+		if (!$found) {
+			return new DataResponse(['error' => 'resource not found'], Http::STATUS_NOT_FOUND);
+		}
+
+		// check if path resolves to a file
+		if (\is_dir($path)) {
+			return new DataResponse(['error' => 'resource not found'], Http::STATUS_NOT_FOUND);
+		}
+		$absolutePath = \dirname(__FILE__, 3) . '/' . $path;
+		if (!($realPath = \realpath($absolutePath))) {
+			return new DataResponse(['error' => 'resource not found'], Http::STATUS_NOT_FOUND);
+		}
+
+		$response = new DataDisplayResponse(\file_get_contents($absolutePath), Http::STATUS_OK, [
+			'Content-Type' => $this->getMimeType($absolutePath),
+			'Content-Length' => \filesize($absolutePath),
+		]);
+		if (\strpos($path, "oidc-callback.html") === 0 || \strpos($path, "oidc-silent-redirect.html") === 0) {
+			$csp = new ContentSecurityPolicy();
+			$csp->allowInlineScript(true);
+			$response->setContentSecurityPolicy($csp);
+		}
+		return $response;
+	}
+
+	private function getMimeType(string $filename): string {
+		$mimeTypes = Mimetypes::getInstance();
+		return $mimeTypes->fromFilename($filename);
+	}
+}

--- a/src/web.js
+++ b/src/web.js
@@ -211,7 +211,7 @@ function loadTranslations () {
 
 (async function () {
   // try to load config.json
-  let config = await fetch('config.json')
+  config = await fetch('config.json')
   // if the config.json is missing, try to find the oc10 app config endpoint
   if (config.status === 404) {
     const baseUrl = window.location.href.substring(0, window.location.href.indexOf('/apps'))

--- a/src/web.js
+++ b/src/web.js
@@ -210,22 +210,17 @@ function loadTranslations () {
 }
 
 (async function () {
-  let config
-  try {
-    config = await fetch('config.json')
-  } catch(e) {
-    // if the config.json is missing, try like we're in an oc10 app
-    let oc10AppUrl = window.location.href.substring(0, window.location.href.indexOf('/#') + 1)
+  // try to load config.json from the cwd
+  let config = await fetch('config.json')
+  // if the config.json is missing, try like we're in an oc10 app
+  if (config.status === 404) {
+    let oc10AppUrl = window.location.href.substring(0, window.location.href.indexOf('/web/') + "/web/".length)
     if (!oc10AppUrl.includes('index.php')) {
       oc10AppUrl = oc10AppUrl.replace('/app', '/index.php/app')
     }
-    try {
-      config = await fetch(oc10AppUrl + 'config')
-    } catch(e) {
-    }
+    config = await fetch(oc10AppUrl + 'config')
   }
-
-  if (!config || config.status === 404) {
+  if (config.status !== 200) {
     router.push('missing-config')
     missingConfig()
     return

--- a/src/web.js
+++ b/src/web.js
@@ -214,11 +214,10 @@ function loadTranslations () {
   try {
     config = await fetch('config.json')
   } catch(e) {
-    // if the config.json is missing, try like we're in an app
+    // if the config.json is missing, try like we're in an oc10 app
     const oc10AppUrl = window.location.href.substring(0, window.location.href.indexOf('/#') + 1)
-    const url = oc10AppUrl + 'config'
     try {
-      config = await fetch(url)
+      config = await fetch(oc10AppUrl + 'config')
     } catch(e) {
     }
   }

--- a/src/web.js
+++ b/src/web.js
@@ -210,15 +210,13 @@ function loadTranslations () {
 }
 
 (async function () {
-  // try to load config.json from the cwd
+  // try to load config.json
   let config = await fetch('config.json')
-  // if the config.json is missing, try like we're in an oc10 app
+  // if the config.json is missing, try to find the oc10 app config endpoint
   if (config.status === 404) {
-    let oc10AppUrl = window.location.href.substring(0, window.location.href.indexOf('/web/') + "/web/".length)
-    if (!oc10AppUrl.includes('index.php')) {
-      oc10AppUrl = oc10AppUrl.replace('/app', '/index.php/app')
-    }
-    config = await fetch(oc10AppUrl + 'config')
+    const baseUrl = window.location.href.substring(0, window.location.href.indexOf('/apps'))
+    const configUrl = baseUrl + (!baseUrl.includes('index.php') ? '/index.php/' : '/') + 'apps/web/config'
+    config = await fetch(configUrl)
   }
   if (config.status !== 200) {
     router.push('missing-config')

--- a/src/web.js
+++ b/src/web.js
@@ -210,9 +210,20 @@ function loadTranslations () {
 }
 
 (async function () {
-  config = await fetch('config.json')
+  let config
+  try {
+    config = await fetch('config.json')
+  } catch(e) {
+    // if the config.json is missing, try like we're in an app
+    const oc10AppUrl = window.location.href.substring(0, window.location.href.indexOf('/#') + 1)
+    const url = oc10AppUrl + 'config'
+    try {
+      config = await fetch(url)
+    } catch(e) {
+    }
+  }
 
-  if (config.status === 404) {
+  if (!config || config.status === 404) {
     router.push('missing-config')
     missingConfig()
     return

--- a/src/web.js
+++ b/src/web.js
@@ -215,7 +215,10 @@ function loadTranslations () {
     config = await fetch('config.json')
   } catch(e) {
     // if the config.json is missing, try like we're in an oc10 app
-    const oc10AppUrl = window.location.href.substring(0, window.location.href.indexOf('/#') + 1)
+    let oc10AppUrl = window.location.href.substring(0, window.location.href.indexOf('/#') + 1)
+    if (!oc10AppUrl.includes('index.php')) {
+      oc10AppUrl = oc10AppUrl.replace('/app', '/index.php/app')
+    }
     try {
       config = await fetch(oc10AppUrl + 'config')
     } catch(e) {

--- a/src/web.js
+++ b/src/web.js
@@ -212,12 +212,6 @@ function loadTranslations () {
 (async function () {
   // try to load config.json
   config = await fetch('config.json')
-  // if the config.json is missing, try to find the oc10 app config endpoint
-  if (config.status === 404) {
-    const baseUrl = window.location.href.substring(0, window.location.href.indexOf('/apps'))
-    const configUrl = baseUrl + (!baseUrl.includes('index.php') ? '/index.php/' : '/') + 'apps/web/config'
-    config = await fetch(configUrl)
-  }
   if (config.status !== 200) {
     router.push('missing-config')
     missingConfig()


### PR DESCRIPTION

## Description
When ownCloud Web is deployed as an app, we need to read the config from the config folder, instead of from within the app folder. Otherwise we'll have issues with the signing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
