### PR TITLE
[Tests Only] Add acceptance tests to restore a trashbin file whose parent folder is renamed or is not restored

### DIFF
--- a/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
@@ -128,12 +128,29 @@ Feature: Restore deleted files/folders
       | simple-folder/file-to-delete-and-restore |
     And user "user1" has renamed folder "simple-folder" to "simple-folder-renamed"
     When the user browses to the trashbin page
-    #And the user restores file "simple-folder/file-to-delete-and-restore" from the trashbin using the webUI
     And the user restores file "simple-folder/file-to-delete-and-restore" from the trashbin using the webUI
-    Then the error message with header "Restoration of file-to-delete-and-restore failed" should be displayed on the webUI
+    Then the error message with header "Restoration of file-to-delete-and-restore failed" and subheader "The destination node is not found" should be displayed on the webUI
     #And a success message "file-to-delete-and-restore was restored successfully" should be displayed on the webUI
     #And as "user1" the file with original path "simple-folder/file-to-delete-and-restore" should not exist in the trashbin
     And as "user1" the file with original path "simple-folder/file-to-delete-and-restore" should exist in the trashbin
+    And as "user1" file "simple-folder-renamed/file-to-delete-and-restore" should not exist
+    #And as "user1" file "simple-folder-renamed/file-to-delete-and-restore" should exist
+    And as "user1" file "simple-folder/file-to-delete-and-restore" should not exist
+
+  @skipOnOC10
+  @issue-product-186
+  @issue-ocis-1057
+  Scenario: Restore a file from trashbin whose parent folder is renamed
+    Given user "user1" has created file "simple-folder/file-to-delete-and-restore"
+    And the following files have been deleted by user "user1"
+      | name                                     |
+      | simple-folder/file-to-delete-and-restore |
+    And user "user1" has renamed folder "simple-folder" to "simple-folder-renamed"
+    When the user browses to the trashbin page
+    And the user restores file "simple-folder/file-to-delete-and-restore" from the trashbin using the webUI
+    Then the error message with header "Restoration of file-to-delete-and-restore failed" and subheader "Unknown error" should be displayed on the webUI
+    #And a success message "file-to-delete-and-restore was restored successfully" should be displayed on the webUI
+    #And as "user1" the file with original path "simple-folder/file-to-delete-and-restore" should not exist in the trashbin
     And as "user1" file "simple-folder-renamed/file-to-delete-and-restore" should not exist
     #And as "user1" file "simple-folder-renamed/file-to-delete-and-restore" should exist
     And as "user1" file "simple-folder/file-to-delete-and-restore" should not exist

--- a/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
@@ -131,8 +131,8 @@ Feature: Restore deleted files/folders
     And the user restores file "simple-folder/file-to-delete-and-restore" from the trashbin using the webUI
     Then the following error message should be displayed on the webUI
      """
-      Restoration of file-to-delete-and-restore failed
-      The destination node is not found
+     Restoration of file-to-delete-and-restore failed
+     The destination node is not found
       """
     #And a success message "file-to-delete-and-restore was restored successfully" should be displayed on the webUI
     #And as "user1" the file with original path "simple-folder/file-to-delete-and-restore" should not exist in the trashbin
@@ -153,7 +153,7 @@ Feature: Restore deleted files/folders
     When the user browses to the trashbin page
     And the user restores file "simple-folder/file-to-delete-and-restore" from the trashbin using the webUI
     Then the following error message should be displayed on the webUI
-     """
+      """
       Restoration of file-to-delete-and-restore failed
       Unknown error
       """

--- a/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
@@ -131,9 +131,9 @@ Feature: Restore deleted files/folders
     And the user restores file "simple-folder/file-to-delete-and-restore" from the trashbin using the webUI
     Then the following error message should be displayed on the webUI
      """
-     Restoration of file-to-delete-and-restore failed
-     The destination node is not found
-      """
+       Restoration of file-to-delete-and-restore failed
+       The destination node is not found
+     """
     #And a success message "file-to-delete-and-restore was restored successfully" should be displayed on the webUI
     #And as "user1" the file with original path "simple-folder/file-to-delete-and-restore" should not exist in the trashbin
     And as "user1" the file with original path "simple-folder/file-to-delete-and-restore" should exist in the trashbin
@@ -162,6 +162,47 @@ Feature: Restore deleted files/folders
     And as "user1" file "simple-folder-renamed/file-to-delete-and-restore" should not exist
     #And as "user1" file "simple-folder-renamed/file-to-delete-and-restore" should exist
     And as "user1" file "simple-folder/file-to-delete-and-restore" should not exist
+
+  @issue-1753
+  @skipOnOCIS
+  @issue-product-186
+  Scenario: Restore a file from trashbin without restoring the parent folder
+    Given user "user1" has created file "simple-folder/file-to-delete-and-restore"
+    And the following files have been deleted by user "user1"
+      | name                                     |
+      | simple-folder/file-to-delete-and-restore |
+    When the user browses to the trashbin page
+    And the user restores file "simple-folder/file-to-delete-and-restore" from the trashbin using the webUI
+    Then the following error message should be displayed on the webUI
+     """
+     Restoration of file-to-delete-and-restore failed
+     The destination node is not found
+     """
+    #And a success message "file-to-delete-and-restore was restored successfully" should be displayed on the webUI
+    #And as "user1" the file with original path "simple-folder/file-to-delete-and-restore" should not exist in the trashbin
+    And as "user1" the file with original path "simple-folder/file-to-delete-and-restore" should exist in the trashbin
+    And as "user1" file "simple-folder/file-to-delete-and-restore" should not exist
+    #And as "user1" file "simple-folder/file-to-delete-and-restore" should exist
+
+  @skipOnOC10
+  @issue-product-186
+  @issue-ocis-1057
+  Scenario: Restore a file from trashbin without restoring the parent folder
+    Given user "user1" has created file "simple-folder/file-to-delete-and-restore"
+    And the following files have been deleted by user "user1"
+      | name                                     |
+      | simple-folder/file-to-delete-and-restore |
+    When the user browses to the trashbin page
+    And the user restores file "simple-folder/file-to-delete-and-restore" from the trashbin using the webUI
+    Then the following error message should be displayed on the webUI
+      """
+      Restoration of file-to-delete-and-restore failed
+      Unknown error
+      """
+    #And a success message "file-to-delete-and-restore was restored successfully" should be displayed on the webUI
+    #And as "user1" the file with original path "simple-folder/file-to-delete-and-restore" should not exist in the trashbin
+    And as "user1" file "simple-folder/file-to-delete-and-restore" should not exist
+    #And as "user1" file "simple-folder/file-to-delete-and-restore" should exist
 
   @issue-1723
   Scenario: Delete and restore a file that has the same name like a deleted folder

--- a/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
@@ -129,7 +129,11 @@ Feature: Restore deleted files/folders
     And user "user1" has renamed folder "simple-folder" to "simple-folder-renamed"
     When the user browses to the trashbin page
     And the user restores file "simple-folder/file-to-delete-and-restore" from the trashbin using the webUI
-    Then the error message with header "Restoration of file-to-delete-and-restore failed" and subheader "The destination node is not found" should be displayed on the webUI
+    Then the following error message should be displayed on the webUI
+     """
+      Restoration of file-to-delete-and-restore failed
+      The destination node is not found
+      """
     #And a success message "file-to-delete-and-restore was restored successfully" should be displayed on the webUI
     #And as "user1" the file with original path "simple-folder/file-to-delete-and-restore" should not exist in the trashbin
     And as "user1" the file with original path "simple-folder/file-to-delete-and-restore" should exist in the trashbin
@@ -148,7 +152,11 @@ Feature: Restore deleted files/folders
     And user "user1" has renamed folder "simple-folder" to "simple-folder-renamed"
     When the user browses to the trashbin page
     And the user restores file "simple-folder/file-to-delete-and-restore" from the trashbin using the webUI
-    Then the error message with header "Restoration of file-to-delete-and-restore failed" and subheader "Unknown error" should be displayed on the webUI
+    Then the following error message should be displayed on the webUI
+     """
+      Restoration of file-to-delete-and-restore failed
+      Unknown error
+      """
     #And a success message "file-to-delete-and-restore was restored successfully" should be displayed on the webUI
     #And as "user1" the file with original path "simple-folder/file-to-delete-and-restore" should not exist in the trashbin
     And as "user1" file "simple-folder-renamed/file-to-delete-and-restore" should not exist

--- a/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
@@ -131,8 +131,8 @@ Feature: Restore deleted files/folders
     And the user restores file "simple-folder/file-to-delete-and-restore" from the trashbin using the webUI
     Then the following error message should be displayed on the webUI
      """
-       Restoration of file-to-delete-and-restore failed
-       The destination node is not found
+     Restoration of file-to-delete-and-restore failed
+     The destination node is not found
      """
     #And a success message "file-to-delete-and-restore was restored successfully" should be displayed on the webUI
     #And as "user1" the file with original path "simple-folder/file-to-delete-and-restore" should not exist in the trashbin

--- a/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
@@ -171,6 +171,7 @@ Feature: Restore deleted files/folders
     And the following files have been deleted by user "user1"
       | name                                     |
       | simple-folder/file-to-delete-and-restore |
+      | simple-folder                            |
     When the user browses to the trashbin page
     And the user restores file "simple-folder/file-to-delete-and-restore" from the trashbin using the webUI
     Then the following error message should be displayed on the webUI
@@ -192,6 +193,7 @@ Feature: Restore deleted files/folders
     And the following files have been deleted by user "user1"
       | name                                     |
       | simple-folder/file-to-delete-and-restore |
+      | simple-folder                            |
     When the user browses to the trashbin page
     And the user restores file "simple-folder/file-to-delete-and-restore" from the trashbin using the webUI
     Then the following error message should be displayed on the webUI

--- a/tests/acceptance/pageObjects/webPage.js
+++ b/tests/acceptance/pageObjects/webPage.js
@@ -194,6 +194,11 @@ module.exports = {
         '//*[contains(@class, "uk-notification-message")]/div/div[contains(@class, "oc-notification-message-title")]',
       locateStrategy: 'xpath'
     },
+    messageSubHeader: {
+      selector:
+        '//*[contains(@class, "uk-notification-message")]/div/div[contains(@class, "uk-text-meta")]',
+      locateStrategy: 'xpath'
+    },
     messages: {
       selector: '//*[contains(@class, "uk-notification-message")]',
       locateStrategy: 'xpath'

--- a/tests/acceptance/pageObjects/webPage.js
+++ b/tests/acceptance/pageObjects/webPage.js
@@ -186,17 +186,24 @@ module.exports = {
     },
     browseToUserProfile: function() {
       return this.click('@userMenuButton')
+    },
+    getDisplayedMessage: async function() {
+      let element = ''
+      let displayedmessage
+      await this.waitForElementVisible('@messages')
+      await this.api.element('@messages', result => {
+        element = result.value.ELEMENT
+      })
+      await this.api.elementIdText(element, function(result) {
+        displayedmessage = result.value
+      })
+      return displayedmessage
     }
   },
   elements: {
     message: {
       selector:
         '//*[contains(@class, "uk-notification-message")]/div/div[contains(@class, "oc-notification-message-title")]',
-      locateStrategy: 'xpath'
-    },
-    messageSubHeader: {
-      selector:
-        '//*[contains(@class, "uk-notification-message")]/div/div[contains(@class, "uk-text-meta")]',
       locateStrategy: 'xpath'
     },
     messages: {

--- a/tests/acceptance/pageObjects/webPage.js
+++ b/tests/acceptance/pageObjects/webPage.js
@@ -186,19 +186,6 @@ module.exports = {
     },
     browseToUserProfile: function() {
       return this.click('@userMenuButton')
-    },
-    getMessages: async function() {
-      let element = ''
-      let msg
-      await this.waitForElementVisible('@messages')
-      await this.api.element('@messages', result => {
-        element = result.value.ELEMENT
-      })
-      await this.api.elementIdText(element, function(result) {
-        msg = result.value
-        console.log(result.value)
-      })
-      return msg
     }
   },
   elements: {

--- a/tests/acceptance/pageObjects/webPage.js
+++ b/tests/acceptance/pageObjects/webPage.js
@@ -186,6 +186,19 @@ module.exports = {
     },
     browseToUserProfile: function() {
       return this.click('@userMenuButton')
+    },
+    getMessages: async function() {
+      let element = ''
+      let msg
+      await this.waitForElementVisible('@messages')
+      await this.api.element('@messages', result => {
+        element = result.value.ELEMENT
+      })
+      await this.api.elementIdText(element, function(result) {
+        msg = result.value
+        console.log(result.value)
+      })
+      return msg
     }
   },
   elements: {

--- a/tests/acceptance/stepDefinitions/generalContext.js
+++ b/tests/acceptance/stepDefinitions/generalContext.js
@@ -95,6 +95,22 @@ Then('the success/error message with header {string} should be displayed on the 
     .text.to.equal(message)
 })
 
+Then(
+  'the success/error message with header {string} and subheader {string} should be displayed on the webUI',
+  async function(headerMessage, subheaderMessage) {
+    await client.page
+      .webPage()
+      .waitForElementVisible('@message')
+      .expect.element('@message')
+      .text.to.equal(headerMessage)
+    return client.page
+      .webPage()
+      .waitForElementVisible('@messageSubHeader')
+      .expect.element('@messageSubHeader')
+      .text.to.equal(subheaderMessage)
+  }
+)
+
 Then('the following success/error message should be displayed on the webUI', function(message) {
   return client.page
     .webPage()

--- a/tests/acceptance/stepDefinitions/generalContext.js
+++ b/tests/acceptance/stepDefinitions/generalContext.js
@@ -3,7 +3,6 @@ const { After, Before, Given, Then, When } = require('cucumber')
 const webdavHelper = require('../helpers/webdavHelper')
 const httpHelper = require('../helpers/httpHelper')
 const backendHelper = require('../helpers/backendHelper')
-const assert = require('assert')
 const fs = require('fs')
 const occHelper = require('../helpers/occHelper')
 
@@ -96,19 +95,13 @@ Then('the success/error message with header {string} should be displayed on the 
     .text.to.equal(message)
 })
 
-Then('the following success/error message should be displayed on the webUI', async function(
-  message
-) {
-  const displayedMessage = await client.page.webPage().getMessages()
-  console.log(displayedMessage)
-  assert.strictEqual(displayedMessage, message)
-  // .waitForElementVisible('@messages')
-  // .getText('xpath', '@messages', function (result) {
-  //   console.log(result)
+Then('the following success/error message should be displayed on the webUI', function(message) {
+  return client.page
+    .webPage()
+    .waitForElementVisible('@messages')
+    .expect.element('@messages')
+    .text.to.equal(message)
 })
-// .expect.element('@messages')
-// .text.to.equal(message)
-// })
 
 Then('the error message {string} should be displayed on the webUI dialog prompt', function(
   message

--- a/tests/acceptance/stepDefinitions/generalContext.js
+++ b/tests/acceptance/stepDefinitions/generalContext.js
@@ -3,6 +3,7 @@ const { After, Before, Given, Then, When } = require('cucumber')
 const webdavHelper = require('../helpers/webdavHelper')
 const httpHelper = require('../helpers/httpHelper')
 const backendHelper = require('../helpers/backendHelper')
+const assert = require('assert')
 const fs = require('fs')
 const occHelper = require('../helpers/occHelper')
 
@@ -95,12 +96,11 @@ Then('the success/error message with header {string} should be displayed on the 
     .text.to.equal(message)
 })
 
-Then('the following success/error message should be displayed on the webUI', function(message) {
-  return client.page
-    .webPage()
-    .waitForElementVisible('@messages')
-    .expect.element('@messages')
-    .text.to.equal(message)
+Then('the following success/error message should be displayed on the webUI', async function(
+  message
+) {
+  const displayedMessage = await client.page.webPage().getDisplayedMessage()
+  assert.strictEqual(displayedMessage, message)
 })
 
 Then('the error message {string} should be displayed on the webUI dialog prompt', function(

--- a/tests/acceptance/stepDefinitions/generalContext.js
+++ b/tests/acceptance/stepDefinitions/generalContext.js
@@ -20,14 +20,6 @@ Given(
   }
 )
 
-const assertErrorMessageWithHeader = function(message) {
-  return client.page
-    .webPage()
-    .waitForElementVisible('@message')
-    .expect.element('@message')
-    .text.to.equal(message)
-}
-
 const getConfigJsonContent = function(fullPathOfConfigFile) {
   if (!fs.existsSync(fullPathOfConfigFile)) {
     throw Error('Could not find configfile')
@@ -96,20 +88,12 @@ Given('the property {string} has been deleted in web config file', function(key)
 Then('the success/error message with header {string} should be displayed on the webUI', function(
   message
 ) {
-  return assertErrorMessageWithHeader(message)
+  return client.page
+    .webPage()
+    .waitForElementVisible('@message')
+    .expect.element('@message')
+    .text.to.equal(message)
 })
-
-Then(
-  'the success/error message with header {string} and subheader {string} should be displayed on the webUI',
-  async function(headerMessage, subheaderMessage) {
-    await assertErrorMessageWithHeader(headerMessage)
-    return client.page
-      .webPage()
-      .waitForElementVisible('@messageSubHeader')
-      .expect.element('@messageSubHeader')
-      .text.to.equal(subheaderMessage)
-  }
-)
 
 Then('the following success/error message should be displayed on the webUI', function(message) {
   return client.page

--- a/tests/acceptance/stepDefinitions/generalContext.js
+++ b/tests/acceptance/stepDefinitions/generalContext.js
@@ -3,6 +3,7 @@ const { After, Before, Given, Then, When } = require('cucumber')
 const webdavHelper = require('../helpers/webdavHelper')
 const httpHelper = require('../helpers/httpHelper')
 const backendHelper = require('../helpers/backendHelper')
+const assert = require('assert')
 const fs = require('fs')
 const occHelper = require('../helpers/occHelper')
 
@@ -95,13 +96,19 @@ Then('the success/error message with header {string} should be displayed on the 
     .text.to.equal(message)
 })
 
-Then('the following success/error message should be displayed on the webUI', function(message) {
-  return client.page
-    .webPage()
-    .waitForElementVisible('@messages')
-    .expect.element('@messages')
-    .text.to.equal(message)
+Then('the following success/error message should be displayed on the webUI', async function(
+  message
+) {
+  const displayedMessage = await client.page.webPage().getMessages()
+  console.log(displayedMessage)
+  assert.strictEqual(displayedMessage, message)
+  // .waitForElementVisible('@messages')
+  // .getText('xpath', '@messages', function (result) {
+  //   console.log(result)
 })
+// .expect.element('@messages')
+// .text.to.equal(message)
+// })
 
 Then('the error message {string} should be displayed on the webUI dialog prompt', function(
   message

--- a/tests/acceptance/stepDefinitions/generalContext.js
+++ b/tests/acceptance/stepDefinitions/generalContext.js
@@ -20,6 +20,14 @@ Given(
   }
 )
 
+const assertErrorMessageWithHeader = function(message) {
+  return client.page
+    .webPage()
+    .waitForElementVisible('@message')
+    .expect.element('@message')
+    .text.to.equal(message)
+}
+
 const getConfigJsonContent = function(fullPathOfConfigFile) {
   if (!fs.existsSync(fullPathOfConfigFile)) {
     throw Error('Could not find configfile')
@@ -88,21 +96,13 @@ Given('the property {string} has been deleted in web config file', function(key)
 Then('the success/error message with header {string} should be displayed on the webUI', function(
   message
 ) {
-  return client.page
-    .webPage()
-    .waitForElementVisible('@message')
-    .expect.element('@message')
-    .text.to.equal(message)
+  return assertErrorMessageWithHeader(message)
 })
 
 Then(
   'the success/error message with header {string} and subheader {string} should be displayed on the webUI',
   async function(headerMessage, subheaderMessage) {
-    await client.page
-      .webPage()
-      .waitForElementVisible('@message')
-      .expect.element('@message')
-      .text.to.equal(headerMessage)
+    await assertErrorMessageWithHeader(headerMessage)
     return client.page
       .webPage()
       .waitForElementVisible('@messageSubHeader')


### PR DESCRIPTION
## Description
This PR adds acceptance tests for:
- restoring a trashbin file whose parent folder is renamed
- restoring a trashbin file whose parent folder is not restored

Also, the method to assert the error/success message is changed in this or. Previously, when the expected error/success message and the actual displayed error/success message in the webUI were different, the error thrown was not clear about what was actually found. Can be seen in this: https://drone.owncloud.com/owncloud/web/12372/44/20 . With the recent change, even when the expected and actual text do not match, we can at least find out what was been expected and what was actually found, as in this: https://drone.owncloud.com/owncloud/web/12407/44/20

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/1057

## How Has This Been Tested?
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...