### PR TITLE
[tests-only] Use owncloudci/nodejs:12 instead of webhippie/nodejs:latest

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -998,7 +998,7 @@ def installFederatedServer(version, db, dbSuffix = '-federated'):
 def installNPM():
 	return [{
 		'name': 'npm-install',
-		'image': 'webhippie/nodejs:latest',
+		'image': 'owncloudci/nodejs:12',
 		'pull': 'always',
 		'commands': [
 			'yarn install --frozen-lockfile'
@@ -1008,7 +1008,7 @@ def installNPM():
 def lintTest():
 	return [{
 		'name': 'lint-test',
-		'image': 'webhippie/nodejs:latest',
+		'image': 'owncloudci/nodejs:12',
 		'pull': 'always',
 		'commands': [
 			'yarn run lint'
@@ -1018,7 +1018,7 @@ def lintTest():
 def buildWeb():
 	return [{
 		'name': 'build-web',
-		'image': 'webhippie/nodejs:latest',
+		'image': 'owncloudci/nodejs:12',
 		'pull': 'always',
 		'commands': [
 			'yarn dist',
@@ -1061,7 +1061,7 @@ def buildRelease(ctx):
 	return [
 		{
 			'name': 'make',
-			'image': 'webhippie/nodejs:latest',
+			'image': 'owncloudci/nodejs:12',
 			'pull': 'always',
 			'commands': [
 				'cd /var/www/owncloud/web',
@@ -1601,7 +1601,7 @@ def runWebuiAcceptanceTests(suite, alternateSuiteName, filterTags, extraEnvironm
 
 	return [{
 		'name': 'webui-acceptance-tests',
-		'image': 'webhippie/nodejs:latest',
+		'image': 'owncloudci/nodejs:12',
 		'pull': 'always',
 		'environment': environment,
 		'commands': [


### PR DESCRIPTION
## Description
https://github.com/owncloud/web/pull/4410/commits/a30718bd6847ba271326938e1c97c1a8eccb692f changed the docker image from `owncloudci/nodejs:11` to `webhippie/nodejs:latest` and that was merged 16 days ago. But "something happened" only a few days ago where the BusyBox `cp` command started spitting out help instead of doing the copy. (see issue)

This PR changes back to the `owncloudci/nodejs:12` - use version 12 which was created by https://github.com/owncloud-ci/nodejs/pull/7 a couple of days ago.

Magic - it works.

TBH I have no iddea why the BusyBox `cp` problem started to happen.

## Related Issue

Fixes #4549 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
