### PR TITLE
[tests-only] Add webui tests for checking different available options of actions menu

### DIFF
--- a/tests/acceptance/features/webUIFiles/fileDetails.feature
+++ b/tests/acceptance/features/webUIFiles/fileDetails.feature
@@ -146,3 +146,9 @@ Feature: User can open the details panel for any file or folder
     Then the app-sidebar should be visible
     When the user closes the app-sidebar using the webUI
     Then the app-sidebar should be invisible
+
+  @issue-4244
+  Scenario: the sidebar is invisible after opening the selected folder
+    Given the app-sidebar for file "simple-folder" has been visible on the webUI
+    When the user opens folder "simple-folder" using the webUI
+    Then the app-sidebar should be invisible

--- a/tests/acceptance/features/webUIFiles/fileFolderActionMenu.feature
+++ b/tests/acceptance/features/webUIFiles/fileFolderActionMenu.feature
@@ -1,0 +1,89 @@
+Feature: User can see the file or folder actions menu options
+  As a user
+  I want to be able to see the actions menu options of file or folder
+  So that the menu options of the selected file type or folder are visible to me
+
+Background: prepare user and files
+    Given user "user1" has been created with default attributes
+    And user "user1" has uploaded file with content "pdf file" to "lorem.pdf"
+    And user "user1" has logged in using the webUI
+    And the user has browsed to the files page
+    
+  Scenario: select folder to see actions menu options
+    When the user picks the row of folder "simple-folder" in the webUI
+    Then the app-sidebar for folder "simple-folder" should be visible on the webUI
+    And the following items should be visible in the actions menu on the webUI
+      | items            |
+      | open folder      |
+      | mark as favorite |
+      | copy             |
+      | move             |
+      | rename           |
+      | delete           |
+
+  Scenario: select text file to see actions menu options
+    When the user picks the row of file "lorem.txt" in the webUI
+    Then the app-sidebar for file "lorem.txt" should be visible on the webUI
+    And the following items should be visible in the actions menu on the webUI
+      | items            |
+      | download         |
+      | mark as favorite |
+      | copy             |
+      | move             |
+      | rename           |
+      | delete           |
+    And the following accordion items should be visible in the details dialog on the webUI
+      | items            |
+      | versions         |
+  
+  Scenario: select pdf file to see actions menu options
+    When the user picks the row of file "lorem.pdf" in the webUI
+    Then the app-sidebar for file "lorem.pdf" should be visible on the webUI
+    And the following items should be visible in the actions menu on the webUI
+      | items            |
+      | open in browser  |
+      | download         |
+      | mark as favorite |
+      | copy             |
+      | move             |
+      | rename           |
+      | delete           |
+    And the following accordion items should be visible in the details dialog on the webUI
+      | items            |
+      | versions         |
+
+  Scenario: select folder while text file's action menu is open
+    Given the app-sidebar for file "lorem.txt" is visible on the webUI
+    When the user picks the row of folder "simple-folder" in the webUI
+    Then the app-sidebar for folder "simple-folder" should be visible on the webUI
+    And the following items should be visible in the actions menu on the webUI
+    | items            |
+    | open folder      |
+    And the following items should not be visible in the actions menu on the webUI
+    | items            |
+    | download         |
+    | open in browser  |
+  
+  Scenario: select file while text folder's action menu is open
+    Given the app-sidebar for folder "simple-folder" is visible on the webUI
+    When the user picks the row of folder "lorem.txt" in the webUI
+    Then the app-sidebar for folder "lorem.txt" should be visible on the webUI
+    And the following items should be visible in the actions menu on the webUI
+    | items            |
+    | download      |
+    And the following items should not be visible in the actions menu on the webUI
+    | items            |
+    | open folder      |
+    | open in browser  |
+  
+  Scenario: select pdf file while text folder's action menu is open
+    Given the app-sidebar for folder "simple-folder" is visible on the webUI
+    When the user picks the row of folder "lorem.pdf" in the webUI
+    Then the app-sidebar for folder "lorem.pdf" should be visible on the webUI
+    And the following items should be visible in the actions menu on the webUI
+    | items            |
+    | open in browser  |
+    | download         |
+    And the following items should not be visible in the actions menu on the webUI
+    | items            |
+    | open folder      |

--- a/tests/acceptance/features/webUIFiles/fileFolderActionMenu.feature
+++ b/tests/acceptance/features/webUIFiles/fileFolderActionMenu.feature
@@ -5,85 +5,34 @@ Feature: User can see the file or folder actions menu options
 
 Background: prepare user and files
     Given user "user1" has been created with default attributes
-    And user "user1" has uploaded file with content "pdf file" to "lorem.pdf"
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
     
-  Scenario: select folder to see actions menu options
+  Scenario: observe different actions menu options on selecting different file types or folder
+    Given user "user1" has uploaded file with content "pdf file" to "lorem.pdf"
+    And the user has reloaded the current page of the webUI
+    And the app-sidebar for file "lorem.txt" has been visible on the webUI
     When the user picks the row of folder "simple-folder" in the webUI
     Then the app-sidebar for folder "simple-folder" should be visible on the webUI
-    And the following items should be visible in the actions menu on the webUI
-      | items            |
-      | open folder      |
-      | mark as favorite |
-      | copy             |
-      | move             |
-      | rename           |
-      | delete           |
-
-  Scenario: select text file to see actions menu options
+    And only the following items with default items should be visible in the actions menu on the webUI
+      | items                     |
+      | open folder               |
     When the user picks the row of file "lorem.txt" in the webUI
     Then the app-sidebar for file "lorem.txt" should be visible on the webUI
-    And the following items should be visible in the actions menu on the webUI
-      | items            |
-      | download         |
-      | mark as favorite |
-      | copy             |
-      | move             |
-      | rename           |
-      | delete           |
-    And the following accordion items should be visible in the details dialog on the webUI
-      | items            |
-      | versions         |
-  
-  Scenario: select pdf file to see actions menu options
+    And only the following items with default items should be visible in the actions menu on the webUI
+      | items                     |
+      | open in markdowneditor    |
+      | download                  |
     When the user picks the row of file "lorem.pdf" in the webUI
     Then the app-sidebar for file "lorem.pdf" should be visible on the webUI
-    And the following items should be visible in the actions menu on the webUI
-      | items            |
-      | open in browser  |
-      | download         |
-      | mark as favorite |
-      | copy             |
-      | move             |
-      | rename           |
-      | delete           |
-    And the following accordion items should be visible in the details dialog on the webUI
-      | items            |
-      | versions         |
-
-  Scenario: select folder while text file's action menu is open
-    Given the app-sidebar for file "lorem.txt" is visible on the webUI
-    When the user picks the row of folder "simple-folder" in the webUI
-    Then the app-sidebar for folder "simple-folder" should be visible on the webUI
-    And the following items should be visible in the actions menu on the webUI
-    | items            |
-    | open folder      |
-    And the following items should not be visible in the actions menu on the webUI
-    | items            |
-    | download         |
-    | open in browser  |
-  
-  Scenario: select file while text folder's action menu is open
-    Given the app-sidebar for folder "simple-folder" is visible on the webUI
-    When the user picks the row of folder "lorem.txt" in the webUI
-    Then the app-sidebar for folder "lorem.txt" should be visible on the webUI
-    And the following items should be visible in the actions menu on the webUI
-    | items            |
-    | download      |
-    And the following items should not be visible in the actions menu on the webUI
-    | items            |
-    | open folder      |
-    | open in browser  |
-  
-  Scenario: select pdf file while text folder's action menu is open
-    Given the app-sidebar for folder "simple-folder" is visible on the webUI
-    When the user picks the row of folder "lorem.pdf" in the webUI
-    Then the app-sidebar for folder "lorem.pdf" should be visible on the webUI
-    And the following items should be visible in the actions menu on the webUI
-    | items            |
-    | open in browser  |
-    | download         |
-    And the following items should not be visible in the actions menu on the webUI
-    | items            |
-    | open folder      |
+    And only the following items with default items should be visible in the actions menu on the webUI
+      | items                     |
+      | open in browser           |
+      | download                  |
+    When the user picks the row of file "testavatar.png" in the webUI
+    Then the app-sidebar for file "testavatar.png" should be visible on the webUI
+    And only the following items with default items should be visible in the actions menu on the webUI
+      | items                     |
+      | open in mediaviewer       |
+      | download                  |
+    

--- a/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
@@ -59,6 +59,19 @@ module.exports = {
       }
       return items
     },
+    getVisibleActionsMenuItems: async function() {
+      const items = []
+      let elements
+      await this.api.elements('@actionPanelItems', function(result) {
+        elements = result.value
+      })
+      for (const { ELEMENT } of elements) {
+        await this.api.elementIdText(ELEMENT, function(result) {
+          items.push(result.value.toLowerCase())
+        })
+      }
+      return items
+    },
     isPanelVisible: async function(panelName, timeout = null) {
       panelName = panelName === 'people' ? 'collaborators' : panelName
       const selector = this.elements[panelName + 'Panel']
@@ -161,6 +174,10 @@ module.exports = {
     },
     actionsPanel: {
       selector: '#oc-files-actions-sidebar'
+    },
+    actionPanelItems: {
+      selector: '//div[@class="oc-accordion-content"]//li/button',
+      locateStrategy: 'xpath'
     }
   }
 }

--- a/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-expressions */
 const util = require('util')
+const _ = require('lodash')
 const timeoutHelper = require('../../helpers/timeoutHelper')
 
 module.exports = {
@@ -68,6 +69,27 @@ module.exports = {
       for (const { ELEMENT } of elements) {
         await this.api.elementIdText(ELEMENT, function(result) {
           items.push(result.value.toLowerCase())
+        })
+      }
+      return items
+    },
+    getActionsMenuItemsExceptDefaults: async function() {
+      const defaultItems = ['mark as favorite', 'copy', 'move', 'rename', 'delete']
+      const items = []
+      let elements
+      await this.api.elements('@actionPanelItems', function(result) {
+        elements = result.value
+      })
+      for (const { ELEMENT } of elements) {
+        await this.api.elementIdText(ELEMENT, function(result) {
+          let notDefault = true
+          for (const item of defaultItems) {
+            if (_.isEqual(item, result.value.toLowerCase())) {
+              notDefault = false
+              break
+            }
+          }
+          notDefault ? items.push(result.value.toLowerCase()) : null
         })
       }
       return items

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -1240,3 +1240,36 @@ Then(
     )
   }
 )
+
+Given('the app-sidebar for file/folder {string} is visible on the webUI', async function(resource) {
+  await client.page.FilesPageElement.filesList().clickRow(resource)
+
+  const visible = await client.page.filesPage().isSidebarVisible()
+  assert.strictEqual(visible, true, 'app-sidebar should be visible, but is not')
+  return client.page.filesPage().checkSidebarItem(resource)
+})
+
+Then('the following items should be visible in the actions menu on the webUI', async function(
+  table
+) {
+  const visibleItems = await client.page.FilesPageElement.appSideBar().getVisibleActionsMenuItems()
+  const expectedVisibleItems = table.rows()
+  const difference = _.difference(expectedVisibleItems.flat(), visibleItems)
+  if (difference.length !== 0) {
+    throw new Error(`${difference}  actions menu item(s) was expected to be visible but not found.`)
+  }
+})
+
+Then('the following items should not be visible in the actions menu on the webUI', async function(
+  table
+) {
+  const visibleItems = await client.page.FilesPageElement.appSideBar().getVisibleActionsMenuItems()
+  const expectedVisibleItems = table.rows()
+
+  expectedVisibleItems.forEach(item => {
+    const index = _.indexOf(visibleItems, item.toString().trim())
+    if (index !== -1) {
+      throw new Error(`${item} actions menu item was expected not to be visible but found.`)
+    }
+  })
+})

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -1241,7 +1241,9 @@ Then(
   }
 )
 
-Given('the app-sidebar for file/folder {string} is visible on the webUI', async function(resource) {
+Given('the app-sidebar for file/folder {string} has been visible on the webUI', async function(
+  resource
+) {
   await client.page.FilesPageElement.filesList().clickRow(resource)
 
   const visible = await client.page.filesPage().isSidebarVisible()
@@ -1249,27 +1251,24 @@ Given('the app-sidebar for file/folder {string} is visible on the webUI', async 
   return client.page.filesPage().checkSidebarItem(resource)
 })
 
-Then('the following items should be visible in the actions menu on the webUI', async function(
-  table
-) {
-  const visibleItems = await client.page.FilesPageElement.appSideBar().getVisibleActionsMenuItems()
-  const expectedVisibleItems = table.rows()
-  const difference = _.difference(expectedVisibleItems.flat(), visibleItems)
-  if (difference.length !== 0) {
-    throw new Error(`${difference}  actions menu item(s) was expected to be visible but not found.`)
+Then(
+  'only the following items with default items should be visible in the actions menu on the webUI',
+  async function(table) {
+    const visibleItems = await client.page.FilesPageElement.appSideBar().getActionsMenuItemsExceptDefaults()
+
+    const tableItems = table.rows()
+    const expectedVisibleItems = []
+    tableItems.forEach(element => {
+      element instanceof Array
+        ? expectedVisibleItems.push(element[0])
+        : expectedVisibleItems.push(element)
+    })
+
+    const isPresent = _.isEqual(_.sortBy(expectedVisibleItems), _.sortBy(visibleItems))
+    assert.strictEqual(
+      isPresent,
+      true,
+      `only '${expectedVisibleItems}' actions menu item(s) was expected to be visible but also found '${visibleItems}'.`
+    )
   }
-})
-
-Then('the following items should not be visible in the actions menu on the webUI', async function(
-  table
-) {
-  const visibleItems = await client.page.FilesPageElement.appSideBar().getVisibleActionsMenuItems()
-  const expectedVisibleItems = table.rows()
-
-  expectedVisibleItems.forEach(item => {
-    const index = _.indexOf(visibleItems, item.toString().trim())
-    if (index !== -1) {
-      throw new Error(`${item} actions menu item was expected not to be visible but found.`)
-    }
-  })
-})
+)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- added webui tests for checking actions menu's different `options` available while selecting different file types or folder
-  added webui test for checking `file details` panel closes while opening a folder
## Related Issue
closes https://github.com/owncloud/web/issues/4244

## How Has This Been Tested?
- local environment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 