### PR TITLE
[Tests-Only]Added test for performing cancel action while moving a file

### DIFF
--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -86,3 +86,9 @@ Feature: move files
     And user "user1" has logged in using the webUI
     When the user tries to move file "lorem.txt" into folder "simple-folder (2)" using the webUI
     Then it should not be possible to move into folder "simple-folder (2)" using the webUI
+
+  Scenario: cancel the moving a file
+    Given user "user1" has logged in using the webUI
+    And the user has browsed to the files page
+    When the user cancels an attempt to move file "data.zip" using the webUI
+    Then file "data.zip" should be listed on the webUI

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -689,6 +689,21 @@ module.exports = {
       return this
     },
 
+    cancelMoveResource: async function(resource) {
+      await this.waitForFileVisible(resource)
+
+      // Trigger move
+      await filesRow.openFileActionsMenu(resource).move()
+
+      // cancel move
+      await this.useXpath()
+        .waitForElementVisible(client.page.filesPage().elements.cancelMoveBtn.selector)
+        .click(this.page.filesPage().elements.cancelMoveBtn.selector)
+        .useCss()
+
+      return this
+    },
+
     navigationNotAllowed: async function(target) {
       await this.waitForFileVisible(target)
       await this.initAjaxCounters()

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -451,6 +451,10 @@ module.exports = {
     },
     editorCloseBtn: {
       selector: '#markdown-editor-app-bar .uk-text-right .oc-button'
+    },
+    cancelMoveBtn: {
+      selector: '//button[.="Cancel"]',
+      locateStrategy: 'xpath'
     }
   }
 }

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -1128,6 +1128,12 @@ When('the user tries to move file/folder {string} into folder {string} using the
   return client.page.FilesPageElement.filesList().attemptToMoveResource(resource, target)
 })
 
+When('the user cancels an attempt to move file/folder {string} using the webUI', function(
+  resource
+) {
+  return client.page.FilesPageElement.filesList().cancelMoveResource(resource)
+})
+
 Then('it should not be possible to copy/move into folder {string} using the webUI', function(
   target
 ) {


### PR DESCRIPTION
## Description
Added test for performing cancel action while moving a file

## Related Issue
- Fixes https://github.com/owncloud/web/issues/4417

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 