### PR TITLE
Start markdown editor service in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -647,6 +647,8 @@ def acceptance():
 									)
 								) +
 								copyFilesForUpload() +
+								buildMarkdownEditor() +
+								markdownEditorService() +
 								runWebuiAcceptanceTests(suite, alternateSuiteName, params['filterTags'], params['extraEnvironment'], browser) +
 								(
 									uploadScreenshots() +
@@ -1696,6 +1698,43 @@ def githubComment():
 				'pull_request'
 			]
 		},
+	}]
+
+def buildMarkdownEditor():
+	return[{
+		'name': 'build-markdown-editor',
+		'image': 'webhippie/golang:1.13',
+		'pull': 'always',
+		'commands': [
+			'mkdir -p /srv/app/src',
+			'cd $GOPATH/src',
+			'mkdir -p github.com/owncloud/',
+			'cd github.com/owncloud/',
+			'git clone https://github.com/owncloud/ocis-markdown-editor.git',
+			'cd ocis-markdown-editor',
+			'make build',
+			'cp bin/ocis-markdown-editor /var/www/owncloud/markdown-editor'
+		],
+		'volumes': [{
+			'name': 'gopath',
+			'path': '/srv/app',
+		}],
+	}]
+
+def markdownEditorService():
+	return[{
+		'name': 'markdown-editor',
+		'image': 'webhippie/golang:1.13',
+		'pull': 'always',
+		'detach': True,
+		'commands': [
+			'cd /var/www/owncloud',
+			'./markdown-editor --log-level debug server',
+		],
+		'volumes': [{
+			'name': 'gopath',
+			'path': '/srv/app',
+		}],
 	}]
 
 def dependsOn(earlierStages, nextStages):

--- a/tests/drone/config.json
+++ b/tests/drone/config.json
@@ -12,7 +12,12 @@
   "apps": [
     "files",
     "draw-io",
-    "markdown-editor",
     "media-viewer"
+  ],
+  "external_apps": [
+    {
+      "id": "markdown-editor",
+      "path": "http://owncloud:9206/markdown-editor.js"
+    }
   ]
 }

--- a/tests/drone/config.json
+++ b/tests/drone/config.json
@@ -17,7 +17,7 @@
   "external_apps": [
     {
       "id": "markdown-editor",
-      "path": "http://owncloud:9206/markdown-editor.js"
+      "path": "http://markdown-editor/markdown-editor.js"
     }
   ]
 }

--- a/tests/drone/ocis-config.json
+++ b/tests/drone/ocis-config.json
@@ -17,7 +17,7 @@
   "external_apps": [
     {
       "id": "markdown-editor",
-      "path": "http://ocis:9206/markdown-editor.js"
+      "path": "http://markdown-editor/markdown-editor.js"
     }
   ]
 }

--- a/tests/drone/ocis-config.json
+++ b/tests/drone/ocis-config.json
@@ -12,7 +12,12 @@
   "apps": [
     "files",
     "draw-io",
-    "markdown-editor",
     "media-viewer"
+  ],
+  "external_apps": [
+    {
+      "id": "markdown-editor",
+      "path": "http://ocis:9206/markdown-editor.js"
+    }
   ]
 }


### PR DESCRIPTION
In order to remove markdown editor from this repo (#4539), we need to start a service with this extension to enable us running file creation tests.