### PR TITLE
[Tests-only] Add webUI test for share folder while federation sharing

### DIFF
--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -380,3 +380,11 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Then folder "simple-folder" should not be listed on the webUI
     # uncomment below line after the issue has been fixed
     # Then folder "simple-folder" should be listed on the webUI
+
+  @issue-4247
+  Scenario: shares folder appears only after reloading the page
+    When user "user1" from remote server shares "simple-folder" with user "user1" from local server
+    And user "user1" from server "LOCAL" accepts the last pending share using the sharing API
+    Then folder "Shares" should not be listed on the webUI
+    When the user reloads the current page of the webUI
+    Then folder "Shares" should be listed on the webUI

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -108,6 +108,20 @@ Given(
   }
 )
 
+When(
+  'user {string} from remote server shares {string} with user {string} from local server',
+  function(sharer, file, receiver) {
+    receiver = util.format('%s@%s', receiver, client.globals.backend_url)
+    return backendHelper.runOnRemoteBackend(
+      shareFileFolder,
+      file,
+      sharer,
+      receiver,
+      SHARE_TYPES.federated_cloud_share
+    )
+  }
+)
+
 /**
  * makes sure share operations are carried out maximum once a second to avoid same stime
  */


### PR DESCRIPTION
## Description
Shares folder appears only after reloading page when using share_folder and accepting remote share via notification 

## Related Issue
-test for https://github.com/owncloud/web/issues/4247



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...