### PR TITLE
[tests-only] Refactor for oCIS

### DIFF
--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -209,18 +209,17 @@ module.exports = {
     },
     /**
      * Returns whether files or folders can be created in the current page.
-     *
-     * @param {Function} callback callback with result
      */
-    canCreateFiles: function(callback) {
-      return this.waitForElementVisible('@newFileMenuButtonAnyState').getAttribute(
+    canCreateFiles: async function() {
+      let canCreate = false
+      await this.waitForElementVisible('@newFileMenuButtonAnyState').getAttribute(
         '@newFileMenuButtonAnyState',
         'disabled',
         result => {
-          const isDisabled = result.value === 'true'
-          callback(isDisabled)
+          canCreate = result.value === 'true'
         }
       )
+      return canCreate
     },
     deleteAllCheckedFiles: function() {
       return this.waitForElementVisible('@deleteSelectedButton')

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -161,4 +161,17 @@ fi
 
 echo "runsh: Exit code: ${FINAL_EXIT_STATUS}"
 
+# sync the file-system so all output will be flushed to storage.
+# In drone we sometimes see that the last lines of output are missing from the
+# drone log.
+sync
+
+# If we are running in drone CI, then sleep for a bit to (hopefully) let the
+# drone agent send all the output to the drone server.
+if [ -n "${CI_REPO}" ]
+then
+  echo "sleeping for 30 seconds at end of test run"
+  sleep 30
+fi
+
 exit ${FINAL_EXIT_STATUS}

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -284,16 +284,14 @@ When(
   }
 )
 
-Then('it should not be possible to create files using the webUI', function() {
-  return client.page.filesPage().canCreateFiles(async isDisabled => {
-    await assert.strictEqual(isDisabled, true, 'Create action must not be enabled')
-  })
+Then('it should not be possible to create files using the webUI', async function() {
+  const canCreate = await client.page.filesPage().canCreateFiles()
+  await assert.strictEqual(canCreate, true, 'Create action must not be enabled')
 })
 
-Then('it should be possible to create files using the webUI', function() {
-  return client.page.filesPage().canCreateFiles(async isDisabled => {
-    await assert.strictEqual(isDisabled, false, 'Create action must be enabled')
-  })
+Then('it should be possible to create files using the webUI', async function() {
+  const canCreate = await client.page.filesPage().canCreateFiles()
+  await assert.strictEqual(canCreate, false, 'Create action must be enabled')
 })
 
 When('the user renames file/folder {string} to {string} using the webUI', function(

--- a/tests/acceptance/stepDefinitions/generalContext.js
+++ b/tests/acceptance/stepDefinitions/generalContext.js
@@ -193,6 +193,7 @@ Given('the setting {string} of app {string} has been set to {string}', function(
   value
 ) {
   if (client.globals.ocis) {
+    // TODO: decide if we fail on OCIS when a scenario even tries to use this given step
     return
   }
   return occHelper.runOcc(['config:app:set', app, setting, '--value=' + value])
@@ -212,10 +213,18 @@ Given('the setting {string} of app {string} has been set to {string} on remote s
 })
 
 Given('the administrator has cleared the versions for user {string}', function(userId) {
+  if (client.globals.ocis) {
+    // TODO: decide if we fail on OCIS when a scenario even tries to use this given step
+    return
+  }
   return occHelper.runOcc(['versions:cleanup', userId])
 })
 
 Given('the administrator has cleared the versions for all users', function() {
+  if (client.globals.ocis) {
+    // TODO: decide if we fail on OCIS when a scenario even tries to use this given step
+    return
+  }
   return occHelper.runOcc(['versions:cleanup'])
 })
 
@@ -294,10 +303,18 @@ After(function() {
 })
 
 Given('the app {string} has been disabled', function(app) {
+  if (client.globals.ocis) {
+    // TODO: decide if we fail on OCIS when a scenario even tries to use this given step
+    return
+  }
   return occHelper.runOcc(['app:disable', app])
 })
 
 Given('default expiration date for users is set to {int} day/days', function(days) {
+  if (client.globals.ocis) {
+    // TODO: decide if we fail on OCIS when a scenario even tries to use this given step
+    return
+  }
   occHelper.runOcc([`config:app:set --value ${days} core shareapi_expire_after_n_days_user_share`])
 
   return this

--- a/tests/acceptance/stepDefinitions/notificationsContext.js
+++ b/tests/acceptance/stepDefinitions/notificationsContext.js
@@ -33,6 +33,11 @@ Given('app {string} has been {}', async function(app, action) {
     "only supported either 'enabled' or 'disabled'. Passed: " + action
   )
 
+  if (client.globals.ocis) {
+    // TODO: decide if we fail on OCIS when a scenario even tries to use this given step
+    return
+  }
+
   const errorMessage = util.format(
     'Failed while trying to %s the app',
     action === 'enabled' ? 'enable' : 'disable'


### PR DESCRIPTION
## Description
While enabling more of the web UI tests on OCIS I discovered these things. The changes can be made in the existing code.

1) sleep at end of test run - the same as https://github.com/owncloud/core/pull/38250 - sync at end of tests to get all test log output

2) Avoid runOcc on OCIS - when enabling test scenarios on OCIS, if they use a step that currently calls `runOcc` then that gets an error that stops the whole test suite. I changed those so that they do nothing if running on OCIS. The "occ" setting will not happen when running on OCIS and the test scenario should fail in some later step, because the system behaviour will not be what is expected. But at least the test suite will continue and report the failed scenarios in a controlled way. In future we will need to sort out what to do about the test scenarios that check the behaviour of "system settings".

3) Refactor canCreateFiles - the steps "it should (not) be possible to create files using the webUI" would crash the test runner if they failed. They have been refactored so that the assert fails more nicely, and the test suite continues running and reports the failed scenarios in a controlled way.

When this PR is merged, I can rebase #4534 so that it contains only changes directly to enabling test scenarios and adjusting expected-failures.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
