### PR TITLE
Fix burger menu button

### DIFF
--- a/changelog/unreleased/fix-burger-menu
+++ b/changelog/unreleased/fix-burger-menu
@@ -1,0 +1,6 @@
+Bugfix: Fully clickable sidebar toggle button
+
+The button for hiding/showing the left sidebar (burger menu) was not fully clickable. We fixed this by removing a negative margin that pulled the rest of the topbar over the button.
+
+https://github.com/owncloud/web/issues/4130
+https://github.com/owncloud/web/pull/4572

--- a/src/components/Top-Bar.vue
+++ b/src/components/Top-Bar.vue
@@ -13,12 +13,7 @@
       </div>
       <search-bar v-if="!isSearchDisabled" />
     </oc-grid>
-    <oc-grid
-      v-if="!isPublicPage"
-      flex
-      gutter="small"
-      class="uk-width-expand uk-flex-right oc-mt-rm"
-    >
+    <oc-grid v-if="!isPublicPage" flex gutter="small" class="uk-width-expand uk-flex-right oc-m-rm">
       <notifications v-if="activeNotifications.length" />
       <applications-menu v-if="applicationsList.length > 0" :applications-list="applicationsList" />
       <user-menu


### PR DESCRIPTION

## Description
The button for hiding/showing the left sidebar (burger menu) was not fully clickable. We fixed this by removing a negative margin that pulled the rest of the topbar over the button.
This bug was only taking effect when the search input field is hidden. This is why this was only a known bug in oCIS, not with oc10 backend (because we typically keep the search input when running with oc10). 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/4130

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- drone and manual

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
