### PR TITLE
[Tests-Only] Adds webUI tests for sharing file after renaming it 

### DIFF
--- a/tests/acceptance/expected-failures-with-ocis-server-owncloud-storage.txt
+++ b/tests/acceptance/expected-failures-with-ocis-server-owncloud-storage.txt
@@ -418,3 +418,6 @@ webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:122
 webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:298
 webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:275
 webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:212
+#
+# https://github.com/owncloud/web/issues/4192 renamed file cannot be shared
+webUISharingInternalUsers/shareWithUsers.feature:595

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -591,6 +591,7 @@ Feature: Sharing files and folders with internal users
     When the user opens folder "Shares" using the webUI
     Then the preview image of file "testavatar.jpg" should not be displayed in the file list view on the webUI
 
+  @issue-4192
   Scenario: sharing file after renaming it is possible
     Given user "user1" has logged in using the webUI
     And user "user1" has uploaded file with content "test" to "lorem.txt"

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -590,3 +590,10 @@ Feature: Sharing files and folders with internal users
     And user "user2" has logged in using the webUI
     When the user opens folder "Shares" using the webUI
     Then the preview image of file "testavatar.jpg" should not be displayed in the file list view on the webUI
+
+  Scenario: sharing file after renaming it is possible
+    Given user "user1" has logged in using the webUI
+    And user "user1" has uploaded file with content "test" to "lorem.txt"
+    And the user has renamed file "lorem.txt" to "new-lorem.txt"
+    When the user shares resource "new-lorem.txt" with user "User Two" using the quick action in the webUI
+    Then user "User Two" should be listed as "Viewer" in the collaborators list for file "new-lorem.txt" on the webUI

--- a/tests/acceptance/features/webUISharingInternalUsersToRoot/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersToRoot/shareWithUsers.feature
@@ -494,3 +494,10 @@ Feature: Sharing files and folders with internal users
     And user "user1" has shared file "testavatar.jpg" with user "user2"
     When user "user2" logs in using the webUI
     Then the preview image of file "testavatar.jpg" should not be displayed in the file list view on the webUI
+
+  Scenario: sharing file after renaming it is possible
+    Given user "user1" has logged in using the webUI
+    And user "user1" has uploaded file with content "test" to "lorem.txt"
+    And the user has renamed file "lorem.txt" to "new-lorem.txt"
+    When the user shares resource "new-lorem.txt" with user "User Two" using the quick action in the webUI
+    Then user "User Two" should be listed as "Viewer" in the collaborators list for file "new-lorem.txt" on the webUI

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -301,6 +301,10 @@ When('the user renames file/folder {string} to {string} using the webUI', functi
   return client.page.FilesPageElement.filesList().renameFile(fromName, toName)
 })
 
+Given('the user has renamed file/folder {string} to {string}', function(fromName, toName) {
+  return client.page.FilesPageElement.filesList().renameFile(fromName, toName)
+})
+
 When('the user tries to rename file/folder {string} to {string} using the webUI', function(
   fromName,
   toName


### PR DESCRIPTION
## Description
 Adds tests for sharing file after renaming it 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- tests for https://github.com/owncloud/web/issues/4192


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot: 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
