### PR TITLE
[Tests-only] Adds webUI tests for deleting and restoring a file inside a received share folder

### DIFF
--- a/tests/acceptance/expected-failures-with-ocis-server-owncloud-storage.txt
+++ b/tests/acceptance/expected-failures-with-ocis-server-owncloud-storage.txt
@@ -422,3 +422,6 @@ webUITrashbinRestore/trashbinRestore.feature:123
 webUIUpload/uploadEdgecases.feature:105
 webUIUpload/uploadEdgecases.feature:121
 webUIUpload/uploadFileGreaterThanQuotaSize.feature:12
+#
+# https://github.com/owncloud/ocis/issues/1124 restoring a file deleted from a received shared folder is not possible
+webUITrashbinRestore/trashbinRestore.feature:240

--- a/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
@@ -235,3 +235,22 @@ Feature: Restore deleted files/folders
     When the user browses to the files page using the webUI
     Then folder "lorem.txt" should be listed on the webUI
     And file "lorem.txt" should not be listed on the webUI
+
+  @issue-ocis-1124
+  Scenario: delete and restore a file inside a received shared folder
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And the administrator has set the default folder for received shares to "Shares"
+    And user "user3" has been created with default attributes
+    And user "user3" has created folder "folder-to-share"
+    And user "user3" has uploaded file with content "does-not-matter" to "folder-to-share/fileToShare.txt"
+    And user "user3" has shared folder "folder-to-share" with user "user1"
+    And user "user1" has accepted the share "folder-to-share" offered by user "user3"
+    And the user has reloaded the current page of the webUI
+    When the user opens folder "Shares" using the webUI
+    And the user opens folder "folder-to-share" using the webUI
+    And the user deletes file "fileToShare.txt" using the webUI
+    When the user browses to the trashbin page
+    Then as "user1" file "fileToShare.txt" should exist in the trashbin
+    When the user restores file "…/folder-to-share/fileToShare.txt" from the trashbin using the webUI
+    Then the success message with header "fileToShare.txt was restored successfully" should be displayed on the webUI
+    And as "user1" file "/Shares/folder-to-share/fileToShare.txt" should exist


### PR DESCRIPTION
## Description
Adds webUI tests for deleting and restoring a file inside a received share folder

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/1124

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot: 


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
