### PR TITLE
[tests-only] Bump OCIS_COMMITID as at 2021-01-06AM

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=e90c4801a70a9311eeeb960db840c04ae8eb402a
+OCIS_COMMITID=17a2270508254ed6379536825cdc52ca37444875
 OCIS_BRANCH=master


### PR DESCRIPTION
There is nothing really exciting changed in OCIS, but I wanted to check anyway that all is good. PR https://github.com/owncloud/ocis/pull/1176 going the other way has some "bonus" failing tests to look into.