### PR TITLE
Rename copy confirmation button

### DIFF
--- a/apps/files/src/components/LocationPicker/LocationPicker.vue
+++ b/apps/files/src/components/LocationPicker/LocationPicker.vue
@@ -236,7 +236,7 @@ export default {
       if (this.currentAction === 'move') {
         return this.$pgettext('Confirm action in the location picker for move', 'Move here')
       } else if (this.currentAction === 'copy') {
-        return this.$pgettext('Confirm action in the location picker for copy', 'Copy here')
+        return this.$pgettext('Confirm action in the location picker for copy', 'Paste here')
       }
 
       return this.$gettext('Confirm')

--- a/changelog/unreleased/copy-action-label
+++ b/changelog/unreleased/copy-action-label
@@ -1,0 +1,5 @@
+Change: Rename confirmation of copy action
+
+We've changed the label of the confirmation button in copy view. Instead of "Copy here", we used "Paste here".
+
+https://github.com/owncloud/web/pull/4590


### PR DESCRIPTION
## Description
We've changed the label of the confirmation button in copy view. Instead of "Copy here", we used "Paste here".

## Motivation and Context
Be closer to desktop explorers