### PR TITLE
[Tests-Only] Add webUI tests for performing cancel action while copying and moving a files/folders

### DIFF
--- a/tests/acceptance/features/webUIFiles/copy.feature
+++ b/tests/acceptance/features/webUIFiles/copy.feature
@@ -97,3 +97,31 @@ Feature: copy files and folders
     And folder "simple-empty-folder" should be listed on the webUI
     And as "user1" folder "folder with space/simple-empty-folder/simple-empty-folder" should exist
     And as "user1" folder "simple-empty-folder" should exist
+
+  Scenario: cancel copying a file
+    Given user "user1" has logged in using the webUI
+    And the user has browsed to the files page
+    When the user tries to copy folder "data.zip" into folder "simple-empty-folder" using the webUI
+    And the user cancels the attempt to copy file into folder "simple-empty-folder" using the webUI
+    Then file "data.zip" should be listed on the webUI
+    But  file "data.zip" should not be listed in the folder "simple-empty-folder" on the webUI
+
+  Scenario: cancel copying of multiple files at once
+    Given user "user1" has logged in using the webUI
+    And the user has browsed to the files page
+    When the user tries to batch copy these files into folder "simple-empty-folder" using the webUI
+      | file_name   |
+      | data.zip    |
+      | lorem.txt   |
+      | testapp.zip |
+    And the user cancels the attempt to copy file into folder "simple-empty-folder" using the webUI
+    Then the following files should be listed on the webUI
+      | file_name   |
+      | data.zip    |
+      | lorem.txt   |
+      | testapp.zip |
+    But these resources should not be listed in the folder "simple-empty-folder" on the webUI
+      | file_name   |
+      | data.zip    |
+      | lorem.txt   |
+      | testapp.zip |

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -90,3 +90,9 @@ Feature: move files
     And user "user1" has logged in using the webUI
     When the user tries to move file "lorem.txt" into folder "simple-folder (2)" using the webUI
     Then it should not be possible to move into folder "simple-folder (2)" using the webUI
+
+  Scenario: cancel the moving a file
+    Given user "user1" has logged in using the webUI
+    And the user has browsed to the files page
+    When the user cancels an attempt to move file "data.zip" using the webUI
+    Then file "data.zip" should be listed on the webUI

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -91,8 +91,30 @@ Feature: move files
     When the user tries to move file "lorem.txt" into folder "simple-folder (2)" using the webUI
     Then it should not be possible to move into folder "simple-folder (2)" using the webUI
 
-  Scenario: cancel the moving a file
+  Scenario: cancel moving a file
     Given user "user1" has logged in using the webUI
     And the user has browsed to the files page
-    When the user cancels an attempt to move file "data.zip" using the webUI
+    When the user tries to move file "data.zip" into folder "simple-empty-folder" using the webUI
+    And the user cancels the attempt to move file into folder "simple-empty-folder" using the webUI
     Then file "data.zip" should be listed on the webUI
+    But  file "data.zip" should not be listed in the folder "simple-empty-folder" on the webUI
+
+  Scenario: cancel moving of multiple files at once
+    Given user "user1" has logged in using the webUI
+    And the user has browsed to the files page
+    When the user tries to batch move these files into folder "simple-empty-folder" using the webUI
+      | file_name   |
+      | data.zip    |
+      | lorem.txt   |
+      | testapp.zip |
+    And the user cancels the attempt to move file into folder "simple-empty-folder" using the webUI
+    Then the following files should be listed on the webUI
+      | file_name   |
+      | data.zip    |
+      | lorem.txt   |
+      | testapp.zip |
+    But these resources should not be listed in the folder "simple-empty-folder" on the webUI
+      | file_name   |
+      | data.zip    |
+      | lorem.txt   |
+      | testapp.zip |

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -723,6 +723,21 @@ module.exports = {
       return this
     },
 
+    cancelMoveResource: async function(resource) {
+      await this.waitForFileVisible(resource)
+
+      // Trigger move
+      await filesRow.openFileActionsMenu(resource).move()
+
+      // cancel move
+      await this.useXpath()
+        .waitForElementVisible(client.page.filesPage().elements.cancelMoveBtn.selector)
+        .click(this.page.filesPage().elements.cancelMoveBtn.selector)
+        .useCss()
+
+      return this
+    },
+
     navigationNotAllowed: async function(target) {
       await this.waitForFileVisible(target)
       await this.initAjaxCounters()

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -723,16 +723,13 @@ module.exports = {
       return this
     },
 
-    cancelMoveResource: async function(resource) {
-      await this.waitForFileVisible(resource)
+    cancelResourceMoveOrCopyProgress: async function(target) {
+      await this.waitForFileVisible(target)
 
-      // Trigger move
-      await filesRow.openFileActionsMenu(resource).move()
-
-      // cancel move
+      // cancel copy or move
       await this.useXpath()
-        .waitForElementVisible(client.page.filesPage().elements.cancelMoveBtn.selector)
-        .click(this.page.filesPage().elements.cancelMoveBtn.selector)
+        .waitForElementVisible(client.page.filesPage().elements.cancelMoveCopyBtn.selector)
+        .click(this.page.filesPage().elements.cancelMoveCopyBtn.selector)
         .useCss()
 
       return this

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -291,6 +291,13 @@ module.exports = {
       return client.page.locationPicker().selectFolderAndConfirm(target)
     },
 
+    attemptToMoveMultipleResources: async function(target) {
+      // Trigger move
+      await this.click('@moveSelectedBtn')
+
+      return client.page.locationPicker().selectFolder(target)
+    },
+
     copyMultipleResources: function(target) {
       // Trigger copy
       this.click('@copySelectedBtn')
@@ -299,6 +306,12 @@ module.exports = {
       return client.page.locationPicker().selectFolderAndConfirm(target)
     },
 
+    attemptToCopyMultipleResources: async function(target) {
+      // Trigger copy
+      await this.click('@copySelectedBtn')
+
+      return client.page.locationPicker().selectFolder(target)
+    },
     /**
      * Create a md file with the given name
      *
@@ -457,7 +470,11 @@ module.exports = {
     editorCloseBtn: {
       selector: '#markdown-editor-app-bar .uk-text-right .oc-button'
     },
-    cancelMoveBtn: {
+    clearSelectionBtn: {
+      selector: '//span[contains(text(),"Clear selection")]',
+      locateStrategy: 'xpath'
+    },
+    cancelMoveCopyBtn: {
       selector: '//button[.="Cancel"]',
       locateStrategy: 'xpath'
     }

--- a/tests/acceptance/pageObjects/filesPage.js
+++ b/tests/acceptance/pageObjects/filesPage.js
@@ -457,8 +457,8 @@ module.exports = {
     editorCloseBtn: {
       selector: '#markdown-editor-app-bar .uk-text-right .oc-button'
     },
-    clearSelectionBtn: {
-      selector: '//span[contains(text(),"Clear selection")]',
+    cancelMoveBtn: {
+      selector: '//button[.="Cancel"]',
       locateStrategy: 'xpath'
     }
   }

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -596,6 +596,21 @@ Then(
   }
 )
 
+Then(
+  'file/folder/resource {string} should not be listed in the folder {string} on the webUI',
+  async function(file, target) {
+    await client.page.filesPage().navigateAndWaitTillLoaded(target)
+    return client.page.FilesPageElement.filesList()
+      .isElementListed(file, 'file', client.globals.waitForNegativeConditionTimeout)
+      .then(state => {
+        const message = state
+          ? `Error: Folder '${file}' is listed on the '${target}'`
+          : `File '${file}' is not listed on the '${target}'`
+        return client.assert.ok(!state, message)
+      })
+  }
+)
+
 /**
  * currently this only works with the files page, on other pages the user cannot navigate into subfolders
  *
@@ -1152,11 +1167,12 @@ When('the user tries to move file/folder {string} into folder {string} using the
   return client.page.FilesPageElement.filesList().attemptToMoveResource(resource, target)
 })
 
-When('the user cancels an attempt to move file/folder {string} using the webUI', function(
-  resource
-) {
-  return client.page.FilesPageElement.filesList().cancelMoveResource(resource)
-})
+When(
+  'the user cancels the attempt to move/copy file/folder into folder {string} using the webUI',
+  function(target) {
+    return client.page.FilesPageElement.filesList().cancelResourceMoveOrCopyProgress(target)
+  }
+)
 
 Then('it should not be possible to copy/move into folder {string} using the webUI', function(
   target
@@ -1172,6 +1188,17 @@ When(
     }
 
     return client.page.filesPage().moveMultipleResources(target)
+  }
+)
+
+When(
+  'the user tries to batch move these files/folders into folder {string} using the webUI',
+  async function(target, resources) {
+    for (const item of resources.rows()) {
+      await client.page.FilesPageElement.filesList().toggleFileOrFolderCheckbox('enable', item[0])
+    }
+
+    return client.page.filesPage().attemptToMoveMultipleResources(target)
   }
 )
 
@@ -1197,6 +1224,17 @@ When(
     }
 
     return client.page.filesPage().copyMultipleResources(target)
+  }
+)
+
+When(
+  'the user tries to batch copy these files/folders into folder {string} using the webUI',
+  async function(target, resources) {
+    for (const item of resources.rows()) {
+      await client.page.FilesPageElement.filesList().toggleFileOrFolderCheckbox('enable', item[0])
+    }
+
+    return client.page.filesPage().attemptToCopyMultipleResources(target)
   }
 )
 

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -1152,6 +1152,12 @@ When('the user tries to move file/folder {string} into folder {string} using the
   return client.page.FilesPageElement.filesList().attemptToMoveResource(resource, target)
 })
 
+When('the user cancels an attempt to move file/folder {string} using the webUI', function(
+  resource
+) {
+  return client.page.FilesPageElement.filesList().cancelMoveResource(resource)
+})
+
 Then('it should not be possible to copy/move into folder {string} using the webUI', function(
   target
 ) {

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -603,10 +603,7 @@ Then(
     return client.page.FilesPageElement.filesList()
       .isElementListed(file, 'file', client.globals.waitForNegativeConditionTimeout)
       .then(state => {
-        const message = state
-          ? `Error: Folder '${file}' is listed on the '${target}'`
-          : `File '${file}' is not listed on the '${target}'`
-        return client.assert.ok(!state, message)
+        return client.assert.ok(!state, `Error: Folder '${file}' is listed on the '${target}'`)
       })
   }
 )


### PR DESCRIPTION
## Description
Added test for performing cancel action while moving and copying a file

## Related Issue

- closes https://github.com/owncloud/web/issues/4417

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
