### PR TITLE
[tests-only] Be more specific matching an expected-failure

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -96,7 +96,10 @@ if [ -n "${EXPECTED_FAILURES_FILE}" ]; then
       continue
     fi
 
-    if [[ "${LINE}" =~ -\ \[(.*?)] ]]; then
+    # Match lines that have [someSuite/someName.feature:n] - the part inside the
+    # brackets is the suite, feature and line number of the expected failure.
+    # Else ignore the line.
+    if [[ "${LINE}" =~ \[(\S+\/\S+\.feature:\d+)] ]]; then
       LINE="${BASH_REMATCH[1]}"
     else
       continue


### PR DESCRIPTION
## Description
Be more specific in matching the format `[someSuite/someFeature.feature:42]` of an expected-failure.

Do not assume that it is preceded by a `-` and a single space. Codacy in `owncloud/ocis` complains a lot about `.md` file format and insists on particular spacing. So we do not want to depend on the exact spacing of this sort of thing.

## Related Issue
- https://github.com/owncloud/ocis/issues/1193

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
