### PR TITLE
Fix paths in l10n Makefile

### DIFF
--- a/l10n/Makefile
+++ b/l10n/Makefile
@@ -7,7 +7,7 @@ export PATH := $(NODE_BINDIR):$(PATH)
 APPS =  ../apps/files ../apps/markdown-editor ../apps/media-viewer
 
 # Where to find core folder
-CORE = ../
+CORE = ..
 
 # List of all files to extract
 INPUT_FILES = $(CORE) $(APPS)
@@ -51,7 +51,7 @@ $(TEMPLATE_FILE):
 			export OUT_DIR=$$app/l10n; \
 		fi; \
 		mkdir -p $$OUT_DIR; \
-		export GETTEXT_APP_SOURCES=`find $$app/src/ -name '*.vue' -o -name '*.js'`;\
+		export GETTEXT_APP_SOURCES=`find $$app/src -name '*.vue' -o -name '*.js'`;\
 		node ../node_modules/easygettext/src/extract-cli.js --attribute v-translate --output $$OUT_DIR/template.pot $$GETTEXT_APP_SOURCES; \
 	done;
 


### PR DESCRIPTION

## Description
The path references in the l10n Makefile contained some wrong placed `/`. This PR fixes that. Behaviour was correct before, it just looks weird in the terminal.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
