### PR TITLE
[tests-only] Adjust regex for SUITE_SCENARIO in acceptance tests

### DIFF
--- a/tests/acceptance/expected-failures-with-ocis-server-owncloud-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-owncloud-storage.md
@@ -18,7 +18,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 
 ### [User request using token and basic authentication gives different display names](https://github.com/owncloud/ocis-reva/issues/107)
 -   [webUIAccount/accountInformation.feature:10](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIAccount/accountInformation.feature#L10)
--   [webUIAccount/accountInformation.feature:42](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIAccount/accountInformation.feature#L10)
 -   [webUIAccount/accountInformation.feature:34](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIAccount/accountInformation.feature#L34)
 
 ### [LDAP Groups not working with konnectd](https://github.com/owncloud/ocis-konnectd/issues/42)
@@ -204,7 +203,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIRenameFiles/renameFiles.feature:124](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFiles/renameFiles.feature#L124)
 -   [webUIRenameFiles/renameFiles.feature:125](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFiles/renameFiles.feature#L125)
 -   [webUIRenameFiles/renameFiles.feature:126](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFiles/renameFiles.feature#L126)
--   [webUIRenameFiles/renameFiles.feature:175](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFiles/renameFiles.feature#L175)
 
 ### [renameFolders](https://github.com/owncloud/ocis/issues/1216)
 -   [webUIRenameFolders/renameFolders.feature:114](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFolders/renameFolders.feature#L114)

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -99,7 +99,7 @@ if [ -n "${EXPECTED_FAILURES_FILE}" ]; then
     # Match lines that have [someSuite/someName.feature:n] - the part inside the
     # brackets is the suite, feature and line number of the expected failure.
     # Else ignore the line.
-    if [[ "${LINE}" =~ \[(\S+\/\S+\.feature:\d+)] ]]; then
+    if [[ "${LINE}" =~ \[([a-zA-Z0-9]+/[a-zA-Z0-9]+\.feature:[0-9]+)] ]]; then
       LINE="${BASH_REMATCH[1]}"
     else
       continue


### PR DESCRIPTION
## Description
The expected-failures processing in `tests/acceptance/run.sh` was not finding unexpected passing scenarios. I had used regex with `\S` and `\d` to try to match non-whitespace and digits. But they were not working in the Bash regex. (Maybe the `\` were getting stripped out somewhere in the Bash command processor before going to the regex or... Maybe I could add more `\` to escape the `\`! I don't really care to know, because that would get too complex for future readers anyway)

Specify the actual character ranges to be matched. `[a-zA-Z0-9]` (alpha-numeric) and `[0-9]` (digit). That is more readable and it works - double bonus!

I tested locally by making some changes to the expected-failures files and seeing that I could get "unexpected passes" reported.

Now CI has found 2 scenarios in the expected-failures file that are actually passing, or do not exist at all. Those have been removed. That also demonstrates that the changed regex is working.

Note: the same fix is also applied in core PR https://github.com/owncloud/core/pull/38317

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
