### PR TITLE
[tests-only] Make visual regression tests fail

### DIFF
--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -80,7 +80,7 @@ const config = {
           baseline_suffix: '',
           diff_screenshots_path: 'tests/vrt/diff',
           diff_suffix: '',
-          threshold: 0.005,
+          threshold: 0.002,
           prompt: false,
           always_save_diff_screenshot: UPDATE_VRT_SCREENSHOTS
         }

--- a/tests/acceptance/features/webUIFiles/fileList.feature
+++ b/tests/acceptance/features/webUIFiles/fileList.feature
@@ -4,8 +4,8 @@ Feature: User can view files inside a folder
   So that I can work with files and folders inside it
 
   Background:
-    Given user "user1" has been created with default attributes
-    And user "user1" has logged in using the webUI
+    Given user "user2" has been created with default attributes
+    And user "user2" has logged in using the webUI
 
   Scenario: Resources are listed
     When the user browses to the files page
@@ -26,7 +26,7 @@ Feature: User can view files inside a folder
 
   @issue-276 @issue-3264
   Scenario: Thumbnails are loaded for paths containing special characters
-    Given user "user1" has renamed folder "simple-folder" to "strängé folder name (duplicate #2 &)"
+    Given user "user2" has renamed folder "simple-folder" to "strängé folder name (duplicate #2 &)"
     When the user browses to the files page
     And the user opens folder "strängé folder name (duplicate #2 &)" directly on the webUI
     Then the file "strängé filename (duplicate #2 &).txt" should have a thumbnail displayed on the webUI


### PR DESCRIPTION
Change `user1` to `user2` in a scenario that has a visual regression test step. That will cause the user display name to be different in the top bar. So it should not match the configured image.

Confirm that CI fails, and that the various pipeline tests to report the fail do run correctly.