### PR TITLE
[tests-only] change visual regression threshold to 0.002

### DIFF
--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -80,7 +80,7 @@ const config = {
           baseline_suffix: '',
           diff_screenshots_path: 'tests/vrt/diff',
           diff_suffix: '',
-          threshold: 0.005,
+          threshold: 0.002,
           prompt: false,
           always_save_diff_screenshot: UPDATE_VRT_SCREENSHOTS
         }


### PR DESCRIPTION
## Description
PR #4632 tried demonstrate making a visual regression test fail. But the threshold is bit high, and a "significant" change to the top-bar image did not trigger failure.

Lowering the threshold did trigger failure, which is what we want. Commit the lower threshold.


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...