### PR TITLE
[tests-only] do not let someone accidentally commit a local .drone.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ tests/testing-app
 # visual regression testing artifacts
 /tests/vrt/diff
 /tests/vrt/latest
+
+# drone CI is in .drone.star, do not let someone accidentally commit a local .drone.yml
+.drone.yml


### PR DESCRIPTION
## Description
When debugging what pipeline `.drone.star` actually produces, it is possibly to locally do:
```
drone starlark
```

And that produces a generated `.drone.yml` that you can examine.

We do not want people to accidentally commit that file.

Note: this is already ignored in `owncloud/core`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
