### PR TITLE
[tests-only] remove trashbinDelete bug demo scenario

### DIFF
--- a/tests/acceptance/features/webUITrashbinDelete/trashbinDelete.feature
+++ b/tests/acceptance/features/webUITrashbinDelete/trashbinDelete.feature
@@ -115,11 +115,3 @@ Feature: files and folders can be deleted from the trashbin
     When the user clears the trashbin
     Then the success message with header "All deleted files were removed" should be displayed on the webUI
     And there should be no resources listed on the webUI
-
-  @skipOnOC10 @issue-product-139
-  # after the issue is fixed delete this scenario and use the one above
-  Scenario: Clear trashbin
-    When the user clears the trashbin
-    Then the error message with header "Could not delete files" should be displayed on the webUI
-    And file "lorem.txt" should be listed on the webUI
-    And folder "simple-folder" should be listed on the webUI


### PR DESCRIPTION
## Description
The trashbin delete problem has been fixed in `cs3org/reva` and `owncloud/ocis` is being updated in PR https://github.com/owncloud/ocis/pull/1372 - that correctly causes the bug-demo scenario to now fail.

It will be easiest to remove the scenario now, and that will avoid having to add it to expected-failures in the OCIS PR.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
