### PR TITLE
[Tests-Only] Strictly check for the image for media viewer preview

### DIFF
--- a/tests/acceptance/expected-failures-with-oc10-server.md
+++ b/tests/acceptance/expected-failures-with-oc10-server.md
@@ -12,5 +12,9 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIPreview/imageMediaViewer.feature:81](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L81)
 -   [webUIPreview/imageMediaViewer.feature:88](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L88)
 
+### [Media Viewer preview not visible for files with .ogg and .webm formats](https://github.com/owncloud/web/issues/4667)
+-   [webUIPreview/imageMediaViewer.feature:136](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L136)
+-   [webUIPreview/imageMediaViewer.feature:154](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L154)
+
 ### [WebUI Login](https://github.com/owncloud/web/issues/4564)
 -   [webUILogin/login.feature:62](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/login.feature#L62)

--- a/tests/acceptance/expected-failures-with-ocis-server-owncloud-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-owncloud-storage.md
@@ -13,9 +13,14 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIPreview/imageMediaViewer.feature:88](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L88)
 
 
-### [Media Viewer preview not visible for files with .jpeg and .gif formats](https://github.com/owncloud/ocis/issues/1490)
--   [webUIPreview/imageMediaViewer.feature:123](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L123)
--   [webUIPreview/imageMediaViewer.feature:141](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L141)
+### [Media Viewer preview not visible for files with .jpeg, .ogg, .webm and .gif formats](https://github.com/owncloud/ocis/issues/1490)
+-   [webUIPreview/imageMediaViewer.feature:127](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L127)
+-   [webUIPreview/imageMediaViewer.feature:136](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L136)
+-   [webUIPreview/imageMediaViewer.feature:145](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L145)
+-   [webUIPreview/imageMediaViewer.feature:154](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L154)
+
+### [Media viewer previews are not visible in public share](https://github.com/owncloud/ocis/issues/1370)
+-   [webUIPreview/imageMediaViewer.feature:110](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L110)
 
 ### [authentication dialog appears when user is deleted](https://github.com/owncloud/web/issues/4564)
 ### [login error page loops when logged in user is deleted](https://github.com/owncloud/ocis/issues/1129)

--- a/tests/acceptance/features/webUIPreview/imageMediaViewer.feature
+++ b/tests/acceptance/features/webUIPreview/imageMediaViewer.feature
@@ -91,11 +91,13 @@ Scenario Outline: preview of image files with media viewer is possible
     When the user views the file "testimage.mp3" in the media viewer using the webUI
     Then the file "testimage.mp3" should be displayed in the media viewer webUI
 
+
   Scenario: preview of image in file list view
     Given user "user1" has uploaded file "testavatar.jpg" to "testavatar.jpg"
     And user "user1" has logged in using the webUI
     When the user browses to the files page
     Then the preview image of file "testavatar.jpg" should be displayed in the file list view on the webUI
+
 
   Scenario: preview of file in file list view when previews is disabled
     Given the property "disablePreviews" of "options" has been set to true in web config file
@@ -104,12 +106,14 @@ Scenario Outline: preview of image files with media viewer is possible
     When the user browses to the files page
     Then the preview image of file "testavatar.jpg" should not be displayed in the file list view on the webUI
 
+
   Scenario: file list view image preview in public share
     Given user "user1" has uploaded file "testavatar.jpg" to "simple-empty-folder/testavatar.jpg"
     And user "user1" has created a public link with following settings
       | path | simple-empty-folder |
     When the public uses the webUI to access the last public link created by user "user1"
     Then the preview image of file "testavatar.jpg" should be displayed in the file list view on the webUI
+
 
   Scenario: file list view image preview in public share when previews is disabled
     Given the property "disablePreviews" of "options" has been set to true in web config file
@@ -128,7 +132,7 @@ Scenario Outline: preview of image files with media viewer is possible
     When the user views the file "testavatar.jpeg" in the media viewer using the webUI
     Then the file "testavatar.jpeg" should be displayed in the media viewer webUI
 
-
+  @issue-ocis-1490 @issue-4667
   Scenario: preview of image in file list view for .ogg format file
     Given user "user1" has uploaded file "sampleOgg.ogg" to "sampleOgg.ogg"
     And user "user1" has logged in using the webUI
@@ -146,7 +150,7 @@ Scenario Outline: preview of image files with media viewer is possible
     When the user views the file "sampleGif.gif" in the media viewer using the webUI
     Then the file "sampleGif.gif" should be displayed in the media viewer webUI
 
-
+  @issue-ocis-1490 @issue-4667
   Scenario: preview of image in file list view for .webm format file
     Given user "user1" has uploaded file "sampleWebm.webm" to "sampleWebm.webm"
     And user "user1" has logged in using the webUI

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -24,17 +24,20 @@ module.exports = {
      * @param {string} fileName
      * @return {Promise<*>}
      */
-    isPreviewImageDisplayed: async function(fileName) {
+    isPreviewImageDisplayed: async function(fileName, shouldOrShouldnot) {
       await this.waitForFileVisible(fileName)
-      const element = util.format(this.elements.previewImage.selector, fileName)
+      const element = util.format(this.elements.previewImageParentDiv.selector, fileName)
+      const imageSelector = util.format(this.elements.previewImage.selector, fileName)
       let previewStatus = ''
-      await this.useXpath()
-        .waitForElementVisible(element)
-        .getAttribute(
-          { selector: element, locateStrategy: this.elements.previewImage.locateStrategy },
-          'data-preview-loaded',
-          result => (previewStatus = result.value === 'true')
-        )
+      await this.useXpath().waitForElementVisible(element)
+      if (shouldOrShouldnot === 'should') {
+        await this.useXpath().waitForElementVisible(imageSelector)
+      }
+      await this.getAttribute(
+        { selector: element, locateStrategy: this.elements.previewImageParentDiv.locateStrategy },
+        'data-preview-loaded',
+        result => (previewStatus = result.value === 'true')
+      )
       return previewStatus
     },
     /**
@@ -907,8 +910,12 @@ module.exports = {
     filesListItem: {
       selector: '.vue-recycle-scroller__item-view'
     },
-    previewImage: {
+    previewImageParentDiv: {
       selector: '//div[@filename="%s"]/ancestor::div[contains(@class, "oc-file")]',
+      locateStrategy: 'xpath'
+    },
+    previewImage: {
+      selector: '//div[@filename="%s"]/ancestor::div[contains(@class, "oc-file")]/img',
       locateStrategy: 'xpath'
     }
   }

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -1259,30 +1259,19 @@ Then('the search bar should be visible in the webUI', async function() {
 })
 
 Then(
-  'the preview image of file {string} should not be displayed in the file list view on the webUI',
-  async function(fileName) {
+  /^the preview image of file "([^"]*)" (should|should not) be displayed in the file list view on the webUI$/,
+  async function(fileName, shouldOrShouldnot) {
+    let expected = true
+    let message = 'Expected preview image to be displayed but is not displayed'
     const isPreviewDisplayed = await client.page.FilesPageElement.filesList().isPreviewImageDisplayed(
-      fileName
+      fileName,
+      shouldOrShouldnot
     )
-    assert.strictEqual(
-      isPreviewDisplayed,
-      false,
-      'Expected preview image to be not displayed but is displayed'
-    )
-  }
-)
-
-Then(
-  'the preview image of file {string} should be displayed in the file list view on the webUI',
-  async function(fileName) {
-    const isPreviewDisplayed = await client.page.FilesPageElement.filesList().isPreviewImageDisplayed(
-      fileName
-    )
-    assert.strictEqual(
-      isPreviewDisplayed,
-      true,
-      'Expected preview image to be displayed but is not displayed'
-    )
+    if (shouldOrShouldnot === 'should not') {
+      expected = false
+      message = 'Expected preview image to be not displayed but is displayed'
+    }
+    assert.strictEqual(isPreviewDisplayed, expected, message)
   }
 )
 


### PR DESCRIPTION
## Description
This PR adjusts the preview image assertion such that the presence of the image is checked strictly.

## Related Issue
- part of https://github.com/owncloud/ocis/issues/1370
## Motivation and Context
The preview of image is not visible but the tests were passing after checking the `preview-loaded` attribute's value and asserting it's true. So the step implementation is adjusted such that when the preview-loaded returns true, the presence of image is also checked.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...