### PR TITLE
[Tests-Only] add webUI tests for user session of a deleted user

### DIFF
--- a/tests/acceptance/expected-failures-with-oc10-server.md
+++ b/tests/acceptance/expected-failures-with-oc10-server.md
@@ -23,3 +23,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 
 ### [WebUI Login](https://github.com/owncloud/web/issues/4677)
 -   [webUILogin/login.feature:62](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/login.feature#L62)
+
+### [Browser session deleted user should not be valid for newly created user of same name](https://github.com/owncloud/ocis/issues/904)
+-   [webUILogin/login.feature:74](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/login.feature#L74)

--- a/tests/acceptance/expected-failures-with-ocis-server-owncloud-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-owncloud-storage.md
@@ -430,6 +430,8 @@ Other free text and markdown formatting can be used elsewhere in the document if
 ### [renamed file cannot be shared](https://github.com/owncloud/web/issues/4192)
 -   [webUISharingInternalUsers/shareWithUsers.feature:595](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature#L595)
 
-
 ### [Blocked user is not logged out](https://github.com/owncloud/ocis/issues/902)
 -   [webUILogin/adminBlocksUser.feature:6](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/adminBlocksUser.feature#L6)
+
+### [Browser session deleted user should not be valid for newly created user of same name](https://github.com/owncloud/ocis/issues/904)
+-   [webUILogin/login.feature:74](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/login.feature#L74)

--- a/tests/acceptance/features/webUILogin/login.feature
+++ b/tests/acceptance/features/webUILogin/login.feature
@@ -70,3 +70,16 @@ Feature: login users
     Then the user should be redirected to the login error page
     When the user exits the login error page
     Then the user should be redirected to the login page
+
+  Scenario: the user session of a deleted user should not be valid for newly created user of same name
+    Given these users have been created with default attributes:
+      | username |
+      | user1    |
+    And user "user1" has logged in using the webUI
+    And the user has browsed to the files page
+    And user "user1" has been deleted
+    And the user has reloaded the current page of the webUI
+    And the user has been redirected to the login error page
+    And user "user1" has been created with default attributes
+    When the user exits the login error page
+    Then the user should be redirected to the login page

--- a/tests/acceptance/features/webUILogin/login.feature
+++ b/tests/acceptance/features/webUILogin/login.feature
@@ -76,7 +76,6 @@ Feature: login users
       | username |
       | user1    |
     And user "user1" has logged in using the webUI
-    And the user has browsed to the files page
     And user "user1" has been deleted
     And user "user1" has been created with default attributes
     When the user reloads the current page of the webUI

--- a/tests/acceptance/features/webUILogin/login.feature
+++ b/tests/acceptance/features/webUILogin/login.feature
@@ -78,8 +78,8 @@ Feature: login users
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
     And user "user1" has been deleted
-    And the user has reloaded the current page of the webUI
-    And the user has been redirected to the login error page
     And user "user1" has been created with default attributes
+    When the user reloads the current page of the webUI
+    Then the user should be redirected to the login error page
     When the user exits the login error page
     Then the user should be redirected to the login page

--- a/tests/acceptance/stepDefinitions/loginContext.js
+++ b/tests/acceptance/stepDefinitions/loginContext.js
@@ -110,6 +110,10 @@ Then('the user should be redirected to the IdP login page', function() {
   return client.page.ownCloudAuthorizePage().waitForPage()
 })
 
+Given('the user has been redirected to the login error page', function() {
+  return client.page.loginErrorPage().waitTillLoaded()
+})
+
 Then('the user should be redirected to the login error page', function() {
   return client.page.loginErrorPage().waitTillLoaded()
 })

--- a/tests/acceptance/stepDefinitions/loginContext.js
+++ b/tests/acceptance/stepDefinitions/loginContext.js
@@ -110,10 +110,6 @@ Then('the user should be redirected to the IdP login page', function() {
   return client.page.ownCloudAuthorizePage().waitForPage()
 })
 
-Given('the user has been redirected to the login error page', function() {
-  return client.page.loginErrorPage().waitTillLoaded()
-})
-
 Then('the user should be redirected to the login error page', function() {
   return client.page.loginErrorPage().waitTillLoaded()
 })


### PR DESCRIPTION
## Description
This PR adds webUI test for user session of a deleted user should not be valid for newly created user of same name.

## Related Issue
- https://github.com/owncloud/ocis/issues/904

## How Has This Been Tested?
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...