### PR TITLE
download password protected public shared files using pre-signed url

### DIFF
--- a/changelog/unreleased/public-link-download
+++ b/changelog/unreleased/public-link-download
@@ -1,0 +1,6 @@
+Change: Use pre-signed url download for password protected shares 
+
+Replaced the blob download with a normal download using a pre-signed url provided by the backend.
+
+https://github.com/owncloud/core/pull/38376
+https://github.com/owncloud/web/pull/4689

--- a/packages/web-app-files/src/store/actions.js
+++ b/packages/web-app-files/src/store/actions.js
@@ -104,7 +104,8 @@ function _buildFile(file) {
     isReceivedShare: function() {
       return this.permissions.indexOf('S') >= 0
     },
-    isChunkedUploadSupported: !!(file.getTusSupport && file.getTusSupport())
+    isChunkedUploadSupported: !!(file.getTusSupport && file.getTusSupport()),
+    downloadURL: file.fileInfo['{http://owncloud.org/ns}downloadURL']
   }
 }
 

--- a/packages/web-app-files/src/store/state.js
+++ b/packages/web-app-files/src/store/state.js
@@ -19,7 +19,8 @@ export default {
     '{http://owncloud.org/ns}size',
     '{DAV:}getlastmodified',
     '{DAV:}getetag',
-    '{DAV:}resourcetype'
+    '{DAV:}resourcetype',
+    '{http://owncloud.org/ns}downloadURL'
   ],
   dropzone: false,
   shareOpen: null,

--- a/packages/web-app-media-viewer/src/App.vue
+++ b/packages/web-app-media-viewer/src/App.vue
@@ -167,10 +167,10 @@ export default {
         a: 1
       }
 
-      return this.$_loader_getDavFilePath(this.activeMediaFile.path, query)
+      return this.$_loader_getDavFilePath(this.activeMediaFile, query)
     },
     rawMediaUrl() {
-      return this.$_loader_getDavFilePath(this.activeMediaFile.path)
+      return this.$_loader_getDavFilePath(this.activeMediaFile)
     },
 
     videoExtensions() {
@@ -263,7 +263,7 @@ export default {
       // workaround for now: Load file as blob for images, load as signed url (if supported) for everything else.
       let promise
       if (this.isActiveMediaFileTypeImage || !this.isUrlSigningEnabled) {
-        promise = this.mediaSource(url, 'url', null)
+        promise = this.mediaSource(decodeURIComponent(url), 'url', null)
       } else {
         promise = this.$client.signUrl(url, 86400) // Timeout of the signed URL = 24 hours
       }

--- a/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
+++ b/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
@@ -11,6 +11,8 @@ Other free text and markdown formatting can be used elsewhere in the document if
 ### [Media Viewer](https://github.com/owncloud/ocis/issues/1106)
 -   [webUIPreview/imageMediaViewer.feature:81](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L81)
 -   [webUIPreview/imageMediaViewer.feature:88](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L88)
+-   [webUIPreview/imageMediaViewer.feature:33](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L33)
+-   [webUIPreview/imageMediaViewer.feature:24](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L24)
 
 ### [Media Viewer does not open upper case file extensions](https://github.com/owncloud/web/issues/4647)
 -   [webUIPreview/imageMediaViewer.feature:172](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L172)


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Replaced the blob download with normal downloads using pre-signed urls provided by the backend.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The blob download had some disadvantages like delayed download for big files and high memory consumption.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally using the OC10 backend

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

