### PR TITLE
[tests-only] Only count fails on attempt 2

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -31,7 +31,12 @@ ACCEPTANCE_TESTS_EXIT_STATUS=${PIPESTATUS[0]}
 if [ "${ACCEPTANCE_TESTS_EXIT_STATUS}" -ne 0 ]; then
   echo "The acceptance tests exited with error status ${ACCEPTANCE_TESTS_EXIT_STATUS}"
 
-  FAILED_SCENARIOS="$(grep -F ') Scenario:' logfile.txt)"
+  # If the first run of a scenario fails, then it gets reported like:
+  # 5) Scenario: try to login with invalid username (attempt 1, retried) # tests/acceptance/features/webUILogin/login.feature:67
+  # If the second run of a scenario fails, hen it gets reported like:
+  # 5) Scenario: try to login with invalid username (attempt 2) # tests/acceptance/features/webUILogin/login.feature:67
+  # So only look for scenarios that failed on attempt 2.
+  FAILED_SCENARIOS="$(grep ') Scenario: .* (attempt 2)' logfile.txt)"
   for FAILED_SCENARIO in ${FAILED_SCENARIOS}; do
     if [[ $FAILED_SCENARIO =~ "tests/acceptance/features/" ]]; then
       SUITE_PATH=$(dirname "${FAILED_SCENARIO}")


### PR DESCRIPTION
## Description

If a test fails after retrying then the failure text includes "(attempt 2)". When filtering the test output to find the failures, just match the lines that have "(attempt 2)", for example:

```
5) Scenario: try to login with invalid username (attempt 1, retried) # tests/acceptance/features/webUILogin/login.feature:67
5) Scenario: try to login with invalid username (attempt 2) # tests/acceptance/features/webUILogin/login.feature:67
```

## Related Issue
- Fixes #4728 

## How Has This Been Tested?
See demonstration in PR #4736 - comment https://github.com/owncloud/web/pull/4736#issuecomment-779781747 details some example results.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
