### PR TITLE
show error message if config could not be parsed

### DIFF
--- a/changelog/unreleased/invalidConfig
+++ b/changelog/unreleased/invalidConfig
@@ -1,0 +1,6 @@
+Bugfix: Fix showing white page with no message if the config could not be parsed
+
+When the config file could not be parsed because of some mistake in the JSON, an empty page without any error message would be shown to the user. We've fixed that behavior and showing now an error page and details of the error in the console.
+
+https://github.com/owncloud/web/issues/4636
+https://github.com/owncloud/web/pull/4749

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-vue": "^6.2.2",
     "fs-extra": "^9.0.1",
     "jest": "^26.6.3",
+    "jest-fetch-mock": "^3.0.3",
     "jest-serializer-vue": "^2.0.2",
     "jest-svg-transformer": "^1.0.0",
     "join-path": "^1.1.1",

--- a/packages/web-runtime/src/configHelper.js
+++ b/packages/web-runtime/src/configHelper.js
@@ -1,0 +1,16 @@
+export const loadConfig = async () => {
+  let config = await fetch('config.json')
+  if (config.status !== 200) {
+    throw new Error(`config could not be loaded. HTTP status-code ${config.status}`)
+  }
+  try {
+    config = await config.json()
+  } catch (e) {
+    throw new Error(`config could not be parsed. ${e}`)
+  }
+  return config
+}
+
+export default {
+  loadConfig: loadConfig
+}

--- a/packages/web-runtime/src/pages/missingOrInvalidConfig.vue
+++ b/packages/web-runtime/src/pages/missingOrInvalidConfig.vue
@@ -7,10 +7,11 @@
         </h1>
         <div class="oc-login-card-body">
           <h3 class="oc-login-card-title">
-            <span v-translate>Missing config</span>
+            <span v-translate>Missing or invalid config</span>
           </h3>
           <p v-translate>
-            Please check if file config.json exists.
+            Please check if the file config.json exists and is correct.<br />
+            Check the console for more information.
           </p>
         </div>
         <div class="oc-login-card-footer">

--- a/tests/unit/specs/loadConfig.spec.js
+++ b/tests/unit/specs/loadConfig.spec.js
@@ -1,0 +1,76 @@
+import { loadConfig } from 'web-runtime/src/configHelper'
+import fetchMock from 'jest-fetch-mock'
+
+fetchMock.enableMocks()
+
+const validConfig = `{
+  "server" : "http://localhost/owncloud-core",
+  "theme": "owncloud",
+  "version": "0.1.0",
+  "auth": {
+    "clientId": "bZrw9cijQ9JGf6wDcLCEuiT9iyah2OzzRycjZc30WDEkMHMRybv7VXENbYGbqy3H",
+    "url": "http://localhost/owncloud-core/index.php/apps/oauth2/api/v1/token",
+    "authUrl": "http://localhost/owncloud-core/index.php/apps/oauth2/authorize"
+  },
+  "apps": [
+    "files",
+    "media-viewer"
+  ],
+  "external_apps": [
+    {
+      "id": "draw-io",
+      "path": "web-app-draw-io",
+      "config": {
+        "url": "https://embed.diagrams.net",
+        "autosave": false,
+        "theme": "minimal"
+      }
+    }
+  ]
+}`
+
+describe('config file loading and error reporting', () => {
+  it('should load and parse a valid config', function() {
+    fetchMock.mockOnce(validConfig)
+    return loadConfig().then(async result => {
+      expect(await result).toMatchObject(JSON.parse(validConfig))
+    })
+  })
+  describe('empty config', () => {
+    it('should throw an exception', function() {
+      fetchMock.mockOnce('')
+      return expect(loadConfig).rejects.toThrow(
+        'config could not be parsed. ' +
+          'FetchError: invalid json response body at  ' +
+          'reason: Unexpected end of JSON input'
+      )
+    })
+  })
+  describe('config with an trailing comma', () => {
+    it('should throw an exception', function() {
+      fetchMock.mockOnce('"title": { "en": "Classic Design", "de": "Dateien", },')
+      return expect(loadConfig).rejects.toThrow(
+        'config could not be parsed. ' +
+          'FetchError: invalid json response body at  ' +
+          'reason: Unexpected token : in JSON at position 7'
+      )
+    })
+  })
+})
+describe('missing config', () => {
+  it('should throw an exception', function() {
+    fetchMock.mockOnce(
+      '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">\n' +
+        '<html><head>\n' +
+        '<title>404 Not Found</title>\n' +
+        '</head><body>\n' +
+        '<h1>Not Found</h1>\n' +
+        '<p>The requested URL was not found on this server.</p>\n' +
+        '<hr>\n' +
+        '<address>Apache/2.4.43 (Ubuntu) Server at localhost Port 80</address>\n' +
+        '</body></html>\n',
+      { status: 404 }
+    )
+    return expect(loadConfig).rejects.toThrow('config could not be loaded. HTTP status-code 404')
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2918,7 +2918,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-fetch@^3.0.6:
+cross-fetch@^3.0.4, cross-fetch@^3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
   integrity sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
@@ -5616,6 +5616,14 @@ jest-environment-node@^26.6.2:
     jest-mock "^26.6.2"
     jest-util "^26.6.2"
 
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
@@ -5840,6 +5848,11 @@ jest-svg-transformer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/jest-svg-transformer/-/jest-svg-transformer-1.0.0.tgz#e38884ca4cd8b2295cdfa2a0b24667920c3a8a6d"
   integrity sha1-44iEykzYsilc36KgskZnkgw6im0=
+
+jest-transform-stub@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/jest-transform-stub/-/jest-transform-stub-2.0.0.tgz#19018b0851f7568972147a5d60074b55f0225a7d"
+  integrity sha512-lspHaCRx/mBbnm3h4uMMS3R5aZzMwyNpNIJLXj4cEsV0mIUtS4IjYJLSoyjRCtnxb6RIGJ4NL2quZzfIeNhbkg==
 
 jest-util@^26.6.2:
   version "26.6.2"
@@ -8275,6 +8288,11 @@ progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+promise-polyfill@^8.1.3:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.2.0.tgz#367394726da7561457aba2133c9ceefbd6267da0"
+  integrity sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g==
 
 promise.series@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
## Description
Show a nice error message not only when the config is missing but also when the config could not be parsed

## Related Issue
- Fixes #4636 

## Motivation and Context
make it easier for the user to find our what is wrong if an error was made writing the config

## How Has This Been Tested?
- unit tests
- load the app with missing config
- load the app with an ivalid config

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
