### PR TITLE
[tests-only] fail CI when there is no expected-to-fail file but some tests failed

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -148,7 +148,7 @@ else
   UNEXPECTED_SUCCESS=false
 fi
 
-if [ "${UNEXPECTED_FAILURE}" != false ] || [ "${UNEXPECTED_SUCCESS}" != false ] || [ "${UNEXPECTED_NIGHTWATCH_CRASH}" = false ] || [ ${FINAL_EXIT_STATUS} -ne 0 ]; then
+if [ "${UNEXPECTED_FAILURE}" = true ] || [ "${UNEXPECTED_SUCCESS}" = true ] || [ "${UNEXPECTED_NIGHTWATCH_CRASH}" = true ] || [ ${FINAL_EXIT_STATUS} -ne 0 ]; then
   FINAL_EXIT_STATUS=1
 fi
 

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -25,6 +25,7 @@ declare -a UNEXPECTED_FAILED_SCENARIOS
 declare -a UNEXPECTED_PASSED_SCENARIOS
 
 UNEXPECTED_NIGHTWATCH_CRASH=false
+FINAL_EXIT_STATUS=0
 
 yarn test:acceptance:drone | tee -a 'logfile.txt'
 ACCEPTANCE_TESTS_EXIT_STATUS=${PIPESTATUS[0]}
@@ -131,6 +132,8 @@ if [ -n "${EXPECTED_FAILURES_FILE}" ]; then
       fi
     done
   done < "${EXPECTED_FAILURES_FILE}"
+elif [ "${ACCEPTANCE_TESTS_EXIT_STATUS}" -ne 0 ]; then
+  FINAL_EXIT_STATUS=1
 fi
 
 if [ ${#UNEXPECTED_FAILED_SCENARIOS[@]} -gt 0 ]; then
@@ -145,9 +148,7 @@ else
   UNEXPECTED_SUCCESS=false
 fi
 
-if [ "${UNEXPECTED_FAILURE}" = false ] && [ "${UNEXPECTED_SUCCESS}" = false ] && [ "${UNEXPECTED_NIGHTWATCH_CRASH}" = false ]; then
-  FINAL_EXIT_STATUS=0
-else
+if [ "${UNEXPECTED_FAILURE}" != false ] || [ "${UNEXPECTED_SUCCESS}" != false ] || [ "${UNEXPECTED_NIGHTWATCH_CRASH}" = false ] || [ ${FINAL_EXIT_STATUS} -ne 0 ]; then
   FINAL_EXIT_STATUS=1
 fi
 


### PR DESCRIPTION
## Description
CI should fail if tests failed but there was no expected to fail file to compare against

## Related Issue
test fail in https://drone.owncloud.com/owncloud/web/13234/52/14 but the CI run is still green

## Motivation and Context
evergreens are great as songs and as plants but not as tests


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
