### PR TITLE
Fix allowed folders and CSP in oc10 app

### DIFF
--- a/changelog/2.0.1_2021-02-18/fix-php-controller
+++ b/changelog/2.0.1_2021-02-18/fix-php-controller
@@ -1,0 +1,5 @@
+Bugfix: Fix oc10 deployment after switch to rollup
+
+Our first release of the oc10 app after the switch to rollup as bundler had a bug as it didn't reflect the new folder structure of the app in the allowed folders. This has been fixed by updating the allowed folders.
+
+https://github.com/owncloud/web/pull/4757

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "workspaces": [
     "packages/web-app-draw-io",

--- a/packages/web-integration-oc10/appinfo/info.xml
+++ b/packages/web-integration-oc10/appinfo/info.xml
@@ -13,7 +13,7 @@ For feedback and bug reports, please use the [public issue tracker](https://gith
 	</description>
 	<licence>AGPL</licence>
 	<author>ownCloud</author>
-	<version>2.0.0</version>
+	<version>2.0.1</version>
 	<category>tools</category>
 	<website>https://github.com/owncloud/web</website>
 	<bugs>https://github.com/owncloud/web/issues</bugs>

--- a/packages/web-integration-oc10/lib/Controller/FilesController.php
+++ b/packages/web-integration-oc10/lib/Controller/FilesController.php
@@ -71,7 +71,7 @@ class FilesController extends Controller {
 		}
 
 		// check if path permitted
-		$permittedPaths = ["apps", "core", "css", "img", "node_modules", "themes", "index.html", "oidc-callback.html", "oidc-silent-redirect.html"];
+		$permittedPaths = ["css", "img", "js", "themes", "index.html", "oidc-callback.html", "oidc-silent-redirect.html"];
 		$found = false;
 		foreach ($permittedPaths as $p) {
 			if (\strpos($path, $p) === 0) {
@@ -104,7 +104,7 @@ class FilesController extends Controller {
 			'Expires' => 'Wed, 11 Jan 1984 05:00:00 GMT',
 			'X-Frame-Options' => 'DENY'
 		]);
-		if (\strpos($path, "oidc-callback.html") === 0 || \strpos($path, "oidc-silent-redirect.html") === 0) {
+		if (\strpos($path, "index.html") === 0 || \strpos($path, "oidc-callback.html") === 0 || \strpos($path, "oidc-silent-redirect.html") === 0) {
 			$csp = new ContentSecurityPolicy();
 			$csp->allowInlineScript(true);
 			$response->setContentSecurityPolicy($csp);


### PR DESCRIPTION

## Description
This PR fixes the oc10 app deployment of the new folder structure after the switch to rollup. The new folder structure was not reflected in the list of allowed folders in the FilesController.

## How Has This Been Tested?
- drone

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
