### PR TITLE
Supress redirect error

### DIFF
--- a/changelog/unreleased/surpress-redirect-error
+++ b/changelog/unreleased/surpress-redirect-error
@@ -1,0 +1,9 @@
+Change: Suppress redirect error during authorization
+
+We've suppressed the error appearing in the console which warned about redirect happening after the oidc callback page.
+This error is being shown because after the oidc callback has successfully processed the authorization request we are redirecting to the `/` path which immediately does another redirect to the extension set as default one.
+In the context of Vue router, this is considered an error even though for us it is a valid use case.
+The error is only informative thus no issue is going to surface if we suppress it.
+This way we are getting closer to a clean console without errors.
+
+https://github.com/owncloud/web/pull/4759

--- a/packages/web-runtime/src/store/user.js
+++ b/packages/web-runtime/src/store/user.js
@@ -111,7 +111,7 @@ const actions = {
         context.commit('SET_USER_READY', true)
 
         if (payload.autoRedirect) {
-          router.push({ path: '/' })
+          router.push({ path: '/' }).catch(() => {})
         }
       } else {
         context.commit('UPDATE_TOKEN', token)


### PR DESCRIPTION
We've suppressed the error appearing in the console which warned about redirect happening after the oidc callback page. This error is being shown because after the oidc callback has successfully processed the authorization request we are redirecting to the `/` path which immediately does another redirect to the extension set as default one. In the context of Vue router, this is considered an error even though for us it is a valid use case. The error is only informative thus no issue is going to surface if we suppress it. This way we are getting closer to a clean console without errors.