### PR TITLE
UX: set focus on input field of modal dialog "New Folder"

### DIFF
--- a/packages/web-runtime/src/App.vue
+++ b/packages/web-runtime/src/App.vue
@@ -58,7 +58,7 @@
         leave-active-class="uk-animation-fade uk-animation-reverse uk-animation-fast"
         name="custom-classes-transition"
       >
-      <div className="focusInput" @mouseover="setFocus" ref="modalDialog">
+      <div @mouseover="setFocus" ref="modalDialog">
         <oc-modal        
           v-if="modal.displayed"
           :variation="modal.variation"

--- a/packages/web-runtime/src/App.vue
+++ b/packages/web-runtime/src/App.vue
@@ -58,7 +58,8 @@
         leave-active-class="uk-animation-fade uk-animation-reverse uk-animation-fast"
         name="custom-classes-transition"
       >
-        <oc-modal
+      <div className="focusInput" @mouseover="setFocus" ref="modalDialog">
+        <oc-modal        
           v-if="modal.displayed"
           :variation="modal.variation"
           :icon="modal.icon"
@@ -75,8 +76,9 @@
           :button-confirm-disabled="modal.confirmDisabled || !!modal.inputError"
           @cancel="modal.onCancel"
           @confirm="modal.onConfirm"
-          @input="modal.onInput"
+          @input="modal.onInput"       
         />
+      </div>
       </transition>
     </div>
   </div>
@@ -281,7 +283,11 @@ export default {
 
   methods: {
     ...mapActions(['initAuth', 'fetchNotifications', 'deleteMessage']),
-
+ 
+    setFocus(){
+      this.$refs.modalDialog.getElementsByClassName("oc-text-input")[0].focus();     
+    },
+    
     hideAppNavigation() {
       this.appNavigationVisible = false
     },


### PR DESCRIPTION
## Description
Modal dialog "oc-modal" gets focus on it's input field of class "oc-text-input" on open so the user can immediately start writing and using "enter" to submit.



## Motivation and Context
UX improvement: removing an unnecessary mouse click

## How Has This Been Tested?
- test: click on "New folder", start typing, press "Enter", caused expected behavior
- tested in Chrome Version 88.0.4324.182 (64-Bit)
- tested in Firefox 78.7.0esr (64-Bit)


## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:

- [x ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks: