### PR TITLE
[Tests-Only]Fixed sharing tests that passed even when they were expected to fail

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -329,7 +329,7 @@ module.exports = {
       return this.initAjaxCounters()
         .waitForElementVisible('@sharingAutoComplete')
         .setValueBySingleKeys('@sharingAutoComplete', input)
-        .waitForOutstandingAjaxCalls()
+        .waitForAjaxCallsToStartAndFinish()
     },
     /**
      *


### PR DESCRIPTION
## Description
Test step `Then "user" "Alice Hansen" should not be listed in the autocomplete list on the webUI` was passing even when it is expected to fail.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/4770

## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 