### PR TITLE
[WIP] Set background color from ODS CSS variable

### DIFF
--- a/changelog/unreleased/bugfix-set-layout-background-color
+++ b/changelog/unreleased/bugfix-set-layout-background-color
@@ -1,0 +1,5 @@
+Bugfix: Set layout background color in main Web app
+
+Accessibility certification requires explicitly color styling of the main column's background.
+
+https://github.com/owncloud/web/pull/4805

--- a/packages/web-runtime/src/App.vue
+++ b/packages/web-runtime/src/App.vue
@@ -37,7 +37,7 @@
             </template>
           </oc-sidebar>
         </transition>
-        <div class="uk-width-expand">
+        <div id="main-container" class="uk-width-expand">
           <top-bar
             v-if="!publicPage() && !$route.meta.verbose"
             class="uk-width-expand"
@@ -326,6 +326,10 @@ export default {
 body {
   height: 100vh;
   overflow: hidden;
+}
+
+#main-container {
+  background-color: var(--oc-background);
 }
 
 #main {


### PR DESCRIPTION
## Description
Explicitly setting the background color in the main web app layout through a CSS variable (introduced in the next ODS release).

## Related Issue
- Fixes #4331 

## Motivation and Context
Solves an offense in regards of accessibility.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Open tasks:
- [ ] Confirm that it works once the next release of the ODS is merged into `web`