### PR TITLE
Delete shareType of 'userGroup'

### DIFF
--- a/changelog/unreleased/fix-remove-unsupported-shareType
+++ b/changelog/unreleased/fix-remove-unsupported-shareType
@@ -1,0 +1,5 @@
+Bugfix: Remove unsupported shareType
+
+We don't support 'userGroup' (originally 'contact', shareType `2`) on the backend side anymore, so we delete it on the frontend, too.
+
+https://github.com/owncloud/web/pull/4809

--- a/packages/web-app-files/src/helpers/shareTypes.js
+++ b/packages/web-app-files/src/helpers/shareTypes.js
@@ -4,7 +4,6 @@
 export const shareTypes = {
   user: 0,
   group: 1,
-  userGroup: 2,
   link: 3,
   guest: 4,
   remote: 6


### PR DESCRIPTION
## Description
Removes unsupported shareType of 'userGroup' (formerly 'contact').

## Motivation and Context
Stumbled upon this by chance - we don't support 'userGroup' (originally 'contact', shareType `2`) on the backend side anymore, so it can be deleted on the frontend, too.

## Types of changes
- [X] Technical debt