### PR TITLE
[Tests-Only]Modified user creation logic to comply with/without skeleton files loading

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -323,7 +323,7 @@ config = {
 				'SERVER_HOST': 'https://ocis:9200',
 				'BACKEND_HOST': 'https://ocis:9200',
 				'RUN_ON_OCIS': 'true',
-				'OCIS_SKELETON_DIR': '/srv/app/testing/data/webUISkeleton',
+				'TESTING_DATA_DIR': '/srv/app/testing/data/',
 				'OCIS_REVA_DATA_ROOT': '/srv/app/tmp/ocis/owncloud/data/',
 				'WEB_UI_CONFIG': '/srv/config/drone/ocis-config.json',
 				'EXPECTED_FAILURES_FILE': '/var/www/owncloud/web/tests/acceptance/expected-failures-with-ocis-server-owncloud-storage.md'

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -75,7 +75,7 @@ In order to run the acceptance tests you need to run ocis using the owncloud sto
 
 - set the `SELENIUM_HOST` environment variable to your host that runs selenium, mostly `localhost`
 - set the `SELENIUM_PORT` environment variable to your selenium port, mostly `4444`
-- set the `OCIS_SKELETON_DIR` when running the tests on ocis pointing to the skeleton files available [here](https://github.com/owncloud/testing/tree/master/data/webUISkeleton). This is handled automatically by the testrunner while running the tests in oc10.
+- set the `TESTING_DATA_DIR` when running the tests on ocis pointing to the testing data that includes data like skeleton directories. The testing directory is available [here](https://github.com/owncloud/testing/tree/master/data). This is handled automatically by the testrunner while running the tests in oc10.
 
 The feature files are located in the "tests/acceptance/features" subdirectories.
 
@@ -134,7 +134,7 @@ These values can be set using the environment variables to configure `yarn test:
 | `REMOTE_BACKEND_HOST` | ownCloud remote server URL                                               | http://localhost:8080 |
 | `RUN_ON_OCIS`       | Running the tests using the OCIS backend                                                            | false |
 | `OCIS_REVA_DATA_ROOT`       | Data directory of OCIS                                             | /var/tmp/reva |
-| `OCIS_SKELETON_DIR`       | Skeleton files directory for new users                                                           | - |
+| `TESTING_DATA_DIR`       | Testing data directory for new users                                                           | - |
 | `WEB_UI_CONFIG`       | Path for the web config file (usually in the dist folder)                       | - |
 | `VISUAL_TEST`       | Run the visual regression comparison while running the acceptance tests                       | - |
 | `UPDATE_VRT_SCREENSHOTS`       | Update the baseline snapshots with the latest images for visual regression tests                       | - |

--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -29,7 +29,7 @@ const OCIS_REVA_DATA_ROOT = process.env.OCIS_REVA_DATA_ROOT || '/var/tmp/ocis/st
 const LDAP_SERVER_URL = process.env.LDAP_SERVER_URL || 'ldap://127.0.0.1'
 const LDAP_BASE_DN = process.env.LDAP_BASE_DN || 'cn=admin,dc=owncloud,dc=com'
 const LDAP_ADMIN_PASSWORD = process.env.LDAP_ADMIN_PASSWORD || 'admin'
-const OCIS_SKELETON_DIR = process.env.OCIS_SKELETON_DIR || './tests/testing-app/data/webUISkeleton/'
+const TESTING_DATA_DIR = process.env.TESTING_DATA_DIR || './tests/testing-app/data/'
 const OPENID_LOGIN = RUN_ON_OCIS || !!process.env.OPENID_LOGIN
 const WEB_UI_CONFIG = process.env.WEB_UI_CONFIG || path.join(__dirname, 'dist/config.json')
 const SCREENSHOTS = !!process.env.SCREENSHOTS
@@ -67,7 +67,7 @@ const config = {
         ldap_url: LDAP_SERVER_URL,
         ocis_data_dir: OCIS_REVA_DATA_ROOT,
         ldap_base_dn: LDAP_BASE_DN,
-        ocis_skeleton_dir: OCIS_SKELETON_DIR,
+        testing_data_dir: TESTING_DATA_DIR,
         ldap_password: LDAP_ADMIN_PASSWORD,
         webUIConfig: WEB_UI_CONFIG,
         visual_test: VISUAL_TEST,

--- a/tests/acceptance/features/webUIAccount/accountInformation.feature
+++ b/tests/acceptance/features/webUIAccount/accountInformation.feature
@@ -4,7 +4,7 @@ Feature: View account information
   So that I can verify and use my account details correctly
 
   Background:
-    Given user "Alice" has been created with default attributes
+    Given user "Alice" has been created with default attributes and large skeleton files
 
   @ocis-reva-issue-107
   Scenario: view account information when the user has been created without groups membership

--- a/tests/acceptance/features/webUIAccount/userProfile.feature
+++ b/tests/acceptance/features/webUIAccount/userProfile.feature
@@ -4,7 +4,7 @@ Feature: view profile
   So that I can manage my account
 
   Background:
-    Given user "Alice" has been created with default attributes
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   @ocis-reva-issue-107
   Scenario: view user profile for the logged in user

--- a/tests/acceptance/features/webUIComments/comments.feature
+++ b/tests/acceptance/features/webUIComments/comments.feature
@@ -5,14 +5,13 @@ Feature: Add, delete and edit comments in files and folders
   So that I can provide more information about the file/folder
 
   Background:
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and large skeleton files:
       | username |
       | Alice    |
       | Brian    |
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 
-  @skip @yetToImplement
   Scenario Outline: user adds and deletes comment for a file/folder
     When the user browses directly to display the "comments" details of file "lorem.txt" in folder "/"
     And the user comments with content "<comment>" using the webUI

--- a/tests/acceptance/setup.js
+++ b/tests/acceptance/setup.js
@@ -1,6 +1,6 @@
 import { setDefaultTimeout, After, Before, defineParameterType } from 'cucumber'
 import { createSession, closeSession, client, startWebDriver, stopWebDriver } from 'nightwatch-api'
-import { rollbackConfigs, setConfigs, cacheConfigs } from './helpers/config'
+import { rollbackConfigs, cacheConfigs } from './helpers/config'
 import { getAllLogsWithDateTime } from './helpers/browserConsole.js'
 const codify = require('./helpers/codify')
 
@@ -62,7 +62,6 @@ async function cacheAndSetConfigs(server) {
     return
   }
   await cacheConfigs(server)
-  return setConfigs(server, client.globals.backend_admin_username)
 }
 
 Before(function cacheAndSetConfigsOnLocal() {


### PR DESCRIPTION
## Description
Modified user creation logic to comply with/without skeleton files loading

## Related Issue
- Part of https://github.com/owncloud/QA/issues/659

## Motivation and Context
Since we are specifying the size of skeleton files (or create a user without skeleton files), web tests should be modified accordingly and we can no longer put skeleton file creation logic on the Before scenario.

## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 