### PR TITLE
Add ability for route meta options to hide search bar

### DIFF
--- a/changelog/unreleased/enable-toggleable-search-bar
+++ b/changelog/unreleased/enable-toggleable-search-bar
@@ -1,0 +1,5 @@
+Enhancement: Enable files app search bar to be toggleable on a per-route basis
+
+Permits the search bar in the files app to be toggleable on a per-route basis as shown or hidden.
+
+https://github.com/owncloud/web/pull/4815

--- a/packages/web-runtime/src/components/TopBar.vue
+++ b/packages/web-runtime/src/components/TopBar.vue
@@ -31,7 +31,7 @@ import ApplicationsMenu from './ApplicationsMenu.vue'
 import UserMenu from './UserMenu.vue'
 import Notifications from './Notifications.vue'
 import SearchBar from './SearchBar.vue'
-
+ 
 export default {
   components: {
     Notifications,
@@ -70,7 +70,7 @@ export default {
     ...mapGetters(['configuration']),
 
     isSearchDisabled() {
-      return this.configuration.options.hideSearchBar === true
+      return this.configuration.options.hideSearchBar === true || this.$route.meta.hideSearchBar
     }
   },
   methods: {

--- a/packages/web-runtime/src/components/TopBar.vue
+++ b/packages/web-runtime/src/components/TopBar.vue
@@ -31,7 +31,7 @@ import ApplicationsMenu from './ApplicationsMenu.vue'
 import UserMenu from './UserMenu.vue'
 import Notifications from './Notifications.vue'
 import SearchBar from './SearchBar.vue'
- 
+
 export default {
   components: {
     Notifications,
@@ -70,7 +70,9 @@ export default {
     ...mapGetters(['configuration']),
 
     isSearchDisabled() {
-      return this.configuration.options.hideSearchBar === true || this.$route.meta.hideSearchBar
+      return (
+        this.configuration.options.hideSearchBar === true || this.$route.meta.hideSearchBar === true
+      )
     }
   },
   methods: {

--- a/packages/web-runtime/tests/components/TopBar.spec.js
+++ b/packages/web-runtime/tests/components/TopBar.spec.js
@@ -4,37 +4,117 @@ import TopBar from 'web-runtime/src/components/TopBar.vue'
 import stubs from '../../../../tests/unit/config/stubs'
 
 const localVue = createLocalVue()
-const search = enabled => ({
+localVue.use(Vuex)
+
+const globalSearch = enabled => ({
   options: { hideSearchBar: !enabled }
 })
 
-localVue.use(Vuex)
+const routeWithHiddenSearchBar = () => ({ meta: { hideSearchBar: true } })
+const defaultRoute = () => ({
+  meta: {
+    /* default is empty */
+  }
+})
 
 describe('Top Bar component', () => {
-  it('Displays search bar if enabled', () => {
-    const wrapper = shallowMount(TopBar, {
-      store: new Vuex.Store({
-        getters: {
-          configuration: () => search(true)
+  describe('when search bar visible globally', () => {
+    it('Displays search bar if not disabled for specified route', () => {
+      const wrapper = shallowMount(TopBar, {
+        store: new Vuex.Store({
+          getters: {
+            configuration: () => globalSearch(true)
+          }
+        }),
+        localVue,
+        stubs,
+        propsData: {
+          userId: 'einstein',
+          userDisplayName: 'Albert Einstein'
+        },
+        mocks: {
+          $route: defaultRoute()
         }
-      }),
-      localVue,
-      stubs,
-      propsData: {
-        userId: 'einstein',
-        userDisplayName: 'Albert Einstein'
-      }
+      })
+
+      expect(wrapper.html().indexOf('search-bar-stub')).toBeGreaterThan(-1)
+      expect(wrapper).toMatchSnapshot()
     })
 
-    expect(wrapper.html().indexOf('search-bar-stub')).toBeGreaterThan(-1)
-    expect(wrapper).toMatchSnapshot()
+    it('Hides the search bar if disabled for specified route', () => {
+      const wrapper = shallowMount(TopBar, {
+        store: new Vuex.Store({
+          getters: {
+            configuration: () => globalSearch(true)
+          }
+        }),
+        localVue,
+        stubs,
+        propsData: {
+          userId: 'einstein',
+          userDisplayName: 'Albert Einstein'
+        },
+        mocks: {
+          $route: routeWithHiddenSearchBar()
+        }
+      })
+
+      expect(wrapper.html().indexOf('search-bar-stub')).toEqual(-1)
+      expect(wrapper).toMatchSnapshot()
+    })
+  })
+
+  describe('when search bar hidden globally', () => {
+    it('Hides search bar even if not disabled for specified route', () => {
+      const wrapper = shallowMount(TopBar, {
+        store: new Vuex.Store({
+          getters: {
+            configuration: () => globalSearch(false)
+          }
+        }),
+        localVue,
+        stubs,
+        propsData: {
+          userId: 'einstein',
+          userDisplayName: 'Albert Einstein'
+        },
+        mocks: {
+          $route: defaultRoute()
+        }
+      })
+
+      expect(wrapper.html().indexOf('search-bar-stub')).toEqual(-1)
+      expect(wrapper).toMatchSnapshot()
+    })
+
+    it('Hides the search bar if disabled for specified route', () => {
+      const wrapper = shallowMount(TopBar, {
+        store: new Vuex.Store({
+          getters: {
+            configuration: () => globalSearch(false)
+          }
+        }),
+        localVue,
+        stubs,
+        propsData: {
+          userId: 'einstein',
+          userDisplayName: 'Albert Einstein'
+        },
+        mocks: {
+          $route: routeWithHiddenSearchBar()
+        }
+      })
+
+      expect(wrapper.html().indexOf('search-bar-stub')).toEqual(-1)
+      expect(wrapper).toMatchSnapshot()
+    })
   })
 
   it('Displays applications menu', () => {
     const wrapper = shallowMount(TopBar, {
       store: new Vuex.Store({
         getters: {
-          configuration: () => search(false)
+          configuration: () => globalSearch(false)
         }
       }),
       localVue,
@@ -43,6 +123,9 @@ describe('Top Bar component', () => {
         userId: 'einstein',
         userDisplayName: 'Albert Einstein',
         applicationsList: ['testApp']
+      },
+      mocks: {
+        $route: defaultRoute()
       }
     })
 
@@ -54,11 +137,14 @@ describe('Top Bar component', () => {
     const wrapper = shallowMount(TopBar, {
       store: new Vuex.Store({
         getters: {
-          configuration: () => search(true)
+          configuration: () => globalSearch(true)
         }
       }),
       localVue,
-      stubs
+      stubs,
+      mocks: {
+        $route: defaultRoute()
+      }
     })
 
     wrapper.find('.oc-app-navigation-toggle').vm.$emit('click')

--- a/packages/web-runtime/tests/components/__snapshots__/TopBar.spec.js.snap
+++ b/packages/web-runtime/tests/components/__snapshots__/TopBar.spec.js.snap
@@ -18,7 +18,43 @@ exports[`Top Bar component Displays applications menu 1`] = `
 </header>
 `;
 
-exports[`Top Bar component Displays search bar if enabled 1`] = `
+exports[`Top Bar component when search bar hidden globally Hides search bar even if not disabled for specified route 1`] = `
+<header class="oc-topbar uk-flex uk-flex-middle uk-flex-wrap oc-border-b oc-p-s">
+  <oc-grid-stub gutter="medium" flex="">
+    <div class="uk-hidden@l">
+      <oc-button-stub appearance="raw" aria-label="Open navigation menu" class="oc-app-navigation-toggle">
+        <oc-icon-stub name="menu"></oc-icon-stub>
+      </oc-button-stub>
+    </div>
+    <!---->
+  </oc-grid-stub>
+  <oc-grid-stub flex="" gutter="small" class="uk-width-expand uk-flex-right oc-m-rm">
+    <!---->
+    <!---->
+    <user-menu-stub userid="einstein" userdisplayname="Albert Einstein" applicationslist=""></user-menu-stub>
+  </oc-grid-stub>
+</header>
+`;
+
+exports[`Top Bar component when search bar hidden globally Hides the search bar if disabled for specified route 1`] = `
+<header class="oc-topbar uk-flex uk-flex-middle uk-flex-wrap oc-border-b oc-p-s">
+  <oc-grid-stub gutter="medium" flex="">
+    <div class="uk-hidden@l">
+      <oc-button-stub appearance="raw" aria-label="Open navigation menu" class="oc-app-navigation-toggle">
+        <oc-icon-stub name="menu"></oc-icon-stub>
+      </oc-button-stub>
+    </div>
+    <!---->
+  </oc-grid-stub>
+  <oc-grid-stub flex="" gutter="small" class="uk-width-expand uk-flex-right oc-m-rm">
+    <!---->
+    <!---->
+    <user-menu-stub userid="einstein" userdisplayname="Albert Einstein" applicationslist=""></user-menu-stub>
+  </oc-grid-stub>
+</header>
+`;
+
+exports[`Top Bar component when search bar visible globally Displays search bar if not disabled for specified route 1`] = `
 <header class="oc-topbar uk-flex uk-flex-middle uk-flex-wrap oc-border-b oc-p-s">
   <oc-grid-stub gutter="medium" flex="">
     <div class="uk-hidden@l">
@@ -27,6 +63,24 @@ exports[`Top Bar component Displays search bar if enabled 1`] = `
       </oc-button-stub>
     </div>
     <search-bar-stub></search-bar-stub>
+  </oc-grid-stub>
+  <oc-grid-stub flex="" gutter="small" class="uk-width-expand uk-flex-right oc-m-rm">
+    <!---->
+    <!---->
+    <user-menu-stub userid="einstein" userdisplayname="Albert Einstein" applicationslist=""></user-menu-stub>
+  </oc-grid-stub>
+</header>
+`;
+
+exports[`Top Bar component when search bar visible globally Hides the search bar if disabled for specified route 1`] = `
+<header class="oc-topbar uk-flex uk-flex-middle uk-flex-wrap oc-border-b oc-p-s">
+  <oc-grid-stub gutter="medium" flex="">
+    <div class="uk-hidden@l">
+      <oc-button-stub appearance="raw" aria-label="Open navigation menu" class="oc-app-navigation-toggle">
+        <oc-icon-stub name="menu"></oc-icon-stub>
+      </oc-button-stub>
+    </div>
+    <!---->
   </oc-grid-stub>
   <oc-grid-stub flex="" gutter="small" class="uk-width-expand uk-flex-right oc-m-rm">
     <!---->


### PR DESCRIPTION
## Description
Simply the ability to toggle on and off the search bar in the files app per-route, so you can customise the interface further depending on what you are showing as content (ie. a file preview or other viewer).

## Motivation and Context
See description.

## How Has This Been Tested?
Tested working locally, it's very simple change.

## Screenshots (if appropriate):
**With**
![files-with-search-bar](https://user-images.githubusercontent.com/876651/111548712-34dfe300-87cf-11eb-9775-e9c4ca173156.png)
**Without**
![files-no-search-bar](https://user-images.githubusercontent.com/876651/111548722-37423d00-87cf-11eb-98f1-5627c3455043.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
