### PR TITLE
Fix extensions and external apps using handler function and pass file…

### DIFF
--- a/changelog/unreleased/fix-detect-handler-for-file-actions
+++ b/changelog/unreleased/fix-detect-handler-for-file-actions
@@ -1,0 +1,6 @@
+Bugfix: Fix detection of handler function when integrating apps
+
+The detection of the optional handler function instead of routes for extensions and external apps was broken
+which prevented the Only Office extension from working, this fixes the issue.
+
+https://github.com/owncloud/web/pull/4816

--- a/packages/web-app-files/src/mixins/fileActions.js
+++ b/packages/web-app-files/src/mixins/fileActions.js
@@ -75,11 +75,15 @@ export default {
           handler: item =>
             this.$_fileActions_openEditor(editor, item.path, item.id, EDITOR_MODE_EDIT),
           isEnabled: ({ resource }) => {
-            if (editor.routes?.length > 0 && !checkRoute(editor.routes, this.$route.name)) {
-              return false
+            if (
+              editor.handler ||
+              !editor.routes?.length ||
+              checkRoute(editor.routes, this.$route.name)
+            ) {
+              return resource.extension === editor.extension
             }
 
-            return resource.extension === editor.extension
+            return false
           },
           canBeDefault: true,
           componentType: 'oc-button',
@@ -107,7 +111,8 @@ export default {
 
       // TODO: Refactor in the store
       this.openFile({
-        filePath
+        filePath,
+        fileId
       })
 
       if (editor.newTab) {
@@ -115,7 +120,7 @@ export default {
           name: editor.routeName,
           params: { filePath, fileId, mode }
         }).href
-        const target = `${editor.routeName}-${filePath}`
+        const target = `${editor.routeName}-${filePath}-${fileId}`
         const win = window.open(path, target)
         // in case popup is blocked win will be null
         if (win) {


### PR DESCRIPTION
## Description
This PR fixes a current issue using the [Only Office Extension](https://owncloud.github.io/extensions/onlyoffice/configuration/), looks like the handler logic got stripped away in previous code changes, it needs the explicit check as the OO Extension doesn't use routes.

This PR also adds the `fileId` parameter, which is useful and sometimes required by extensions to know what the `fileId` of the resource is (not just the name).  (I will have an example of this in a future PR for consideration in integrating Only Office as an extension rather than an external app.)

## Motivation and Context
As above

## How Has This Been Tested?
I have tested locally, including modifying an existing app inside `phoenix` to integrate into Only Office and the existing frontend while keeping the current header bar of the new UI.

## Screenshots (if appropriate):
**Before Fix**
![oo-extension-not-showing](https://user-images.githubusercontent.com/876651/111580166-3f1fd280-880b-11eb-8065-f55f1758c7e8.png)

**After Fix**
![oo-extension-showing](https://user-images.githubusercontent.com/876651/111580174-41822c80-880b-11eb-9650-bbf5019d1195.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 