### PR TITLE
[Tests-Only]Logic for create group and add user to group in ocis has been fixed

### DIFF
--- a/tests/acceptance/stepDefinitions/provisioningContext.js
+++ b/tests/acceptance/stepDefinitions/provisioningContext.js
@@ -125,7 +125,7 @@ function initUser(userId) {
  * @returns {*|Promise}
  */
 function createGroup(groupId) {
-  if (client.globals.ocis) {
+  if (client.globals.ldap) {
     return ldap.createGroup(client.globals.ldapClient, groupId).then(err => {
       if (!err) {
         userSettings.addGroupToCreatedGroupsList(groupId)
@@ -151,7 +151,7 @@ function deleteGroup(groupId) {
 }
 
 function addToGroup(userId, groupId) {
-  if (client.globals.ocis) {
+  if (client.globals.ldap) {
     return ldap.addUserToGroup(client.globals.ldapClient, userId, groupId)
   }
   const body = new URLSearchParams()


### PR DESCRIPTION
## Description
If the test is running in OCIS, then the user creation and adding user to the group was done using `ldap` which is no longer valid. So, this logic has been fixed.

## Related Issue
- Fixes <issue_link>

## How Has This Been Tested?
- locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 