### PR TITLE
set NODE_ENV based on rollup build type

### DIFF
--- a/changelog/unreleased/fix-node-env
+++ b/changelog/unreleased/fix-node-env
@@ -1,0 +1,6 @@
+Bugfix: NODE_ENV based on rollup mode
+
+The NODE_ENV was set to production by default, now we use development if rollup is started in watch mode so that the vue devtools can be used.
+
+https://github.com/owncloud/web/issues/4819
+https://github.com/owncloud/web/pull/4820

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -47,7 +47,7 @@ const plugins = [
     exclude: 'node_modules/**'
   }),
   modify({
-    'process.env.NODE_ENV': JSON.stringify('production'),
+    'process.env.NODE_ENV': JSON.stringify(production ? 'production' : 'development'),
     // todo: remove after pending PR is merged
     // fix for 'assignment to undeclared variable dav' in davclient.js/lib/client.js 6:0
     "if (typeof dav === 'undefined') { dav = {}; }": 'var dav = dav || {}',


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
NODE_ENV is always set to production

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #4819

## Motivation and Context
have NODE_ENV set correct to current env