### PR TITLE
[Tests-Only]refactor steps for user creation with appropriate skeleton files.

### DIFF
--- a/tests/acceptance/expected-failures-with-ocis-server-owncloud-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-owncloud-storage.md
@@ -30,7 +30,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIAccount/accountInformation.feature:20](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIAccount/accountInformation.feature#L20)
 
 ### [REPORT request not implemented](https://github.com/owncloud/ocis/issues/1330)
--   [webUIDeleteFilesFolders/deleteFilesFolders.feature:249](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L249)
+-   [webUIDeleteFilesFolders/deleteFilesFolders.feature:291](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L291)
 -   [webUIFavorites/favoritesFile.feature:14](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFavorites/favoritesFile.feature#L14)
 -   [webUIFavorites/favoritesFile.feature:27](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFavorites/favoritesFile.feature#L27)
 -   [webUIFavorites/favoritesFile.feature:40](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFavorites/favoritesFile.feature#L40)
@@ -51,7 +51,8 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIFilesDetails/fileDetails.feature:46](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesDetails/fileDetails.feature#L46)
 
 ### [Sharing seems to work but does not work](https://github.com/owncloud/ocis/issues/1303)
--   [webUIDeleteFilesFolders/deleteFilesFolders.feature:198](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L198)
+-   [webUIDeleteFilesFolders/deleteFilesFolders.feature:77](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L77)
+-   [webUIDeleteFilesFolders/deleteFilesFolders.feature:231](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L231)
 -   [webUIFilesDetails/fileDetails.feature:88](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesDetails/fileDetails.feature#L88)
 -   [webUIFilesDetails/fileDetails.feature:103](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesDetails/fileDetails.feature#L103)
 -   [webUIFilesActionMenu/versions.feature:33](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L33)

--- a/tests/acceptance/features/webUIAccount/accountInformation.feature
+++ b/tests/acceptance/features/webUIAccount/accountInformation.feature
@@ -4,7 +4,7 @@ Feature: View account information
   So that I can verify and use my account details correctly
 
   Background:
-    Given user "Alice" has been created with default attributes and large skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   @ocis-reva-issue-107
   Scenario: view account information when the user has been created without group memberships

--- a/tests/acceptance/features/webUIAccount/logout.feature
+++ b/tests/acceptance/features/webUIAccount/logout.feature
@@ -6,7 +6,7 @@ Feature: Logout users
 
 
   Scenario:logging out
-    Given user "Alice" has been created with default attributes
+    Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has logged in using the webUI
     When the user browses to the account page
     And the user logs out of the webUI

--- a/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
@@ -18,7 +18,7 @@ Feature: admin storage settings
 
   @skip @yetToImplement
   Scenario: administrator creates a local storage mount
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and without skeleton files
     And the administrator has browsed to the admin storage settings page
     And the administrator has enabled the external storage
     When the administrator creates the local storage mount "local_storage1" using the webUI
@@ -27,7 +27,7 @@ Feature: admin storage settings
 
   @skip @yetToImplement
   Scenario: administrator assigns an applicable user to a local storage mount
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | user0    |
       | Alice    |
@@ -46,7 +46,7 @@ Feature: admin storage settings
 
   @skip @yetToImplement
   Scenario: user should get access if the user is removed from the applicable user and the user was the only applicable user
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | user0    |
       | Alice    |
@@ -62,7 +62,7 @@ Feature: admin storage settings
 
   @skip @yetToImplement
   Scenario: administrator should be able to create a local mount for a specific group
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | user0    |
       | Alice    |
@@ -79,7 +79,7 @@ Feature: admin storage settings
 
   @skip @yetToImplement
   Scenario: removing group from applicable group of a local mount
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | user0    |
       | Alice    |
@@ -97,7 +97,7 @@ Feature: admin storage settings
 
   @skip @yetToImplement
   Scenario: administrator deletes local storage mount
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and without skeleton files
     And the administrator has browsed to the admin storage settings page
     And the administrator has enabled the external storage
     And the administrator has created the local storage mount "local_storage1" from the admin storage settings page
@@ -107,7 +107,7 @@ Feature: admin storage settings
 
   @skip @yetToImplement
   Scenario: local storage mount is deleted when the last user applicable to it is deleted
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and without skeleton files
     And the administrator has browsed to the admin storage settings page
     And the administrator has enabled the external storage
     And the administrator has created the local storage mount "local_storage1" from the admin storage settings page
@@ -118,7 +118,7 @@ Feature: admin storage settings
 
   @skip @yetToImplement
   Scenario: local storage mount is not deleted when the last group applicable to it is deleted but the member of the deleted group should not have access to it
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and without skeleton files
     And group "newgroup" has been created
     And user "user0" has been added to group "newgroup"
     And the administrator has browsed to the admin storage settings page
@@ -133,7 +133,7 @@ Feature: admin storage settings
 
   @skip @yetToImplement
   Scenario: local storage mount is not deleted when the one of two users applicable to the mount is deleted
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | user0    |
       | Alice    |

--- a/tests/acceptance/features/webUIComments/comments.feature
+++ b/tests/acceptance/features/webUIComments/comments.feature
@@ -5,10 +5,11 @@ Feature: Add, delete and edit comments in files and folders
   So that I can provide more information about the file/folder
 
   Background:
-    Given these users have been created with default attributes and large skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
+    And user "Alice" has created file "/lorem.txt"
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 

--- a/tests/acceptance/features/webUICreateFilesFolders/createFile.feature
+++ b/tests/acceptance/features/webUICreateFilesFolders/createFile.feature
@@ -4,7 +4,8 @@ Feature: create files
   So that I can organize my data
 
   Background:
-    Given user "Alice" has been created with default attributes
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created file "/lorem.txt"
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 

--- a/tests/acceptance/features/webUICreateFilesFolders/createFolderEdgeCases.feature
+++ b/tests/acceptance/features/webUICreateFilesFolders/createFolderEdgeCases.feature
@@ -4,7 +4,7 @@ Feature: create folder
   So that I can organise my data structure
 
   Background:
-    Given user "Alice" has been created with default attributes
+    Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 
@@ -47,6 +47,8 @@ Feature: create folder
   Scenario Outline: Create a sub-folder inside an existing folder with problematic name
     # Use an existing folder with problematic name to create a sub-folder
     # Uses the folder created by skeleton
+    Given user "Alice" has created folder <folder>
+    And the user has reloaded the current page of the webUI
     When the user opens folder <folder> using the webUI
     And the user creates a folder with the name "sub-folder" using the webUI
     Then folder "sub-folder" should be listed on the webUI

--- a/tests/acceptance/features/webUICreateFilesFolders/createFolders.feature
+++ b/tests/acceptance/features/webUICreateFilesFolders/createFolders.feature
@@ -4,7 +4,7 @@ Feature: create folders
   So that I can organise my data structure
 
   Background:
-    Given user "Alice" has been created with default attributes
+    Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 
@@ -30,6 +30,8 @@ Feature: create folders
 
 
   Scenario: Try to create a folder with existing name
+    Given user "Alice" has created folder "simple-folder"
+    And the user has reloaded the current page of the webUI
     When the user creates a folder with the invalid name "simple-folder" using the webUI
     Then the error message 'simple-folder already exists' should be displayed on the webUI dialog prompt
 
@@ -53,7 +55,9 @@ Feature: create folders
 
   @skip @yetToImplement
   Scenario: Create a folder in a public share
-    Given the user has created a new public link for folder "simple-empty-folder" using the webUI with
+    Given user "Alice" has created folder "simple-empty-folder"
+    And the user has reloaded the current page of the webUI
+    And the user has created a new public link for folder "simple-empty-folder" using the webUI with
       | permission | read-write |
     And the public accesses the last created public link using the webUI
     When the user creates a folder with the name "top-folder" using the webUI

--- a/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
@@ -4,13 +4,19 @@ Feature: deleting files and folders
   So that I can keep my filing system clean and tidy
 
   Background:
-    Given user "Alice" has been created with default attributes
+    Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 
   @smokeTest @ocisSmokeTest @disablePreviews
   Scenario: Delete files & folders one by one and check its existence after page reload
-    Given user "Alice" has created file "sample,1.txt"
+    Given user "Alice" has created folder "simple-empty-folder"
+    And user "Alice" has created folder "simple-folder"
+    And user "Alice" has created file "lorem.txt"
+    And user "Alice" has created file "lorem-big.txt"
+    And user "Alice" has created folder "strängé नेपाली folder"
+    And user "Alice" has created file "strängé filename (duplicate #2 &).txt"
+    And user "Alice" has created file "sample,1.txt"
     And user "Alice" has created folder "Sample,Folder,With,Comma"
     And the user has reloaded the current page of the webUI
     When the user deletes the following elements using the webUI
@@ -51,6 +57,10 @@ Feature: deleting files and folders
 
   @smokeTest @issue-4582 @disablePreviews
   Scenario: Delete multiple files at once
+    Given user "Alice" has created file "data.zip"
+    And user "Alice" has created file "lorem.txt"
+    And user "Alice" has created folder "simple-folder"
+    And the user has reloaded the current page of the webUI
     When the user batch deletes these files using the webUI
       | name          |
       | data.zip      |
@@ -73,6 +83,10 @@ Feature: deleting files and folders
 
   @ocis-reva-issue-106 @ocis-reve-issue-442 @skipOnOC10 @issue-4582
   Scenario: Delete all except for a few files at once
+    Given user "Alice" has created file "data.zip"
+    And user "Alice" has created file "lorem.txt"
+    And user "Alice" has created folder "simple-folder"
+    And the user has reloaded the current page of the webUI
     When the user marks all files for batch action using the webUI
     And the user unmarks these files for batch action using the webUI
       | name          |
@@ -102,6 +116,8 @@ Feature: deleting files and folders
 
 
   Scenario: Delete the last file in a folder
+    Given user "Alice" has created file "zzzz-must-be-last-file-in-folder.txt"
+    And the user has reloaded the current page of the webUI
     When the user deletes file "zzzz-must-be-last-file-in-folder.txt" using the webUI
     Then as "Alice" file "zzzz-must-be-last-file-in-folder.txt" should not exist
     And file "zzzz-must-be-last-file-in-folder.txt" should not be listed on the webUI
@@ -109,7 +125,9 @@ Feature: deleting files and folders
 
   @skip @yetToImplement @public_link_share-feature-required
   Scenario: delete files from shared by link page
-    Given the user has created a new public link for file "lorem.txt" using the webUI
+    Given user "Alice" has created file "lorem.txt"
+    And the user has reloaded the current page of the webUI
+    And the user has created a new public link for file "lorem.txt" using the webUI
     And the user has browsed to the shared-by-link page
     Then file "lorem.txt" should be listed on the webUI
     When the user deletes file "lorem.txt" using the webUI
@@ -120,7 +138,9 @@ Feature: deleting files and folders
 
   @skip @yetToImplement @systemtags-app-required
   Scenario: delete files from tags page
-    Given user "Alice" has created a "normal" tag with name "lorem"
+    Given user "Alice" has created file "lorem.txt"
+    And the user has reloaded the current page of the webUI
+    And user "Alice" has created a "normal" tag with name "lorem"
     And user "Alice" has added tag "lorem" to file "/lorem.txt"
     When the user browses to the tags page
     And the user searches for tag "lorem" using the webUI
@@ -133,7 +153,12 @@ Feature: deleting files and folders
 
   @ocis-reva-issue-64
   Scenario: delete a file on a public share
-    Given user "Alice" has shared folder "simple-folder" with link with "read, update, create, delete" permissions
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has created file "simple-folder/lorem.txt"
+    And user "Alice" has created folder "simple-folder/simple-empty-folder"
+    And user "Alice" has created folder "simple-folder/strängé filename (duplicate #2 &).txt"
+    And the user has reloaded the current page of the webUI
+    And user "Alice" has shared folder "simple-folder" with link with "read, update, create, delete" permissions
     When the public uses the webUI to access the last public link created by user "Alice"
     And the user deletes the following elements using the webUI
       | name                                  |
@@ -149,7 +174,10 @@ Feature: deleting files and folders
 
   @ocis-reva-issue-64
   Scenario: delete a file on a public share with problematic characters
-    Given user "Alice" has renamed the following file
+    Given user "Alice" has created file "lorem.txt"
+    And user "Alice" has created folder "simple-folder"
+    And the user has reloaded the current page of the webUI
+    And user "Alice" has renamed the following file
       | from-name-parts | to-name-parts   |
       | lorem.txt       | simple-folder/  |
       |                 | 'single'        |
@@ -181,7 +209,12 @@ Feature: deleting files and folders
 
   @skip @yetToImplement @issue-4582
   Scenario: Delete multiple files at once on a public share
-    Given user "Alice" has shared folder "simple-folder" with link with "read, update, create, delete" permissions
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has created file "simple-folder/data.zip"
+    And user "Alice" has created file "simple-folder/lorem.txt"
+    And user "Alice" has created file "simple-folder/simple-empty-folder"
+    And the user has reloaded the current page of the webUI
+    And user "Alice" has shared folder "simple-folder" with link with "read, update, create, delete" permissions
     When the public uses the webUI to access the last public link created by user "Alice"
     And the user batch deletes these files using the webUI
       | name                |
@@ -196,19 +229,24 @@ Feature: deleting files and folders
 
   @ocis-reva-issue-64
   Scenario: Delete a file and folder from shared with me page
-    Given user "Brian" has been created with default attributes
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "simple-folder"
+    And user "Brian" has created file "lorem.txt"
     And user "Brian" has shared folder "simple-folder" with user "Alice"
     And user "Brian" has shared file "lorem.txt" with user "Alice"
     And the user has browsed to the shared-with-me page
-    When the user deletes folder "simple-folder (2)" using the webUI
-    And the user deletes file "lorem (2).txt" using the webUI
-    Then as "Alice" folder "simple-folder (2)" should not exist
-    And as "Alice" file "lorem (2).txt" should not exist
+    When the user deletes folder "simple-folder" using the webUI
+    And the user deletes file "lorem.txt" using the webUI
+    Then as "Alice" folder "simple-folder" should not exist
+    And as "Alice" file "lorem.txt" should not exist
     And no message should be displayed on the webUI
 
   @ocis-reva-issue-64
   Scenario: Delete a file and folder in shared with others page
-    Given user "Brian" has been created with default attributes
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has created file "lorem.txt"
+    And the user has reloaded the current page of the webUI
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has shared file "lorem.txt" with user "Brian"
     And user "Alice" has shared folder "simple-folder" with user "Brian"
     When the user browses to the shared-with-others page
@@ -228,7 +266,11 @@ Feature: deleting files and folders
 
   @ocis-reva-issue-64
   Scenario: Delete multiple files at once from shared with others page
-    Given user "Brian" has been created with default attributes
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has created file "lorem.txt"
+    And user "Alice" has created file "data.zip"
+    And the user has reloaded the current page of the webUI
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has shared file "lorem.txt" with user "Brian"
     And user "Alice" has shared folder "simple-folder" with user "Brian"
     And user "Alice" has shared file "data.zip" with user "Brian"
@@ -247,7 +289,10 @@ Feature: deleting files and folders
 
   @ocis-reva-issue-39
   Scenario: Try to delete file and folder from favorites page
-    Given user "Alice" has favorited element "simple-folder"
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has created file "lorem.txt"
+    And the user has reloaded the current page of the webUI
+    And user "Alice" has favorited element "simple-folder"
     And user "Alice" has favorited element "lorem.txt"
     When the user browses to the favorites page
     And the user deletes file "lorem.txt" using the webUI
@@ -257,7 +302,9 @@ Feature: deleting files and folders
 
 
   Scenario: Try to delete file and folder that used to exist but does not anymore
-    Given the user has browsed to the files page
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has created file "lorem.txt"
+    And the user has browsed to the files page
     And the following files have been deleted by user "Alice"
       | name          |
       | lorem.txt     |


### PR DESCRIPTION
## Description
refactor steps for user creation with appropriate skeleton files.
Following suites have been refactored: 
- webUIAccount
- webUIAdminSettings
- webUIComments
- webUICreateFilesFolders
- webUIDeleteFilesFolders

## Related Issue
- Part of https://github.com/owncloud/QA/issues/659

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- 🤖 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 