### PR TITLE
Added only office extension opening into a new window

### DIFF
--- a/changelog/unreleased/only-office-integration-new-window
+++ b/changelog/unreleased/only-office-integration-new-window
@@ -1,0 +1,5 @@
+Enhancement: Added only office extension opening into a new window window
+
+This integrates the OC10 OnlyOffice extension into the OCIS web frontend opening it in a new window.
+
+https://github.com/owncloud/web/pull/4836

--- a/packages/web-app-files/src/mixins/fileActions.js
+++ b/packages/web-app-files/src/mixins/fileActions.js
@@ -49,11 +49,11 @@ export default {
           icon: this.apps.meta[editor.app].icon,
           handler: item => this.$_fileActions_openEditor(editor, item.path, item.id),
           isEnabled: ({ resource }) => {
-            if (editor.routes && !checkRoute(editor.routes, this.$route.name)) {
-              return false
+            if (editor.handler || (editor.routes && checkRoute(editor.routes, this.$route.name))) {
+              return resource.extension === editor.extension
             }
 
-            return resource.extension === editor.extension
+            return false
           },
           canBeDefault: true
         }
@@ -76,17 +76,17 @@ export default {
 
       // TODO: Refactor in the store
       this.openFile({
-        filePath: filePath
+        filePath: filePath,
+        fileId: fileId
       })
 
       if (editor.newTab) {
         const path = this.$router.resolve({
           name: editor.routeName,
-          params: { filePath: filePath }
+          params: { filePath: filePath, fileId: fileId }
         }).href
-        const target = `${editor.routeName}-${filePath}`
+        const target = `${editor.routeName}-${filePath}-${fileId}`
         const win = window.open(path, target)
-        // in case popup is blocked win will be null
         if (win) {
           win.focus()
         }
@@ -95,6 +95,7 @@ export default {
 
       const routeName = editor.routeName || editor.app
       const params = {
+        fileId,
         filePath,
         contextRouteName: this.$route.name
       }

--- a/packages/web-app-onlyoffice/package.json
+++ b/packages/web-app-onlyoffice/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "ocis-onlyoffice",
+  "version": "0.0.0",
+  "description": "ownCloud onlyoffice viewer",
+  "license": "AGPL-3.0"
+}

--- a/packages/web-app-onlyoffice/src/App.vue
+++ b/packages/web-app-onlyoffice/src/App.vue
@@ -1,0 +1,126 @@
+<template>
+  <div>
+    <oc-spinner
+      v-if="loading"
+      :aria-label="this.$gettext('Loading Onlyoffice')"
+      class="uk-position-center"
+      size="xlarge"
+    />
+    <iframe v-else id="onlyoffice-editor" ref="onlyOfficeEditor" :src="iframeSource" />
+  </div>
+</template>
+<script>
+import { mapGetters, mapActions } from 'vuex'
+import queryString from 'query-string'
+import { DateTime } from 'luxon'
+
+export default {
+  name: 'OnlyOfficeEditor',
+  data: () => ({
+    loading: true,
+    filePath: '',
+    fileExtension: '',
+    isReadOnly: null,
+    currentETag: null
+  }),
+  computed: {
+    ...mapGetters(['configuration']),
+    config() {
+      const {
+        url = `${this.configuration.server}apps/onlyoffice/`,
+        theme = 'minimal',
+        autosave = false
+      } =
+        this.$store.state.apps.fileEditors.find(editor => editor.app === 'onlyoffice').config || {}
+      return { url, theme, autosave: autosave ? 1 : 0 }
+    },
+    iframeSource() {
+      const query = queryString.stringify({
+        filePath: encodeURIComponent(this.filePath)
+      })
+
+      return `${this.config.url}/${this.fileId}?${query}`
+    }
+  },
+  created() {
+    this.filePath = this.$route.params.filePath
+    this.fileId = this.$route.params.fileId
+    this.fileExtension = this.filePath.split('.').pop()
+    this.checkPermissions()
+    window.addEventListener('message', event => {
+      if (event.data.length > 0) {
+        var payload = JSON.parse(event.data)
+        switch (payload.event) {
+          case 'init':
+            this.fileExtension === 'vsdx' ? this.importVisio() : this.load()
+            break
+          case 'autosave':
+          case 'save':
+            this.save(payload)
+            break
+          case 'exit':
+            this.exit()
+            break
+        }
+      }
+    })
+  },
+  methods: {
+    ...mapActions(['showMessage']),
+    error(error) {
+      this.showMessage({
+        title: this.$gettext('The document could not be loaded…'),
+        desc: error,
+        status: 'danger',
+        autoClose: {
+          enabled: true
+        }
+      })
+    },
+    checkPermissions() {
+      this.$client.files
+        .fileInfo(this.filePath, ['{http://owncloud.org/ns}permissions'])
+        .then(v => {
+          this.isReadOnly = v.fileInfo['{http://owncloud.org/ns}permissions'].indexOf('W') === -1
+          this.loading = false
+        })
+        .catch(error => {
+          this.error(error)
+        })
+    },
+    load() {
+      this.$client.files
+        .getFileContents(this.filePath, { resolveWithResponseObject: true })
+        .then(resp => {
+          this.currentETag = resp.headers.ETag
+        })
+        .catch(error => {
+          this.error(error)
+        })
+    },
+    exit() {
+      window.close()
+    },
+    getTimestamp() {
+      return DateTime.local().toFormat('YYYYMMDD[T]HHmmss')
+    }
+  }
+}
+</script>
+<style scoped>
+#onlyoffice-editor {
+  position: fixed; /* use if full screen */
+  top: -45px; /* use if full screen */
+
+  /* margin-top: -45px; don't use if full screen */
+  left: 0;
+  bottom: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}
+</style>

--- a/packages/web-app-onlyoffice/src/index.js
+++ b/packages/web-app-onlyoffice/src/index.js
@@ -1,0 +1,69 @@
+import App from './App.vue'
+
+const routes = [
+  {
+    path: '/edit/:fileId/:filePath',
+    components: {
+      fullscreen: App
+    },
+    name: 'onlyoffice-edit',
+    meta: { hideHeadbar: true }
+  }
+]
+
+const routeDefinitions = [
+  'files-list',
+  'files-favorites',
+  'files-shared-with-others',
+  'files-shared-with-me',
+  'public-files'
+]
+
+const appInfo = {
+  name: 'OnlyOffice',
+  id: 'onlyoffice',
+  icon: 'x-office-document',
+  isFileEditor: true,
+  extensions: [
+    {
+      newTab: true,
+      extension: 'docx',
+      routeName: 'onlyoffice-edit',
+      routes: routeDefinitions,
+      newFileMenu: {
+        menuTitle($gettext) {
+          return $gettext('New OnlyOffice document')
+        },
+        icon: 'x-office-document'
+      }
+    },
+    {
+      newTab: true,
+      extension: 'xlsx',
+      routeName: 'onlyoffice-edit',
+      routes: routeDefinitions,
+      newFileMenu: {
+        menuTitle($gettext) {
+          return $gettext('New OnlyOffice spreadsheet')
+        },
+        icon: 'x-office-document'
+      }
+    },
+    {
+      newTab: true,
+      extension: 'pptx',
+      routeName: 'onlyoffice-edit',
+      routes: routeDefinitions,
+      newFileMenu: {
+        menuTitle($gettext) {
+          return $gettext('New OnlyOffice presentation')
+        },
+        icon: 'x-office-document'
+      }
+    }
+  ]
+}
+export default {
+  appInfo,
+  routes
+}


### PR DESCRIPTION
## Description
This is an adaptation of the Only Office external app for OCIS which is compatible with OC10 backend without requiring any OCIS server or runtime.  This simplifies the integration and avoids using a customer `handler` function to integrate Only Office.

This is partly raised to demonstrate another approach for integrating OO, and could be used as a stepping stone to a deeper integration down the track to actually use the JS APIs in OO directly (for things like automated background saves and triggering behaviour via post messages between the application and the extension.

I have raised another similar PR https://github.com/owncloud/web/pull/4837 which opens in the same window.  If this approach continued to implement the direct JS API, I believe opening in the same window is a better approach (in terms of UX) but would warrant being able to hide the left-hand sidebar (which is possible) and also adding a top 'Back' button or other actions at the top to facilitate navigating out of the integrated document editor.

## Motivation and Context
It simplifies the integration point of Only Office in OCIS.  This implementation still uses the OC10 OO plugin, but could be updated to not use it at all (and use direct JS integration with the OO JS API).

## How Has This Been Tested?
Tested on the latest version of **owncloud/web** for a week, involving opening each type of document, making changes, going back into the parent app, seeing the changes then re-editing or downloading to confirm changes were applied.

## Screenshots (if appropriate):
![Screenshot (315)](https://user-images.githubusercontent.com/876651/112070574-12303e80-8bc2-11eb-941d-c23b42e98c3e.png)
![Screenshot (316)](https://user-images.githubusercontent.com/876651/112070572-10ff1180-8bc2-11eb-84a3-8999474d8c38.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 