### PR TITLE
Added only office extension opening into the existing window

### DIFF
--- a/changelog/unreleased/only-office-integration-same-window
+++ b/changelog/unreleased/only-office-integration-same-window
@@ -1,0 +1,5 @@
+Enhancement: Added only office extension opening into the existing window
+
+This integrates the OC10 OnlyOffice extension into the OCIS web frontend rendering it in the same window.
+
+https://github.com/owncloud/web/pull/4837

--- a/packages/web-app-files/src/mixins/fileActions.js
+++ b/packages/web-app-files/src/mixins/fileActions.js
@@ -49,11 +49,11 @@ export default {
           icon: this.apps.meta[editor.app].icon,
           handler: item => this.$_fileActions_openEditor(editor, item.path, item.id),
           isEnabled: ({ resource }) => {
-            if (editor.routes && !checkRoute(editor.routes, this.$route.name)) {
-              return false
+            if (editor.handler || (editor.routes && checkRoute(editor.routes, this.$route.name))) {
+              return resource.extension === editor.extension
             }
 
-            return resource.extension === editor.extension
+            return false
           },
           canBeDefault: true
         }
@@ -76,17 +76,17 @@ export default {
 
       // TODO: Refactor in the store
       this.openFile({
-        filePath: filePath
+        filePath: filePath,
+        fileId: fileId
       })
 
       if (editor.newTab) {
         const path = this.$router.resolve({
           name: editor.routeName,
-          params: { filePath: filePath }
+          params: { filePath: filePath, fileId: fileId }
         }).href
-        const target = `${editor.routeName}-${filePath}`
+        const target = `${editor.routeName}-${filePath}-${fileId}`
         const win = window.open(path, target)
-        // in case popup is blocked win will be null
         if (win) {
           win.focus()
         }
@@ -95,6 +95,7 @@ export default {
 
       const routeName = editor.routeName || editor.app
       const params = {
+        fileId,
         filePath,
         contextRouteName: this.$route.name
       }

--- a/packages/web-app-onlyoffice/package.json
+++ b/packages/web-app-onlyoffice/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ocis-onlyoffice",
+  "version": "0.0.0",
+  "description": "ownCloud onlyoffice viewer",
+  "license": "AGPL-3.0",
+  "devDependencies": {
+    "luxon": "^1.22.0",
+    "query-string": "^6.8.3",
+    "vuex": "3.1.3"
+  }
+}

--- a/packages/web-app-onlyoffice/src/App.vue
+++ b/packages/web-app-onlyoffice/src/App.vue
@@ -1,0 +1,124 @@
+<template>
+  <div>
+    <oc-spinner
+      v-if="loading"
+      :aria-label="this.$gettext('Loading Onlyoffice')"
+      class="uk-position-center"
+      size="xlarge"
+    />
+    <iframe v-else id="onlyoffice-editor" ref="onlyOfficeEditor" :src="iframeSource" />
+  </div>
+</template>
+<script>
+import { mapGetters, mapActions } from 'vuex'
+import queryString from 'query-string'
+import { DateTime } from 'luxon'
+
+export default {
+  name: 'OnlyOfficeEditor',
+  data() {
+    return {
+      loading: true,
+      filePath: '',
+      fileExtension: '',
+      isReadOnly: null,
+      currentETag: null
+    }
+  },
+  computed: {
+    ...mapGetters(['configuration']),
+    config() {
+      const {
+        url = `${this.configuration.server}apps/onlyoffice/`,
+        theme = 'minimal',
+        autosave = false
+      } =
+        this.$store.state.apps.fileEditors.find(editor => editor.app === 'onlyoffice').config || {}
+      return { url, theme, autosave: autosave ? 1 : 0 }
+    },
+    iframeSource() {
+      const query = queryString.stringify({
+        filePath: encodeURIComponent(this.filePath)
+      })
+
+      return `${this.config.url}/${this.fileId}?${query}`
+    }
+  },
+  created() {
+    this.filePath = this.$route.params.filePath
+    this.fileId = this.$route.params.fileId
+    this.fileExtension = this.filePath.split('.').pop()
+    this.checkPermissions()
+    window.addEventListener('message', event => {
+      if (event.data.length > 0) {
+        var payload = JSON.parse(event.data)
+        switch (payload.event) {
+          case 'init':
+            this.fileExtension === 'vsdx' ? this.importVisio() : this.load()
+            break
+          case 'autosave':
+          case 'save':
+            this.save(payload)
+            break
+          case 'exit':
+            this.exit()
+            break
+        }
+      }
+    })
+  },
+  methods: {
+    ...mapActions(['showMessage']),
+    error(error) {
+      this.showMessage({
+        title: this.$gettext('The document could not be loaded…'),
+        desc: error,
+        status: 'danger',
+        autoClose: {
+          enabled: true
+        }
+      })
+    },
+    checkPermissions() {
+      this.$client.files
+        .fileInfo(this.filePath, ['{http://owncloud.org/ns}permissions'])
+        .then(v => {
+          this.isReadOnly = v.fileInfo['{http://owncloud.org/ns}permissions'].indexOf('W') === -1
+          this.loading = false
+        })
+        .catch(error => {
+          this.error(error)
+        })
+    },
+    load() {
+      this.$client.files
+        .getFileContents(this.filePath, { resolveWithResponseObject: true })
+        .then(resp => {
+          this.currentETag = resp.headers.ETag
+        })
+        .catch(error => {
+          this.error(error)
+        })
+    },
+    exit() {
+      window.close()
+    },
+    getTimestamp() {
+      return DateTime.local().toFormat('YYYYMMDD[T]HHmmss')
+    }
+  }
+}
+</script>
+<style scoped>
+#onlyoffice-editor {
+  margin-top: -45px; /* hide OC10 top banner */
+  left: 0;
+  bottom: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+  padding: 0;
+  overflow: hidden;
+}
+</style>

--- a/packages/web-app-onlyoffice/src/index.js
+++ b/packages/web-app-onlyoffice/src/index.js
@@ -1,0 +1,65 @@
+import App from './App.vue'
+
+const routes = [
+  {
+    path: '/edit/:fileId/:filePath',
+    components: {
+      app: App
+    },
+    name: 'edit',
+    meta: { hideHeadbar: false, hideSearchBar: true }
+  }
+]
+
+const routeDefinitions = [
+  'files-personal',
+  'files-favorites',
+  'files-shared-with-others',
+  'files-shared-with-me',
+  'files-public-list'
+]
+
+const appInfo = {
+  name: 'OnlyOffice',
+  id: 'onlyoffice',
+  icon: 'x-office-document',
+  extensions: [
+    {
+      extension: 'docx',
+      newTab: false,
+      routeName: 'onlyoffice-edit',
+      newFileMenu: {
+        menuTitle($gettext) {
+          return $gettext('New OnlyOffice document')
+        }
+      },
+      routes: routeDefinitions
+    },
+    {
+      extension: 'xlsx',
+      newTab: false,
+      routeName: 'onlyoffice-edit',
+      newFileMenu: {
+        menuTitle($gettext) {
+          return $gettext('New OnlyOffice spreadsheet')
+        }
+      },
+      routes: routeDefinitions
+    },
+    {
+      extension: 'pptx',
+      newTab: false,
+      routeName: 'onlyoffice-edit',
+      newFileMenu: {
+        menuTitle($gettext) {
+          return $gettext('New OnlyOffice presentation')
+        }
+      },
+      routes: routeDefinitions
+    }
+  ]
+}
+export default {
+  appInfo,
+  routes
+}

--- a/packages/web-runtime/src/App.vue
+++ b/packages/web-runtime/src/App.vue
@@ -426,4 +426,9 @@ export default {
   border: 10px solid;
   border-bottom: 10px solid transparent;
 }
+
+/* move to owncloud-design-system */
+.oc-app-container {
+  height: 100%;
+}
 </style>


### PR DESCRIPTION
## Description
This is an adaptation of the Only Office external app for OCIS which is compatible with OC10 backend without requiring any OCIS server or runtime.  This simplifies the integration and avoids using a customer `handler` function to integrate Only Office.

This is partly raised to demonstrate another approach for integrating OO, and could be used as a stepping stone to a deeper integration down the track to actually use the JS APIs in OO directly (for things like automated background saves and triggering behaviour via post messages between the application and the extension.

I have raised another similar PR https://github.com/owncloud/web/pull/4836 which opens in a new window (as per existing design).  If this approach continued to implement the direct JS API, I believe opening in the same window is a better approach (in terms of UX) but would warrant being able to hide the left-hand sidebar (which is possible) and also adding a top 'Back' button or other actions at the top to facilitate navigating out of the integrated document editor.

* Could also specify `hideSideBar: true` in route to claim more screen real estate (will raise in a separate PR) but this will disappear if the user has a constrainted viewport by default anyway.

## Motivation and Context
It simplifies the integration point of Only Office in OCIS.  This implementation still uses the OC10 OO plugin, but could be updated to not use it at all (and use direct JS integration with the OO JS API).

## How Has This Been Tested?
Tested on the latest version of **owncloud/web** for a week, involving opening each type of document, making changes, going back into the parent app, seeing the changes then re-editing or downloading to confirm changes were applied.

Keep in mind you will have to add:
```
apps: [..., "onlyoffice"],
```
to your `config.json` to enable this app.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/876651/112093446-816f5800-8bed-11eb-9f4d-87a7105e8ad6.png)
![image](https://user-images.githubusercontent.com/876651/116342412-ee49c380-a825-11eb-8a3f-eba4773699f1.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 