### PR TITLE
Added upload pending prompt on close/reload

### DIFF
--- a/packages/web-app-files/src/components/UploadProgress.vue
+++ b/packages/web-app-files/src/components/UploadProgress.vue
@@ -108,6 +108,10 @@ export default {
       } else {
         return 100
       }
+    },
+
+    uploadPending() {
+      return this.totalUploadProgress < 100
     }
   },
   watch: {
@@ -122,12 +126,19 @@ export default {
     this.$root.$on('upload-start', () => {
       this.$nextTick(() => {
         this.delayForScreenreader(() => this.$refs.progressbar.$el.focus())
+        window.addEventListener('beforeunload', this.handlerClose);
       })
     })
   },
   methods: {
     $_toggleExpanded() {
       this.expanded = !this.expanded
+    },
+    handlerClose(event) {
+      if (this.uploadPending) {
+        event.preventDefault()    
+        event.returnValue = ""
+      }
     }
   }
 }

--- a/packages/web-app-files/src/components/UploadProgress.vue
+++ b/packages/web-app-files/src/components/UploadProgress.vue
@@ -126,9 +126,12 @@ export default {
     this.$root.$on('upload-start', () => {
       this.$nextTick(() => {
         this.delayForScreenreader(() => this.$refs.progressbar.$el.focus())
-        window.addEventListener('beforeunload', this.handlerClose);
       })
     })
+    window.addEventListener('beforeunload', this.handlerClose)
+  },
+  beforeDestroy() {
+    window.removeEventListener('beforeunload', this.handlerClose)
   },
   methods: {
     $_toggleExpanded() {
@@ -136,8 +139,8 @@ export default {
     },
     handlerClose(event) {
       if (this.uploadPending) {
-        event.preventDefault()    
-        event.returnValue = ""
+        event.preventDefault()
+        event.returnValue = ''
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description

Added an unload event listener that prompts user if there are pending uploads while user closes/ reloads/ navigates to another URL. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #2590

## Motivation and Context
The pending uploads are cancelled on closing/reloading window. A prompt is required to warn users of upload cancellation. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- tested with the latest changes from owncloud/web master branch
- tested by uploading many files and also with large files
- tested on tab close/ reload/ navigating to another URL
- tested on Chrome 88.0 and Firefox 86.0

## Screenshots (if appropriate):
![owncloud-2590](https://user-images.githubusercontent.com/42616235/112231114-14df7200-8c5c-11eb-9476-8bfe12fbfd20.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Detect tab close/ reload/ navigation and prompt if any uploads are pending. 

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Added unload event listener 
- [ ] Remove unload event listener before component destroy

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...