### PR TITLE
Remove <main> tags from container & runtime and move them to extension level

### DIFF
--- a/changelog/unreleased/bugfix-only-one-main-tag
+++ b/changelog/unreleased/bugfix-only-one-main-tag
@@ -1,0 +1,9 @@
+Bugfix: Only one `<main>` tag per HTML document
+
+Only one `<main>` tag is allowed per HTML document. 
+This change removes the ones in `web-container` and `web-runtime` and 
+adds one to each extension (files-list, mediaviewer, markdowneditor, drawio) 
+since they can't be loaded at the same time.
+
+https://github.com/owncloud/web/issues/1652
+https://github.com/owncloud/web/pull/4627

--- a/packages/web-app-draw-io/src/App.vue
+++ b/packages/web-app-draw-io/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <main>
     <oc-spinner
       v-if="loading"
       :aria-label="this.$gettext('Loading media')"
@@ -7,7 +7,7 @@
       size="xlarge"
     />
     <iframe v-else id="drawio-editor" ref="drawIoEditor" :src="iframeSource" />
-  </div>
+  </main>
 </template>
 <script>
 import { mapGetters, mapActions } from 'vuex'

--- a/packages/web-app-files/src/App.vue
+++ b/packages/web-app-files/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="files" class="uk-flex uk-height-1-1">
+  <main id="files" class="uk-flex uk-height-1-1">
     <div
       ref="filesListWrapper"
       tabindex="-1"
@@ -21,7 +21,7 @@
       class="uk-width-1-1 uk-width-1-2@m uk-width-1-3@xl"
       @reset="setHighlightedFile(null)"
     />
-  </div>
+  </main>
 </template>
 <script>
 import Mixins from './mixins'

--- a/packages/web-app-markdown-editor/src/App.vue
+++ b/packages/web-app-markdown-editor/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="markdown-editor">
+  <main id="markdown-editor">
     <markdown-editor-app-bar />
     <oc-notifications>
       <oc-notification-message
@@ -26,7 +26,7 @@
         <div v-html="renderedMarkdown"></div>
       </div>
     </div>
-  </div>
+  </main>
 </template>
 <script>
 import MarkdownEditorAppBar from './MarkdownEditorAppBar.vue'

--- a/packages/web-app-media-viewer/src/App.vue
+++ b/packages/web-app-media-viewer/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="mediaviewer" class="uk-position-relative">
+  <main id="mediaviewer" class="uk-position-relative">
     <div class="uk-text-center oc-p-s">
       <transition
         name="custom-classes-transition"
@@ -89,7 +89,7 @@
         </div>
       </div>
     </div>
-  </div>
+  </main>
 </template>
 <script>
 import { mapGetters } from 'vuex'

--- a/packages/web-container/index.html.ejs
+++ b/packages/web-container/index.html.ejs
@@ -1,42 +1,44 @@
 <!DOCTYPE html>
 <html<%- helpers.makeHtmlAttributes(data.attributes.html) %>>
 <head>
-    <% data.meta.forEach((m) => { %>
-        <meta<%- helpers.makeHtmlAttributes(m) %>>
-    <% }); %>
-    <title><%= data.title %></title>
-    <link rel="manifest" href="manifest.json">
-    <% Object.keys(data.bundle.css).forEach((s) => { %>
-        <link href="<%- data.bundle.css[s] %>" rel="stylesheet">
-    <% }); %>
-    <script src="js/require.js"></script>
-    <noscript>
-        <style>#enable-js-banner {
-                display: flex;
-                flex-direction: row;
-                justify-content: center;
-                padding: 0.5rem;
-                background-color: #467391;
-            }
-
-            #banner-content {
-                color: white;
-            }</style>
-    </noscript>
+  <% data.meta.forEach((m) => { %>
+    <meta<%- helpers.makeHtmlAttributes(m) %>>
+  <% }); %>
+  <title><%= data.title %></title>
+  <link rel="manifest" href="manifest.json">
+  <% Object.keys(data.bundle.css).forEach((s) => { %>
+    <link href="<%- data.bundle.css[s] %>" rel="stylesheet">
+  <% }); %>
+  <script src="js/require.js"></script>
+  <noscript>
+    <style>
+      #enable-js-banner {
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+        padding: 0.5rem;
+        background-color: #467391;
+      }
+      #banner-content {
+        color: white;
+      }
+    </style>
+  </noscript>
 </head>
 <body>
-<main id="owncloud"></main>
-<noscript>
+  <div id="owncloud"></div>
+  <noscript>
     <div id="enable-js-banner"><span id="banner-content"><h3>Please enable JavaScript</h3></span></div>
-</noscript>
-<script type="text/javascript">
-  requirejs.config({
-    baseUrl: <%- JSON.stringify(data.roots.js) %>,
-    paths: <%- JSON.stringify(data.bundle.js) %>
-  })
+  </noscript>
+  <script type="text/javascript">
+    requirejs.config({
+      baseUrl: <%- JSON.stringify(data.roots.js) %>,
+      paths: <%- JSON.stringify(data.bundle.js) %>
+    })
 
-  requirejs(['web-runtime'], function (runtime) {
-    runtime.exec()
-  })</script>
+    requirejs(['web-runtime'], function (runtime) {
+      runtime.exec()
+    })
+  </script>
 </body>
 </html>

--- a/packages/web-runtime/src/App.vue
+++ b/packages/web-runtime/src/App.vue
@@ -47,10 +47,10 @@
             :user-display-name="user.displayname"
             @toggleAppNavigationVisibility="toggleAppNavigationVisibility"
           />
-          <main id="main">
+          <div id="main">
             <message-bar :active-messages="activeMessages" @deleteMessage="$_deleteMessage" />
             <router-view class="oc-app-container" name="app" />
-          </main>
+          </div>
         </div>
       </div>
       <transition


### PR DESCRIPTION
## Description
As explained in #1652 we only can have one `<main>` tag per HTML document. This PR removes the ones in `web-container` and `web-runtime` and adds one to each extension (files-list, mediaviewer, markdowneditor, drawio) since they can't be loaded at the same time.

## Related Issue
- Fixes #1652

## Motivation and Context
Important for accessibility-compliance (and to produce valid HTML)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)