### PR TITLE
[tests-only] speed up web tests by reducing timeouts

### DIFF
--- a/tests/acceptance/customCommands/waitForAjaxCallsToStartAndFinish.js
+++ b/tests/acceptance/customCommands/waitForAjaxCallsToStartAndFinish.js
@@ -29,7 +29,7 @@ exports.command = function() {
     numAjaxRequestsStart = result.value
   })
   start = Date.now()
-  end = start + this.globals.waitForConditionTimeout
+  end = start + this.globals.waitForNegativeConditionTimeout
   checkSumStartedAjaxRequests(this)
   this.waitForOutstandingAjaxCalls()
 }

--- a/tests/acceptance/pageObjects/personalPage.js
+++ b/tests/acceptance/pageObjects/personalPage.js
@@ -149,7 +149,7 @@ module.exports = {
       return this.selectFileForUpload(filePath)
         .waitForElementVisible(
           '@fileUploadProgress',
-          this.api.globals.waitForConditionTimeout,
+          this.api.globals.waitForNegativeConditionTimeout,
           this.api.globals.waitForConditionPollInterval,
           false
         )
@@ -199,7 +199,7 @@ module.exports = {
         .setValue('@folderUploadInput', folderName)
         .waitForElementVisible(
           '@fileUploadProgress',
-          this.api.globals.waitForConditionTimeout,
+          this.api.globals.waitForNegativeConditionTimeout,
           this.api.globals.waitForConditionPollInterval,
           false
         )


### PR DESCRIPTION
- only wait for 1sec for the upload progress bar to appear
- reduce timeout when waiting to ajax calls to start
## Description
1. reduce the timeout waiting for the upload progress bar to appear, for small uploads we are checking too late
2. reduce timeout when waiting to ajax calls to start, when the call started and is already finished we are checking too late and there is no need to wait for so long then

I found these issues while running random tests, it has not been a search for all issues

## Motivation and Context
speed up CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
