### PR TITLE
[Tests-Only]Adjusts the function to assert deleted Elements are not listed

### DIFF
--- a/tests/acceptance/expected-failures-with-ocis-server-owncloud-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-owncloud-storage.md
@@ -30,7 +30,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIAccount/accountInformation.feature:20](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIAccount/accountInformation.feature#L20)
 
 ### [REPORT request not implemented](https://github.com/owncloud/ocis/issues/1330)
--   [webUIDeleteFilesFolders/deleteFilesFolders.feature:253](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L253)
+-   [webUIDeleteFilesFolders/deleteFilesFolders.feature:249](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L249)
 -   [webUIFavorites/favoritesFile.feature:14](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFavorites/favoritesFile.feature#L14)
 -   [webUIFavorites/favoritesFile.feature:27](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFavorites/favoritesFile.feature#L27)
 -   [webUIFavorites/favoritesFile.feature:40](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFavorites/favoritesFile.feature#L40)
@@ -51,7 +51,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIFilesDetails/fileDetails.feature:46](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesDetails/fileDetails.feature#L46)
 
 ### [Sharing seems to work but does not work](https://github.com/owncloud/ocis/issues/1303)
--   [webUIDeleteFilesFolders/deleteFilesFolders.feature:202](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L202)
+-   [webUIDeleteFilesFolders/deleteFilesFolders.feature:198](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L198)
 -   [webUIFilesDetails/fileDetails.feature:88](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesDetails/fileDetails.feature#L88)
 -   [webUIFilesDetails/fileDetails.feature:103](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesDetails/fileDetails.feature#L103)
 -   [webUIFilesActionMenu/versions.feature:33](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L33)

--- a/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
@@ -8,7 +8,7 @@ Feature: deleting files and folders
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 
-  @skip @smokeTest @ocisSmokeTest
+  @skipOnOC10 @smokeTest @ocisSmokeTest
   Scenario: Delete files & folders one by one and check its existence after page reload
     Given user "Alice" has created file "sample,1.txt"
     And user "Alice" has created folder "Sample,Folder,With,Comma"
@@ -70,10 +70,6 @@ Feature: deleting files and folders
     And there should be no resources listed on the webUI
     And there should be no resources listed on the webUI after a page reload
     And no message should be displayed on the webUI
-
-
-
-
 
   @ocis-reva-issue-106 @ocis-reve-issue-442 @skipOnOC10 @issue-4582
   Scenario: Delete all except for a few files at once

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -41,7 +41,7 @@ Feature: move files
     When the user tries to move file "strängé filename (duplicate #2 &).txt" into folder "strängé नेपाली folder" using the webUI
     Then the error message with header 'An error occurred while moving strängé filename (duplicate #2 &).txt' should be displayed on the webUI
 
-  @smokeTest @skip
+  @smokeTest @skipOnOC10
   Scenario: Move multiple files at once
     Given user "Alice" has logged in using the webUI
     And the user has browsed to the files page

--- a/tests/acceptance/features/webUITrashbinFilesFolders/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/webUITrashbinFilesFolders/trashbinFilesFolders.feature
@@ -11,7 +11,7 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "Alice" has created folder "Folder,With,Comma"
     And the user has browsed to the files page
 
-  @smokeTest @ocis-reva-issue-111 @skipOnOCIS @issue-product-186 @skip
+  @smokeTest @ocis-reva-issue-111 @skipOnOCIS @issue-product-186 @skipOnOC10
   Scenario: Delete files & folders one by one and check that they are all in the trashbin
     When the user deletes the following elements using the webUI
       | name                                  |

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -833,7 +833,7 @@ const assertElementsAreNotListed = async function(elements) {
   for (const element of elements) {
     const state = await client.page.FilesPageElement.filesList().isElementListed(
       element,
-      'file',
+      'any',
       client.globals.waitForNegativeConditionTimeout
     )
     assert.ok(!state, `Expected resource '${element}' to be 'not present' but found 'present'`)


### PR DESCRIPTION

## Description
This PR adjusts the function to assert deleted elements are not listed such that all types of resources are checked.

## Related Issue
- Fixes https://github.com/owncloud/QA/issues/664

## How Has This Been Tested?
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...