### PR TITLE
[Tests-Only]DisablePreviews for the tests with disable previews tag

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1565,6 +1565,7 @@ def setupServerAndApp(logLevel):
 			'php occ config:list',
 			'php occ config:system:set skeletondirectory --value=/var/www/owncloud/server/apps/testing/data/webUISkeleton',
 			'php occ config:system:set dav.enable.tech_preview  --type=boolean --value=true',
+			'php occ config:system:set enable_previews  --type=boolean --value=true',
 			'php occ config:system:set web.baseUrl --value="http://web"',
 			'php occ config:system:set sharing.federation.allowHttpFallback --value=true --type=bool'
 		]

--- a/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
@@ -8,7 +8,7 @@ Feature: deleting files and folders
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 
-  @skipOnOC10 @smokeTest @ocisSmokeTest
+  @smokeTest @ocisSmokeTest @disablePreviews
   Scenario: Delete files & folders one by one and check its existence after page reload
     Given user "Alice" has created file "sample,1.txt"
     And user "Alice" has created folder "Sample,Folder,With,Comma"
@@ -49,7 +49,7 @@ Feature: deleting files and folders
       | "question?"         |
       | "&and#hash"         |
 
-  @smokeTest @skipOnOC10 @issue-4582
+  @smokeTest @issue-4582 @disablePreviews
   Scenario: Delete multiple files at once
     When the user batch deletes these files using the webUI
       | name          |

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -41,7 +41,7 @@ Feature: move files
     When the user tries to move file "strängé filename (duplicate #2 &).txt" into folder "strängé नेपाली folder" using the webUI
     Then the error message with header 'An error occurred while moving strängé filename (duplicate #2 &).txt' should be displayed on the webUI
 
-  @smokeTest @skipOnOC10
+   @smokeTest @disablePreviews
   Scenario: Move multiple files at once
     Given user "Alice" has logged in using the webUI
     And the user has browsed to the files page

--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -82,7 +82,7 @@ Feature: rename files
     And file "lorem.txt" should be listed on the webUI
     And file "  multiple   space    all     over   .  dat  " should not be listed on the webUI
 
-  @skip @issue-4859
+  @issue-4859 @disablePreviews
   Scenario: Rename a file using both double and single quotes
     When the user renames the following file using the webUI
       | fromName      | toName                         |

--- a/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic/shareByPublicLink.feature
@@ -420,7 +420,7 @@ Feature: Share by public link
     Then file "lorem.txt" should be listed on the webUI
     And it should not be possible to delete file "lorem.txt" using the webUI
 
-  @issue-ocis-reva-292
+  @issue-ocis-reva-292 @disablePreviews
   Scenario: user edits the permission of an already existing public link from read to read-write
     Given user "Alice" has created a public link with following settings
       | path        | simple-folder |

--- a/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature
+++ b/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature
@@ -88,7 +88,7 @@ Feature: Share by public link with different roles
     When the public uses the webUI to access the last public link created by user "Alice"
     Then there should be no resources listed on the webUI
 
-  @skipOnOC10 @issue-4582
+  @issue-4582 @disablePreviews
   Scenario: creating a public link with "Editor" role makes it possible to delete files via the link
     Given user "Alice" has shared folder "simple-folder" with link with "read, update, create, delete" permissions
     When the public uses the webUI to access the last public link created by user "Alice"
@@ -101,7 +101,7 @@ Feature: Share by public link with different roles
     Then the deleted elements should not be listed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload
 
-  @skipOnOC10 @issue-4582
+  @issue-4582 @disablePreviews
   Scenario: creating a public link with "Editor" role makes it possible to delete files via the link even with password set
     Given user "Alice" has shared folder "simple-folder" with link with "read, update, create, delete" permissions and password "pass123"
     When the public uses the webUI to access the last public link created by user "Alice" with password "pass123"

--- a/tests/acceptance/features/webUITrashbinFilesFolders/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/webUITrashbinFilesFolders/trashbinFilesFolders.feature
@@ -11,7 +11,7 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "Alice" has created folder "Folder,With,Comma"
     And the user has browsed to the files page
 
-  @smokeTest @ocis-reva-issue-111 @skipOnOCIS @issue-product-186 @skipOnOC10
+  @smokeTest @ocis-reva-issue-111 @skipOnOCIS @issue-product-186 @skip @disablePreviews
   Scenario: Delete files & folders one by one and check that they are all in the trashbin
     When the user deletes the following elements using the webUI
       | name                                  |

--- a/tests/acceptance/helpers/config.js
+++ b/tests/acceptance/helpers/config.js
@@ -41,6 +41,10 @@ function rollbackSystemConfigs(oldSysConfig, newSysConfig) {
     const value = _.get(oldSysConfig, [key])
     if (value === undefined) {
       _rollbacks.push(limit(occHelper.runOcc, ['config:system:delete', key]))
+    } else if (typeof value === 'boolean') {
+      _rollbacks.push(
+        limit(occHelper.runOcc, ['config:system:set', key, `--type=boolean --value=${value}`])
+      )
     } else {
       _rollbacks.push(limit(occHelper.runOcc, ['config:system:set', key, `--value=${value}`]))
     }

--- a/tests/acceptance/stepDefinitions/generalContext.js
+++ b/tests/acceptance/stepDefinitions/generalContext.js
@@ -9,6 +9,7 @@ const occHelper = require('../helpers/occHelper')
 
 let initialConfigJsonSettings
 let createdFiles = []
+let oldPreviewSetting = ''
 
 Given(
   'a file with the size of {string} bytes and the name {string} has been created locally',
@@ -293,6 +294,23 @@ Before(function() {
       '\x1b[33m%s\x1b[0m',
       `\tCould not read config file.\n\tSet correct path of config file in WEB_UI_CONFIG env variable to fix this.\n\tSome tests may fail as a result.`
     )
+  }
+})
+
+const getConfigSystem = async function(name) {
+  if (!client.globals.ocis) {
+    const value = await occHelper.runOcc(['config:system:get ' + name])
+    return value.ocs.data.stdOut
+  }
+}
+
+Before({ tags: '@disablePreviews' }, async () => {
+  if (!client.globals.ocis) {
+    if (!oldPreviewSetting) {
+      oldPreviewSetting = await getConfigSystem('enable_previews')
+      oldPreviewSetting = oldPreviewSetting.toString().trim()
+    }
+    occHelper.runOcc(['config:system:set enable_previews --type=boolean --value=false'])
   }
 })
 


### PR DESCRIPTION
## Description
This PR adds a before scenario to disable Previews for the tests with disable previews tag. The `disablePreviews` tags are added in the intermittent failing tests of deleteFilesFolders, moveFiles, renameFiles, shareByPublicLinkDifferentRoles and shareByPublicLink.feature


## How Has This Been Tested?
- CI


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...