### PR TITLE
Update appSwitcher titles & fix typo in group memberships

### DIFF
--- a/packages/web-app-files/src/store/actions.js
+++ b/packages/web-app-files/src/store/actions.js
@@ -536,7 +536,7 @@ export default {
         continue
       }
 
-      const etag = (resource.etag || '').replace('"', '')
+      const etag = (resource.etag || '').replaceAll('"', '')
       if (etag) {
         query.c = etag
       }

--- a/packages/web-runtime/src/components/ApplicationsMenu.vue
+++ b/packages/web-runtime/src/components/ApplicationsMenu.vue
@@ -23,11 +23,11 @@
         <div v-for="(n, nid) in menuItems" :key="`apps-menu-${nid}`" class="uk-width-1-3">
           <a v-if="n.url" key="apps-menu-external-link" :target="n.target" :href="n.url">
             <oc-icon :name="n.iconMaterial" size="xlarge" />
-            <div v-translate>{{ n.title }}</div>
+            <span class="uk-display-block" v-text="$gettext(n.title)" />
           </a>
           <router-link v-else key="apps-menu-internal-link" :to="n.path">
             <oc-icon :name="n.iconMaterial" size="xlarge" />
-            <div v-translate>{{ n.title }}</div>
+            <span class="uk-display-block" v-text="$gettext(n.title)" />
           </router-link>
         </div>
       </div>

--- a/packages/web-runtime/src/pages/account.vue
+++ b/packages/web-runtime/src/pages/account.vue
@@ -37,7 +37,7 @@
           class="uk-width-1-2@s oc-mb account-page-info-groups"
           @click="$_oc_settingsAccount_getGroup"
         >
-          <div class="uk-text-meta"><translate>Groups membership</translate></div>
+          <div class="uk-text-meta"><translate>Group memberships</translate></div>
           <span v-if="groupNames">{{ groupNames }}</span>
           <span v-else v-translate>You are not part of any group</span>
         </div>

--- a/packages/web-runtime/themes/owncloud/theme.json
+++ b/packages/web-runtime/themes/owncloud/theme.json
@@ -10,9 +10,6 @@
       "login": "themes/owncloud/assets/logo.svg",
       "notFound": "themes/owncloud/assets/cloud.svg"
     },
-    "filesList": {
-      "hideDefaultStatusIndicators": false
-    },
     "loginPage": {
       "autoRedirect": true,
       "backgroundImg": "themes/owncloud/assets/loginBackground.jpg"

--- a/tests/acceptance/features/webUIAccount/accountInformation.feature
+++ b/tests/acceptance/features/webUIAccount/accountInformation.feature
@@ -7,14 +7,14 @@ Feature: View account information
     Given user "Alice" has been created with default attributes and large skeleton files
 
   @ocis-reva-issue-107
-  Scenario: view account information when the user has been created without groups membership
+  Scenario: view account information when the user has been created without group memberships
     Given user "Alice" has logged in using the webUI
     When the user browses to the account page
     Then the user should have following details displayed on the account information
       | Username          | Alice                         |
       | Display name      | Alice Hansen                      |
       | Email             | alice@example.org             |
-      | Groups membership | You are not part of any group |
+      | Group memberships | You are not part of any group |
 
   @ocis-konnectd-issue-42
   Scenario: view account information when the user has been added to a group
@@ -28,7 +28,7 @@ Feature: View account information
       | Username          | Alice             |
       | Display name      | Alice Hansen          |
       | Email             | alice@example.org |
-      | Groups membership | Group1            |
+      | Group memberships | Group1            |
 
   @ocis-reva-issue-107 @ocis-konnectd-issue-42
   Scenario: view account information when the user has been added to multiple groups
@@ -52,4 +52,4 @@ Feature: View account information
       | Username          | Alice                                            |
       | Display name      | Alice Hansen                                         |
       | Email             | alice@example.org                                |
-      | Groups membership | Group1, Group2, Group3, Group4, Group31, A111111 |
+      | Group memberships | Group1, Group2, Group3, Group4, Group31, A111111 |

--- a/tests/acceptance/stepDefinitions/accountContext.js
+++ b/tests/acceptance/stepDefinitions/accountContext.js
@@ -14,7 +14,7 @@ Then('the user should have following details displayed on the account informatio
   const actualAccInfo = await client.page.accountPage().getAccountInformation()
   const actualEntries = Object.entries(actualAccInfo)
   for (const [key, value] of actualEntries) {
-    if (key === 'Groups membership') {
+    if (key === 'Group memberships') {
       const actualGroupMembership = value.split(',').map(grp => grp.trim())
       const expectedGroupMembership = expectedAccInfo[key].split(',').map(grp => grp.trim())
       const differenceInGroups = _.difference(actualGroupMembership, expectedGroupMembership)


### PR DESCRIPTION
## Description
Related to accessibility & translations
- Changed "Groups membership" => "Group memberships"
- Changed the way extension titles are rendered in the appSwitcher, so they hopefully don't show up as `{{ n.title }}` in Transifex anymore