### PR TITLE
Fix loading shares of the current folder twice

### DIFF
--- a/changelog/unreleased/bugfix-parent-paths
+++ b/changelog/unreleased/bugfix-parent-paths
@@ -1,0 +1,6 @@
+Bugfix: Parent paths traversal for shares
+
+We fixed a bug in parent paths traversals for loading shares. A path with a trailing slash was twice in the result of (parent-)paths, leading to fetching the existing shares on the current folder twice. Since we fetch incoming and outgoing shares this caused 2 unnecessary requests on every page load that changed into a child folder or a folder unrelated to the current path.
+
+https://github.com/owncloud/web/issues/4860
+https://github.com/owncloud/web/pull/4918

--- a/packages/web-app-files/src/helpers/path.js
+++ b/packages/web-app-files/src/helpers/path.js
@@ -2,7 +2,7 @@
  * Return all absolute parent paths.
  *
  * For example if passing in "a/b/c" it will return
- * ["a/b", "a", ""]
+ * ["/a/b", "/a", ""]
 
  * If an empty string or "/" is passed in, an empty array is returned.
  *
@@ -11,19 +11,18 @@
  * @return {Array.<String>} parent paths
  */
 export function getParentPaths(path, includeCurrent = false) {
-  if (path === '' || path === '/') {
+  // remove potential leading and trailing slash from current path (so that the resulting array doesn't start with an empty string).
+  // then reintroduce the leading slash, because we know that we need it.
+  const s = '/' + path.replace(/^\/+/, '').replace(/\/+$/, '')
+  if (s === '/') {
     return []
   }
 
-  if (path.charAt(0) !== '/') {
-    path = '/' + path
-  }
-
   const paths = []
-  const sections = path.split('/')
+  const sections = s.split('/')
 
   if (includeCurrent) {
-    paths.push(path)
+    paths.push(s)
   }
 
   sections.pop()

--- a/packages/web-app-files/tests/helpers/path.spec.js
+++ b/packages/web-app-files/tests/helpers/path.spec.js
@@ -22,6 +22,11 @@ describe('build an array of parent paths from a provided path', () => {
     expect(paths1).toEqual(paths2)
   })
 
+  it('should not interpret a trailing slash as yet another path segment', () => {
+    const paths = getParentPaths('/a/b/c/', true)
+    expect(paths).toEqual(['/a/b/c', '/a/b', '/a', ''])
+  })
+
   it('should include the provided path in the result if includeCurrent=true', () => {
     const paths = getParentPaths('a/b/c', true)
     expect(paths).toEqual(['/a/b/c', '/a/b', '/a', ''])

--- a/packages/web-app-files/tests/helpers/path.spec.js
+++ b/packages/web-app-files/tests/helpers/path.spec.js
@@ -1,0 +1,29 @@
+import { getParentPaths } from '../../src/helpers/path'
+
+describe('build an array of parent paths from a provided path', () => {
+  it('should return an empty array on an empty path', () => {
+    const paths = getParentPaths('', false)
+    expect(paths).toHaveLength(0)
+  })
+
+  it('should return an empty array on "/" as path', () => {
+    const paths = getParentPaths('/', false)
+    expect(paths).toHaveLength(0)
+  })
+
+  it('should prepend resulting paths with a "/" if none was given', () => {
+    const paths = getParentPaths('a/b/c', false)
+    expect(paths).toEqual(['/a/b', '/a', ''])
+  })
+
+  it('should make no difference between "a/b/c" and "/a/b/c"', () => {
+    const paths1 = getParentPaths('a/b/c', false)
+    const paths2 = getParentPaths('/a/b/c', false)
+    expect(paths1).toEqual(paths2)
+  })
+
+  it('should include the provided path in the result if includeCurrent=true', () => {
+    const paths = getParentPaths('a/b/c', true)
+    expect(paths).toEqual(['/a/b/c', '/a/b', '/a', ''])
+  })
+})

--- a/packages/web-app-files/tests/helpers/path.spec.js
+++ b/packages/web-app-files/tests/helpers/path.spec.js
@@ -16,10 +16,22 @@ describe('build an array of parent paths from a provided path', () => {
     expect(paths).toEqual(['/a/b', '/a', ''])
   })
 
-  it('should make no difference between "a/b/c" and "/a/b/c"', () => {
+  it('should make no difference between "a/b/c" and "/a/b/c" with includeCurrent=false', () => {
     const paths1 = getParentPaths('a/b/c', false)
     const paths2 = getParentPaths('/a/b/c', false)
     expect(paths1).toEqual(paths2)
+  })
+
+  it('should make no difference between "a/b/c" and "/a/b/c" with includeCurrent=true', () => {
+    const paths1 = getParentPaths('a/b/c', true)
+    const paths2 = getParentPaths('/a/b/c', true)
+    expect(paths1).toEqual(paths2)
+  })
+
+  it('should have different results for different values of includeCurrent', () => {
+    const paths1 = getParentPaths('a/b/c', true)
+    const paths2 = getParentPaths('a/b/c', false)
+    expect(paths1).not.toEqual(paths2)
   })
 
   it('should not interpret a trailing slash as yet another path segment', () => {


### PR DESCRIPTION
## Description
We had a bug that caused loading incoming and outgoing shares of the current folder twice (leading to two extra requests). Fixed it by cleaning up the helper for building parent paths. Added unit tests.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/4860

## Motivation and Context
Bugfixing

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- unit tests + looking at the network tab and not seeing duplicate share listing requests anymore for the current folder.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 