### PR TITLE
[Tests-Only]Remove enable previews in setup in drone.star

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1565,7 +1565,6 @@ def setupServerAndApp(logLevel):
 			'php occ config:list',
 			'php occ config:system:set skeletondirectory --value=/var/www/owncloud/server/apps/testing/data/webUISkeleton',
 			'php occ config:system:set dav.enable.tech_preview  --type=boolean --value=true',
-			'php occ config:system:set enable_previews  --type=boolean --value=true',
 			'php occ config:system:set web.baseUrl --value="http://web"',
 			'php occ config:system:set sharing.federation.allowHttpFallback --value=true --type=bool'
 		]

--- a/tests/acceptance/stepDefinitions/generalContext.js
+++ b/tests/acceptance/stepDefinitions/generalContext.js
@@ -9,7 +9,6 @@ const occHelper = require('../helpers/occHelper')
 
 let initialConfigJsonSettings
 let createdFiles = []
-let oldPreviewSetting = ''
 
 Given(
   'a file with the size of {string} bytes and the name {string} has been created locally',
@@ -297,19 +296,8 @@ Before(function() {
   }
 })
 
-const getConfigSystem = async function(name) {
+Before({ tags: '@disablePreviews' }, () => {
   if (!client.globals.ocis) {
-    const value = await occHelper.runOcc(['config:system:get ' + name])
-    return value.ocs.data.stdOut
-  }
-}
-
-Before({ tags: '@disablePreviews' }, async () => {
-  if (!client.globals.ocis) {
-    if (!oldPreviewSetting) {
-      oldPreviewSetting = await getConfigSystem('enable_previews')
-      oldPreviewSetting = oldPreviewSetting.toString().trim()
-    }
     occHelper.runOcc(['config:system:set enable_previews --type=boolean --value=false'])
   }
 })


### PR DESCRIPTION
## Description
This PR reverts the config system setup done in drone.star in this PR https://github.com/owncloud/web/pull/4908 as it is not necessary.  Also, the use of `oldPreviewSetting` is redundant as the configs set in the before steps are rolled back again with the previously existing function.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...