### PR TITLE
[Tests-Only]Unskip trashbinFilesFolders tests

### DIFF
--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -11,7 +11,7 @@ Feature: rename files
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 
-  @smokeTest @ocisSmokeTest
+  @smokeTest @ocisSmokeTest @disablePreviews
   Scenario Outline: Rename a file
     When the user renames file "lorem.txt" to <to_file_name> using the webUI
     Then file <to_file_name> should be listed on the webUI

--- a/tests/acceptance/features/webUITrashbinFilesFolders/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/webUITrashbinFilesFolders/trashbinFilesFolders.feature
@@ -19,7 +19,7 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "Alice" has uploaded file "lorem.txt" to "strängé नेपाली folder/lorem.txt"
     And user "Alice" has logged in using the webUI
 
-  @smokeTest @ocis-reva-issue-111 @skipOnOCIS @issue-product-186 @skip @disablePreviews
+  @smokeTest @ocis-reva-issue-111 @skipOnOCIS @issue-product-186 @disablePreviews
   Scenario: Delete files & folders one by one and check that they are all in the trashbin
     When the user deletes the following elements using the webUI
       | name                                  |


### PR DESCRIPTION
## Description
This Pr unskips trashbinFilesFolders tests. Also, the intermittent failing rename files tests are tagged with `disablePreviews` tag

## Related Issue
- https://github.com/owncloud/web/issues/4919

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...