### PR TITLE
Update web container

### DIFF
--- a/changelog/unreleased/bugfix-improve-web-container
+++ b/changelog/unreleased/bugfix-improve-web-container
@@ -1,0 +1,5 @@
+Bugfix: Improve web container
+
+The wrapping `index.html.ejs` had some minor problems with HTML validators which are now fixed.
+
+https://github.com/owncloud/web/pull/4942

--- a/packages/web-container/index.html.ejs
+++ b/packages/web-container/index.html.ejs
@@ -28,9 +28,9 @@
 <body>
   <div id="owncloud"></div>
   <noscript>
-    <div id="enable-js-banner"><span id="banner-content"><h3>Please enable JavaScript</h3></span></div>
+    <div id="enable-js-banner"><h3 id="banner-content">Please enable JavaScript</h3></div>
   </noscript>
-  <script type="text/javascript">
+  <script>
     requirejs.config({
       baseUrl: <%- JSON.stringify(data.roots.js) %>,
       paths: <%- JSON.stringify(data.bundle.js) %>

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -92,7 +92,7 @@ const plugins = [
       },
       {
         'http-equiv': 'x-ua-compatible',
-        content: 'IE=11'
+        content: 'IE=edge'
       }
     ],
     template: ({ attributes, files, meta, publicPath, title }) => {


### PR DESCRIPTION
## Description
- A `meta` element with an `http-equiv` attribute whose value is X-UA-Compatible must have a content attribute with the value `IE=edge`. (fixed in rollup)
- Element `h3` not allowed as child of element `span` in this context.
- The type attribute is unnecessary for JavaScript resources.