### PR TITLE
[Tests-Only]Removed duplicated scenario in shareWithUsers feature

### DIFF
--- a/tests/acceptance/features/webUISharingInternalUsersToRootCollaborator/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersToRootCollaborator/shareWithUsers.feature
@@ -116,14 +116,3 @@ Feature: Shares collaborator list
       | file_target | /simple-folder (2) |
       | item_type   | folder             |
       | permissions | read,share         |
-
-  @issue-2898
-  Scenario: see resource owner of parent shares in collaborators list
-    Given user "Carol" has been created with default attributes
-    And user "Alice" has shared folder "simple-folder" with user "Brian"
-    And user "Brian" has shared folder "simple-folder (2)" with user "Carol"
-    And user "Carol" has logged in using the webUI
-    And the user opens folder "simple-folder (2)" using the webUI
-    When the user opens the share dialog for folder "simple-empty-folder" using the webUI
-    Then user "Alice Hansen" should be listed as "Owner" reshared through "Brian Murphy" via "simple-folder (2)" in the collaborators list on the webUI
-    And the current collaborators list should have order "Alice Hansen,Carol King"


### PR DESCRIPTION
## Description
Removed duplicated scenario share a file with another internal user via collaborators quick action. The same scenario was in https://github.com/owncloud/web/blob/d901d2e67dda7ce024917bc5f94f705fdb4714ca/tests/acceptance/features/webUISharingInternalUsersToRootCollaborator/shareWithUsers.feature#L53 and https://github.com/owncloud/web/blob/d901d2e67dda7ce024917bc5f94f705fdb4714ca/tests/acceptance/features/webUISharingInternalUsersToRootCollaborator/shareWithUsers.feature#L121

## How Has This Been Tested?
- 🤖 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
