### PR TITLE
[Tests-Only] Refactor `webUIInternalUsersToRoot` tests to not use skeleton files (part 1)

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -242,7 +242,7 @@ config = {
 					'webUITags',
 					'webUIWebdavLockProtection',
 					'webUIWebdavLocks',
-					],
+				],
 				'iPhone2': [
 					'webUIMoveFilesFolders',
 					'webUIResharing1',
@@ -272,6 +272,7 @@ config = {
 					'webUISharingInternalUsersToRootSharingIndicator',
 					'webUISharingInternalUsersExpireToRoot',
 					'webUISharingInternalUsersToRoot',
+					'webUISharingInternalUsersToRootBlacklisted',
 					'webUISharingPermissionsUsers',
 					'webUISharingPermissionToRoot',
 					'webUISharingPublicBasic',

--- a/tests/acceptance/features/webUISharingInternalUsersToRoot/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersToRoot/shareWithUsers.feature
@@ -5,15 +5,18 @@ Feature: Sharing files and folders with internal users
   So that those users can access the files and folders
 
   Background:
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
 
   @yetToImplement @smokeTest
   Scenario Outline: share a file & folder with another internal user
-    Given user "Brian" has logged in using the webUI
-    And the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    And user "Brian" has created folder "simple-folder"
+    And user "Brian" has created file "simple-folder/lorem.txt"
+    And user "Brian" has uploaded file "testavatar.jpg" to "testimage.jpg"
+    And user "Brian" has logged in using the webUI
     When the user shares folder "simple-folder" with user "Alice Hansen" as "<set-role>" using the webUI
     And the user shares file "testimage.jpg" with user "Alice Hansen" as "<set-role>" using the webUI
     Then user "Alice Hansen" should be listed as "<expected-role>" in the collaborators list for folder "simple-folder" on the webUI
@@ -22,28 +25,28 @@ Feature: Sharing files and folders with internal users
       | field       | value                |
       | uid_owner   | Brian                |
       | share_with  | Alice                |
-      | file_target | /simple-folder (2)   |
+      | file_target | /simple-folder       |
       | item_type   | folder               |
       | permissions | <permissions-folder> |
     And user "Alice" should have received a share with these details:
       | field       | value              |
       | uid_owner   | Brian              |
       | share_with  | Alice              |
-      | file_target | /testimage (2).jpg |
+      | file_target | /testimage.jpg     |
       | item_type   | file               |
       | permissions | <permissions-file> |
     And as "Alice" these resources should be listed on the webUI
-      | entry_name        |
-      | simple-folder (2) |
-      | testimage (2).jpg |
-    And these resources should be listed in the folder "simple-folder (2)" on the webUI
+      | entry_name    |
+      | simple-folder |
+      | testimage.jpg |
+    And these resources should be listed in the folder "simple-folder" on the webUI
       | entry_name |
       | lorem.txt  |
-    But these resources should not be listed in the folder "simple-folder (2)" on the webUI
-      | entry_name        |
-      | simple-folder (2) |
-    #    And folder "simple-folder (2)" should be marked as shared by "Brian Murphy" on the webUI
-    #    And file "testimage (2).jpg" should be marked as shared by "Brian Murphy" on the webUI
+    But these resources should not be listed in the folder "simple-folder" on the webUI
+      | entry_name    |
+      | simple-folder |
+    #    And folder "simple-folder" should be marked as shared by "Brian Murphy" on the webUI
+    #    And file "testimage.jpg" should be marked as shared by "Brian Murphy" on the webUI
     Examples:
       | set-role             | expected-role        | permissions-folder              | permissions-file  |
       | Viewer               | Viewer               | read,share                      | read,share        |
@@ -52,8 +55,8 @@ Feature: Sharing files and folders with internal users
 
 
   Scenario: share a file with another internal user who overwrites and unshares the file
-    Given user "Brian" has logged in using the webUI
-    And user "Brian" has renamed file "lorem.txt" to "new-lorem.txt"
+    Given user "Brian" has created file "new-lorem.txt"
+    And user "Brian" has logged in using the webUI
     And user "Brian" has shared file "new-lorem.txt" with user "Alice" with "all" permissions
     When the user re-logs in as "Alice" using the webUI
     Then as "Alice" the content of "new-lorem.txt" should not be the same as the local "new-lorem.txt"
@@ -69,9 +72,11 @@ Feature: Sharing files and folders with internal users
 
 
   Scenario: share a folder with another internal user who uploads, overwrites and deletes files
-    Given user "Brian" has logged in using the webUI
-    When the user renames folder "simple-folder" to "new-simple-folder" using the webUI
-    And the user shares folder "new-simple-folder" with user "Alice Hansen" as "Editor" using the webUI
+    Given user "Brian" has created folder "new-simple-folder"
+    And user "Brian" has created file "new-simple-folder/lorem.txt"
+    And user "Brian" has uploaded file "data.zip" to "new-simple-folder/data.zip"
+    And user "Brian" has logged in using the webUI
+    When the user shares folder "new-simple-folder" with user "Alice Hansen" as "Editor" using the webUI
     And the user re-logs in as "Alice" using the webUI
     And the user opens folder "new-simple-folder" using the webUI
     Then as "Alice" the content of "new-simple-folder/lorem.txt" should not be the same as the local "lorem.txt"
@@ -96,9 +101,10 @@ Feature: Sharing files and folders with internal users
 
 
   Scenario: share a folder with another internal user who unshares the folder
-    Given user "Brian" has logged in using the webUI
-    When the user renames folder "simple-folder" to "new-simple-folder" using the webUI
-    And the user shares folder "new-simple-folder" with user "Alice Hansen" as "Editor" using the webUI
+    Given user "Brian" has created folder "new-simple-folder"
+    And user "Brian" has uploaded file "lorem.txt" to "new-simple-folder/lorem.txt"
+    And user "Brian" has logged in using the webUI
+    When the user shares folder "new-simple-folder" with user "Alice Hansen" as "Editor" using the webUI
     # unshare the received shared folder and check it is gone
     And the user re-logs in as "Alice" using the webUI
     Then folder "new-simple-folder" should be listed on the webUI
@@ -107,49 +113,55 @@ Feature: Sharing files and folders with internal users
     # check that the folder is still visible for the share owner
     When the user re-logs in as "Brian" using the webUI
     Then folder "new-simple-folder" should be listed on the webUI
-    And as "Brian" the content of "new-simple-folder/lorem.txt" should be the same as the original "simple-folder/lorem.txt"
+    And as "Brian" the content of "new-simple-folder/lorem.txt" should be the same as the local "lorem.txt"
 
 
   Scenario: share a folder with another internal user and prohibit deleting
-    Given user "Brian" has logged in using the webUI
+    Given user "Brian" has created folder "simple-folder"
+    And user "Brian" has created file "simple-folder/lorem.txt"
+    And user "Brian" has logged in using the webUI
     And user "Brian" has shared folder "simple-folder" with user "Alice" with "create, read, share" permissions
     And the user re-logs in as "Alice" using the webUI
-    And the user opens folder "simple-folder (2)" using the webUI
+    And the user opens folder "simple-folder" using the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
 
   Scenario: user shares the file/folder with another internal user and delete the share with user
-    Given user "Alice" has logged in using the webUI
+    Given user "Alice" has created file "lorem.txt"
+    And user "Alice" has logged in using the webUI
     And user "Alice" has shared file "lorem.txt" with user "Brian"
     When the user opens the share dialog for file "lorem.txt" using the webUI
     Then user "Brian Murphy" should be listed as "Editor" in the collaborators list on the webUI
-    And as "Brian" file "lorem (2).txt" should exist
+    And as "Brian" file "lorem.txt" should exist
     When the user deletes "Brian Murphy" as collaborator for the current file using the webUI
     Then user "Brian Murphy" should not be listed in the collaborators list on the webUI
     And file "lorem.txt" should not be listed in shared-with-others page on the webUI
-    And as "Brian" file "lorem (2).txt" should not exist
+    And as "Brian" file "lorem.txt" should not exist
 
 
   Scenario: user shares the file/folder with multiple internal users and delete the share with one user
-    Given user "Carol" has been created with default attributes
+    Given user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has created file "lorem.txt"
     And user "Alice" has logged in using the webUI
     And user "Alice" has shared file "lorem.txt" with user "Brian"
     And user "Alice" has shared file "lorem.txt" with user "Carol"
     When the user opens the share dialog for file "lorem.txt" using the webUI
     Then user "Brian Murphy" should be listed as "Editor" in the collaborators list on the webUI
     And user "Carol King" should be listed as "Editor" in the collaborators list on the webUI
-    And as "Brian" file "lorem (2).txt" should exist
-    And as "Carol" file "lorem (2).txt" should exist
+    And as "Brian" file "lorem.txt" should exist
+    And as "Carol" file "lorem.txt" should exist
     When the user deletes "Brian Murphy" as collaborator for the current file using the webUI
     Then user "Brian Murphy" should not be listed in the collaborators list on the webUI
     And user "Carol King" should be listed as "Editor" in the collaborators list on the webUI
     And file "lorem.txt" should be listed in shared-with-others page on the webUI
-    And as "Brian" file "lorem (2).txt" should not exist
-    But as "Carol" file "lorem (2).txt" should exist
+    And as "Brian" file "lorem.txt" should not exist
+    But as "Carol" file "lorem.txt" should exist
 
 
   Scenario: Try to share file and folder that used to exist but does not anymore
-    Given user "Alice" has logged in using the webUI
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has created file "lorem.txt"
+    And user "Alice" has logged in using the webUI
     And the following files have been deleted by user "Alice"
       | name          |
       | lorem.txt     |
@@ -169,7 +181,9 @@ Feature: Sharing files and folders with internal users
 
   @issue-2897
   Scenario: sharing details of items inside a shared folder
-    Given user "Carol" has been created with default attributes
+    Given user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "simple-folder"
+    And user "Alice" has created folder "simple-folder/simple-empty-folder"
     And user "Alice" has uploaded file with content "test" to "/simple-folder/lorem.txt"
     And user "Alice" has shared folder "simple-folder" with user "Brian"
     And user "Alice" has logged in using the webUI
@@ -181,20 +195,23 @@ Feature: Sharing files and folders with internal users
 
   @issue-2897
   Scenario: sharing details of items inside a re-shared folder
-    Given user "Carol" has been created with default attributes
+    Given user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "simple-folder"
+    And user "Alice" has created folder "simple-folder/simple-empty-folder"
     And user "Alice" has uploaded file with content "test" to "/simple-folder/lorem.txt"
     And user "Alice" has shared folder "simple-folder" with user "Brian"
-    And user "Brian" has shared folder "simple-folder (2)" with user "Carol"
+    And user "Brian" has shared folder "simple-folder" with user "Carol"
     And user "Brian" has logged in using the webUI
-    And the user opens folder "simple-folder (2)" using the webUI
+    And the user opens folder "simple-folder" using the webUI
     When the user opens the share dialog for folder "simple-empty-folder" using the webUI
-    Then user "Carol King" should be listed as "Editor" via "simple-folder (2)" in the collaborators list on the webUI
+    Then user "Carol King" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
     When the user opens the share dialog for file "lorem.txt" using the webUI
-    Then user "Carol King" should be listed as "Editor" via "simple-folder (2)" in the collaborators list on the webUI
+    Then user "Carol King" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
 
   @issue-2897
   Scenario: sharing details of items inside a shared folder shared with multiple users
-    Given user "Carol" has been created with default attributes
+    Given user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "simple-folder"
     And user "Alice" has created folder "/simple-folder/sub-folder"
     And user "Alice" has uploaded file with content "test" to "/simple-folder/sub-folder/lorem.txt"
     And user "Alice" has shared folder "simple-folder" with user "Brian"
@@ -207,10 +224,10 @@ Feature: Sharing files and folders with internal users
 
 
   Scenario Outline: Share files/folders with special characters in their name
-    Given user "Brian" has created folder "Sample,Folder,With,Comma"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    And user "Brian" has created folder "Sample,Folder,With,Comma"
     And user "Brian" has created file "sample,1.txt"
     And user "Brian" has logged in using the webUI
-    And the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
     When the user shares folder "Sample,Folder,With,Comma" with user "Alice Hansen" as "<set-role>" using the webUI
     And the user shares file "sample,1.txt" with user "Alice Hansen" as "<set-role>" using the webUI
     Then user "Alice Hansen" should be listed as "<expected-role>" in the collaborators list for folder "Sample,Folder,With,Comma" on the webUI
@@ -239,44 +256,13 @@ Feature: Sharing files and folders with internal users
       | Editor               | Editor               | read,update,create,delete,share | read,update,share |
       | Advanced permissions | Advanced permissions | read                            | read              |
 
-    Scenario Outline: Share files/folders with special characters in their name (duplicate)
-      Given user "Brian" has created folder "Sample,Folder,With,Comma"
-      And user "Brian" has created file "sample,1.txt"
-      And user "Brian" has logged in using the webUI
-      And the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
-      When the user shares folder "Sample,Folder,With,Comma" with user "Alice Hansen" as "<set-role>" using the webUI
-      And the user shares file "sample,1.txt" with user "Alice Hansen" as "<set-role>" using the webUI
-      Then user "Alice Hansen" should be listed as "<expected-role>" in the collaborators list for folder "Sample,Folder,With,Comma" on the webUI
-      And user "Alice Hansen" should be listed as "<expected-role>" in the collaborators list for file "sample,1.txt" on the webUI
-      And user "Alice" should have received a share with these details:
-        | field       | value                    |
-        | uid_owner   | Brian                    |
-        | share_with  | Alice                    |
-        | file_target | /Sample,Folder,With,Comma |
-        | item_type   | folder                   |
-        | permissions | <permissions-folder>     |
-      And user "Alice" should have received a share with these details:
-        | field       | value              |
-        | uid_owner   | Brian              |
-        | share_with  | Alice              |
-        | file_target | /sample,1.txt      |
-        | item_type   | file               |
-        | permissions | <permissions-file> |
-      And as "Alice" these resources should be listed on the webUI
-        | entry_name               |
-        | Sample,Folder,With,Comma |
-        | sample,1.txt             |
-      Examples:
-        | set-role             | expected-role        | permissions-folder              | permissions-file       |
-        | Viewer               | Viewer               | read,share                      | read,share             |
-        | Editor               | Editor               | read,update,create,delete,share | read,update,share      |
-        | Advanced permissions | Advanced permissions | read                            | read                   |
 
   Scenario: file list view image preview in file share
     Given user "Alice" has uploaded file "testavatar.jpg" to "testavatar.jpg"
     And user "Alice" has shared file "testavatar.jpg" with user "Brian"
     When user "Brian" logs in using the webUI
     Then the preview image of file "testavatar.jpg" should be displayed in the file list view on the webUI
+
 
   Scenario: file list view image preview in file share when previews is disabled
     Given the property "disablePreviews" of "options" has been set to true in web config file
@@ -285,9 +271,10 @@ Feature: Sharing files and folders with internal users
     When user "Brian" logs in using the webUI
     Then the preview image of file "testavatar.jpg" should not be displayed in the file list view on the webUI
 
+
   Scenario: sharing file after renaming it is possible
-    Given user "Alice" has logged in using the webUI
-    And user "Alice" has uploaded file with content "test" to "lorem.txt"
+    Given user "Alice" has uploaded file with content "test" to "lorem.txt"
+    And user "Alice" has logged in using the webUI
     And the user has renamed file "lorem.txt" to "new-lorem.txt"
     When the user shares resource "new-lorem.txt" with user "Brian Murphy" using the quick action in the webUI
     Then user "Brian Murphy" should be listed as "Viewer" in the collaborators list for file "new-lorem.txt" on the webUI

--- a/tests/acceptance/features/webUISharingInternalUsersToRootBlacklisted/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersToRootBlacklisted/shareWithUsers.feature
@@ -5,7 +5,7 @@ Feature: Sharing files and folders with internal users
   So that those users can access the files and folders
 
   Background:
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -14,7 +14,8 @@ Feature: Sharing files and folders with internal users
   Scenario: user tries to share a file from a group which is blacklisted from sharing
     Given group "grp1" has been created
     And user "Alice" has been added to group "grp1"
-    And user "Carol" has been created with default attributes
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "testavatar.jpg" to "testimage.jpg"
     And the administrator has browsed to the admin sharing settings page
     When the administrator enables exclude groups from sharing using the webUI
     And the administrator adds group "grp1" to the group sharing blacklist using the webUI
@@ -22,29 +23,27 @@ Feature: Sharing files and folders with internal users
 
 
   Scenario: member of a blacklisted from sharing group tries to re-share a file or folder received as a share
-    Given these users have been created with default attributes:
-      | username |
-      | Carol    |
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Carol" has created folder "simple-folder"
+    And user "Carol" has uploaded file "testavatar.jpg" to "testimage.jpg"
     And group "grp1" has been created
     And user "Alice" has been added to group "grp1"
-    And the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
     And user "Carol" has shared file "testimage.jpg" with user "Alice"
     And user "Carol" has shared folder "simple-folder" with user "Alice"
     And the administrator has enabled exclude groups from sharing
     And the administrator has excluded group "grp1" from sharing
     When user "Alice" logs in using the webUI
-    Then the user should not be able to share file "testimage (2).jpg" using the webUI
-    And the user should not be able to share folder "simple-folder (2)" using the webUI
+    Then the user should not be able to share file "testimage.jpg" using the webUI
+    And the user should not be able to share folder "simple-folder" using the webUI
 
 
   Scenario: member of a blacklisted from sharing group tries to re-share a file inside a folder received as a share
-    Given these users have been created with default attributes:
-      | username |
-      | Carol    |
+    Given user "Carol" has been created with default attributes and without skeleton files
+    And user "Carol" has created folder "common"
+    And user "Carol" has uploaded file "testavatar.jpg" to "common/testimage.jpg"
     And group "grp1" has been created
     And user "Alice" has been added to group "grp1"
-    And user "Carol" has created folder "common"
-    And user "Carol" has moved file "testimage.jpg" to "common/testimage.jpg"
     And user "Carol" has shared folder "common" with user "Alice"
     And the administrator has enabled exclude groups from sharing
     And the administrator has excluded group "grp1" from sharing
@@ -54,13 +53,11 @@ Feature: Sharing files and folders with internal users
 
 
   Scenario: member of a blacklisted from sharing group tries to re-share a folder inside a folder received as a share
-    Given these users have been created with default attributes:
-      | username |
-      | Carol    |
-    And group "grp1" has been created
-    And user "Alice" has been added to group "grp1"
+    Given user "Carol" has been created with default attributes and without skeleton files
     And user "Carol" has created folder "common"
     And user "Carol" has created folder "common/inside-common"
+    And group "grp1" has been created
+    And user "Alice" has been added to group "grp1"
     And user "Carol" has shared folder "common" with user "Alice"
     And the administrator has enabled exclude groups from sharing
     And the administrator has excluded group "grp1" from sharing
@@ -70,7 +67,9 @@ Feature: Sharing files and folders with internal users
 
 
   Scenario: user tries to share a file or folder from a group which is blacklisted from sharing from files page
-    Given group "grp1" has been created
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has uploaded file "testavatar.jpg" to "testimage.jpg"
+    And group "grp1" has been created
     And user "Alice" has been added to group "grp1"
     And the administrator has enabled exclude groups from sharing
     And the administrator has excluded group "grp1" from sharing
@@ -80,13 +79,13 @@ Feature: Sharing files and folders with internal users
 
 
   Scenario: user tries to re-share a file from a group which is blacklisted from sharing using webUI from shared with you page
-    Given group "grp1" has been created
+    Given user "Brian" has uploaded file "testavatar.jpg" to "testimage.jpg"
+    And group "grp1" has been created
     And user "Alice" has been added to group "grp1"
-    And user "Carol" has been created with default attributes
     And user "Brian" has shared file "/testimage.jpg" with user "Alice"
     And the administrator has enabled exclude groups from sharing
     And the administrator has excluded group "grp1" from sharing
     And user "Alice" has logged in using the webUI
     When the user browses to the shared-with-me page
-    And the user opens the share dialog for file "testimage (2).jpg" using the webUI
-    Then the user should not be able to share file "testimage (2).jpg" using the webUI
+    And the user opens the share dialog for file "testimage.jpg" using the webUI
+    Then the user should not be able to share file "testimage.jpg" using the webUI

--- a/tests/acceptance/features/webUISharingInternalUsersToRootCollaborator/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersToRootCollaborator/shareWithUsers.feature
@@ -5,24 +5,25 @@ Feature: Shares collaborator list
   So that I can know the collaborators of a shared resource
 
   Background:
-    Given these users have been created with default attributes:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
+    And user "Alice" has created folder "simple-folder"
 
   Scenario Outline: change the collaborators of a file & folder
-    Given user "Brian" has logged in using the webUI
-    And user "Brian" has shared folder "/simple-folder" with user "Alice" with "<initial-permissions>" permissions
-    When the user changes the collaborator role of "Alice Hansen" for folder "simple-folder" to "<set-role>" using the webUI
+    Given user "Alice" has logged in using the webUI
+    And user "Alice" has shared folder "/simple-folder" with user "Brian" with "<initial-permissions>" permissions
+    When the user changes the collaborator role of "Brian Murphy" for folder "simple-folder" to "<set-role>" using the webUI
     # check role without reloading the collaborators panel, see issue #1786
-    Then user "Alice Hansen" should be listed as "<expected-role>" in the collaborators list on the webUI
+    Then user "Brian Murphy" should be listed as "<expected-role>" in the collaborators list on the webUI
     # check role after reopening the collaborators panel
-    And user "Alice Hansen" should be listed as "<expected-role>" in the collaborators list for folder "simple-folder" on the webUI
-    And user "Alice" should have received a share with these details:
+    And user "Brian Murphy" should be listed as "<expected-role>" in the collaborators list for folder "simple-folder" on the webUI
+    And user "Brian" should have received a share with these details:
       | field       | value                  |
-      | uid_owner   | Brian                  |
-      | share_with  | Alice                  |
-      | file_target | /simple-folder (2)     |
+      | uid_owner   | Alice                  |
+      | share_with  | Brian                  |
+      | file_target | /simple-folder         |
       | item_type   | folder                 |
       | permissions | <expected-permissions> |
     Examples:
@@ -36,28 +37,29 @@ Feature: Shares collaborator list
   Scenario: see resource owner in collaborators list for direct shares
     Given user "Alice" has shared folder "simple-folder" with user "Brian"
     And user "Brian" has logged in using the webUI
-    When the user opens the share dialog for folder "simple-folder (2)" using the webUI
+    When the user opens the share dialog for folder "simple-folder" using the webUI
     Then user "Alice Hansen" should be listed as "Owner" in the collaborators list on the webUI
 
   @issue-2898
   Scenario: see resource owner in collaborators list for reshares
-    Given user "Carol" has been created with default attributes
+    Given user "Carol" has been created with default attributes and without skeleton files
     And user "Alice" has shared folder "simple-folder" with user "Brian"
-    And user "Brian" has shared folder "simple-folder (2)" with user "Carol"
+    And user "Brian" has shared folder "simple-folder" with user "Carol"
     And user "Carol" has logged in using the webUI
-    When the user opens the share dialog for folder "simple-folder (2)" using the webUI
+    When the user opens the share dialog for folder "simple-folder" using the webUI
     Then user "Alice Hansen" should be listed as "Owner" reshared through "Brian Murphy" in the collaborators list on the webUI
     And the current collaborators list should have order "Alice Hansen,Carol King"
 
   @issue-2898
   Scenario: see resource owner of parent shares in collaborators list
-    Given user "Carol" has been created with default attributes
+    Given user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "simple-folder/simple-empty-folder"
     And user "Alice" has shared folder "simple-folder" with user "Brian"
-    And user "Brian" has shared folder "simple-folder (2)" with user "Carol"
+    And user "Brian" has shared folder "simple-folder" with user "Carol"
     And user "Carol" has logged in using the webUI
-    And the user opens folder "simple-folder (2)" using the webUI
+    And the user opens folder "simple-folder" using the webUI
     When the user opens the share dialog for folder "simple-empty-folder" using the webUI
-    Then user "Alice Hansen" should be listed as "Owner" reshared through "Brian Murphy" via "simple-folder (2)" in the collaborators list on the webUI
+    Then user "Alice Hansen" should be listed as "Owner" reshared through "Brian Murphy" via "simple-folder" in the collaborators list on the webUI
     And the current collaborators list should have order "Alice Hansen,Carol King"
 
 
@@ -91,7 +93,7 @@ Feature: Shares collaborator list
   Scenario: collaborators list contains the current user when they are a receiver of the resource
     Given user "Alice" has shared folder "simple-folder" with user "Brian"
     When user "Brian" has logged in using the webUI
-    And the user opens the share dialog for folder "simple-folder (2)" using the webUI
+    And the user opens the share dialog for folder "simple-folder" using the webUI
     Then user "Brian Murphy" should be listed with additional info "(me)" in the collaborators list on the webUI
 
 
@@ -101,18 +103,18 @@ Feature: Shares collaborator list
     And user "Alice" has shared folder "simple-folder" with user "Brian" with "read" permission
     And user "Alice" has shared folder "simple-folder" with group "grp1" with "read,update,create,delete" permissions
     When user "Brian" has logged in using the webUI
-    Then user "Brian Murphy" should be listed as "Advanced permissions" in the collaborators list for folder "simple-folder (2)" on the webUI
+    Then user "Brian Murphy" should be listed as "Advanced permissions" in the collaborators list for folder "simple-folder" on the webUI
 
 
   Scenario: share a file with another internal user via collaborators quick action
-    Given user "Alice" has logged in using the webUI
-    And the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    And user "Alice" has logged in using the webUI
     When the user shares resource "simple-folder" with user "Brian Murphy" using the quick action in the webUI
     Then user "Brian Murphy" should be listed as "Viewer" in the collaborators list for folder "simple-folder" on the webUI
     And user "Brian" should have received a share with these details:
       | field       | value              |
       | uid_owner   | Alice              |
       | share_with  | Brian              |
-      | file_target | /simple-folder (2) |
+      | file_target | /simple-folder     |
       | item_type   | folder             |
       | permissions | read,share         |


### PR DESCRIPTION
## Description
Refactor  `webUIResharing` and `webUIResharingToRoot`  tests to not use skeleton files:
- webUIInternalUsersToRoot
- webUIInternalUsersToRootBlacklisted
- webUIInternalUsersToRootCollaborator

## Related Issue
https://github.com/owncloud/QA/issues/659

## How Has This Been Tested?
- test environment: :robot: 

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 