### PR TITLE
[Tests-Only] Refactor `webUISharingExternal` tests to not use skeleton files

### DIFF
--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -343,9 +343,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "simple-folder"
-    And user "Alice" has created folder "simple-folder/sub-folder"
-    And user "Alice" has created folder "simple-folder/sub-folder/simple-empty-folder"
-    And user "Alice" has created file "simple-folder/sub-folder/lorem.txt"
+    And user "Alice" has created folder "simple-folder/simple-empty-folder"
+    And user "Alice" has created file "simple-folder/lorem.txt"
     And user "Alice" has shared folder "simple-folder" with user "Brian"
     And user "Brian" has accepted the share "simple-folder" offered by user "Alice"
     When the user re-logs in as "Brian" using the webUI
@@ -355,7 +354,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Then the following resources should have share indicators on the webUI
       | fileName      | expectedIndicators |
       | simple-folder | user-indirect      |
-    When the user opens folder "/Shares/simple-folder/sub-folder" directly on the webUI
+    When the user opens folder "simple-folder" using the webUI
     Then the following resources should have share indicators on the webUI
       | fileName            | expectedIndicators |
       | simple-empty-folder | user-direct        |

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -16,12 +16,16 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And server "%backend_url%" has been added as trusted server
     And server "%backend_url%" has been added as trusted server on remote server
     And server "%remote_backend_url%" has been added as trusted server on remote server
-    And user "Alice" has been created with default attributes on remote server
-    And user "Alice" has been created with default attributes
+    And user "Alice" has been created with default attributes and without skeleton files on remote server
+    And user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has logged in using the webUI
 
 
   Scenario: test the single steps of sharing a folder to a remote server
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has created folder "simple-empty-folder"
+    And user "Alice" has created file "simple-folder/lorem.txt"
+    And the user has reloaded the current page of the webUI
     When the user shares folder "simple-folder" with remote user "Alice" as "Editor" using the webUI
     And user "Alice" from server "REMOTE" accepts the last pending share using the sharing API
     And the user shares folder "simple-empty-folder" with remote user "Alice" as "Editor" using the webUI
@@ -32,8 +36,12 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-2510 @yetToImplement
   Scenario: test the single steps of receiving a federation share
-    Given user "Brian" has been created with default attributes on remote server
-    And user "Carol" has been created with default attributes on remote server
+    Given user "Brian" has been created with default attributes and without skeleton files on remote server
+    And user "Carol" has been created with default attributes and without skeleton files on remote server
+    And user "Alice" has created folder "simple-folder" on remote server
+    And user "Alice" has uploaded file "lorem.txt" to "simple-folder/lorem.txt" on remote server
+    And user "Brian" has created folder "simple-empty-folder" on remote server
+    And user "Carol" has uploaded file "lorem.txt" to "lorem.txt" on remote server
     And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server
     And user "Brian" from remote server has shared "simple-empty-folder" with user "Alice" from local server
     And user "Carol" from remote server has shared "lorem.txt" with user "Alice" from local server
@@ -47,11 +55,11 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And the user reloads the current page of the webUI
     And the user opens folder "Shares" using the webUI
     Then file "lorem.txt" should be listed on the webUI
-    And as "Alice" the content of "Shares/lorem.txt" should be the same as the original "lorem.txt"
+    And as "Alice" the content of "Shares/lorem.txt" should be the same as the local "lorem.txt"
     And folder "simple-folder" should be listed on the webUI
     And the user opens folder "simple-folder" using the webUI
     And file "lorem.txt" should be listed on the webUI
-    And as "Alice" the content of "Shares/simple-folder/lorem.txt" should be the same as the original "simple-folder/lorem.txt"
+    And as "Alice" the content of "Shares/simple-folder/lorem.txt" should be the same as the local "lorem.txt"
     #    When the user browses to the shared-with-me page
     #    Then file "Shares/lorem.txt" should be listed on the webUI
     #    And folder "Shares/simple-folder" should be listed on the webUI
@@ -59,7 +67,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
 
   Scenario: declining a federation share on the webUI
-    Given user "Alice" from remote server has shared "/lorem.txt" with user "Alice" from local server
+    Given user "Alice" has created file "lorem.txt" on remote server
+    And user "Alice" from remote server has shared "/lorem.txt" with user "Alice" from local server
     And the user has reloaded the current page of the webUI
     When the user declines all shares displayed in the notifications on the webUI
     Then folder "Shares" should not be listed on the webUI
@@ -69,6 +78,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
 
   Scenario: share a folder with an remote user with "Viewer" role
+    Given user "Alice" has created folder "simple-empty-folder"
+    And the user has reloaded the current page of the webUI
     When the user shares folder "simple-empty-folder" with remote user "Alice" as "Viewer" using the webUI
     And user "Alice" from server "REMOTE" accepts the last pending share using the sharing API
     Then user "Alice" should have shared a folder "simple-empty-folder" with these details:
@@ -81,7 +92,9 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-3309 @issue-4247
   Scenario: share a folder with an remote user and prohibit deleting - remote server shares - local server receives
-    Given user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server with "read" permissions
+    Given user "Alice" has created folder "simple-folder" on remote server
+    And user "Alice" has created file "simple-folder/lorem.txt" on remote server
+    And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server with "read" permissions
     When the user reloads the current page of the webUI
     And the user accepts all shares displayed in the notifications on the webUI
     And the user reloads the current page of the webUI
@@ -91,7 +104,9 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-3309
   Scenario: overwrite a file in a received share - remote server shares - local server receives
-    Given user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server
+    Given user "Alice" has created folder "simple-folder" on remote server
+    And user "Alice" has created file "simple-folder/lorem.txt" on remote server
+    And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server
     And user "Alice" from server "LOCAL" has accepted the last pending share
     When the user reloads the current page of the webUI
     And the user opens folder "Shares" using the webUI
@@ -101,7 +116,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-3309
   Scenario: upload a new file in a received share - remote server shares - local server receives
-    Given user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server
+    Given user "Alice" has created folder "simple-folder" on remote server
+    And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server
     And user "Alice" from server "LOCAL" has accepted the last pending share
     When the user reloads the current page of the webUI
     And the user opens folder "Shares" using the webUI
@@ -111,7 +127,9 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-3309
   Scenario: rename a file in a received share - remote server shares - local server receives
-    Given user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server
+    Given user "Alice" has created folder "simple-folder" on remote server
+    And user "Alice" has created file "simple-folder/lorem.txt" on remote server
+    And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server
     And user "Alice" from server "LOCAL" has accepted the last pending share
     When the user reloads the current page of the webUI
     And the user opens folder "Shares" using the webUI
@@ -122,7 +140,9 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-3309
   Scenario: delete a file in a received share - remote server shares - local server receives
-    Given user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server
+    Given user "Alice" has created folder "simple-folder" on remote server
+    And user "Alice" has created file "simple-folder/lorem.txt" on remote server
+    And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server
     And user "Alice" from server "LOCAL" has accepted the last pending share
     When the user reloads the current page of the webUI
     And the user opens folder "Shares" using the webUI
@@ -132,7 +152,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @skip @issue-4102
   Scenario: unshare a federation share
-    Given user "Alice" from remote server has shared "lorem.txt" with user "Alice" from local server
+    Given user "Alice" has created file "lorem.txt" on remote server
+    And user "Alice" from remote server has shared "lorem.txt" with user "Alice" from local server
     And user "Alice" from server "LOCAL" has accepted the last pending share
     When the user reloads the current page of the webUI
     And the user opens folder "Shares" using the webUI
@@ -143,21 +164,24 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-2510 @skip @yetToImplement
   Scenario: unshare a federation share from "share-with-you" page
-    Given user "Alice" from server "REMOTE" has shared "/lorem.txt" with user "Alice" from server "LOCAL"
+    Given user "Alice" has created file "lorem.txt" on remote server
+    And user "Alice" from remote server has shared "lorem.txt" with user "Alice" from local server
     And user "Alice" from server "LOCAL" has accepted the last pending share
     And the user has reloaded the current page of the webUI
-    When the user unshares file "lorem (2).txt" using the webUI
-    Then file "lorem (2).txt" should not be listed on the webUI
-    And file "lorem (2).txt" should not be listed in the files page on the webUI
+    When the user unshares file "lorem.txt" using the webUI
+    Then file "lorem.txt" should not be listed on the webUI
+    And file "lorem.txt" should not be listed in the files page on the webUI
 
 
   Scenario: test resharing folder with "Viewer" role
-    Given user "Brian" has been created with default attributes
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "simple-folder" on remote server
+    And user "Alice" has created file "simple-folder/lorem.txt" on remote server
     And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server
     And user "Alice" from server "LOCAL" has accepted the last pending share
     And the user has reloaded the current page of the webUI
-    And the user opens folder "Shares" using the webUI
-    When the user shares folder "simple-folder" with user "Brian Murphy" as "Viewer" using the webUI
+    When the user opens folder "Shares" using the webUI
+    And the user shares folder "simple-folder" with user "Brian Murphy" as "Viewer" using the webUI
     And user "Brian" accepts the share "Shares/simple-folder" offered by user "Alice" using the sharing API
     Then as "Brian" folder "Shares/simple-folder/lorem.txt" should exist
     And user "Brian" should have received a share with these details:
@@ -169,7 +193,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
 
   Scenario: test resharing a federated server to remote again
-    Given user "Brian" has been created with default attributes on remote server
+    Given user "Brian" has been created with default attributes and without skeleton files on remote server
+    And user "Alice" has created folder "simple-folder" on remote server
     And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server with "read, share" permissions
     And user "Alice" from server "LOCAL" has accepted the last pending share
     And the user has reloaded the current page of the webUI
@@ -186,23 +211,28 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
 
   Scenario: try resharing a folder with read-only permissions
-    Given user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server with "read" permissions
+    Given user "Alice" has created folder "simple-folder" on remote server
+    And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server with "read" permissions
     And user "Alice" from server "LOCAL" has accepted the last pending share
-    And the user reloads the current page of the webUI
+    When the user reloads the current page of the webUI
     And the user opens folder "Shares" using the webUI
     Then the user should not be able to share folder "simple-folder" using the webUI
 
 
   Scenario: test sharing long file names with federation share
-    When user "Alice" has uploaded file with content "secret" to "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt"
+    Given user "Alice" has uploaded file with content "secret" to "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt"
     And the user has reloaded the current page of the webUI
-    And the user shares file "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" with remote user "Alice" as "Viewer" using the webUI
+    When the user shares file "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" with remote user "Alice" as "Viewer" using the webUI
     And user "Alice" from server "REMOTE" accepts the last pending share using the sharing API
     Then as "Alice" file "Shares/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should exist on remote server
 
 
   Scenario: sharee should be able to access the files/folders inside other folder
-    Given user "Alice" from remote server has shared "'single'quotes" with user "Alice" from local server
+    Given user "Alice" has created folder "'single'quotes" on remote server
+    And user "Alice" has created folder "'single'quotes/simple-empty-folder" on remote server
+    And user "Alice" has uploaded file "lorem.txt" to "'single'quotes/lorem.txt" on remote server
+    And user "Alice" has uploaded file "lorem.txt" to "'single'quotes/simple-empty-folder/lorem.txt" on remote server
+    And user "Alice" from remote server has shared "'single'quotes" with user "Alice" from local server
     And user "Alice" from server "LOCAL" has accepted the last pending share
     And the user has reloaded the current page of the webUI
     When the user opens folder "Shares" using the webUI
@@ -210,20 +240,21 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Then as "Alice" these resources should be listed on the webUI
       | entry_name          |
       | simple-empty-folder |
-      | for-git-commit      |
       | lorem.txt           |
     When the user opens folder "simple-empty-folder" using the webUI
     Then as "Alice" these resources should be listed on the webUI
       | entry_name     |
-      | for-git-commit |
-    When the user downloads file "for-git-commit" using the webUI
+      | lorem.txt      |
+    When the user downloads file "lorem.txt" using the webUI
     Then no message should be displayed on the webUI
-    And as "Alice" the content of "Shares/'single'quotes/lorem.txt" should be the same as the original "'single'quotes/lorem.txt"
-    And as "Alice" the content of "Shares/'single'quotes/simple-empty-folder/for-git-commit" should be the same as the original "'single'quotes/simple-empty-folder/for-git-commit"
+    And as "Alice" the content of "Shares/'single'quotes/lorem.txt" should be the same as the local "lorem.txt"
+    And as "Alice" the content of "Shares/'single'quotes/simple-empty-folder/lorem.txt" should be the same as the local "lorem.txt"
 
 
   Scenario: uploading a file inside a folder of a folder
-    Given user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server
+    Given user "Alice" has created folder "simple-folder" on remote server
+    And user "Alice" has created folder "simple-folder/simple-empty-folder" on remote server
+    And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server
     And user "Alice" from server "LOCAL" has accepted the last pending share
     When the user opens folder "Shares/simple-folder/simple-empty-folder" directly on the webUI
     And the user uploads file "new-lorem.txt" using the webUI
@@ -233,7 +264,10 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
 
   Scenario: rename a file in a folder inside a shared folder
-    Given user "Alice" from remote server has shared "'single'quotes" with user "Alice" from local server
+    Given user "Alice" has created folder "'single'quotes" on remote server
+    And user "Alice" has created folder "'single'quotes/simple-empty-folder" on remote server
+    And user "Alice" has created file "'single'quotes/simple-empty-folder/for-git-commit" on remote server
+    And user "Alice" from remote server has shared "'single'quotes" with user "Alice" from local server
     And user "Alice" from server "LOCAL" has accepted the last pending share
     When the user opens folder "Shares/'single'quotes/simple-empty-folder" directly on the webUI
     And the user renames file "for-git-commit" to "not-for-git-commit" using the webUI
@@ -246,7 +280,10 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
 
   Scenario: delete a file in a folder inside a shared folder
-    Given user "Alice" from remote server has shared "'single'quotes" with user "Alice" from local server
+    Given user "Alice" has created folder "'single'quotes" on remote server
+    And user "Alice" has created folder "'single'quotes/simple-empty-folder" on remote server
+    And user "Alice" has created file "'single'quotes/simple-empty-folder/for-git-commit" on remote server
+    And user "Alice" from remote server has shared "'single'quotes" with user "Alice" from local server
     And user "Alice" from server "LOCAL" has accepted the last pending share
     When the user opens folder "Shares/'single'quotes/simple-empty-folder" directly on the webUI
     And the user deletes file "for-git-commit" using the webUI
@@ -256,11 +293,14 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-2060
   Scenario: sharing indicator of items inside a shared folder two levels down
-    Given user "Alice" has created folder "/simple-folder/simple-empty-folder/new-folder"
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has created folder "simple-folder/simple-empty-folder"
+    And user "Alice" has created folder "simple-folder/simple-empty-folder/new-folder"
     And user "Alice" has uploaded file with content "test" to "/simple-folder/simple-empty-folder/lorem.txt"
-    And the user shares folder "simple-folder" with remote user "Alice" as "Editor" using the webUI
+    And the user has reloaded the current page of the webUI
+    When the user shares folder "simple-folder" with remote user "Alice" as "Editor" using the webUI
     And user "Alice" from server "REMOTE" has accepted the last pending share
-    When the user opens folder "/" directly on the webUI
+    And the user opens folder "/" directly on the webUI
     Then the following resources should have share indicators on the webUI
       | fileName      | expectedIndicators |
       | simple-folder | user-direct        |
@@ -276,17 +316,19 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-2060
   Scenario: sharing indicator of items inside a re-shared folder
-    Given user "Brian" has been created with default attributes
-    And user "Carol" has been created with default attributes
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "simple-folder"
+    And user "Alice" has created folder "simple-folder/simple-empty-folder"
+    And user "Alice" has created file "simple-folder/lorem.txt"
     And user "Alice" has shared folder "simple-folder" with user "Brian"
     And user "Brian" has accepted the share "simple-folder" offered by user "Alice"
-    And the user re-logs in as "Brian" using the webUI
     And user "Brian" has shared folder "Shares/simple-folder" with user "Carol"
-    And the user opens folder "Shares" using the webUI
-    And the user opens folder "simple-folder" using the webUI
+    When the user re-logs in as "Brian" using the webUI
+    And the user opens folder "Shares/simple-folder" directly on the webUI
     And the user shares folder "simple-empty-folder" with remote user "Alice" as "Editor" using the webUI
     And user "Alice" from server "REMOTE" has accepted the last pending share
-    When the user opens folder "/Shares" directly on the webUI
+    And the user opens folder "/Shares" directly on the webUI
     Then the following resources should have share indicators on the webUI
       | fileName      | expectedIndicators |
       | simple-folder | user-direct        |
@@ -298,18 +340,22 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-2060
   Scenario: sharing indicator of items inside a re-shared subfolder
-    Given user "Brian" has been created with default attributes
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "simple-folder"
+    And user "Alice" has created folder "simple-folder/sub-folder"
+    And user "Alice" has created folder "simple-folder/sub-folder/simple-empty-folder"
+    And user "Alice" has created file "simple-folder/sub-folder/lorem.txt"
     And user "Alice" has shared folder "simple-folder" with user "Brian"
     And user "Brian" has accepted the share "simple-folder" offered by user "Alice"
-    And the user re-logs in as "Brian" using the webUI
-    And the user opens folder "Shares" using the webUI
-    And the user opens folder "simple-folder" using the webUI
+    When the user re-logs in as "Brian" using the webUI
+    And the user opens folder "Shares/simple-folder" directly on the webUI
     And the user shares folder "simple-empty-folder" with remote user "Alice" as "Editor" using the webUI
-    When the user opens folder "/Shares" directly on the webUI
+    And the user opens folder "/Shares" directly on the webUI
     Then the following resources should have share indicators on the webUI
       | fileName      | expectedIndicators |
       | simple-folder | user-indirect      |
-    When the user opens folder "simple-folder" using the webUI
+    When the user opens folder "/Shares/simple-folder/sub-folder" directly on the webUI
     Then the following resources should have share indicators on the webUI
       | fileName            | expectedIndicators |
       | simple-empty-folder | user-direct        |
@@ -317,8 +363,10 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-2060
   Scenario: sharing indicator for file uploaded inside a shared folder
-    Given the user shares folder "simple-empty-folder" with remote user "Alice" as "Editor" using the webUI
+    Given user "Alice" has created folder "simple-empty-folder"
+    And user "Alice" has shared folder "simple-empty-folder" with user "Alice@%remote_backend_url%" with "all" permissions
     And user "Alice" from server "REMOTE" has accepted the last pending share
+    And the user has reloaded the current page of the webUI
     When the user opens folder "simple-empty-folder" using the webUI
     And the user uploads file "new-lorem.txt" using the webUI
     Then the following resources should have share indicators on the webUI
@@ -327,8 +375,10 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-2060
   Scenario: sharing indicator for folder created inside a shared folder
-    Given the user shares folder "simple-empty-folder" with remote user "Alice" as "Editor" using the webUI
+    Given user "Alice" has created folder "simple-empty-folder"
+    And user "Alice" has shared folder "simple-empty-folder" with user "Alice@%remote_backend_url%" with "all" permissions
     And user "Alice" from server "REMOTE" has accepted the last pending share
+    And the user has reloaded the current page of the webUI
     When the user opens folder "simple-empty-folder" using the webUI
     And the user creates a folder with the name "sub-folder" using the webUI
     Then the following resources should have share indicators on the webUI
@@ -337,6 +387,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-2939
   Scenario: sharing indicator for federated shares stays up to date
+    Given user "Alice" has created folder "simple-folder"
+    And the user has reloaded the current page of the webUI
     When the user shares folder "simple-folder" with remote user "Alice" as "Editor" using the webUI
     And user "Alice" from server "REMOTE" accepts the last pending share using the sharing API
     Then the following resources should have share indicators on the webUI
@@ -349,10 +401,12 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-2897
   Scenario: sharing details inside folder shared using federated sharing
-    Given user "Alice" has created folder "/simple-folder/sub-folder"
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has created folder "/simple-folder/sub-folder"
     And user "Alice" has uploaded file with content "test" to "/simple-folder/textfile.txt"
-    And the user shares folder "simple-folder" with remote user "Alice" as "Editor" using the webUI
+    And user "Alice" has shared folder "simple-folder" with user "Alice@%remote_backend_url%" with "all" permissions
     And user "Alice" from server "REMOTE" has accepted the last pending share
+    And the user has reloaded the current page of the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user opens the share dialog for folder "sub-folder" using the webUI
     Then remote user "Alice" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
@@ -361,11 +415,14 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-2897
   Scenario: sharing details of items inside a shared folder shared with local user and federated user
-    Given user "Brian" has been created with default attributes
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "simple-folder"
     And user "Alice" has created folder "/simple-folder/sub-folder"
     And user "Alice" has uploaded file with content "test" to "/simple-folder/sub-folder/textfile.txt"
-    And the user shares folder "simple-folder" with remote user "Alice" as "Editor" using the webUI
+    And user "Alice" has shared folder "simple-folder" with user "Alice@%remote_backend_url%" with "all" permissions
+    And user "Alice" from server "REMOTE" has accepted the last pending share
     And user "Alice" has shared folder "simple-folder/sub-folder" with user "Brian"
+    And the user has reloaded the current page of the webUI
     When the user opens folder "simple-folder/sub-folder" directly on the webUI
     And the user opens the share dialog for file "textfile.txt" using the webUI
     Then remote user "Alice" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
@@ -373,7 +430,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-4246
   Scenario: accepting folder shared by remote user is listed in shared-with-me page
-    Given user "Alice" from remote server has shared "/simple-folder" with user "Alice" from local server
+    Given user "Alice" has created folder "simple-folder" on remote server
+    And user "Alice" from remote server has shared "/simple-folder" with user "Alice" from local server
     And user "Alice" from server "LOCAL" has accepted the last pending share
     When the user browses to the shared-with-me page using the webUI
     # delete below line after the issue has been fixed
@@ -383,6 +441,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-4247
   Scenario: shares folder appears only after reloading the page
+    Given user "Alice" has created folder "simple-folder" on remote server
     When user "Alice" from remote server shares "simple-folder" with user "Alice" from local server
     And user "Alice" from server "LOCAL" accepts the last pending share using the sharing API
     Then folder "Shares" should not be listed on the webUI

--- a/tests/acceptance/features/webUISharingExternalToRoot/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternalToRoot/federationSharing.feature
@@ -334,7 +334,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "simple-folder"
     And user "Alice" has created folder "simple-folder/simple-empty-folder"
-    And user "Alice" has created file "simple-folder/simple-empty-folder/lorem.txt"
+    And user "Alice" has created file "simple-folder/lorem.txt"
     And user "Alice" has shared folder "simple-folder" with user "Brian"
     When the user re-logs in as "Brian" using the webUI
     And the user opens folder "simple-folder" using the webUI

--- a/tests/acceptance/features/webUISharingExternalToRoot/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternalToRoot/federationSharing.feature
@@ -12,22 +12,30 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And server "%backend_url%" has been added as trusted server
     And server "%backend_url%" has been added as trusted server on remote server
     And server "%remote_backend_url%" has been added as trusted server on remote server
-    And user "Alice" has been created with default attributes on remote server
-    And user "Alice" has been created with default attributes
+    And user "Alice" has been created with default attributes and without skeleton files on remote server
+    And user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has logged in using the webUI
 
 
   Scenario: test the single steps of sharing a folder to a remote server
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has created folder "simple-empty-folder"
+    And user "Alice" has created file "simple-folder/lorem.txt"
+    And the user has reloaded the current page of the webUI
     When the user shares folder "simple-folder" with remote user "Alice" as "Editor" using the webUI
     And the user shares folder "simple-empty-folder" with remote user "Alice" as "Editor" using the webUI
-    Then as "Alice" folder "/simple-folder (2)" should exist on remote server
-    And as "Alice" file "/simple-folder (2)/lorem.txt" should exist on remote server
-    And as "Alice" folder "/simple-empty-folder (2)" should exist on remote server
+    Then as "Alice" folder "/simple-folder" should exist on remote server
+    And as "Alice" file "/simple-folder/lorem.txt" should exist on remote server
+    And as "Alice" folder "/simple-empty-folder" should exist on remote server
 
   @issue-2510 @yetToImplement
   Scenario: test the single steps of receiving a federation share
-    Given user "Brian" has been created with default attributes on remote server
-    And user "Carol" has been created with default attributes on remote server
+    Given user "Brian" has been created with default attributes and without skeleton files on remote server
+    And user "Carol" has been created with default attributes and without skeleton files on remote server
+    And user "Alice" has created folder "simple-folder" on remote server
+    And user "Alice" has uploaded file "lorem.txt" to "simple-folder/lorem.txt" on remote server
+    And user "Brian" has created folder "simple-empty-folder" on remote server
+    And user "Carol" has uploaded file "lorem.txt" to "lorem.txt" on remote server
     And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server
     And user "Brian" from remote server has shared "simple-empty-folder" with user "Alice" from local server
     And user "Carol" from remote server has shared "lorem.txt" with user "Alice" from local server
@@ -39,31 +47,33 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | "Carol@%remote_backend_url%" shared "lorem.txt" with you           |
     When the user accepts all shares displayed in the notifications on the webUI
     And the user reloads the current page of the webUI
-    Then file "lorem (2).txt" should be listed on the webUI
-    And as "Alice" the content of "lorem (2).txt" should be the same as the original "lorem.txt"
-    And folder "simple-folder (2)" should be listed on the webUI
-    And folder "simple-folder (2)" should be listed on the webUI
-    When the user opens folder "simple-folder (2)" using the webUI
     Then file "lorem.txt" should be listed on the webUI
-    And as "Alice" the content of "simple-folder (2)/lorem.txt" should be the same as the original "simple-folder/lorem.txt"
+    And as "Alice" the content of "lorem.txt" should be the same as the local "lorem.txt"
+    And folder "simple-folder" should be listed on the webUI
+    When the user opens folder "simple-folder" using the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    And as "Alice" the content of "simple-folder/lorem.txt" should be the same as the local "lorem.txt"
     #    When the user browses to the shared-with-me page
-    #    Then file "lorem (2).txt" should be listed on the webUI
-    #    And folder "simple-folder (2)" should be listed on the webUI
-    #    And folder "simple-empty-folder (2)" should be listed on the webUI
+    #    Then file "lorem.txt" should be listed on the webUI
+    #    And folder "simple-folder" should be listed on the webUI
+    #    And folder "simple-empty-folder" should be listed on the webUI
 
 
   Scenario: declining a federation share on the webUI
-    Given user "Alice" from remote server has shared "/lorem.txt" with user "Alice" from local server
+    Given user "Alice" has created file "lorem.txt" on remote server
+    And user "Alice" from remote server has shared "/lorem.txt" with user "Alice" from local server
     And the user has reloaded the current page of the webUI
     When the user declines all shares displayed in the notifications on the webUI
-    Then file "lorem (2).txt" should not be listed on the webUI
+    Then file "lorem.txt" should not be listed on the webUI
     When the user browses to the shared-with-me page
     And the user reloads the current page of the webUI
-    Then file "lorem (2).txt" should not be listed on the webUI
+    Then file "lorem.txt" should not be listed on the webUI
 
   @issue-2510 @yetToImplement
   Scenario: automatically accept a federation share when it is allowed by the config
     Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "Alice" has created folder "simple-folder" on remote server
+    And user "Alice" has created file "simple-folder/lorem.txt" on remote server
     And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server
     When the user reloads the current page of the webUI
     Then folder "simple-folder" should be listed on the webUI
@@ -75,6 +85,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
 
   Scenario: share a folder with an remote user with "Viewer" role
+    Given user "Alice" has created folder "simple-empty-folder"
+    And the user has reloaded the current page of the webUI
     When the user shares folder "simple-empty-folder" with remote user "Alice" as "Viewer" using the webUI
     Then user "Alice" should have shared a folder "simple-empty-folder" with these details:
       | field       | value                      |
@@ -86,37 +98,45 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-3309
   Scenario: share a folder with an remote user and prohibit deleting - remote server shares - local server receives
-    Given user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server with "read" permissions
+    Given user "Alice" has created folder "simple-folder" on remote server
+    And user "Alice" has created file "simple-folder/lorem.txt" on remote server
+    And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server with "read" permissions
     When the user reloads the current page of the webUI
     And the user accepts all shares displayed in the notifications on the webUI
-    And the user opens folder "simple-folder (2)" directly on the webUI
+    And the user opens folder "simple-folder" directly on the webUI
     And the user reloads the current page of the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
   @issue-3309
   Scenario: overwrite a file in a received share - remote server shares - local server receives
     Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "Alice" has created folder "simple-folder" on remote server
+    And user "Alice" has created file "simple-folder/lorem.txt" on remote server
     And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server
     And the user reloads the current page of the webUI
-    And the user opens folder "simple-folder (2)" using the webUI
+    And the user opens folder "simple-folder" using the webUI
     When the user uploads overwriting file "lorem.txt" using the webUI
-    Then as "Alice" the content of "simple-folder (2)/lorem.txt" should be the same as the local "lorem.txt"
+    Then as "Alice" the content of "simple-folder/lorem.txt" should be the same as the local "lorem.txt"
 
   @issue-3309
   Scenario: upload a new file in a received share - remote server shares - local server receives
     Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "Alice" has created folder "simple-folder" on remote server
+    And user "Alice" has created file "simple-folder/lorem.txt" on remote server
     And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server
     When the user reloads the current page of the webUI
-    And the user opens folder "simple-folder (2)" using the webUI
+    And the user opens folder "simple-folder" using the webUI
     And the user uploads file "new-lorem.txt" using the webUI
     Then as "Alice" file "simple-folder/new-lorem.txt" should exist on remote server
 
   @issue-3309
   Scenario: rename a file in a received share - remote server shares - local server receives
     Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "Alice" has created folder "simple-folder" on remote server
+    And user "Alice" has created file "simple-folder/lorem.txt" on remote server
     And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server
     When the user reloads the current page of the webUI
-    And the user opens folder "simple-folder (2)" using the webUI
+    And the user opens folder "simple-folder" using the webUI
     And the user renames file "lorem.txt" to "new-lorem.txt" using the webUI
     Then as "Alice" file "simple-folder/new-lorem.txt" should exist on remote server
     But as "Alice" file "simple-folder/lorem.txt" should not exist on remote server
@@ -124,39 +144,45 @@ Feature: Federation Sharing - sharing with users on other cloud storages
   @issue-3309
   Scenario: delete a file in a received share - remote server shares - local server receives
     Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "Alice" has created folder "simple-folder" on remote server
+    And user "Alice" has created file "simple-folder/lorem.txt" on remote server
     And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server
     When the user reloads the current page of the webUI
-    And the user opens folder "simple-folder (2)" using the webUI
+    And the user opens folder "simple-folder" using the webUI
     And the user deletes file "lorem.txt" using the webUI
     Then as "Alice" file "simple-folder/lorem.txt" should not exist on remote server
 
 
   Scenario: unshare a federation share
     Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "Alice" has created file "lorem.txt" on remote server
     And user "Alice" from remote server has shared "lorem.txt" with user "Alice" from local server
     When the user reloads the current page of the webUI
-    And the user deletes file "lorem (2).txt" using the webUI
-    Then file "lorem (2).txt" should not be listed on the webUI
-    And as "Alice" file "lorem (2).txt" should not exist
+    And the user deletes file "lorem.txt" using the webUI
+    Then file "lorem.txt" should not be listed on the webUI
+    And as "Alice" file "lorem.txt" should not exist
     And as "Alice" file "lorem.txt" should exist on remote server
 
   @issue-2510 @skip @yetToImplement
   Scenario: unshare a federation share from "share-with-you" page
-    Given user "Alice" from server "REMOTE" has shared "/lorem.txt" with user "Alice" from server "LOCAL"
+    Given user "Alice" has created file "lorem.txt" on remote server
+    And user "Alice" from server "REMOTE" has shared "/lorem.txt" with user "Alice" from remote server
     And user "Alice" from server "LOCAL" has accepted the last pending share
     And the user has reloaded the current page of the webUI
-    When the user unshares file "lorem (2).txt" using the webUI
-    Then file "lorem (2).txt" should not be listed on the webUI
-    And file "lorem (2).txt" should not be listed in the files page on the webUI
+    When the user unshares file "lorem.txt" using the webUI
+    Then file "lorem.txt" should not be listed on the webUI
+    And file "lorem.txt" should not be listed in the files page on the webUI
 
 
   Scenario: test resharing folder with "Viewer" role
     Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
-    And user "Brian" has been created with default attributes
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "simple-folder" on remote server
+    And user "Alice" has created file "simple-folder/lorem.txt" on remote server
     And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server
     And the user has reloaded the current page of the webUI
-    When the user shares folder "simple-folder (2)" with user "Brian Murphy" as "Viewer" using the webUI
-    Then as "Brian" folder "simple-folder (2)/lorem.txt" should exist
+    When the user shares folder "simple-folder" with user "Brian Murphy" as "Viewer" using the webUI
+    Then as "Brian" folder "simple-folder/lorem.txt" should exist
     And user "Brian" should have received a share with these details:
       | field       | value       |
       | uid_owner   | Alice       |
@@ -167,91 +193,107 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Scenario: test resharing a federated server to remote again
     Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
-    And user "Brian" has been created with default attributes on remote server
+    And user "Brian" has been created with default attributes and without skeleton files on remote server
+    And user "Alice" has created folder "simple-folder" on remote server
     And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server with "read, share" permissions
     And the user has reloaded the current page of the webUI
-    When the user shares folder "simple-folder (2)" with remote user "Brian" as "Viewer" using the webUI
-    Then user "Alice" should have shared a folder "simple-folder (2)" with these details:
+    When the user shares folder "simple-folder" with remote user "Brian" as "Viewer" using the webUI
+    Then user "Alice" should have shared a folder "simple-folder" with these details:
       | field       | value                      |
       | uid_owner   | Alice                      |
       | share_with  | Brian@%remote_backend_url% |
       | item_type   | folder                     |
       | permissions | read, share                |
-    And as "Brian" folder "simple-folder (2)" should exist on remote server
+    And as "Brian" folder "simple-folder" should exist on remote server
 
 
   Scenario: try resharing a folder with read-only permissions
     Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "Alice" has created folder "simple-folder" on remote server
     And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server with "read" permissions
     When the user reloads the current page of the webUI
-    Then the user should not be able to share folder "simple-folder (2)" using the webUI
+    Then the user should not be able to share folder "simple-folder" using the webUI
 
 
   Scenario: test sharing long file names with federation share
-    When user "Alice" has uploaded file with content "secret" to "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt"
+    Given user "Alice" has uploaded file with content "secret" to "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt"
     And the user has reloaded the current page of the webUI
-    And the user shares file "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" with remote user "Alice" as "Viewer" using the webUI
+    When the user shares file "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" with remote user "Alice" as "Viewer" using the webUI
     Then as "Alice" file "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should exist on remote server
 
 
   Scenario: sharee should be able to access the files/folders inside other folder
     Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "Alice" has created folder "'single'quotes" on remote server
+    And user "Alice" has created folder "'single'quotes/simple-empty-folder" on remote server
+    And user "Alice" has uploaded file "lorem.txt" to "'single'quotes/lorem.txt" on remote server
+    And user "Alice" has uploaded file "lorem.txt" to "'single'quotes/simple-empty-folder/lorem.txt" on remote server
     And user "Alice" from remote server has shared "'single'quotes" with user "Alice" from local server
     And the user has reloaded the current page of the webUI
-    When the user opens folder "'single'quotes (2)" using the webUI
+    When the user opens folder "'single'quotes" using the webUI
     Then as "Alice" these resources should be listed on the webUI
       | entry_name          |
       | simple-empty-folder |
-      | for-git-commit      |
       | lorem.txt           |
     When the user opens folder "simple-empty-folder" using the webUI
     Then as "Alice" these resources should be listed on the webUI
       | entry_name     |
-      | for-git-commit |
-    When the user downloads file "for-git-commit" using the webUI
+      | lorem.txt      |
+    When the user downloads file "lorem.txt" using the webUI
     Then no message should be displayed on the webUI
-    And as "Alice" the content of "'single'quotes (2)/lorem.txt" should be the same as the original "'single'quotes/lorem.txt"
-    And as "Alice" the content of "'single'quotes (2)/simple-empty-folder/for-git-commit" should be the same as the original "'single'quotes/simple-empty-folder/for-git-commit"
+    And as "Alice" the content of "'single'quotes/lorem.txt" should be the same as the local "lorem.txt"
+    And as "Alice" the content of "'single'quotes/simple-empty-folder/lorem.txt" should be the same as the local "lorem.txt"
 
 
   Scenario: uploading a file inside a folder of a folder
     Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "Alice" has created folder "simple-folder" on remote server
+    And user "Alice" has created folder "simple-folder/simple-empty-folder" on remote server
     And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server
-    When the user opens folder "simple-folder (2)/simple-empty-folder" directly on the webUI
+    When the user opens folder "simple-folder/simple-empty-folder" directly on the webUI
     And the user uploads file "new-lorem.txt" using the webUI
     Then file "new-lorem.txt" should be listed on the webUI
     And as "Alice" file "simple-folder/simple-empty-folder/new-lorem.txt" should exist on remote server
-    And as "Alice" file "simple-folder (2)/simple-empty-folder/new-lorem.txt" should exist
+    And as "Alice" file "simple-folder/simple-empty-folder/new-lorem.txt" should exist
 
 
   Scenario: rename a file in a folder inside a shared folder
     Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "Alice" has created folder "'single'quotes" on remote server
+    And user "Alice" has created folder "'single'quotes/simple-empty-folder" on remote server
+    And user "Alice" has created file "'single'quotes/simple-empty-folder/for-git-commit" on remote server
     And user "Alice" from remote server has shared "'single'quotes" with user "Alice" from local server
-    When the user opens folder "/'single'quotes (2)/simple-empty-folder" directly on the webUI
+    When the user opens folder "/'single'quotes/simple-empty-folder" directly on the webUI
     And the user renames file "for-git-commit" to "not-for-git-commit" using the webUI
     Then file "for-git-commit" should not be listed on the webUI
-    And as "Alice" file "'single'quotes (2)/simple-empty-folder/for-git-commit" should not exist
+    And as "Alice" file "'single'quotes/simple-empty-folder/for-git-commit" should not exist
     And as "Alice" file "'single'quotes/simple-empty-folder/for-git-commit" should not exist on remote server
     But file "not-for-git-commit" should be listed on the webUI
-    And as "Alice" file "'single'quotes (2)/simple-empty-folder/not-for-git-commit" should exist
+    And as "Alice" file "'single'quotes/simple-empty-folder/not-for-git-commit" should exist
     And as "Alice" file "'single'quotes/simple-empty-folder/not-for-git-commit" should exist on remote server
 
 
   Scenario: delete a file in a folder inside a shared folder
     Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And user "Alice" has created folder "'single'quotes" on remote server
+    And user "Alice" has created folder "'single'quotes/simple-empty-folder" on remote server
+    And user "Alice" has created file "'single'quotes/simple-empty-folder/for-git-commit" on remote server
     And user "Alice" from remote server has shared "'single'quotes" with user "Alice" from local server
-    When the user opens folder "/'single'quotes (2)/simple-empty-folder" directly on the webUI
+    When the user opens folder "/'single'quotes/simple-empty-folder" directly on the webUI
     And the user deletes file "for-git-commit" using the webUI
     Then file "for-git-commit" should not be listed on the webUI
-    And as "Alice" file "'single'quotes (2)/simple-empty-folder/for-git-commit" should not exist
+    And as "Alice" file "'single'quotes/simple-empty-folder/for-git-commit" should not exist
     And as "Alice" file "'single'quotes/simple-empty-folder/for-git-commit" should not exist on remote server
 
   @issue-2060
   Scenario: sharing indicator of items inside a shared folder two levels down
-    Given user "Alice" has created folder "/simple-folder/simple-empty-folder/new-folder"
+    Given user "Alice" has created folder "/simple-folder"
+    And user "Alice" has created folder "/simple-folder/simple-empty-folder"
+    And user "Alice" has created folder "/simple-folder/simple-empty-folder/new-folder"
     And user "Alice" has uploaded file with content "test" to "/simple-folder/simple-empty-folder/lorem.txt"
-    And the user shares folder "simple-folder" with remote user "Alice" as "Editor" using the webUI
-    When the user opens folder "/" directly on the webUI
+    And the user has reloaded the current page of the webUI
+    When the user shares folder "simple-folder" with remote user "Alice" as "Editor" using the webUI
+    And the user opens folder "/" directly on the webUI
     Then the following resources should have share indicators on the webUI
       | fileName      | expectedIndicators |
       | simple-folder | user-direct        |
@@ -267,18 +309,21 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-2060
   Scenario: sharing indicator of items inside a re-shared folder
-    Given user "Brian" has been created with default attributes
-    And user "Carol" has been created with default attributes
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "simple-folder"
+    And user "Alice" has created folder "simple-folder/simple-empty-folder"
+    And user "Alice" has created file "simple-folder/lorem.txt"
     And user "Alice" has shared folder "simple-folder" with user "Brian"
     And the user re-logs in as "Brian" using the webUI
-    And user "Brian" has shared folder "simple-folder (2)" with user "Carol"
-    And the user opens folder "simple-folder (2)" using the webUI
+    And user "Brian" has shared folder "simple-folder" with user "Carol"
+    And the user opens folder "simple-folder" using the webUI
     And the user shares folder "simple-empty-folder" with remote user "Alice" as "Editor" using the webUI
     When the user opens folder "/" directly on the webUI
     Then the following resources should have share indicators on the webUI
       | fileName          | expectedIndicators |
-      | simple-folder (2) | user-direct        |
-    When the user opens folder "simple-folder (2)" using the webUI
+      | simple-folder     | user-direct        |
+    When the user opens folder "simple-folder" using the webUI
     Then the following resources should have share indicators on the webUI
       | fileName            | expectedIndicators |
       | simple-empty-folder | user-direct        |
@@ -286,16 +331,19 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-2060
   Scenario: sharing indicator of items inside a re-shared subfolder
-    Given user "Brian" has been created with default attributes
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "simple-folder"
+    And user "Alice" has created folder "simple-folder/simple-empty-folder"
+    And user "Alice" has created file "simple-folder/simple-empty-folder/lorem.txt"
     And user "Alice" has shared folder "simple-folder" with user "Brian"
-    And the user re-logs in as "Brian" using the webUI
-    And the user opens folder "simple-folder (2)" using the webUI
+    When the user re-logs in as "Brian" using the webUI
+    And the user opens folder "simple-folder" using the webUI
     And the user shares folder "simple-empty-folder" with remote user "Alice" as "Editor" using the webUI
-    When the user opens folder "/" directly on the webUI
+    And the user opens folder "/" directly on the webUI
     Then the following resources should have share indicators on the webUI
       | fileName          | expectedIndicators |
-      | simple-folder (2) | user-indirect      |
-    When the user opens folder "simple-folder (2)" using the webUI
+      | simple-folder     | user-indirect      |
+    When the user opens folder "simple-folder" directly on the webUI
     Then the following resources should have share indicators on the webUI
       | fileName            | expectedIndicators |
       | simple-empty-folder | user-direct        |
@@ -303,8 +351,10 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-2060
   Scenario: sharing indicator for file uploaded inside a shared folder
-    Given the user shares folder "simple-empty-folder" with remote user "Alice" as "Editor" using the webUI
-    When the user opens folder "simple-empty-folder" using the webUI
+    Given user "Alice" has created folder "simple-empty-folder"
+    And the user has reloaded the current page of the webUI
+    When the user shares folder "simple-empty-folder" with remote user "Alice" as "Editor" using the webUI
+    And the user opens folder "simple-empty-folder" using the webUI
     And the user uploads file "new-lorem.txt" using the webUI
     Then the following resources should have share indicators on the webUI
       | fileName      | expectedIndicators |
@@ -312,8 +362,10 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-2060
   Scenario: sharing indicator for folder created inside a shared folder
-    Given the user shares folder "simple-empty-folder" with remote user "Alice" as "Editor" using the webUI
-    When the user opens folder "simple-empty-folder" using the webUI
+    Given user "Alice" has created folder "simple-empty-folder"
+    And the user has reloaded the current page of the webUI
+    When the user shares folder "simple-empty-folder" with remote user "Alice" as "Editor" using the webUI
+    And the user opens folder "simple-empty-folder" using the webUI
     And the user creates a folder with the name "sub-folder" using the webUI
     Then the following resources should have share indicators on the webUI
       | fileName   | expectedIndicators |
@@ -321,6 +373,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-2939
   Scenario: sharing indicator for federated shares stays up to date
+    Given user "Alice" has created folder "simple-folder"
+    And the user has reloaded the current page of the webUI
     When the user shares folder "simple-folder" with remote user "Alice" as "Editor" using the webUI
     Then the following resources should have share indicators on the webUI
       | fileName      | expectedIndicators |
@@ -332,10 +386,12 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-2897
   Scenario: sharing details inside folder shared using federated sharing
-    Given user "Alice" has created folder "/simple-folder/sub-folder"
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has created folder "/simple-folder/sub-folder"
     And user "Alice" has uploaded file with content "test" to "/simple-folder/textfile.txt"
-    And the user shares folder "simple-folder" with remote user "Alice" as "Editor" using the webUI
-    When the user opens folder "simple-folder" using the webUI
+    And the user has reloaded the current page of the webUI
+    When the user shares folder "simple-folder" with remote user "Alice" as "Editor" using the webUI
+    And the user opens folder "simple-folder" using the webUI
     And the user opens the share dialog for folder "sub-folder" using the webUI
     Then remote user "Alice" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
     When the user opens the share dialog for file "textfile.txt" using the webUI
@@ -343,11 +399,13 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-2897
   Scenario: sharing details of items inside a shared folder shared with local user and federated user
-    Given user "Brian" has been created with default attributes
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "simple-folder"
     And user "Alice" has created folder "/simple-folder/sub-folder"
     And user "Alice" has uploaded file with content "test" to "/simple-folder/sub-folder/textfile.txt"
-    And the user shares folder "simple-folder" with remote user "Alice" as "Editor" using the webUI
+    And user "Alice" has shared folder "simple-folder" with user "Alice@%remote_backend_url%" with "all" permissions
     And user "Alice" has shared folder "simple-folder/sub-folder" with user "Brian"
+    And the user has reloaded the current page of the webUI
     When the user opens folder "simple-folder/sub-folder" directly on the webUI
     And the user opens the share dialog for file "textfile.txt" using the webUI
     Then remote user "Alice" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -110,7 +110,7 @@ Given('user {string} has uploaded file {string} to {string}', async function(
   await webdav.createFile(user, filename, content)
 })
 
-Given('user {string} has uploaded file {string} to {string} on remote server', async function(
+Given('user {string} has uploaded file {string} to {string} on remote server', function(
   user,
   source,
   filename

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -6,6 +6,7 @@ const webdav = require('../helpers/webdavHelper')
 const _ = require('lodash')
 const loginHelper = require('../helpers/loginHelper')
 const xpathHelper = require('../helpers/xpath')
+const backendHelper = require('../helpers/backendHelper')
 const { move } = require('../helpers/webdavHelper')
 const path = require('../helpers/path')
 const util = require('util')
@@ -107,6 +108,18 @@ Given('user {string} has uploaded file {string} to {string}', async function(
   const filePath = path.join(client.globals.filesForUpload, source)
   const content = fs.readFileSync(filePath)
   await webdav.createFile(user, filename, content)
+})
+
+Given('user {string} has uploaded file {string} to {string} on remote server', async function(
+  user,
+  source,
+  filename
+) {
+  return backendHelper.runOnRemoteBackend(async function() {
+    const filePath = path.join(client.globals.filesForUpload, source)
+    const content = fs.readFileSync(filePath)
+    await webdav.createFile(user, filename, content)
+  })
 })
 
 When('the user browses to display the {string} details of file {string}', async function(
@@ -888,6 +901,18 @@ Given('user {string} has renamed the following files', function(userId, table) {
 Given('user {string} has renamed file/folder {string} to {string}', webdav.move)
 
 Given('user {string} has created folder {string}', webdav.createFolder)
+
+Given('user {string} has created folder {string} on remote server', function(userId, folderName) {
+  return backendHelper.runOnRemoteBackend(async function() {
+    await webdav.createFolder(userId, folderName)
+  })
+})
+
+Given('user {string} has created file {string} on remote server', function(userId, fileName) {
+  return backendHelper.runOnRemoteBackend(async function() {
+    await webdav.createFile(userId, fileName, '')
+  })
+})
 
 Then(
   'file/folder {string} should not be listed in shared-with-others page on the webUI',

--- a/tests/acceptance/stepDefinitions/provisioningContext.js
+++ b/tests/acceptance/stepDefinitions/provisioningContext.js
@@ -198,8 +198,8 @@ Given('user {string} has been created with default attributes on remote server',
 
 Given(
   /^user "([^"]*)" has been created with default attributes and (without|large|small) skeleton files on remote server$/,
-  function(userId) {
-    return backendHelper.runOnRemoteBackend(async function(skeletonType) {
+  function(userId, skeletonType) {
+    return backendHelper.runOnRemoteBackend(async function() {
       await deleteUser()
         .then(() => createDefaultUser(userId, skeletonType))
         .then(() => initUser(userId))

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -163,6 +163,10 @@ const shareFileFolder = async function(
   const permissions = sharingHelper.humanReadablePermissionsToBitmask(permissionString)
   params.append('path', elementToShare)
   if (receiver) {
+    if (receiver.endsWith('@%remote_backend_url%')) {
+      shareType = SHARE_TYPES.federated_cloud_share
+      receiver = receiver.replace('%remote_backend_url%', client.globals.remote_backend_url)
+    }
     params.append('shareWith', receiver)
   }
   params.append('shareType', shareType)


### PR DESCRIPTION
## Description
Refactor  `webUISharingExternal`  tests to not use skeleton files:
- webUISharingExternal
- webUISharingExternalToRoot

## Related Issue
https://github.com/owncloud/QA/issues/659

## How Has This Been Tested?
- test environment: :robot: 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 