### PR TITLE
[Tests-Only] Get share indicators of a resource with retry

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -242,7 +242,7 @@ config = {
 					'webUITags',
 					'webUIWebdavLockProtection',
 					'webUIWebdavLocks',
-				],
+					],
 				'iPhone2': [
 					'webUIMoveFilesFolders',
 					'webUIResharing1',
@@ -272,7 +272,6 @@ config = {
 					'webUISharingInternalUsersToRootSharingIndicator',
 					'webUISharingInternalUsersExpireToRoot',
 					'webUISharingInternalUsersToRoot',
-					'webUISharingInternalUsersToRootBlacklisted',
 					'webUISharingPermissionsUsers',
 					'webUISharingPermissionToRoot',
 					'webUISharingPublicBasic',

--- a/.drone.star
+++ b/.drone.star
@@ -242,7 +242,7 @@ config = {
 					'webUITags',
 					'webUIWebdavLockProtection',
 					'webUIWebdavLocks',
-					],
+				],
 				'iPhone2': [
 					'webUIMoveFilesFolders',
 					'webUIResharing1',
@@ -272,6 +272,7 @@ config = {
 					'webUISharingInternalUsersToRootSharingIndicator',
 					'webUISharingInternalUsersExpireToRoot',
 					'webUISharingInternalUsersToRoot',
+					'webUISharingInternalUsersToRootBlacklisted',
 					'webUISharingPermissionsUsers',
 					'webUISharingPermissionToRoot',
 					'webUISharingPublicBasic',

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -453,10 +453,11 @@ module.exports = {
         this.elements.shareIndicatorsInFileRow.locateStrategy,
         shareIndicatorsXpath,
         result => {
-          console.log(result)
           result.value.forEach(element => {
             this.api.elementIdAttribute(element.ELEMENT, 'class', attr => {
-              console.log(attr)
+              if (parseInt(attr.status) < 0) {
+                return
+              }
               if (attr.value.indexOf('uk-invisible') >= 0) {
                 return
               }
@@ -482,6 +483,30 @@ module.exports = {
           })
         }
       )
+      return indicators
+    },
+
+    /**
+     *
+     * @param {string} fileName
+     * @param {boolean} sharingIndicatorExpectedToBeVisible
+     * @returns {Array} array of sharing indicator
+     */
+    getShareIndicatorsForResourceWithRetry: async function(
+      fileName,
+      sharingIndicatorExpectedToBeVisible
+    ) {
+      let indicators = await this.getShareIndicatorsForResource(
+        fileName,
+        sharingIndicatorExpectedToBeVisible
+      )
+      if (!indicators.length) {
+        console.log('Share indicators not found on first try, Retrying again')
+        indicators = await this.getShareIndicatorsForResource(
+          fileName,
+          sharingIndicatorExpectedToBeVisible
+        )
+      }
       return indicators
     },
 

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -453,8 +453,10 @@ module.exports = {
         this.elements.shareIndicatorsInFileRow.locateStrategy,
         shareIndicatorsXpath,
         result => {
+          console.log(result)
           result.value.forEach(element => {
             this.api.elementIdAttribute(element.ELEMENT, 'class', attr => {
+              console.log(attr)
               if (attr.value.indexOf('uk-invisible') >= 0) {
                 return
               }

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -1110,7 +1110,7 @@ Then('the following resources should have share indicators on the webUI', async 
   dataTable
 ) {
   for (const { fileName, expectedIndicators } of dataTable.hashes()) {
-    const indicatorsArray = await client.page.FilesPageElement.filesList().getShareIndicatorsForResource(
+    const indicatorsArray = await client.page.FilesPageElement.filesList().getShareIndicatorsForResourceWithRetry(
       fileName,
       true
     )


### PR DESCRIPTION
## Description
This PR adds functionality to try to get share indicator of a resource a second time when the first try fails
Hopefully, it will prevent intermittent fails of the sharing-indicator tests that occur due to the unavailability of share indicators.

## Related Issue
- part of https://github.com/owncloud/web/issues/4919


## How Has This Been Tested?
- test environment: :robot: 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 