### PR TITLE
[Tests-Only] Refactor webUI scenarios to prevent unnecessary skeleton file creation

### DIFF
--- a/tests/acceptance/expected-failures-with-ocis-server-owncloud-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-owncloud-storage.md
@@ -20,7 +20,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIPreview/imageMediaViewer.feature:112](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L112)
 
 ### [Exit page re-appears in loop when logged in user is deleted](https://github.com/owncloud/web/issues/4677)
--   [webUILogin/openidLogin.feature:62](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/openidLogin.feature#L62)
+-   [webUILogin/openidLogin.feature:53](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/openidLogin.feature#L53)
 
 ### [User request using token and basic authentication gives different display names](https://github.com/owncloud/ocis/issues/1312)
 -   [webUIAccount/accountInformation.feature:10](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIAccount/accountInformation.feature#L10)
@@ -124,8 +124,8 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUISharingPermissionsUsers/sharePermissionsUsers.feature:224](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPermissionsUsers/sharePermissionsUsers.feature#L224)
 -   [webUIFilesCopy/copy.feature:71](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesCopy/copy.feature#L71)
 -   [webUIFilesCopy/copy.feature:79](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesCopy/copy.feature#L79)
--   [webUIMoveFilesFolders/moveFiles.feature:87](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature#L87)
--   [webUIMoveFilesFolders/moveFolders.feature:67](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature#L67)
+-   [webUIMoveFilesFolders/moveFiles.feature:97](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature#L97)
+-   [webUIMoveFilesFolders/moveFolders.feature:72](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature#L72)
 -   [webUISharingPublicManagement/publicLinkIndicator.feature:12](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkIndicator.feature#L12)
 -   [webUISharingPublicManagement/publicLinkIndicator.feature:47](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkIndicator.feature#L47)
 -   [webUISharingPublicManagement/publicLinkIndicator.feature:64](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkIndicator.feature#L64)
@@ -192,7 +192,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUISharingInternalUsersBlacklisted/shareWithUsers.feature:92](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalUsersBlacklisted/shareWithUsers.feature#L92)
 
 ### [Can login with invalid password while logging in with openidconnect in oc10](https://github.com/owncloud/ocis/issues/1428)
--   [webUILogin/openidLogin.feature:52](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/openidLogin.feature#L52)
+-   [webUILogin/openidLogin.feature:46](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/openidLogin.feature#L46)
 
 ### Image-Media-Viewer-Issue
 -   [webUIPreview/imageMediaViewer.feature:34](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L34)
@@ -327,13 +327,13 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUISharingInternalUsers/shareWithUsers.feature:341](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature#L341)
 
 ### [Blocked user is not logged out](https://github.com/owncloud/ocis/issues/902)
--   [webUILogin/adminBlocksUser.feature:7](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/adminBlocksUser.feature#L7)
+-   [webUILogin/adminBlocksUser.feature:13](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/adminBlocksUser.feature#L13)
 
 ### [Browser session deleted user should not be valid for newly created user of same name](https://github.com/owncloud/ocis/issues/904)
--   [webUILogin/openidLogin.feature:74](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/openidLogin.feature#L74)
+-   [webUILogin/openidLogin.feature:62](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/openidLogin.feature#L62)
 
 ### [Moving files in a shared folder causes errors but succeeds](https://github.com/owncloud/ocis/issues/873)
--   [webUIMoveFilesFolders/moveFiles.feature:127](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature#L127)
+-   [webUIMoveFilesFolders/moveFiles.feature:140](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature#L140)
 
 ### [enable re-sharing is not possible](https://github.com/owncloud/ocis/issues/1743)
 -   [webUISharingFolderAdvancedPermissionMultipleUsers/sharedFolderWithMultipleUsersAdvancedPermissions.feature:65](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingFolderAdvancedPermissionMultipleUsers/sharedFolderWithMultipleUsersAdvancedPermissions.feature#L65)

--- a/tests/acceptance/features/webUILogin/adminBlocksUser.feature
+++ b/tests/acceptance/features/webUILogin/adminBlocksUser.feature
@@ -3,14 +3,14 @@ Feature: view profile
   I want to be able to disable a user
   So that I can remove access to files and resources for a user, without actually deleting the files and resources
 
-  @openIdLogin
-  Scenario: the user session of a blocked user is cleared properly using openid authentication
-    Given these users have been created with default attributes:
-      | username |
-      | Alice    |
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
     And user "Alice" has been blocked by admin
+
+  @openIdLogin
+  Scenario: the user session of a blocked user is cleared properly using openid authentication
     When the user reloads the current page of the webUI
     Then the user should be redirected to the login error page
     When the user exits the login error page
@@ -18,11 +18,5 @@ Feature: view profile
 
   @oauthLogin @notToImplementOnOCIS
   Scenario: the user session of a blocked user is cleared properly using oauth authentication
-    Given these users have been created with default attributes:
-      | username |
-      | Alice    |
-    And user "Alice" has logged in using the webUI
-    And the user has browsed to the files page
-    And user "Alice" has been blocked by admin
     When the user reloads the current page of the webUI
     Then the user should be redirected to the user disabled page

--- a/tests/acceptance/features/webUILogin/oauthLogin.feature
+++ b/tests/acceptance/features/webUILogin/oauthLogin.feature
@@ -8,6 +8,8 @@ Feature: login users
   I want only authorised users to log in
   So that unauthorised access is impossible
 
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   Scenario: admin login
     Given the user has browsed to the login page
@@ -18,38 +20,26 @@ Feature: login users
 
 
   Scenario: logging out
-    Given these users have been created with default attributes:
-      | username |
-      | Alice    |
-    And user "Alice" has logged in using the webUI
+    Given user "Alice" has logged in using the webUI
     And the user has browsed to the files page
     When the user logs out of the webUI
     Then the user should be redirected to the IdP login page
 
 
   Scenario: try to login with invalid username
-    Given these users have been created with default attributes:
-      | username |
-      | Alice    |
-    And the user has browsed to the login page
+    Given the user has browsed to the login page
     When the user tries to log in with username "invalid" and password "1234" using the webUI
     Then the warning 'Wrong password. Reset it?' should be displayed on the login page
 
 
   Scenario: try to login with valid username and invalid password
-    Given these users have been created with default attributes:
-      | username |
-      | Alice    |
-    And the user has browsed to the login page
+    Given the user has browsed to the login page
     When the user tries to log in with username "Alice" and password "invalid" using the webUI
     Then the warning 'Wrong password. Reset it?' should be displayed on the login page
 
 
   Scenario: the user session of a deleted user is cleared properly
-    Given these users have been created with default attributes:
-      | username |
-      | Alice    |
-    And user "Alice" has logged in using the webUI
+    Given user "Alice" has logged in using the webUI
     And the user has browsed to the files page
     And user "Alice" has been deleted
     When the user reloads the current page of the webUI
@@ -57,11 +47,8 @@ Feature: login users
 
 
   Scenario: the user session of a deleted user should not be valid for newly created user of same name
-    Given these users have been created with default attributes:
-      | username |
-      | Alice    |
-    And user "Alice" has logged in using the webUI
+    Given user "Alice" has logged in using the webUI
     And user "Alice" has been deleted
-    And user "Alice" has been created with default attributes
+    And user "Alice" has been created with default attributes and without skeleton files
     When the user reloads the current page of the webUI
     Then the user should be redirected to the owncloud login page

--- a/tests/acceptance/features/webUILogin/openidLogin.feature
+++ b/tests/acceptance/features/webUILogin/openidLogin.feature
@@ -8,6 +8,9 @@ Feature: login users
   I want only authorised users to log in
   So that unauthorised access is impossible
 
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+
   @skip
   Scenario: admin login
     Given the user has browsed to the login page
@@ -19,20 +22,14 @@ Feature: login users
 
 
   Scenario: logging out
-    Given these users have been created with default attributes:
-      | username |
-      | Alice    |
-    And user "Alice" has logged in using the webUI
+    Given user "Alice" has logged in using the webUI
     And the user has browsed to the files page
     When the user logs out of the webUI
     Then the user should be redirected to the IdP login page
 
   @ocisSmokeTest
   Scenario: logging out redirects to the url with state attribute
-    Given these users have been created with default attributes:
-      | username |
-      | Alice    |
-    And user "Alice" has logged in using the webUI
+    Given user "Alice" has logged in using the webUI
     And the user has browsed to the files page
     When the user logs out of the webUI
     Then the user should be on page with the url containing "state="
@@ -41,29 +38,20 @@ Feature: login users
 
 
   Scenario: try to login with invalid username
-    Given these users have been created with default attributes:
-      | username |
-      | Alice    |
-    And the user has browsed to the login page
+    Given the user has browsed to the login page
     When the user tries to log in with username "invalid" and password "1234" using the webUI
     Then the warning 'Logon failed. Please verify your credentials and try again.' should be displayed on the login page
 
   @ocis-konnectd-issue-68
   Scenario: try to login with valid username and invalid password
-    Given these users have been created with default attributes:
-      | username |
-      | Alice    |
-    And the user has browsed to the login page
+    Given the user has browsed to the login page
     When the user tries to log in with username "Alice" and password "invalid" using the webUI
     Then the files table should be displayed
 #      Then the warning 'Logon failed. Please verify your credentials and try again.' should be displayed on the login page
 
 
   Scenario: the user session of a deleted user is cleared properly
-    Given these users have been created with default attributes:
-      | username |
-      | Alice    |
-    And user "Alice" has logged in using the webUI
+    Given user "Alice" has logged in using the webUI
     And the user has browsed to the files page
     And user "Alice" has been deleted
     When the user reloads the current page of the webUI
@@ -72,10 +60,7 @@ Feature: login users
     Then the user should be redirected to the login page
 
   Scenario: the user session of a deleted user should not be valid for newly created user of same name
-    Given these users have been created with default attributes:
-      | username |
-      | Alice    |
-    And user "Alice" has logged in using the webUI
+    Given user "Alice" has logged in using the webUI
     And user "Alice" has been deleted
     And user "Alice" has been created with default attributes
     When the user reloads the current page of the webUI

--- a/tests/acceptance/features/webUIMarkdownEditor/markdownFile.feature
+++ b/tests/acceptance/features/webUIMarkdownEditor/markdownFile.feature
@@ -4,7 +4,7 @@ Feature: create markdown files
   So that I can organize my text data in formatted form
 
   Background:
-    Given user "Alice" has been created with default attributes
+    Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "simple markdown file" to "simple.md"
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
@@ -47,10 +47,14 @@ Feature: create markdown files
     Then the preview panel should have the content "updating the file with new content" in the WebUI
 
   Scenario: open text file in markdown editor
+    Given user "Alice" has uploaded file with content "test" to "lorem.txt"
+    And the user has reloaded the current page of the webUI
     When the user opens file "lorem.txt" in the markdown editor webUI
     Then the file "lorem.txt" should be displayed in the markdown editor webUI
 
   Scenario Outline: preview of files with markdown editor by clicking the action menu option
+    Given user "Alice" has uploaded file with content "test" to "lorem.txt"
+    And the user has reloaded the current page of the webUI
     When the user opens file "<file>" in the markdown editor using the action menu option in the webUI
     Then the file "<file>" should be displayed in the markdown editor webUI
     Examples:

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -4,23 +4,28 @@ Feature: move files
   So that I can organise my data structure
 
   Background:
-    Given user "Alice" has been created with default attributes
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "simple-folder"
+    And user "Alice" has uploaded file "lorem.txt" to "lorem.txt"
 
 
   Scenario: An attempt to move a file into a sub-folder using rename is not allowed
     Given user "Alice" has logged in using the webUI
     And the user has browsed to the files page
-    When the user tries to rename file "data.zip" to "simple-folder/data.zip" using the webUI
+    When the user tries to rename file "lorem.txt" to "simple-folder/lorem.txt" using the webUI
     Then the error message 'The name cannot contain "/"' should be displayed on the webUI dialog prompt
-    And file "data.zip" should be listed on the webUI
+    And file "lorem.txt" should be listed on the webUI
 
   @smokeTest
   Scenario: move a file into a folder
     Given user "Alice" has logged in using the webUI
+    And user "Alice" has uploaded file "data.tar.gz" to "data.tar.gz"
+    And user "Alice" has uploaded file "strängé filename (duplicate #2 &).txt" to "strängé filename (duplicate #2 &).txt"
+    And user "Alice" has created folder "strängé नेपाली folder empty"
     And the user has browsed to the files page
-    When the user moves file "data.zip" into folder "simple-empty-folder" using the webUI
-    Then breadcrumb for folder "simple-empty-folder" should be displayed on the webUI
-    And file "data.zip" should be listed on the webUI
+    When the user moves file "lorem.txt" into folder "simple-folder" using the webUI
+    Then breadcrumb for folder "simple-folder" should be displayed on the webUI
+    And file "lorem.txt" should be listed on the webUI
     When the user browses to the files page
     And the user moves file "data.tar.gz" into folder "strängé नेपाली folder empty" using the webUI
     Then breadcrumb for folder "strängé नेपाली folder empty" should be displayed on the webUI
@@ -30,27 +35,30 @@ Feature: move files
     Then breadcrumb for folder "strängé नेपाली folder empty" should be displayed on the webUI
     And file "strängé filename (duplicate #2 &).txt" should be listed on the webUI
     When the user browses to the files page
-    Then file "data.zip" should not be listed on the webUI
+    Then file "lorem.txt" should not be listed on the webUI
     And file "data.tar.gz" should not be listed on the webUI
     And file "strängé filename (duplicate #2 &).txt" should not be listed on the webUI
 
 
   Scenario: move a file into a folder where a file with the same name already exists
     Given user "Alice" has logged in using the webUI
+    And user "Alice" has uploaded file "lorem.txt" to "simple-folder/lorem.txt"
     And the user has browsed to the files page
-    When the user tries to move file "strängé filename (duplicate #2 &).txt" into folder "strängé नेपाली folder" using the webUI
-    Then the error message with header 'An error occurred while moving strängé filename (duplicate #2 &).txt' should be displayed on the webUI
+    When the user tries to move file "lorem.txt" into folder "simple-folder" using the webUI
+    Then the error message with header 'An error occurred while moving lorem.txt' should be displayed on the webUI
 
    @smokeTest @disablePreviews
   Scenario: Move multiple files at once
     Given user "Alice" has logged in using the webUI
+    And user "Alice" has uploaded file "data.zip" to "data.zip"
+    And user "Alice" has uploaded file "data.zip" to "testapp.zip"
     And the user has browsed to the files page
-    When the user batch moves these files into folder "simple-empty-folder" using the webUI
+    When the user batch moves these files into folder "simple-folder" using the webUI
       | file_name   |
       | data.zip    |
       | lorem.txt   |
       | testapp.zip |
-    Then breadcrumb for folder "simple-empty-folder" should be displayed on the webUI
+    Then breadcrumb for folder "simple-folder" should be displayed on the webUI
     And the following files should be listed on the webUI
       | file_name   |
       | data.zip    |
@@ -62,7 +70,7 @@ Feature: move files
     Given user "Alice" has logged in using the webUI
     And the user has browsed to the files page
     When the user renames file "lorem.txt" to <file_name> using the webUI
-    And the user renames folder "simple-empty-folder" to <folder_name> using the webUI
+    And the user renames folder "simple-folder" to <folder_name> using the webUI
     And the user moves file <file_name> into folder <folder_name> using the webUI
     Then breadcrumb for folder <folder_name> should be displayed on the webUI
     And file <file_name> should be listed on the webUI
@@ -75,7 +83,9 @@ Feature: move files
 
 
   Scenario: move files on a public share
-    Given user "Alice" has shared folder "simple-folder" with link with "read, update, create, delete" permissions
+    Given user "Alice" has uploaded file "data.zip" to "simple-folder/data.zip"
+    And user "Alice" has created folder "simple-folder/simple-empty-folder"
+    And user "Alice" has shared folder "simple-folder" with link with "read, update, create, delete" permissions
     And the public uses the webUI to access the last public link created by user "Alice"
     And the user moves file "data.zip" into folder "simple-empty-folder" using the webUI
     Then breadcrumb for folder "simple-empty-folder" should be displayed on the webUI
@@ -85,24 +95,27 @@ Feature: move files
 
   @issue-ocis-reva-243
   Scenario: move a file into another folder with no change permission
-    Given user "Brian" has been created with default attributes
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "simple-folder"
     And user "Brian" has shared folder "simple-folder" with user "Alice" with "read" permissions
     And user "Alice" has logged in using the webUI
     When the user tries to move file "lorem.txt" into folder "simple-folder (2)" using the webUI
-    Then as "Alice" file "simple-folder (2)/lorem (2).txt" should not exist
+    Then as "Alice" file "simple-folder (2)/lorem.txt" should not exist
 
   Scenario: cancel moving a file
     Given user "Alice" has logged in using the webUI
     And the user has browsed to the files page
-    When the user opens the file action menu of folder "data.zip" using the webUI
-    And the user selects move action for folder "data.zip" using the webUI
-    And the user selects the folder "simple-empty-folder" as a place to move the file using the webUI
+    When the user opens the file action menu of file "lorem.txt" using the webUI
+    And the user selects move action for file "lorem.txt" using the webUI
+    And the user selects the folder "simple-folder" as a place to move the file using the webUI
     And the user cancels the attempt to move resources using the webUI
-    Then file "data.zip" should be listed on the webUI
-    But  file "data.zip" should not be listed in the folder "simple-empty-folder" on the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    But  file "lorem.txt" should not be listed in the folder "simple-folder" on the webUI
 
   Scenario: cancel moving of multiple files at once
     Given user "Alice" has logged in using the webUI
+    And user "Alice" has uploaded file "data.zip" to "data.zip"
+    And user "Alice" has uploaded file "data.zip" to "testapp.zip"
     And the user has browsed to the files page
     When the user marks these files for batch action using the webUI
       | file_name   |
@@ -110,14 +123,14 @@ Feature: move files
       | lorem.txt   |
       | testapp.zip |
     And the user selects the move button to move files using the webUI
-    And the user selects the folder "simple-empty-folder" as a place to move the files using the webUI
+    And the user selects the folder "simple-folder" as a place to move the files using the webUI
     And the user cancels the attempt to move resources using the webUI
     Then the following files should be listed on the webUI
       | file_name   |
       | data.zip    |
       | lorem.txt   |
       | testapp.zip |
-    But these resources should not be listed in the folder "simple-empty-folder" on the webUI
+    But these resources should not be listed in the folder "simple-folder" on the webUI
       | file_name   |
       | data.zip    |
       | lorem.txt   |
@@ -127,14 +140,14 @@ Feature: move files
   Scenario: sharee moves a file shared by sharer into another folder
     Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
     And the administrator has set the default folder for received shares to "Shares"
-    And user "Brian" has been created with default attributes
-    And user "Alice" has uploaded file with content "test content" to "simple-empty-folder/testFile.txt"
-    And user "Alice" has shared folder "/simple-empty-folder" with user "Brian"
-    And user "Brian" has accepted the share "simple-empty-folder" offered by user "Alice"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "test content" to "simple-folder/testFile.txt"
+    And user "Alice" has shared folder "/simple-folder" with user "Brian"
+    And user "Brian" has accepted the share "simple-folder" offered by user "Alice"
     And user "Brian" has logged in using the webUI
     And user "Brian" has created folder "/Shares/testFolder"
     And the user has opened folder "Shares"
-    And the user has opened folder "simple-empty-folder"
+    And the user has opened folder "simple-folder"
     When the user batch moves these files into folder "/Shares/testFolder" using the webUI
       | file_name    |
       | testFile.txt |

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
@@ -4,7 +4,9 @@ Feature: move folders
   So that I can organise my data structure
 
   Background:
-    Given user "Alice" has been created with default attributes
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "simple-folder"
+    And user "Alice" has created folder "simple-empty-folder"
 
 
   Scenario: An attempt to move a folder into a sub-folder using rename is not allowed
@@ -16,26 +18,29 @@ Feature: move folders
 
   @smokeTest
   Scenario: move a folder into another folder
-    Given user "Alice" has logged in using the webUI
+    Given user "Alice" has created folder "strängé नेपाली folder"
+    And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
     When the user moves folder "simple-folder" into folder "simple-empty-folder" using the webUI
     Then breadcrumb for folder "simple-empty-folder" should be displayed on the webUI
     And folder "simple-folder" should be listed on the webUI
     When the user browses to the files page
-    And the user moves folder "strängé नेपाली folder" into folder "strängé नेपाली folder empty" using the webUI
-    Then breadcrumb for folder "strängé नेपाली folder empty" should be displayed on the webUI
+    And the user moves folder "strängé नेपाली folder" into folder "simple-empty-folder" using the webUI
+    Then breadcrumb for folder "simple-empty-folder" should be displayed on the webUI
     And folder "strängé नेपाली folder" should be listed on the webUI
 
 
   Scenario: move a folder into another folder where a folder with the same name already exists
-    Given user "Alice" has logged in using the webUI
+    Given user "Alice" has created folder "simple-folder/simple-empty-folder"
+    And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
     When the user tries to move folder "simple-empty-folder" into folder "simple-folder" using the webUI
     Then the error message with header 'An error occurred while moving simple-empty-folder' should be displayed on the webUI
 
   @smokeTest
   Scenario: Move multiple folders at once
-    Given user "Alice" has logged in using the webUI
+    Given user "Alice" has created folder "strängé नेपाली folder"
+    And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
     When the user batch moves these folders into folder "simple-empty-folder" using the webUI
       | name                  |
@@ -65,11 +70,12 @@ Feature: move folders
 
   @issue-ocis-reva-243
   Scenario: move a folder into another folder with no change permission
-    Given user "Brian" has been created with default attributes
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "/simple-folder"
     And user "Brian" has shared folder "simple-folder" with user "Alice" with "read" permissions
     And user "Alice" has logged in using the webUI
     When the user tries to move folder "simple-empty-folder" into folder "simple-folder (2)" using the webUI
-    Then as "Alice" folder "simple-folder (2)/simple-empty-folder (2)" should not exist
+    Then as "Alice" folder "simple-folder (2)/simple-empty-folder" should not exist
 
 
   Scenario: move a folder into the same folder
@@ -80,9 +86,10 @@ Feature: move folders
 
 
   Scenario: move a folder into another folder with same name
-    Given user "Alice" has logged in using the webUI
-    When the user moves folder "simple-empty-folder" into folder "folder with space/simple-empty-folder" using the webUI
+    Given user "Alice" has created folder "simple-folder/simple-empty-folder"
+    And user "Alice" has logged in using the webUI
+    When the user moves folder "simple-empty-folder" into folder "simple-folder/simple-empty-folder" using the webUI
     Then breadcrumb for folder "simple-empty-folder" should be displayed on the webUI
     And folder "simple-empty-folder" should be listed on the webUI
-    And as "Alice" folder "folder with space/simple-empty-folder/simple-empty-folder" should exist
+    And as "Alice" folder "simple-folder/simple-empty-folder/simple-empty-folder" should exist
     And as "Alice" folder "simple-empty-folder" should not exist

--- a/tests/acceptance/features/webUINotifications/displayNotificationsOnWebUI.feature
+++ b/tests/acceptance/features/webUINotifications/displayNotificationsOnWebUI.feature
@@ -6,7 +6,7 @@ Feature: display notifications on the webUI
   So that I can stay informed
 
   Background:
-    Given user "Alice" has been created with default attributes
+    Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has logged in using the webUI
 
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Refactor the following suite tests to not use skeleton files:

- webUILogin
- webUIMarkdownEditor
- webUIMoveFilesFolders
- webUINotifications
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/QA/issues/659

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...