### PR TITLE
[Tests-Only] Wait for Rename button to be in enabled state

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/fileActionsMenu.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/fileActionsMenu.js
@@ -81,6 +81,7 @@ module.exports = {
         .waitForAnimationToFinish()
         .clearValue('@dialogInput')
         .setValue('@dialogInput', toName)
+        .waitForAnimationToFinish()
         .click('@dialogConfirmBtn')
         .useCss()
 


### PR DESCRIPTION
## Description
```
When the user renames file "lorem.txt" to "newName.txt" using the webUI
```
The above step failed few times. The screenshots show that the rename dialog box has not been closed, so I suspect that the click event may have been fired before the button is clickable.
So, this PR is a proposed solution to wait for `Rename` button to be enabled (from disabled state) before firing click event.

Tested with multiple run of rename test suite:
https://drone.owncloud.com/owncloud/web/14880/6/14

## Related Issue
- part of https://github.com/owncloud/web/issues/4919

## How Has This Been Tested?
- test environment: :robot: 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 