### PR TITLE
Implement a proper direct delete

### DIFF
--- a/changelog/unreleased/enhancement-direct-delete
+++ b/changelog/unreleased/enhancement-direct-delete
@@ -1,0 +1,6 @@
+Enhancement: Implement proper direct delete
+
+Implement a proper delete action for a single file. Previously this was being handled via selecting the file.
+This also solves the issue with the checkbox being checked when opening the delete modal, which was not a11y compliant.
+
+https://github.com/owncloud/web/pull/4991

--- a/changelog/unreleased/enhancement-direct-delete
+++ b/changelog/unreleased/enhancement-direct-delete
@@ -1,6 +1,6 @@
 Enhancement: Implement proper direct delete
 
-Implement a proper delete action for a single file. Previously this was being handled via selecting the file.
+We implemented a proper delete action for a single file instead of reusing the batch action for deleting multiple files.
 This also solves the issue with the checkbox being checked when opening the delete modal, which was not a11y compliant.
 
 https://github.com/owncloud/web/pull/4991

--- a/packages/web-app-files/src/mixins/deleteResources.js
+++ b/packages/web-app-files/src/mixins/deleteResources.js
@@ -7,7 +7,7 @@ export default {
   data: () => ({
     deleteResources_queue: new PQueue({ concurrency: 4 }),
     deleteResources_deleteOps: [],
-    filesToDelete: []
+    resourcesToDelete: []
   }),
 
   computed: {
@@ -19,7 +19,7 @@ export default {
     },
 
     $_deleteResources_resources() {
-      return cloneStateObject(this.filesToDelete)
+      return cloneStateObject(this.resourcesToDelete)
     },
 
     $_deleteResources_dialogTitle() {
@@ -186,9 +186,9 @@ export default {
     $_deleteResources_displayDialog(resources = null, direct = false) {
       // Deleting a resource via direct action
       if (direct) {
-        this.filesToDelete = [resources]
+        this.resourcesToDelete = [resources]
       } else {
-        this.filesToDelete = this.selectedFiles
+        this.resourcesToDelete = this.selectedFiles
       }
 
       const modal = {

--- a/packages/web-app-files/src/mixins/deleteResources.js
+++ b/packages/web-app-files/src/mixins/deleteResources.js
@@ -6,7 +6,8 @@ import PQueue from 'p-queue'
 export default {
   data: () => ({
     deleteResources_queue: new PQueue({ concurrency: 4 }),
-    deleteResources_deleteOps: []
+    deleteResources_deleteOps: [],
+    filesToDelete: []
   }),
 
   computed: {
@@ -18,7 +19,7 @@ export default {
     },
 
     $_deleteResources_resources() {
-      return cloneStateObject(this.selectedFiles)
+      return cloneStateObject(this.filesToDelete)
     },
 
     $_deleteResources_dialogTitle() {
@@ -184,10 +185,10 @@ export default {
 
     $_deleteResources_displayDialog(resources = null, direct = false) {
       // Deleting a resource via direct action
-      // TODO: Do a direct delete without actually selecting the resource and resetting the selection
       if (direct) {
-        this.resetFileSelection()
-        this.addFileSelection(resources)
+        this.filesToDelete = [resources]
+      } else {
+        this.filesToDelete = this.selectedFiles
       }
 
       const modal = {


### PR DESCRIPTION
## Description
Implement a proper delete action for a single file. Previously this was being handled via selecting the file. This also solves the issue with the checkbox being checked when opening the delete modal, which was not a11y compliant.

Honestly I'm not quite sure about the approach, it seems too easy... but it works well on my side 🤷 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...