### PR TITLE
Focus-Management

### DIFF
--- a/changelog/unreleased/enhancement-focus-management
+++ b/changelog/unreleased/enhancement-focus-management
@@ -1,0 +1,7 @@
+Enhancement: Focus management
+
+We added a mixin that makes it able to manage, record and reverse-replay the focus for the current document.
+The first components that using it are modal and sidebar in the files app.
+
+https://github.com/owncloud/web/pull/4993
+https://github.com/owncloud/web/issues/4992

--- a/packages/web-app-files/src/App.vue
+++ b/packages/web-app-files/src/App.vue
@@ -14,8 +14,13 @@
     <sidebar
       v-if="_sidebarOpen"
       id="files-sidebar"
+      ref="filesSidebar"
+      tabindex="-1"
       class="uk-width-1-1 uk-width-1-2@m uk-width-1-3@xl"
       @reset="setHighlightedFile(null)"
+      @beforeDestroy="focusSideBar"
+      @mounted="focusSideBar"
+      @fileChanged="focusSideBar"
     />
   </main>
 </template>
@@ -89,6 +94,13 @@ export default {
     openSideBar(file, sideBarName) {
       this.setHighlightedFile(file)
       this.SET_APP_SIDEBAR_EXPANDED_ACCORDION(sideBarName)
+    },
+    focusSideBar(component, event) {
+      this.focus({
+        from: document.activeElement,
+        to: this.$refs.filesSidebar?.$el,
+        revert: event === 'beforeDestroy'
+      })
     },
 
     $_ocApp_dragOver() {

--- a/packages/web-app-files/src/components/Sidebar.vue
+++ b/packages/web-app-files/src/components/Sidebar.vue
@@ -158,6 +158,7 @@ export default {
       if (this.expandedAccordionId === null) {
         this.expandActionsAccordion()
       }
+      this.$nextTick(() => this.$emit('fileChanged', this, 'fileChanged'))
     }
   },
 

--- a/packages/web-runtime/src/App.vue
+++ b/packages/web-runtime/src/App.vue
@@ -79,6 +79,8 @@
           @cancel="modal.onCancel"
           @confirm="modal.onConfirm"
           @input="modal.onInput"
+          @mounted="focusModal"
+          @beforeDestroy="focusModal"
         />
       </transition>
     </div>
@@ -291,6 +293,12 @@ export default {
 
   methods: {
     ...mapActions(['initAuth', 'fetchNotifications', 'deleteMessage']),
+
+    focusModal(component, event) {
+      this.focus({
+        revert: event === 'beforeDestroy'
+      })
+    },
 
     hideAppNavigation() {
       this.appNavigationVisible = false

--- a/packages/web-runtime/src/components/UserMenu.vue
+++ b/packages/web-runtime/src/components/UserMenu.vue
@@ -36,6 +36,7 @@
             appearance="raw"
             gap-size="xsmall"
             justify-content="left"
+            tabindex="0"
           >
             <oc-icon name="portrait" />
             <translate>Profile</translate>
@@ -50,6 +51,7 @@
             justify-content="left"
             :target="n.target"
             :href="n.url"
+            tabindex="0"
           >
             <oc-icon :name="n.iconMaterial" />
             <span>{{ n.title }}</span>
@@ -61,6 +63,7 @@
             gap-size="xsmall"
             justify-content="left"
             :to="{ path: n.path }"
+            tabindex="0"
           >
             <oc-icon :name="n.iconMaterial" />
             <span v-text="n.title" />

--- a/packages/web-runtime/src/index.js
+++ b/packages/web-runtime/src/index.js
@@ -22,6 +22,10 @@ import VueScrollTo from 'vue-scrollto'
 import VueMeta from 'vue-meta'
 import Vue2TouchEvents from 'vue2-touch-events'
 
+// --- Mixins ----
+import focusMixin from './mixins/focusMixin'
+import lifecycleMixin from './mixins/lifecycleMixin'
+
 // --- Gettext ----
 import GetTextPlugin from 'vue-gettext'
 import coreTranslations from '../l10n/translations.json'
@@ -71,6 +75,9 @@ Vue.use(Vue2TouchEvents)
 Vue.component('drag', Drag)
 Vue.component('drop', Drop)
 Vue.component('avatar-image', Avatar)
+
+Vue.mixin(focusMixin)
+Vue.mixin(lifecycleMixin)
 
 // --- Router ----
 

--- a/packages/web-runtime/src/mixins/focusMixin.js
+++ b/packages/web-runtime/src/mixins/focusMixin.js
@@ -1,0 +1,30 @@
+const tape = []
+const isDomNode = node => node instanceof Element
+const DIRECTION_FORWARD = 'forward'
+const DIRECTION_BACKWARD = 'backward'
+
+export default {
+  methods: {
+    focus({ from, to, revert }) {
+      const direction = revert ? DIRECTION_BACKWARD : DIRECTION_FORWARD
+
+      if (from && direction === DIRECTION_FORWARD) {
+        tape.splice(0, tape.length)
+      } else {
+        from = document.activeElement
+      }
+
+      if (direction === DIRECTION_FORWARD) {
+        tape.push(from)
+      }
+
+      if (direction === DIRECTION_BACKWARD) {
+        to = tape.pop()
+      }
+
+      if (isDomNode(to)) {
+        to.focus()
+      }
+    }
+  }
+}

--- a/packages/web-runtime/src/mixins/lifecycleMixin.js
+++ b/packages/web-runtime/src/mixins/lifecycleMixin.js
@@ -1,0 +1,11 @@
+export default {
+  mounted() {
+    this.$nextTick(() => this.$emit('mounted', this, 'mounted'))
+  },
+  beforeDestroy() {
+    this.$emit('beforeDestroy', this, 'beforeDestroy')
+  },
+  updated() {
+    this.$nextTick(() => this.$emit('updated', this, 'updated'))
+  }
+}

--- a/packages/web-runtime/tests/mixins/focusMixin.spec.js
+++ b/packages/web-runtime/tests/mixins/focusMixin.spec.js
@@ -1,0 +1,134 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils'
+import focusMixin from '../../src/mixins/focusMixin'
+
+const localVue = createLocalVue()
+localVue.mixin(focusMixin)
+const wrapper = shallowMount(
+  {
+    name: 'dummy',
+    // language=HTML
+    template: `
+          <ul>
+            <li v-for="index in 10" :key="index">
+              <a v-bind:id="'item-' + index" tabindex="0">{{index}}</a>
+            </li>
+          </ul>
+        `
+  },
+  {
+    localVue,
+    attachTo: document.body
+  }
+)
+const wrapperComponent = wrapper.findComponent({ name: 'dummy' })
+const item1 = wrapper.get('#item-1')
+const item2 = wrapper.get('#item-2')
+const item3 = wrapper.get('#item-3')
+const item4 = wrapper.get('#item-4')
+const item5 = wrapper.get('#item-5')
+const item6 = wrapper.get('#item-6')
+const item7 = wrapper.get('#item-7')
+const item8 = wrapper.get('#item-8')
+const item9 = wrapper.get('#item-9')
+const item10 = wrapper.get('#item-10')
+const focus = wrapperComponent.vm?.focus
+
+describe('focusMixin', () => {
+  // trap -----------------------
+  // #item-1  || ---  x ||  3 <--
+  // #item-2  || -->  4 ||  x ---
+  // #item-3  || -->  1 ||  5 <--
+  // #item-4  || -->  6 ||  2 <--
+  // #item-5  || -->  3 ||  7 <--
+  // #item-6  || -->  8 ||  4 <--
+  // #item-7  || -->  5 ||  9 <--
+  // #item-8  || --> 10 ||  6 <--
+  // #item-9  || -->  7 || 10 <--
+  // #item-10 || -->  9 ||  8 <--
+  it('records and replays focus events', async () => {
+    focus({ from: item2.element, to: item4.element })
+    expect(document.activeElement.id).toBe(item4.element.id)
+
+    focus({ to: item6.element })
+    expect(document.activeElement.id).toBe(item6.element.id)
+
+    focus({ to: item8.element })
+    expect(document.activeElement.id).toBe(item8.element.id)
+
+    focus({ to: item10.element })
+    expect(document.activeElement.id).toBe(item10.element.id)
+
+    focus({ to: item9.element })
+    expect(document.activeElement.id).toBe(item9.element.id)
+
+    focus({ to: item7.element })
+    expect(document.activeElement.id).toBe(item7.element.id)
+
+    focus({ to: item5.element })
+    expect(document.activeElement.id).toBe(item5.element.id)
+
+    focus({ to: item3.element })
+    expect(document.activeElement.id).toBe(item3.element.id)
+
+    focus({ to: item1.element })
+    expect(document.activeElement.id).toBe(item1.element.id)
+
+    focus({ revert: true })
+    expect(document.activeElement.id).toBe(item3.element.id)
+
+    focus({ revert: true })
+    expect(document.activeElement.id).toBe(item5.element.id)
+
+    focus({ revert: true })
+    expect(document.activeElement.id).toBe(item7.element.id)
+
+    focus({ revert: true })
+    expect(document.activeElement.id).toBe(item9.element.id)
+
+    focus({ revert: true })
+    expect(document.activeElement.id).toBe(item10.element.id)
+
+    focus({ revert: true })
+    expect(document.activeElement.id).toBe(item8.element.id)
+
+    focus({ revert: true })
+    expect(document.activeElement.id).toBe(item6.element.id)
+
+    focus({ revert: true })
+    expect(document.activeElement.id).toBe(item4.element.id)
+
+    focus({ revert: true })
+    expect(document.activeElement.id).toBe(item2.element.id)
+  })
+
+  // trap ----------------------
+  // #item-2  || -->  4 || x ---
+  // #item-4  || -->  6 || x ---
+  // #item-6  || ---  x || 4 <--
+  // restart trap --------------
+  // #item-1  || -->  8 || x ---
+  // #item-8  || --> 10 || 1 <--
+  // #item-10 || ---  x || 8 <--
+  it('can be restarted', async () => {
+    focus({ from: item2.element, to: item4.element })
+    expect(document.activeElement.id).toBe(item4.element.id)
+
+    focus({ to: item6.element })
+    expect(document.activeElement.id).toBe(item6.element.id)
+
+    focus({ revert: true })
+    expect(document.activeElement.id).toBe(item4.element.id)
+
+    focus({ from: item1.element, to: item8.element })
+    expect(document.activeElement.id).toBe(item8.element.id)
+
+    focus({ to: item10.element })
+    expect(document.activeElement.id).toBe(item10.element.id)
+
+    focus({ revert: true })
+    expect(document.activeElement.id).toBe(item8.element.id)
+
+    focus({ revert: true })
+    expect(document.activeElement.id).toBe(item1.element.id)
+  })
+})

--- a/packages/web-runtime/tests/mixins/lifecycleMixin.spec.js
+++ b/packages/web-runtime/tests/mixins/lifecycleMixin.spec.js
@@ -1,0 +1,46 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils'
+import lifecycleMixin from '../../src/mixins/lifecycleMixin'
+
+const localVue = createLocalVue()
+localVue.mixin(lifecycleMixin)
+const wrapper = shallowMount(
+  {
+    name: 'dummy',
+    data: () => ({
+      id: 'dummy'
+    }),
+    template: '<div v-bind:id="id">{{id}}</div>'
+  },
+  {
+    localVue
+  }
+)
+const wrapperComponent = wrapper.findComponent({ name: 'dummy' })
+
+describe('livecycleMixin', () => {
+  it('handles mounted', async () => {
+    await wrapper.vm.$nextTick()
+    const event = 'mounted'
+    const [emittedComponent, emittedEvent] = wrapper.emitted(event)[0]
+    expect(emittedComponent.$el.outerHTML).toBe(wrapperComponent.html())
+    expect(emittedEvent).toBe(event)
+  })
+
+  it('handles updated', async () => {
+    const event = 'updated'
+    wrapperComponent.vm.$data.id = event
+    await wrapper.vm.$nextTick()
+    const [emittedComponent, emittedEvent] = wrapper.emitted(event)[0]
+    expect(emittedComponent.$el.outerHTML).toBe(wrapperComponent.html())
+    expect(emittedEvent).toBe(event)
+  })
+
+  it('handles beforeDestroy', async () => {
+    const event = 'beforeDestroy'
+    wrapperComponent.destroy()
+    await wrapper.vm.$nextTick()
+    const [emittedComponent, emittedEvent] = wrapper.emitted(event)[0]
+    expect(emittedComponent.$el.outerHTML).toBe(wrapperComponent.element.outerHTML)
+    expect(emittedEvent).toBe(event)
+  })
+})


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
to get a better background why this is needed please read #4992 beforehand.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #4992 

## Motivation and Context
This pr introduces the concept of user driven focus management.

This is helpful when a user navigates using the keyboard and the given context switches, for example the sidebar or and a modal opens which has a different tabindex and the user will never get there (more or less). 

Now it's possible to decide which item should be focused after a given action (modal open, sidebar show). 
The important part here is that those interactions need to be able to be rolled back.  (replayed in a reverse order).

- if a user closes a modal, the focus should jump back to the exact position where he started.
- if a sidebar opens the focus should jump into the sidebar or vice versa if it gets closed.

following worst case scenario is part of the idea behind it.
- user tabs through the page
- user opens the sidebar by pressing enter on the dedicated button
- the sidebar opens and the focus needs to jump to the close button of it
- the user tabs through the links in the sidebar and hits enter on "rename"
- the rename modal opens, the user tabs to update
- the modal closes and the focus must jump back to "rename" in sidebar
- the user tabs back to the sidebar close button and press enter which closes the sidebar
- the focus must jump back to the element where the user started (the three dots for example)

all this needs to be replayable in random order.

On top of this we also fixed some minor issues regarding tabindex in the top-bar. It also includes a new global lifecycle mixing which makes it possible to listen to events like mounted, replayable, ... without the requirement that those are defined by the consumed component.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- manual

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] tests
- [ ] discuss the scope of this
- [ ] changelog