### PR TITLE
Improve accessibility for the files sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Summary
 * Enhancement - Accessibility improvements: [#4965](https://github.com/owncloud/web/pull/4965)
 * Enhancement - Implement proper direct delete: [#4991](https://github.com/owncloud/web/pull/4991)
 * Enhancement - Enable files app search bar to be toggleable on a per-route basis: [#4815](https://github.com/owncloud/web/pull/4815)
+* Enhancement - Focus management: [#4993](https://github.com/owncloud/web/pull/4993)
 * Enhancement - Use list for displaying added people: [#4915](https://github.com/owncloud/web/pull/4915)
 * Enhancement - Show search button in search bar: [#4985](https://github.com/owncloud/web/pull/4985)
 
@@ -49,6 +50,14 @@ Details
    Permits the search bar in the files app to be toggleable on a per-route basis as shown or hidden.
 
    https://github.com/owncloud/web/pull/4815
+
+* Enhancement - Focus management: [#4993](https://github.com/owncloud/web/pull/4993)
+
+   We added a mixin that makes it able to manage, record and reverse-replay the focus for the
+   current document. The first components that using it are modal and sidebar in the files app.
+
+   https://github.com/owncloud/web/issues/4992
+   https://github.com/owncloud/web/pull/4993
 
 * Enhancement - Use list for displaying added people: [#4915](https://github.com/owncloud/web/pull/4915)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Summary
 * Enhancement - Implement proper direct delete: [#4991](https://github.com/owncloud/web/pull/4991)
 * Enhancement - Enable files app search bar to be toggleable on a per-route basis: [#4815](https://github.com/owncloud/web/pull/4815)
 * Enhancement - Focus management: [#4993](https://github.com/owncloud/web/pull/4993)
+* Enhancement - Align headline hierarchy: [#5003](https://github.com/owncloud/web/pull/5003)
 * Enhancement - Use list for displaying added people: [#4915](https://github.com/owncloud/web/pull/4915)
 * Enhancement - Show search button in search bar: [#4985](https://github.com/owncloud/web/pull/4985)
 
@@ -58,6 +59,12 @@ Details
 
    https://github.com/owncloud/web/issues/4992
    https://github.com/owncloud/web/pull/4993
+
+* Enhancement - Align headline hierarchy: [#5003](https://github.com/owncloud/web/pull/5003)
+
+   Streamlined headline tags so that pages have a h1 tag and the headline hierarchy is adhered.
+
+   https://github.com/owncloud/web/pull/5003
 
 * Enhancement - Use list for displaying added people: [#4915](https://github.com/owncloud/web/pull/4915)
 

--- a/changelog/unreleased/enhancement-files-sidebar-accessibility
+++ b/changelog/unreleased/enhancement-files-sidebar-accessibility
@@ -1,12 +1,13 @@
 Enhancement: Improve accessibility for the files sidebar
 
 We've did several improvements to enhance the accessibility on the files sidebar:
-- Transformed the file name to a h3 element
+- Transformed the file name to a h2 element
 - Transformed the "Open folder"-action to a link instead of a button
 - Transformed the favorite-star to a button-element
 - Adjusted aria-label of the favorite-star to describe what it does instead of its current state
 - Added a more descriptive close button label
 - Clicking outside of the sidebar now closes it
 - Removed the aria-label on the action buttons as they already include proper labels
+- Added a hint for screen readers if an action opens a new window/tab
 
 https://github.com/owncloud/web/pull/5000

--- a/changelog/unreleased/enhancement-files-sidebar-accessibility
+++ b/changelog/unreleased/enhancement-files-sidebar-accessibility
@@ -1,0 +1,12 @@
+Enhancement: Improve accessibility for the files sidebar
+
+We've did several improvements to enhance the accessibility on the files sidebar:
+- Transformed the file name to a h3 element
+- Transformed the "Open folder"-action to a link instead of a button
+- Transformed the favorite-star to a button-element
+- Adjusted aria-label of the favorite-star to describe what it does instead of its current state
+- Added a more descriptive close button label
+- Clicking outside of the sidebar now closes it
+- Removed the aria-label on the action buttons as they already include proper labels
+
+https://github.com/owncloud/web/pull/5000

--- a/packages/web-app-files/src/components/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar.vue
@@ -10,7 +10,7 @@
       @error="onFileError"
       @progress="onFileProgress"
     />
-    <div>
+    <div class="files-topbar">
       <oc-breadcrumb
         v-if="showBreadcrumb"
         id="files-breadcrumb"

--- a/packages/web-app-files/src/components/Sidebar.vue
+++ b/packages/web-app-files/src/components/Sidebar.vue
@@ -221,6 +221,6 @@ export default {
   }
 }
 #files-sidebar-item-name {
-  font-size: medium;
+  font-size: 1rem;
 }
 </style>

--- a/packages/web-app-files/src/components/Sidebar.vue
+++ b/packages/web-app-files/src/components/Sidebar.vue
@@ -3,6 +3,7 @@
     :key="highlightedFile.id"
     class="files-sidebar oc-p-s oc-border-l"
     :disable-action="false"
+    :close-button-label="$gettext('Close file sidebar')"
     @close="close()"
   >
     <template v-if="highlightedFile" slot="title">
@@ -11,9 +12,10 @@
       </div>
       <div class="uk-inline">
         <div class="uk-flex uk-flex-middle">
-          <span
+          <h3
             id="files-sidebar-item-name"
-            class="oc-mr-s oc-text-bold"
+            class="oc-mr-s oc-text-bold uk-margin-remove"
+            tabindex="-1"
             v-text="highlightedFile.name"
           />
         </div>
@@ -217,5 +219,8 @@ export default {
   &-shining svg {
     fill: #ffba0a !important;
   }
+}
+#files-sidebar-item-name {
+  font-size: medium;
 }
 </style>

--- a/packages/web-app-files/src/components/Sidebar.vue
+++ b/packages/web-app-files/src/components/Sidebar.vue
@@ -13,7 +13,7 @@
       </div>
       <div class="uk-inline">
         <div class="uk-flex uk-flex-middle">
-          <h3
+          <h2
             id="files-sidebar-item-name"
             class="oc-text-initial oc-mr-s oc-text-bold uk-margin-remove"
             tabindex="-1"

--- a/packages/web-app-files/src/components/Sidebar.vue
+++ b/packages/web-app-files/src/components/Sidebar.vue
@@ -1,6 +1,7 @@
 <template>
   <oc-app-side-bar
     :key="highlightedFile.id"
+    v-click-outside="onClickOutside"
     class="files-sidebar oc-p-s oc-border-l"
     :disable-action="false"
     :close-button-label="$gettext('Close file sidebar')"
@@ -206,6 +207,12 @@ export default {
 
     expandActionsAccordion() {
       this.SET_APP_SIDEBAR_EXPANDED_ACCORDION('files-actions')
+    },
+
+    onClickOutside(event) {
+      if (!document.querySelector('.files-table').contains(event.target)) {
+        this.close()
+      }
     }
   }
 }

--- a/packages/web-app-files/src/components/Sidebar.vue
+++ b/packages/web-app-files/src/components/Sidebar.vue
@@ -20,18 +20,20 @@
           />
         </div>
         <div class="uk-flex uk-flex-middle">
-          <oc-icon
+          <oc-button
             v-if="!publicPage() && isFavoritesEnabled"
             id="files-sidebar-star-icon"
-            :class="['uk-inline', 'oc-mr-xs', favoriteIconClass]"
-            name="star"
-            :accessible-label="
+            :aria-label="
               highlightedFile.starred
-                ? $gettext('File is marked as favorite')
-                : $gettext('File is not marked as favorite')
+                ? $gettext('Click to remove this file from your favorites')
+                : $gettext('Click to mark this file as favorite')
             "
+            appearance="raw"
+            class="oc-mr-xs"
             @click.native.stop="toggleFileFavorite(highlightedFile)"
-          />
+          >
+            <oc-icon :class="favoriteIconClass" name="star" />
+          </oc-button>
           <template v-if="highlightedFile.size > -1">
             {{ getResourceSize(highlightedFile.size) }},
           </template>

--- a/packages/web-app-files/src/components/Sidebar.vue
+++ b/packages/web-app-files/src/components/Sidebar.vue
@@ -210,7 +210,12 @@ export default {
     },
 
     onClickOutside(event) {
-      if (!document.querySelector('.files-table').contains(event.target)) {
+      if (
+        document.querySelector('.files-topbar').contains(event.target) ||
+        document.querySelector('.oc-topbar').contains(event.target) ||
+        document.querySelector('.oc-app-navigation').contains(event.target) ||
+        event.target.id === 'files-view'
+      ) {
         this.close()
       }
     }

--- a/packages/web-app-files/src/components/Sidebar.vue
+++ b/packages/web-app-files/src/components/Sidebar.vue
@@ -210,6 +210,11 @@ export default {
     },
 
     onClickOutside(event) {
+      /*
+       * We need to go for this opt-out solution because under circumstances a model will be rendered,
+       * for example if we click rename, clicking in this model would otherwise falsy close the sidebar.
+       */
+
       if (
         document.querySelector('.files-topbar').contains(event.target) ||
         document.querySelector('.oc-topbar').contains(event.target) ||

--- a/packages/web-app-files/src/components/Sidebar.vue
+++ b/packages/web-app-files/src/components/Sidebar.vue
@@ -211,8 +211,8 @@ export default {
 
     onClickOutside(event) {
       /*
-       * We need to go for this opt-out solution because under circumstances a model will be rendered,
-       * for example if we click rename, clicking in this model would otherwise falsy close the sidebar.
+       * We need to go for this opt-out solution because under circumstances a modal will be rendered,
+       * for example if we click rename, clicking in this modal would otherwise falsy close the sidebar.
        */
 
       if (

--- a/packages/web-app-files/src/components/Sidebar/ActionsAccordion.vue
+++ b/packages/web-app-files/src/components/Sidebar/ActionsAccordion.vue
@@ -8,7 +8,9 @@
         @click.stop="action.handler(highlightedFile, action.handlerData)"
       >
         <oc-icon :name="action.icon" size="medium" />
-        {{ action.label(highlightedFile) }}
+        <span class="oc-files-actions-sidebar-action-label">{{
+          action.label(highlightedFile)
+        }}</span>
         <span
           v-if="action.opensInNewWindow"
           class="oc-invisible-sr"

--- a/packages/web-app-files/src/components/Sidebar/ActionsAccordion.vue
+++ b/packages/web-app-files/src/components/Sidebar/ActionsAccordion.vue
@@ -1,10 +1,9 @@
 <template>
-  <ul id="oc-files-actions-sidebar" class="uk-list oc-mt-s">
+  <ul id="oc-files-actions-sidebar" class="uk-list oc-mt-s oc-files-actions-sidebar-actions">
     <li v-for="action in actions" :key="action.label(highlightedFile)" class="oc-py-xs">
       <component
         :is="action.componentType"
         v-bind="getComponentProps(action, highlightedFile)"
-        appearance="raw"
         class="oc-text-bold"
         @click.stop="action.handler(highlightedFile, action.handlerData)"
       >
@@ -53,8 +52,23 @@ export default {
         }
       }
 
-      return {}
+      return {
+        appearance: 'raw'
+      }
     }
   }
 }
 </script>
+
+<style lang="scss">
+.oc-files-actions-sidebar-actions {
+  > li a,
+  > li a:hover {
+    text-decoration: none;
+    color: var(--oc-color-swatch-passive-default);
+    display: inline-flex;
+    gap: 10px;
+    vertical-align: top;
+  }
+}
+</style>

--- a/packages/web-app-files/src/components/Sidebar/ActionsAccordion.vue
+++ b/packages/web-app-files/src/components/Sidebar/ActionsAccordion.vue
@@ -1,16 +1,15 @@
 <template>
   <ul id="oc-files-actions-sidebar" class="uk-list oc-mt-s">
-    <li v-for="action in actions" :key="action.ariaLabel(highlightedFile)" class="oc-py-xs">
+    <li v-for="action in actions" :key="action.label(highlightedFile)" class="oc-py-xs">
       <component
-        :is="getComponentType(action)"
-        v-bind="getComponentProps(action)"
-        :aria-Label="action.ariaLabel(highlightedFile)"
+        :is="action.componentType"
+        v-bind="getComponentProps(action, highlightedFile)"
         appearance="raw"
         class="oc-text-bold"
         @click.stop="action.handler(highlightedFile, action.handlerData)"
       >
         <oc-icon :name="action.icon" size="medium" />
-        {{ action.ariaLabel(highlightedFile) }}
+        {{ action.label(highlightedFile) }}
       </component>
     </li>
   </ul>
@@ -42,18 +41,15 @@ export default {
     }
   },
   methods: {
-    getComponentType(action) {
-      if (action.componentType) {
-        return action.componentType
-      }
-
-      return 'oc-button'
-    },
-    getComponentProps(action) {
-      const route = action.getRoute()
-      if (action.componentType === 'router-link' && route) {
+    getComponentProps(action, highlightedFile) {
+      if (action.componentType === 'router-link' && action.route) {
         return {
-          to: route
+          to: {
+            name: action.route,
+            params: {
+              item: highlightedFile.path
+            }
+          }
         }
       }
 

--- a/packages/web-app-files/src/components/Sidebar/ActionsAccordion.vue
+++ b/packages/web-app-files/src/components/Sidebar/ActionsAccordion.vue
@@ -1,7 +1,9 @@
 <template>
   <ul id="oc-files-actions-sidebar" class="uk-list oc-mt-s">
     <li v-for="action in actions" :key="action.ariaLabel(highlightedFile)" class="oc-py-xs">
-      <oc-button
+      <component
+        :is="getComponentType(action)"
+        v-bind="getComponentProps(action)"
         :aria-Label="action.ariaLabel(highlightedFile)"
         appearance="raw"
         class="oc-text-bold"
@@ -9,7 +11,7 @@
       >
         <oc-icon :name="action.icon" size="medium" />
         {{ action.ariaLabel(highlightedFile) }}
-      </oc-button>
+      </component>
     </li>
   </ul>
 </template>
@@ -37,6 +39,25 @@ export default {
           parent: this.currentFolder
         })
       )
+    }
+  },
+  methods: {
+    getComponentType(action) {
+      if (action.componentType) {
+        return action.componentType
+      }
+
+      return 'oc-button'
+    },
+    getComponentProps(action) {
+      const route = action.getRoute()
+      if (action.componentType === 'router-link' && route) {
+        return {
+          to: route
+        }
+      }
+
+      return {}
     }
   }
 }

--- a/packages/web-app-files/src/components/Sidebar/ActionsAccordion.vue
+++ b/packages/web-app-files/src/components/Sidebar/ActionsAccordion.vue
@@ -9,6 +9,11 @@
       >
         <oc-icon :name="action.icon" size="medium" />
         {{ action.label(highlightedFile) }}
+        <span
+          v-if="action.opensInNewWindow"
+          class="oc-invisible-sr"
+          v-text="$gettext('(Opens in new window)')"
+        />
       </component>
     </li>
   </ul>

--- a/packages/web-app-files/src/mixins/actions/copy.js
+++ b/packages/web-app-files/src/mixins/actions/copy.js
@@ -11,7 +11,7 @@ export default {
         {
           icon: 'file_copy',
           handler: this.$_copy_trigger,
-          ariaLabel: () => this.$gettext('Copy'),
+          label: () => this.$gettext('Copy'),
           isEnabled: () => {
             if (
               !checkRoute(
@@ -27,7 +27,8 @@ export default {
             }
 
             return true
-          }
+          },
+          componentType: 'oc-button'
         }
       ]
     }

--- a/packages/web-app-files/src/mixins/actions/delete.js
+++ b/packages/web-app-files/src/mixins/actions/delete.js
@@ -8,7 +8,7 @@ export default {
       return [
         {
           icon: 'delete',
-          ariaLabel: () => {
+          label: () => {
             return this.$gettext('Delete')
           },
           handler: this.$_delete_trigger,
@@ -18,13 +18,15 @@ export default {
             }
 
             return resource.canBeDeleted()
-          }
+          },
+          componentType: 'oc-button'
         },
         {
           icon: 'delete',
-          ariaLabel: () => this.$gettext('Delete'),
+          label: () => this.$gettext('Delete'),
           handler: this.$_delete_trigger,
-          isEnabled: () => checkRoute(['files-trashbin'], this.$route.name)
+          isEnabled: () => checkRoute(['files-trashbin'], this.$route.name),
+          componentType: 'oc-button'
         }
       ]
     }

--- a/packages/web-app-files/src/mixins/actions/download.js
+++ b/packages/web-app-files/src/mixins/actions/download.js
@@ -7,7 +7,7 @@ export default {
         {
           icon: 'file_download',
           handler: this.$_download_trigger,
-          ariaLabel: () => {
+          label: () => {
             return this.$gettext('Download')
           },
           isEnabled: ({ resource }) => {
@@ -17,7 +17,8 @@ export default {
 
             return resource.canDownload()
           },
-          canBeDefault: true
+          canBeDefault: true,
+          componentType: 'oc-button'
         }
       ]
     }

--- a/packages/web-app-files/src/mixins/actions/favorite.js
+++ b/packages/web-app-files/src/mixins/actions/favorite.js
@@ -9,7 +9,7 @@ export default {
         {
           icon: 'star',
           handler: this.$_favorite_trigger,
-          ariaLabel: item => {
+          label: item => {
             if (item.starred) {
               return this.$gettext('Unmark as favorite')
             }
@@ -27,7 +27,8 @@ export default {
               this.capabilities.files.favorites &&
               isRouteAllowed
             )
-          }
+          },
+          componentType: 'oc-button'
         }
       ]
     }

--- a/packages/web-app-files/src/mixins/actions/fetch.js
+++ b/packages/web-app-files/src/mixins/actions/fetch.js
@@ -22,7 +22,8 @@ export default {
           },
           canBeDefault: true,
           componentType: 'oc-button',
-          class: 'oc-files-actions-sidebar-fetch-trigger'
+          class: 'oc-files-actions-sidebar-fetch-trigger',
+          opensInNewWindow: true
         }
       ]
     }

--- a/packages/web-app-files/src/mixins/actions/fetch.js
+++ b/packages/web-app-files/src/mixins/actions/fetch.js
@@ -10,7 +10,7 @@ export default {
         {
           icon: 'remove_red_eye',
           handler: file => this.$_fetch_trigger(file, 'application/pdf', this.isPublicFilesRoute),
-          ariaLabel: () => {
+          label: () => {
             return this.$gettext('Open in browser')
           },
           isEnabled: ({ resource }) => {
@@ -20,7 +20,8 @@ export default {
 
             return resource.extension === 'pdf'
           },
-          canBeDefault: true
+          canBeDefault: true,
+          componentType: 'oc-button'
         }
       ]
     }

--- a/packages/web-app-files/src/mixins/actions/move.js
+++ b/packages/web-app-files/src/mixins/actions/move.js
@@ -12,7 +12,7 @@ export default {
         {
           icon: 'folder-move',
           handler: resource => this.$_move_trigger(resource),
-          ariaLabel: () =>
+          label: () =>
             this.$pgettext(
               'Action in the files list row to initiate move of a single resource',
               'Move'
@@ -32,7 +32,8 @@ export default {
             }
 
             return canBeMoved(resource, this.currentFolder.path)
-          }
+          },
+          componentType: 'oc-button'
         }
       ]
     }

--- a/packages/web-app-files/src/mixins/actions/navigate.js
+++ b/packages/web-app-files/src/mixins/actions/navigate.js
@@ -18,7 +18,9 @@ export default {
 
             return resource.type === 'folder'
           },
-          canBeDefault: true
+          canBeDefault: true,
+          componentType: 'router-link',
+          getRoute: () => this.$route.name
         }
       ]
     }

--- a/packages/web-app-files/src/mixins/actions/navigate.js
+++ b/packages/web-app-files/src/mixins/actions/navigate.js
@@ -9,7 +9,7 @@ export default {
         {
           icon: 'folder-open',
           handler: resource => this.$_navigate_trigger(resource),
-          ariaLabel: () =>
+          label: () =>
             this.$pgettext('Action in the files list row to open a folder', 'Open folder'),
           isEnabled: ({ resource }) => {
             if (checkRoute(['files-trashbin'], this.$route.name)) {
@@ -20,9 +20,18 @@ export default {
           },
           canBeDefault: true,
           componentType: 'router-link',
-          getRoute: () => this.$route.name
+          route: this.route,
+          getRouterLink: resource => this.getRouterLink(resource)
         }
       ]
+    },
+    route() {
+      let route = 'files-personal'
+      if (this.publicPage()) {
+        route = 'files-public-list'
+      }
+
+      return route
     }
   },
   methods: {
@@ -32,12 +41,9 @@ export default {
       if (this.searchTerm !== '' && this.$route.params.item === folder.path) {
         this.resetSearch()
       }
-      let route = 'files-personal'
-      if (this.publicPage()) {
-        route = 'files-public-list'
-      }
+
       this.$router.push({
-        name: route,
+        name: this.route,
         params: {
           item: folder.path
         }

--- a/packages/web-app-files/src/mixins/actions/navigate.js
+++ b/packages/web-app-files/src/mixins/actions/navigate.js
@@ -20,8 +20,7 @@ export default {
           },
           canBeDefault: true,
           componentType: 'router-link',
-          route: this.route,
-          getRouterLink: resource => this.getRouterLink(resource)
+          route: this.route
         }
       ]
     },

--- a/packages/web-app-files/src/mixins/actions/rename.js
+++ b/packages/web-app-files/src/mixins/actions/rename.js
@@ -10,7 +10,7 @@ export default {
       return [
         {
           icon: 'edit',
-          ariaLabel: () => {
+          label: () => {
             return this.$gettext('Rename')
           },
           handler: this.$_rename_trigger,
@@ -20,7 +20,8 @@ export default {
             }
 
             return resource.canRename()
-          }
+          },
+          componentType: 'oc-button'
         }
       ]
     }

--- a/packages/web-app-files/src/mixins/actions/restore.js
+++ b/packages/web-app-files/src/mixins/actions/restore.js
@@ -8,9 +8,10 @@ export default {
       return [
         {
           icon: 'restore',
-          ariaLabel: () => this.$gettext('Restore'),
+          label: () => this.$gettext('Restore'),
           handler: this.$_restore_trigger,
-          isEnabled: () => checkRoute(['files-trashbin'], this.$route.name)
+          isEnabled: () => checkRoute(['files-trashbin'], this.$route.name),
+          componentType: 'oc-button'
         }
       ]
     }

--- a/packages/web-runtime/src/App.vue
+++ b/packages/web-runtime/src/App.vue
@@ -24,7 +24,7 @@
             v-touch:swipe.left="handleNavSwipe"
             class="oc-app-navigation"
             :logo-img="logoImage"
-            :product-name="productName"
+            product-name="ffff"
             :nav-items="sidebarNavItems"
             :hide-nav="sidebar.navigationHidden"
             :class="sidebarClasses"

--- a/packages/web-runtime/src/App.vue
+++ b/packages/web-runtime/src/App.vue
@@ -24,7 +24,7 @@
             v-touch:swipe.left="handleNavSwipe"
             class="oc-app-navigation"
             :logo-img="logoImage"
-            product-name="ffff"
+            :product-name="productName"
             :nav-items="sidebarNavItems"
             :hide-nav="sidebar.navigationHidden"
             :class="sidebarClasses"

--- a/packages/web-runtime/src/directives/clickOutside.js
+++ b/packages/web-runtime/src/directives/clickOutside.js
@@ -1,0 +1,13 @@
+export default {
+  bind: function(el, binding, vnode) {
+    window.event = function(event) {
+      if (!(el === event.target || el.contains(event.target))) {
+        vnode.context[binding.expression](event)
+      }
+    }
+    document.body.addEventListener('click', window.event)
+  },
+  unbind: function(el) {
+    document.body.removeEventListener('click', window.event)
+  }
+}

--- a/packages/web-runtime/src/index.js
+++ b/packages/web-runtime/src/index.js
@@ -26,6 +26,9 @@ import Vue2TouchEvents from 'vue2-touch-events'
 import focusMixin from './mixins/focusMixin'
 import lifecycleMixin from './mixins/lifecycleMixin'
 
+// --- Directive ---
+import ClickOutsideDirective from './directives/clickOutside'
+
 // --- Gettext ----
 import GetTextPlugin from 'vue-gettext'
 import coreTranslations from '../l10n/translations.json'
@@ -78,6 +81,8 @@ Vue.component('avatar-image', Avatar)
 
 Vue.mixin(focusMixin)
 Vue.mixin(lifecycleMixin)
+
+Vue.directive('click-outside', ClickOutsideDirective)
 
 // --- Router ----
 

--- a/tests/acceptance/features/webUIFilesActionMenu/fileFolderActionMenu.feature
+++ b/tests/acceptance/features/webUIFilesActionMenu/fileFolderActionMenu.feature
@@ -7,7 +7,7 @@ Background: prepare user and files
     Given user "Alice" has been created with default attributes
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
-    
+
   Scenario: observe different actions menu options on selecting different file types or folder
     Given user "Alice" has uploaded file with content "pdf file" to "lorem.pdf"
     And the user has reloaded the current page of the webUI
@@ -26,13 +26,12 @@ Background: prepare user and files
     When the user picks the row of file "lorem.pdf" in the webUI
     Then the app-sidebar for file "lorem.pdf" should be visible on the webUI
     And only the following items with default items should be visible in the actions menu on the webUI
-      | items                     |
-      | open in browser           |
-      | download                  |
+      | items                                           |
+      | open in browser (opens in new window)           |
+      | download                                        |
     When the user picks the row of file "testavatar.png" in the webUI
     Then the app-sidebar for file "testavatar.png" should be visible on the webUI
     And only the following items with default items should be visible in the actions menu on the webUI
       | items                     |
       | open in mediaviewer       |
       | download                  |
-    

--- a/tests/acceptance/features/webUIFilesActionMenu/fileFolderActionMenu.feature
+++ b/tests/acceptance/features/webUIFilesActionMenu/fileFolderActionMenu.feature
@@ -26,9 +26,9 @@ Background: prepare user and files
     When the user picks the row of file "lorem.pdf" in the webUI
     Then the app-sidebar for file "lorem.pdf" should be visible on the webUI
     And only the following items with default items should be visible in the actions menu on the webUI
-      | items                                           |
-      | open in browser (opens in new window)           |
-      | download                                        |
+      | items                     |
+      | open in browser           |
+      | download                  |
     When the user picks the row of file "testavatar.png" in the webUI
     Then the app-sidebar for file "testavatar.png" should be visible on the webUI
     And only the following items with default items should be visible in the actions menu on the webUI

--- a/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
@@ -199,7 +199,7 @@ module.exports = {
     },
     actionPanelItems: {
       selector:
-        '//div[@class="oc-accordion-content"]//li/button | //div[@class="oc-accordion-content"]//li/a',
+        '//div[@class="oc-accordion-content"]//li/button/span[@class="oc-files-actions-sidebar-action-label"] | //div[@class="oc-accordion-content"]//li/a/span[@class="oc-files-actions-sidebar-action-label"]',
       locateStrategy: 'xpath'
     }
   }

--- a/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
@@ -198,7 +198,8 @@ module.exports = {
       selector: '#oc-files-actions-sidebar'
     },
     actionPanelItems: {
-      selector: '//div[@class="oc-accordion-content"]//li/button',
+      selector:
+        '//div[@class="oc-accordion-content"]//li/button | //div[@class="oc-accordion-content"]//li/a',
       locateStrategy: 'xpath'
     }
   }


### PR DESCRIPTION
## Description
* Transform file name to `h2` element
* Transform `Open folder` action to link instead of button
* Add a more descriptive close button label
* Close sidebar when clicking outside of it
* Remove `aria-label` on the action buttons as they already include proper labels
* Transform the favorite-star in sidebar to a button-element, adjust `aria-label`
* Add a hint for screen readers if an action opens a new window/tab

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
