### PR TITLE
Sync page title and h1 tag

### DIFF
--- a/changelog/unreleased/enhancement-h-tags
+++ b/changelog/unreleased/enhancement-h-tags
@@ -2,4 +2,6 @@ Enhancement: Align headline hierarchy
 
 Streamlined headline tags so that pages have a h1 tag and the headline hierarchy is adhered.
 
-https://github.com/owncloud/web/pull/5003
+https://github.com/owncloud/web/issues/5003
+https://github.com/owncloud/web/pull/5004
+https://github.com/owncloud/web/pull/5005

--- a/packages/web-app-files/src/index.js
+++ b/packages/web-app-files/src/index.js
@@ -224,7 +224,8 @@ const routes = [
     },
     meta: {
       auth: false,
-      hideHeadbar: true
+      hideHeadbar: true,
+      title: $gettext('Resolving public link')
     }
   },
   {
@@ -233,7 +234,7 @@ const routes = [
     components: {
       fullscreen: PrivateLink
     },
-    meta: { hideHeadbar: true }
+    meta: { hideHeadbar: true, title: $gettext('Resolving private link') }
   },
   {
     path: '/location-picker/:context/:action/:item?',
@@ -252,7 +253,7 @@ const routes = [
     components: {
       app: FilesDrop
     },
-    meta: { auth: false }
+    meta: { auth: false, title: $gettext('Public file upload') }
   }
 ]
 

--- a/packages/web-app-files/src/views/FilesDrop.vue
+++ b/packages/web-app-files/src/views/FilesDrop.vue
@@ -1,8 +1,6 @@
 <template>
   <div id="files-drop-container" class="uk-height-1-1 uk-flex uk-flex-column uk-flex-between">
-    <h1 class="oc-invisible-sr">
-      <translate>Public file upload</translate>
-    </h1>
+    <h1 class="oc-invisible-sr">{{ pageTitle }}</h1>
     <div class="oc-p uk-height-1-1">
       <div v-if="loading" key="loading-drop" class="uk-flex uk-flex-column uk-flex-middle">
         <h2 class="oc-login-card-title">
@@ -97,6 +95,9 @@ export default {
   computed: {
     ...mapGetters(['configuration']),
     ...mapGetters('Files', ['davProperties', 'publicLinkPassword']),
+    pageTitle() {
+      return this.$gettext(this.$route.meta.title)
+    },
     publicLinkToken() {
       return this.$route.params.token
     },

--- a/packages/web-app-files/src/views/PrivateLink.vue
+++ b/packages/web-app-files/src/views/PrivateLink.vue
@@ -4,9 +4,7 @@
     uk-height-viewport
     :style="{ backgroundImage: 'url(' + backgroundImg + ')' }"
   >
-    <h1 class="oc-invisible-sr">
-      <translate>Resolving private link</translate>
-    </h1>
+    <h1 class="oc-invisible-sr">{{ pageTitle }}</h1>
     <div class="oc-login-card uk-position-center">
       <img class="oc-login-logo" :src="logoImg" alt="" :aria-hidden="true" />
       <div v-if="loading" class="oc-login-card-body">
@@ -37,6 +35,10 @@ export default {
   },
   computed: {
     ...mapGetters(['configuration']),
+
+    pageTitle() {
+      return this.$gettext(this.$route.meta.title)
+    },
 
     backgroundImg() {
       return this.configuration.theme.loginPage.backgroundImg

--- a/packages/web-app-files/src/views/PublicLink.vue
+++ b/packages/web-app-files/src/views/PublicLink.vue
@@ -4,9 +4,7 @@
     uk-height-viewport
     :style="{ backgroundImage: 'url(' + backgroundImg + ')' }"
   >
-    <h1 class="oc-invisible-sr">
-      <translate>Resolving public link</translate>
-    </h1>
+    <h1 class="oc-invisible-sr">{{ pageTitle }}</h1>
     <div class="oc-login-card uk-position-center">
       <img class="oc-login-logo" :src="logoImg" alt="" :aria-hidden="true" />
       <div class="oc-login-card-body">
@@ -74,6 +72,11 @@ export default {
   computed: {
     ...mapGetters(['configuration']),
     ...mapGetters('Files', ['davProperties', 'publicLinkPassword']),
+
+    pageTitle() {
+      return this.$gettext(this.$route.meta.title)
+    },
+
     passwordFieldLabel() {
       return this.$gettext('Enter password for public link')
     },

--- a/packages/web-runtime/src/pages/accessDenied.vue
+++ b/packages/web-runtime/src/pages/accessDenied.vue
@@ -4,6 +4,7 @@
     uk-height-viewport
     :style="{ backgroundImage: 'url(' + backgroundImg + ')' }"
   >
+    <h1 class="oc-invisible-sr">{{ pageTitle }}</h1>
     <div class="oc-login-card uk-position-center">
       <img class="oc-login-logo" :src="logoImg" alt="" :aria-hidden="true" />
       <div class="oc-login-card-body uk-width-large">
@@ -36,6 +37,9 @@ export default {
   name: 'AccessDeniedPage',
   computed: {
     ...mapGetters(['configuration']),
+    pageTitle() {
+      return this.$gettext(this.$route.meta.title)
+    },
     helpDeskText() {
       if (
         this.configuration.theme.general.helpDeskText &&

--- a/packages/web-runtime/src/pages/account.vue
+++ b/packages/web-runtime/src/pages/account.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="uk-width-1-1 uk-container oc-p">
     <div v-if="loading" class="uk-flex uk-flex-between uk-flex-middle">
-      <h1 v-translate class="oc-page-title">Account</h1>
+      <h1 class="oc-page-title">{{ pageTitle }}</h1>
       <oc-loader />
     </div>
     <template v-else>
@@ -61,6 +61,9 @@ export default {
   },
   computed: {
     ...mapGetters(['user', 'configuration', 'getNavItemsByExtension', 'isOcis']),
+    pageTitle() {
+      return this.$gettext(this.$route.meta.title)
+    },
     editUrl() {
       if (this.isOcis) {
         return null

--- a/packages/web-runtime/src/pages/login.vue
+++ b/packages/web-runtime/src/pages/login.vue
@@ -5,14 +5,15 @@
     uk-height-viewport
     :style="{ backgroundImage: 'url(' + backgroundImg + ')' }"
   >
+    <h1 class="oc-invisible-sr">{{ pageTitle }}</h1>
     <div class="oc-login-card uk-position-center">
       <img class="oc-login-logo" :src="logoImg" alt="" :aria-hidden="true" />
       <div class="oc-login-card-body">
-        <h1 class="oc-login-card-title">
+        <h2 class="oc-login-card-title">
           <translate :translate-params="{ productName: $_productName }"
             >Welcome to %{productName}</translate
           >
-        </h1>
+        </h2>
         <p v-translate>
           Please click the button below to authenticate and get access to your data.
         </p>
@@ -48,6 +49,10 @@ export default {
   },
   computed: {
     ...mapGetters(['configuration']),
+
+    pageTitle() {
+      return this.$gettext(this.$route.meta.title)
+    },
 
     $_productName() {
       return this.configuration.theme.general.name

--- a/packages/web-runtime/src/pages/oidcCallback.vue
+++ b/packages/web-runtime/src/pages/oidcCallback.vue
@@ -4,12 +4,13 @@
     :style="{ backgroundImage: 'url(' + backgroundImg + ')' }"
     uk-height-viewport
   >
+    <h1 class="oc-invisible-sr">{{ pageTitle }}</h1>
     <div class="oc-login-card uk-position-center">
       <img class="oc-login-logo" :src="logoImg" alt="" :aria-hidden="true" />
       <div v-show="error" class="oc-login-card-body">
-        <h1 class="oc-login-card-title">
+        <h2 class="oc-login-card-title">
           <translate>Authentication failed</translate>
-        </h1>
+        </h2>
         <p v-translate>
           Please contact the administrator if this error persists.
         </p>
@@ -43,6 +44,10 @@ export default {
 
   computed: {
     ...mapGetters(['configuration']),
+
+    pageTitle() {
+      return this.$gettext(this.$route.meta.title)
+    },
 
     backgroundImg() {
       return this.configuration.theme.loginPage.backgroundImg

--- a/packages/web-runtime/src/router/index.js
+++ b/packages/web-runtime/src/router/index.js
@@ -23,33 +23,33 @@ const router = new Router({
       components: {
         fullscreen: LoginPage
       },
-      meta: { auth: false, hideHeadbar: true, pageTitle: $gettext('Login') }
+      meta: { auth: false, hideHeadbar: true, title: $gettext('Login') }
     },
     {
       path: '/oidc-callback',
       components: {
         fullscreen: OidcCallbackPage
       },
-      meta: { auth: false, hideHeadbar: true, pageTitle: $gettext('Oidc callback') }
+      meta: { auth: false, hideHeadbar: true, title: $gettext('Oidc callback') }
     },
     {
       path: '/oidc-silent-redirect',
       components: {
         fullscreen: OidcCallbackPage
       },
-      meta: { auth: false, hideHeadbar: true, pageTitle: $gettext('Oidc redirect') }
+      meta: { auth: false, hideHeadbar: true, title: $gettext('Oidc redirect') }
     },
     {
       path: '/f/:fileId',
       name: 'privateLink',
       redirect: '/files/private-link/:fileId',
-      meta: { hideHeadbar: true, pageTitle: $gettext('Private link') }
+      meta: { hideHeadbar: true, title: $gettext('Private link') }
     },
     {
       path: '/s/:token',
       name: 'publicLink',
       redirect: '/files/public-link/:token',
-      meta: { auth: false, hideHeadbar: true, pageTitle: $gettext('Public link') }
+      meta: { auth: false, hideHeadbar: true, title: $gettext('Public link') }
     },
     {
       path: '/access-denied',
@@ -57,7 +57,7 @@ const router = new Router({
       components: {
         fullscreen: AccessDeniedPage
       },
-      meta: { auth: false, hideHeadbar: true, pageTitle: $gettext('Access denied') }
+      meta: { auth: false, hideHeadbar: true, title: $gettext('Access denied') }
     },
     {
       path: '/account',
@@ -65,7 +65,7 @@ const router = new Router({
       components: {
         app: Account
       },
-      meta: { pageTitle: $gettext('Account') }
+      meta: { title: $gettext('Account') }
     }
   ]
 })


### PR DESCRIPTION
## Description
The [last PR](https://github.com/owncloud/web/pull/5004) was not paying attention to actual page titles. With this PR the h1 tags reflect the relevant bit of the page title.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/5003

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
