### PR TITLE
[Tests-Only] Debug filesList intermittent fails

### DIFF
--- a/tests/acceptance/features/webUIFilesList/fileList.feature
+++ b/tests/acceptance/features/webUIFilesList/fileList.feature
@@ -56,7 +56,7 @@ Feature: User can view files inside a folder
       | simple-empty-folder |
       | data.zip            |
 
-
+  @disablePreviews
   Scenario: select files
     When the user marks these files for batch action using the webUI
       | name                |
@@ -69,7 +69,7 @@ Feature: User can view files inside a folder
       | simple-empty-folder |
       | data.zip            |
 
-
+  @disablePreviews
   Scenario: select files and clear the selection
     When the user marks these files for batch action using the webUI
       | name                |


### PR DESCRIPTION
## Description
disabling preview on multi-selection tests as it seems preview sometimes unselect the selected file when preview appears.

## Related Issue
part of https://github.com/owncloud/web/issues/4919

## How Has This Been Tested?
- test environment:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
