### PR TITLE
feat: use real titles in location picker

### DIFF
--- a/changelog/unreleased/enhancement-real-location-picker-title
+++ b/changelog/unreleased/enhancement-real-location-picker-title
@@ -1,0 +1,5 @@
+Enhancement: Use real page title for location picker
+
+We've added real page titles to the location picker. The title is consisted of the current action, target and product name.
+
+https://github.com/owncloud/web/pull/5009

--- a/packages/web-app-files/src/views/LocationPicker.vue
+++ b/packages/web-app-files/src/views/LocationPicker.vue
@@ -101,6 +101,20 @@ export default {
 
   mixins: [MixinsGeneral, MixinResources, MixinRoutes],
 
+  metaInfo() {
+    const translated =
+      this.currentAction === 'move'
+        ? this.$gettext('Move into %{ target } - %{ name }')
+        : this.$gettext('Copy into %{ target } - %{ name }')
+    const target = basename(this.target) || this.$gettext('All files')
+    const title = this.$gettextInterpolate(translated, {
+      target,
+      name: this.configuration.theme.general.name
+    })
+
+    return { title }
+  },
+
   data: () => ({
     headerPosition: 0,
     originalLocation: '',
@@ -122,6 +136,7 @@ export default {
       'activeFilesCount',
       'filesTotalSize'
     ]),
+    ...mapGetters('configuration'),
 
     currentAction() {
       return this.$route.params.action


### PR DESCRIPTION
## Description
We've added real page titles to the location picker. The title is consisted of the current action, target and product name.

## Screenshots (if appropriate):
![Screenshot 2021-04-23 at 14 16 55](https://user-images.githubusercontent.com/25989331/115870063-0644d000-a43f-11eb-89ab-e412a0b8e1b3.png)
![Screenshot 2021-04-23 at 14 16 59](https://user-images.githubusercontent.com/25989331/115870066-06dd6680-a43f-11eb-89ea-2f32711b0888.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
