### PR TITLE
Re-enable yarn link ods by disabling postcss-config in rollup

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,7 +30,8 @@ const plugins = [
   }),
   postcss({
     extract: path.join('css', 'web.css'),
-    minimize: production
+    minimize: production,
+    config: false
   }),
   vue({
     css: false


### PR DESCRIPTION
## Description
After changing the way dependencies in ODS were declared some weeks ago, running `yarn link owncloud-design-system` failed due to a PostCSS config error. This change re-enables linking & testing locally between `web` and `owncloud-design-system`