### PR TITLE
fix: display navigation for resolved private link

### DIFF
--- a/changelog/unreleased/bugfix-navigation-in-private-links
+++ b/changelog/unreleased/bugfix-navigation-in-private-links
@@ -1,0 +1,5 @@
+Bugfix: Display navigation for resolved private link
+
+We've fixed that the navigation in the left sidebar is visible for a resolved private link as well
+
+https://github.com/owncloud/web/pull/5023

--- a/packages/web-app-files/src/views/PrivateLink.vue
+++ b/packages/web-app-files/src/views/PrivateLink.vue
@@ -60,7 +60,7 @@ export default {
         this.$router.push({
           name: 'files-personal',
           params: {
-            item: folder
+            item: folder || '/'
           },
           query: {
             scrollTo: file


### PR DESCRIPTION
## Description
We've fixed that the navigation in the left sidebar is visible for a resolved private link as well

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Chrome
- test case 1: Visit a private link for resource in the root level
- test case 2: Visit a private link for a nested resource


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests