### PR TITLE
Make external app config available in `apps` getter

### DIFF
--- a/changelog/unreleased/enhancement-extension-config
+++ b/changelog/unreleased/enhancement-extension-config
@@ -1,0 +1,5 @@
+Enhancement: Extension config
+
+Loading extension specific config was only possible for file editors. We now also load it in the general app information, so that it's available in the `apps` getter of the global vuex store.
+
+https://github.com/owncloud/web/pull/5024

--- a/packages/web-runtime/src/store/apps.js
+++ b/packages/web-runtime/src/store/apps.js
@@ -99,15 +99,21 @@ const mutations = {
   },
 
   LOAD_EXTENSION_CONFIG(state, { id, config }) {
-    const editors = state.fileEditors
-
+    // make available in editors
+    const editors = [...state.fileEditors]
     for (const editor of editors) {
       if (editor.app === id) {
         editor.config = config
       }
     }
-
     state.fileEditors = editors
+
+    // make available in meta
+    if (state.meta[id]) {
+      const meta = { ...state.meta }
+      meta[id].config = config
+      state.meta = meta
+    }
   }
 }
 


### PR DESCRIPTION
## Description
This PR makes the config object of an `external_apps` object (if one was provided) available in the global vuex `apps` getter.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- drone

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 