### PR TITLE
Fix: hide navigation on route change

### DIFF
--- a/changelog/unreleased/bugfix-hide-navigation-on-route-change
+++ b/changelog/unreleased/bugfix-hide-navigation-on-route-change
@@ -1,0 +1,6 @@
+Bugfix: Hide left sidebar navigation when switching routes
+
+On smaller screens, the left sidebar containing the extension navigation is collapsed.
+We've fixed that when the user expanded the sidebar and navigated to a different route the sidebar is collapsed again.
+
+https://github.com/owncloud/web/pull/5025

--- a/packages/web-runtime/src/App.vue
+++ b/packages/web-runtime/src/App.vue
@@ -230,6 +230,7 @@ export default {
       handler: function(to) {
         this.announceRouteChange(to)
         document.title = this.extractPageTitleFromRoute(to)
+        this.appNavigationVisible = false
       }
     },
     capabilities(caps) {


### PR DESCRIPTION
On smaller screens, the left sidebar containing the extension navigation is collapsed. We've fixed that when the user expanded the sidebar and navigated to a different route the sidebar is collapsed again.