### PR TITLE
[tests-only] Remove tech_preview setting from CI and docs

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1651,7 +1651,6 @@ def setupServerAndApp(logLevel):
 			'php occ log:manage --level %s' % logLevel,
 			'php occ config:list',
 			'php occ config:system:set skeletondirectory --value=/var/www/owncloud/server/apps/testing/data/webUISkeleton',
-			'php occ config:system:set dav.enable.tech_preview  --type=boolean --value=true',
 			'php occ config:system:set web.baseUrl --value="http://web"',
 			'php occ config:system:set sharing.federation.allowHttpFallback --value=true --type=bool'
 		]
@@ -1669,7 +1668,6 @@ def setupFedServerAndApp(logLevel):
 			'php occ log:manage --level %s' % logLevel,
 			'php occ config:list',
 			'php occ config:system:set skeletondirectory --value=/var/www/owncloud/federated/apps/testing/data/webUISkeleton',
-			'php occ config:system:set dav.enable.tech_preview  --type=boolean --value=true',
 			'php occ config:system:set sharing.federation.allowHttpFallback --value=true --type=bool'
 		]
 	}]

--- a/docs/backend-oc10.md
+++ b/docs/backend-oc10.md
@@ -34,11 +34,6 @@ Add the following entries to config/config.php:
 'cors.allowed-domains' => ['<web-domain>'],
 ```
 
-- optional: when developing against unstable APIs (technical preview), these need to be enabled in the server core:
-```
-dav.enable.tech_preview => true,
-```
-
 ### Setting up OAuth2
 
 To connect to the ownCloud server, it is necessary to set it up with OAuth2.


### PR DESCRIPTION
## Description
`dav.enable.tech_preview` was used in about ownCloud server 10.4. We don't need to use that setting in CI any more, so remove it.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
