### PR TITLE
fix: add missing healthcheck script

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1212,13 +1212,14 @@ def buildDockerImage():
 		'pull': 'always',
 		'settings': {
 			'username': {
-			'from_secret': 'docker_username',
-		},
-		'password': {
-			'from_secret': 'docker_password',
-		},
-		'auto_tag': True,
-		'repo': 'owncloud/web',
+				'from_secret': 'docker_username',
+			},
+			'password': {
+				'from_secret': 'docker_password',
+			},
+			'auto_tag': True,
+			'dockerfile': 'docker/Dockerfile',
+			'repo': 'owncloud/web',
 		},
 		'when': {
 			'ref': {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,7 @@ LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
 
 RUN rm -f /var/lib/nginx/html/*
 
+ADD docker/overlay /
 ADD dist/ /var/lib/nginx/html
 
 EXPOSE 8080

--- a/docker/overlay/usr/bin/healthcheck
+++ b/docker/overlay/usr/bin/healthcheck
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+set -eo pipefail
+
+URL=http://127.0.0.1:8080
+
+wget --quiet --tries=1 --spider ${URL}
+[ $? -ne 0 ] && exit 1
+
+exit 0


### PR DESCRIPTION
## Description
Add back a minimal healtchcheck script as the new docker base image does not ship a default one anymore.

## How Has This Been Tested?
- local docker run and build

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests