### PR TITLE
Change appearance of the share action buttons

### DIFF
--- a/changelog/unreleased/enhancement-share-action-buttons
+++ b/changelog/unreleased/enhancement-share-action-buttons
@@ -1,0 +1,6 @@
+Enhancement: Share action button appearance
+
+Changed the appearance of the "accept/decline share" buttons in the "Shared With Me" file list
+so they actually look like buttons.
+
+https://github.com/owncloud/web/pull/5053

--- a/packages/web-app-files/src/views/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/SharedWithMe.vue
@@ -35,16 +35,18 @@
           >
             <oc-button
               v-if="resource.status === 1 || resource.status === 2"
-              appearance="raw"
-              class="file-row-share-status-action oc-text-muted"
+              appearance="filled"
+              variation="primary"
+              size="small"
+              class="file-row-share-status-action"
               @click.stop="triggerShareAction(resource, 'POST')"
             >
               <translate>Accept</translate>
             </oc-button>
             <oc-button
               v-if="resource.status === 1 || resource.status === 0"
-              appearance="raw"
-              class="file-row-share-status-action oc-text-muted oc-ml"
+              size="small"
+              class="file-row-share-status-action oc-ml-s"
               @click.stop="triggerShareAction(resource, 'DELETE')"
             >
               <translate>Decline</translate>


### PR DESCRIPTION
## Description
Changed the appearance of the "accept/decline share" buttons in the "Shared With Me" file list so they actually look like buttons.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
