### PR TITLE
Fix z-index on the new file menu

### DIFF
--- a/changelog/unreleased/bugfix-new-file-menu-z-index
+++ b/changelog/unreleased/bugfix-new-file-menu-z-index
@@ -1,6 +1,6 @@
 Bugfix: Fix z-index on the new file menu
 
-Removed the z-index on the files-app-bar because it prevented the new file menu from having a higher z-index
+Added a z-index to files-view because it prevented the new file menu from having a higher z-index
 than the table headers. As a result the new file menu was being overlapped by them.
 
 https://github.com/owncloud/web/pull/5056

--- a/changelog/unreleased/bugfix-new-file-menu-z-index
+++ b/changelog/unreleased/bugfix-new-file-menu-z-index
@@ -3,4 +3,4 @@ Bugfix: Fix z-index on the new file menu
 Removed the z-index on the files-app-bar because it prevented the new file menu from having a higher z-index
 than the table headers. As a result the new file menu was being overlapped by them.
 
-https://github.com/owncloud/web/pull/5039
+https://github.com/owncloud/web/pull/5056

--- a/changelog/unreleased/bugfix-new-file-menu-z-index
+++ b/changelog/unreleased/bugfix-new-file-menu-z-index
@@ -1,0 +1,6 @@
+Bugfix: Fix z-index on the new file menu
+
+Removed the z-index on the files-app-bar because it prevented the new file menu from having a higher z-index
+than the table headers. As a result the new file menu was being overlapped by them.
+
+https://github.com/owncloud/web/pull/5039

--- a/packages/web-app-files/src/App.vue
+++ b/packages/web-app-files/src/App.vue
@@ -139,11 +139,13 @@ export default {
 #files-app-bar {
   position: sticky;
   height: auto;
+  z-index: 1;
   grid-area: header;
 }
 
 #files-view {
   grid-area: main;
+  z-index: 0;
 }
 
 #files-upload-progress {

--- a/packages/web-app-files/src/App.vue
+++ b/packages/web-app-files/src/App.vue
@@ -139,7 +139,6 @@ export default {
 #files-app-bar {
   position: sticky;
   height: auto;
-  z-index: 1;
   grid-area: header;
 }
 


### PR DESCRIPTION
## Description
Removed the z-index on the files-app-bar because it prevented the new file menu from having a higher z-index than the table headers. As a result the new file menu was being overlapped by them.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
