### PR TITLE
[tests-only] Refactor webdavHelper:getTrashBinElements function

### DIFF
--- a/tests/acceptance/helpers/webdavHelper.js
+++ b/tests/acceptance/helpers/webdavHelper.js
@@ -136,8 +136,14 @@ exports.getTrashBinElements = function(user, depth = 2) {
         depth
       )
       .then(str => {
-        const trashData = convert.xml2js(str, { compact: true })['d:multistatus']['d:response']
+        let trashData = convert.xml2js(str, { compact: true })['d:multistatus']['d:response']
         const trashItems = []
+        // 'trashData' gets object instead of array when there are no any files/folders in the trashbin
+        // so trashData.map() will cause error if trashData gets object
+        // following wraps the object in array
+        if (!Array.isArray(trashData)) {
+          trashData = [trashData]
+        }
         trashData.map(trash => {
           if (trash['d:propstat']['d:prop'] === undefined) {
             reject(new Error('trashbin data not defined'))


### PR DESCRIPTION
## Description
`trashData` gets object instead of array when there are no any files/folders in the trashbin, so trashData.map() will cause error if trashData gets object

## Related Issue
- Closes https://github.com/owncloud/web/issues/5064

## How Has This Been Tested?
- test environment:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 