### PR TITLE
[tests-only] Refactor restrictSharing test to not use skeleton files

### DIFF
--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -12,7 +12,7 @@ Feature: restrict Sharing
       | Alice    |
       | Brian    |
       | Carol    |
-    And these users have been created but not initialized:
+    And these users have been created without initialization and without skeleton files:
       | username  | password  | displayname     | email             |
       | Alison    | %regular% | Alison Cooper   | alson@oc.com.np   |
     And these groups have been created:


### PR DESCRIPTION
## Description

## Related Issue
- part of https://github.com/owncloud/QA/issues/659

## How Has This Been Tested?
- test environment:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 