### PR TITLE
[Tests-Only] removed redis information from web testing docs

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -47,16 +47,12 @@ When running a standalone Selenium server, make sure to set the environment vari
 - clone and install the [testing app](http://github.com/owncloud/testing) into ownCloud
 
 ### oCIS
-In order to run the acceptance tests you need to run ocis using the owncloud storage driver. Also, you need to enable basic auth on the server with these environment variables.
+In order to run the acceptance tests you need to run ocis using the ocis storage driver. Also, you need to enable basic auth on the server with these environment variables.
 
 `PROXY_ENABLE_BASIC_AUTH=true STORAGE_HOME_DRIVER=owncloud STORAGE_USERS_DRIVER=owncloud`
 
 - set up the [oCIS backend]({{< ref "backend-ocis.md" >}})
   - if you are a Mac user, you need to start the server with additional environment variables: `STORAGE_HOME_DATA_SERVER_URL='http://host.docker.internal:9155/data' STORAGE_DATAGATEWAY_PUBLIC_URL='https://host.docker.internal:9200/data' STORAGE_USERS_DATA_SERVER_URL='http://host.docker.internal:9158/data' STORAGE_FRONTEND_PUBLIC_URL='https://host.docker.internal:9200' PROXY_ENABLE_BASIC_AUTH=true PROXY_OIDC_ISSUER='https://host.docker.internal:9200' IDP_INSECURE='true' IDP_IDENTIFIER_REGISTRATION_CONF='<web-path>/tests/acceptance/mac-identifier-registration.yml' IDP_ISS='https://host.docker.internal:9200' IDP_TLS='true'` (`<web-path>` needs to be replaced with the your local clone of ownCloud Web)
-
-- oCIS also uses redis for caching, so run redis with this command
-
-  `docker run -e REDIS_DATABASES=1 -p 6379:6379 -d webhippie/redis:latest`
 
 ## Setup ownCloud Web
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
After the use of `ocis` server with `ocis storage driver`, _redis_ usage is not required. With this PR that information is also removed from the testing documentation

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/2008

