### PR TITLE
Add hints about actions above table to live region update

### DIFF
--- a/changelog/unreleased/enhancement-accessibility-improvements
+++ b/changelog/unreleased/enhancement-accessibility-improvements
@@ -9,7 +9,9 @@ A lot of random changes:
 - Renamed "personal files" to "all files" in routes (soft rename, due to changes in the future)
 - Updated ODS to v5.1.0
 - Translate quick action labels/tooltips properly
+- Added a note about actions being available above the file list to the live region update for selection
 
 https://github.com/owncloud/web/pull/4965
 https://github.com/owncloud/web/pull/4975
 https://github.com/owncloud/web/pull/5030
+https://github.com/owncloud/web/pull/5088

--- a/packages/web-app-files/src/components/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar.vue
@@ -253,8 +253,8 @@ export default {
 
     selectedResourcesAnnouncement() {
       const translated = this.$ngettext(
-        '%{ amount } selected item',
-        '%{ amount } selected items',
+        '%{ amount } selected item. Actions are available above the table.',
+        '%{ amount } selected items. Actions are available above the table.',
         this.selectedFiles.length
       )
       return this.$gettextInterpolate(translated, { amount: this.selectedFiles.length })


### PR DESCRIPTION
## Description
Live region update about file/folder selection with checkboxes was lacking a hint that actions for the selection are available above the table. This PR adds those hints.

## How Has This Been Tested?
- drone

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
