### PR TITLE
Skip editors route check on empty array

### DIFF
--- a/changelog/unreleased/bugfix-editors-for-all-routes
+++ b/changelog/unreleased/bugfix-editors-for-all-routes
@@ -1,0 +1,5 @@
+Bugfix: Editors for all routes
+
+If an extension doesn't define valid routes it should be allowed for all routes by default. That behaviour was not working properly and is fixed now.
+
+https://github.com/owncloud/web/pull/5095

--- a/packages/web-app-files/src/mixins/fileActions.js
+++ b/packages/web-app-files/src/mixins/fileActions.js
@@ -49,7 +49,7 @@ export default {
           icon: this.apps.meta[editor.app].icon,
           handler: item => this.$_fileActions_openEditor(editor, item.path, item.id),
           isEnabled: ({ resource }) => {
-            if (editor.routes && !checkRoute(editor.routes, this.$route.name)) {
+            if (editor.routes?.length > 0 && !checkRoute(editor.routes, this.$route.name)) {
               return false
             }
 


### PR DESCRIPTION
## Description
If an extension doesn't define valid routes it should be allowed for all routes by default. That behaviour was not working properly and is fixed with this PR.

## How Has This Been Tested?
- drone

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 