### PR TITLE
Fix collaborator tag for currentUser in sidebar

### DIFF
--- a/changelog/unreleased/bugfix-sharee-tag
+++ b/changelog/unreleased/bugfix-sharee-tag
@@ -1,0 +1,7 @@
+Bugfix: Correct sharee tag
+
+The tag _inside_ a shared folder always announced the current user as "owner", 
+since the shares lookup didn't check for the parent folders' ownership. This has 
+been fixed now and users get the correct tag (e.g. "Viewer", "Editor" etc) in the sidebar.
+
+https://github.com/owncloud/web/pull/5112

--- a/packages/web-app-files/src/components/FileSharingSidebar.vue
+++ b/packages/web-app-files/src/components/FileSharingSidebar.vue
@@ -277,10 +277,10 @@ export default {
     },
 
     currentUsersPermissions() {
-      if (this.incomingShares.length > 0) {
+      if (this.$_allIncomingShares.length > 0) {
         let permissions = permissionsBitmask.read
 
-        for (const share of this.incomingShares) {
+        for (const share of this.$_allIncomingShares) {
           permissions |= share.permissions
         }
 


### PR DESCRIPTION
## Description
Role setting didn't look up parent file ownership and announced the current user as "owner" even though they might've only been viewer, editor etc. This has been fixed now

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)