### PR TITLE
Add "height-table-row" to size examples in theming docs [docs-only]

### DIFF
--- a/docs/theming/_index.md
+++ b/docs/theming/_index.md
@@ -171,6 +171,7 @@ Again, you can use the [ownCloud design tokens](https://owncloud.design/#/Design
       "size": {
         "form-check-default": "",
         "height-small": "",
+        "height-table-row": "",
         "icon-default": "",
         "width-medium": ""
       },
@@ -263,6 +264,7 @@ An empty template for your custom theme is provided below, and you can use the i
       "sizes": {
         "form-check-default": "",
         "height-small": "",
+        "height-table-row": "",
         "icon-default": "",
         "width-medium": ""
       },


### PR DESCRIPTION
## Description
Tiny detail I missed when adding the "height-table-row" to the ODS recently
