### PR TITLE
Fix indirect via-share in collaborator sidebar section

### DIFF
--- a/changelog/unreleased/bugfix-navigate-to-share-parent
+++ b/changelog/unreleased/bugfix-navigate-to-share-parent
@@ -1,0 +1,8 @@
+Bugfix: Correct navigation through "via"-tags
+
+The "shared via X" link in the indirect share tag in the sidebar was 
+navigating to the parent directory of the indirect share entry.
+This has been fixed for the collaborators sidebar section and 
+the link target is the share entry itself now.
+
+https://github.com/owncloud/web/pull/5122

--- a/packages/web-app-files/src/components/Collaborators/Collaborator.vue
+++ b/packages/web-app-files/src/components/Collaborators/Collaborator.vue
@@ -175,7 +175,7 @@
 import { mapGetters } from 'vuex'
 import moment from 'moment'
 import { shareTypes } from '../../helpers/shareTypes'
-import { basename, dirname } from 'path'
+import { basename } from 'path'
 import CollaboratorsMixins from '../../mixins/collaborators'
 import Mixins from '../../mixins'
 
@@ -249,14 +249,10 @@ export default {
     },
 
     viaRouterParams() {
-      const viaPath = this.collaborator.path
       return {
         name: 'files-personal',
         params: {
-          item: dirname(viaPath) || '/'
-        },
-        query: {
-          scrollTo: basename(viaPath)
+          item: this.collaborator.path || '/'
         }
       }
     },


### PR DESCRIPTION
## Description
The "Via" button in the collaborators according section in the sidebar sends you to the parent of the share entry, while it actually should send you the to share entry itself.

## Related Issue
- Fixes #5082