### PR TITLE
Hide new public link share button if user lacks permissions

### DIFF
--- a/changelog/unreleased/bugfix-hide-new-link-button
+++ b/changelog/unreleased/bugfix-hide-new-link-button
@@ -1,0 +1,7 @@
+Bugfix: Hide "Create new public link" button
+
+The button to create new public links was visible even if the user lacked 
+the permissions to create one. It is now being hidden unless the user is 
+allowed to create a share of the respective file.
+
+https://github.com/owncloud/web/pull/5126

--- a/packages/web-app-files/src/components/FileLinkSidebar.vue
+++ b/packages/web-app-files/src/components/FileLinkSidebar.vue
@@ -9,11 +9,11 @@
       <template v-else>
         <private-link-item />
         <h4 v-translate class="oc-text-bold oc-m-rm oc-text-initial">Public Links</h4>
-        <p v-translate class="oc-text-muted oc-my-rm">
-          Any external person with the respective link can access this resource. No sign-in
-          required. Assign a password to avoid unintended document exposure.
-        </p>
-        <div class="oc-my-s">
+        <div v-if="canCreatePublicLinks" class="oc-my-s">
+          <p v-translate class="oc-text-muted">
+            Any external person with the respective link can access this resource. No sign-in
+            required. Assign a password to avoid unintended document exposure.
+          </p>
           <oc-button
             id="files-file-link-add"
             icon="add"
@@ -25,6 +25,7 @@
             {{ $_addButtonLabel }}
           </oc-button>
         </div>
+        <p v-else class="oc-mt-s" v-text="noResharePermsMessage" />
         <transition-group
           class="uk-list uk-list-divider uk-overflow-hidden oc-m-rm"
           :enter-active-class="$_transitionGroupEnter"
@@ -36,7 +37,12 @@
             <public-link-list-item :link="link" />
           </li>
         </transition-group>
-        <p v-if="$_noPublicLinks" key="oc-file-links-no-results" v-translate class="oc-my-rm">
+        <p
+          v-if="$_noPublicLinks && canCreatePublicLinks"
+          key="oc-file-links-no-results"
+          v-translate
+          class="oc-my-rm"
+        >
           No public links
         </p>
       </template>
@@ -100,6 +106,16 @@ export default {
     },
     $_transitionGroupLeave() {
       return 'uk-animation-slide-right-medium uk-animation-reverse'
+    },
+
+    canCreatePublicLinks() {
+      return this.highlightedFile.canShare()
+    },
+
+    noResharePermsMessage() {
+      const translatedFile = this.$gettext("You don't have permission to share this file.")
+      const translatedFolder = this.$gettext("You don't have permission to share this folder.")
+      return this.highlightedFile.type === 'file' ? translatedFile : translatedFolder
     },
 
     linksLoading() {


### PR DESCRIPTION
## Description
Hides "Create public link" button if user has insufficient share permissions. Debatable if we should only hide the "Create" button and if users with e.g. view/edit rights should be at least displayed links (even if they can't edit/create/delete them)

## Related Issue
- Fixes #5080