### PR TITLE
feat: send focus to add people btn

### DIFF
--- a/changelog/unreleased/enhancement-people-focus
+++ b/changelog/unreleased/enhancement-people-focus
@@ -1,0 +1,5 @@
+Enhancement: Send focus to "Add people" btn after closing Add/Edit panels
+
+We've started sending the focus to "Add people" button after the Add or Edit panels in the people accordion have been closed.
+
+https://github.com/owncloud/web/pull/5129

--- a/packages/web-app-files/src/components/FileSharingSidebar.vue
+++ b/packages/web-app-files/src/components/FileSharingSidebar.vue
@@ -9,6 +9,7 @@
       <template v-else>
         <div v-if="$_ocCollaborators_canShare" class="oc-mt-s oc-mb-s">
           <oc-button
+            ref="addCollaborators"
             variation="primary"
             class="files-collaborators-open-add-share-dialog-button"
             @click="$_ocCollaborators_addShare"
@@ -371,6 +372,9 @@ export default {
     $_ocCollaborators_showList() {
       this.SET_APP_SIDEBAR_ACCORDION_CONTEXT(PANEL_SHOW)
       this.currentShare = null
+      this.$nextTick(() => {
+        this.$refs.addCollaborators.$el.focus()
+      })
     },
     $_ocCollaborators_isUser(collaborator) {
       return (


### PR DESCRIPTION
We've started sending the focus to "Add people" button after the Add or Edit panels in the people accordion have been closed.