### PR TITLE
[Tests-Only]Adjust the tries to steps for rename files/folders

### DIFF
--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -179,7 +179,7 @@ Feature: rename files
 
   @skipOnOC10
   Scenario: Rename a file to .part
-    When the user tries to rename file "data.zip" to "data.part" using the webUI
+    When the user renames file "data.zip" to "data.part" using the webUI
     Then file 'data.part' should be listed on the webUI
 
   @ocis-reva-issue-64

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -110,7 +110,7 @@ Feature: rename folders
 
   @skipOnOC10
   Scenario Outline: Rename a folder using forbidden characters
-    When the user tries to rename folder <from_name> to <to_name> using the webUI
+    When the user renames folder <from_name> to <to_name> using the webUI
     Then folder <to_name> should be listed on the webUI
     Examples:
       | from_name       | to_name           |
@@ -141,7 +141,7 @@ Feature: rename folders
 
   @skipOnOC10
   Scenario: Rename a folder to .part (on ocis)
-    When the user tries to rename folder "simple-folder" to "simple.part" using the webUI
+    When the user renames folder "simple-folder" to "simple.part" using the webUI
     Then folder "simple.part" should be listed on the webUI
 
   Scenario: User tries to rename a folder that used to exist but does not anymore


### PR DESCRIPTION
## Description
This PR adjusts the tries to step in rename files/folders tests such that the rename is actually performed when the result of the step is expected for the resource to be renamed successfully.

## Related Issue
- https://github.com/owncloud/web/issues/4933

## How Has This Been Tested?
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...