### PR TITLE
[Tests-Only]Adjust steps that try to edit public link shares

### DIFF
--- a/tests/acceptance/features/webUISharingPublicBasic/publicLinkEdit.feature
+++ b/tests/acceptance/features/webUISharingPublicBasic/publicLinkEdit.feature
@@ -16,7 +16,7 @@ Feature: Edit public link shares
       | name        | Public-link           |
       | permissions | <initial-permissions> |
     And user "Alice" has logged in using the webUI
-    When the user edits the public link named "Public-link" of folder "simple-folder" changing following
+    When the user tries to edit the public link named "Public-link" of folder "simple-folder" changing following
       | role | <role> |
     Then the user should see an error message on the public link share dialog saying "Passwords are enforced for link shares"
     And user "Alice" should have a share with these details:
@@ -42,7 +42,7 @@ Feature: Edit public link shares
       | permissions | <initial-permissions> |
       | password    | 123                   |
     And user "Alice" has logged in using the webUI
-    When the user edits the public link named "Public-link" of folder "simple-folder" changing following
+    When the user tries to edit the public link named "Public-link" of folder "simple-folder" changing following
       | password |  |
     Then the user should see an error message on the public link share dialog saying "Passwords are enforced for link shares"
     And user "Alice" should have a share with these details:
@@ -137,9 +137,9 @@ Feature: Edit public link shares
       | permissions | read, update, create, delete |
       | password    | pass123                      |
     And user "Alice" has logged in using the webUI
-    And the user edits the public link named "Public-link" of folder "simple-folder" changing following
+    When the user tries to edit the public link named "Public-link" of folder "simple-folder" changing following
       | password | qwertyui |
-    When the public uses the webUI to access the last public link created by user "Alice" with password "pass123"
+    And the public uses the webUI to access the last public link created by user "Alice" with password "pass123"
     Then the public should not get access to the publicly shared file
 
   @issue-ocis-reva-292

--- a/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
@@ -122,12 +122,18 @@ module.exports = {
      *
      * @returns {exports}
      */
-    savePublicLink: function() {
-      return this.waitForElementVisible('@publicLinkSaveButton')
+    savePublicLink: async function() {
+      await this.waitForElementVisible('@publicLinkSaveButton')
         .initAjaxCounters()
         .click('@publicLinkSaveButton')
-        .waitForElementNotPresent({ selector: '@publicLinkSaveButton', abortOnFailure: false })
-        .waitForOutstandingAjaxCalls()
+      try {
+        await this.waitForElementNotPresent({
+          selector: '@publicLinkSaveButton'
+        }).waitForOutstandingAjaxCalls()
+      } catch (e) {
+        throw new Error('ElementPresentError')
+      }
+      return this
     },
     /**
      * deletes existing public link share

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -1186,13 +1186,21 @@ When('the user tries to move file/folder {string} into folder {string} using the
   resource,
   target
 ) {
-  return client.page.FilesPageElement.filesList()
-    .moveResource(resource, target)
-    .catch(error => {
+  return (
+    client.page.FilesPageElement.filesList()
+      .moveResource(resource, target)
       // while moving resource, after clicking the "Paste here" button, the button should disappear but if it doesn't
       // we throw "ElementPresentError" error. So, all the error except "ElementPresentError" is caught and thrown back
-      if (error.message !== 'ElementPresentError') throw error
-    })
+      // Also, when no error is thrown, the button seems to disappear, so an error should be thrown in such case as well.
+      .then(() => {
+        throw new Error('ElementPresentError')
+      })
+      .catch(err => {
+        if (err.message !== 'ElementPresentError') {
+          throw new Error(err)
+        }
+      })
+  )
 })
 
 When('the user selects move action for folder/file {string} using the webUI', async function(


### PR DESCRIPTION
## Description
This PR adjusts steps that try to edit public link shares.
Also, few adjustments is made in the changes made by this pr https://github.com/owncloud/web/pull/4824

## Related Issue
- https://github.com/owncloud/web/issues/4933

## How Has This Been Tested?
- CI


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...