### PR TITLE
add example deployment

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -546,8 +546,8 @@ def main(ctx):
     after = afterPipelines(ctx)
     dependsOn(stages, after)
 
-    if ctx.build.event == "cron":
-        return example_deploys(ctx)
+    # if ctx.build.event == "cron":
+    return example_deploys(ctx)
 
     return before + stages + after + example_deploys(ctx) + checkStarlark()
 
@@ -2329,6 +2329,7 @@ def deploy(ctx, config, rebuild):
         ],
         "trigger": {
             "ref": [
+                "refs/heads/continuous_deployment_latest_web",
                 "refs/heads/master",
                 "refs/tags/v*",
             ],

--- a/.drone.star
+++ b/.drone.star
@@ -549,7 +549,14 @@ def main(ctx):
     if ctx.build.event == "cron":
         return example_deploys(ctx)
 
-    return before + stages + after + example_deploys(ctx) + checkStarlark()
+    pipelines = before + stages + after
+
+    deploys = example_deploys(ctx)
+    dependsOn(pipelines, deploys)
+
+    return pipelines + deploys + checkStarlark()
+
+    return pipelines
 
 def beforePipelines(ctx):
     return yarnlint() + changelog(ctx) + website(ctx) + cacheOcisPipeline(ctx)
@@ -2375,4 +2382,7 @@ def checkStarlark():
 def dependsOn(earlierStages, nextStages):
     for earlierStage in earlierStages:
         for nextStage in nextStages:
-            nextStage["depends_on"].append(earlierStage["name"])
+            if "depends_on" in nextStage.keys():
+                nextStage["depends_on"].append(earlierStage["name"])
+            else:
+                nextStage["depends_on"] = [earlierStage["name"]]

--- a/.drone.star
+++ b/.drone.star
@@ -546,7 +546,10 @@ def main(ctx):
     after = afterPipelines(ctx)
     dependsOn(stages, after)
 
-    return before + stages + after + checkStarlark()
+    if ctx.build.event == "cron":
+        return example_deploys(ctx)
+
+    return before + stages + after + example_deploys(ctx) + checkStarlark()
 
 def beforePipelines(ctx):
     return yarnlint() + changelog(ctx) + website(ctx) + cacheOcisPipeline(ctx)
@@ -2256,6 +2259,81 @@ def githubComment():
             ],
         },
     }]
+
+def example_deploys(ctx):
+    latest_configs = [
+        "ocis_web/latest.yml",
+    ]
+    released_configs = []
+
+    # if on master branch:
+    configs = latest_configs
+    rebuild = "false"
+
+    if ctx.build.event == "tag":
+        configs = released_configs
+        rebuild = "false"
+
+    if ctx.build.event == "cron":
+        configs = latest_configs + released_configs
+        rebuild = "true"
+
+    deploys = []
+    for config in configs:
+        deploys.append(deploy(ctx, config, rebuild))
+
+    return deploys
+
+def deploy(ctx, config, rebuild):
+    return {
+        "kind": "pipeline",
+        "type": "docker",
+        "name": "deploy_%s" % (config),
+        "platform": {
+            "os": "linux",
+            "arch": "amd64",
+        },
+        "steps": [
+            {
+                "name": "clone continuous deployment playbook",
+                "image": "alpine/git:latest",
+                "commands": [
+                    "cd deployments/continuous-deployment-config",
+                    "git clone https://github.com/owncloud-devops/continuous-deployment.git",
+                ],
+            },
+            {
+                "name": "deploy",
+                "image": "owncloudci/drone-ansible:latest",
+                "failure": "ignore",
+                "environment": {
+                    "CONTINUOUS_DEPLOY_SERVERS_CONFIG": "../%s" % (config),
+                    "REBUILD": "%s" % (rebuild),
+                    "HCLOUD_API_TOKEN": {
+                        "from_secret": "hcloud_api_token",
+                    },
+                    "CLOUDFLARE_API_TOKEN": {
+                        "from_secret": "cloudflare_api_token",
+                    },
+                },
+                "settings": {
+                    "playbook": "deployments/continuous-deployment-config/continuous-deployment/playbook-all.yml",
+                    "galaxy": "deployments/continuous-deployment-config/continuous-deployment/requirements.yml",
+                    "requirements": "deployments/continuous-deployment-config/continuous-deployment/py-requirements.txt",
+                    "inventory": "localhost",
+                    "private_key": {
+                        "from_secret": "ssh_private_key",
+                    },
+                },
+            },
+        ],
+        "trigger": {
+            "ref": [
+                "refs/heads/master",
+                "refs/tags/v*",
+            ],
+        },
+    }
 
 def checkStarlark():
     return [{

--- a/.drone.star
+++ b/.drone.star
@@ -546,8 +546,8 @@ def main(ctx):
     after = afterPipelines(ctx)
     dependsOn(stages, after)
 
-    # if ctx.build.event == "cron":
-    return example_deploys(ctx)
+    if ctx.build.event == "cron":
+        return example_deploys(ctx)
 
     return before + stages + after + example_deploys(ctx) + checkStarlark()
 
@@ -2329,7 +2329,6 @@ def deploy(ctx, config, rebuild):
         ],
         "trigger": {
             "ref": [
-                "refs/heads/continuous_deployment_latest_web",
                 "refs/heads/master",
                 "refs/tags/v*",
             ],

--- a/changelog/unreleased/continuously-deployed-demo-instance
+++ b/changelog/unreleased/continuously-deployed-demo-instance
@@ -1,4 +1,4 @@
-Deployment: Continuously deployed demo instance with latest Web
+Enhancement: Continuously deployed demo instance with latest Web
 
 Whenever a commit or merge to master happens, a demo instance with the latest Web build will be deployed.
 

--- a/changelog/unreleased/continuously-deployed-demo-instance
+++ b/changelog/unreleased/continuously-deployed-demo-instance
@@ -1,0 +1,5 @@
+Deployment: Continuously deployed demo instance with latest Web
+
+Whenever a commit or merge to master happens, a demo instance with the latest Web build will be deployed.
+
+https://github.com/owncloud/web/pull/5145

--- a/deployments/continuous-deployment-config/ocis_web/latest.yml
+++ b/deployments/continuous-deployment-config/ocis_web/latest.yml
@@ -1,0 +1,40 @@
+---
+- name: continuous-deployment-ocis-web-latest
+  server:
+    server_type: cx21
+    image: ubuntu-20.04
+    location: nbg1
+    initial_ssh_key_names:
+      - owncloud-ocis@drone.owncloud.com
+    labels:
+      owner: wkloucek
+      for: oCIS-continuous-deployment-examples
+    rebuild: $REBUILD
+    rebuild_carry_paths:
+      - /var/lib/docker/volumes/ocis_certs
+
+  domains:
+    - "*.ocis-web.latest.owncloud.works"
+
+  vars:
+    docker_compose_projects:
+      - name: ocis
+        git_url: https://github.com/owncloud/web.git
+        ref: master
+        docker_compose_path: deployments/examples/ocis_web
+        env:
+          INSECURE: "false"
+          TRAEFIK_ACME_MAIL: wkloucek@owncloud.com
+          OCIS_DOCKER_TAG: latest
+          OCIS_DOMAIN: ocis.ocis-traefik.latest.owncloud.works
+          COMPOSE_FILE: docker-compose.yml:monitoring_tracing/docker-compose-additions.yml
+      - name: monitoring
+        git_url: https://github.com/owncloud-devops/monitoring-tracing-client.git
+        ref: master
+        env:
+          NETWORK_NAME: ocis-net
+          TELEMETRY_SERVE_DOMAIN: telemetry.ocis-traefik.latest.owncloud.works
+          JAEGER_COLLECTOR: jaeger-collector.infra.owncloud.works:443
+          TELEGRAF_SPECIFIC_CONFIG: ocis_single_container
+          OCIS_URL: ocis.ocis-traefik.latest.owncloud.works
+          OCIS_DEPLOYMENT_ID: continuous-deployment-ocis-traefik-latest

--- a/deployments/continuous-deployment-config/ocis_web/latest.yml
+++ b/deployments/continuous-deployment-config/ocis_web/latest.yml
@@ -20,7 +20,7 @@
     docker_compose_projects:
       - name: web
         git_url: https://github.com/owncloud/web.git
-        ref: continuous_deployment_latest_web #TODO: set to master
+        ref: master
         docker_compose_path: deployments/examples/ocis_web
         env:
           INSECURE: "false"

--- a/deployments/continuous-deployment-config/ocis_web/latest.yml
+++ b/deployments/continuous-deployment-config/ocis_web/latest.yml
@@ -5,7 +5,7 @@
     image: ubuntu-20.04
     location: nbg1
     initial_ssh_key_names:
-      - owncloud-ocis@drone.owncloud.com
+      - owncloud-web@drone.owncloud.com
     labels:
       owner: wkloucek
       for: oCIS-continuous-deployment-examples
@@ -26,15 +26,16 @@
           INSECURE: "false"
           TRAEFIK_ACME_MAIL: wkloucek@owncloud.com
           OCIS_DOCKER_TAG: latest
-          OCIS_DOMAIN: ocis.ocis-traefik.latest.owncloud.works
+          OCIS_DOMAIN: ocis.ocis-web.latest.owncloud.works
+          WEB_DOCKER_TAG: latest
           COMPOSE_FILE: docker-compose.yml:monitoring_tracing/docker-compose-additions.yml
       - name: monitoring
         git_url: https://github.com/owncloud-devops/monitoring-tracing-client.git
         ref: master
         env:
           NETWORK_NAME: ocis-net
-          TELEMETRY_SERVE_DOMAIN: telemetry.ocis-traefik.latest.owncloud.works
+          TELEMETRY_SERVE_DOMAIN: telemetry.ocis-web.latest.owncloud.works
           JAEGER_COLLECTOR: jaeger-collector.infra.owncloud.works:443
           TELEGRAF_SPECIFIC_CONFIG: ocis_single_container
-          OCIS_URL: ocis.ocis-traefik.latest.owncloud.works
-          OCIS_DEPLOYMENT_ID: continuous-deployment-ocis-traefik-latest
+          OCIS_URL: ocis.ocis-web.latest.owncloud.works
+          OCIS_DEPLOYMENT_ID: continuous-deployment-ocis-web-latest

--- a/deployments/continuous-deployment-config/ocis_web/latest.yml
+++ b/deployments/continuous-deployment-config/ocis_web/latest.yml
@@ -18,9 +18,9 @@
 
   vars:
     docker_compose_projects:
-      - name: ocis
+      - name: web
         git_url: https://github.com/owncloud/web.git
-        ref: master
+        ref: continuous_deployment_latest_web #TODO: set to master
         docker_compose_path: deployments/examples/ocis_web
         env:
           INSECURE: "false"

--- a/deployments/examples/ocis_web/.env
+++ b/deployments/examples/ocis_web/.env
@@ -1,0 +1,34 @@
+# If you're on a internet facing server please comment out following line.
+# It skips certificate validation for various parts of oCIS and is needed if you use self signed certificates.
+INSECURE=true
+
+### Traefik settings ###
+# Serve Treafik dashboard. Defaults to "false".
+TRAEFIK_DASHBOARD=
+# Domain of Traefik, where you can find the dashboard. Defaults to "traefik.owncloud.test"
+TRAEFIK_DOMAIN=
+# Basic authentication for the dashboard. Defaults to user "admin" and password "admin"
+TRAEFIK_BASIC_AUTH_USERS=
+# Email address for obtaining LetsEncrypt certificates, needs only be changed if this is a public facing server
+TRAEFIK_ACME_MAIL=
+
+### oCIS settings ###
+# oCIS version. Defaults to "latest"
+OCIS_DOCKER_TAG=
+# Domain of oCIS, where you can find the frontend. Defaults to "ocis.owncloud.test"
+OCIS_DOMAIN=
+# IDP LDAP bind password. Must be changed in order to have a secure oCIS. Defaults to "idp".
+IDP_LDAP_BIND_PASSWORD=
+# Storage LDAP bind password. Must be changed in order to have a secure oCIS. Defaults to "reva".
+STORAGE_LDAP_BIND_PASSWORD=
+# JWT secret which is used for the storage provider. Must be changed in order to have a secure oCIS. Defaults to "Pive-Fumkiu4"
+OCIS_JWT_SECRET=
+
+### ownCloud Web settings ###
+# ownCloud Web version. Defaults to "latest"
+WEB_DOCKER_TAG=
+
+# If you want to use debugging and tracing with this stack,
+# you need uncomment following line. Please see documentation at
+# https://owncloud.dev/ocis/deployment/monitoring-tracing/
+#COMPOSE_FILE=docker-compose.yml:monitoring_tracing/docker-compose-additions.yml

--- a/deployments/examples/ocis_web/README.md
+++ b/deployments/examples/ocis_web/README.md
@@ -1,0 +1,6 @@
+---
+document this deployment example in: docs/ocis/deployment/ocis_traefik.md
+---
+
+Please refer to [our documentation](https://owncloud.dev/ocis/deployment/ocis_traefik/)
+for instructions on how to deploy this scenario.

--- a/deployments/examples/ocis_web/README.md
+++ b/deployments/examples/ocis_web/README.md
@@ -1,6 +1,5 @@
 ---
-document this deployment example in: docs/ocis/deployment/ocis_traefik.md
 ---
 
-Please refer to [our documentation](https://owncloud.dev/ocis/deployment/ocis_traefik/)
-for instructions on how to deploy this scenario.
+Please refer to [our documentation](https://owncloud.dev/ocis/deployment/)
+for deployment instructions.

--- a/deployments/examples/ocis_web/config/ocis/entrypoint-override.sh
+++ b/deployments/examples/ocis_web/config/ocis/entrypoint-override.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -e
+
+ocis server&
+sleep 10
+
+echo "##################################################"
+echo "change default secrets:"
+
+# IDP
+IDP_USER_UUID=$(ocis accounts list | grep "| Kopano IDP " | egrep '[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}' -o)
+echo "  IDP user UUID: $IDP_USER_UUID"
+ocis accounts update --password $IDP_LDAP_BIND_PASSWORD $IDP_USER_UUID
+
+# REVA
+REVA_USER_UUID=$(ocis accounts list | grep " | Reva Inter " | egrep '[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}' -o)
+echo "  Reva user UUID: $REVA_USER_UUID"
+ocis accounts update --password $STORAGE_LDAP_BIND_PASSWORD $REVA_USER_UUID
+
+echo "default secrets changed"
+echo "##################################################"
+
+ocis kill proxy
+sleep 10
+ocis proxy server # workaround for loading proxy configuration
+
+wait # wait for oCIS to exit

--- a/deployments/examples/ocis_web/config/ocis/proxy-config.json
+++ b/deployments/examples/ocis_web/config/ocis/proxy-config.json
@@ -1,0 +1,103 @@
+{
+  "HTTP": {
+    "Namespace": "com.owncloud"
+  },
+  "policy_selector": {
+    "static": {
+      "policy": "ocis"
+    }
+  },
+  "policies": [
+    {
+      "name": "ocis",
+      "routes": [
+        {
+          "endpoint": "/",
+          "backend": "http://web:8080"
+        },
+        {
+          "endpoint": "/config.json",
+          "backend": "http://localhost:9100"
+        },
+        {
+          "endpoint": "/.well-known/",
+          "backend": "http://localhost:9130"
+        },
+        {
+          "endpoint": "/konnect/",
+          "backend": "http://localhost:9130"
+        },
+        {
+          "endpoint": "/signin/",
+          "backend": "http://localhost:9130"
+        },
+        {
+          "type": "regex",
+          "endpoint": "/ocs/v[12].php/cloud/(users?|groups)",
+          "backend": "http://localhost:9110"
+        },
+        {
+          "endpoint": "/ocs/",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "type": "query",
+          "endpoint": "/remote.php/?preview=1",
+          "backend": "http://localhost:9115"
+        },
+        {
+          "endpoint": "/remote.php/",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/dav/",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/webdav/",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/status.php",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/index.php/",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/data",
+          "backend": "http://localhost:9140"
+        },
+        {
+          "endpoint": "/graph/",
+          "backend": "http://localhost:9120"
+        },
+        {
+          "endpoint": "/graph-explorer/",
+          "backend": "http://localhost:9135"
+        },
+        {
+          "endpoint": "/api/v0/accounts",
+          "backend": "http://localhost:9181"
+        },
+        {
+          "endpoint": "/accounts.js",
+          "backend": "http://localhost:9181"
+        },
+        {
+          "endpoint": "/api/v0/settings",
+          "backend": "http://localhost:9190"
+        },
+        {
+          "endpoint": "/settings.js",
+          "backend": "http://localhost:9190"
+        },
+        {
+          "endpoint": "/onlyoffice.js",
+          "backend": "http://localhost:9220"
+        }
+      ]
+    }
+  ]
+}

--- a/deployments/examples/ocis_web/docker-compose.yml
+++ b/deployments/examples/ocis_web/docker-compose.yml
@@ -1,0 +1,95 @@
+---
+version: "3.7"
+
+services:
+  traefik:
+    image: traefik:v2.4
+    networks:
+      ocis-net:
+        aliases:
+          - ${OCIS_DOMAIN:-ocis.owncloud.test}
+    command:
+      #- "--log.level=DEBUG"
+      - "--certificatesResolvers.http.acme.email=${TRAEFIK_ACME_MAIL:-example@example.org}"
+      - "--certificatesResolvers.http.acme.storage=/certs/acme.json"
+      - "--certificatesResolvers.http.acme.httpChallenge.entryPoint=http"
+      - "--api.dashboard=true"
+      - "--entryPoints.http.address=:80"
+      - "--entryPoints.https.address=:443"
+      - "--providers.docker.endpoint=unix:///var/run/docker.sock"
+      - "--providers.docker.exposedByDefault=false"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "certs:/certs"
+    labels:
+      - "traefik.enable=${TRAEFIK_DASHBOARD:-false}"
+      - "traefik.http.routers.traefik.entrypoints=http"
+      - "traefik.http.routers.traefik.rule=Host(`${TRAEFIK_DOMAIN:-traefik.owncloud.test}`)"
+      - "traefik.http.middlewares.traefik-auth.basicauth.users=${TRAEFIK_BASIC_AUTH_USERS:-admin:$apr1$4vqie50r$YQAmQdtmz5n9rEALhxJ4l.}" # defaults to admin:admin
+      - "traefik.http.middlewares.traefik-https-redirect.redirectscheme.scheme=https"
+      - "traefik.http.routers.traefik.middlewares=traefik-https-redirect"
+      - "traefik.http.routers.traefik-secure.entrypoints=https"
+      - "traefik.http.routers.traefik-secure.rule=Host(`${TRAEFIK_DOMAIN:-traefik.owncloud.test}`)"
+      - "traefik.http.routers.traefik-secure.middlewares=traefik-auth"
+      - "traefik.http.routers.traefik-secure.tls=true"
+      - "traefik.http.routers.traefik-secure.tls.certresolver=http"
+      - "traefik.http.routers.traefik-secure.service=api@internal"
+    logging:
+      driver: "local"
+    restart: always
+
+  ocis:
+    image: owncloud/ocis:${OCIS_DOCKER_TAG:-latest}
+    networks:
+      ocis-net:
+    entrypoint:
+      - /bin/sh
+      - /entrypoint-override.sh
+    environment:
+      OCIS_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}
+      OCIS_LOG_LEVEL: ${OCIS_LOG_LEVEL:-error} # make oCIS less verbose
+      PROXY_OIDC_INSECURE: "${INSECURE:-false}" # needed if Traefik is using self generated certificates
+      PROXY_TLS: "false" # do not use SSL between Traefik and oCIS
+      # change default secrets
+      IDP_LDAP_BIND_PASSWORD: ${IDP_LDAP_BIND_PASSWORD:-idp}
+      STORAGE_LDAP_BIND_PASSWORD: ${STORAGE_LDAP_BIND_PASSWORD:-reva}
+      OCIS_JWT_SECRET: ${OCIS_JWT_SECRET:-Pive-Fumkiu4}
+      # proxy
+      PROXY_CONFIG_FILE: "/config/proxy-config.json"
+    volumes:
+      - ./config/ocis/entrypoint-override.sh:/entrypoint-override.sh
+      - ./config/ocis/proxy-config.json:/config/proxy-config.json
+      - ocis-data:/var/tmp/ocis
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.ocis.entrypoints=http"
+      - "traefik.http.routers.ocis.rule=Host(`${OCIS_DOMAIN:-ocis.owncloud.test}`)"
+      - "traefik.http.middlewares.ocis-https-redirect.redirectscheme.scheme=https"
+      - "traefik.http.routers.ocis.middlewares=ocis-https-redirect"
+      - "traefik.http.routers.ocis-secure.entrypoints=https"
+      - "traefik.http.routers.ocis-secure.rule=Host(`${OCIS_DOMAIN:-ocis.owncloud.test}`)"
+      - "traefik.http.routers.ocis-secure.tls=true"
+      - "traefik.http.routers.ocis-secure.tls.certresolver=http"
+      - "traefik.http.routers.ocis-secure.service=ocis"
+      - "traefik.http.services.ocis.loadbalancer.server.port=9200"
+    logging:
+      driver: "local"
+    restart: always
+
+  web:
+    image: owncloud/web:${WEB_DOCKER_TAG:-latest}
+    networks:
+      ocis-net:
+    logging:
+      driver: "local"
+    restart: always
+
+volumes:
+  certs:
+  ocis-data:
+
+networks:
+  ocis-net:

--- a/deployments/examples/ocis_web/monitoring_tracing/docker-compose-additions.yml
+++ b/deployments/examples/ocis_web/monitoring_tracing/docker-compose-additions.yml
@@ -1,0 +1,12 @@
+---
+version: "3.7"
+
+services:
+  ocis:
+    environment:
+      OCIS_TRACING_ENABLED: "true"
+      OCIS_TRACING_ENDPOINT: jaeger-agent:6831
+
+networks:
+  ocis-net:
+    external: true


### PR DESCRIPTION
## Description
Adds a continuously deployed oCIS with the latest (master) Web UI. First deployment already online at https://ocis.ocis-web.latest.owncloud.works/.
Fixes #5150 

## Open tasks
[x] Add secrets
[x] add docs to https://owncloud.dev/ocis/deployment/continuous_deployment/ -> see https://github.com/owncloud/ocis/pull/2076
[x] setup drone cron schedule