### PR TITLE
Action toasts

### DIFF
--- a/changelog/unreleased/bugfix-copy-to-clipboard-with-keyboard
+++ b/changelog/unreleased/bugfix-copy-to-clipboard-with-keyboard
@@ -1,0 +1,5 @@
+Bugfix: Keyboard navigation for copy to clipboard
+
+We've fixed that the buttons for copying (private/public) links to the clipboard were not usable via keyboard.
+
+https://github.com/owncloud/web/pull/5147

--- a/changelog/unreleased/enhancement-copy-link-toasts
+++ b/changelog/unreleased/enhancement-copy-link-toasts
@@ -1,0 +1,5 @@
+Enhancement: Confirmation message when copying links
+
+We've added confirmation messages (toasts) when a private or public link is copied to the clipboard.
+
+https://github.com/owncloud/web/pull/5147

--- a/packages/web-app-files/src/components/FileLinkSidebar.vue
+++ b/packages/web-app-files/src/components/FileLinkSidebar.vue
@@ -230,27 +230,6 @@ export default {
   }
 }
 </script>
-<style scoped>
-/* FIXME: Move to design system */
-._clipboard-success-animation {
-  animation-name: _clipboard-success-animation;
-  animation-duration: 0.5s;
-  animation-timing-function: ease-out;
-  animation-fill-mode: both;
-}
-
-@keyframes _clipboard-success-animation {
-  0% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.9;
-  }
-  100% {
-    opacity: 0;
-  }
-}
-</style>
 <style>
 /* FIXME: Move to design system (copied from FileSharingSidebar.vue) */
 .oc-app-side-bar .oc-label {

--- a/packages/web-app-files/src/components/PublicLinksSidebar/CopyToClipboardButton.vue
+++ b/packages/web-app-files/src/components/PublicLinksSidebar/CopyToClipboardButton.vue
@@ -5,7 +5,12 @@
     appearance="raw"
     @click="copyValueToClipboard"
   >
-    <oc-icon v-if="copied" key="oc-copy-to-clipboard-copied" name="ready" />
+    <oc-icon
+      v-if="copied"
+      key="oc-copy-to-clipboard-copied"
+      name="ready"
+      class="_clipboard-success-animation"
+    />
     <oc-icon v-else key="oc-copy-to-clipboard-copy" name="copy_to_clipboard" />
   </oc-button>
 </template>
@@ -73,3 +78,24 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+._clipboard-success-animation {
+  animation-name: _clipboard-success-animation;
+  animation-duration: 0.5s;
+  animation-timing-function: ease-out;
+  animation-fill-mode: both;
+}
+
+@keyframes _clipboard-success-animation {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.9;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+</style>

--- a/packages/web-app-files/src/components/PublicLinksSidebar/CopyToClipboardButton.vue
+++ b/packages/web-app-files/src/components/PublicLinksSidebar/CopyToClipboardButton.vue
@@ -1,0 +1,75 @@
+<template>
+  <oc-button
+    v-oc-tooltip="label"
+    :aria-label="label"
+    appearance="raw"
+    @click="copyValueToClipboard"
+  >
+    <oc-icon v-if="copied" key="oc-copy-to-clipboard-copied" name="ready" />
+    <oc-icon v-else key="oc-copy-to-clipboard-copy" name="copy_to_clipboard" />
+  </oc-button>
+</template>
+
+<script>
+import { mapActions } from 'vuex'
+import copyToClipboard from 'copy-to-clipboard'
+
+export default {
+  props: {
+    /**
+     * Content which is to be copied to the clipboard
+     */
+    value: {
+      type: String,
+      required: true
+    },
+    /**
+     * Tooltip and aria-label for the button (describing the action, e.g. "Copy link to clipboard")
+     */
+    label: {
+      type: String,
+      required: true
+    },
+    /**
+     * Title for the success message toast
+     */
+    successMsgTitle: {
+      type: String,
+      required: true
+    },
+    /**
+     * Content for the success message toast
+     */
+    successMsgText: {
+      type: String,
+      required: true
+    }
+  },
+  data: () => ({
+    copied: false,
+    timeout: null
+  }),
+  methods: {
+    ...mapActions(['showMessage']),
+    copyValueToClipboard() {
+      copyToClipboard(this.value)
+      this.clipboardSuccessHandler()
+      this.showMessage({
+        title: this.successMsgTitle,
+        desc: this.successMsgText,
+        status: 'success',
+        autoClose: {
+          enabled: true
+        }
+      })
+    },
+    clipboardSuccessHandler() {
+      this.copied = true
+      clearTimeout(this.timeout)
+      this.timeout = setTimeout(() => {
+        this.copied = false
+      }, 550)
+    }
+  }
+}
+</script>

--- a/packages/web-app-files/src/components/PublicLinksSidebar/LinkInfo.vue
+++ b/packages/web-app-files/src/components/PublicLinksSidebar/LinkInfo.vue
@@ -132,9 +132,6 @@ export default {
 
     copyToClipboardSuccessMsgTitle() {
       return this.$gettext('Public link copied')
-    },
-    copyToClipboardSuccessMsgText() {
-      return this.$gettext('The public link has been copied to your clipboard.')
     }
   },
 

--- a/packages/web-app-files/src/components/PublicLinksSidebar/LinkInfo.vue
+++ b/packages/web-app-files/src/components/PublicLinksSidebar/LinkInfo.vue
@@ -13,7 +13,7 @@
           v-text="link.url"
         />
         <copy-to-clipboard-button
-          class="oc-files-file-link-copy-url oc-ml-xs"
+          class="oc-files-public-link-copy-url oc-ml-xs"
           :value="link.url"
           :label="copyToClipboardLabel"
           :success-msg-title="copyToClipboardSuccessMsgTitle"

--- a/packages/web-app-files/src/components/PublicLinksSidebar/LinkInfo.vue
+++ b/packages/web-app-files/src/components/PublicLinksSidebar/LinkInfo.vue
@@ -9,29 +9,16 @@
         <a
           :href="link.url"
           target="_blank"
-          class="oc-files-file-link-url oc-mr-xs uk-text-truncate"
+          class="oc-files-file-link-url uk-text-truncate"
           v-text="link.url"
         />
-        <oc-button
-          v-oc-tooltip="copyLabel"
-          :aria-label="copyLabel"
-          appearance="raw"
-          class="oc-files-file-link-copy-url"
-        >
-          <oc-icon
-            v-if="linkCopied"
-            key="copy-link-icon-copied"
-            name="ready"
-            class="oc-files-file-link-copied-url _clipboard-success-animation"
-          />
-          <oc-icon
-            v-else
-            key="copy-link-icon"
-            v-clipboard:copy="link.url"
-            v-clipboard:success="clipboardSuccessHandler"
-            name="copy_to_clipboard"
-          />
-        </oc-button>
+        <copy-to-clipboard-button
+          class="oc-files-file-link-copy-url oc-ml-xs"
+          :value="link.url"
+          :label="copyToClipboardLabel"
+          :success-msg-title="copyToClipboardSuccessMsgTitle"
+          :success-msg-text="getCopyToClipboardSuccessMsgText(link)"
+        />
       </div>
     </div>
     <oc-grid gutter="small">
@@ -73,10 +60,11 @@
 <script>
 import { basename, dirname } from 'path'
 import Mixins from '../../mixins'
+import CopyToClipboardButton from './CopyToClipboardButton.vue'
 
 export default {
   name: 'LinkInfo',
-
+  components: { CopyToClipboardButton },
   mixins: [Mixins],
 
   props: {
@@ -86,19 +74,9 @@ export default {
     }
   },
 
-  data: () => ({
-    linkCopied: false
-  }),
-
   computed: {
     linkName() {
       return this.link.name ? this.link.name : this.link.token
-    },
-
-    copyLabel() {
-      return this.linkCopied
-        ? this.$gettext('Public link successfully copied')
-        : this.$gettext('Copy public link url')
     },
 
     roleTagIcon() {
@@ -146,16 +124,32 @@ export default {
 
     viaTooltip() {
       return this.$gettext('Navigate to the parent')
+    },
+
+    copyToClipboardLabel() {
+      return this.$gettext('Copy link to clipboard')
+    },
+
+    copyToClipboardSuccessMsgTitle() {
+      return this.$gettext('Public link copied')
+    },
+    copyToClipboardSuccessMsgText() {
+      return this.$gettext('The public link has been copied to your clipboard.')
     }
   },
 
   methods: {
-    clipboardSuccessHandler() {
-      this.linkCopied = true
-
-      setTimeout(() => {
-        this.linkCopied = false
-      }, 550)
+    getCopyToClipboardSuccessMsgText(link) {
+      const translated = this.$gettext(
+        'The public link "%{linkName}" has been copied to your clipboard.'
+      )
+      return this.$gettextInterpolate(
+        translated,
+        {
+          linkName: link.name
+        },
+        true
+      )
     }
   }
 }

--- a/packages/web-app-files/src/components/PublicLinksSidebar/PrivateLinkItem.vue
+++ b/packages/web-app-files/src/components/PublicLinksSidebar/PrivateLinkItem.vue
@@ -5,7 +5,7 @@
     <div class="uk-width-1-1 uk-flex uk-flex-middle">
       <a :href="link" target="_blank" class="uk-text-truncate" v-text="link" />
       <copy-to-clipboard-button
-        class="oc-files-file-link-copy-url oc-ml-xs"
+        class="oc-files-private-link-copy-url oc-ml-xs"
         :value="link"
         :label="copyToClipboardLabel"
         :success-msg-title="copyToClipboardSuccessMsgTitle"

--- a/packages/web-app-files/src/components/PublicLinksSidebar/PrivateLinkItem.vue
+++ b/packages/web-app-files/src/components/PublicLinksSidebar/PrivateLinkItem.vue
@@ -4,23 +4,13 @@
     <p v-translate class="oc-text-muted oc-my-rm">Only invited people can use this link.</p>
     <div class="uk-width-1-1 uk-flex uk-flex-middle">
       <a :href="link" target="_blank" class="uk-text-truncate" v-text="link" />
-      <oc-button v-oc-tooltip="copyLabel" :aria-label="copyLabel" appearance="raw" class="oc-ml-s">
-        <oc-icon
-          v-if="linkCopied"
-          id="files-sidebar-private-link-icon-copied"
-          key="private-link-copy-icon-copied"
-          name="ready"
-          class="_clipboard-success-animation"
-        />
-        <oc-icon
-          v-else
-          id="files-sidebar-private-link-label"
-          key="private-link-copy-icon"
-          v-clipboard:copy="link"
-          v-clipboard:success="clipboardSuccessHandler"
-          name="copy_to_clipboard"
-        />
-      </oc-button>
+      <copy-to-clipboard-button
+        class="oc-files-file-link-copy-url oc-ml-xs"
+        :value="link"
+        :label="copyToClipboardLabel"
+        :success-msg-title="copyToClipboardSuccessMsgTitle"
+        :success-msg-text="copyToClipboardSuccessMsgText"
+      />
     </div>
     <hr />
   </div>
@@ -28,21 +18,14 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import CopyToClipboardButton from './CopyToClipboardButton.vue'
 
 export default {
   name: 'PrivateLinkItem',
-
-  data: () => ({
-    linkCopied: false
-  }),
-
+  components: { CopyToClipboardButton },
   computed: {
     ...mapGetters('Files', ['highlightedFile']),
     ...mapGetters(['capabilities']),
-
-    copyLabel() {
-      return this.$gettext('Copy private link url')
-    },
 
     link() {
       if (this.highlightedFile.isMounted()) {
@@ -56,16 +39,17 @@ export default {
 
     privateLinkEnabled() {
       return this.capabilities.files.privateLinks
-    }
-  },
+    },
 
-  methods: {
-    clipboardSuccessHandler() {
-      this.linkCopied = true
+    copyToClipboardLabel() {
+      return this.$gettext('Copy private link to clipboard')
+    },
 
-      setTimeout(() => {
-        this.linkCopied = false
-      }, 550)
+    copyToClipboardSuccessMsgTitle() {
+      return this.$gettext('Private link copied')
+    },
+    copyToClipboardSuccessMsgText() {
+      return this.$gettext('The private link has been copied to your clipboard.')
     }
   }
 }

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -22,7 +22,6 @@
     "uikit": "3.5.16",
     "vue": "^2.6.10",
     "vue-axe": "^2.4.4",
-    "vue-clipboard2": "^0.3.1",
     "vue-datetime": "^1.0.0-beta.10",
     "vue-drag-drop": "^1.1.4",
     "vue-events": "^3.1.0",

--- a/packages/web-runtime/src/index.js
+++ b/packages/web-runtime/src/index.js
@@ -19,7 +19,6 @@ import router from './router'
 import VueResize from 'vue-resize'
 import VueEvents from 'vue-events'
 import VueRouter from 'vue-router'
-import VueClipboard from 'vue-clipboard2'
 import VueScrollTo from 'vue-scrollto'
 import VueMeta from 'vue-meta'
 import Vue2TouchEvents from 'vue2-touch-events'
@@ -66,7 +65,6 @@ Vue.prototype.$client = new OwnCloud()
 
 Vue.use(VueEvents)
 Vue.use(VueRouter)
-Vue.use(VueClipboard)
 Vue.use(VueScrollTo)
 Vue.use(MediaSource)
 Vue.use(WebPlugin)

--- a/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
@@ -429,6 +429,11 @@ module.exports = {
     sidebarPrivateLinkLabel: {
       selector: '#files-sidebar-private-link-label'
     },
+    privateLinkURLCopyButton: {
+      selector:
+        '//div[contains(@class, "oc-files-file-link-name") and text()="%s"]/../../..//button[contains(@class, "oc-files-file-private-link-copy-url")]',
+      locateStrategy: 'xpath'
+    },
     sidebarPrivateLinkIconCopied: {
       selector: '#files-sidebar-private-link-icon-copied'
     },

--- a/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
@@ -335,12 +335,8 @@ module.exports = {
       return this.waitForElementVisible(this.api.page.personalPage().elements.sideBar)
         .waitForElementVisible(linksAccordionItem)
         .click(linksAccordionItem)
-        .waitForElementVisible('@sidebarPrivateLinkLabel')
+        .waitForElementVisible('@privateLinkURLCopyButton')
         .click('@sidebarPrivateLinkLabel')
-        .waitForElementNotPresent('@sidebarPrivateLinkLabel')
-        .waitForElementVisible('@sidebarPrivateLinkIconCopied')
-        .waitForElementNotPresent('@sidebarPrivateLinkIconCopied')
-        .waitForElementVisible('@sidebarPrivateLinkLabel')
     }
   },
   elements: {
@@ -410,7 +406,7 @@ module.exports = {
     },
     publicLinkURLCopyButton: {
       selector:
-        '//div[contains(@class, "oc-files-file-link-name") and text()="%s"]/../../..//button[contains(@class, "oc-files-file-link-copy-url")]',
+        '//div[contains(@class, "oc-files-file-link-name") and text()="%s"]/../../..//button[contains(@class, "oc-files-public-link-copy-url")]',
       locateStrategy: 'xpath'
     },
     publicLinkPasswordField: {
@@ -426,16 +422,8 @@ module.exports = {
     publicLinkSaveButton: {
       selector: '#oc-files-file-link-save'
     },
-    sidebarPrivateLinkLabel: {
-      selector: '#files-sidebar-private-link-label'
-    },
     privateLinkURLCopyButton: {
-      selector:
-        '//div[contains(@class, "oc-files-file-link-name") and text()="%s"]/../../..//button[contains(@class, "oc-files-file-private-link-copy-url")]',
-      locateStrategy: 'xpath'
-    },
-    sidebarPrivateLinkIconCopied: {
-      selector: '#files-sidebar-private-link-icon-copied'
+      selector: '.oc-files-private-link-copy-url'
     },
     publicLinkRoleSelectionDropdown: {
       selector: '//div[contains(@class, "files-file-link-role-button-wrapper")]//span[.="%s"]',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2718,15 +2718,6 @@ cli-width@^3.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
-clipboard@^2.0.0:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.6.tgz#52921296eec0fdf77ead1749421b21c968647376"
-  integrity sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==
-  dependencies:
-    good-listener "^1.2.2"
-    select "^1.1.2"
-    tiny-emitter "^2.0.0"
-
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
@@ -3600,11 +3591,6 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
-
-delegate@^3.1.2:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
-  integrity sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==
 
 depcheck@^1.3.1:
   version "1.3.1"
@@ -4964,13 +4950,6 @@ globby@^11.0.1:
     ignore "^5.1.4"
     merge2 "^1.3.0"
     slash "^3.0.0"
-
-good-listener@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
-  integrity sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=
-  dependencies:
-    delegate "^3.1.2"
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
   version "4.2.6"
@@ -9574,11 +9553,6 @@ seed-random@~2.2.0:
   resolved "https://registry.yarnpkg.com/seed-random/-/seed-random-2.2.0.tgz#2a9b19e250a817099231a5b99a4daf80b7fbed54"
   integrity sha1-KpsZ4lCoFwmSMaW5mk2vgLf77VQ=
 
-select@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
-  integrity sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=
-
 semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
@@ -10300,11 +10274,6 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
-tiny-emitter@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
-  integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
-
 tinycolor2@^1.1.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.2.tgz#3f6a4d1071ad07676d7fa472e1fac40a719d8803"
@@ -10784,13 +10753,6 @@ vue-axe@^2.4.4:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/vue-axe/-/vue-axe-2.4.4.tgz#fbe7ee93bc7e4cacf9dac0a1b0cfaa9e91f66dda"
   integrity sha512-zIhIenmvSzzDYLSGMRCZWHPXGryW5qAWNSKGzuzgn1/tK9zwYpWXagIihD91egyHKz9yWkPjcTO25bnxq9/OPg==
-
-vue-clipboard2@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/vue-clipboard2/-/vue-clipboard2-0.3.1.tgz#6e551fb7bd384889b28b0da3b12289ed6bca4894"
-  integrity sha512-H5S/agEDj0kXjUb5GP2c0hCzIXWRBygaWLN3NEFsaI9I3uWin778SFEMt8QRXiPG+7anyjqWiw2lqcxWUSfkYg==
-  dependencies:
-    clipboard "^2.0.0"
 
 vue-datetime@^1.0.0-beta.10:
   version "1.0.0-beta.14"


### PR DESCRIPTION
## Description
This PR introduces confirmation toasts for copying (private/public) links to the clipboard. Refactored into a `CopyToClipboardButton` component. We can decide later on if we want to move it to ODS (would need to extract the confirmation message then, as that needs to stay in web, and replace it with just emitting an event).

## Motivation and Context
a11y improvements

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- drone

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
