### PR TITLE
Unique IDs in people shares sidebar & outline button in batch actions

### DIFF
--- a/changelog/unreleased/bugfix-quick-action-ids
+++ b/changelog/unreleased/bugfix-quick-action-ids
@@ -1,6 +1,0 @@
-Bugfix: Change quick action from IDs to classes
-
-Quick action button IDs were repeated in every row of the file table, which isn't allowed in HTML (IDs must be unique per document).
-By changing to classes, this offense was resolved.
-
-https://github.com/owncloud/web/pull/5028

--- a/changelog/unreleased/bugfix-unique-ids
+++ b/changelog/unreleased/bugfix-unique-ids
@@ -1,0 +1,12 @@
+Bugfix: Make sure IDs in HTML are unique
+
+Quick action button IDs were repeated in every row of the file table, 
+which isn't allowed in HTML (IDs must be unique per document).
+By changing to classes, this offense was resolved.
+
+The same goes for IDs in the people shares part of the sidebar where IDs 
+are now appended with the share ID, which is necessary since they need to be 
+both unique and referenced by ID for accessibility reasons.
+
+https://github.com/owncloud/web/pull/5028
+https://github.com/owncloud/web/pull/5148

--- a/changelog/unreleased/enhancement-button-appearance
+++ b/changelog/unreleased/enhancement-button-appearance
@@ -1,0 +1,10 @@
+Enhancement: Button appearance
+
+Changed the appearance of the "accept/decline share" buttons in the "Shared With Me" file list
+so they actually look like buttons.
+
+Also changed the "Clear selection" button in the files table batch actions 
+from `raw` to `outline` appearance.
+
+https://github.com/owncloud/web/pull/5053
+https://github.com/owncloud/web/pull/5148

--- a/changelog/unreleased/enhancement-share-action-buttons
+++ b/changelog/unreleased/enhancement-share-action-buttons
@@ -1,6 +1,0 @@
-Enhancement: Share action button appearance
-
-Changed the appearance of the "accept/decline share" buttons in the "Shared With Me" file list
-so they actually look like buttons.
-
-https://github.com/owncloud/web/pull/5053

--- a/packages/web-app-files/src/components/BatchActions.vue
+++ b/packages/web-app-files/src/components/BatchActions.vue
@@ -4,6 +4,7 @@
       <oc-button
         v-if="selectedFiles.length > 0"
         key="restore-btn"
+        variation="primary"
         class="oc-mr-s"
         @click="restoreFiles()"
       >
@@ -14,6 +15,7 @@
         v-if="!isEmpty"
         id="delete-selected-btn"
         key="delete-btn"
+        variation="danger"
         @click="selectedFiles.length < 1 ? emptyTrashbin() : $_deleteResources_displayDialog()"
       >
         <oc-icon name="delete" />
@@ -25,6 +27,7 @@
         <oc-button
           id="copy-selected-btn"
           key="copy-selected-btn"
+          variation="primary"
           @click="triggerLocationPicker('copy')"
         >
           <oc-icon name="file_copy" />
@@ -35,6 +38,7 @@
         <oc-button
           id="move-selected-btn"
           key="move-selected-btn"
+          variation="primary"
           @click="triggerLocationPicker('move')"
         >
           <oc-icon name="folder-move" />
@@ -45,6 +49,7 @@
         <oc-button
           id="delete-selected-btn"
           key="delete-selected-btn"
+          variation="primary"
           @click="$_deleteResources_displayDialog"
         >
           <oc-icon name="delete" />

--- a/packages/web-app-files/src/components/Collaborators/Collaborator.vue
+++ b/packages/web-app-files/src/components/Collaborators/Collaborator.vue
@@ -51,11 +51,12 @@
               v-text="collaborator.collaborator.additionalInfo"
             />
           </div>
-          <span id="collaborator-list-label" v-translate class="oc-invisible-sr">Tags</span>
+          <span :id="`collaborator-list-label-${shareId}`" v-translate class="oc-invisible-sr"
+            >Tags</span
+          >
           <ul
-            id="collaborator-list"
-            class="oc-my-rm oc-pl-rm"
-            aria-labelledby="collaborator-list-label"
+            class="collaborator-list oc-my-rm oc-pl-rm"
+            :aria-labelledby="`collaborator-list-label-${shareId}`"
           >
             <li v-if="!isCurrentUser" class="oc-py-rm">
               <oc-tag class="files-collaborators-collaborator-share-type">
@@ -84,10 +85,10 @@
                 class="oc-mt-s"
                 close-on-click
               >
-                <h4 id="resharer-info" v-translate>Shared by</h4>
+                <h4 :id="`resharer-info-${shareId}`" v-translate>Shared by</h4>
                 <ul
                   class="uk-list uk-list-divider uk-overflow-hidden oc-m-rm"
-                  aria-labelledby="resharer-info"
+                  :aria-labelledby="`resharer-info-${shareId}`"
                 >
                   <li
                     v-for="resharer in collaborator.resharers"
@@ -218,6 +219,10 @@ export default {
 
     shareTypes() {
       return shareTypes
+    },
+
+    shareId() {
+      return this.collaborator.id
     },
 
     $_resharerToggleId() {
@@ -366,7 +371,7 @@ export default {
 </script>
 
 <style lang="scss" scoped="scoped">
-#collaborator-list {
+.collaborator-list {
   list-style-type: none;
 
   li {

--- a/packages/web-app-files/src/components/InfoSelectedResources.vue
+++ b/packages/web-app-files/src/components/InfoSelectedResources.vue
@@ -18,9 +18,13 @@
       translate-comment="Number of selected resources displayed above the files list"
       >%{ amount } selected item
     </translate>
-    <span class="oc-ml-s oc-mr-s">|</span>
-    <oc-button v-translate appearance="outline" @click="RESET_SELECTION">
-      Clear selection
+    <oc-button
+      v-oc-tooltip="clearSelectionLabel"
+      :aria-label="clearSelectionLabel"
+      class="oc-ml oc-mr-xs"
+      @click="RESET_SELECTION"
+    >
+      <oc-icon name="close" />
     </oc-button>
   </div>
 </template>
@@ -49,6 +53,10 @@ export default {
       }
 
       return this.getResourceSize(size)
+    },
+
+    clearSelectionLabel() {
+      return this.$gettext('Clear selection')
     }
   },
 

--- a/packages/web-app-files/src/components/InfoSelectedResources.vue
+++ b/packages/web-app-files/src/components/InfoSelectedResources.vue
@@ -19,8 +19,8 @@
       >%{ amount } selected item
     </translate>
     <span class="oc-ml-s oc-mr-s">|</span>
-    <oc-button appearance="raw" @click="RESET_SELECTION">
-      <translate>Clear selection</translate>
+    <oc-button v-translate appearance="outline" @click="RESET_SELECTION">
+      Clear selection
     </oc-button>
   </div>
 </template>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10785,11 +10785,6 @@ vue-axe@^2.4.4:
   resolved "https://registry.yarnpkg.com/vue-axe/-/vue-axe-2.4.4.tgz#fbe7ee93bc7e4cacf9dac0a1b0cfaa9e91f66dda"
   integrity sha512-zIhIenmvSzzDYLSGMRCZWHPXGryW5qAWNSKGzuzgn1/tK9zwYpWXagIihD91egyHKz9yWkPjcTO25bnxq9/OPg==
 
-vue-axe@^2.4.4:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/vue-axe/-/vue-axe-2.4.4.tgz#fbe7ee93bc7e4cacf9dac0a1b0cfaa9e91f66dda"
-  integrity sha512-zIhIenmvSzzDYLSGMRCZWHPXGryW5qAWNSKGzuzgn1/tK9zwYpWXagIihD91egyHKz9yWkPjcTO25bnxq9/OPg==
-
 vue-clipboard2@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/vue-clipboard2/-/vue-clipboard2-0.3.1.tgz#6e551fb7bd384889b28b0da3b12289ed6bca4894"


### PR DESCRIPTION
## Description
- IDs in people shares in the sidebar were created inside a loop and needed an appendix to make sure they're unique
- Changed the selector of the `collaborator-list` `<ul>` CSS selector to class to avoid a11y offenses
- Outlined button in the batch actions (not the most beautiful solution on some viewports with the sidebar expanded)

*Edit / Side note:* ` vue-axe@^2.4.4` appeared as a duplicate in the `yarn.lock`, perhaps due to some rebase earlier - this is why I commited the change