### PR TITLE
[debatable] Hide left sidebar if no navitems present

### DIFF
--- a/changelog/unreleased/enhancement-hide-navbar-if-no-navitems
+++ b/changelog/unreleased/enhancement-hide-navbar-if-no-navitems
@@ -1,0 +1,7 @@
+Enhancement: Hide left sidebar if no navitems are present
+
+For extensions / pages without nav items and public link pages, 
+we now hide the left sidebar to not confuse screen readers and 
+give more screen space for the content.
+
+https://github.com/owncloud/web/pull/5149

--- a/packages/web-runtime/src/App.vue
+++ b/packages/web-runtime/src/App.vue
@@ -225,6 +225,9 @@ export default {
     },
 
     isSidebarVisible() {
+      if (this.sidebarNavItems.length === 0) {
+        return false
+      }
       return this.windowWidth >= 1200 || this.appNavigationVisible
     },
 


### PR DESCRIPTION
## Description
Felt surprisingly easy, I'd vote in favor of only hiding the navigation (and not the whole sidebar) to keep the iconic CI blue plus OC logo present for public links though...