### PR TITLE
[tests-only] Adjust steps that try to create files/folder

### DIFF
--- a/tests/acceptance/features/webUICreateFilesFolders/createFolders.feature
+++ b/tests/acceptance/features/webUICreateFilesFolders/createFolders.feature
@@ -25,25 +25,27 @@ Feature: create folders
 
 
   Scenario: Try to create a folder without name
-    When the user creates a folder without name using the webUI
+    When the user tries to create a folder with the invalid name "" using the webUI
     Then the error message 'Folder name cannot be empty' should be displayed on the webUI dialog prompt
+    And the create folder button should be disabled
 
 
   Scenario: Try to create a folder with existing name
     Given user "Alice" has created folder "simple-folder"
     And the user has reloaded the current page of the webUI
-    When the user creates a folder with the invalid name "simple-folder" using the webUI
+    When the user tries to create a folder with the invalid name "simple-folder" using the webUI
     Then the error message 'simple-folder already exists' should be displayed on the webUI dialog prompt
-
+    And the create folder button should be disabled
 
   Scenario: Try to create a folder with invalid name
-    When the user creates a folder with the invalid name "../folder" using the webUI
+    When the user tries to create a folder with the invalid name "../folder" using the webUI
     Then the error message 'Folder name cannot contain "/"' should be displayed on the webUI dialog prompt
-
+    And the create folder button should be disabled
 
   Scenario: Try to create a folder with another invalid name
-    When the user creates a folder with the invalid name "folder/subfolder" using the webUI
+    When the user tries to create a folder with the invalid name "folder/subfolder" using the webUI
     Then the error message 'Folder name cannot contain "/"' should be displayed on the webUI dialog prompt
+    And the create folder button should be disabled
 
   @issue-2467
   Scenario: Create folder with special characters in its name and browse to that folder

--- a/tests/acceptance/pageObjects/personalPage.js
+++ b/tests/acceptance/pageObjects/personalPage.js
@@ -101,6 +101,10 @@ module.exports = {
 
       if (expectToSucceed) {
         await this.waitForElementNotPresent('@dialog')
+      } else {
+        await this.waitForElementPresent('@dialogBoxInputTextInRed')
+          // checking if the button is disabled
+          .waitForElementPresent('@dialogConfirmBtnDisabled')
       }
 
       return this
@@ -128,6 +132,10 @@ module.exports = {
 
       if (expectToSucceed) {
         await this.waitForElementNotPresent('@dialog')
+      } else {
+        await this.waitForElementPresent('@dialogBoxInputTextInRed')
+          // checking if the button is disabled
+          .waitForElementPresent('@dialogConfirmBtnDisabled')
       }
 
       return this
@@ -265,15 +273,6 @@ module.exports = {
           .waitForElementNotPresent('@dialog')
           .waitForAjaxCallsToStartAndFinish()
       )
-    },
-    triesToCreateExistingFile: function(fileName) {
-      return this.waitForElementVisible('@newFileMenuButton')
-        .click('@newFileMenuButton')
-        .waitForElementVisible('@newFileButton')
-        .click('@newFileButton')
-        .waitForElementVisible('@dialogInput')
-        .clearValueWithEvent('@dialogInput')
-        .setValue('@dialogInput', fileName)
     },
     checkForButtonDisabled: function() {
       return this.waitForElementVisible('@dialogConfirmBtnDisabled')
@@ -460,6 +459,9 @@ module.exports = {
     cancelMoveCopyBtn: {
       selector: '//button[.="Cancel"]',
       locateStrategy: 'xpath'
+    },
+    dialogBoxInputTextInRed: {
+      selector: '.oc-text-input-danger'
     }
   }
 }

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -150,14 +150,10 @@ When('the user creates a file with the name {string} using the webUI', function(
 })
 
 When('the user creates a folder with default name using the webUI', function() {
-  return client.page.personalPage().createFolder(null, false)
+  return client.page.personalPage().createFolder(null)
 })
 
-When('the user creates a folder without name using the webUI', function() {
-  return client.page.personalPage().createFolder('', false)
-})
-
-When('the user creates a folder with the invalid name {string} using the webUI', function(
+When('the user tries to create a folder with the invalid name {string} using the webUI', function(
   folderName
 ) {
   return client.page.personalPage().createFolder(folderName, false)
@@ -1041,11 +1037,11 @@ When('the user uploads overwriting file {string} using the webUI', function(file
 When(
   'the user tries to create a file with already existing name {string} using the webUI',
   function(fileName) {
-    return client.page.personalPage().triesToCreateExistingFile(fileName)
+    return client.page.personalPage().createFile(fileName, false)
   }
 )
 
-Then('the create file button should be disabled', function() {
+Then('the create file/folder button should be disabled', function() {
   return client.page.personalPage().checkForButtonDisabled()
 })
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
This PR adjusts the test step that tries to create files and folder, meaning that the resource creation process is supposed to be unsuccessful.

The changes made by this PR and how they work

- When the user creates a resource using the web UI and it's supposed to be successful the parameter `expectedToSucceed` in
` createFolder/createFile` function is set to `true` by default and the user will successfully create a folder
- When the user tries to creates a resource then same function  ` createFolder/createFile` is called but we set `expectedToSucceed` to `false` . In this case we check if the name of the resource in `inputTextField` is in `red colour` and if the `create button` has been `disabled`, as these are the actual behavior that should take place when resource creation is supposed to be unsuccessful

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- part of : https://github.com/owncloud/web/issues/4933

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
These changes were necessary because previously in steps dealing with `tries to` we used to check the errors in `then` and in `when `step we used to check the behavior of the webUI while trying to do certain operation like `creating resource` in this case but we didn't check everything.
Now we want our `when` step to perform all the task that we perform while actually ` creating resource` and we want to make sure that the `resource ` creation process is unsuccessful at when step, so that we know the cause if that step fails for some reason or starts behaving in undesired manner.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot:

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...