### PR TITLE
[tests-only] Adjust steps that try to navigate private links

### DIFF
--- a/tests/acceptance/stepDefinitions/privateLinksContext.js
+++ b/tests/acceptance/stepDefinitions/privateLinksContext.js
@@ -36,6 +36,9 @@ When(
   'the user tries to navigate to the private link created by user {string} for file/folder {string}',
   async function(user, resource) {
     const item = await webdav.getProperties(resource, user, ['oc:privatelink'])
-    await client.url(item['oc:privatelink'])
+    await client
+      .url(item['oc:privatelink'])
+      .page.webPage()
+      .waitForElementNotPresent('@webContainer')
   }
 )


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
This PR adjusts the test step that tries to navigate private link, meaning that the navigation process is supposed to be unsuccessful.

The changes made by this PR and how they work

- When a user `tries to` navigate a private link which they don't have permission to , they shouldn't be able to do so and should be redirected to the login page. When a user with permission accesses the private link then `#webContainer` should be visible to them and they shouldn't be logged out . But for user trying to access it without permission  `#webContainer` shloudn't be present and they should be redirected to login page. This PR adds that extra check

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- part of : https://github.com/owncloud/web/issues/4933

## Motivation and Context
These changes were necessary because previously in steps dealing with `tries to` we used to check the errors in `then` and in `when `step we used to check the behavior of the webUI while trying to do certain operation like `navigating private link` in this case but we didn't check everything.
Now we want our `when` step to perform all the task that we perform while actually `navigating private link` and we want to make sure that the process is unsuccessful at when step, so that we know the cause if that step fails for some reason or starts behaving in undesired manner.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...