### PR TITLE
Divide "Shared with me" view into pending, accepted and declined sections

### DIFF
--- a/packages/web-app-files/src/views/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/SharedWithMe.vue
@@ -257,13 +257,12 @@ import MixinFilesListPositioning from '../mixins/filesListPositioning'
 import MixinFilesListPagination from '../mixins/filesListPagination'
 import ListLoader from '../components/ListLoader.vue'
 import NoContentMessage from '../components/NoContentMessage.vue'
-import ListInfo from '../components/FilesListFooterInfo.vue'
 import { VisibilityObserver } from 'web-pkg/src/observer'
 import { ImageDimension } from '../constants'
 import debounce from 'lodash-es/debounce'
 const visibilityObserver = new VisibilityObserver()
 export default {
-  components: { ListLoader, NoContentMessage, ListInfo },
+  components: { ListLoader, NoContentMessage },
   mixins: [FileActions, MixinFilesListPositioning, MixinFilesListPagination],
   data: () => ({
     loading: true,

--- a/packages/web-app-files/src/views/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/SharedWithMe.vue
@@ -2,77 +2,248 @@
   <div>
     <list-loader v-if="loading" />
     <template v-else>
-      <no-content-message
-        v-if="isEmpty"
-        id="files-shared-with-me-empty"
-        class="files-empty"
-        icon="group"
+      <!-- Pending shares -->
+
+      <div
+        v-if="filterDataByStatus(activeFiles, shareStatus.pending).length > 0"
+        id="pending-shares"
+        class="oc-mb"
       >
-        <template #message>
-          <span v-translate>
-            You are currently not collaborating on other people's resources
-          </span>
-        </template>
-      </no-content-message>
-      <oc-table-files
-        v-else
-        id="files-shared-with-me-table"
-        v-model="selected"
-        class="files-table"
-        :class="{ 'files-table-squashed': isSidebarOpen }"
-        :are-previews-displayed="displayPreviews"
-        :resources="activeFiles"
-        :target-route="targetRoute"
-        :highlighted="highlightedFile ? highlightedFile.id : null"
-        :header-position="headerPosition"
-        @showDetails="setHighlightedFile"
-        @fileClick="$_fileActions_triggerDefaultAction"
-        @rowMounted="rowMounted"
-      >
-        <template v-slot:status="{ resource }">
+        <div class="oc-app-bar shares-bar">
+          <h2 v-translate>Pending Shares</h2>
+          <div class="oc-ml-s">
+            <p>({{ filterDataByStatus(activeFiles, shareStatus.pending).length }})</p>
+          </div>
+        </div>
+
+        <div id="pending-highlight">
+          <oc-table-files
+            id="files-shared-with-me-pending-table"
+            v-model="selectedPending"
+            class="files-table"
+            :class="{ 'files-table-squashed': isSidebarOpen }"
+            :are-previews-displayed="displayPreviews"
+            :resources="
+              showAllPending === false
+                ? filterDataByStatus(activeFiles, 1).slice(0, 3)
+                : filterDataByStatus(activeFiles, 1)
+            "
+            :target-route="targetRoute"
+            :are-resources-clickable="false"
+            :highlighted="highlightedFile ? highlightedFile.id : null"
+            :has-actions="false"
+            :header-position="headerPosition"
+          >
+            <template v-slot:status="{ resource }">
+              <div
+                :key="resource.id + resource.status"
+                class="uk-text-nowrap uk-flex uk-flex-middle uk-flex-right"
+              >
+                <oc-button
+                  v-if="[shareStatus.declined, shareStatus.pending].includes(resource.status)"
+                  v-translate
+                  variation="success"
+                  size="small"
+                  class="file-row-share-status-action"
+                  @click.stop="triggerShareAction(resource, 'POST')"
+                >
+                  Accept
+                </oc-button>
+                <oc-button
+                  v-if="[shareStatus.accepted, shareStatus.pending].includes(resource.status)"
+                  v-translate
+                  size="small"
+                  class="file-row-share-status-action oc-ml"
+                  @click.stop="triggerShareAction(resource, 'DELETE')"
+                >
+                  Decline
+                </oc-button>
+                <span
+                  class="uk-text-small oc-ml file-row-share-status-text uk-text-baseline"
+                  v-text="getShareStatusText(resource.status)"
+                />
+              </div>
+            </template>
+          </oc-table-files>
+
           <div
-            :key="resource.id + resource.status"
-            class="uk-text-nowrap uk-flex uk-flex-middle uk-flex-right"
+            v-if="
+              showAllPending === false &&
+                filterDataByStatus(activeFiles, shareStatus.pending).length > 3
+            "
+            class="oc-app-bar centered"
           >
             <oc-button
-              v-if="[shareStatus.pending, shareStatus.declined].includes(resource.status)"
-              size="small"
-              class="file-row-share-status-action"
-              @click.stop="triggerShareAction(resource, 'POST')"
+              key="show-all-button"
+              v-translate
+              appearance="raw"
+              class="show-hide-pending"
+              @click="showAllPending = true"
             >
-              <translate>Accept</translate>
-            </oc-button>
-            <oc-button
-              v-if="[shareStatus.pending, shareStatus.accepted].includes(resource.status)"
-              size="small"
-              class="file-row-share-status-action oc-ml-s"
-              @click.stop="triggerShareAction(resource, 'DELETE')"
+              Show all</oc-button
             >
-              <translate>Decline</translate>
-            </oc-button>
-            <span
-              class="uk-text-small oc-ml file-row-share-status-text uk-text-baseline"
-              v-text="getShareStatusText(resource.status)"
-            />
           </div>
-        </template>
-        <template #footer>
-          <oc-pagination
-            v-if="pages > 1"
-            :pages="pages"
-            :current-page="currentPage"
-            :max-displayed="3"
-            :current-route="$_filesListPagination_targetRoute"
-            class="files-pagination uk-flex uk-flex-center oc-my-s"
-          />
-          <list-info
-            v-if="activeFiles.length > 0"
-            class="uk-width-1-1 oc-my-s"
-            :files="totalFilesCount.files"
-            :folders="totalFilesCount.folders"
-          />
-        </template>
-      </oc-table-files>
+
+          <div
+            v-else-if="
+              showAllPending === true &&
+                filterDataByStatus(activeFiles, shareStatus.pending).length > 3
+            "
+            class="oc-app-bar centered"
+          >
+            <oc-button
+              key="show-less-button"
+              v-translate
+              appearance="raw"
+              class="show-hide-pending"
+              @click="showAllPending = false"
+            >
+              Show less
+            </oc-button>
+          </div>
+        </div>
+      </div>
+      <br />
+
+      <!-- Accepted shares -->
+      <div v-if="!showDeclined">
+        <div class="oc-app-bar shares-bar">
+          <h2 key="accepted-shares-header" v-translate>Accepted Shares</h2>
+          <div
+            v-if="filterDataByStatus(activeFiles, shareStatus.accepted).length > 0"
+            class="oc-ml-s"
+          >
+            <p>({{ filterDataByStatus(activeFiles, shareStatus.accepted).length }})</p>
+          </div>
+
+          <div class="oc-ml-m">
+            <oc-button
+              id="show-declined"
+              key="show-declined-button"
+              v-translate
+              appearance="raw"
+              @click="showDeclined = true"
+              >Show declined shares</oc-button
+            >
+          </div>
+        </div>
+        <no-content-message
+          v-if="isEmpty || filterDataByStatus(activeFiles, shareStatus.accepted).length === 0"
+          id="files-shared-with-me-accepted-empty"
+          class="files-empty"
+          icon="group"
+        >
+          <template #message>
+            <span v-translate>
+              You are currently not collaborating on other people's resources
+            </span>
+          </template>
+        </no-content-message>
+        <oc-table-files
+          v-else
+          id="files-shared-with-me-accepted-table"
+          v-model="selectedAccepted"
+          class="files-table"
+          :class="{ 'files-table-squashed': isSidebarOpen }"
+          :are-previews-displayed="displayPreviews"
+          :resources="filterDataByStatus(activeFiles, shareStatus.accepted)"
+          :target-route="targetRoute"
+          :highlighted="highlightedFile ? highlightedFile.id : null"
+          :header-position="headerPosition"
+          @showDetails="setHighlightedFile"
+          @fileClick="$_fileActions_triggerDefaultAction"
+        >
+          <template v-slot:status="{ resource }">
+            <div
+              :key="resource.id + resource.status"
+              class="uk-text-nowrap uk-flex uk-flex-middle uk-flex-right"
+            >
+              <oc-button
+                v-if="[shareStatus.accepted, shareStatus.pending].includes(resource.status)"
+                v-translate
+                size="small"
+                class="file-row-share-status-action oc-ml"
+                @click.stop="triggerShareAction(resource, 'DELETE')"
+              >
+                Decline
+              </oc-button>
+              <span
+                class="uk-text-small oc-ml file-row-share-status-text uk-text-baseline"
+                v-text="getShareStatusText(resource.status)"
+              />
+            </div>
+          </template>
+        </oc-table-files>
+      </div>
+
+      <!-- Declined shares -->
+      <div v-else>
+        <div class="oc-app-bar shares-bar">
+          <h2 key="declined-shares-header" v-translate>Declined Shares</h2>
+          <div
+            v-if="filterDataByStatus(activeFiles, shareStatus.declined).length > 0"
+            class="oc-ml-s"
+          >
+            <p>({{ filterDataByStatus(activeFiles, shareStatus.declined).length }})</p>
+          </div>
+          <div class="oc-ml-m">
+            <oc-button
+              id="show-accepted"
+              key="show-accepted-button"
+              v-translate
+              appearance="raw"
+              @click="showDeclined = false"
+              >Show accepted shares</oc-button
+            >
+          </div>
+        </div>
+        <no-content-message
+          v-if="isEmpty || filterDataByStatus(activeFiles, shareStatus.declined).length === 0"
+          id="files-shared-with-me-declined-empty"
+          class="files-empty"
+          icon="group"
+        >
+          <template #message>
+            <span v-translate> No declined shares found </span>
+          </template>
+        </no-content-message>
+        <oc-table-files
+          v-else
+          id="files-shared-with-me-declined-table"
+          v-model="selectedDeclined"
+          class="files-table"
+          :class="{ 'files-table-squashed': isSidebarOpen }"
+          :are-previews-displayed="displayPreviews"
+          :resources="filterDataByStatus(activeFiles, shareStatus.declined)"
+          :target-route="targetRoute"
+          :are-resources-clickable="false"
+          :highlighted="highlightedFile ? highlightedFile.id : null"
+          :has-actions="false"
+          :header-position="headerPosition"
+          @fileClick="$_fileActions_triggerDefaultAction"
+        >
+          <template v-slot:status="{ resource }">
+            <div
+              :key="resource.id + resource.status"
+              class="uk-text-nowrap uk-flex uk-flex-middle uk-flex-right"
+            >
+              <oc-button
+                v-if="[shareStatus.declined, shareStatus.pending].includes(resource.status)"
+                v-translate
+                size="small"
+                class="file-row-share-status-action"
+                @click.stop="triggerShareAction(resource, 'POST')"
+              >
+                Accept
+              </oc-button>
+              <span
+                class="uk-text-small oc-ml file-row-share-status-text uk-text-baseline"
+                v-text="getShareStatusText(resource.status)"
+              />
+            </div>
+          </template>
+        </oc-table-files>
+      </div>
     </template>
   </div>
 </template>
@@ -84,26 +255,22 @@ import { aggregateResourceShares, buildResource, buildSharedResource } from '../
 import FileActions from '../mixins/fileActions'
 import MixinFilesListPositioning from '../mixins/filesListPositioning'
 import MixinFilesListPagination from '../mixins/filesListPagination'
-
 import ListLoader from '../components/ListLoader.vue'
 import NoContentMessage from '../components/NoContentMessage.vue'
 import ListInfo from '../components/FilesListFooterInfo.vue'
 import { VisibilityObserver } from 'web-pkg/src/observer'
 import { ImageDimension } from '../constants'
 import debounce from 'lodash-es/debounce'
-
 const visibilityObserver = new VisibilityObserver()
-
 export default {
   components: { ListLoader, NoContentMessage, ListInfo },
-
   mixins: [FileActions, MixinFilesListPositioning, MixinFilesListPagination],
-
   data: () => ({
     loading: true,
-    shareStatus
+    shareStatus,
+    showDeclined: false,
+    showAllPending: false
   }),
-
   computed: {
     ...mapState(['app']),
     ...mapState('Files', ['currentPage', 'files']),
@@ -114,10 +281,10 @@ export default {
       'selectedFiles',
       'inProgress',
       'totalFilesCount',
-      'pages'
+      'pages',
+      'activeFilesCount'
     ]),
     ...mapGetters(['isOcis', 'configuration', 'getToken', 'user']),
-
     selected: {
       get() {
         return this.selectedFiles
@@ -126,28 +293,49 @@ export default {
         this.SELECT_RESOURCES(resources)
       }
     },
-
+    selectedPending: {
+      get() {
+        return this.selectedFiles.filter(r => r.status === shareStatus.pending)
+      },
+      set(resources) {
+        resources = resources.filter(r => r.status === shareStatus.pending)
+        this.SELECT_RESOURCES(resources)
+      }
+    },
+    selectedAccepted: {
+      get() {
+        return this.selectedFiles.filter(r => r.status === shareStatus.accepted)
+      },
+      set(resources) {
+        resources = resources.filter(r => r.status === shareStatus.accepted)
+        this.SELECT_RESOURCES(resources)
+      }
+    },
+    selectedDeclined: {
+      get() {
+        return this.selectedFiles.filter(r => r.status === shareStatus.declined)
+      },
+      set(resources) {
+        resources = resources.filter(r => r.status === shareStatus.declined)
+        this.SELECT_RESOURCES(resources)
+      }
+    },
     isEmpty() {
       return this.activeFiles.length < 1
     },
-
     isSidebarOpen() {
       return this.highlightedFile !== null
     },
-
     uploadProgressVisible() {
       return this.inProgress.length > 0
     },
-
     targetRoute() {
       return { name: 'files-personal' }
     },
-
     displayPreviews() {
       return !this.configuration.options.disablePreviews
     }
   },
-
   watch: {
     uploadProgressVisible() {
       this.adjustTableHeaderPosition()
@@ -157,20 +345,16 @@ export default {
       immediate: true
     }
   },
-
   created() {
     this.loadResources()
     window.onresize = this.adjustTableHeaderPosition
   },
-
   mounted() {
     this.adjustTableHeaderPosition()
   },
-
   beforeDestroy() {
     visibilityObserver.disconnect()
   },
-
   methods: {
     ...mapActions('Files', ['setHighlightedFile', 'loadIndicators', 'loadPreview', 'loadAvatars']),
     ...mapActions(['showMessage']),
@@ -181,65 +365,56 @@ export default {
       'UPDATE_RESOURCE'
     ]),
     ...mapMutations(['SET_QUOTA']),
-
     rowMounted(resource, component) {
       const debounced = debounce(({ unobserve }) => {
         unobserve()
         this.loadAvatars({ resource })
-
         if (!this.displayPreviews) {
           return
         }
-
         this.loadPreview({
           resource,
           isPublic: false,
           dimensions: ImageDimension.ThumbNail
         })
       }, 250)
-
       visibilityObserver.observe(component.$el, { onEnter: debounced, onExit: debounced.cancel })
     },
-
+    filterDataByStatus(data, status) {
+      return data.filter(item => item.status === status)
+    },
     async loadResources() {
       this.loading = true
       this.CLEAR_CURRENT_FILES_LIST()
-
       let resources = await this.$client.requests.ocs({
         service: 'apps/files_sharing',
         action: '/api/v1/shares?format=json&shared_with_me=true&state=all&include_tags=false',
         method: 'GET'
       })
       let rootFolder = await this.$client.files.fileInfo('/', this.davProperties)
-
       resources = await resources.json()
       resources = resources.ocs.data
       rootFolder = buildResource(rootFolder)
-
       if (resources.length < 1) {
         this.LOAD_FILES({ currentFolder: rootFolder, files: [] })
         this.loading = false
-
         return
       }
-
       resources = aggregateResourceShares(
         resources,
         true,
         !this.isOcis,
         this.configuration.server,
-        this.getToken
+        this.getToken,
+        this.$client,
+        this.UPDATE_RESOURCE
       )
-
       this.LOAD_FILES({ currentFolder: rootFolder, files: resources })
-
       // Load quota
       const user = await this.$client.users.getUser(this.user.id)
-
       this.SET_QUOTA(user.quota)
       this.loading = false
     },
-
     getShareStatusText(status) {
       switch (status) {
         case shareStatus.accepted:
@@ -251,7 +426,6 @@ export default {
           return this.$gettext('Pending')
       }
     },
-
     async triggerShareAction(resource, type) {
       try {
         // exec share action
@@ -260,7 +434,6 @@ export default {
           action: `api/v1/shares/pending/${resource.share.id}`,
           method: type
         })
-
         // exit on failure
         if (response.status !== 200) {
           throw new Error(response.statusText)
@@ -270,7 +443,6 @@ export default {
         // oc10
         if (parseInt(response.headers.get('content-length')) > 0) {
           response = await response.json()
-
           if (response.ocs.data.length > 0) {
             share = response.ocs.data[0]
           }
@@ -279,7 +451,6 @@ export default {
           const { shareInfo } = await this.$client.shares.getShare(resource.share.id)
           share = shareInfo
         }
-
         // update share in store
         if (share) {
           const sharedResource = await buildSharedResource(
@@ -292,13 +463,36 @@ export default {
           this.UPDATE_RESOURCE(sharedResource)
         }
       } catch (error) {
+        this.loadResources()
         this.showMessage({
           title: this.$gettext('Error while changing share state'),
           desc: error.message,
-          status: 'danger'
+          status: 'danger',
+          autoClose: {
+            enabled: true
+          }
         })
       }
     }
   }
 }
 </script>
+
+<style>
+.centered {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+}
+.shares-bar {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+}
+#pending-highlight {
+  background-color: var(--oc-color-background-highlight);
+}
+.show-hide-pending {
+  text-align: center;
+}
+</style>


### PR DESCRIPTION
## Description
The "Shared with me" view shows 2 different lists for pending and accepted shares. On request user can see the declined files (clicking "show declined shares).


## Motivation and Context
General UX improvement: Motivate the user to accept or decline the shares through better overview of the statuses and highlighted pending section. 

## How Has This Been Tested?
UI test scenario: Sharing multiple files through one testing account with another
- test case 1: pending shares, 3 or less pending shares --> simple list of pending shares
- test case 2: pending shares, more than 3 shares --> "show all", "show less" option
- test case 3: no pending shares--> no pending shares list shown
- test case 4: no accepted shares--> "You are currently not collaborating on other people's resources" message shown, "show declined shares" option appears at pending shares
- test case 5: accepted shares exist--> list with accepted shares and option to show declined shares appears
- test case 6: no declined shares--> "No declined files found" message appears
- test case 7 declined shares exist --> list with declined shares shown on click of "show declined shares"

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 


## General view
![Bildschirmfoto vom 2021-05-31 10-14-23](https://user-images.githubusercontent.com/7430156/120162767-0338be80-c1f9-11eb-8a30-f61f9c0f4b7e.png)
