### PR TITLE
[tests-only] [full-ci] Do not do earlyFail in CI if full-ci requested

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -838,6 +838,9 @@ def acceptance(ctx):
             for item in default:
                 params[item] = matrix[item] if item in matrix else default[item]
 
+            if ("full-ci" in ctx.build.title.lower()):
+                params["earlyFail"] = False
+
             for server in params["servers"]:
                 for browser in params["browsers"]:
                     for db in params["databases"]:


### PR DESCRIPTION
## Description
With this PR, a developer can mention `full-ci` in the PR title, and that will override the `earlyFail` behavior.

Normally when the first UI test pipeline fails, it cancels the whole build, to save CI resources.

But now, if you mention `full-ci` in the PR title, then the UI tests pipelines will all run to completion, even if one or more of them fails. That can help a developer to see all the fails "at once". And they can do it without actually editing `.drone.star` - so the PR can be merged when it passes (there will be no need to revert an edit of `.drone.star`)

## Related Issue
Fixes #5183 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...