### PR TITLE
[tests-only] Use github_token for posting comments

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2308,8 +2308,8 @@ def githubComment():
             "message_file": "/var/www/owncloud/web/comments.file",
         },
         "environment": {
-            "PLUGIN_API_KEY": {
-                "from_secret": "plugin_api_key",
+            "GITHUB_TOKEN": {
+                "from_secret": "github_token",
             },
         },
         "when": {


### PR DESCRIPTION
## Description
`github_token` should be a global secret that is available for all drone runs, so use that.

## How Has This Been Tested?
Demonstrated in #5187 - test fails do still get reported in GitHub comments.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
