### PR TITLE
[tests-only] [full-ci] Exit early from build-github-comment-vrt if there are no diffs

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2222,7 +2222,10 @@ def buildGithubCommentVisualDiff(ctx, suite, alternateSuiteName, runningOnOCIS):
         "image": "owncloud/ubuntu:16.04",
         "pull": "always",
         "commands": [
-            "cd /var/www/owncloud/web/tests/vrt/diff",
+            "cd /var/www/owncloud/web/tests/vrt",
+            "if [ ! -d diff ]; then exit 0; fi",
+            "cd diff",
+            "if [ ! -d %s ]; then exit 0; fi" % backend,
             "cd %s" % backend,
             "ls -la",
             'echo "<details><summary>:boom: Visual regression tests <strong>%s</strong> failed. Please find the screenshots inside ...</summary>\\n\\n${DRONE_BUILD_LINK}/${DRONE_JOB_NUMBER}\\n\\n<p>\\n\\n" >> /var/www/owncloud/web/comments.file' % alternateSuiteName,


### PR DESCRIPTION
## Description
If ordinary UI test scenarios fail for "ordinary" reasons, and there are no Visual Regression Test diffs, then the `build-github-comment-vrt` pipeline step was failing, complaining that `cd /var/www/owncloud/web/tests/vrt/diff` does not exist. The step would be marked with a red "x" on the drone UI. That was a bit misleading - there was nothing wrong with that step. The actual acceptance tests step was the only step that really failed.

This PR adds some extra checks for existence of the `diff` directory structure, and the step exits early if the directory structure does not exist.

## How Has This Been Tested?
PR #5192 demostrates this. It introduces some failing tests. The drone pipeline https://drone.owncloud.com/owncloud/web/15916/6/18 looks better now - only the `webui-acceptance-tests` step is showing a red "x".

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...