### PR TITLE
[tests-only] Add test tag federated-server-needed

### DIFF
--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -1,4 +1,4 @@
-@ocis-product-issue-277
+@ocis-product-issue-277 @federated-server-needed
 Feature: Federation Sharing - sharing with users on other cloud storages
   As a user
   I want to share files with any users on other cloud storages


### PR DESCRIPTION
## Description
When running tests with the "run parts" feature implement in PR #5188 the logic just runs all the suites that it can find. But from OCIS we currently do not run tests that use a federated server.

Add a filter tag to federated server tests, so that there is an easy way to skip those whenever we need to do that.

## Related Issue
Part of https://github.com/owncloud/ocis/issues/2107

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...