### PR TITLE
[Tests-Only] used get text instead of getAttribute

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -322,7 +322,8 @@ module.exports = {
       const rowSelector = this.getFileRowSelectorByFileName(path, elementType)
       return this.useXpath()
         .waitForElementVisible(rowSelector)
-        .getAttribute(linkSelector, 'innerText', function(result) {
+        .waitForElementVisible(linkSelector)
+        .getText(linkSelector, function(result) {
           assert.strictEqual(result.value.trim(), path, 'displayed file name not as expected')
         })
         .useCss()

--- a/tests/acceptance/pageObjects/personalPage.js
+++ b/tests/acceptance/pageObjects/personalPage.js
@@ -253,7 +253,7 @@ module.exports = {
       return this.waitForElementVisible('@permalinkCopyButton').click('@permalinkCopyButton')
     },
     checkSidebarItem: function(resourceName) {
-      return this.getAttribute('@sidebarItemName', 'innerText', function(itemName) {
+      return this.getText('@sidebarItemName', function(itemName) {
         this.assert.strictEqual(
           itemName.value,
           resourceName,


### PR DESCRIPTION
# Description
- `getAttribute("selector", "innerText", callback)` is throwing `result` with `null` even if the element is already visible on the dom
- `getText` is used to get element
 
# Related issue
https://github.com/owncloud/web/issues/4919#issuecomment-856434313