### PR TITLE
Update handling of no permission in link reshare

### DIFF
--- a/packages/web-app-files/src/components/FileLinkSidebar.vue
+++ b/packages/web-app-files/src/components/FileLinkSidebar.vue
@@ -25,7 +25,12 @@
             {{ $_addButtonLabel }}
           </oc-button>
         </div>
-        <p v-else class="oc-mt-s" v-text="noResharePermsMessage" />
+        <p
+          v-else
+          data-test-id="files-links-no-reshare-permissions-message"
+          class="oc-mt-s"
+          v-text="noResharePermsMessage"
+        />
         <transition-group
           class="uk-list uk-list-divider uk-overflow-hidden oc-m-rm"
           :enter-active-class="$_transitionGroupEnter"

--- a/packages/web-app-files/src/components/FileSharingSidebar.vue
+++ b/packages/web-app-files/src/components/FileSharingSidebar.vue
@@ -21,7 +21,7 @@
         <p
           v-else
           key="no-reshare-permissions-message"
-          class="files-collaborators-no-reshare-permissions-message"
+          data-test-id="files-collaborators-no-reshare-permissions-message"
           v-text="noResharePermsMessage"
         />
         <template v-if="$_ownerAsCollaborator">

--- a/tests/acceptance/features/webUISharingPublicBasic/publicLinkCreate.feature
+++ b/tests/acceptance/features/webUISharingPublicBasic/publicLinkCreate.feature
@@ -201,6 +201,5 @@ Feature: Create public link shares
     And user "Brian" has shared folder "simple-folder" with user "Alice"
     And user "Alice" has accepted the share "simple-folder" offered by user "Brian"
     And user "Alice" has logged in using the webUI
-    When the user creates a new public link for folder "Shares" using the webUI with
-      | name | link |
-    Then the user should see an error message on the public link share dialog saying "Path contains files shared with you"
+    And the user opens the link share dialog for folder "Shares" using the webUI
+    Then the link share permission denied message should be displayed in the sharing dialog on the webUI

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -606,23 +606,20 @@ module.exports = {
     },
     /**
      *
-     * @returns {Promise<string>}
+     * @returns {boolean} Whether the message has been found
      */
-    getSharePermissionMessage: async function() {
-      let message
-      await this.waitForElementVisible('@sharingPermissionDisabledMessage').getText(
-        this.elements.sharingPermissionDisabledMessage.selector,
-        function(result) {
-          message = result.value
-        }
-      )
-      return message
+    isSharePermissionMessageVisible: function() {
+      return this.waitForElementVisible('@noResharePermissions')
+    },
+    /**
+     *
+     * @returns {boolean} Whether the message has been found
+     */
+    isLinkSharePermissionMessageVisible: function() {
+      return this.waitForElementVisible('@noReshareLinkPermissions')
     }
   },
   elements: {
-    sharingPermissionDisabledMessage: {
-      selector: '.files-collaborators-no-reshare-permissions-message'
-    },
     collaboratorErrorAlert: {
       selector: '//div[contains(@class, "collaborator-error-alert")]',
       locateStrategy: 'xpath'
@@ -632,7 +629,14 @@ module.exports = {
       locateStrategy: 'xpath'
     },
     noResharePermissions: {
-      selector: '#oc-files-sharing-sidebar .files-collaborators-no-reshare-permissions-message'
+      selector:
+        '//p[@data-test-id="files-collaborators-no-reshare-permissions-message"]',
+      locateStrategy: 'xpath'
+    },
+    noReshareLinkPermissions: {
+      selector:
+        '//p[@data-test-id="files-links-no-reshare-permissions-message"]',
+      locateStrategy: 'xpath'
     },
     sharingAutoComplete: {
       selector: '#oc-sharing-autocomplete .oc-autocomplete-input'

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -882,11 +882,15 @@ Then('{string} {string} should be listed in the autocomplete list on the webUI',
 
 Then(
   'the share permission denied message should be displayed in the sharing dialog on the webUI',
-  async function() {
-    const permissionDeniedMessage = "You don't have permission to share this folder."
-    const dialogMessage = await client.page.FilesPageElement.sharingDialog().getSharePermissionMessage()
+  function() {
+    return client.page.FilesPageElement.sharingDialog().isSharePermissionMessageVisible()
+  }
+)
 
-    return assert.strictEqual(dialogMessage, permissionDeniedMessage)
+Then(
+  'the link share permission denied message should be displayed in the sharing dialog on the webUI',
+  function() {
+    return client.page.FilesPageElement.sharingDialog().isLinkSharePermissionMessageVisible()
   }
 )
 


### PR DESCRIPTION
## Description
- Removed duplicate selector
- Added class to "You have no permission" paragraph 
- Refactored test to expect "You have no permission" string instead of a failure notification

Fixes `webUISharingPublicBasic/publicLinkCreate.feature:195`