### PR TITLE
[tests-only] unit tests for Notifications.vue

### DIFF
--- a/packages/web-runtime/tests/components/Notification.spec.js
+++ b/packages/web-runtime/tests/components/Notification.spec.js
@@ -165,16 +165,15 @@ describe('Notification component', () => {
       it('displays the resolve notification button', () => {
         expect(wrapper.find(selectors.resolveNotificationButton).exists()).toBeTruthy()
       })
-      it('dispatches deleteNotification when resolve notification is clicked', () => {
+      it('dispatches deleteNotification when resolve notification is clicked', async () => {
         const resolveNotificationButton = wrapper.find(selectors.resolveNotificationButton)
         expect(resolveNotificationButton.exists()).toBeTruthy()
         resolveNotificationButton.trigger('click')
-        wrapper.vm.$nextTick(() => {
-          expect(store.dispatch).toHaveBeenCalledTimes(1)
-          expect(store.dispatch).toHaveBeenCalledWith('deleteNotification', {
-            client: localVue.prototype.$client,
-            notification: 1
-          })
+        await wrapper.vm.$nextTick()
+        expect(store.dispatch).toHaveBeenCalledTimes(1)
+        expect(store.dispatch).toHaveBeenCalledWith('deleteNotification', {
+          client: localVue.prototype.$client,
+          notification: 1
         })
       })
     })
@@ -198,12 +197,11 @@ describe('Notification component', () => {
       it("doesn't displays the resolve notification button", () => {
         expect(wrapper.find(selectors.resolveNotificationButton).exists()).toBeFalsy()
       })
-      it('calls executeRequest when action button is clicked', () => {
+      it('calls executeRequest when action button is clicked', async () => {
         const actionButton = wrapper.find(selectors.actionButton)
         actionButton.trigger('click')
-        actionButton.vm.$nextTick(() => {
-          expect(mockMethods.executeRequest).toHaveBeenCalledTimes(1)
-        })
+        await actionButton.vm.$nextTick()
+        expect(mockMethods.executeRequest).toHaveBeenCalledTimes(1)
       })
     })
   })

--- a/packages/web-runtime/tests/components/Notification.spec.js
+++ b/packages/web-runtime/tests/components/Notification.spec.js
@@ -1,0 +1,235 @@
+import { config, createLocalVue, mount, shallowMount } from '@vue/test-utils'
+import { Store } from 'vuex-mock-store'
+import Notifications from 'web-runtime/src/components/Notifications.vue'
+import stubs from '../../../../tests/unit/stubs'
+import DesignSystem from 'owncloud-design-system'
+const localVue = createLocalVue()
+localVue.use(DesignSystem)
+
+config.showDeprecationWarnings = false
+
+const selectors = {
+  notificationBell: '#oc-notification-bell',
+  ocIconStub: 'oc-icon-stub',
+  actionButton: '.oc-ml-s',
+  resolveNotificationButton: '#resolve-notification-button',
+  link: '.uk-link',
+  subject: 'h4',
+  message: '.uk-text-small'
+}
+
+const defaultNotificationData = {
+  notification_id: 1,
+  subject: 'Test',
+  message: 'This is a test message',
+  actions: []
+}
+
+function getStoreWithActiveNotifications(activeNotifications) {
+  return new Store({
+    getters: {
+      activeNotifications: activeNotifications
+    }
+  })
+}
+
+function getStoreWithEmptyActions() {
+  return getStoreWithActiveNotifications([
+    {
+      ...defaultNotificationData
+    }
+  ])
+}
+
+function getStoreWithSingleAction() {
+  return getStoreWithActiveNotifications([
+    {
+      ...defaultNotificationData,
+      actions: [
+        {
+          label: 'Test Action'
+        }
+      ]
+    }
+  ])
+}
+
+function getStoreWithTwoActiveNotifications() {
+  return getStoreWithActiveNotifications([
+    {
+      subject: 'First Notification',
+      message: 'This is first test message',
+      actions: []
+    },
+    {
+      subject: 'Second Notification',
+      message: 'This is second test message',
+      actions: []
+    }
+  ])
+}
+
+function getStoreWithLinkActions() {
+  return getStoreWithActiveNotifications([
+    {
+      link: 'http://test.link',
+      actions: []
+    }
+  ])
+}
+
+describe('Notification component', () => {
+  describe('notification bell', () => {
+    const store = getStoreWithEmptyActions()
+    const mocks = {
+      $store: store
+    }
+    let wrapper
+    beforeEach(() => {
+      store.reset()
+      wrapper = shallowMount(Notifications, { stubs, mocks })
+    })
+    it('displays notification bell', () => {
+      const bell = wrapper.find(selectors.notificationBell)
+      expect(bell.exists()).toBeTruthy()
+      expect(bell.find(selectors.ocIconStub).exists()).toBeTruthy()
+      expect(bell.find(selectors.ocIconStub).attributes('name')).toBe('bell')
+      expect(bell.attributes('uk-tooltip')).toBe('Notifications')
+      expect(bell.attributes('aria-label')).toBe('Notifications')
+    })
+  })
+  describe('when active notification contains a message', () => {
+    const store = getStoreWithEmptyActions()
+    const mocks = {
+      $store: store
+    }
+    let wrapper
+    beforeEach(() => {
+      store.reset()
+      wrapper = shallowMount(Notifications, { stubs, mocks })
+    })
+    it('displays the notification message', () => {
+      const messageElement = wrapper.find(selectors.message)
+      expect(messageElement.exists()).toBeTruthy()
+      expect(messageElement.text()).toBe('This is a test message')
+    })
+    it('displays the notification subject', () => {
+      const subjectElement = wrapper.find(selectors.subject)
+      expect(subjectElement.exists()).toBeTruthy()
+      expect(subjectElement.text()).toBe('Test')
+    })
+  })
+
+  describe('active notifications actions', () => {
+    describe('when active notification action is empty', () => {
+      let wrapper, store
+      beforeEach(() => {
+        store = getStoreWithEmptyActions()
+        const mocks = { $store: store }
+        wrapper = mount(Notifications, {
+          localVue,
+          mocks
+        })
+        store.reset()
+      })
+      it('does not displays action button', () => {
+        expect(wrapper.find(selectors.actionButton).exists()).toBeFalsy()
+      })
+      it('displays the resolve notification button', () => {
+        expect(wrapper.find(selectors.resolveNotificationButton).exists()).toBeTruthy()
+      })
+      it('dispatches deleteNotification when resolve notification is clicked', () => {
+        const resolveNotificationButton = wrapper.find(selectors.resolveNotificationButton)
+        expect(resolveNotificationButton.exists()).toBeTruthy()
+        resolveNotificationButton.trigger('click')
+        wrapper.vm.$nextTick(() => {
+          expect(store.dispatch).toHaveBeenCalledTimes(1)
+          expect(store.dispatch).toHaveBeenCalledWith('deleteNotification', {
+            client: localVue.prototype.$client,
+            notification: 1
+          })
+        })
+      })
+    })
+    describe('when active notification action has a action', () => {
+      let store, wrapper
+      const mockMethods = {
+        executeRequest: jest.fn(),
+        reloadFilesList: jest.fn()
+      }
+      beforeEach(() => {
+        store = getStoreWithSingleAction()
+        store.reset()
+        const mocks = { $store: store }
+        wrapper = mount(Notifications, {
+          localVue,
+          methods: mockMethods,
+          mocks
+        })
+      })
+      it('displays the action button with action label', () => {
+        const actionButton = wrapper.find(selectors.actionButton)
+        expect(actionButton.exists()).toBeTruthy()
+        expect(actionButton.text()).toBe('Test Action')
+      })
+      it("doesn't displays the resolve notification button", () => {
+        expect(wrapper.find(selectors.resolveNotificationButton).exists()).toBeFalsy()
+      })
+      it('calls executeRequest when action button is clicked', () => {
+        const actionButton = wrapper.find(selectors.actionButton)
+        actionButton.trigger('click')
+        actionButton.vm.$nextTick(() => {
+          expect(mockMethods.executeRequest).toHaveBeenCalledTimes(1)
+        })
+      })
+    })
+  })
+  describe('active notifications links', () => {
+    let store
+    afterEach(() => {
+      store.reset()
+    })
+    it('does not display link if no link is given', () => {
+      store = getStoreWithEmptyActions()
+      const mocks = {
+        $store: store
+      }
+      const wrapper = shallowMount(Notifications, { stubs, mocks })
+      const linkButton = wrapper.find(selectors.link)
+      expect(linkButton.exists()).toBeFalsy()
+    })
+    it('displays link if a link is given', () => {
+      store = getStoreWithLinkActions()
+      const mocks = {
+        $store: store
+      }
+      const wrapper = shallowMount(Notifications, { stubs, mocks })
+      const linkButton = wrapper.find(selectors.link)
+      expect(linkButton.exists()).toBeTruthy()
+      expect(linkButton.text()).toBe('http://test.link')
+    })
+  })
+  describe('when active notification has multiple notifications', () => {
+    let store, wrapper
+    beforeEach(() => {
+      store = getStoreWithTwoActiveNotifications()
+      store.reset()
+      const mocks = {
+        $store: store
+      }
+      wrapper = shallowMount(Notifications, { stubs, mocks })
+    })
+    it('displays all notifications from active notifications', () => {
+      const subject = wrapper.findAll(selectors.subject)
+      const message = wrapper.findAll(selectors.message)
+      expect(subject.exists()).toBeTruthy()
+      expect(message.exists()).toBeTruthy()
+      expect(subject).toHaveLength(2)
+      expect(message).toHaveLength(2)
+      expect(subject.at(0).text()).toBe('First Notification')
+      expect(subject.at(1).text()).toBe('Second Notification')
+      expect(message.at(0).text()).toBe('This is first test message')
+      expect(message.at(1).text()).toBe('This is second test message')
+    })
+  })
+})

--- a/packages/web-runtime/tests/components/Notification.spec.js
+++ b/packages/web-runtime/tests/components/Notification.spec.js
@@ -8,6 +8,8 @@ localVue.use(DesignSystem)
 
 config.showDeprecationWarnings = false
 
+const OcTooltip = jest.fn()
+
 const selectors = {
   notificationBell: '#oc-notification-bell',
   ocIconStub: 'oc-icon-stub',
@@ -78,35 +80,64 @@ function getStoreWithLinkActions() {
   ])
 }
 
+function getWrapper(mocks) {
+  return shallowMount(Notifications, {
+    stubs,
+    mocks,
+    directives: {
+      OcTooltip
+    }
+  })
+}
+
+function getMountWrapper(mocks) {
+  return mount(Notifications, {
+    localVue,
+    mocks,
+    directives: {
+      OcTooltip
+    }
+  })
+}
+
+function getMountWrapperWithMockMethods(mocks, mockMethods) {
+  return mount(Notifications, {
+    localVue,
+    mocks,
+    methods: mockMethods,
+    directives: {
+      OcTooltip
+    }
+  })
+}
+
 describe('Notification component', () => {
   describe('notification bell', () => {
     const store = getStoreWithEmptyActions()
-    const mocks = {
-      $store: store
-    }
     let wrapper
     beforeEach(() => {
       store.reset()
-      wrapper = shallowMount(Notifications, { stubs, mocks })
+      wrapper = getWrapper({
+        $store: store
+      })
     })
     it('displays notification bell', () => {
       const bell = wrapper.find(selectors.notificationBell)
       expect(bell.exists()).toBeTruthy()
       expect(bell.find(selectors.ocIconStub).exists()).toBeTruthy()
       expect(bell.find(selectors.ocIconStub).attributes('name')).toBe('bell')
-      expect(bell.attributes('uk-tooltip')).toBe('Notifications')
       expect(bell.attributes('aria-label')).toBe('Notifications')
     })
   })
+
   describe('when active notification contains a message', () => {
     const store = getStoreWithEmptyActions()
-    const mocks = {
-      $store: store
-    }
     let wrapper
     beforeEach(() => {
       store.reset()
-      wrapper = shallowMount(Notifications, { stubs, mocks })
+      wrapper = getWrapper({
+        $store: store
+      })
     })
     it('displays the notification message', () => {
       const messageElement = wrapper.find(selectors.message)
@@ -125,11 +156,7 @@ describe('Notification component', () => {
       let wrapper, store
       beforeEach(() => {
         store = getStoreWithEmptyActions()
-        const mocks = { $store: store }
-        wrapper = mount(Notifications, {
-          localVue,
-          mocks
-        })
+        wrapper = getMountWrapper({ $store: store })
         store.reset()
       })
       it('does not displays action button', () => {
@@ -151,7 +178,8 @@ describe('Notification component', () => {
         })
       })
     })
-    describe('when active notification action has a action', () => {
+
+    describe('when active notification action has an action', () => {
       let store, wrapper
       const mockMethods = {
         executeRequest: jest.fn(),
@@ -159,13 +187,8 @@ describe('Notification component', () => {
       }
       beforeEach(() => {
         store = getStoreWithSingleAction()
+        wrapper = getMountWrapperWithMockMethods({ $store: store }, mockMethods)
         store.reset()
-        const mocks = { $store: store }
-        wrapper = mount(Notifications, {
-          localVue,
-          methods: mockMethods,
-          mocks
-        })
       })
       it('displays the action button with action label', () => {
         const actionButton = wrapper.find(selectors.actionButton)
@@ -184,6 +207,7 @@ describe('Notification component', () => {
       })
     })
   })
+
   describe('active notifications links', () => {
     let store
     afterEach(() => {
@@ -191,33 +215,25 @@ describe('Notification component', () => {
     })
     it('does not display link if no link is given', () => {
       store = getStoreWithEmptyActions()
-      const mocks = {
-        $store: store
-      }
-      const wrapper = shallowMount(Notifications, { stubs, mocks })
+      const wrapper = getWrapper({ $store: store })
       const linkButton = wrapper.find(selectors.link)
       expect(linkButton.exists()).toBeFalsy()
     })
     it('displays link if a link is given', () => {
       store = getStoreWithLinkActions()
-      const mocks = {
-        $store: store
-      }
-      const wrapper = shallowMount(Notifications, { stubs, mocks })
+      const wrapper = getWrapper({ $store: store })
       const linkButton = wrapper.find(selectors.link)
       expect(linkButton.exists()).toBeTruthy()
       expect(linkButton.text()).toBe('http://test.link')
     })
   })
+
   describe('when active notification has multiple notifications', () => {
     let store, wrapper
     beforeEach(() => {
       store = getStoreWithTwoActiveNotifications()
       store.reset()
-      const mocks = {
-        $store: store
-      }
-      wrapper = shallowMount(Notifications, { stubs, mocks })
+      wrapper = getWrapper({ $store: store })
     })
     it('displays all notifications from active notifications', () => {
       const subject = wrapper.findAll(selectors.subject)


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
testing `Notifications.vue`
- test if the notification message is displayed
- test if the action button is not displayed when actions are not set in `activeNotifications`
- if action button is displayed if actions is present in `activeNotifications`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/web/issues/5217

## Motivation and Context
https://github.com/owncloud/web/pull/5206


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- 🤖 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...