### PR TITLE
Hide end-to-end test definitions in GH repo language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/acceptance/features/* linguist-vendored=false


### PR DESCRIPTION
## Description
Hides all the `.feature` files from linguist so this repo isn't shown as a (mainly) Gherkin project

<img width="333" alt="Screenshot 2021-06-09 at 11 41 03" src="https://user-images.githubusercontent.com/16822008/121340546-a8e5df00-c917-11eb-8e92-6b816bb76f61.png">
<img width="333" alt="Screenshot 2021-06-09 at 11 41 21" src="https://user-images.githubusercontent.com/16822008/121340553-abe0cf80-c917-11eb-97e2-51372a4b178a.png">
