### PR TITLE
unit tests for SidebarQuota.vue

### DIFF
--- a/changelog/unreleased/bugfix-show-0-when-negative-quota-given
+++ b/changelog/unreleased/bugfix-show-0-when-negative-quota-given
@@ -1,0 +1,5 @@
+Bugfix: show `0` as used quota if a negative number is given
+
+In the case if the server returns a negative number as used quota (what should not happen) show `0 B of 2 GB` and not only of ` 2 GB`
+
+https://github.com/owncloud/web/pull/5229

--- a/packages/web-runtime/src/helpers/resource.js
+++ b/packages/web-runtime/src/helpers/resource.js
@@ -6,9 +6,7 @@ import filesize from 'filesize'
  * @returns {String} formatted size
  */
 export function getResourceSize(size) {
-  if (size < 0) {
-    return ''
-  }
+  size = size < 0 ? 0 : size
 
   if (isNaN(size)) {
     return '?'

--- a/packages/web-runtime/tests/components/SidebarQuota.spec.js
+++ b/packages/web-runtime/tests/components/SidebarQuota.spec.js
@@ -1,0 +1,47 @@
+import { createLocalVue, mount } from '@vue/test-utils'
+import Vuex from 'vuex'
+import GetTextPlugin from 'vue-gettext'
+import SidebarQuota from 'web-runtime/src/components/SidebarQuota.vue'
+import stubs from '../../../../tests/unit/stubs'
+import DesignSystem from 'owncloud-design-system'
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
+localVue.use(DesignSystem)
+
+describe('Sidebar Quota component', () => {
+  it.each([2, 3.34, 0])('displays the progressbar', relativeQuota => {
+    const wrapper = mount(SidebarQuota, {
+      store: new Vuex.Store({
+        getters: {
+          quota: function() {
+            return { relative: relativeQuota }
+          }
+        }
+      }),
+      localVue,
+      stubs: { ...stubs, translate: true }
+    })
+    expect(wrapper.find('progress').exists()).toBeTruthy()
+    expect(wrapper.find('progress').element.getAttribute('value')).toEqual(relativeQuota.toString())
+    expect(wrapper.find('progress').element.getAttribute('max')).toEqual('100')
+  })
+  it('displays the quota information', () => {
+    localVue.use(GetTextPlugin, {
+      translations: 'does-not-matter.json',
+      silent: true
+    })
+    const wrapper = mount(SidebarQuota, {
+      store: new Vuex.Store({
+        getters: {
+          quota: function() {
+            return { used: 1287654323, definition: '2 GB' }
+          }
+        }
+      }),
+      localVue,
+      stubs
+    })
+    expect(wrapper.html()).toContain('1.2 GB of 2 GB')
+  })
+})

--- a/packages/web-runtime/tests/helpers/resource.spec.js
+++ b/packages/web-runtime/tests/helpers/resource.spec.js
@@ -1,0 +1,15 @@
+import { getResourceSize } from 'web-runtime/src/helpers/resource'
+
+describe('getResourceSize', () => {
+  it.each`
+    size          | result
+    ${0}          | ${'0 B'}
+    ${1023}       | ${'1023 B'}
+    ${1024}       | ${'1 KB'}
+    ${1287654323} | ${'1.2 GB'}
+    ${-1}         | ${'0 B'}
+    ${'string'}   | ${'?'}
+  `('converts the size integer to human readable format', ({ size, result }) => {
+    expect(getResourceSize(size)).toEqual(result)
+  })
+})

--- a/tests/unit/stubs/index.js
+++ b/tests/unit/stubs/index.js
@@ -4,5 +4,7 @@ export default {
   'oc-icon': true,
   'oc-checkbox': true,
   'oc-button': true,
-  'oc-breadcrumb': true
+  'oc-breadcrumb': true,
+  'oc-drop': true,
+  'avatar-image': true
 }


### PR DESCRIPTION

## Description
- unit tests for SidebarQuota.vue
- show `0 B of 2 GB` as quota in case of a negative number given as used quota and not only ` of 2 GB`

## Related Issue
part of #5217

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
increase unit test coverage

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
