### PR TITLE
[CI-only] fix path in continuous deployed example

### DIFF
--- a/deployments/continuous-deployment-config/ocis_web/latest.yml
+++ b/deployments/continuous-deployment-config/ocis_web/latest.yml
@@ -11,7 +11,7 @@
       for: oCIS-continuous-deployment-examples
     rebuild: $REBUILD
     rebuild_carry_paths:
-      - /var/lib/docker/volumes/ocis_certs
+      - /var/lib/docker/volumes/web_certs
 
   domains:
     - "*.ocis-web.latest.owncloud.works"


### PR DESCRIPTION
## Description
Nightly deployment / rebuild of the deployment example fails because of a wrong path: https://drone.owncloud.com/owncloud/web/16102/66/3