### PR TITLE
Improve size of hamburger icon in condensed width (medium and less responsive view) top section

### DIFF
--- a/packages/web-runtime/src/components/TopBar.vue
+++ b/packages/web-runtime/src/components/TopBar.vue
@@ -7,7 +7,7 @@
       <div class="uk-hidden@l">
         <oc-button
           appearance="raw"
-          class="oc-app-navigation-toggle"
+          class="oc-m-s oc-app-navigation-toggle"
           :aria-label="$gettext('Open navigation menu')"
           @click="toggleAppNavigationVisibility"
         >

--- a/packages/web-runtime/tests/unit/components/__snapshots__/TopBar.spec.js.snap
+++ b/packages/web-runtime/tests/unit/components/__snapshots__/TopBar.spec.js.snap
@@ -4,7 +4,7 @@ exports[`Top Bar component Displays applications menu 1`] = `
 <header aria-label="Top bar" class="oc-topbar uk-flex uk-flex-middle uk-flex-wrap oc-border-b oc-p-s">
   <oc-grid-stub gutter="medium" flex="">
     <div class="uk-hidden@l">
-      <oc-button-stub appearance="raw" aria-label="Open navigation menu" class="oc-app-navigation-toggle">
+      <oc-button-stub appearance="raw" aria-label="Open navigation menu" class="oc-m-s oc-app-navigation-toggle">
         <oc-icon-stub name="menu"></oc-icon-stub>
       </oc-button-stub>
     </div>
@@ -22,7 +22,7 @@ exports[`Top Bar component when search bar hidden globally Hides search bar even
 <header aria-label="Top bar" class="oc-topbar uk-flex uk-flex-middle uk-flex-wrap oc-border-b oc-p-s">
   <oc-grid-stub gutter="medium" flex="">
     <div class="uk-hidden@l">
-      <oc-button-stub appearance="raw" aria-label="Open navigation menu" class="oc-app-navigation-toggle">
+      <oc-button-stub appearance="raw" aria-label="Open navigation menu" class="oc-m-s oc-app-navigation-toggle">
         <oc-icon-stub name="menu"></oc-icon-stub>
       </oc-button-stub>
     </div>
@@ -40,7 +40,7 @@ exports[`Top Bar component when search bar hidden globally Hides the search bar 
 <header aria-label="Top bar" class="oc-topbar uk-flex uk-flex-middle uk-flex-wrap oc-border-b oc-p-s">
   <oc-grid-stub gutter="medium" flex="">
     <div class="uk-hidden@l">
-      <oc-button-stub appearance="raw" aria-label="Open navigation menu" class="oc-app-navigation-toggle">
+      <oc-button-stub appearance="raw" aria-label="Open navigation menu" class="oc-m-s oc-app-navigation-toggle">
         <oc-icon-stub name="menu"></oc-icon-stub>
       </oc-button-stub>
     </div>
@@ -58,7 +58,7 @@ exports[`Top Bar component when search bar visible globally Displays search bar 
 <header aria-label="Top bar" class="oc-topbar uk-flex uk-flex-middle uk-flex-wrap oc-border-b oc-p-s">
   <oc-grid-stub gutter="medium" flex="">
     <div class="uk-hidden@l">
-      <oc-button-stub appearance="raw" aria-label="Open navigation menu" class="oc-app-navigation-toggle">
+      <oc-button-stub appearance="raw" aria-label="Open navigation menu" class="oc-m-s oc-app-navigation-toggle">
         <oc-icon-stub name="menu"></oc-icon-stub>
       </oc-button-stub>
     </div>
@@ -76,7 +76,7 @@ exports[`Top Bar component when search bar visible globally Hides the search bar
 <header aria-label="Top bar" class="oc-topbar uk-flex uk-flex-middle uk-flex-wrap oc-border-b oc-p-s">
   <oc-grid-stub gutter="medium" flex="">
     <div class="uk-hidden@l">
-      <oc-button-stub appearance="raw" aria-label="Open navigation menu" class="oc-app-navigation-toggle">
+      <oc-button-stub appearance="raw" aria-label="Open navigation menu" class="oc-m-s oc-app-navigation-toggle">
         <oc-icon-stub name="menu"></oc-icon-stub>
       </oc-button-stub>
     </div>


### PR DESCRIPTION
## Description
Purely a CSS change to make the Top Bar more consistent in.  It looked strange before.

## Motivation and Context
As above.

## How Has This Been Tested?
Tested in Edge and Chrome.

## Screenshots (if appropriate):
Note - the only change is on the hamburger, even though the pointer is on the space between.

Before
![image](https://user-images.githubusercontent.com/876651/121619100-563d2c00-caab-11eb-9106-a963304835bc.png)

After
![image](https://user-images.githubusercontent.com/876651/121619153-6f45dd00-caab-11eb-9a96-7a5cc0abc650.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Add screenshots
- [ ] Update visual test snapshots