### PR TITLE
[CI-only] run example deploys always on cron

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -727,7 +727,9 @@ def main(ctx):
     pipelines = before + stages + after
 
     deploys = example_deploys(ctx)
-    dependsOn(pipelines, deploys)
+    if ctx.build.event != "cron":
+        # run example deploys on cron even if some prior pipelines fail
+        dependsOn(pipelines, deploys)
 
     return pipelines + deploys + checkStarlark()
 


### PR DESCRIPTION
## Description
even after #5235 the example deploy https://ocis.ocis-web.latest.owncloud.works/ is not pruned during the Drone CI Cron run, because prior pipeline steps are failing (https://drone.owncloud.com/owncloud/web/16150/66/1). On cron we do not need to wait for build artifacts from prior pipelines to do the actual deploy so we don't need to add the dependencies on the other pipelines. Therefore the examples deploy will always executed for crons even if tests fail.
