### PR TITLE
Add more spacing between edit and delete collaborator icons

### DIFF
--- a/packages/web-app-files/src/components/Collaborators/Collaborator.vue
+++ b/packages/web-app-files/src/components/Collaborators/Collaborator.vue
@@ -156,7 +156,7 @@
             v-oc-tooltip="editShareHint"
             :aria-label="editShareHint"
             appearance="raw"
-            class="files-collaborators-collaborator-edit"
+            class="files-collaborators-collaborator-edit oc-mr-xs"
             @click="$emit('onEdit', collaborator)"
           >
             <oc-icon name="edit" />


### PR DESCRIPTION
## Description
Doesn't really feel like it deserves a dedicated Changelog item, just adding a utility class here

## Related Issue
- Fixes #5240
