### PR TITLE
unit tests for packages/web-app-files/src/mixins.js:fileTypeIcon

### DIFF
--- a/changelog/unreleased/bugfix-typeerror-fileTypeIcon
+++ b/changelog/unreleased/bugfix-typeerror-fileTypeIcon
@@ -1,0 +1,5 @@
+Bugfix: prevent `fileTypeIcon` to throw a TypeError
+
+The function would die with `TypeError: file.extension.toLowerCase is not a function` if `file.extension` was set to something that is not a string.
+
+https://github.com/owncloud/web/pull/5253

--- a/packages/web-app-files/src/mixins.js
+++ b/packages/web-app-files/src/mixins.js
@@ -88,8 +88,12 @@ export default {
         if (file.type === 'folder') {
           return 'folder'
         }
-        const icon = fileTypeIconMappings[file.extension.toLowerCase()]
-        if (icon) return `${icon}`
+        if (typeof file.extension === 'string') {
+          const icon = fileTypeIconMappings[file.extension.toLowerCase()]
+          if (icon) {
+            return `${icon}`
+          }
+        }
       }
       return 'file'
     },

--- a/packages/web-app-files/tests/mixins.spec.js
+++ b/packages/web-app-files/tests/mixins.spec.js
@@ -1,0 +1,52 @@
+import mixins from '../src/mixins'
+
+describe('mixins', () => {
+  describe('fileTypeIcon', () => {
+    it.each(['', false, NaN, undefined, 1, {}])(
+      'should return "file" if invalid data is provided',
+      inputData => {
+        expect(mixins.methods.fileTypeIcon(inputData)).toEqual('file')
+      }
+    )
+    it.each([
+      { type: 'file', extension: 'not existing' },
+      { type: 'file', extension: 'UTF नेपालि' },
+      { type: 'file', extension: '' },
+      { type: 'file', extension: false },
+      { type: 'file', extension: undefined },
+      { type: 'file', extension: 1 },
+      { type: 'file', extension: 0 },
+      { type: 'file', extension: '.tar.bz2' },
+      { type: '', extension: '.tar.bz2' },
+      { type: 0, extension: '.tar.bz2' },
+      { type: false, extension: '.tar.bz2' },
+      { type: undefined, extension: '.tar.bz2' }
+    ])('should return "file" for an unknown extension', inputData => {
+      expect(mixins.methods.fileTypeIcon(inputData)).toEqual('file')
+    })
+    it.each([
+      { type: 'folder', extension: '' },
+      { type: 'folder', extension: 'pdf' },
+      { type: 'folder' },
+      { type: 'folder', extension: false },
+      { type: 'folder', extension: undefined },
+      { type: 'folder', extension: 1 },
+      { type: 'folder', extension: 0 }
+    ])('should return "folder" if type is set to "folder"', inputData => {
+      expect(mixins.methods.fileTypeIcon(inputData)).toEqual('folder')
+    })
+    it.each([
+      { type: 'file', extension: 'tar.bz2' },
+      { type: 'file', extension: 'tAr.Bz2' },
+      { type: false, extension: 'tar.bz2' },
+      { type: undefined, extension: 'tar.bz2' },
+      { type: 1, extension: 'tar.bz2' },
+      { type: '', extension: 'tar.bz2' },
+      { type: 0, extension: 'tar.bz2' },
+      { type: false, extension: 'tar.bz2' },
+      { type: '0', extension: 'tar.bz2' }
+    ])('should return the icon for a known file extension, regardless of the type', inputData => {
+      expect(mixins.methods.fileTypeIcon(inputData)).toEqual('package-x-generic')
+    })
+  })
+})


### PR DESCRIPTION
## Description
unit tests for `fileTypeIcon` function and a small fix for the case if the extension is not a string

## Related Issue
part of #5236

## How Has This Been Tested?
`yarn test:unit`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
