### PR TITLE
[test-only][unit-tests-only] Do not run acceptance tests if only unit tests are changed

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -981,7 +981,7 @@ def unitTests(ctx):
 def acceptance(ctx):
     pipelines = []
 
-    if "acceptance" not in config:
+    if "acceptance" not in config or "unit-tests-only" in ctx.build.title.lower():
         return pipelines
 
     if type(config["acceptance"]) == "bool":


### PR DESCRIPTION
## Description
If PR title contains `unit-tests-only` then the acceptance tests suite is turned off.


## Motivation
Do not run acceptance tests if only unit test files are changed

## Related Issue
- Part of https://github.com/owncloud/web/issues/5217
- Part of https://github.com/owncloud/web/issues/5231