### PR TITLE
Add mode prop for opening file editors

### DIFF
--- a/changelog/unreleased/enhancement-editor-mode
+++ b/changelog/unreleased/enhancement-editor-mode
@@ -1,0 +1,8 @@
+Enhancement: File editor mode
+
+We've added a parameter called `mode` to the different ways of opening a file editor.
+The mode can be `edit` or `create` and reflects whether the file editor was opened
+in an editing mode or in a creation mode.
+
+https://github.com/owncloud/web/issues/5226
+https://github.com/owncloud/web/pull/5256

--- a/packages/web-app-files/src/components/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar.vue
@@ -108,7 +108,7 @@ import pathUtil from 'path'
 import isEmpty from 'lodash-es/isEmpty'
 
 import Mixins from '../mixins'
-import MixinFileActions from '../mixins/fileActions'
+import MixinFileActions, { EDITOR_MODE_CREATE } from '../mixins/fileActions'
 import MixinRoutes from '../mixins/routes'
 import MixinScrollToResource from '../mixins/filesListScrolling'
 import { buildResource } from '../helpers/resources'
@@ -419,7 +419,7 @@ export default {
         if (this.newFileAction) {
           const fileId = resource.fileInfo['{http://owncloud.org/ns}fileid']
 
-          this.$_fileActions_openEditor(this.newFileAction, path, fileId)
+          this.$_fileActions_openEditor(this.newFileAction, path, fileId, EDITOR_MODE_CREATE)
           this.hideModal()
 
           return

--- a/packages/web-app-files/src/mixins/fileActions.js
+++ b/packages/web-app-files/src/mixins/fileActions.js
@@ -24,6 +24,9 @@ const actionsMixins = [
   'delete'
 ]
 
+export const EDITOR_MODE_EDIT = 'edit'
+export const EDITOR_MODE_CREATE = 'create'
+
 export default {
   mixins: [Copy, Delete, Download, Favorite, Fetch, Move, Navigate, Rename, Restore],
   computed: {
@@ -53,7 +56,8 @@ export default {
             )
           },
           icon: this.apps.meta[editor.app].icon,
-          handler: item => this.$_fileActions_openEditor(editor, item.path, item.id),
+          handler: item =>
+            this.$_fileActions_openEditor(editor, item.path, item.id, EDITOR_MODE_EDIT),
           isEnabled: ({ resource }) => {
             if (editor.routes?.length > 0 && !checkRoute(editor.routes, this.$route.name)) {
               return false
@@ -74,25 +78,26 @@ export default {
   methods: {
     ...mapActions(['openFile']),
 
-    $_fileActions_openEditor(editor, filePath, fileId) {
+    $_fileActions_openEditor(editor, filePath, fileId, mode) {
       if (editor.handler) {
         return editor.handler({
           config: this.configuration,
           extensionConfig: editor.config,
           filePath,
-          fileId
+          fileId,
+          mode
         })
       }
 
       // TODO: Refactor in the store
       this.openFile({
-        filePath: filePath
+        filePath
       })
 
       if (editor.newTab) {
         const path = this.$router.resolve({
           name: editor.routeName,
-          params: { filePath: filePath }
+          params: { filePath, fileId, mode }
         }).href
         const target = `${editor.routeName}-${filePath}`
         const win = window.open(path, target)
@@ -103,15 +108,14 @@ export default {
         return
       }
 
-      const routeName = editor.routeName || editor.app
-      const params = {
-        filePath,
-        contextRouteName: this.$route.name
-      }
-
       this.$router.push({
-        name: routeName,
-        params
+        name: editor.routeName || editor.app,
+        params: {
+          filePath,
+          fileId,
+          mode,
+          contextRouteName: this.$route.name
+        }
       })
     },
 


### PR DESCRIPTION
## Description
We've added a parameter called `mode` to the different ways of opening a file editor. The mode can be `edit` or `create` and reflects whether the file editor was opened in an editing mode or in a creation mode.

Resisted the urge to refactor anything, as the extension loading and handling will get an urgently needed overhaul soon anyway.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/5226

## Motivation and Context
Enable extension developers to react differently to edit and create actions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 