### PR TITLE
[full-ci][tests-only]Changed some steps that were creating user with default attributes

### DIFF
--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -312,7 +312,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 
 
 ### [Listing shares via ocs API does not show path for parent folders](https://github.com/owncloud/ocis/issues/1231)
--   [webUISharingPublicManagement/shareByPublicLink.feature:146](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature#L146)
+-   [webUISharingPublicManagement/shareByPublicLink.feature:148](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature#L148)
 
 ### [Propfind response to trashbin endpoint is different in ocis](https://github.com/owncloud/product/issues/186)
 ### [restoring a file from "Deleted files" (trashbin) is not possible if the original folder does not exist any-more](https://github.com/owncloud/web/issues/1753)

--- a/tests/acceptance/features/webUILogin/openidLogin.feature
+++ b/tests/acceptance/features/webUILogin/openidLogin.feature
@@ -62,7 +62,7 @@ Feature: login users
   Scenario: the user session of a deleted user should not be valid for newly created user of same name
     Given user "Alice" has logged in using the webUI
     And user "Alice" has been deleted
-    And user "Alice" has been created with default attributes
+    And user "Alice" has been created with default attributes and without skeleton files
     When the user reloads the current page of the webUI
     Then the user should be redirected to the login error page
     When the user exits the login error page

--- a/tests/acceptance/features/webUISharingAcceptSharesToRoot/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingAcceptSharesToRoot/acceptShares.feature
@@ -253,7 +253,7 @@ Feature: accept/decline shares coming from internal users
 
 
   Scenario: receive shares with same name from different users
-    Given user "Carol" has been created with default attributes
+    Given user "Carol" has been created with default attributes and without skeleton files
     And the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
     And user "Alice" has created file "lorem.txt"
     And user "Carol" has created file "lorem.txt"

--- a/tests/acceptance/features/webUISharingPermissionToRoot/sharePermissionsFileGroup.feature
+++ b/tests/acceptance/features/webUISharingPermissionToRoot/sharePermissionsFileGroup.feature
@@ -19,7 +19,7 @@ Feature: Sharing files with internal groups with permissions
 
 
   Scenario Outline: share a file with multiple users with different roles and permissions
-    Given user "user0" has been created with default attributes
+    Given user "user0" has been created with default attributes and without skeleton files
     And group "grp2" has been created
     And user "Brian" has been added to group "grp2"
     And user "Alice" has logged in using the webUI

--- a/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature
@@ -30,7 +30,8 @@ Feature: Public link share management
   @skip @yetToImplement
   Scenario: mount public link
     Given using server "REMOTE"
-    And user "Brian" has been created with default attributes
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "/simple-folder"
     When the user creates a new public link for folder "simple-folder" using the webUI
     And the user logs out of the webUI
     And the public accesses the last created public link using the webUI
@@ -45,7 +46,8 @@ Feature: Public link share management
   @skip @yetToImplement
   Scenario: mount public link and overwrite file
     Given using server "REMOTE"
-    And user "Brian" has been created with default attributes
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "/simple-folder"
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     And the user logs out of the webUI

--- a/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
@@ -260,7 +260,7 @@ Feature: Restore deleted files/folders
   Scenario: delete and restore a file inside a received shared folder
     Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
     And the administrator has set the default folder for received shares to "Shares"
-    And user "Carol" has been created with default attributes
+    And user "Carol" has been created with default attributes and without skeleton files
     And user "Carol" has created folder "folder-to-share"
     And user "Carol" has uploaded file with content "does-not-matter" to "folder-to-share/fileToShare.txt"
     And user "Carol" has shared folder "folder-to-share" with user "Alice"

--- a/tests/acceptance/stepDefinitions/provisioningContext.js
+++ b/tests/acceptance/stepDefinitions/provisioningContext.js
@@ -165,12 +165,6 @@ function blockUser(userId) {
   return httpHelper.putOCS(apiURL, 'admin')
 }
 
-Given('user {string} has been created with default attributes', async function(userId) {
-  await deleteUser(userId)
-  await createDefaultUser(userId, 'large')
-  await initUser(userId)
-})
-
 Given(
   /^user "([^"]*)" has been created with default attributes and (without|large|small) skeleton files$/,
   async function(userId, skeletonType) {


### PR DESCRIPTION
## Description
Some steps were missed while refactoring scenarios to avoid the use of skeleton as much as possible. Those missed steps has been fixed in this PR. Also, since the step `Given('user {string} has been created with default attributes', async function(userId)` is being no longer used, I have removed that step definition.

## Related Issue
- Part of https://github.com/owncloud/QA/issues/659
- 
## How Has This Been Tested?
- 🤖 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 