### PR TITLE
[unit-tests-only] test collaborator additional info when collaborator is not current user

### DIFF
--- a/packages/web-app-files/tests/components/Collaborators/Collaborator.spec.js
+++ b/packages/web-app-files/tests/components/Collaborators/Collaborator.spec.js
@@ -83,25 +83,39 @@ describe('Collaborator component', () => {
       })
       expect(wrapper.find(selectors.collaboratorName).text()).toEqual('Alice Hansen')
     })
-    it.each([0, 3, 4, 6])('indicates the current user', shareType => {
-      const wrapper = createWrapper({
-        shareType: shareType,
-        collaborator: {
-          name: 'carol'
-        },
-        currentUserId: 'carol'
+    describe('collaborator is the current user', () => {
+      it.each([0, 3, 4, 6])('indicates the current user', shareType => {
+        const wrapper = createWrapper({
+          shareType: shareType,
+          collaborator: {
+            name: 'carol'
+          },
+          currentUserId: 'carol'
+        })
+        expect(wrapper.find(selectors.collaboratorAdditionalInfo).text()).toEqual('(me)')
       })
-      expect(wrapper.find(selectors.collaboratorAdditionalInfo).text()).toEqual('(me)')
+      it('does not indicate the current user for group shares', () => {
+        const wrapper = createWrapper({
+          shareType: 1,
+          collaborator: {
+            name: 'carol'
+          },
+          currentUserId: 'carol'
+        })
+        expect(wrapper.find(selectors.collaboratorAdditionalInfo).exists()).toBeFalsy()
+      })
     })
-    it('does not indicate the current user for group shares', () => {
-      const wrapper = createWrapper({
-        shareType: 1,
-        collaborator: {
-          name: 'carol'
-        },
-        currentUserId: 'carol'
+    describe('collaborator is not the current user', () => {
+      it.each([0, 3, 4, 6])('does not indicate the current user', shareType => {
+        const wrapper = createWrapper({
+          shareType: shareType,
+          collaborator: {
+            name: 'brian'
+          },
+          currentUserId: 'carol'
+        })
+        expect(wrapper.find(selectors.collaboratorAdditionalInfo).exists()).toBeFalsy()
       })
-      expect(wrapper.find(selectors.collaboratorAdditionalInfo).exists()).toBeFalsy()
     })
     it('shows additional infos about collaborator if set', () => {
       const wrapper = createWrapper({


### PR DESCRIPTION
## Description
test that if the collaborator is not the current user the indicator `(me)` should not be shown
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
part of #5234

## How Has This Been Tested?
`yarn run test:unit` 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
