### PR TITLE
[tests-only] [full-ci] Remove old OCIS bug-demo scenarios

### DIFF
--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -228,11 +228,11 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUISharingPublicExpire/shareByPublicLinkExpiringLinks.feature:106](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicExpire/shareByPublicLinkExpiringLinks.feature#L106)
 -   [webUISharingPublicExpire/shareByPublicLinkExpiringLinks.feature:130](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicExpire/shareByPublicLinkExpiringLinks.feature#L130)
 -   [webUISharingPublicExpire/shareByPublicLinkExpiringLinks.feature:147](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicExpire/shareByPublicLinkExpiringLinks.feature#L147)
--   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:335](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L335)
--   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:343](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L343)
--   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:352](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L352)
--   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:361](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L361)
--   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:370](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L370)
+-   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:279](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L279)
+-   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:287](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L287)
+-   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:296](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L296)
+-   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:305](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L305)
+-   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:314](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L314)
 
 
 ### [Cannot delete a received share](https://github.com/owncloud/ocis/issues/714)
@@ -324,13 +324,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 
 ### [restoring a file deleted from a received shared folder is not possible](https://github.com/owncloud/ocis/issues/1124)
 -   [webUITrashbinRestore/trashbinRestore.feature:260](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature#L260)
-
-### [Adjust web UI test scenarios that demonstrate fixed bugs](https://github.com/owncloud/web/issues/4601)
--   [webUISharingPublicManagement/shareByPublicLink.feature:183](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature#L183)
--   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:142](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L142)
--   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:322](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L322)
--   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:299](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L299)
--   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:236](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L236)
 
 ### [Blocked user is not logged out](https://github.com/owncloud/ocis/issues/902)
 -   [webUILogin/adminBlocksUser.feature:13](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/adminBlocksUser.feature#L13)

--- a/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature
+++ b/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature
@@ -137,14 +137,6 @@ Feature: Share by public link with different roles
     When the public uses the webUI to access the last public link created by user "Alice"
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
-  @skipOnOC10 @issue-ocis-270
-  #after fixing the issue delete this scenario and use the one above by deleting the @skipOnOCIS tag there
-  Scenario: creating a public link with "Viewer" role only makes it impossible to delete files via the link (ocis bug demonstration)
-    Given user "Alice" has created file "simple-folder/lorem.txt"
-    And user "Alice" has shared folder "simple-folder" with link with "read" permissions
-    When the public uses the webUI to access the last public link created by user "Alice"
-    Then it should be possible to delete file "lorem.txt" using the webUI
-
 
   Scenario: creating a public link with "Editor" role makes it possible to upload a file
     Given user "Alice" has shared folder "simple-folder" with link with "read, update, create, delete" permissions
@@ -231,29 +223,6 @@ Feature: Share by public link with different roles
     When the public uses the webUI to access the last public link created by user "Alice" with password "pass123"
     Then it should not be possible to create files using the webUI
 
-  @skipOnOC10 @issue-ocis-reva-383
-  #after fixing the issue delete this scenario and use the one above by deleting the @skipOnOCIS tag there
-  Scenario: creating a public link with "Viewer" role makes it impossible to create files via the link even with password set (ocis bug demonstration)
-    Given user "Alice" has shared folder "simple-folder" with link with "read" permissions and password "pass123"
-    When the public uses the webUI to access the last public link created by user "Alice" with password "pass123"
-    Then it should be possible to create files using the webUI
-
-  # TODO: Remove blank lines after adjusing expected failures
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
   Scenario: creating a public link with "Uploader" role makes it possible to upload a file through files-drop page
     Given user "Alice" has shared folder "simple-folder" with link with "create" permissions
@@ -294,17 +263,6 @@ Feature: Share by public link with different roles
       | 'single'quotes.txt |
     And as "Alice" the content of "simple-folder/'single'quotes.txt" should be the same as the local "'single'quotes.txt"
 
-  @skipOnOC10 @issue-ocis-723
-  #after fixing the issue delete this scenario and use the one above by deleting the @skipOnOCIS tag there
-  Scenario: creating a public link with "Uploader" role makes it possible to create files through files-drop page even with password set (ocis bug demonstration)
-    Given user "Alice" has shared folder "simple-folder" with link with "create" permissions and password "pass123"
-    When the public uses the webUI to access the last public link created by user "Alice" with password "pass123"
-    And the public uploads file "'single'quotes.txt" in files-drop page
-    Then the following resources should be listed on the webUI
-      | file-name          |
-      | 'single'quotes.txt |
-    And as "Alice" the content of "simple-folder/'single'quotes.txt" should be the same as the local "'single'quotes.txt"
-
   @issue-ocis-723
   Scenario: creating a public link with "Uploader" role makes it possible to upload multiple files via files-drop page even with password set
     Given user "Alice" has shared folder "simple-folder" with link with "create" permissions and password "pass123"
@@ -312,20 +270,6 @@ Feature: Share by public link with different roles
     And the public uploads file "'single'quotes.txt" in files-drop page
     And the public uploads file "new-lorem.txt" in files-drop page
     Then the following files should be listed on the files-drop page:
-      | 'single'quotes.txt |
-      | new-lorem.txt      |
-    And as "Alice" the content of "simple-folder/'single'quotes.txt" should be the same as the local "'single'quotes.txt"
-    And as "Alice" the content of "simple-folder/new-lorem.txt" should be the same as the local "new-lorem.txt"
-
-  @skipOnOC10 @issue-ocis-723
-  #after fixing the issue delete this scenario and use the one above by deleting the @skipOnOCIS tag there
-  Scenario: creating a public link with "Uploader" role makes it possible to upload multiple files via files-drop page even with password set (ocis bug demonstration)
-    Given user "Alice" has shared folder "simple-folder" with link with "create" permissions and password "pass123"
-    When the public uses the webUI to access the last public link created by user "Alice" with password "pass123"
-    And the public uploads file "'single'quotes.txt" in files-drop page
-    And the public uploads file "new-lorem.txt" in files-drop page
-    Then the following resources should be listed on the webUI
-      | file-name          |
       | 'single'quotes.txt |
       | new-lorem.txt      |
     And as "Alice" the content of "simple-folder/'single'quotes.txt" should be the same as the local "'single'quotes.txt"

--- a/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature
@@ -178,25 +178,6 @@ Feature: Public link share management
     Then file "lorem.txt" should be listed on the webUI
     And it should not be possible to create files using the webUI
 
-  @skipOnOC10 @issue-product-130
-  # When this issue is fixed delete this scenario and use the one above
-  Scenario: User can attempt to upload a file in public link (ocis bug demonstration)
-    Given user "Alice" has created file "lorem.txt"
-    And user "Alice" has created a public link with following settings
-      | path        | lorem.txt   |
-      | name        | public link |
-      | permissions | read        |
-    When the public uses the webUI to access the last public link created by user "Alice"
-    Then file "lorem.txt" should be listed on the webUI
-    And it should be possible to create files using the webUI
-#    And it should not be possible to create files using the webUI
-    When the public uploads file "textfile.txt" using the webUI
-    Then the following error message should be displayed on the webUI
-      """
-      File upload failed…
-      Unknown error
-      """
-
 
   Scenario: Shared via link page is displayed
     Given user "Alice" has created file "lorem.txt"


### PR DESCRIPTION
## Description
These bug-demo scenarios were left behind after the bugs were fixed. The corresponding good scenarios are all in the feature files, and are passing on OCIS (as well as on oC10)

This PR deletes the bug-demo scenarios and adjusts the expected-failures.

## Related Issue
- Fixes #4601 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
