### PR TITLE
Don't reload resources when going to a different page on the same route/resource

### DIFF
--- a/changelog/unreleased/enhancement-add-pagination
+++ b/changelog/unreleased/enhancement-add-pagination
@@ -3,3 +3,4 @@ Enhancement: Add pagination
 We've added pagination to all files lists. Current limit for displayed resources is 100.
 
 https://github.com/owncloud/web/pull/5224
+https://github.com/owncloud/web/pull/5309

--- a/packages/web-app-files/src/views/LocationPicker.vue
+++ b/packages/web-app-files/src/views/LocationPicker.vue
@@ -249,8 +249,12 @@ export default {
 
   watch: {
     $route: {
-      handler: function() {
-        this.navigateToTarget(this.$route)
+      handler: function(to, from) {
+        const sameRoute = to.name === from?.name
+        const sameItem = to.params?.item === from?.params?.item
+        if (!sameRoute || !sameItem) {
+          this.navigateToTarget(this.$route)
+        }
         this.$_filesListPagination_updateCurrentPage()
       },
       immediate: true

--- a/packages/web-app-files/src/views/Personal.vue
+++ b/packages/web-app-files/src/views/Personal.vue
@@ -163,7 +163,10 @@ export default {
         }
 
         const sameRoute = to.name === from?.name
-        this.loadResources(sameRoute)
+        const sameItem = to.params?.item === from?.params?.item
+        if (!sameRoute || !sameItem) {
+          this.loadResources(sameRoute)
+        }
         this.$_filesListPagination_updateCurrentPage()
       },
       immediate: true

--- a/packages/web-app-files/src/views/PublicFiles.vue
+++ b/packages/web-app-files/src/views/PublicFiles.vue
@@ -144,7 +144,10 @@ export default {
     $route: {
       handler: function(to, from) {
         const sameRoute = to.name === from?.name
-        this.loadResources(sameRoute)
+        const sameItem = to.params?.item === from?.params?.item
+        if (!sameRoute || !sameItem) {
+          this.loadResources(sameRoute)
+        }
         this.$_filesListPagination_updateCurrentPage()
       },
       immediate: true


### PR DESCRIPTION
## Description
This PR fixes an implementation detail of the pagination that we brought in https://github.com/owncloud/web/pull/5224: on pagination the resources were reloaded entirely. If the set of resources didn't change (which can be expected when only the page number is different to the route from before) this is unnecessary network traffic.

## Motivation and Context
Performance

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
