### PR TITLE
Fix reactivity overload (frozen UI when displaying lots of files while developing in web-app-files)

### DIFF
--- a/changelog/unreleased/enhancement-resource-field-update
+++ b/changelog/unreleased/enhancement-resource-field-update
@@ -1,0 +1,6 @@
+Enhancement: Ability to update file resource fields
+
+We've introduced the ability to update individual resource fields only instead
+of updating the whole resource at once.
+
+https://github.com/owncloud/web/pull/5311

--- a/packages/web-app-files/src/components/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar.vue
@@ -498,7 +498,7 @@ export default {
         this.UPSERT_RESOURCE(resource)
 
         if (this.isPersonalRoute) {
-          await this.loadIndicators({
+          this.loadIndicators({
             client: this.$client,
             currentFolder: this.currentFolder.path,
             encodePath: this.encodePath

--- a/packages/web-app-files/src/helpers/statusIndicators.js
+++ b/packages/web-app-files/src/helpers/statusIndicators.js
@@ -34,7 +34,7 @@ const isIndirectLinkShare = (resource, sharesTree) => {
   return shareTypesIndirect(resource.path, sharesTree).indexOf(shareTypes.link) >= 0
 }
 
-const isUserShare = (resource, sharesTree) => {
+export const isUserShare = (resource, sharesTree) => {
   return isDirectUserShare(resource) || isIndirectUserShare(resource, sharesTree)
 }
 

--- a/packages/web-app-files/src/helpers/statusIndicators.js
+++ b/packages/web-app-files/src/helpers/statusIndicators.js
@@ -34,7 +34,7 @@ const isIndirectLinkShare = (resource, sharesTree) => {
   return shareTypesIndirect(resource.path, sharesTree).indexOf(shareTypes.link) >= 0
 }
 
-export const isUserShare = (resource, sharesTree) => {
+const isUserShare = (resource, sharesTree) => {
   return isDirectUserShare(resource) || isIndirectUserShare(resource, sharesTree)
 }
 

--- a/packages/web-app-files/src/store/actions.js
+++ b/packages/web-app-files/src/store/actions.js
@@ -520,9 +520,9 @@ export default {
           },
           true
         ).then(url =>
-          commit('UPDATE_RESOURCE_KEY', {
+          commit('UPDATE_RESOURCE_FIELD', {
             id: resource.id,
-            key: `${k}.[${i}].avatar`,
+            field: `${k}.[${i}].avatar`,
             value: url
           })
         )
@@ -557,7 +557,7 @@ export default {
     }
 
     if (preview) {
-      commit('UPDATE_RESOURCE_KEY', { id: resource.id, key: 'preview', value: preview })
+      commit('UPDATE_RESOURCE_FIELD', { id: resource.id, field: 'preview', value: preview })
     }
   }
 }

--- a/packages/web-app-files/src/store/actions.js
+++ b/packages/web-app-files/src/store/actions.js
@@ -6,7 +6,7 @@ import { buildResource, buildShare, buildCollaboratorShare } from '../helpers/re
 import { $gettext, $gettextInterpolate } from '../gettext'
 import { privatePreviewBlob, publicPreviewUrl } from '../helpers/resource'
 import { avatarUrl } from '../helpers/user'
-import { has, set, cloneDeep } from 'lodash-es'
+import { has } from 'lodash-es'
 
 export default {
   updateFileProgress({ commit }, progress) {
@@ -506,55 +506,28 @@ export default {
     commit('LOAD_INDICATORS')
   },
 
-  async loadAvatars({ commit, rootGetters }, { resource }) {
-    const avatars = new Map()
-
+  loadAvatars({ commit, rootGetters }, { resource }) {
     ;['sharedWith', 'owner'].forEach(k => {
       ;(resource[k] || []).forEach((obj, i) => {
         if (!has(obj, 'avatar')) {
           return
         }
-        avatars.set(`${k}.[${i}].avatar`, obj.username)
+        avatarUrl(
+          {
+            username: obj.username,
+            server: rootGetters.configuration.server,
+            token: rootGetters.getToken
+          },
+          true
+        ).then(url =>
+          commit('UPDATE_RESOURCE_KEY', {
+            id: resource.id,
+            key: `${k}.[${i}].avatar`,
+            value: url
+          })
+        )
       })
     })
-
-    if (!avatars.size) {
-      return
-    }
-
-    await Promise.all(
-      Array.from(avatars).map(avatar =>
-        (async () => {
-          let url
-          try {
-            url = await avatarUrl(
-              {
-                username: avatar[1],
-                server: rootGetters.configuration.server,
-                token: rootGetters.getToken
-              },
-              true
-            )
-          } catch (e) {
-            avatars.delete(avatar[0])
-            return
-          }
-
-          avatars.set(avatar[0], url)
-        })()
-      )
-    )
-
-    if (!avatars.size) {
-      return
-    }
-
-    const cResource = cloneDeep(resource)
-    avatars.forEach((value, key) => {
-      set(cResource, key, value)
-    })
-
-    commit('UPDATE_RESOURCE', cResource)
   },
 
   async loadPreview({ commit, rootGetters }, { resource, isPublic, dimensions }) {
@@ -584,8 +557,7 @@ export default {
     }
 
     if (preview) {
-      resource.preview = preview
-      commit('UPDATE_RESOURCE', resource)
+      commit('UPDATE_RESOURCE_KEY', { id: resource.id, key: 'preview', value: preview })
     }
   }
 }

--- a/packages/web-app-files/src/store/mutations.js
+++ b/packages/web-app-files/src/store/mutations.js
@@ -1,7 +1,8 @@
 import Vue from 'vue'
 import pickBy from 'lodash-es/pickBy'
 import moment from 'moment'
-import { attachIndicators } from '../helpers/resources'
+import { set, has } from 'lodash-es'
+import { getIndicators } from '../helpers/statusIndicators'
 
 /**
  * @param {Array.<Object>} shares array of shares
@@ -297,9 +298,19 @@ export default {
   },
 
   LOAD_INDICATORS(state) {
-    const files = [...state.files]
-    files.forEach(resource => attachIndicators(resource, state.sharesTree))
-    state.files = files
+    for (const resource of state.files) {
+      const indicators = getIndicators(resource, state.sharesTree)
+
+      if (!indicators && !resource.indicators.length) {
+        continue
+      }
+
+      this.commit('Files/UPDATE_RESOURCE_KEY', {
+        id: resource.id,
+        key: 'indicators',
+        value: indicators
+      })
+    }
   },
 
   SELECT_RESOURCES(state, resources) {
@@ -327,6 +338,31 @@ export default {
    */
   UPDATE_RESOURCE(state, resource) {
     $_upsertResource(state, resource, false)
+  },
+
+  /**
+   * Updates a single resource key. If the resource with given id doesn't exist nothing will happen.
+   *
+   * @param state Current state of this store module
+   * @param params.id Id of the resource to be updated
+   * @param params.key the resource key that the value should be applied to
+   * @param params.value the value that will be attached to the key
+   */
+  UPDATE_RESOURCE_KEY(state, params) {
+    const index = state.files.findIndex(r => r.id === params.id)
+    if (index < 0) {
+      return
+    }
+
+    const resource = state.files[index]
+    const isReactive = has(resource, params.key)
+    const newResource = set(resource, params.key, params.value)
+
+    if (isReactive) {
+      return
+    }
+
+    Vue.set(state.files, index, newResource)
   },
 
   UPDATE_CURRENT_PAGE(state, page) {

--- a/packages/web-app-files/src/store/mutations.js
+++ b/packages/web-app-files/src/store/mutations.js
@@ -305,9 +305,9 @@ export default {
         continue
       }
 
-      this.commit('Files/UPDATE_RESOURCE_KEY', {
+      this.commit('Files/UPDATE_RESOURCE_FIELD', {
         id: resource.id,
-        key: 'indicators',
+        field: 'indicators',
         value: indicators
       })
     }
@@ -341,22 +341,22 @@ export default {
   },
 
   /**
-   * Updates a single resource key. If the resource with given id doesn't exist nothing will happen.
+   * Updates a single resource field. If the resource with given id doesn't exist nothing will happen.
    *
    * @param state Current state of this store module
    * @param params.id Id of the resource to be updated
-   * @param params.key the resource key that the value should be applied to
+   * @param params.field the resource field that the value should be applied to
    * @param params.value the value that will be attached to the key
    */
-  UPDATE_RESOURCE_KEY(state, params) {
+  UPDATE_RESOURCE_FIELD(state, params) {
     const index = state.files.findIndex(r => r.id === params.id)
     if (index < 0) {
       return
     }
 
     const resource = state.files[index]
-    const isReactive = has(resource, params.key)
-    const newResource = set(resource, params.key, params.value)
+    const isReactive = has(resource, params.field)
+    const newResource = set(resource, params.field, params.value)
 
     if (isReactive) {
       return

--- a/packages/web-app-files/src/views/LocationPicker.vue
+++ b/packages/web-app-files/src/views/LocationPicker.vue
@@ -308,7 +308,10 @@ export default {
         : await this.$client.files.list(target, 1, this.davProperties)
 
       this.loadFiles({ currentFolder: resources[0], files: resources.slice(1) })
-      this.loadIndicators({ client: this.$client, currentFolder: this.$route.params.item || '/' })
+      this.loadIndicators({
+        client: this.$client,
+        currentFolder: this.$route.params.item || '/'
+      })
       this.adjustTableHeaderPosition()
       this.loading = false
     },


### PR DESCRIPTION
## Description
when a lot of files are displayed in files table, the web ui lacks.
This happens because we update a reference to a files object, even if we clone the collection by using the spread operator
`[...this.object]` child objects are still passed by [reference not value](https://www.oreilly.com/library/view/javascript-the-definitive/0596000480/ch04s04.html). 

The update event then gets triggered multiple times even if it's not needed.... resulting with a frozen ui.

This only happens in dev mode because of strict mode and outside mutation: https://github.com/owncloud/web/blob/39cdc0993c0a55a13f790ced1f40f2e7a92494da/packages/web-runtime/src/store/index.js#L28

we also hammer vuex by adding the full resource on every mutation, this pr also adds the ability to update certain resource keys only.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- no issue, was discussed in rocket-chat and be treated as a kind of `fastlane` item

## Motivation and Context
have a snappy ui ;)

## How Has This Been Tested?
- local installation with 4k of dummy files

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [X] Code changes
- [-] Unit tests added `not now, will be done in the process of typescript migration`
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 