### PR TITLE
Shared with me split

### DIFF
--- a/packages/web-app-files/src/views/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/SharedWithMe.vue
@@ -19,7 +19,7 @@
         <div id="pending-highlight">
           <oc-table-files
             id="files-shared-with-me-pending-table"
-            v-model="selected"
+            v-model="selectedPending"
             class="files-table"
             :class="{ 'files-table-squashed': isSidebarOpen }"
             :are-previews-displayed="displayPreviews"
@@ -133,7 +133,6 @@
         <no-content-message
           v-if="isEmpty || filterDataByStatus(activeFiles, shareStatus.accepted).length === 0"
           id="files-shared-with-me-accepted-empty"
-          key="files-shared-with-me-accepted-empty"
           class="files-empty"
           icon="group"
         >
@@ -146,7 +145,7 @@
         <oc-table-files
           v-else
           id="files-shared-with-me-accepted-table"
-          v-model="selected"
+          v-model="selectedAccepted"
           class="files-table"
           :class="{ 'files-table-squashed': isSidebarOpen }"
           :are-previews-displayed="displayPreviews"
@@ -164,7 +163,7 @@
               class="uk-text-nowrap uk-flex uk-flex-middle uk-flex-right"
             >
               <oc-button
-                v-if="resource.status === 1 || resource.status === 0"
+                v-if="[shareStatus.accepted, shareStatus.pending].includes(resource.status)"
                 v-translate
                 size="small"
                 class="file-row-share-status-action oc-ml"
@@ -221,7 +220,6 @@
         <no-content-message
           v-if="isEmpty || filterDataByStatus(activeFiles, shareStatus.declined).length === 0"
           id="files-shared-with-me-declined-empty"
-          key="files-shared-with-me-declined-empty"
           class="files-empty"
           icon="group"
         >
@@ -232,15 +230,16 @@
         <oc-table-files
           v-else
           id="files-shared-with-me-declined-table"
-          v-model="selected"
+          v-model="selectedDeclined"
           class="files-table"
           :class="{ 'files-table-squashed': isSidebarOpen }"
           :are-previews-displayed="displayPreviews"
           :resources="filterDataByStatus(activeFiles, shareStatus.declined)"
           :target-route="targetRoute"
+          :are-resources-clickable="false"
           :highlighted="highlightedFile ? highlightedFile.id : null"
+          :has-actions="false"
           :header-position="headerPosition"
-          @showDetails="setHighlightedFile"
           @fileClick="$_fileActions_triggerDefaultAction"
           @rowMounted="rowMounted"
         >
@@ -250,9 +249,9 @@
               class="uk-text-nowrap uk-flex uk-flex-middle uk-flex-right"
             >
               <oc-button
+                v-if="[shareStatus.declined, shareStatus.pending].includes(resource.status)"
                 v-translate
                 size="small"
-                variation="success"
                 class="file-row-share-status-action"
                 @click.stop="triggerShareAction(resource, 'POST')"
               >
@@ -337,7 +336,33 @@ export default {
         this.SELECT_RESOURCES(resources)
       }
     },
-
+    selectedPending: {
+      get() {
+        return this.selectedFiles.filter(r => r.status === shareStatus.pending)
+      },
+      set(resources) {
+        resources = resources.filter(r => r.status === shareStatus.pending)
+        this.SELECT_RESOURCES(resources)
+      }
+    },
+    selectedAccepted: {
+      get() {
+        return this.selectedFiles.filter(r => r.status === shareStatus.accepted)
+      },
+      set(resources) {
+        resources = resources.filter(r => r.status === shareStatus.accepted)
+        this.SELECT_RESOURCES(resources)
+      }
+    },
+    selectedDeclined: {
+      get() {
+        return this.selectedFiles.filter(r => r.status === shareStatus.declined)
+      },
+      set(resources) {
+        resources = resources.filter(r => r.status === shareStatus.declined)
+        this.SELECT_RESOURCES(resources)
+      }
+    },
     isEmpty() {
       return this.activeFiles.length < 1
     },
@@ -511,7 +536,10 @@ export default {
         this.showMessage({
           title: this.$gettext('Error while changing share state'),
           desc: error.message,
-          status: 'danger'
+          status: 'danger',
+          autoClose: {
+            enabled: true
+          }
         })
       }
     }
@@ -531,7 +559,7 @@ export default {
   align-items: baseline;
 }
 #pending-highlight {
-  background-color: #f0f8ff;
+  background-color: var(--oc-color-background-highlight);
 }
 .show-hide-pending {
   text-align: center;

--- a/packages/web-app-files/src/views/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/SharedWithMe.vue
@@ -133,6 +133,7 @@
         <no-content-message
           v-if="isEmpty || filterDataByStatus(activeFiles, shareStatus.accepted).length === 0"
           id="files-shared-with-me-accepted-empty"
+          key="files-shared-with-me-accepted-empty"
           class="files-empty"
           icon="group"
         >
@@ -165,9 +166,8 @@
               <oc-button
                 v-if="resource.status === 1 || resource.status === 0"
                 v-translate
-                appearance="raw"
                 size="small"
-                class="file-row-share-status-action oc-text-meta oc-ml"
+                class="file-row-share-status-action oc-ml"
                 @click.stop="triggerShareAction(resource, 'DELETE')"
               >
                 Decline
@@ -221,6 +221,7 @@
         <no-content-message
           v-if="isEmpty || filterDataByStatus(activeFiles, shareStatus.declined).length === 0"
           id="files-shared-with-me-declined-empty"
+          key="files-shared-with-me-declined-empty"
           class="files-empty"
           icon="group"
         >
@@ -252,7 +253,7 @@
                 v-translate
                 size="small"
                 variation="success"
-                class="file-row-share-status-action oc-text-meta"
+                class="file-row-share-status-action"
                 @click.stop="triggerShareAction(resource, 'POST')"
               >
                 Accept


### PR DESCRIPTION
Copied over from https://github.com/owncloud/web/pull/5177 - needed to rebase and can't push to the origin of that PR.

## Description
The "Shared with me" view shows 2 different lists for pending and accepted shares. On request user can see the declined files (clicking "show declined shares).


## Motivation and Context
General UX improvement: Motivate the user to accept or decline the shares through better overview of the statuses and highlighted pending section. 

## How Has This Been Tested?
UI test scenario: Sharing multiple files through one testing account with another
- test case 1: pending shares, 3 or less pending shares --> simple list of pending shares
- test case 2: pending shares, more than 3 shares --> "show all", "show less" option
- test case 3: no pending shares--> no pending shares list shown
- test case 4: no accepted shares--> "You are currently not collaborating on other people's resources" message shown, "show declined shares" option appears at pending shares
- test case 5: accepted shares exist--> list with accepted shares and option to show declined shares appears
- test case 6: no declined shares--> "No declined files found" message appears
- test case 7 declined shares exist --> list with declined shares shown on click of "show declined shares"

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 


## General view
![Bildschirmfoto vom 2021-05-31 10-14-23](https://user-images.githubusercontent.com/7430156/120162767-0338be80-c1f9-11eb-8a30-f61f9c0f4b7e.png)
