### PR TITLE
[full-ci][tests-only] Remove @yetToImplement tags from tests (Part-3)

### DIFF
--- a/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
+++ b/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
@@ -97,6 +97,14 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIFilesSearch/search.feature:63](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L63)
 -   [webUIFilesSearch/search.feature:71](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L71)
 -   [webUIFilesSearch/search.feature:84](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L84)
+-   [webUITags/tagsSuggestion.feature:25](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITags/tagsSuggestion.feature#L25)
+-   [webUITags/tagsSuggestion.feature:35](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITags/tagsSuggestion.feature#L35)
+-   [webUITags/createTags.feature:16](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITags/createTags.feature#L16)
+-   [webUITags/createTags.feature:26](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITags/createTags.feature#L26)
+-   [webUITags/createTags.feature:37](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITags/createTags.feature#L37)
+-   [webUITags/createTags.feature:51](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITags/createTags.feature#L51)
+-   [webUITags/createTags.feature:61](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITags/createTags.feature#L61)
+-   [webUITags/createTags.feature:79](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITags/createTags.feature#L79)
 
 ### [When a user shares folder to a group, the sharer is shown as group in group member's sharing-sidebar] (https://github.com/owncloud/web/issues/5216)
 -   [webUISharingInternalGroupsEdgeCases/shareWithGroupsEdgeCases.feature:41](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalGroupsEdgeCases/shareWithGroupsEdgeCases.feature#L41)
@@ -107,3 +115,20 @@ Other free text and markdown formatting can be used elsewhere in the document if
 ### [File link in notifications seems to not work] (https://github.com/owncloud/web/issues/5227)
 -   [webUISharingNotifications/notificationLink.feature:18](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingNotifications/notificationLink.feature#L18)
 -   [webUISharingNotificationsToRoot/notificationLink.feature:17](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingNotificationsToRoot/notificationLink.feature#L17)
+
+### [Cannot determine share source path when sharing same name file from different path in shared-with pages] (https://github.com/owncloud/web/issues/5302)
+-   [webUISharingPublicBasic/publicLinkCreate.feature:88](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicBasic/publicLinkCreate.feature#L88)
+
+### [impossible to navigate into a folder in the trashbin] (https://github.com/owncloud/web/issues/1725)
+-   [webUITrashbinDelete/trashbinDelete.feature:29](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITrashbinDelete/trashbinDelete.feature#L29)
+
+### [Saving public share is not possible] (https://github.com/owncloud/web/issues/5321)
+-   [webUISharingPublicManagement/shareByPublicLink.feature:31](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature#L31)
+
+### [Public link send by email field] (https://github.com/owncloud/web/issues/2422)
+-   [webUISharingPublicManagement/publicLinkShareByEmail.feature:15](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkShareByEmail.feature#L15)
+-   [webUISharingPublicManagement/publicLinkShareByEmail.feature:25](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkShareByEmail.feature#L25)
+-   [webUISharingPublicManagement/publicLinkShareByEmail.feature:41](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkShareByEmail.feature#L41)
+-   [webUISharingPublicManagement/publicLinkShareByEmail.feature:56](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkShareByEmail.feature#L56)
+-   [webUISharingPublicManagement/publicLinkShareByEmail.feature:71](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkShareByEmail.feature#L71)
+-   [webUISharingPublicManagement/publicLinkShareByEmail.feature:99](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkShareByEmail.feature#L99)

--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -228,11 +228,11 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUISharingPublicExpire/shareByPublicLinkExpiringLinks.feature:106](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicExpire/shareByPublicLinkExpiringLinks.feature#L106)
 -   [webUISharingPublicExpire/shareByPublicLinkExpiringLinks.feature:130](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicExpire/shareByPublicLinkExpiringLinks.feature#L130)
 -   [webUISharingPublicExpire/shareByPublicLinkExpiringLinks.feature:147](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicExpire/shareByPublicLinkExpiringLinks.feature#L147)
--   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:279](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L279)
--   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:287](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L287)
--   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:296](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L296)
--   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:305](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L305)
--   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:314](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L314)
+-   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:278](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L278)
+-   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:286](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L286)
+-   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:295](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L295)
+-   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:304](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L304)
+-   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:313](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L313)
 
 
 ### [Cannot delete a received share](https://github.com/owncloud/ocis/issues/714)
@@ -309,10 +309,8 @@ Other free text and markdown formatting can be used elsewhere in the document if
 ### [Cannot upload files to the ownCloud storage](https://github.com/owncloud/ocis-reva/issues/398)
 -   [webUISharingPublicBasic/publicLinkPublicActions.feature:12](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicBasic/publicLinkPublicActions.feature#L12)
 
-
-
 ### [Listing shares via ocs API does not show path for parent folders](https://github.com/owncloud/ocis/issues/1231)
--   [webUISharingPublicManagement/shareByPublicLink.feature:148](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature#L148)
+-   [webUISharingPublicManagement/shareByPublicLink.feature:134](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature#L134)
 
 ### [Propfind response to trashbin endpoint is different in ocis](https://github.com/owncloud/product/issues/186)
 ### [restoring a file from "Deleted files" (trashbin) is not possible if the original folder does not exist any-more](https://github.com/owncloud/web/issues/1753)
@@ -421,13 +419,13 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUISharingInternalGroupsSharingIndicator/shareWithGroups.feature:80](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalGroupsSharingIndicator/shareWithGroups.feature#L80)
 
 ### [Deletion of a recursive folder from trashbin is not possible](https://github.com/owncloud/product/issues/188)
--   [webUITrashbinDelete/trashbinDelete.feature:106](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITrashbinDelete/trashbinDelete.feature#L106)
--   [webUITrashbinDelete/trashbinDelete.feature:86](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITrashbinDelete/trashbinDelete.feature#L86)
--   [webUITrashbinDelete/trashbinDelete.feature:50](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITrashbinDelete/trashbinDelete.feature#L50)
+-   [webUITrashbinDelete/trashbinDelete.feature:105](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITrashbinDelete/trashbinDelete.feature#L105)
+-   [webUITrashbinDelete/trashbinDelete.feature:85](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITrashbinDelete/trashbinDelete.feature#L85)
+-   [webUITrashbinDelete/trashbinDelete.feature:49](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITrashbinDelete/trashbinDelete.feature#L49)
 
 ### [Trying to create a (public) link share of the Shares folder throws an error](https://github.com/owncloud/web/issues/5152)
 -   [webUISharingInternalUsers/shareWithUsers.feature:360](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature#L360)
--   [webUISharingPublicBasic/publicLinkCreate.feature:195](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicBasic/publicLinkCreate.feature#L195)
+-   [webUISharingPublicBasic/publicLinkCreate.feature:187](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicBasic/publicLinkCreate.feature#L187)
 
 ### [Admin settings feature not implemented yet] (https://github.com/owncloud/web/issues/5015)
 -   [webUIAdminSettings/adminAppsSettings.feature:11](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIAdminSettings/adminAppsSettings.feature#L11)
@@ -484,7 +482,32 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIFilesSearch/search.feature:63](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L63)
 -   [webUIFilesSearch/search.feature:71](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L71)
 -   [webUIFilesSearch/search.feature:84](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L84)
+-   [webUITags/tagsSuggestion.feature:25](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITags/tagsSuggestion.feature#L25)
+-   [webUITags/tagsSuggestion.feature:35](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITags/tagsSuggestion.feature#L35)
+-   [webUITags/createTags.feature:16](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITags/createTags.feature#L16)
+-   [webUITags/createTags.feature:26](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITags/createTags.feature#L26)
+-   [webUITags/createTags.feature:37](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITags/createTags.feature#L37)
+-   [webUITags/createTags.feature:51](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITags/createTags.feature#L51)
+-   [webUITags/createTags.feature:61](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITags/createTags.feature#L61)
+-   [webUITags/createTags.feature:79](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITags/createTags.feature#L79)
 
 ### [When a user shares folder to a group, the sharer is shown as group in group member's sharing-sidebar] (https://github.com/owncloud/web/issues/5216)
 -   [webUISharingInternalGroupsEdgeCases/shareWithGroupsEdgeCases.feature:41](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalGroupsEdgeCases/shareWithGroupsEdgeCases.feature#L41)
 -   [webUISharingInternalGroupsEdgeCases/shareWithGroupsEdgeCases.feature:42](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalGroupsEdgeCases/shareWithGroupsEdgeCases.feature#L42)
+
+### [Cannot determine share source path when sharing same name file from different path in shared-with pages] (https://github.com/owncloud/web/issues/5302)
+-   [webUISharingPublicBasic/publicLinkCreate.feature:88](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicBasic/publicLinkCreate.feature#L88)
+
+### [impossible to navigate into a folder in the trashbin] (https://github.com/owncloud/web/issues/1725)
+-   [webUITrashbinDelete/trashbinDelete.feature:29](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITrashbinDelete/trashbinDelete.feature#L29)
+
+### [Saving public share is not possible] (https://github.com/owncloud/web/issues/5321)
+-   [webUISharingPublicManagement/shareByPublicLink.feature:31](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature#L31)
+
+### [Public link send by email field] (https://github.com/owncloud/web/issues/2422)
+-   [webUISharingPublicManagement/publicLinkShareByEmail.feature:15](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkShareByEmail.feature#L15)
+-   [webUISharingPublicManagement/publicLinkShareByEmail.feature:25](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkShareByEmail.feature#L25)
+-   [webUISharingPublicManagement/publicLinkShareByEmail.feature:41](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkShareByEmail.feature#L41)
+-   [webUISharingPublicManagement/publicLinkShareByEmail.feature:56](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkShareByEmail.feature#L56)
+-   [webUISharingPublicManagement/publicLinkShareByEmail.feature:71](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkShareByEmail.feature#L71)
+-   [webUISharingPublicManagement/publicLinkShareByEmail.feature:99](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkShareByEmail.feature#L99)

--- a/tests/acceptance/features/webUISharingPublicBasic/publicLinkCreate.feature
+++ b/tests/acceptance/features/webUISharingPublicBasic/publicLinkCreate.feature
@@ -84,17 +84,16 @@ Feature: Create public link shares
     And the public uses the webUI to access the last public link created by user "Alice"
     Then file "lorem.txt" should be listed on the webUI
 
-  @skip @yetToImplement
+  @issue-5302
   Scenario: share two file with same name but different paths by public link
     Given user "Alice" has created folder "simple-folder"
     And user "Alice" has created file "simple-folder/lorem.txt"
     And user "Alice" has created file "lorem.txt"
     And user "Alice" has logged in using the webUI
     When the user creates a new public link for file "lorem.txt" using the webUI
-    And the user closes the details dialog
     And the user opens folder "simple-folder" using the webUI
     And the user creates a new public link for file "lorem.txt" using the webUI
-    And the user browses to the shared-by-link page
+    And the user browses to the shared-via-link page using the webUI
     Then file "lorem.txt" with path "" should be listed in the shared with others page on the webUI
     And file "lorem.txt" with path "/simple-folder" should be listed in the shared with others page on the webUI
 
@@ -152,13 +151,6 @@ Feature: Create public link shares
     And a link named "first-name" should be listed with role "Viewer" in the public link list of file "lorem.txt" on the webUI
     And a link named "second-name" should be listed with role "Viewer" in the public link list of folder "lorem.txt" on the webUI
 
-  @skip @yetToImplement
-  Scenario: user creates public link with view and upload feature
-    Given user "Alice" has created folder "simple-folder"
-    And user "Alice" has logged in using the webUI
-    When the user creates a new public link for folder "simple-folder" using the webUI with
-      | permission | upload-write-without-modify |
-    And the public accesses the last created public link using the webUI
 
   Scenario Outline: user creates multiple public links with same name for the same file/folder
     Given user "Alice" has created <element> "<name>"

--- a/tests/acceptance/features/webUISharingPublicBasic/publicLinkEdit.feature
+++ b/tests/acceptance/features/webUISharingPublicBasic/publicLinkEdit.feature
@@ -84,7 +84,7 @@ Feature: Edit public link shares
       | read, update, create, delete | Uploader    | shareapi_enforce_links_password_read_write_delete | create                       |
       | create                       | Editor      | shareapi_enforce_links_password_write_only        | read, update, create, delete |
 
-  @yetToImplement @issue-ocis-reva-41
+  @issue-ocis-reva-41
   Scenario: user edits a public link and does not save the changes
     Given the setting "shareapi_allow_public_notification" of app "core" has been set to "yes"
     And user "Alice" has created folder "simple-folder"
@@ -92,7 +92,6 @@ Feature: Edit public link shares
       | path     | simple-folder    |
       | name     | test_public_link |
       | password | pass123          |
-#      | email     | foo1234@bar.co   |
     And user "Alice" has logged in using the webUI
     When the user edits the public link named "test_public_link" of folder "simple-folder" changing following but not saving
       | password | qwertyui |
@@ -188,17 +187,21 @@ Feature: Edit public link shares
     When the user removes the public link named "Public-link" of file "lorem.txt" using the webUI
     Then user "Alice" should not have any public link
 
-  @skip @yetToImplement
-  Scenario: user edits the permission of an already existing public link from read-write to upload-write-without-overwrite
+
+  Scenario: user edits the permission of an already existing public link from read-write to read-create
     Given user "Alice" has created folder "simple-folder"
-    And user "Alice" has created file "simple-folder/lorem.txt"
-    And the user has created a new public link for folder "simple-folder" using the webUI with
-      | permission | read-write |
-    When the user changes the permission of the public link named "Public link" to "upload-write-without-modify"
-    And the public accesses the last created public link using the webUI
-    And the user uploads file "lorem.txt" keeping both new and existing files using the webUI
-    Then file "lorem.txt" should be listed on the webUI
-    And file "lorem (2).txt" should be listed on the webUI
+    And user "Alice" has created file "simple-folder/simple.txt"
+    And user "Alice" has created a public link with following settings
+      | path        | simple-folder                |
+      | name        | Public-link                  |
+      | permissions | read, update, create, delete |
+    And user "Alice" has logged in using the webUI
+    When the user edits the public link named "Public-link" of folder "simple-folder" changing following
+      | role | Contributor |
+    And the public uses the webUI to access the last public link created by user "Alice"
+    And the user uploads file "lorem.txt" using the webUI
+    Then file "simple.txt" should be listed on the webUI
+    And file "lorem.txt" should be listed on the webUI
 
 
   Scenario: assign password to already created public share

--- a/tests/acceptance/features/webUISharingPublicBasic/publicLinkPublicActions.feature
+++ b/tests/acceptance/features/webUISharingPublicBasic/publicLinkPublicActions.feature
@@ -34,17 +34,6 @@ Feature: Access public link shares by public
     When the public uses the webUI to access the last public link created by user "Alice" with password "pass12"
     Then the public should not get access to the publicly shared file
 
-  @yetToImplement
-  Scenario: public should be able to access the shared file through public link
-    Given user "Alice" has uploaded file with content "Lorem ipsum dolor sit amet, consectetur" to "lorem.txt"
-    And user "Alice" has logged in using the webUI
-    And user "Alice" has created a public link with following settings
-      | path | lorem.txt   |
-      | name | Public link |
-    When the public uses the webUI to access the last public link created by user "Alice"
-    Then file "lorem.txt" should be listed on the webUI
-#    Then the text preview of the public link should contain "Lorem ipsum dolor sit amet, consectetur"
-#    And the content of the file shared by the last public link should be the same as "lorem.txt"
 
   Scenario: public creates a folder in the public link
     Given user "Alice" has created a public link with following settings

--- a/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature
+++ b/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature
@@ -244,15 +244,14 @@ Feature: Share by public link with different roles
     And as "Alice" the content of "simple-folder/'single'quotes.txt" should be the same as the local "'single'quotes.txt"
     And as "Alice" the content of "simple-folder/new-lorem.txt" should be the same as the local "new-lorem.txt"
 
-  @issue-2443 @yetToImplement
+  @issue-2443
   Scenario: creating a public link with "Uploader" role makes it possible to upload a folder
     Given user "Alice" has shared folder "simple-folder" with link with "create" permissions
     When the public uses the webUI to access the last public link created by user "Alice"
     And the public uploads file "FOLDER" in files-drop page
     Then the following files should be listed on the files-drop page:
       | FOLDER |
-    And as "Alice" file "simple-folder/FOLDER" should exist
-    And the content of file "simple-folder/FOLDER" for user "Alice" should be ""
+    And as "Alice" folder "simple-folder/FOLDER" should exist
 
   @issue-ocis-723
   Scenario: creating a public link with "Uploader" role makes it possible to create files through files-drop page even with password set

--- a/tests/acceptance/features/webUISharingPublicManagement/publicLinkShareByEmail.feature
+++ b/tests/acceptance/features/webUISharingPublicManagement/publicLinkShareByEmail.feature
@@ -11,7 +11,7 @@ Feature: Share public link shares via email
     And user "Alice" has logged in using the webUI
     And the user reloads the current page of the webUI
 
-  @skip @yetToImplement
+  @issue-2422
   Scenario: user shares a public link via email
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | email | foo@bar.co |
@@ -21,7 +21,7 @@ Feature: Share public link shares via email
       """
     And the email address "foo@bar.co" should have received an email containing the last shared public link
 
-  @skip @yetToImplement
+  @issue-2422
   Scenario: user shares a public link via email and sends a copy to self
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | email       | foo@bar.co |
@@ -37,7 +37,7 @@ Feature: Share public link shares via email
     And the email address "foo@bar.co" should have received an email containing the last shared public link
     And the email address "alice@example.org" should have received an email containing the last shared public link
 
-  @skip @yetToImplement
+  @issue-2422
   Scenario: user shares a public link via email with multiple addresses
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | email | foo@bar.co, foo@barr.co |
@@ -52,7 +52,7 @@ Feature: Share public link shares via email
     And the email address "foo@bar.co" should have received an email containing the last shared public link
     And the email address "foo@barr.co" should have received an email containing the last shared public link
 
-  @skip @yetToImplement
+  @issue-2422
   Scenario: user shares a public link via email with a personal message
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | email           | foo@bar.co  |
@@ -67,7 +67,7 @@ Feature: Share public link shares via email
       """
     And the email address "foo@bar.co" should have received an email containing the last shared public link
 
-  @skip @yetToImplement
+  @issue-2422
   Scenario: user shares a public link via email adding few addresses before and then removing some addresses afterwards
     When the user opens the link share dialog for folder "simple-folder" using the webUI
     And the user opens the create public link share popup
@@ -95,7 +95,7 @@ Feature: Share public link shares via email
     But the email address "foo1234@bar.co" should not have received an email
     And the email address "foo5678@barr.co" should not have received an email
 
-  @skip @yetToImplement @issue-ocis-reva-41
+  @issue-2422 @issue-ocis-reva-41
   Scenario: user shares a public link via email with a personal message (duplicate)
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | email           | foo@bar.co  |

--- a/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature
@@ -27,40 +27,23 @@ Feature: Public link share management
     When the public uses the webUI to access the last public link created by user "Alice"
     Then the user should be redirected to the files-drop page
 
-  @skip @yetToImplement
+  @issue-5321
   Scenario: mount public link
-    Given using server "REMOTE"
-    And user "Brian" has been created with default attributes and without skeleton files
-    And user "Brian" has created folder "/simple-folder"
-    When the user creates a new public link for folder "simple-folder" using the webUI
-    And the user logs out of the webUI
-    And the public accesses the last created public link using the webUI
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "Alice file" to "simple-folder/lorem.txt"
+    And user "Alice" has created a public link with following settings
+      | path        | simple-folder                |
+      | name        | Public-link                  |
+      | permissions | read, update, create, delete |
+    When the public uses the webUI to access the last public link created by user "Alice"
     And the public adds the public link to "%remote_server%" as user "Brian" with password "%alt2%" using the webUI
-    And the user accepts the offered remote shares using the webUI
-    Then folder "simple-folder (2)" should be listed on the webUI
-    When the user opens folder "simple-folder (2)" using the webUI
+    Then folder "simple-folder" should be listed on the webUI
+    When the user opens folder "simple-folder" using the webUI
     Then file "lorem.txt" should be listed on the webUI
-    And the content of "lorem.txt" on the remote server should be the same as the original "simple-folder/lorem.txt"
-    And it should not be possible to delete file "lorem.txt" using the webUI
-
-  @skip @yetToImplement
-  Scenario: mount public link and overwrite file
-    Given using server "REMOTE"
-    And user "Brian" has been created with default attributes and without skeleton files
-    And user "Brian" has created folder "/simple-folder"
-    When the user creates a new public link for folder "simple-folder" using the webUI with
-      | permission | read-write |
-    And the user logs out of the webUI
-    And the public accesses the last created public link using the webUI
-    And the public adds the public link to "%remote_server%" as user "Brian" with password "%alt2%" using the webUI
-    And the user accepts the offered remote shares using the webUI
-    Then folder "simple-folder (2)" should be listed on the webUI
-    When the user opens folder "simple-folder (2)" using the webUI
+    And the content of file "simple-folder/lorem.txt" for user "Brian" should be "Alice file"
+    When the user uploads overwriting file "lorem.txt" using the webUI
     Then file "lorem.txt" should be listed on the webUI
-    And the content of "lorem.txt" on the remote server should be the same as the original "simple-folder/lorem.txt"
-    When the user uploads overwriting file "lorem.txt" using the webUI and retries if the file is locked
-    Then file "lorem.txt" should be listed on the webUI
-    And the content of "lorem.txt" on the remote server should be the same as the local "lorem.txt"
+    And as "Brian" the content of "simple-folder/lorem.txt" should be the same as the local "lorem.txt"
 
   @issue-ocis-reva-41
   Scenario: user shares a file through public link and then it appears in a shared-with-others page
@@ -80,13 +63,16 @@ Feature: Public link share management
       | fileName      | expectedCollaborators    |
       | simple-folder | link-editor, link-viewer |
 
-  @skip @yetToImplement
+
   Scenario: user cancel removes operation for the public link of a file
     Given user "Alice" has created file "lorem.txt"
-    And the user has created a new public link for file "lorem.txt" using the webUI
-    When the user tries to remove the public link of file "lorem.txt" but later cancels the remove dialog using webUI
-    And the public accesses the last created public link using the webUI
-    Then the content of the file shared by the last public link should be the same as "lorem.txt"
+    And user "Alice" has logged in using the webUI
+    And user "Alice" has created a public link with following settings
+      | path        | lorem.txt   |
+      | name        | Public-link |
+      | permissions | read        |
+    When the user cancels remove the public link named "Public-link" of file "lorem.txt" using the webUI
+    Then user "Alice" should have some public shares
 
   @ocisSmokeTest
   Scenario: user browses to public link share using copy link button

--- a/tests/acceptance/features/webUITags/createTags.feature
+++ b/tests/acceptance/features/webUITags/createTags.feature
@@ -12,7 +12,7 @@ Feature: Creation of tags for the files and folders
     And the user has browsed to the login page
     And user "Alice" has logged in using the webUI
 
-  @skip @yetToImplement
+  @issue-5017
   Scenario: Create a new tag that does not exist for a file in the root
     Given user "Alice" has uploaded file "lorem.txt" to "lorem.txt"
     When the user browses directly to display the details of file "lorem.txt" in folder "/"
@@ -22,7 +22,7 @@ Feature: Creation of tags for the files and folders
       | Top Secret   | normal |
       | Confidential | normal |
 
-  @skip @yetToImplement
+  @issue-5017
   Scenario: Create a new tag that does not exist for a file in a folder
     Given user "Alice" has created folder "simple-folder"
     And user "Alice" has uploaded file "lorem.txt" to "simple-folder/lorem.txt"
@@ -33,7 +33,7 @@ Feature: Creation of tags for the files and folders
       | Top Secret | normal |
       | Top        | normal |
 
-  @skip @yetToImplement
+  @issue-5017
   Scenario: Add a new tag that already exists for a file in a folder
     Given user "Alice" has created folder "simple-folder"
     And user "Alice" has uploaded file "lorem.txt" to "simple-folder/lorem.txt"
@@ -47,7 +47,7 @@ Feature: Creation of tags for the files and folders
     And file "simple-folder/lorem-big.txt" should have the following tags for user "Alice"
       | lorem | normal |
 
-  @skip @yetToImplement
+  @issue-5017
   Scenario: Remove a tag that already exists for a file in a folder
     Given user "Alice" has created folder "simple-folder"
     And user "Alice" has uploaded file "lorem.txt" to "simple-folder/lorem.txt"
@@ -57,7 +57,7 @@ Feature: Creation of tags for the files and folders
     And the user toggles a tag "lorem" on the file using the webUI
     Then file "simple-folder/lorem.txt" should have no tags for user "Alice"
 
-  @skip @yetToImplement
+  @issue-5017
   Scenario: Create and add tag on a shared file
     Given user "Alice" has created folder "simple-folder"
     And user "Alice" has uploaded file "lorem.txt" to "lorem.txt"
@@ -75,7 +75,7 @@ Feature: Creation of tags for the files and folders
       | tag1 | normal |
       | tag2 | normal |
 
-  @skip @yetToImplement
+  @issue-5017
   Scenario: Delete a tag in a shared file
     Given user "Alice" has created folder "simple-folder"
     And user "Alice" has uploaded file "lorem.txt" to "lorem.txt"

--- a/tests/acceptance/features/webUITags/tagsSuggestion.feature
+++ b/tests/acceptance/features/webUITags/tagsSuggestion.feature
@@ -21,7 +21,7 @@ Feature: Suggestion for matching tag names
     And user "Alice" has uploaded file "lorem.txt" to "simple-folder/lorem.txt"
     And user "Alice" has logged in using the webUI
 
-  @skip @yetToImplement
+  @issue-5017
   Scenario: User should get suggestion from already existing tags
     When the user browses directly to display the details of file "lorem.txt" in folder "simple-folder"
     And the user types "sp" in the collaborative tags field using the webUI
@@ -31,7 +31,7 @@ Feature: Suggestion for matching tag names
     And tag "Violates T&C" should not be listed in the dropdown list on the webUI
     And tag "sponsored" should not be listed in the dropdown list on the webUI
 
-  @skip @yetToImplement
+  @issue-5017
   Scenario: User of static tags group should get suggestion for static tags
     When the user browses directly to display the details of file "lorem.txt" in folder "simple-folder"
     And the administrator has created a "static" tag with name "StaticTagName" and groups "group1"

--- a/tests/acceptance/features/webUITrashbinDelete/trashbinDelete.feature
+++ b/tests/acceptance/features/webUITrashbinDelete/trashbinDelete.feature
@@ -25,17 +25,16 @@ Feature: files and folders can be deleted from the trashbin
     And user "Alice" has logged in using the webUI
     And the user has browsed to the trashbin page
 
-  @smokeTest @yetToImplement
+  @issue-1725
   Scenario: Delete files and check that they are gone
     When the user deletes file "lorem.txt" using the webUI
     And the user deletes file "sample,1.txt" using the webUI
-    # web does not yet support navigating into deleted folders
-    # And the user opens folder "simple-folder" using the webUI
-    # And the user deletes file "lorem-big.txt" using the webUI
+    And the user opens folder "simple-folder" using the webUI
+    And the user deletes file "lorem-big.txt" using the webUI
     Then file "lorem.txt" should not be listed on the webUI
     And file "sample,1.txt" should not be listed on the webUI
-    # But file "lorem.txt" should be listed in the trashbin folder "simple-folder" on the webUI
-    # And file "lorem-big.txt" should not be listed in the trashbin folder "simple-folder" on the webUI
+    But file "lorem.txt" should be listed in the trashbin folder "simple-folder" on the webUI
+    And file "lorem-big.txt" should not be listed in the trashbin folder "simple-folder" on the webUI
     But file "lorem-big.txt" should be listed on the webUI
 
   @issue-product-188

--- a/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/publicLinksDialog.js
@@ -155,6 +155,29 @@ module.exports = {
         .waitForOutstandingAjaxCalls()
     },
     /**
+     * cancels remove public link share action
+     *
+     * @param {string} linkName Name of the public link share of a resource to be deleted
+     * @returns {exports}
+     */
+    cancelRemovePublicLink: function(linkName) {
+      const linkRowDeleteButtonSelector =
+        this.elements.publicLinkContainer.selector +
+        util.format(this.elements.publicLinkDeleteButton.selector, linkName)
+      const linkRowDeleteButton = {
+        locateStrategy: this.elements.publicLinkDeleteButton.locateStrategy,
+        selector: linkRowDeleteButtonSelector
+      }
+      return this.waitForElementVisible(linkRowDeleteButton)
+        .initAjaxCounters()
+        .click(linkRowDeleteButton)
+        .waitForElementVisible('@dialog')
+        .waitForAnimationToFinish()
+        .click('@dialogCancelBtn')
+        .waitForAnimationToFinish()
+        .waitForOutstandingAjaxCalls()
+    },
+    /**
      * checks if public link share with given name is present
      *
      * @param {string} linkName - Name of the public link share to be asserted
@@ -443,6 +466,9 @@ module.exports = {
     },
     dialogConfirmBtn: {
       selector: '.oc-modal-body-actions-confirm'
+    },
+    dialogCancelBtn: {
+      selector: '.oc-modal-body-actions-cancel'
     }
   }
 }

--- a/tests/acceptance/stepDefinitions/publicLinkContext.js
+++ b/tests/acceptance/stepDefinitions/publicLinkContext.js
@@ -224,6 +224,16 @@ When(
   }
 )
 
+When(
+  'the user cancels remove the public link named {string} of file/folder/resource {string} using the webUI',
+  async function(linkName, resource) {
+    await client.page.FilesPageElement.appSideBar()
+      .closeSidebar(100)
+      .openPublicLinkDialog(resource)
+    return client.page.FilesPageElement.publicLinksDialog().cancelRemovePublicLink(linkName)
+  }
+)
+
 Then(
   'public link named {string} should not be listed on the public links list on the webUI',
   async function(linkName) {


### PR DESCRIPTION
## Description
remove @yetToImplement from tests and add them to expected-failures if required features not implemented yet

## Related Issue
- part of 
https://github.com/owncloud/web/issues/4977

## How Has This Been Tested?
- test environment: local

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 