### PR TITLE
[tests-only] Improve failed acceptance test GitHub comment

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2436,7 +2436,7 @@ def buildGithubCommentForBuildStopped(suite, alternateSuiteName):
         "image": "owncloud/ubuntu:20.04",
         "pull": "always",
         "commands": [
-            'echo "<summary>:boom: Acceptance tests <strong>%s</strong> failed. The build is cancelled...</summary>\\n\\n${DRONE_BUILD_LINK}/${DRONE_JOB_NUMBER}/${DRONE_STAGE_NUMBER}\\n" >> %s/comments.file' % (alternateSuiteName, dir["web"]),
+            'echo "<summary>:boom: Acceptance tests <strong>%s</strong> failed. The build is cancelled...</summary>\\n\\n${DRONE_BUILD_LINK}/${DRONE_JOB_NUMBER}${DRONE_STAGE_NUMBER}/1\\n" >> %s/comments.file' % (alternateSuiteName, dir["web"]),
         ],
         "when": {
             "status": [

--- a/.drone.star
+++ b/.drone.star
@@ -2436,7 +2436,7 @@ def buildGithubCommentForBuildStopped(suite, alternateSuiteName):
         "image": "owncloud/ubuntu:20.04",
         "pull": "always",
         "commands": [
-            'echo "<summary>:boom: Acceptance tests <strong>%s</strong> failed. The build is cancelled...</summary>\\n\\n${DRONE_BUILD_LINK}/${DRONE_JOB_NUMBER}\\n" >> %s/comments.file' % (alternateSuiteName, dir["web"]),
+            'echo "<summary>:boom: Acceptance tests <strong>%s</strong> failed. The build is cancelled...</summary>\\n\\n${DRONE_BUILD_LINK}/${DRONE_JOB_NUMBER}/${DRONE_STAGE_NUMBER}\\n" >> %s/comments.file' % (alternateSuiteName, dir["web"]),
         ],
         "when": {
             "status": [

--- a/.drone.star
+++ b/.drone.star
@@ -2436,7 +2436,7 @@ def buildGithubCommentForBuildStopped(suite, alternateSuiteName):
         "image": "owncloud/ubuntu:20.04",
         "pull": "always",
         "commands": [
-            'echo "<details><summary>:boom: Acceptance tests <strong>%s</strong> failed. The build is cancelled...</summary>\\n\\n" >> %s/comments.file' % (alternateSuiteName, dir["web"]),
+            'echo "<summary>:boom: Acceptance tests <strong>%s</strong> failed. The build is cancelled...</summary>\\n\\n${DRONE_BUILD_LINK}/${DRONE_JOB_NUMBER}\\n" >> %s/comments.file' % (alternateSuiteName, dir["web"]),
         ],
         "when": {
             "status": [


### PR DESCRIPTION
## Description
When acceptance tests fail, a GitHub comment is posted to notify about which test pipeline failed. Currently that shows a dropdown for "details" but actually there are no extra details. There is also no link to the failing drone job.

This PR:
- removes the `details` section
- adds a link to the drone job and pipeline stage that failed. The link goes to step 1 of the pipeline.

The available `DRONE*` env vars are documented at https://docs.drone.io/pipeline/environment/reference/

## How Has This Been Tested?
CI - see demo PR #5332 

Comment https://github.com/owncloud/web/pull/5332#issuecomment-865649142 has a working link to the drone pipeline stage that failed.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
