### PR TITLE
[tests-only] Refactor skipping of acceptance test steps

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1470,7 +1470,7 @@ def installCore(version, db):
         stepDefinition.update({"commands": [
             ". %s/.drone.env" % dir["web"],
             "export PLUGIN_GIT_REFERENCE=$CORE_COMMITID",
-            "if test -f runUnitTestsOnly; then echo 'Bye!'; else bash /usr/sbin/plugin.sh; fi",
+            "if test -f runUnitTestsOnly; then echo 'skipping installCore'; else bash /usr/sbin/plugin.sh; fi",
         ]})
 
     return [stepDefinition]
@@ -1517,7 +1517,7 @@ def installFederatedServer(version, db, dbSuffix = "-federated"):
         stepDefinition.update({"commands": [
             ". %s/.drone.env" % dir["web"],
             "export PLUGIN_GIT_REFERENCE=$CORE_COMMITID",
-            "if test -f runUnitTestsOnly; then echo 'Bye!'; else bash /usr/sbin/plugin.sh; fi",
+            "if test -f runUnitTestsOnly; then echo 'skipping installFederatedServer'; else bash /usr/sbin/plugin.sh; fi",
         ]})
 
     return [stepDefinition]
@@ -1528,7 +1528,7 @@ def installNPM():
         "image": "owncloudci/nodejs:16",
         "pull": "always",
         "commands": [
-            "if test -f runUnitTestsOnly; then echo 'Bye!'; else yarn install --frozen-lockfile; fi",
+            "if test -f runUnitTestsOnly; then echo 'skipping installNPM'; else yarn install --frozen-lockfile; fi",
         ],
     }]
 
@@ -1752,7 +1752,7 @@ def getSkeletonFiles():
         "image": "owncloudci/php:7.4",
         "pull": "always",
         "commands": [
-            "if test -f runUnitTestsOnly; then echo 'Bye!'; else git clone https://github.com/owncloud/testing.git /srv/app/testing; fi",
+            "if test -f runUnitTestsOnly; then echo 'installNPM getSkeletonFiles'; else git clone https://github.com/owncloud/testing.git /srv/app/testing; fi",
         ],
         "volumes": [{
             "name": "gopath",
@@ -2019,8 +2019,7 @@ def fixPermissions():
         "image": "owncloudci/php:7.4",
         "pull": "always",
         "commands": [
-            "cd %s" % dir["server"],
-            "if test -f runUnitTestsOnly; then echo 'Bye!'; else chown www-data * -R; fi",
+            "if test -f runUnitTestsOnly; then echo 'skipping fixPermissions'; else cd %s && chown www-data * -R; fi" % dir["server"],
         ],
     }]
 
@@ -2030,8 +2029,7 @@ def fixPermissionsFederated():
         "image": "owncloudci/php:7.4",
         "pull": "always",
         "commands": [
-            "cd %s" % dir["federated"],
-            "if test -f runUnitTestsOnly; then echo 'Bye!'; else chown www-data * -R; fi",
+            "if test -f runUnitTestsOnly; then echo 'skipping fixPermissions'; else cd %s && chown www-data * -R; fi" % dir["federated"],
         ],
     }]
 
@@ -2112,8 +2110,7 @@ def runWebuiAcceptanceTests(suite, alternateSuiteName, filterTags, extraEnvironm
         "pull": "always",
         "environment": environment,
         "commands": [
-            "cd %s" % dir["web"],
-            "if test -f runUnitTestsOnly; then echo 'Bye!'; else ./tests/acceptance/run.sh; fi",
+            "if test -f runUnitTestsOnly; then echo 'skipping webui-acceptance-tests'; else cd %s && ./tests/acceptance/run.sh; fi" % dir["web"],
         ],
         "volumes": [{
             "name": "gopath",

--- a/.drone.star
+++ b/.drone.star
@@ -2433,7 +2433,7 @@ def buildGithubCommentForBuildStopped(suite, alternateSuiteName):
         "image": "owncloud/ubuntu:20.04",
         "pull": "always",
         "commands": [
-            'echo "<summary>:boom: Acceptance tests <strong>%s</strong> failed. The build is cancelled...</summary>\\n\\n${DRONE_BUILD_LINK}/${DRONE_JOB_NUMBER}${DRONE_STAGE_NUMBER}/1\\n" >> %s/comments.file' % (alternateSuiteName, dir["web"]),
+            'echo ":boom: Acceptance tests pipeline <strong>%s</strong> failed. The build has been cancelled.\\n\\n${DRONE_BUILD_LINK}/${DRONE_JOB_NUMBER}${DRONE_STAGE_NUMBER}/1\\n" >> %s/comments.file' % (alternateSuiteName, dir["web"]),
         ],
         "when": {
             "status": [

--- a/tests/drone/build-glauth.sh
+++ b/tests/drone/build-glauth.sh
@@ -2,7 +2,7 @@
 # Input parameters
 # $1 base directory
 if test -f runUnitTestsOnly
-then echo 'Bye!'
+then echo 'skipping build-glauth'
 else
 	cd /srv/app/src/github.com/owncloud/ocis/glauth || exit
 	make build

--- a/tests/drone/build-idp.sh
+++ b/tests/drone/build-idp.sh
@@ -3,7 +3,7 @@
 # $1 base directory
 
 if test -f runUnitTestsOnly
-then echo 'Bye!'
+then echo 'skipping build-idp'
 else
 	cd /srv/app/src/github.com/owncloud/ocis || exit
 	cd idp || exit

--- a/tests/drone/build-ocis-web.sh
+++ b/tests/drone/build-ocis-web.sh
@@ -3,7 +3,7 @@
 # $1 base directory
 
 if test -f runUnitTestsOnly
-then echo 'Bye!'
+then echo 'skipping build-ocis-web'
 else
 	cd /srv/app/src/github.com/owncloud/ocis || exit
 	cd web || exit

--- a/tests/drone/build-web-app.sh
+++ b/tests/drone/build-web-app.sh
@@ -3,7 +3,7 @@
 # $1 the directory where the installed web app code is found
 
 if test -f runUnitTestsOnly
-then echo 'Bye!'
+then echo 'skipping build-web-app'
 else
 	yarn build
 	mkdir -p /srv/config

--- a/tests/drone/build-web.sh
+++ b/tests/drone/build-web.sh
@@ -3,7 +3,7 @@
 # $1 the directory where the installed web app code is found
 
 if test -f runUnitTestsOnly
-then echo 'Bye!'
+then echo 'skipping build-web'
 else
 	yarn build
 	cp tests/drone/config-oc10-oauth.json dist/config.json

--- a/tests/drone/copy-files-for-upload.sh
+++ b/tests/drone/copy-files-for-upload.sh
@@ -3,7 +3,7 @@
 # $1 web directory
 
 if test -f runUnitTestsOnly
-then echo 'Bye!'
+then echo 'skipping copy-files-for-upload'
 else
 	ls -la /filesForUpload
 	cp -a "$1"/tests/acceptance/filesForUpload/. /filesForUpload

--- a/tests/drone/get-ocis.sh
+++ b/tests/drone/get-ocis.sh
@@ -4,7 +4,7 @@
 # $2 web directory
 
 if test -f runUnitTestsOnly
-then echo 'Bye!'
+then echo 'skipping get-ocis'
 else
 	source "$2"/.drone.env
 	mkdir -p "$1"/ocis-build

--- a/tests/drone/setup-fed-server-and-app.sh
+++ b/tests/drone/setup-fed-server-and-app.sh
@@ -4,7 +4,7 @@
 # $2 log level
 
 if test -f runUnitTestsOnly
-then echo 'Bye!'
+then echo 'skipping setup-fed-server-and-app'
 else
 	cd "$1"/ || exit
 	php occ a:e testing

--- a/tests/drone/setup-graph-api-oidc.sh
+++ b/tests/drone/setup-graph-api-oidc.sh
@@ -3,7 +3,7 @@
 # $1 the directory where the installed server code is found
 
 if test -f runUnitTestsOnly
-then echo 'Bye!'
+then echo 'skipping setup-graph-api-oidc'
 else
 	git clone -b master https://github.com/owncloud/graphapi.git "$1"/apps/graphapi
 	cd "$1"/apps/graphapi || exit

--- a/tests/drone/setup-integration-web-app.sh
+++ b/tests/drone/setup-integration-web-app.sh
@@ -4,7 +4,7 @@
 # $2 the directory where the installed web app code is found
 
 if test -f runUnitTestsOnly
-then echo 'Bye!'
+then echo 'skipping setup-integration-web-app'
 else
 	cd "$1" || exit
 	mkdir apps-external/web

--- a/tests/drone/setup-notifications-app.sh
+++ b/tests/drone/setup-notifications-app.sh
@@ -3,7 +3,7 @@
 # $1 server directory
 
 if test -f runUnitTestsOnly
-then echo 'Bye!'
+then echo 'skipping setup-notifications-app'
 else
 	git clone -b master https://github.com/owncloud/notifications.git "$1"/apps/notifications
 	cd "$1" || exit

--- a/tests/drone/setup-oauth2.sh
+++ b/tests/drone/setup-oauth2.sh
@@ -4,7 +4,7 @@
 # $2 oidc url
 
 if test -f runUnitTestsOnly
-then echo 'Bye!'
+then echo 'skipping setup-oauth2'
 else
 	git clone -b master https://github.com/owncloud/oauth2.git "$1"/apps/oauth2
 	cd "$1"/apps/oauth2 || exit

--- a/tests/drone/setup-server-and-app.sh
+++ b/tests/drone/setup-server-and-app.sh
@@ -6,7 +6,7 @@
 #    else setup to use the "web" being server at http://web
 if test -f runUnitTestsOnly
 then
-	echo "Bye!"
+	echo "skipping setup-server-and-app"
 else
 	cd $1
 	php occ app:enable testing


### PR DESCRIPTION
## Description
PR #5336 demonstrates changing only a unit test in a PR.

When the drone starlark tries to skip the acceptance test steps, it gets problems with `fixPermissions()` and `fixPermissionsFederated()` - those try to `cd` into the server or federated dorectory first. And that `cd` fails. There is potential for a similar problem in `runWebuiAcceptanceTests()`. The starlark should also skip the `cd` commands when acceptance tests are not required.

This PR:
- combines the `cd` and next command into a single bash command line, so it is all encapsulated by the bash `if` test.
- changes all the "Bye!" messages that happen when a step is skipped. More informative message text has been added.


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
