### PR TITLE
Remove unnecessary Propfind requests

### DIFF
--- a/changelog/unreleased/bugfix-unnecessary-webdav-propfind
+++ b/changelog/unreleased/bugfix-unnecessary-webdav-propfind
@@ -1,0 +1,8 @@
+Bugfix: Remove unnecessary Propfind requests
+
+in the the files-app views `Favorites`, `SharedViaLink`, `SharedWithMe` and `SharedWithOthers`
+we did a unnecessary propfind request to obtain the rootFolder which is not required there.
+
+This has been fixed by removing those requests.
+
+https://github.com/owncloud/web/pull/5339

--- a/packages/web-app-files/src/views/Favorites.vue
+++ b/packages/web-app-files/src/views/Favorites.vue
@@ -171,10 +171,9 @@ export default {
       this.CLEAR_CURRENT_FILES_LIST()
 
       let resources = await this.$client.files.getFavoriteFiles(this.davProperties)
-      const rootFolder = await this.$client.files.fileInfo('/', this.davProperties)
 
       resources = resources.map(buildResource)
-      this.LOAD_FILES({ currentFolder: buildResource(rootFolder), files: resources })
+      this.LOAD_FILES({ currentFolder: null, files: resources })
       this.loadIndicators({ client: this.$client, currentFolder: '/' })
 
       // Load quota

--- a/packages/web-app-files/src/views/SharedViaLink.vue
+++ b/packages/web-app-files/src/views/SharedViaLink.vue
@@ -174,28 +174,21 @@ export default {
         action: '/api/v1/shares?format=json&share_types=3&include_tags=false',
         method: 'GET'
       })
-      let rootFolder = await this.$client.files.fileInfo('/', this.davProperties)
 
       resources = await resources.json()
       resources = resources.ocs.data
-      rootFolder = buildResource(rootFolder)
 
-      if (resources.length < 1) {
-        this.LOAD_FILES({ currentFolder: rootFolder, files: [] })
-        this.loading = false
-
-        return
+      if (resources.length) {
+        resources = aggregateResourceShares(
+          resources,
+          false,
+          !this.isOcis,
+          this.configuration.server,
+          this.getToken
+        )
       }
 
-      resources = aggregateResourceShares(
-        resources,
-        false,
-        !this.isOcis,
-        this.configuration.server,
-        this.getToken
-      )
-
-      this.LOAD_FILES({ currentFolder: rootFolder, files: resources })
+      this.LOAD_FILES({ currentFolder: null, files: resources })
 
       // Load quota
       const user = await this.$client.users.getUser(this.user.id)

--- a/packages/web-app-files/src/views/SharedViaLink.vue
+++ b/packages/web-app-files/src/views/SharedViaLink.vue
@@ -51,7 +51,7 @@
 <script>
 import { mapGetters, mapState, mapActions, mapMutations } from 'vuex'
 
-import { aggregateResourceShares, buildResource } from '../helpers/resources'
+import { aggregateResourceShares } from '../helpers/resources'
 import FileActions from '../mixins/fileActions'
 import MixinFilesListPositioning from '../mixins/filesListPositioning'
 import MixinResources from '../mixins/resources'

--- a/packages/web-app-files/src/views/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/SharedWithMe.vue
@@ -80,7 +80,7 @@
 <script>
 import { mapGetters, mapState, mapActions, mapMutations } from 'vuex'
 import { shareStatus } from '../helpers/shareStatus'
-import { aggregateResourceShares, buildResource, buildSharedResource } from '../helpers/resources'
+import { aggregateResourceShares, buildSharedResource } from '../helpers/resources'
 import FileActions from '../mixins/fileActions'
 import MixinFilesListPositioning from '../mixins/filesListPositioning'
 import MixinFilesListPagination from '../mixins/filesListPagination'

--- a/packages/web-app-files/src/views/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/SharedWithMe.vue
@@ -210,28 +210,21 @@ export default {
         action: '/api/v1/shares?format=json&shared_with_me=true&state=all&include_tags=false',
         method: 'GET'
       })
-      let rootFolder = await this.$client.files.fileInfo('/', this.davProperties)
 
       resources = await resources.json()
       resources = resources.ocs.data
-      rootFolder = buildResource(rootFolder)
 
-      if (resources.length < 1) {
-        this.LOAD_FILES({ currentFolder: rootFolder, files: [] })
-        this.loading = false
-
-        return
+      if (resources.length) {
+        resources = aggregateResourceShares(
+          resources,
+          true,
+          !this.isOcis,
+          this.configuration.server,
+          this.getToken
+        )
       }
 
-      resources = aggregateResourceShares(
-        resources,
-        true,
-        !this.isOcis,
-        this.configuration.server,
-        this.getToken
-      )
-
-      this.LOAD_FILES({ currentFolder: rootFolder, files: resources })
+      this.LOAD_FILES({ currentFolder: null, files: resources })
 
       // Load quota
       const user = await this.$client.users.getUser(this.user.id)

--- a/packages/web-app-files/src/views/SharedWithOthers.vue
+++ b/packages/web-app-files/src/views/SharedWithOthers.vue
@@ -53,7 +53,7 @@
 <script>
 import { mapGetters, mapState, mapActions, mapMutations } from 'vuex'
 
-import { aggregateResourceShares, buildResource } from '../helpers/resources'
+import { aggregateResourceShares } from '../helpers/resources'
 import FileActions from '../mixins/fileActions'
 import MixinFilesListPositioning from '../mixins/filesListPositioning'
 import MixinResources from '../mixins/resources'

--- a/packages/web-app-files/src/views/SharedWithOthers.vue
+++ b/packages/web-app-files/src/views/SharedWithOthers.vue
@@ -182,30 +182,21 @@ export default {
         action: '/api/v1/shares?format=json&reshares=true&include_tags=false',
         method: 'GET'
       })
-      let rootFolder = await this.$client.files.fileInfo('/', this.davProperties)
 
       resources = await resources.json()
       resources = resources.ocs.data
-      rootFolder = buildResource(rootFolder)
 
-      if (resources.length < 1) {
-        this.LOAD_FILES({ currentFolder: rootFolder, files: [] })
-        this.loading = false
-
-        return
+      if (resources.length) {
+        resources = aggregateResourceShares(
+          resources,
+          false,
+          !this.isOcis,
+          this.configuration.server,
+          this.getToken
+        )
       }
 
-      resources = aggregateResourceShares(
-        resources,
-        false,
-        !this.isOcis,
-        this.configuration.server,
-        this.getToken,
-        this.$client,
-        this.UPDATE_RESOURCE
-      )
-
-      this.LOAD_FILES({ currentFolder: rootFolder, files: resources })
+      this.LOAD_FILES({ currentFolder: null, files: resources })
 
       // Load quota
       const user = await this.$client.users.getUser(this.user.id)


### PR DESCRIPTION
## Description
in the the files-app views `Favorites`, `SharedViaLink`, `SharedWithMe` and `SharedWithOthers`
we did a unnecessary propfind request to obtain the rootFolder which is not required there.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #5337

## Motivation and Context
less requests

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- local test with ocis and oc10

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...