### PR TITLE
[tests-only] Respect interaction between full-ci and calculateDiffContainsUnitTestsOnly

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1083,8 +1083,13 @@ def acceptance(ctx):
                             print("Error: generated stage name of length", nameLength, "is not supported. The maximum length is " + str(maxLength) + ".", name)
                             errorFound = True
 
-                        # Basic steps and services for all testing
-                        steps = calculateDiffContainsUnitTestsOnly() + installNPM()
+                        steps = []
+
+                        if (params["earlyFail"]):
+                            steps += calculateDiffContainsUnitTestsOnly()
+
+                        steps += installNPM()
+
                         if (params["oc10IntegrationAppIncluded"]):
                             steps += buildWebApp()
                         else:


### PR DESCRIPTION
## Description
If someone puts `full-ci` in the PR  title, or sets `earlyFail` to false, then we should run all the CI - even if they only changed unit tests.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
