### PR TITLE
[full-ci][tests-only]Removed unused step for comparing with files in skeleton directory

### DIFF
--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -137,7 +137,7 @@ Feature: Sharing files and folders with internal groups
   @skip @issue-4102
   Scenario: share a folder with an internal group and a member unshares the folder
     Given user "Carol" has created folder "simple-folder"
-    And user "Carol" has created file "simple-folder/lorem.txt"
+    And user "Carol" has uploaded file with content "lorem content" to "simple-folder/lorem.txt"
     And user "Carol" has logged in using the webUI
     When the user renames folder "simple-folder" to "new-simple-folder" using the webUI
     And the user shares folder "new-simple-folder" with group "grp1" as "Editor" using the webUI
@@ -154,13 +154,13 @@ Feature: Sharing files and folders with internal groups
     Then folder "new-simple-folder" should be listed on the webUI
     When the user opens folder "new-simple-folder" using the webUI
     Then file "lorem.txt" should be listed on the webUI
-    And as "Brian" the content of "/Shares/new-simple-folder/lorem.txt" should be the same as the original "simple-folder/lorem.txt"
+    And the content of file "/Shares/new-simple-folder/lorem.txt" for user "Brian" should be "lorem content"
     # check that the folder is still visible for the share owner
     When the user re-logs in as "Carol" using the webUI
     Then folder "new-simple-folder" should be listed on the webUI
     When the user opens folder "new-simple-folder" using the webUI
     Then file "lorem.txt" should be listed on the webUI
-    And as "Carol" the content of "new-simple-folder/lorem.txt" should be the same as the original "simple-folder/lorem.txt"
+    And the content of file "/new-simple-folder/lorem.txt" for user "Carol" should be "lorem content"
 
   @issue-ocis-1277
   Scenario: user shares the file/folder with a group and delete the share with group

--- a/tests/acceptance/helpers/webdavHelper.js
+++ b/tests/acceptance/helpers/webdavHelper.js
@@ -4,7 +4,6 @@ const backendHelper = require('./backendHelper')
 const convert = require('xml-js')
 const _ = require('lodash/object')
 const { normalize, join, filename } = require('../helpers/path')
-const occHelper = require('../helpers/occHelper')
 
 const uploadTimeStamps = {}
 const deleteTimestamps = {}
@@ -241,21 +240,6 @@ exports.getProperties = function(path, userId, requestedProps) {
       return resolve(properties)
     })
   })
-}
-
-exports.getSkeletonFile = function(filename) {
-  return occHelper
-    .runOcc(['config:system:get', 'skeletondirectory'])
-    .then(resp => resp.ocs.data.stdOut)
-    .then(dir => {
-      const element = join(dir.trim(), filename)
-      const apiURL = `apps/testing/api/v1/file?file=${encodeURIComponent(element)}&absolute=true`
-      return httpHelper.getOCS(apiURL, 'admin')
-    })
-    .then(res => res.json())
-    .then(body => {
-      return decodeURIComponent(body.ocs.data[0].contentUrlEncoded)
-    })
 }
 
 exports.getFavouritedResources = function(user) {

--- a/tests/acceptance/stepDefinitions/generalContext.js
+++ b/tests/acceptance/stepDefinitions/generalContext.js
@@ -169,24 +169,6 @@ const assertContentOfLocalFileIsNot = function(fullPathOfLocalFile, expectedCont
   )
 }
 
-const assertRemoteFileSameAsSkeletonFile = async function(userId, remoteFile, skeletonFile) {
-  const skeleton = await webdavHelper.getSkeletonFile(skeletonFile)
-  const remote = await webdavHelper.download(userId, remoteFile)
-  return client.assert.strictEqual(
-    skeleton,
-    remote,
-    `Failed asserting remote file ${remoteFile} is same as skeleton file ${skeletonFile} for user${userId}`
-  )
-}
-
-Then('as {string} the content of {string} should be the same as the original {string}', function(
-  user,
-  remoteFile,
-  skeletonFile
-) {
-  return assertRemoteFileSameAsSkeletonFile(user, remoteFile, skeletonFile)
-})
-
 Given('the setting {string} of app {string} has been set to {string}', function(
   setting,
   app,


### PR DESCRIPTION
## Description
reviewed and removed the step
```
Then('as {string} the content of {string} should be the same as the original {string}', function(
  user,
  remoteFile,
  skeletonFile
) {
  return assertRemoteFileSameAsSkeletonFile(user, remoteFile, skeletonFile)
})
```

## Related Issue
- Part of https://github.com/owncloud/QA/issues/659

## How Has This Been Tested?
- 🤖 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 