### PR TITLE
[full-ci][tests-only]Removed skeletondirectory from system config

### DIFF
--- a/tests/drone/setup-fed-server-and-app.sh
+++ b/tests/drone/setup-fed-server-and-app.sh
@@ -11,7 +11,6 @@ else
 	php occ config:system:set trusted_domains 2 --value=federated
 	php occ log:manage --level "$2"
 	php occ config:list
-	php occ config:system:set skeletondirectory --value="$1"/apps/testing/data/webUISkeleton
 	php occ config:system:set sharing.federation.allowHttpFallback --value=true --type=bool
 	php occ config:system:set web.rewriteLinks --type=boolean --value=true
 fi

--- a/tests/drone/setup-server-and-app.sh
+++ b/tests/drone/setup-server-and-app.sh
@@ -18,7 +18,6 @@ else
 	php occ config:system:set trusted_domains 1 --value=owncloud
 	php occ log:manage --level $2
 	php occ config:list
-	php occ config:system:set skeletondirectory --value=$1/apps/testing/data/webUISkeleton
 	if [ "$3" == "builtInWeb" ]
 	then
 		php occ config:system:set web.baseUrl --value="http://owncloud/index.php/apps/web"


### PR DESCRIPTION
## Description
As all the tests in web are independent to the skeleton directory, the command `'php occ config:system:set skeletondirectory --value=/var/www/owncloud/server/apps/testing/data/webUISkeleton',` is not necessary.

## Related Issue
- Fixes https://github.com/owncloud/QA/issues/659
-  Fixes https://github.com/owncloud/QA/issues/628

## How Has This Been Tested?
- 🤖 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
