### PR TITLE
[tests-only] Use correct skeleton file in tests

### DIFF
--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -12,7 +12,7 @@ Feature: restrict Sharing
       | Alice    |
       | Brian    |
       | Carol    |
-    And these users have been created but not initialized:
+    And these users have been created without initialization and without skeleton files:
       | username  | password  | displayname     | email             |
       | Alison    | %regular% | Alison Cooper   | alson@oc.com.np   |
     And these groups have been created:

--- a/tests/acceptance/stepDefinitions/provisioningContext.js
+++ b/tests/acceptance/stepDefinitions/provisioningContext.js
@@ -240,21 +240,6 @@ Given(
   }
 )
 
-Given('these users have been created but not initialized:', function(dataTable) {
-  codify.replaceInlineTable(dataTable)
-  return Promise.all(
-    dataTable.hashes().map(user => {
-      const userId = user.username
-      const password = user.password || userSettings.getPasswordForUser(userId)
-      const displayName = user.displayname || false
-      const email = user.email || false
-      return deleteUser(userId).then(() =>
-        createUser(userId, password, displayName, email, 'large')
-      )
-    })
-  )
-})
-
 Given(
   /^these users have been created without initialization and (without|small|large) skeleton files:$/,
   function(skeletonType, dataTable) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
This PR removes the incorrect test step and replaces it with the new one and also removes the unused step-definition

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- part of : https://github.com/owncloud/QA/issues/659

## Motivation and Context
We had a issue to remove the use of skeleton files and use the correct ones when needed. This file seem to have been missed during that refactoring process.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally
-  CI 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...