### PR TITLE
[full-ci] [tests-only] investigate unexpected passes not reporting

### DIFF
--- a/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
+++ b/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
@@ -19,10 +19,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 ### [webUILogin/adminBlocksUser.feature:20 behaves differently on CI](https://github.com/owncloud/web/issues/4743)
 -   [webUILogin/adminBlocksUser.feature:20](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/adminBlocksUser.feature#L120)
 
-### [sorting for files lists needs to be reimplemented](https://github.com/owncloud/ocis/issues/1179)
--   [webUIFilesList/sort.feature:51](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesList/sort.feature#L51)
--   [webUIFilesList/sort.feature:72](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesList/sort.feature#L72)
-
 ### [regression in accepting shares from notifications](https://github.com/owncloud/web/issues/4839)
 -   [webUISharingNotificationsToRoot/shareWithUsers.feature:40](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingNotificationsToRoot/shareWithUsers.feature#L40)
 
@@ -75,8 +71,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIAdminSettings/helpAndTips.feature:18](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIAdminSettings/helpAndTips.feature#L18)
 -   [webUIAdminSettings/helpAndTips.feature:19](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIAdminSettings/helpAndTips.feature#L19)
 -   [webUIAdminSettings/helpAndTips.feature:20](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIAdminSettings/helpAndTips.feature#L20)
--   [webUISharingInternalGroups/shareWithGroups.feature:166](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature#L166)
--   [webUISharingInternalGroups/shareWithGroups.feature:174](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature#L174)
 
 ### [Comments in sidebar] (https://github.com/owncloud/web/issues/1158)
 -   [webUIComments/comments.feature:25](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIComments/comments.feature#L25)
@@ -93,7 +87,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 
 ### [Tags page not implemented yet] (https://github.com/owncloud/web/issues/5017)
 -   [webUIDeleteFilesFolders/deleteFilesFolders.feature:144](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L144)
--   [webUIFilesDetails/fileDetails.feature:141](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesDetails/fileDetails.feature#L141)
 -   [webUIFilesSearch/search.feature:63](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L63)
 -   [webUIFilesSearch/search.feature:71](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L71)
 -   [webUIFilesSearch/search.feature:84](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L84)

--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -397,11 +397,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIFilesDetails/fileDetails.feature:116](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesDetails/fileDetails.feature#L116)
 -   [webUIFilesDetails/fileDetails.feature:143](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesDetails/fileDetails.feature#L143)
 
-
-
-### [Groups endpoint does not exist](https://github.com/owncloud/ocis-reva/issues/34)
--   [webUIRestrictSharing/restrictSharing.feature:49](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature:49)
-
 ### [Group shares support](https://github.com/owncloud/ocis/issues/1289)
 -   [webUISharingInternalGroupsSharingIndicator/shareWithGroups.feature:80](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalGroupsSharingIndicator/shareWithGroups.feature#L80)
 
@@ -500,4 +495,3 @@ Other free text and markdown formatting can be used elsewhere in the document if
 
 ### [Uploading folders does not work in files-drop] (https://github.com/owncloud/web/issues/2443)
 -   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:248](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L248)
-

--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -20,13 +20,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 ### [Exit page re-appears in loop when logged in user is deleted](https://github.com/owncloud/web/issues/4677)
 -   [webUILogin/openidLogin.feature:53](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/openidLogin.feature#L53)
 
-### [User request using token and basic authentication gives different display names](https://github.com/owncloud/ocis/issues/1312)
--   [webUIAccount/accountInformation.feature:10](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIAccount/accountInformation.feature#L10)
--   [webUIAccount/accountInformation.feature:34](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIAccount/accountInformation.feature#L34)
-
-### [LDAP Groups not working with konnectd](https://github.com/owncloud/ocis-konnectd/issues/42)
--   [webUIAccount/accountInformation.feature:20](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIAccount/accountInformation.feature#L20)
-
 ### [REPORT request not implemented](https://github.com/owncloud/ocis/issues/1330)
 -   [webUIDeleteFilesFolders/deleteFilesFolders.feature:295](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L295)
 -   [webUIFavorites/favoritesFile.feature:14](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFavorites/favoritesFile.feature#L14)
@@ -50,8 +43,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 
 ### [Sharing seems to work but does not work](https://github.com/owncloud/ocis/issues/1303)
 -   [webUIDeleteFilesFolders/deleteFilesFolders.feature:235](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L235)
--   [webUIFilesDetails/fileDetails.feature:97](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesDetails/fileDetails.feature#L97)
--   [webUIFilesDetails/fileDetails.feature:114](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesDetails/fileDetails.feature#L114)
 -   [webUIFilesActionMenu/versions.feature:36](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L36)
 -   [webUIRenameFiles/renameFiles.feature:202](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFiles/renameFiles.feature#L202)
 -   [webUIRenameFiles/renameFiles.feature:227](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFiles/renameFiles.feature#L227)
@@ -392,10 +383,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [apiSharees/sharees.feature:702](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharees/sharees.feature#L702)
 -   [apiSharees/sharees.feature:703](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharees/sharees.feature#L703)
 
-### [sorting for files lists needs to be reimplemented](https://github.com/owncloud/ocis/issues/1179)
--   [webUIFilesList/sort.feature:51](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesList/sort.feature#L51)
--   [webUIFilesList/sort.feature:72](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesList/sort.feature#L72)
-
 
 ### [Comments in sidebar] (https://github.com/owncloud/web/issues/1158)
 -   [webUIComments/comments.feature:25](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIComments/comments.feature#L25)
@@ -478,7 +465,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 
 ### [Tags page not implemented yet] (https://github.com/owncloud/web/issues/5017)
 -   [webUIDeleteFilesFolders/deleteFilesFolders.feature:144](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L144)
--   [webUIFilesDetails/fileDetails.feature:141](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesDetails/fileDetails.feature#L141)
 -   [webUIFilesSearch/search.feature:63](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L63)
 -   [webUIFilesSearch/search.feature:71](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L71)
 -   [webUIFilesSearch/search.feature:84](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L84)
@@ -514,3 +500,4 @@ Other free text and markdown formatting can be used elsewhere in the document if
 
 ### [Uploading folders does not work in files-drop] (https://github.com/owncloud/web/issues/2443)
 -   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:248](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L248)
+

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -278,7 +278,8 @@ if [ -n "${EXPECTED_FAILURES_FILE}" ]; then
     EXPECTED_FAILURE_SUITE=$(dirname "${LINE}")
 
     for SUITE_IN_THIS_RUN in "${SUITES_IN_THIS_RUN[@]}"; do
-      if [ "${SUITE_IN_THIS_RUN}" == "${EXPECTED_FAILURE_SUITE}" ]
+      SUITE_IN_RUN="$(basename "${SUITE_IN_THIS_RUN}")"
+      if [ "${SUITE_IN_RUN}" == "${EXPECTED_FAILURE_SUITE}" ]
       then
         # This line in the expected failures file is for a suite that has been run.
         # So we expect that the scenario in LINE has run and failed.


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
If a test that was expected to fail passes then CI should report it and the build should be cancelled but it was not happening. This PR solves that problem and makes the CI report unexpected passes and removes the passing tests from expected to fail file.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/5356

## Motivation and Context
As unexpected passes were not reported it was confusing to see tests failing out of nowhere. We weren't sure if the line of test-step has been changed or new tests were failing , we also didn't know about the passing test that were in expected to fail file.

The changes made in this PR 
- Add new variable `SUITE_IN_RUN` which contains the suite that is in run ie `webUILogin`, previously  we had `SUITE_IN_THIS_RUN` which contained the full path of the test suite which was the reason behind passed suites not being reported.
- Remove passing tests from expected to fail file

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
-  CI
-  locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...