### PR TITLE
[unit-tests-only] move typescript tests to unit folder

### DIFF
--- a/packages/web-pkg/tests/unit/cache/cache.spec.ts
+++ b/packages/web-pkg/tests/unit/cache/cache.spec.ts
@@ -1,4 +1,4 @@
-import Cache from './cache'
+import Cache from '../../../src/cache/cache'
 
 const newCache = <T>(vs: T[], ttl?: number, capacity?: number): Cache<number, T> => {
   const cache = new Cache<number, T>({ ttl, capacity })

--- a/packages/web-pkg/tests/unit/http/client.spec.ts
+++ b/packages/web-pkg/tests/unit/http/client.spec.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from './client'
+import { HttpClient } from '../../../src/http'
 import mockAxios from 'jest-mock-axios'
 
 beforeEach(mockAxios.reset)

--- a/packages/web-pkg/tests/unit/observer/visibility.spec.ts
+++ b/packages/web-pkg/tests/unit/observer/visibility.spec.ts
@@ -1,4 +1,4 @@
-import { VisibilityObserver } from './visibility'
+import { VisibilityObserver } from '../../../src/observer'
 
 let callback
 let mockIntersectionObserver

--- a/packages/web-pkg/tests/unit/utils/encodePath.spec.ts
+++ b/packages/web-pkg/tests/unit/utils/encodePath.spec.ts
@@ -1,4 +1,4 @@
-import { encodePath } from './encodePath'
+import { encodePath } from '../../../src/utils'
 
 describe('encodePath', () => {
   it('is empty if input is empty', () => {

--- a/packages/web-pkg/tests/unit/utils/objectKeys.spec.ts
+++ b/packages/web-pkg/tests/unit/utils/objectKeys.spec.ts
@@ -1,4 +1,4 @@
-import { objectKeys } from './objectKeys'
+import { objectKeys } from '../../../src/utils'
 
 describe('objectKeys', () => {
   it('should return the correct keys', () => {


### PR DESCRIPTION
## Description
move tests to unit test folder, following the pattern set by #5224 and finally decided by #5425

fixes #5471

after this PR all spec files should be in the right place:
```
find -name *spec.* | grep -v node_modules
./packages/web-pkg/tests/unit/utils/encodePath.spec.ts
./packages/web-pkg/tests/unit/utils/objectKeys.spec.ts
./packages/web-pkg/tests/unit/observer/visibility.spec.ts
./packages/web-pkg/tests/unit/cache/cache.spec.ts
./packages/web-pkg/tests/unit/http/client.spec.ts
./packages/web-app-files/tests/unit/views/Favorites.spec.js
./packages/web-app-files/tests/unit/mixins.spec.js
./packages/web-app-files/tests/unit/mixins/collaborators.spec.js
./packages/web-app-files/tests/unit/services/client.spec.ts
./packages/web-app-files/tests/unit/services/cache.spec.ts
./packages/web-app-files/tests/unit/store/mutations.spec.js
./packages/web-app-files/tests/unit/store/getters.spec.js
./packages/web-app-files/tests/unit/helpers/path.spec.js
./packages/web-app-files/tests/unit/helpers/user/avatarUrl.spec.ts
./packages/web-app-files/tests/unit/helpers/share/triggerShareAction.spec.js
./packages/web-app-files/tests/unit/helpers/resource/asset.spec.ts
./packages/web-app-files/tests/unit/helpers/resource/common.spec.ts
./packages/web-app-files/tests/unit/helpers/resource/privatePreviewBlob.spec.ts
./packages/web-app-files/tests/unit/helpers/resource/publicPreviewUrl.spec.ts
./packages/web-app-files/tests/unit/components/AppBar/SelectedResources/BatchActions.spec.js
./packages/web-app-files/tests/unit/components/AppBar/AppBar.spec.js
./packages/web-app-files/tests/unit/components/AppBar/Upload/FileUpload.spec.js
./packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/ShowCollaborator.spec.js
./packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/AutocompleteItem.spec.js
./packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.js
./packages/web-app-files/tests/integration/specs/pagination.spec.js
./packages/web-runtime/tests/unit/mixins/lifecycleMixin.spec.js
./packages/web-runtime/tests/unit/mixins/focusMixin.spec.js
./packages/web-runtime/tests/unit/store/config.spec.js
./packages/web-runtime/tests/unit/helpers/config.spec.js
./packages/web-runtime/tests/unit/helpers/resource.spec.js
./packages/web-runtime/tests/unit/helpers/theme.spec.js
./packages/web-runtime/tests/unit/components/Notification.spec.js
./packages/web-runtime/tests/unit/components/UserMenu.spec.js
./packages/web-runtime/tests/unit/components/__snapshots__/TopBar.spec.js.snap
./packages/web-runtime/tests/unit/components/SidebarQuota.spec.js
./packages/web-runtime/tests/unit/components/TopBar.spec.js
```

## Motivation and Context
fixing sonar cloud coverage report

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
