### PR TITLE
[unit-tests-only] ignore mocks and fixtures for coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -32,4 +32,4 @@ sonar.pullrequest.key=${env.SONAR_PULL_REQUEST_KEY}
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 
 # Exclude files
-sonar.exclusions=docs/**,node_modules/**,deployments/**,**/tests/**,dist/**,changelog/**,config/**,docker/**,release/**,**/package.json,package.json,rollup.config.js,nightwatch.conf.js,Makefile,Makefile.release,CHANGELOG.md,README.md
+sonar.exclusions=docs/**,node_modules/**,deployments/**,**/tests/**,__mocks__/**,__fixtures__/**,dist/**,changelog/**,config/**,docker/**,release/**,**/package.json,package.json,rollup.config.js,nightwatch.conf.js,Makefile,Makefile.release,CHANGELOG.md,README.md


### PR DESCRIPTION
## Description
ignore test related files for sonar cloud analysis
maybe they could also be moved into the `tests` folder and by that they would be ignored altogether see #5412

## Motivation and Context
correct sonarcloud coverage report

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
