### PR TITLE
Apply CSP rules for onlyoffice and richdocuments

### DIFF
--- a/changelog/unreleased/enhancement-oc10-web-csp
+++ b/changelog/unreleased/enhancement-oc10-web-csp
@@ -1,0 +1,5 @@
+Enhancement: Content Security Policy for known iframe integrations
+
+We added CSP rules for allowing iframe integrations of the onlyoffice and richdocuments documentservers.
+
+https://github.com/owncloud/web/pull/5420

--- a/packages/web-integration-oc10/lib/Controller/FilesController.php
+++ b/packages/web-integration-oc10/lib/Controller/FilesController.php
@@ -141,29 +141,16 @@ class FilesController extends Controller {
     }
 
     /**
-     * Extracts the onlyoffice document server URL from the app-config or system-config, in the same manner
-     * like the onlyoffice connector app:
-     * - https://github.com/ONLYOFFICE/onlyoffice-owncloud/blob/34f69c833ee4b00880d538aed1ecc48025ac8791/lib/appconfig.php#L379
-     * - https://github.com/ONLYOFFICE/onlyoffice-owncloud/blob/34f69c833ee4b00880d538aed1ecc48025ac8791/lib/appconfig.php#L278
+     * Extracts the onlyoffice document server URL from the app
      *
      * @return string
      */
     private function getOnlyOfficeDocumentServerUrl(): string {
-        $appName = 'onlyoffice';
-        $documentServerKey = 'DocumentServerUrl';
-        $documentServerUrl = $this->config->getAppValue($appName, $documentServerKey);
-        if (!empty($documentServerUrl)) {
-            return $documentServerUrl;
+        if (!class_exists("\OCA\Onlyoffice\AppConfig")) {
+            return "";
         }
-        $documentServerUrl = $this->config->getSystemValue($documentServerKey);
-        if (!empty($documentServerUrl)) {
-            return $documentServerUrl;
-        }
-        $onlyOfficeConfig = $this->config->getSystemValue($appName);
-        if (\is_array($onlyOfficeConfig) && \array_key_exists($documentServerKey, $onlyOfficeConfig)) {
-            return $onlyOfficeConfig[$documentServerKey];
-        }
-        return "";
+        $onlyofficeConfig = new \OCA\Onlyoffice\AppConfig("onlyoffice");
+        return $onlyofficeConfig->GetDocumentServerUrl();
     }
 
     private function applyCSPRichDocuments(ContentSecurityPolicy $csp): ContentSecurityPolicy {

--- a/packages/web-integration-oc10/lib/Controller/FilesController.php
+++ b/packages/web-integration-oc10/lib/Controller/FilesController.php
@@ -129,11 +129,14 @@ class FilesController extends Controller {
 	}
 
 	private function applyCSPOnlyOffice(ContentSecurityPolicy $csp): ContentSecurityPolicy {
-        $documentServerUrl = $this->extractDomain($this->getOnlyOfficeDocumentServerUrl());
+        $ooUrl = $this->getOnlyOfficeDocumentServerUrl();
+        $documentServerUrl = $this->extractDomain($ooUrl);
         if (!empty($documentServerUrl)) {
             $csp->addAllowedScriptDomain($documentServerUrl);
             $csp->addAllowedFrameDomain($documentServerUrl);
-        }
+        } else if (!empty($ooUrl)) {
+            $csp->addAllowedFrameDomain("'self'");
+	}
         return $csp;
     }
 

--- a/packages/web-integration-oc10/lib/Controller/FilesController.php
+++ b/packages/web-integration-oc10/lib/Controller/FilesController.php
@@ -149,7 +149,7 @@ class FilesController extends Controller {
         if (!class_exists("\OCA\Onlyoffice\AppConfig")) {
             return "";
         }
-        $onlyofficeConfig = new \OCA\Onlyoffice\AppConfig("onlyoffice");
+        $onlyofficeConfig = \OC::$server->query(\OCA\Onlyoffice\AppConfig::class);
         return $onlyofficeConfig->GetDocumentServerUrl();
     }
 
@@ -168,15 +168,14 @@ class FilesController extends Controller {
      * - https://github.com/owncloud/richdocuments/blob/9a23f426048c540793fc16119f71a44c26077f16/lib/Controller/DocumentController.php#L393
      *
      * @return string
+     * @throws \OCP\AppFramework\QueryException
      */
     private function getRichDocumentsServerUrl(): string {
-        $appName = 'richdocuments';
-        $documentServerKey = 'wopi_url';
-        $documentServerUrl = $this->config->getAppValue($appName, $documentServerKey);
-        if (!empty($documentServerUrl)) {
-            return $documentServerUrl;
+        if (!class_exists("\OCA\Richdocuments\AppConfig")) {
+            return "";
         }
-        return "";
+        $richdocumentsConfig = \OC::$server->query(\OCA\Richdocuments\AppConfig::class);
+        return $richdocumentsConfig->getAppValue('wopi_url');
     }
 
     /**


### PR DESCRIPTION
## Description
The iframe integrations of the documentserver coming from onlyoffice / richdocuments need certain CSP rules. With this PR we're extracting the respective documentserver domains from the two apps. We'll work on a generic solution when it becomes relevant.

## Motivation and Context
Enable onlyoffice to build an integration of their documentserver into a web extension.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 