### PR TITLE
extract loadPreview into helper

### DIFF
--- a/packages/web-app-files/src/helpers/resource/asset.ts
+++ b/packages/web-app-files/src/helpers/resource/asset.ts
@@ -1,0 +1,47 @@
+import { privatePreviewBlob } from './privatePreviewBlob'
+import { publicPreviewUrl } from './publicPreviewUrl'
+
+export const loadPreview = async (
+  {
+    resource,
+    isPublic,
+    dimensions,
+    server,
+    userId,
+    token
+  }: {
+    resource: any
+    isPublic: boolean
+    dimensions: [number, number]
+    server?: string
+    userId?: string
+    token?: string
+  },
+  cached = false
+): Promise<string> => {
+  let preview = ''
+  if (resource.type === 'folder' || !resource.extension) {
+    return preview
+  }
+
+  if (!isPublic && (!server || !userId || !token)) {
+    return preview
+  }
+
+  if (isPublic) {
+    preview = await publicPreviewUrl({ resource, dimensions })
+  } else {
+    preview = await privatePreviewBlob(
+      {
+        server,
+        userId,
+        token,
+        resource,
+        dimensions
+      },
+      cached
+    )
+  }
+
+  return preview
+}

--- a/packages/web-app-files/src/helpers/resource/index.ts
+++ b/packages/web-app-files/src/helpers/resource/index.ts
@@ -1,2 +1,3 @@
+export * from './asset'
 export * from './privatePreviewBlob'
 export * from './publicPreviewUrl'

--- a/packages/web-app-files/src/store/actions.js
+++ b/packages/web-app-files/src/store/actions.js
@@ -4,7 +4,7 @@ import { getParentPaths } from '../helpers/path'
 import { shareTypes } from '../helpers/shareTypes'
 import { buildResource, buildShare, buildCollaboratorShare } from '../helpers/resources'
 import { $gettext, $gettextInterpolate } from '../gettext'
-import { privatePreviewBlob, publicPreviewUrl } from '../helpers/resource'
+import { loadPreview } from '../helpers/resource'
 import { avatarUrl } from '../helpers/user'
 import { has } from 'lodash-es'
 
@@ -532,29 +532,23 @@ export default {
 
   async loadPreview({ commit, rootGetters }, { resource, isPublic, dimensions }) {
     if (
-      resource.type === 'folder' ||
-      !resource.extension ||
-      (rootGetters.previewFileExtensions.length &&
-        !rootGetters.previewFileExtensions.includes(resource.extension))
+      rootGetters.previewFileExtensions.length &&
+      !rootGetters.previewFileExtensions.includes(resource.extension)
     ) {
       return
     }
 
-    let preview
-    if (isPublic) {
-      preview = await publicPreviewUrl({ resource, dimensions })
-    } else {
-      preview = await privatePreviewBlob(
-        {
-          server: rootGetters.configuration.server,
-          userId: rootGetters.user.id,
-          token: rootGetters.getToken,
-          resource,
-          dimensions
-        },
-        true
-      )
-    }
+    const preview = await loadPreview(
+      {
+        resource,
+        isPublic,
+        dimensions,
+        server: rootGetters.configuration.server,
+        userId: rootGetters.user.id,
+        token: rootGetters.getToken
+      },
+      true
+    )
 
     if (preview) {
       commit('UPDATE_RESOURCE_FIELD', { id: resource.id, field: 'preview', value: preview })

--- a/packages/web-app-files/tests/unit/helpers/resource/asset.spec.ts
+++ b/packages/web-app-files/tests/unit/helpers/resource/asset.spec.ts
@@ -1,0 +1,83 @@
+import { loadPreview } from '../../../../src/helpers/resource'
+
+jest.mock('../../../../src/helpers/resource/publicPreviewUrl', () => ({
+  publicPreviewUrl: jest.fn().mockReturnValue('publicPreviewUrl')
+}))
+
+jest.mock('../../../../src/helpers/resource/privatePreviewBlob', () => ({
+  privatePreviewBlob: jest.fn().mockReturnValue('privatePreviewBlob')
+}))
+
+describe('loadPreview', () => {
+  it('returns empty string if resource is a folder', async () => {
+    const preview = await loadPreview({
+      resource: { type: 'folder' },
+      isPublic: true,
+      dimensions: [0, 0]
+    })
+
+    expect(preview).toBe('')
+  })
+
+  it('returns empty string if resource has no extension', async () => {
+    const preview = await loadPreview({
+      resource: {},
+      isPublic: true,
+      dimensions: [0, 0]
+    })
+
+    expect(preview).toBe('')
+  })
+
+  it('returns empty string if is private but no server, userId or token is given', async () => {
+    await expect(
+      loadPreview({
+        resource: { extension: 'jpg' },
+        isPublic: false,
+        dimensions: [0, 0]
+      })
+    ).resolves.toBe('')
+
+    await expect(
+      loadPreview({
+        resource: { extension: 'jpg' },
+        isPublic: false,
+        dimensions: [0, 0],
+        server: 'server'
+      })
+    ).resolves.toBe('')
+
+    await expect(
+      loadPreview({
+        resource: { extension: 'jpg' },
+        isPublic: false,
+        dimensions: [0, 0],
+        server: 'server',
+        userId: 'userId'
+      })
+    ).resolves.toBe('')
+  })
+
+  it('returns a publicPreviewUrl', async () => {
+    await expect(
+      loadPreview({
+        resource: { extension: 'jpg' },
+        isPublic: true,
+        dimensions: [0, 0]
+      })
+    ).resolves.toBe('publicPreviewUrl')
+  })
+
+  it('returns a privatePreviewBlob', async () => {
+    await expect(
+      loadPreview({
+        resource: { extension: 'jpg' },
+        isPublic: false,
+        dimensions: [0, 0],
+        server: 'server',
+        userId: 'userId',
+        token: 'token'
+      })
+    ).resolves.toBe('privatePreviewBlob')
+  })
+})

--- a/packages/web-app-files/tests/unit/helpers/resource/privatePreviewBlob.spec.ts
+++ b/packages/web-app-files/tests/unit/helpers/resource/privatePreviewBlob.spec.ts
@@ -60,7 +60,7 @@ describe('privatePreviewBlob', () => {
     await expect(window.URL.createObjectURL).toHaveBeenCalledWith('data')
 
     privatePreviewBlobPromise = privatePreviewBlob(
-      merge({ resource: { etag: 'other' }, dimensions: [10, 10] }, defaultOptions),
+      merge({ resource: { etag: 'other' }, dimensions: [10, 10] }, defaultOptions) as any,
       true
     )
     mockAxios.mockResponse({ data: 'data' })


### PR DESCRIPTION
## Description
in the past loadPreview only was needed from within vuex store, with the upcoming preview feature and search // filter it is required to be able to use preview loading outside the store too. This pr utilize loadPreview and make it available as a helper.

## Related Issue
- required for https://github.com/owncloud/web/pull/5415
- required for https://github.com/owncloud/web/issues/5161

## Motivation and Context
extract more and more logic out of vuex

## How Has This Been Tested?
- local installation and unit tests
- ...

## Screenshots (if appropriate):
-
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Technical debt
- [X] Tests

## Checklist:
- [X] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
-