### PR TITLE
Allow onlyoffice on the same domain

### DIFF
--- a/packages/web-integration-oc10/lib/Controller/FilesController.php
+++ b/packages/web-integration-oc10/lib/Controller/FilesController.php
@@ -129,11 +129,14 @@ class FilesController extends Controller {
 	}
 
 	private function applyCSPOnlyOffice(ContentSecurityPolicy $csp): ContentSecurityPolicy {
-        $documentServerUrl = $this->extractDomain($this->getOnlyOfficeDocumentServerUrl());
+        $ooUrl = $this->getOnlyOfficeDocumentServerUrl();
+        $documentServerUrl = $this->extractDomain($ooUrl);
         if (!empty($documentServerUrl)) {
             $csp->addAllowedScriptDomain($documentServerUrl);
             $csp->addAllowedFrameDomain($documentServerUrl);
-        }
+        } else if (!empty($ooUrl)) {
+            $csp->addAllowedFrameDomain("'self'");
+	}
         return $csp;
     }
 


### PR DESCRIPTION
These edits must be included in the request https://github.com/owncloud/web/pull/5420

It is possible to connect ONLYOFFICE with a relative path. https://github.com/onlyoffice/docker-onlyoffice-owncloud
Then the address for the editor is relative `/ds-vpath/`:
https://github.com/ONLYOFFICE/docker-onlyoffice-owncloud/blob/790ef3ccf88ec0a5ec856f703c5066fd3997e074/run.sh#L10

The old solution has a similar action:
https://github.com/ONLYOFFICE/onlyoffice-owncloud/blob/34f69c833ee4b00880d538aed1ecc48025ac8791/controller/editorcontroller.php#L762

@kulmann @pmaier1 Thanks