### PR TITLE
Fix delete batch action in read only shares

### DIFF
--- a/changelog/unreleased/bugfix-delete-batch-action-in-viewer-shares
+++ b/changelog/unreleased/bugfix-delete-batch-action-in-viewer-shares
@@ -1,0 +1,5 @@
+Bugfix: Batch action for deleting adhering permissions
+
+We fixed that the batch actions for deleting files and folders was showing for shares that only have viewer permissions.
+
+https://github.com/owncloud/web/pull/5441

--- a/packages/web-app-files/src/components/AppBar/SelectedResources/BatchActions.vue
+++ b/packages/web-app-files/src/components/AppBar/SelectedResources/BatchActions.vue
@@ -114,11 +114,10 @@ export default {
         return false
       }
 
-      const insufficientPermissions = this.selectedFiles.some(resource => {
+      const moveDisabled = this.selectedFiles.some(resource => {
         return canBeMoved(resource, this.currentFolder.path) === false
       })
-
-      return insufficientPermissions === false
+      return !moveDisabled
     },
 
     canCopy() {
@@ -144,32 +143,32 @@ export default {
         return this.currentFolder.canBeDeleted()
       }
 
-      return true
+      const deleteDisabled = this.selectedFiles.some(resource => {
+        return !resource.canBeDeleted()
+      })
+      return !deleteDisabled
     },
 
     canAccept() {
       if (!this.isSharedWithMeRoute) {
         return false
       }
-      let canAccept = true
-      this.selectedFiles.forEach(file => {
-        if (file.status === shareStatus.accepted) {
-          canAccept = false
-        }
-      })
 
-      return canAccept
+      const acceptDisabled = this.selectedFiles.some(resource => {
+        return resource.status === shareStatus.accepted
+      })
+      return !acceptDisabled
     },
 
     canDecline() {
       if (!this.isSharedWithMeRoute) {
         return false
       }
-      let canDecline = true
-      this.selectedFiles.forEach(file => {
-        if (file.status === shareStatus.declined) canDecline = false
+
+      const declineDisabled = this.selectedFiles.some(resource => {
+        return resource.status === shareStatus.declined
       })
-      return canDecline
+      return !declineDisabled
     },
 
     displayBulkActions() {
@@ -184,7 +183,7 @@ export default {
   methods: {
     ...mapActions('Files', ['removeFilesFromTrashbin', 'resetFileSelection', 'setHighlightedFile']),
     ...mapActions(['showMessage']),
-    ...mapMutations('Files', ['SELECT_RESOURCES', 'UPDATE_RESOURCE']),
+    ...mapMutations('Files', ['UPDATE_RESOURCE']),
 
     restoreFiles(resources = this.selectedFiles) {
       for (const resource of resources) {
@@ -281,7 +280,7 @@ export default {
       await Promise.all(triggerPromises)
 
       if (errors.length === 0) {
-        this.SELECT_RESOURCES([])
+        this.resetFileSelection()
         return
       }
 

--- a/packages/web-app-files/src/helpers/resources.js
+++ b/packages/web-app-files/src/helpers/resources.js
@@ -196,12 +196,21 @@ export function buildSharedResource(share, incomingShares = false, allowSharePer
   // FIXME: add actual permission parsing
   resource.canUpload = () => true
   resource.canBeDeleted = () => {
+    if (!resource.isReceivedShare()) {
+      return true
+    }
     return checkPermission(share.permissions, 'delete')
   }
   resource.canRename = () => {
+    if (!resource.isReceivedShare()) {
+      return true
+    }
     return checkPermission(share.permissions, 'update')
   }
   resource.canShare = () => {
+    if (!resource.isReceivedShare()) {
+      return true
+    }
     return checkPermission(share.permissions, 'share')
   }
   resource.isMounted = () => false

--- a/packages/web-app-files/src/helpers/resources.js
+++ b/packages/web-app-files/src/helpers/resources.js
@@ -195,8 +195,12 @@ export function buildSharedResource(share, incomingShares = false, allowSharePer
   resource.extension = isFolder ? '' : _getFileExtension(resource.name)
   // FIXME: add actual permission parsing
   resource.canUpload = () => true
-  resource.canBeDeleted = () => true
-  resource.canRename = () => true
+  resource.canBeDeleted = () => {
+    return checkPermission(share.permissions, 'delete')
+  }
+  resource.canRename = () => {
+    return checkPermission(share.permissions, 'update')
+  }
   resource.canShare = () => {
     return checkPermission(share.permissions, 'share')
   }

--- a/packages/web-app-files/tests/unit/components/BatchActions.spec.js
+++ b/packages/web-app-files/tests/unit/components/BatchActions.spec.js
@@ -77,6 +77,7 @@ describe('Batch Actions component', () => {
       let deleteButton
 
       BatchActions.computed.canMove = jest.fn(() => true)
+      BatchActions.computed.canDelete = jest.fn(() => true)
       const spyTriggerLocationPicker = jest
         .spyOn(BatchActions.methods, 'triggerLocationPicker')
         .mockImplementation()


### PR DESCRIPTION
## Description
This PR fixes that we showed the batch action for deleting files/folders for read only shares. Additionally we return early in the batch action availability checks.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
