### PR TITLE
Make view options button less prominent

### DIFF
--- a/changelog/unreleased/enhancement-add-view-options
+++ b/changelog/unreleased/enhancement-add-view-options
@@ -5,3 +5,4 @@ Currently, it is possible to toggle visibility of hidden files.
 Changes in view options are persisted in local storage.
 
 https://github.com/owncloud/web/pull/5408
+https://github.com/owncloud/web/pull/5450

--- a/packages/web-app-files/src/components/AppBar/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar/AppBar.vue
@@ -105,13 +105,19 @@
           data-test-id="files-view-options-btn"
           :aria-label="viewButtonAriaLabel"
           variation="passive"
-          appearance="outline"
+          appearance="raw"
           size="small"
+          gap-size="xsmall"
         >
           <oc-icon name="tune" size="small" />
           <translate>View</translate>
         </oc-button>
-        <oc-drop drop-id="files-view-options-drop" toggle="#files-view-options-btn" mode="click">
+        <oc-drop
+          drop-id="files-view-options-drop"
+          toggle="#files-view-options-btn"
+          mode="click"
+          class="uk-width-auto"
+        >
           <oc-list>
             <li>
               <oc-switch


### PR DESCRIPTION
This PR makes the `view options` button less prominent by giving it a `raw` appearance, making the gap size of the button smaller and shrinking the width of the drop to the actually needed size.

<img width="1416" alt="Screenshot 2021-07-05 at 17 06 05" src="https://user-images.githubusercontent.com/3532843/124491269-5af7b600-ddb3-11eb-802a-114fcc9cb292.png">
<img width="1415" alt="Screenshot 2021-07-05 at 17 06 12" src="https://user-images.githubusercontent.com/3532843/124491275-5c28e300-ddb3-11eb-99bc-0bb1d048fe86.png">
