### PR TITLE
fix: copy action permission check

### DIFF
--- a/changelog/unreleased/bugfix-copy-action-permissions
+++ b/changelog/unreleased/bugfix-copy-action-permissions
@@ -1,0 +1,6 @@
+Bugfix: Copy action permission
+
+Prevent copy action from being shown when the user does not have the relevant permission.
+
+https://github.com/owncloud/web/pull/5475
+https://github.com/owncloud/web/issues/5452

--- a/packages/web-app-files/src/components/AppBar/SelectedResources/BatchActions.vue
+++ b/packages/web-app-files/src/components/AppBar/SelectedResources/BatchActions.vue
@@ -127,11 +127,7 @@ export default {
         return false
       }
 
-      if (this.isPublicFilesRoute) {
-        return this.currentFolder.canCreate()
-      }
-
-      return true
+      return this.currentFolder.canCreate()
     },
 
     canDelete() {

--- a/packages/web-app-files/src/components/AppBar/SelectedResources/BatchActions.vue
+++ b/packages/web-app-files/src/components/AppBar/SelectedResources/BatchActions.vue
@@ -127,7 +127,7 @@ export default {
         return false
       }
 
-      return this.currentFolder.canCreate()
+      return this.currentFolder?.canCreate()
     },
 
     canDelete() {

--- a/packages/web-app-files/src/mixins/actions/copy.js
+++ b/packages/web-app-files/src/mixins/actions/copy.js
@@ -22,7 +22,7 @@ export default {
               return false
             }
 
-            return this.currentFolder.canCreate()
+            return this.currentFolder?.canCreate()
           },
           componentType: 'oc-button',
           class: 'oc-files-actions-sidebar-copy-trigger'

--- a/packages/web-app-files/src/mixins/actions/copy.js
+++ b/packages/web-app-files/src/mixins/actions/copy.js
@@ -22,11 +22,7 @@ export default {
               return false
             }
 
-            if (this.publicPage()) {
-              return this.currentFolder.canCreate()
-            }
-
-            return true
+            return this.currentFolder.canCreate()
           },
           componentType: 'oc-button',
           class: 'oc-files-actions-sidebar-copy-trigger'

--- a/packages/web-app-files/tests/unit/components/AppBar/SelectedResources/BatchActions.spec.js
+++ b/packages/web-app-files/tests/unit/components/AppBar/SelectedResources/BatchActions.spec.js
@@ -23,7 +23,7 @@ describe('Batch Actions component', () => {
   }
 
   const state = {
-    currentFolder: { path: '' }
+    currentFolder: { path: '', canCreate: () => true }
   }
 
   afterEach(() => {
@@ -224,7 +224,7 @@ function createStore(state) {
       Files: {
         state: {
           ...state,
-          currentFolder: { path: '' }
+          currentFolder: { path: '', canCreate: () => true }
         },
         namespaced: true,
         getters: {


### PR DESCRIPTION
## Description
Fixes copy action not checking permission to be able to perform the action.

## Related Issue
Fixes https://github.com/owncloud/web/issues/5452

## Motivation and Context
Copy will take user to a dead end when the user clicks it so it shouldn't be shown.

There are 2 instances where this needs fixing - in the copy action from the RHS sidebar, and also as a bulk action when ticked on the LHS main panel.

## How Has This Been Tested?
a) Copy Action (when file selected first)

1.  Create a folder and add a file into it, share the folder with another user (without the ability to for that user to write to the shared folder).
2. Login as the user.
3. Navigate into the shared folder.
4. Click on the file in the folder to see the Actions menu.
5. The 'copy' action appears, but clicking opens the location picker which doesn't allow you to confirm it as `canCopy` in `LocationPicker.vue` returns false (as it should).

b) Copy Bulk Action

1.  Repeat steps 1,2,3,4 as above
2. Click the [ ] to the left of the file to open the bulk actions header above the file listing.
3. Click the 'Copy' button.
4. This is the same as 5 above (see screenshot below).

![image](https://user-images.githubusercontent.com/876651/124877161-2c294c00-e00e-11eb-85a5-58da8e3c2c73.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
