### PR TITLE
fix: download action permission check

### DIFF
--- a/changelog/unreleased/bugfix-download-action-permissions
+++ b/changelog/unreleased/bugfix-download-action-permissions
@@ -1,0 +1,6 @@
+Bugfix: Download action permission
+
+Prevent download action from being shown when the user does not have the relevant permission.
+
+https://github.com/owncloud/web/pull/5476
+https://github.com/owncloud/web/issues/5451

--- a/packages/web-app-files/src/helpers/resources.js
+++ b/packages/web-app-files/src/helpers/resources.js
@@ -64,7 +64,7 @@ export function buildResource(resource) {
     },
     canDownload: function() {
       // TODO: as soon as we allow folder downloads as archive we want to return `true` here without exceptions
-      return !isFolder
+      return !isFolder && this.permissions.indexOf('V') >= 0
     },
     canBeDeleted: function() {
       return this.permissions.indexOf('D') >= 0
@@ -215,6 +215,8 @@ export function buildSharedResource(share, incomingShares = false, allowSharePer
     return checkPermission(share.permissions, 'share')
   }
   resource.isMounted = () => false
+  // FIXME: add actual permission parsing, should test via:
+  // !isFolder && this.permissions.indexOf('V') >= 0
   resource.canDownload = () => !isFolder
   resource.share = buildShare(share, resource, allowSharePerm)
   resource.indicators = []

--- a/packages/web-app-files/src/helpers/resources.js
+++ b/packages/web-app-files/src/helpers/resources.js
@@ -63,7 +63,7 @@ export function buildResource(resource) {
       return this.permissions.indexOf('C') >= 0
     },
     canDownload: function() {
-      // TODO: as soon as we allow folder downloads as archive we want to return `true` here without exceptions
+      // TODO: as soon as we allow folder downloads as archive we want to remove !isFolder from this test
       return !isFolder && this.permissions.indexOf('V') >= 0
     },
     canBeDeleted: function() {


### PR DESCRIPTION
## Description
Fixes download action not checking permission to be able to perform the action.

## Related Issue
Fixes https://github.com/owncloud/web/issues/5451

## Motivation and Context
Download action when clicked without correct permission will given an Error Notification with a 403 forbidden, so it shouldn't be shown.

## How Has This Been Tested?
1.  Create a folder and add a file into it, share the folder with another user (without the ability to for that user to write to the shared folder).
2.  Login as the user.
3.  Navigate into the shared folder.
4.  Click on the file in the folder to see the Actions menu.
5.  The 'download' action appears, but clicking the action results in an Error Notification with 403 Forbidden (as it should, see below.)

![image](https://user-images.githubusercontent.com/876651/124880845-0d2cb900-e012-11eb-8420-a6e231b9dd84.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
