### PR TITLE
[tests-only] [full-ci] Run all acceptance tests on tag event

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1076,7 +1076,7 @@ def acceptance(ctx):
                         steps = []
 
                         if (params["earlyFail"]):
-                            steps += calculateDiffContainsUnitTestsOnly()
+                            steps += calculateDiffContainsUnitTestsOnly(ctx)
 
                         steps += installNPM()
 
@@ -2587,7 +2587,12 @@ def dependsOn(earlierStages, nextStages):
             else:
                 nextStage["depends_on"] = [earlierStage["name"]]
 
-def calculateDiffContainsUnitTestsOnly():
+def calculateDiffContainsUnitTestsOnly(ctx):
+    # Do all the pipeline steps fully on tag events. Do not try to analyze diffs
+    # and short-circuit the tests that are executed.
+    if ctx.build.event == "tag":
+        return []
+
     return [
         {
             "name": "calculate-diff",


### PR DESCRIPTION
## Description
When CI is running for a "tag" event, then we do not want to do any `calculate-diff` step. That step calculates if nothing else was changed, and short-circuits the running of acceptance tests. But for a "tag" event, nothing has changed, but we do want to run all the tests.

## Related Issue
- Fixes #5500 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
