### PR TITLE
add option to define how many share recipients should be shown

### DIFF
--- a/changelog/unreleased/enhancement-share-recipients-number
+++ b/changelog/unreleased/enhancement-share-recipients-number
@@ -1,0 +1,6 @@
+Enhancement: Define the number of visible share recipients
+
+We've added a new configuration option `sharingRecipientsPerPage` to
+define how many recipients should be shown in the share recipients dropdown.
+
+https://github.com/owncloud/web/pull/5506

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,6 +51,7 @@ substring of a value of the authenticated user. Examples are `/Shares`, `/{{.Id}
 - `options.previewFileExtensions` Specifies which filetypes will be previewed in the ui. For example to only preview jpg and txt files set this option to `["jpg", "txt"]`.
 - `options.disableFeedbackLink` Set this option to `true` to disable the feedback link in the topbar. Keeping it enabled (value `false` or absence of the option)
   allows ownCloud to get feedback from your user base through a dedicated survey website.
+- `options.sharingRecipientsPerPage` Sets the amount of users shown as recipients in the dropdown when sharing resources. Default amount is 200.
 
 ## Setting up backend and running
 

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/NewCollaborator.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/NewCollaborator.vue
@@ -139,7 +139,6 @@ export default {
     },
 
     $_onAutocompleteInput(value) {
-      console.log(this.$store)
       const minSearchLength = parseInt(this.user.capabilities.files_sharing.search_min_length, 10)
       if (value.length < minSearchLength) {
         this.autocompleteInProgress = false

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/NewCollaborator.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/NewCollaborator.vue
@@ -108,6 +108,7 @@ export default {
   computed: {
     ...mapGetters('Files', ['currentFileOutgoingCollaborators', 'highlightedFile']),
     ...mapGetters(['user']),
+    ...mapGetters(['configuration']),
 
     $_ocCollaborationStatus_autocompleteDescriptionMessage() {
       return this.$gettext("Add new person by name, email or federation ID's")
@@ -138,6 +139,7 @@ export default {
     },
 
     $_onAutocompleteInput(value) {
+      console.log(this.$store)
       const minSearchLength = parseInt(this.user.capabilities.files_sharing.search_min_length, 10)
       if (value.length < minSearchLength) {
         this.autocompleteInProgress = false
@@ -148,7 +150,7 @@ export default {
       this.autocompleteResults = []
       // TODO: move to store
       this.$client.shares
-        .getRecipients(value, 'folder')
+        .getRecipients(value, 'folder', 1, this.configuration.options.sharingRecipientsPerPage)
         .then(recipients => {
           this.autocompleteInProgress = false
           const users = recipients.exact.users
@@ -156,7 +158,6 @@ export default {
             .filter(user => user.value.shareWith !== this.user.id)
           const groups = recipients.exact.groups.concat(recipients.groups)
           const remotes = recipients.exact.remotes.concat(recipients.remotes)
-
           this.autocompleteResults = users.concat(groups, remotes).filter(collaborator => {
             const selected = this.selectedCollaborators.find(selectedCollaborator => {
               return (

--- a/packages/web-runtime/src/store/config.js
+++ b/packages/web-runtime/src/store/config.js
@@ -39,7 +39,8 @@ const state = {
     hideSearchBar: false,
     homeFolder: '',
     disablePreviews: false,
-    previewFileExtensions: []
+    previewFileExtensions: [],
+    sharingRecipientsPerPage: 200
   }
 }
 


### PR DESCRIPTION
## Description
the oc-select or share recipients only had only shown 200 users even if the backend has way more. This introduces a option to decide in configuration how many items should be there.

## Related Issue
- Fixes #5499

## Motivation and Context
let the user decide how many users should be shown in the recipients dropdown

## How Has This Been Tested?
- unit tests
- local oc10 installation with openLDAP and 1k users

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] add changelog