### PR TITLE
Prevent binding to only loopback IP when running in watch mode

### DIFF
--- a/changelog/unreleased/enhancement-prevent-bind-to-loopback-address
+++ b/changelog/unreleased/enhancement-prevent-bind-to-loopback-address
@@ -1,0 +1,5 @@
+Enhancement: Prevent binding to only loopback IP when running in watch mode
+
+This is required when running the acceptance tests on Windows, it allows the selenium docker containers to access the frontend due to the host binding in rollup (when running `yarn serve`). Does not break any existing functionality.
+
+https://github.com/owncloud/web/pull/5515

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -158,6 +158,7 @@ if (production) {
 if (process.env.SERVER === 'true') {
   plugins.push(
     serve({
+      host: '0.0.0.0',
       contentBase: ['dist'],
       port: process.env.PORT || 9100
     })


### PR DESCRIPTION
## Description
This is required when running the acceptance tests on Windows, it allows the selenium docker containers to access the frontend due to the host binding in rollup (when running `yarn serve`).  I have considered the implications but can't see any downside to having this as the default, it doesn't break any existing functionality.

## Motivation and Context
As above.

## How Has This Been Tested?
Tested on Windows with WSL2 and also on MacOS.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
