### PR TITLE
[unit-tests] add unit tests for QuickActions component

### DIFF
--- a/packages/web-app-files/tests/unit/components/FilesList/QuickActions.spec.js
+++ b/packages/web-app-files/tests/unit/components/FilesList/QuickActions.spec.js
@@ -1,0 +1,110 @@
+import { createLocalVue } from '@vue/test-utils'
+import DesignSystem from 'owncloud-design-system'
+import QuickActions from '../../../../src/components/FilesList/QuickActions.vue'
+const { shallowMount, mount } = require('@vue/test-utils')
+
+const localVue = createLocalVue()
+localVue.use(DesignSystem)
+
+const collaboratorAction = {
+  displayed: jest.fn(() => true),
+  handler: jest.fn(),
+  icon: 'group-add',
+  id: 'collaborators',
+  label: 'Add people'
+}
+
+const publicLinkAction = {
+  displayed: jest.fn(() => false),
+  handler: jest.fn(),
+  icon: 'link-add',
+  id: 'public-link',
+  label: 'Create and copy public link'
+}
+
+const testItem = {
+  icon: 'file',
+  name: 'lorem.txt',
+  path: '/lorem.txt',
+  size: '12220'
+}
+
+const options = {
+  localVue,
+  propsData: {
+    actions: {
+      collaborators: collaboratorAction,
+      publicLink: publicLinkAction
+    },
+    item: testItem
+  },
+  directives: {
+    'oc-tooltip': jest.fn()
+  }
+}
+
+function getShallowMountedWrapper() {
+  return shallowMount(QuickActions, {
+    ...options,
+    stubs: {
+      'oc-icon': true,
+      'oc-button': true
+    }
+  })
+}
+
+function getMountedWrapper() {
+  return mount(QuickActions, {
+    ...options,
+    stubs: {
+      'oc-icon': false,
+      'oc-button': false
+    }
+  })
+}
+
+describe('QuickActions', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('when multiple actions are provided', () => {
+    const wrapper = getShallowMountedWrapper()
+
+    it('should display all action buttons where "displayed" is set to true', () => {
+      const actionButtons = wrapper.findAll('oc-button-stub')
+      // there are two items provided as actions, with only one item set to display
+      expect(actionButtons.length).toBe(1)
+
+      const actionButton = actionButtons.at(0)
+      const iconEl = actionButton.find('oc-icon-stub')
+
+      expect(actionButton.exists()).toBeTruthy()
+      expect(actionButton.attributes().class).toContain('files-quick-action-collaborators')
+      expect(iconEl.exists()).toBeTruthy()
+      expect(iconEl.attributes().name).toBe('group-add')
+      expect(actionButton.attributes('arialabel')).toBe('Add people')
+    })
+
+    it('should not display action buttons where "displayed" is set to false', () => {
+      const linkActionButton = wrapper.find('.files-quick-action-public-link')
+
+      expect(linkActionButton.exists()).toBeFalsy()
+    })
+  })
+
+  describe('action handler', () => {
+    it('should call action handler on click', async () => {
+      const wrapper = getMountedWrapper()
+      const handlerAction = jest.spyOn(collaboratorAction, 'handler').mockImplementation()
+
+      const actionButton = wrapper.find('button')
+      await actionButton.trigger('click')
+      expect(handlerAction).toHaveBeenCalledTimes(1)
+      expect(handlerAction).toHaveBeenCalledWith({
+        item: testItem,
+        store: undefined // undefined because not provided with wrapper
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Description
- added unit tests for `QuickActions` component from `FilesList` view

## Related Issue
- Part of #5234 

## Motivation and Context
- every component should be tested

## How Has This Been Tested?
- :robot:
- 💇🏼‍♂️ 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
