### PR TITLE
make openidconnect in oC10 possible

### DIFF
--- a/changelog/unreleased/bugfix-oc10-web-oidc-csp
+++ b/changelog/unreleased/bugfix-oc10-web-oidc-csp
@@ -1,0 +1,5 @@
+Bugfix: Content Security Policy for OpenID Connect authentication
+
+We added CSP rules for allowing OpenID Connect authentication when running ownCloud Web as app in ownCloud 10.
+
+https://github.com/owncloud/web/pull/5536


### PR DESCRIPTION
## Description
One can currently not use ownCloud Web with ownCloud 10 and OpenID connect, because proper content policies are missing and calls to the OIDC provider will fail.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- none

## Motivation and Context
The oCIS migration strategy requires to run ownCloud 10 with OIDC and Web. This is currently not possible.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- https://github.com/owncloud/ocis/pull/2302


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...