### PR TITLE
Remove quota requests where not needed

### DIFF
--- a/changelog/unreleased/bugfix-unnecessary-quota-requests
+++ b/changelog/unreleased/bugfix-unnecessary-quota-requests
@@ -1,0 +1,5 @@
+Bugfix: Unnecessary quota requests
+
+We've removed requests that checked for a user's quota on pages where it was not relevant.
+
+https://github.com/owncloud/web/pull/5539

--- a/packages/web-app-files/src/views/Favorites.vue
+++ b/packages/web-app-files/src/views/Favorites.vue
@@ -141,7 +141,6 @@ export default {
   methods: {
     ...mapActions('Files', ['loadIndicators', 'loadPreview']),
     ...mapMutations('Files', ['SELECT_RESOURCES', 'LOAD_FILES', 'CLEAR_CURRENT_FILES_LIST']),
-    ...mapMutations(['SET_QUOTA']),
 
     rowMounted(resource, component) {
       if (!this.displayThumbnails) {
@@ -171,10 +170,6 @@ export default {
       this.LOAD_FILES({ currentFolder: null, files: resources })
       this.loadIndicators({ client: this.$client, currentFolder: '/' })
 
-      // Load quota
-      const user = await this.$client.users.getUser(this.user.id)
-
-      this.SET_QUOTA(user.quota)
       this.loading = false
     }
   }

--- a/packages/web-app-files/src/views/SharedViaLink.vue
+++ b/packages/web-app-files/src/views/SharedViaLink.vue
@@ -146,7 +146,6 @@ export default {
   methods: {
     ...mapActions('Files', ['loadIndicators', 'loadPreview']),
     ...mapMutations('Files', ['LOAD_FILES', 'SELECT_RESOURCES', 'CLEAR_CURRENT_FILES_LIST']),
-    ...mapMutations(['SET_QUOTA']),
 
     rowMounted(resource, component) {
       if (!this.displayThumbnails) {
@@ -191,10 +190,6 @@ export default {
 
       this.LOAD_FILES({ currentFolder: null, files: resources })
 
-      // Load quota
-      const user = await this.$client.users.getUser(this.user.id)
-
-      this.SET_QUOTA(user.quota)
       this.loading = false
     }
   }

--- a/packages/web-app-files/src/views/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/SharedWithMe.vue
@@ -191,7 +191,6 @@ export default {
       'CLEAR_CURRENT_FILES_LIST',
       'UPDATE_RESOURCE'
     ]),
-    ...mapMutations(['SET_QUOTA']),
 
     rowMounted(resource, component) {
       const debounced = debounce(({ unobserve }) => {
@@ -241,10 +240,6 @@ export default {
 
       this.LOAD_FILES({ currentFolder: null, files: resources })
 
-      // Load quota
-      const user = await this.$client.users.getUser(this.user.id)
-
-      this.SET_QUOTA(user.quota)
       this.loading = false
     },
 

--- a/packages/web-app-files/src/views/SharedWithOthers.vue
+++ b/packages/web-app-files/src/views/SharedWithOthers.vue
@@ -153,7 +153,6 @@ export default {
       'CLEAR_CURRENT_FILES_LIST',
       'UPDATE_RESOURCE'
     ]),
-    ...mapMutations(['SET_QUOTA']),
 
     rowMounted(resource, component) {
       const debounced = debounce(({ unobserve }) => {
@@ -200,10 +199,6 @@ export default {
 
       this.LOAD_FILES({ currentFolder: null, files: resources })
 
-      // Load quota
-      const user = await this.$client.users.getUser(this.user.id)
-
-      this.SET_QUOTA(user.quota)
       this.loading = false
     },
 


### PR DESCRIPTION
## Description
We were fetching the user quota on views where it is not needed as part of an outdated component structure of the frontend. Removing the unnecessary parts for now, we'll have to (re-)introduce them somewhere else when implementing spaces sometime soon

## Related Issue
- Fixes #5337

## Motivation and Context
Less

## How Has This Been Tested?
Manually

## Types of changes
- [X] Bug fix
- [X] Technical debt

## Checklist:
- [X] Code changes
