### PR TITLE
[tests-only] Refactor 'in the webUI' to 'on the webUI'

### DIFF
--- a/tests/acceptance/features/webUIAccount/userProfile.feature
+++ b/tests/acceptance/features/webUIAccount/userProfile.feature
@@ -9,13 +9,13 @@ Feature: view profile
   @ocis-reva-issue-107
   Scenario: view user profile for the logged in user
     When user "Alice" logs in using the webUI
-    Then the user profile should be visible in the webUI
+    Then the user profile should be visible on the webUI
     When the user opens the user profile
-    Then username "Alice Hansen" should be visible in the webUI
+    Then username "Alice Hansen" should be visible on the webUI
 
 
   Scenario: browse to account page to manage user account
     Given user "Alice" has logged in using the webUI
     When the user opens the user profile
     And the user browses to manage the account
-    Then the accounts page should be visible in the webUI
+    Then the accounts page should be visible on the webUI

--- a/tests/acceptance/features/webUIFavorites/favoritesFile.feature
+++ b/tests/acceptance/features/webUIFavorites/favoritesFile.feature
@@ -100,11 +100,11 @@ Feature: Mark file as favorite
     And the user opens folder "strängé नेपाली folder" using the webUI
     And the user marks file "lorem.txt" as favorite using the webUI
     And the user browses to the favorites page
-    Then file with path "lorem.txt" should be listed in the webUI
-    And file with path "simple-folder/lorem.txt" should be listed in the webUI
-    And folder with path "simple-empty-folder" should be listed in the webUI
-    And folder with path "simple-folder/simple-empty-folder" should be listed in the webUI
-    And file with path "strängé नेपाली folder/lorem.txt" should be listed in the webUI
+    Then file with path "lorem.txt" should be listed on the webUI
+    And file with path "simple-folder/lorem.txt" should be listed on the webUI
+    And folder with path "simple-empty-folder" should be listed on the webUI
+    And folder with path "simple-folder/simple-empty-folder" should be listed on the webUI
+    And file with path "strängé नेपाली folder/lorem.txt" should be listed on the webUI
 
   @issue-1720
   Scenario: Try to favorite file and folder that used to exist but does not anymore

--- a/tests/acceptance/features/webUIFiles/options.feature
+++ b/tests/acceptance/features/webUIFiles/options.feature
@@ -8,31 +8,31 @@ Feature: Set config options from web config file
     Given the property "hideSearchBar" of "options" has been set to true in web config file
     And user "Alice" has logged in using the webUI
     When the user browses to the files page
-    Then the search bar should not be visible in the webUI
+    Then the search bar should not be visible on the webUI
 
 
   Scenario: Set config to show the search bar
     Given the property "hideSearchBar" of "options" has been set to false in web config file
     And user "Alice" has logged in using the webUI
     When the user browses to the files page
-    Then the search bar should be visible in the webUI
+    Then the search bar should be visible on the webUI
 
 
   Scenario: Set config to hide the search bar while the user is logged in
     Given the property "hideSearchBar" of "options" has been set to false in web config file
     And user "Alice" has logged in using the webUI
     When the user browses to the files page
-    Then the search bar should be visible in the webUI
+    Then the search bar should be visible on the webUI
     When the property "hideSearchBar" of "options" is changed to true in web config file
     And the user reloads the current page of the webUI
-    Then the search bar should not be visible in the webUI
+    Then the search bar should not be visible on the webUI
 
 
   Scenario: Set config to show the search bar while the user is logged in
     Given the property "hideSearchBar" of "options" has been set to true in web config file
     And user "Alice" has logged in using the webUI
     When the user browses to the files page
-    Then the search bar should not be visible in the webUI
+    Then the search bar should not be visible on the webUI
     When the property "hideSearchBar" of "options" is changed to false in web config file
     And the user reloads the current page of the webUI
-    Then the search bar should be visible in the webUI
+    Then the search bar should be visible on the webUI

--- a/tests/acceptance/features/webUIFilesActionMenu/fileFolderActionMenu.feature
+++ b/tests/acceptance/features/webUIFilesActionMenu/fileFolderActionMenu.feature
@@ -15,24 +15,24 @@ Background: prepare user and files
     Given user "Alice" has uploaded file with content "pdf file" to "lorem.pdf"
     And the user has reloaded the current page of the webUI
     And the app-sidebar for file "lorem.txt" has been visible on the webUI
-    When the user opens the actions sidebar accordion of folder "simple-folder" in the webUI
+    When the user opens the actions sidebar accordion of folder "simple-folder" on the webUI
     Then the app-sidebar for folder "simple-folder" should be visible on the webUI
     And only the following items with default items should be visible in the actions menu on the webUI
       | items                     |
       | open folder               |
-    When the user opens the actions sidebar accordion of file "lorem.txt" in the webUI
+    When the user opens the actions sidebar accordion of file "lorem.txt" on the webUI
     Then the app-sidebar for file "lorem.txt" should be visible on the webUI
     And only the following items with default items should be visible in the actions menu on the webUI
       | items                     |
       | open in markdowneditor    |
       | download                  |
-    When the user opens the actions sidebar accordion of file "lorem.pdf" in the webUI
+    When the user opens the actions sidebar accordion of file "lorem.pdf" on the webUI
     Then the app-sidebar for file "lorem.pdf" should be visible on the webUI
     And only the following items with default items should be visible in the actions menu on the webUI
       | items                     |
       | open in browser           |
       | download                  |
-    When the user opens the actions sidebar accordion of file "testavatar.png" in the webUI
+    When the user opens the actions sidebar accordion of file "testavatar.png" on the webUI
     Then the app-sidebar for file "testavatar.png" should be visible on the webUI
     And only the following items with default items should be visible in the actions menu on the webUI
       | items                     |

--- a/tests/acceptance/features/webUIFilesActionMenu/versions.feature
+++ b/tests/acceptance/features/webUIFilesActionMenu/versions.feature
@@ -45,7 +45,7 @@ Feature: Versions of a file
 
   @ocis-reva-issue-110
   @skipOnStorage:ceph @files_primary_s3-issue-1
-  Scenario: file versions cannot be seen in the webUI after deleting versions
+  Scenario: file versions cannot be seen on the webUI after deleting versions
     Given user "user0" has uploaded file with content "lorem content" to "lorem-file.txt"
     And user "user0" has uploaded file with content "lorem" to "lorem-file.txt"
     And user "user0" has uploaded file with content "new lorem content" to "lorem-file.txt"
@@ -56,7 +56,7 @@ Feature: Versions of a file
 
   @ocis-reva-issue-110
   @skipOnStorage:ceph @files_primary_s3-issue-155
-  Scenario: file versions cannot be seen in the webUI only for user whose versions is deleted
+  Scenario: file versions cannot be seen on the webUI only for user whose versions is deleted
     Given user "user0" has uploaded file with content "lorem content" to "lorem-file.txt"
     And user "user0" has uploaded file with content "lorem" to "lorem-file.txt"
     And user "Alice" has uploaded file with content "lorem content" to "lorem-file.txt"
@@ -71,7 +71,7 @@ Feature: Versions of a file
 
   @ocis-reva-issue-110
   @skipOnStorage:ceph @files_primary_s3-issue-155
-  Scenario: file versions cannot be seen in the webUI for all users after deleting versions for all users
+  Scenario: file versions cannot be seen on the webUI for all users after deleting versions for all users
     Given user "user0" has uploaded file with content "lorem content" to "/lorem-file.txt"
     And user "user0" has uploaded file with content "lorem" to "/lorem-file.txt"
     And user "Alice" has uploaded file with content "lorem content" to "/lorem-file.txt"

--- a/tests/acceptance/features/webUIFilesDetails/fileDetails.feature
+++ b/tests/acceptance/features/webUIFilesDetails/fileDetails.feature
@@ -14,7 +14,7 @@ Feature: User can open the details panel for any file or folder
   Scenario: View different areas of the app-sidebar for a file in files page
     Given user "Alice" has created file "lorem.txt"
     And the user has browsed to the files page
-    When the user picks the row of file "lorem.txt" in the webUI
+    When the user picks the row of file "lorem.txt" on the webUI
     Then the app-sidebar should be visible
     And the thumbnail should be visible in the app-sidebar
     And the "details" details panel should be visible
@@ -27,7 +27,7 @@ Feature: User can open the details panel for any file or folder
   Scenario: View different areas of the app-sidebar for a folder in files page
     Given user "Alice" has created folder "simple-folder"
     And the user has browsed to the files page
-    When the user picks the row of folder "simple-folder" in the webUI
+    When the user picks the row of folder "simple-folder" on the webUI
     Then the app-sidebar should be visible
     And the thumbnail should be visible in the app-sidebar
     And the "details" details panel should be visible
@@ -44,7 +44,7 @@ Feature: User can open the details panel for any file or folder
     And the user has browsed to the files page
     And user "Alice" has favorited element "lorem.txt"
     And the user has browsed to the favorites page
-    When the user picks the row of file "lorem.txt" in the webUI
+    When the user picks the row of file "lorem.txt" on the webUI
     Then the app-sidebar should be visible
     And the thumbnail should be visible in the app-sidebar
     And the "details" details panel should be visible
@@ -59,7 +59,7 @@ Feature: User can open the details panel for any file or folder
     And the user has browsed to the files page
     And user "Alice" has favorited element "simple-folder"
     And the user has browsed to the favorites page
-    When the user picks the row of folder "simple-folder" in the webUI
+    When the user picks the row of folder "simple-folder" on the webUI
     Then the app-sidebar should be visible
     And the thumbnail should be visible in the app-sidebar
     And the "details" details panel should be visible
@@ -93,7 +93,7 @@ Feature: User can open the details panel for any file or folder
     And user "Alice" has shared folder "simple-folder" with user "Brian"
     When the user browses to the shared-with-others page
     Then folder "simple-folder" should be listed on the webUI
-    When the user picks the row of folder "simple-folder" in the webUI
+    When the user picks the row of folder "simple-folder" on the webUI
     Then the app-sidebar should be visible
     And the thumbnail should be visible in the app-sidebar
     When the user switches to "people" accordion item in details panel using the webUI
@@ -110,7 +110,7 @@ Feature: User can open the details panel for any file or folder
     And user "Alice" has created a new public link for resource "simple-folder"
     When the user browses to the shared-with-others page
     Then folder "simple-folder" should be listed on the webUI
-    When the user picks the row of folder "simple-folder" in the webUI
+    When the user picks the row of folder "simple-folder" on the webUI
     Then the app-sidebar should be visible
     And the thumbnail should be visible in the app-sidebar
     When the user switches to "people" accordion item in details panel using the webUI
@@ -128,7 +128,7 @@ Feature: User can open the details panel for any file or folder
     And the user re-logs in as "Brian" using the webUI
     When the user browses to the shared-with-me page
     Then folder "simple-folder" should be listed on the webUI
-    When the user picks the row of folder "simple-folder" in the webUI
+    When the user picks the row of folder "simple-folder" on the webUI
     Then the app-sidebar should be visible
     And the thumbnail should be visible in the app-sidebar
     When the user switches to "people" accordion item in details panel using the webUI
@@ -171,7 +171,7 @@ Feature: User can open the details panel for any file or folder
   Scenario: the sidebar is invisible after closing
     Given user "Alice" has created file "lorem.txt"
     And the user has browsed to the files page
-    When the user picks the row of file "lorem.txt" in the webUI
+    When the user picks the row of file "lorem.txt" on the webUI
     Then the app-sidebar should be visible
     When the user closes the app-sidebar using the webUI
     Then the app-sidebar should be invisible

--- a/tests/acceptance/features/webUIMarkdownEditor/markdownFile.feature
+++ b/tests/acceptance/features/webUIMarkdownEditor/markdownFile.feature
@@ -39,12 +39,12 @@ Feature: create markdown files
   Scenario: preview content of the file
     When the user opens file "simple.md" in the markdown editor webUI
     Then the file "simple.md" should be displayed in the markdown editor webUI
-    And the preview panel should have the content "simple markdown file" in the WebUI
+    And the preview panel should have the content "simple markdown file" on the webUI
 
   Scenario: preview content of the file while editing
     Given the user has opened file "simple.md" in the markdown editor webUI
     When the user inputs the content "updating the file with new content" in the markdown editor webUI
-    Then the preview panel should have the content "updating the file with new content" in the WebUI
+    Then the preview panel should have the content "updating the file with new content" on the webUI
 
   Scenario: open text file in markdown editor
     Given user "Alice" has uploaded file with content "test" to "lorem.txt"
@@ -55,7 +55,7 @@ Feature: create markdown files
   Scenario Outline: preview of files with markdown editor by clicking the action menu option
     Given user "Alice" has uploaded file with content "test" to "lorem.txt"
     And the user has reloaded the current page of the webUI
-    When the user opens file "<file>" in the markdown editor using the action menu option in the webUI
+    When the user opens file "<file>" in the markdown editor using the action menu option on the webUI
     Then the file "<file>" should be displayed in the markdown editor webUI
     Examples:
       | file          |

--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -31,7 +31,7 @@ Feature: restrict Sharing
   Scenario: Restrict users to only share with users in their groups
     Given the setting "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
     When the user opens the share dialog for folder "simple-folder" using the webUI
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user types "Ali" in the share-with-field
     Then "user" "Alison Cooper" should not be listed in the autocomplete list on the webUI
     But "user" "Alice Hansen" should be listed in the autocomplete list on the webUI
@@ -40,7 +40,7 @@ Feature: restrict Sharing
   Scenario: Restrict users to only share with groups they are member of
     Given the setting "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
     When the user opens the share dialog for folder "simple-folder" using the webUI
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user types "grp" in the share-with-field
     Then "group" "grp2" should not be listed in the autocomplete list on the webUI
     But "group" "grp1" should be listed in the autocomplete list on the webUI
@@ -56,7 +56,7 @@ Feature: restrict Sharing
   Scenario: Forbid sharing with groups
     Given the setting "shareapi_allow_group_sharing" of app "core" has been set to "no"
     When the user opens the share dialog for folder "simple-folder" using the webUI
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user types "grp" in the share-with-field
     Then "group" "grp1" should not be listed in the autocomplete list on the webUI
     And "group" "grp2" should not be listed in the autocomplete list on the webUI

--- a/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
@@ -42,7 +42,7 @@ Feature: accept/decline shares coming from internal users
     And the user deletes folder "simple-folder" using the webUI
     And the user browses to the shared-with-me page using the webUI
     Then folder "simple-folder" shared by "Alice Hansen" should be in "Declined" state on the webUI
-    And folder "simple-folder" shared by "Brian Murphy" should not be listed in the webUI
+    And folder "simple-folder" shared by "Brian Murphy" should not be listed on the webUI
     And folder "simple-folder" should not be listed on the webUI
 
   @issue-4102 @issue-5531

--- a/tests/acceptance/features/webUISharingAcceptSharesToRoot/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingAcceptSharesToRoot/acceptShares.feature
@@ -43,7 +43,7 @@ Feature: accept/decline shares coming from internal users
     And the user deletes folder "simple-folder (2)" using the webUI
     And the user browses to the shared-with-me page using the webUI
     Then folder "simple-folder (2)" shared by "Alice Hansen" should be in "Declined" state on the webUI
-    And folder "simple-folder" shared by "Brian Murphy" should not be listed in the webUI
+    And folder "simple-folder" shared by "Brian Murphy" should not be listed on the webUI
     And folder "simple-folder" should not be listed on the webUI
 
   @smokeTest

--- a/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature
@@ -34,7 +34,7 @@ Feature: Autocompletion of share-with names
     And user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     When the user types "us" in the share-with-field
     Then all users and groups that contain the string "us" in their name should be listed in the autocomplete list on the webUI
     But only users and groups that contain the string "us" in their name or displayname should be listed in the autocomplete list on the webUI
@@ -46,7 +46,7 @@ Feature: Autocompletion of share-with names
     And user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     When the user types "fi" in the share-with-field
     Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI
     But only users and groups that contain the string "fi" in their name or displayname should be listed in the autocomplete list on the webUI
@@ -58,7 +58,7 @@ Feature: Autocompletion of share-with names
     And user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     When the user types "doesnotexist" in the share-with-field
     Then the autocomplete list should not be displayed on the webUI
 
@@ -68,7 +68,7 @@ Feature: Autocompletion of share-with names
     And user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     When the user types "u" in the share-with-field
     Then the autocomplete list should not be displayed on the webUI
 
@@ -79,7 +79,7 @@ Feature: Autocompletion of share-with names
     And user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     When the user types "use" in the share-with-field
     Then the autocomplete list should not be displayed on the webUI
 
@@ -93,7 +93,7 @@ Feature: Autocompletion of share-with names
       | username | password | displayname | email        |
       | use      | %alt1%   | Use         | uz@oc.com.np |
     And the user has opened the share dialog for folder "simple-folder"
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     When the user types "Use" in the share-with-field
     Then "user" "Use" should be listed in the autocomplete list on the webUI
 
@@ -107,7 +107,7 @@ Feature: Autocompletion of share-with names
     And user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     When the user types "fi" in the share-with-field
     Then "group" "fi" should be listed in the autocomplete list on the webUI
 
@@ -118,7 +118,7 @@ Feature: Autocompletion of share-with names
     And user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     When the user types "use" in the share-with-field
     Then all users and groups that contain the string "use" in their name should be listed in the autocomplete list on the webUI
     But only users and groups that contain the string "use" in their name or displayname should be listed in the autocomplete list on the webUI
@@ -131,7 +131,7 @@ Feature: Autocompletion of share-with names
     And the user has browsed to the files page
     And user "regularuser" has shared folder "simple-folder" with user "Alice"
     And the user has opened the share dialog for folder "simple-folder"
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     When the user types "user" in the share-with-field
     Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "Alice Hansen"
     But only users and groups that contain the string "user" in their name or displayname should be listed in the autocomplete list on the webUI
@@ -144,7 +144,7 @@ Feature: Autocompletion of share-with names
     And the user has browsed to the files page
     And user "regularuser" has shared file "data.zip" with user "usergrp"
     And the user has opened the share dialog for file "data.zip"
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     When the user types "user" in the share-with-field
     Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "User Grp"
     But only users and groups that contain the string "user" in their name or displayname should be listed in the autocomplete list on the webUI
@@ -158,7 +158,7 @@ Feature: Autocompletion of share-with names
     And the user has browsed to the files page
     And user "regularuser" has shared folder "simple-folder" with group "finance1"
     And the user has opened the share dialog for folder "simple-folder"
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     When the user types "fi" in the share-with-field
     Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI except group "finance1"
     But only users and groups that contain the string "fi" in their name or displayname should be listed in the autocomplete list on the webUI
@@ -172,7 +172,7 @@ Feature: Autocompletion of share-with names
     And the user has browsed to the files page
     And user "regularuser" has shared file "data.zip" with group "finance1"
     And the user has opened the share dialog for file "data.zip"
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     When the user types "fi" in the share-with-field
     Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI except group "finance1"
     But only users and groups that contain the string "fi" in their name or displayname should be listed in the autocomplete list on the webUI

--- a/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletionSpecialChars.feature
+++ b/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletionSpecialChars.feature
@@ -28,7 +28,7 @@ Feature: Autocompletion of share-with names
     And user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for file "data.zip"
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     When the user types "<search>" in the share-with-field
     Then only users and groups that contain the string "<search>" in their name or displayname should be listed in the autocomplete list on the webUI
     Examples:
@@ -47,7 +47,7 @@ Feature: Autocompletion of share-with names
     And user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for file "data.zip"
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     When the user types "<search>" in the share-with-field
     Then only users and groups that contain the string "<search>" in their name or displayname should be listed in the autocomplete list on the webUI
     Examples:
@@ -65,7 +65,7 @@ Feature: Autocompletion of share-with names
     And user "regularuser" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for file "data.zip"
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     When the user types "<search>" in the share-with-field
     Then only users and groups that contain the string "<search>" in their name or displayname should be listed in the autocomplete list on the webUI
     Examples:

--- a/tests/acceptance/features/webUISharingFilePermissionMultipleUsers/shareFileWithMultipleUsers.feature
+++ b/tests/acceptance/features/webUISharingFilePermissionMultipleUsers/shareFileWithMultipleUsers.feature
@@ -21,7 +21,7 @@ Feature: Sharing files with multiple internal users with different permissions
     And user "Alice" has created file "lorem.txt"
     And user "Alice" has logged in using the webUI
     When the user opens the share dialog for file "lorem.txt" using the webUI
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user selects the following collaborators for the share as "<role>" with "<extra-permissions>" permissions:
       | collaborator | type |
       | Regular User | user |

--- a/tests/acceptance/features/webUISharingFilePermissionsGroups/sharePermissionsGroup.feature
+++ b/tests/acceptance/features/webUISharingFilePermissionsGroups/sharePermissionsGroup.feature
@@ -26,7 +26,7 @@ Feature: Sharing files with internal groups with permissions
     And user "Alice" has created file "lorem.txt"
     And user "Alice" has logged in using the webUI
     When the user opens the share dialog for file "lorem.txt" using the webUI
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user selects the following collaborators for the share as "<role>" with "<extra-permissions>" permissions:
       | collaborator | type  |
       | grp1         | group |

--- a/tests/acceptance/features/webUISharingFolderAdvancedPermissionMultipleUsers/sharedFolderWithMultipleUsersAdvancedPermissions.feature
+++ b/tests/acceptance/features/webUISharingFolderAdvancedPermissionMultipleUsers/sharedFolderWithMultipleUsersAdvancedPermissions.feature
@@ -21,7 +21,7 @@ Feature: Sharing folders with multiple internal users using advanced permissions
     And user "Alice" has created folder "/simple-folder"
     And user "Alice" has logged in using the webUI
     When the user opens the share dialog for folder "simple-folder" using the webUI
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user selects the following collaborators for the share as "<role>" with "<extra-permissions>" permissions:
       | collaborator | type |
       | Regular User | user |

--- a/tests/acceptance/features/webUISharingFolderAdvancedPermissionsGroups/shareAdvancePermissionsGroup.feature
+++ b/tests/acceptance/features/webUISharingFolderAdvancedPermissionsGroups/shareAdvancePermissionsGroup.feature
@@ -25,7 +25,7 @@ Feature: Sharing folders with internal groups with role as advanced permissions
     And user "Alice" has created folder "simple-folder"
     And user "Alice" has logged in using the webUI
     When the user opens the share dialog for folder "simple-folder" using the webUI
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user selects the following collaborators for the share as "<role>" with "<extra-permissions>" permissions:
       | collaborator | type  |
       | grp1         | group |

--- a/tests/acceptance/features/webUISharingFolderPermissionMultipleUsers/shareFolderWithMultipleUsers.feature
+++ b/tests/acceptance/features/webUISharingFolderPermissionMultipleUsers/shareFolderWithMultipleUsers.feature
@@ -22,7 +22,7 @@ Feature: Sharing folders with multiple internal users with different permissions
     And user "Alice" has created folder "simple-folder"
     And user "Alice" has logged in using the webUI
     When the user opens the share dialog for folder "simple-folder" using the webUI
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user selects the following collaborators for the share as "<role>" with "<extra-permissions>" permissions:
       | collaborator | type |
       | Regular User | user |

--- a/tests/acceptance/features/webUISharingFolderPermissionsGroups/sharePermissionsGroup.feature
+++ b/tests/acceptance/features/webUISharingFolderPermissionsGroups/sharePermissionsGroup.feature
@@ -25,7 +25,7 @@ Feature: Sharing folders with internal groups with different roles and permissio
     And user "Brian" has been added to group "grp2"
     And user "Alice" has logged in using the webUI
     When the user opens the share dialog for folder "simple-folder" using the webUI
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user selects the following collaborators for the share as "<role>" with "<extra-permissions>" permissions:
       | collaborator | type  |
       | grp1         | group |

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -204,7 +204,7 @@ Feature: Sharing files and folders with internal groups
     When the user re-logs in as "Alice" using the webUI
     And the user browses to the files page
     And the user opens the share dialog for folder "simple-folder" using the webUI
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user types "system-group" in the share-with-field
     Then the autocomplete list should not be displayed on the webUI
 

--- a/tests/acceptance/features/webUISharingInternalGroupsEdgeCases/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroupsEdgeCases/shareWithGroupsEdgeCases.feature
@@ -53,7 +53,7 @@ Feature: Sharing files and folders with internal groups
     And the user shares file "randomfile.txt" with group "Alice" as "Editor" using the webUI
     And user "Alice" accepts the share "randomfile.txt" offered by user "Carol" using the sharing API
     And user "Brian" accepts the share "randomfile.txt" offered by user "Carol" using the sharing API
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user types "Alice" in the share-with-field
     Then "group" "Alice" should not be listed in the autocomplete list on the webUI
     And the content of file "Shares/randomfile.txt" for user "Alice" should be "Carol file"
@@ -71,7 +71,7 @@ Feature: Sharing files and folders with internal groups
     And the user shares file "randomfile.txt" with user "Alice Hansen" as "Editor" using the webUI
     And user "Alice" accepts the share "randomfile.txt" offered by user "Carol" using the sharing API
     And user "Brian" accepts the share "randomfile.txt" offered by user "Carol" using the sharing API
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user types "Alice" in the share-with-field
     Then "user" "Alice Hansen" should not be listed in the autocomplete list on the webUI
     And the content of file "Shares/randomfile.txt" for user "Brian" should be "Carol file"
@@ -89,7 +89,7 @@ Feature: Sharing files and folders with internal groups
     And the user shares file "randomfile.txt" with group "ALICE" as "Editor" using the webUI
     And user "Alice" accepts the share "randomfile.txt" offered by user "Carol" using the sharing API
     And user "Brian" accepts the share "randomfile.txt" offered by user "Carol" using the sharing API
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user types "ALICE" in the share-with-field
     Then "group" "ALICE" should not be listed in the autocomplete list on the webUI
     And the content of file "Shares/randomfile.txt" for user "Brian" should be "Carol file"
@@ -107,7 +107,7 @@ Feature: Sharing files and folders with internal groups
     And the user shares file "randomfile.txt" with user "Alice Hansen" as "Editor" using the webUI
     And user "Alice" accepts the share "randomfile.txt" offered by user "Carol" using the sharing API
     And user "Brian" accepts the share "randomfile.txt" offered by user "Carol" using the sharing API
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user types "Alice" in the share-with-field
     Then "user" "Alice Hansen" should not be listed in the autocomplete list on the webUI
     And the content of file "Shares/randomfile.txt" for user "Brian" should be "Carol file"

--- a/tests/acceptance/features/webUISharingInternalGroupsToRoot/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroupsToRoot/shareWithGroups.feature
@@ -185,7 +185,7 @@ Feature: Sharing files and folders with internal groups
     When the user re-logs in as "Alice" using the webUI
     And the user browses to the files page
     And the user opens the share dialog for folder "simple-folder" using the webUI
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user types "system-group" in the share-with-field
     Then the autocomplete list should not be displayed on the webUI
 

--- a/tests/acceptance/features/webUISharingInternalGroupsToRootEdgeCases/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroupsToRootEdgeCases/shareWithGroupsEdgeCases.feature
@@ -46,7 +46,7 @@ Feature: Sharing files and folders with internal groups
     And user "Carol" has logged in using the webUI
     When the user shares file "randomfile.txt" with user "Alice Hansen" as "Editor" using the webUI
     And the user shares file "randomfile.txt" with group "Alice" as "Editor" using the webUI
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user types "Alice" in the share-with-field
     Then "group" "Alice" should not be listed in the autocomplete list on the webUI
     And the content of file "randomfile.txt" for user "Alice" should be "Carol file"
@@ -62,7 +62,7 @@ Feature: Sharing files and folders with internal groups
     And user "Carol" has logged in using the webUI
     When the user shares file "randomfile.txt" with group "Alice" as "Editor" using the webUI
     And the user shares file "randomfile.txt" with user "Alice Hansen" as "Editor" using the webUI
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user types "Alice" in the share-with-field
     Then "user" "Alice Hansen" should not be listed in the autocomplete list on the webUI
     And the content of file "randomfile.txt" for user "Brian" should be "Carol file"
@@ -78,7 +78,7 @@ Feature: Sharing files and folders with internal groups
     And user "Carol" has logged in using the webUI
     When the user shares file "randomfile.txt" with user "Alice Hansen" as "Editor" using the webUI
     And the user shares file "randomfile.txt" with group "ALICE" as "Editor" using the webUI
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user types "ALICE" in the share-with-field
     Then "group" "ALICE" should not be listed in the autocomplete list on the webUI
     And the content of file "randomfile.txt" for user "Brian" should be "Carol file"
@@ -94,7 +94,7 @@ Feature: Sharing files and folders with internal groups
     And user "Carol" has logged in using the webUI
     When the user shares file "randomfile.txt" with group "ALICE" as "Editor" using the webUI
     And the user shares file "randomfile.txt" with user "Alice Hansen" as "Editor" using the webUI
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user types "Alice" in the share-with-field
     Then "user" "Alice Hansen" should not be listed in the autocomplete list on the webUI
     And the content of file "randomfile.txt" for user "Brian" should be "Carol file"

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -339,7 +339,7 @@ Feature: Sharing files and folders with internal users
     And user "Alice" has logged in using the webUI
     And user "Alice" has uploaded file with content "test" to "lorem.txt"
     And the user has renamed file "lorem.txt" to "new-lorem.txt"
-    When the user shares resource "new-lorem.txt" with user "Brian Murphy" using the quick action in the webUI
+    When the user shares resource "new-lorem.txt" with user "Brian Murphy" using the quick action on the webUI
     Then user "Brian Murphy" should be listed as "Viewer" in the collaborators list for file "new-lorem.txt" on the webUI
 
 

--- a/tests/acceptance/features/webUISharingInternalUsersExpire/shareWithUsersExpiringShares.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersExpire/shareWithUsersExpiringShares.feature
@@ -218,8 +218,8 @@ Feature: Sharing files and folders with internal users with expiry date
     And the setting "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And user "Alice" has logged in using the webUI
     When the user tries to edit the collaborator expiry date of "Brian Murphy" of resource "lorem.txt" to "+14" days using the webUI
-    Then the expiration date field should be marked as required on the WebUI
-    And the expiration date for "+14 days" should be disabled on the WebUI
+    Then the expiration date field should be marked as required on the webUI
+    And the expiration date for "+14 days" should be disabled on the webUI
     And the expiration date shown on the webUI should be "+7" days
     And it should not be possible to save the pending share on the webUI
 
@@ -233,7 +233,7 @@ Feature: Sharing files and folders with internal users with expiry date
     And the setting "shareapi_expire_after_n_days_user_share" of app "core" has been set to "7"
     And the setting "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     When user "Alice" logs in using the webUI
-    Then the share "lorem.txt" shared with user "Brian Murphy" should have no expiration information displayed on the WebUI
+    Then the share "lorem.txt" shared with user "Brian Murphy" should have no expiration information displayed on the webUI
 
   @issue-4169
   Scenario: setting default expiration date and enforcing it does not change the expiration date of a previously created share which is beyond the new maximum date(enforced)
@@ -246,4 +246,4 @@ Feature: Sharing files and folders with internal users with expiry date
     And the setting "shareapi_expire_after_n_days_user_share" of app "core" has been set to "7"
     And the setting "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     When user "Alice" logs in using the webUI
-    Then the expiration information displayed on the WebUI of share "lorem.txt" shared with user "Brian Murphy" should be "Expires in 15 days" or "Expires in 14 days"
+    Then the expiration information displayed on the webUI of share "lorem.txt" shared with user "Brian Murphy" should be "Expires in 15 days" or "Expires in 14 days"

--- a/tests/acceptance/features/webUISharingInternalUsersExpireToRoot/shareWithUsersExpiringShares.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersExpireToRoot/shareWithUsersExpiringShares.feature
@@ -211,8 +211,8 @@ Feature: Sharing files and folders with internal users with expiry date
     And the setting "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And user "Alice" has logged in using the webUI
     When the user tries to edit the collaborator expiry date of "Brian Murphy" of resource "lorem.txt" to "+14" days using the webUI
-    Then the expiration date field should be marked as required on the WebUI
-    And the expiration date for "+14 days" should be disabled on the WebUI
+    Then the expiration date field should be marked as required on the webUI
+    And the expiration date for "+14 days" should be disabled on the webUI
     And the expiration date shown on the webUI should be "+7" days
     And it should not be possible to save the pending share on the webUI
 
@@ -226,7 +226,7 @@ Feature: Sharing files and folders with internal users with expiry date
     And the setting "shareapi_expire_after_n_days_user_share" of app "core" has been set to "7"
     And the setting "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     When user "Alice" logs in using the webUI
-    Then the share "lorem.txt" shared with user "Brian Murphy" should have no expiration information displayed on the WebUI
+    Then the share "lorem.txt" shared with user "Brian Murphy" should have no expiration information displayed on the webUI
 
 
   Scenario: setting default expiration date and enforcing it does not change the expiration date of a previously created share which is beyond the new maximum date(enforced)
@@ -239,4 +239,4 @@ Feature: Sharing files and folders with internal users with expiry date
     And the setting "shareapi_expire_after_n_days_user_share" of app "core" has been set to "7"
     And the setting "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     When user "Alice" logs in using the webUI
-    Then the expiration information displayed on the WebUI of share "lorem.txt" shared with user "Brian Murphy" should be "Expires in 15 days" or "Expires in 14 days"
+    Then the expiration information displayed on the webUI of share "lorem.txt" shared with user "Brian Murphy" should be "Expires in 15 days" or "Expires in 14 days"

--- a/tests/acceptance/features/webUISharingInternalUsersShareWithPage/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersShareWithPage/shareWithUsers.feature
@@ -198,7 +198,7 @@ Feature: Shares in share-with pages
   Scenario: share a file with another internal user via collaborators quick action
     Given user "Alice" has created folder "simple-folder"
     And user "Alice" has logged in using the webUI
-    When the user shares resource "simple-folder" with user "Brian Murphy" using the quick action in the webUI
+    When the user shares resource "simple-folder" with user "Brian Murphy" using the quick action on the webUI
     And user "Brian" accepts the share "simple-folder" offered by user "Alice" using the sharing API
     Then user "Brian Murphy" should be listed as "Viewer" in the collaborators list for folder "simple-folder" on the webUI
     And user "Brian" should have received a share with these details:

--- a/tests/acceptance/features/webUISharingInternalUsersToRoot/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersToRoot/shareWithUsers.feature
@@ -272,5 +272,5 @@ Feature: Sharing files and folders with internal users
     Given user "Alice" has uploaded file with content "test" to "lorem.txt"
     And user "Alice" has logged in using the webUI
     And the user has renamed file "lorem.txt" to "new-lorem.txt"
-    When the user shares resource "new-lorem.txt" with user "Brian Murphy" using the quick action in the webUI
+    When the user shares resource "new-lorem.txt" with user "Brian Murphy" using the quick action on the webUI
     Then user "Brian Murphy" should be listed as "Viewer" in the collaborators list for file "new-lorem.txt" on the webUI

--- a/tests/acceptance/features/webUISharingInternalUsersToRootCollaborator/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersToRootCollaborator/shareWithUsers.feature
@@ -109,7 +109,7 @@ Feature: Shares collaborator list
   Scenario: share a file with another internal user via collaborators quick action
     Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
     And user "Alice" has logged in using the webUI
-    When the user shares resource "simple-folder" with user "Brian Murphy" using the quick action in the webUI
+    When the user shares resource "simple-folder" with user "Brian Murphy" using the quick action on the webUI
     Then user "Brian Murphy" should be listed as "Viewer" in the collaborators list for folder "simple-folder" on the webUI
     And user "Brian" should have received a share with these details:
       | field       | value              |

--- a/tests/acceptance/features/webUISharingPermissionToRoot/shareAdvancePermissionsGroup.feature
+++ b/tests/acceptance/features/webUISharingPermissionToRoot/shareAdvancePermissionsGroup.feature
@@ -24,7 +24,7 @@ Feature: Sharing folders with internal groups with role as advanced permissions
     And user "Brian" has been added to group "grp2"
     And user "Alice" has logged in using the webUI
     When the user opens the share dialog for folder "simple-folder" using the webUI
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user selects the following collaborators for the share as "<role>" with "<extra-permissions>" permissions:
       | collaborator | type  |
       | grp1         | group |

--- a/tests/acceptance/features/webUISharingPermissionToRoot/shareFileWithMultipleUsers.feature
+++ b/tests/acceptance/features/webUISharingPermissionToRoot/shareFileWithMultipleUsers.feature
@@ -20,7 +20,7 @@ Feature: Sharing files with multiple internal users with different permissions
       | David    |
     And user "Alice" has logged in using the webUI
     When the user opens the share dialog for file "lorem.txt" using the webUI
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user selects the following collaborators for the share as "<role>" with "<extra-permissions>" permissions:
       | collaborator | type |
       | Regular User | user |

--- a/tests/acceptance/features/webUISharingPermissionToRoot/shareFolderWithMultipleUsers.feature
+++ b/tests/acceptance/features/webUISharingPermissionToRoot/shareFolderWithMultipleUsers.feature
@@ -21,7 +21,7 @@ Feature: Sharing folders with multiple internal users with different permissions
       | David    |
     And user "Alice" has logged in using the webUI
     When the user opens the share dialog for folder "simple-folder" using the webUI
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user selects the following collaborators for the share as "<role>" with "<extra-permissions>" permissions:
       | collaborator | type |
       | Regular User | user |

--- a/tests/acceptance/features/webUISharingPermissionToRoot/sharePermissionsFileGroup.feature
+++ b/tests/acceptance/features/webUISharingPermissionToRoot/sharePermissionsFileGroup.feature
@@ -24,7 +24,7 @@ Feature: Sharing files with internal groups with permissions
     And user "Brian" has been added to group "grp2"
     And user "Alice" has logged in using the webUI
     When the user opens the share dialog for file "lorem.txt" using the webUI
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user selects the following collaborators for the share as "<role>" with "<extra-permissions>" permissions:
       | collaborator | type  |
       | grp1         | group |

--- a/tests/acceptance/features/webUISharingPermissionToRoot/sharePermissionsFoldersGroup.feature
+++ b/tests/acceptance/features/webUISharingPermissionToRoot/sharePermissionsFoldersGroup.feature
@@ -24,7 +24,7 @@ Feature: Sharing folders with internal groups with different roles and permissio
     And user "Brian" has been added to group "grp2"
     And user "Alice" has logged in using the webUI
     When the user opens the share dialog for folder "simple-folder" using the webUI
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user selects the following collaborators for the share as "<role>" with "<extra-permissions>" permissions:
       | collaborator | type  |
       | grp1         | group |

--- a/tests/acceptance/features/webUISharingPermissionToRoot/sharedFolderWithMultipleUsersAdvancedPermissions.feature
+++ b/tests/acceptance/features/webUISharingPermissionToRoot/sharedFolderWithMultipleUsersAdvancedPermissions.feature
@@ -20,7 +20,7 @@ Feature: Sharing folders with multiple internal users using advanced permissions
       | David    |
     And user "Alice" has logged in using the webUI
     When the user opens the share dialog for folder "simple-folder" using the webUI
-    And the user opens the share creation dialog in the webUI
+    And the user opens the share creation dialog on the webUI
     And the user selects the following collaborators for the share as "<role>" with "<extra-permissions>" permissions:
       | collaborator | type |
       | Regular User | user |

--- a/tests/acceptance/features/webUISharingPublicBasic/publicLinkCreate.feature
+++ b/tests/acceptance/features/webUISharingPublicBasic/publicLinkCreate.feature
@@ -94,11 +94,11 @@ Feature: Create public link shares
     And the user opens folder "simple-folder" using the webUI
     And the user creates a new public link for file "lorem.txt" using the webUI
     And the user browses to the shared-via-link page using the webUI
-    Then file with path "lorem.txt" should be listed in the webUI
-    And file with path "simple-folder/lorem.txt" should be listed in the webUI
+    Then file with path "lorem.txt" should be listed on the webUI
+    And file with path "simple-folder/lorem.txt" should be listed on the webUI
     When the user browses to the shared-with-others page using the webUI
-    Then file with path "lorem.txt" should be listed in the webUI
-    And file with path "simple-folder/lorem.txt" should be listed in the webUI
+    Then file with path "lorem.txt" should be listed on the webUI
+    And file with path "simple-folder/lorem.txt" should be listed on the webUI
 
 
   Scenario: user creates a multiple public link of a file and delete the first link

--- a/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature
@@ -93,7 +93,7 @@ Feature: Public link share management
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | role | Editor |
     And the public uses the webUI to access the last public link created by user "Alice"
-    And the user picks the row of file "lorem.txt" in the webUI
+    And the user picks the row of file "lorem.txt" on the webUI
     Then the following accordion items should be visible in the details dialog on the webUI
       | name     |
       | versions |

--- a/tests/acceptance/features/webUISharingPublicManagement/sharingPublicSession.feature
+++ b/tests/acceptance/features/webUISharingPublicManagement/sharingPublicSession.feature
@@ -40,7 +40,7 @@ Feature: Session storage for public link
     And user "Alice" changes the password of last public link  to "newpass" using the Sharing API
     Then file "lorem.txt" should be listed on the webUI
     When the user reloads the current page of the webUI
-    Then the password input for the public link should appear in the webUI
+    Then the password input for the public link should appear on the webUI
     When the user accesses the public link with password "newpass" using the webUI
     Then file "lorem.txt" should be listed on the webUI
 
@@ -52,6 +52,6 @@ Feature: Session storage for public link
     And user "Alice" changes the password of last public link  to "newpass" using the Sharing API
     Then file "lorem.txt" should be listed on the webUI
     When the user reloads the current page of the webUI
-    Then the password input for the public link should appear in the webUI
+    Then the password input for the public link should appear on the webUI
     When the user accesses the public link with password "newpass" using the webUI
     Then file "lorem.txt" should be listed on the webUI

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -420,7 +420,7 @@ Then('folder {string} should be listed on the webUI', folder => {
   return client.page.FilesPageElement.filesList().waitForFileVisible(folder, 'folder')
 })
 
-Then('file/folder with path {string} should be listed in the webUI', function(path) {
+Then('file/folder with path {string} should be listed on the webUI', function(path) {
   return client.page.FilesPageElement.filesList().waitForFileWithPathVisible(path)
 })
 
@@ -598,7 +598,7 @@ When('the user batch restores the marked files using the webUI', function() {
   return client.page.FilesPageElement.filesList().restoreSelected()
 })
 
-When('the user picks the row of file/folder {string} in the webUI', function(item) {
+When('the user picks the row of file/folder {string} on the webUI', function(item) {
   return client.page.FilesPageElement.filesList().clickRow(item)
 })
 
@@ -1019,7 +1019,7 @@ Then(
 )
 
 When(
-  'the user opens the actions sidebar accordion of file/folder {string} in the webUI',
+  'the user opens the actions sidebar accordion of file/folder {string} on the webUI',
   async function(resource) {
     await client.page.FilesPageElement.filesRow().openFileActionsMenu(resource)
   }
@@ -1134,7 +1134,7 @@ Then('the user should be redirected to the public links page', function() {
   return client.page.publicLinkFilesPage().waitForPage()
 })
 
-Then('file/folder {string} shared by {string} should not be listed in the webUI', async function(
+Then('file/folder {string} shared by {string} should not be listed on the webUI', async function(
   element,
   sharer
 ) {
@@ -1368,13 +1368,13 @@ Then('the user should be in the root directory on the webUI', async function() {
   assert.ok(!isUserInRootDirectory, 'Expected user in the root directory but found elsewhere')
 })
 
-Then('the search bar should not be visible in the webUI', async function() {
+Then('the search bar should not be visible on the webUI', async function() {
   await client.page.FilesPageElement.filesList().waitForLoadingFinished(false)
   const isVisible = await client.page.personalPage().isSearchBarVisible()
   assert.strictEqual(isVisible, false, 'Expected search bar to be invisible but is visible')
 })
 
-Then('the search bar should be visible in the webUI', async function() {
+Then('the search bar should be visible on the webUI', async function() {
   await client.page.FilesPageElement.filesList().waitForLoadingFinished(false)
   const isVisible = await client.page.personalPage().isSearchBarVisible()
   assert.strictEqual(isVisible, true, 'Expected search bar to be visible but is not visible')

--- a/tests/acceptance/stepDefinitions/loginContext.js
+++ b/tests/acceptance/stepDefinitions/loginContext.js
@@ -76,7 +76,7 @@ When('the user re-logs in as {string} using the webUI', user => {
   return loginHelper.reLoginAsUser(user)
 })
 
-Then('the user profile should be visible in the webUI', function() {
+Then('the user profile should be visible on the webUI', function() {
   return client.page.webPage().waitForElementVisible('@userMenuButton')
 })
 
@@ -84,7 +84,7 @@ When('the user opens the user profile', function() {
   return client.page.webPage().browseToUserProfile()
 })
 
-Then('username {string} should be visible in the webUI', async function(username) {
+Then('username {string} should be visible on the webUI', async function(username) {
   const profileUserName = await client.page.profilePage().getUserProfileName()
   assert.strictEqual(profileUserName, username)
 })
@@ -93,7 +93,7 @@ When('the user browses to manage the account', function() {
   return client.page.profilePage().browseToManageAccount()
 })
 
-Then('the accounts page should be visible in the webUI', async function() {
+Then('the accounts page should be visible on the webUI', async function() {
   const isPageVisible = await client.page.accountPage().isPageVisible()
   return assert.ok(isPageVisible)
 })

--- a/tests/acceptance/stepDefinitions/markdownEditorContext.js
+++ b/tests/acceptance/stepDefinitions/markdownEditorContext.js
@@ -48,7 +48,7 @@ Then('the file should not have content {string} in the markdown editor webUI', a
   return assertNotEqualText(content, contentInEditor, 'content')
 })
 
-Then('the preview panel should have the content {string} on the WebUI', async content => {
+Then('the preview panel should have the content {string} on the webUI', async content => {
   const contentInPreview = await markdownEditor.getContentFromPanel()
   return assertEqualText(content, contentInPreview, 'content')
 })

--- a/tests/acceptance/stepDefinitions/markdownEditorContext.js
+++ b/tests/acceptance/stepDefinitions/markdownEditorContext.js
@@ -48,13 +48,13 @@ Then('the file should not have content {string} in the markdown editor webUI', a
   return assertNotEqualText(content, contentInEditor, 'content')
 })
 
-Then('the preview panel should have the content {string} in the WebUI', async content => {
+Then('the preview panel should have the content {string} on the WebUI', async content => {
   const contentInPreview = await markdownEditor.getContentFromPanel()
   return assertEqualText(content, contentInPreview, 'content')
 })
 
 When(
-  'the user opens file {string} in the markdown editor using the action menu option in the webUI',
+  'the user opens file {string} in the markdown editor using the action menu option on the webUI',
   async fileName => {
     return await markdownEditor.openMdEditorUsingActionMenu(fileName)
   }

--- a/tests/acceptance/stepDefinitions/publicLinkContext.js
+++ b/tests/acceptance/stepDefinitions/publicLinkContext.js
@@ -49,7 +49,7 @@ When(
   }
 )
 
-Then('the password input for the public link should appear in the webUI', function() {
+Then('the password input for the public link should appear on the webUI', function() {
   return client.page.publicLinkPasswordPage().waitForVisible()
 })
 

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -952,7 +952,7 @@ Then('user {string} should be listed as {string} in the collaborators list on th
 })
 
 Then(
-  'the share {string} shared with user {string} should have no expiration information displayed on the WebUI',
+  'the share {string} shared with user {string} should have no expiration information displayed on the webUI',
   async function(item, user) {
     await client.page.FilesPageElement.filesList().clickRow(item)
     await client.page.FilesPageElement.appSideBar().selectAccordionItem('people')
@@ -968,7 +968,7 @@ Then(
 )
 
 Then(
-  'the expiration information displayed on the WebUI of share {string} shared with user {string} should be {string} or {string}',
+  'the expiration information displayed on the webUI of share {string} shared with user {string} should be {string} or {string}',
   async function(item, user, information1, information2) {
     await client.page.FilesPageElement.filesList().clickRow(item)
     await client.page.FilesPageElement.appSideBar().selectAccordionItem('people')
@@ -1135,13 +1135,13 @@ Then('the collaborators list for file/folder/resource {string} should be empty',
   )
 })
 
-Then('the expiration date field should be marked as required on the WebUI', async function() {
+Then('the expiration date field should be marked as required on the webUI', async function() {
   await client.page.FilesPageElement.sharingDialog().waitForElementVisible(
     '@requiredLabelInCollaboratorsExpirationDate'
   )
 })
 
-Then('the expiration date for {string} should be disabled on the WebUI', async function(
+Then('the expiration date for {string} should be disabled on the webUI', async function(
   expiration
 ) {
   const dateToSet = calculateDate(expiration)

--- a/tests/acceptance/stepDefinitions/sharingContext.js
+++ b/tests/acceptance/stepDefinitions/sharingContext.js
@@ -589,11 +589,11 @@ Given('the administrator has excluded group {string} from receiving shares', asy
   }
 })
 
-When('the user opens the share creation dialog in the webUI', function() {
+When('the user opens the share creation dialog on the webUI', function() {
   return client.page.FilesPageElement.SharingDialog.collaboratorsDialog().clickCreateShare()
 })
 
-When('the user cancels the share creation dialog in the webUI', function() {
+When('the user cancels the share creation dialog on the webUI', function() {
   return client.page.FilesPageElement.sharingDialog().clickCancel()
 })
 
@@ -1384,7 +1384,7 @@ Then('it should not be possible to save the pending share on the webUI', async f
 })
 
 When(
-  'the user shares resource {string} with user {string} using the quick action in the webUI',
+  'the user shares resource {string} with user {string} using the quick action on the webUI',
   function(resource, user) {
     return userSharesFileOrFolderWithUserOrGroup(
       resource,


### PR DESCRIPTION
## Description
Change the remaining "in the webUI" to "on the webUI" in acceptance tests to be consistent.

## Related Issue
- Fixes #5545 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...