### PR TITLE
[tests-only] change the file content of a received share

### DIFF
--- a/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
+++ b/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
@@ -165,3 +165,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 
 ### [reshared share that is shared with a group the sharer is part of shows twice on "Share with me" page](https://github.com/owncloud/web/issues/2512)
 -   [webUISharingAcceptShares/acceptShares.feature:31](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature#L31)
+
+### [Change the file content of a received shared file](https://github.com/owncloud/web/pull/5534)
+-   [webUIFilesActionMenu/versions.feature:87](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L87)

--- a/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
+++ b/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
@@ -166,5 +166,5 @@ Other free text and markdown formatting can be used elsewhere in the document if
 ### [reshared share that is shared with a group the sharer is part of shows twice on "Share with me" page](https://github.com/owncloud/web/issues/2512)
 -   [webUISharingAcceptShares/acceptShares.feature:31](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature#L31)
 
-### [Change the file content of a received shared file](https://github.com/owncloud/web/pull/5534)
--   [webUIFilesActionMenu/versions.feature:87](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L87)
+### [Change the file content of a received shared file](https://github.com/owncloud/web/pull/5548)
+-   [webUIFilesActionMenu/versions.feature:88](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L88)

--- a/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
+++ b/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
@@ -166,5 +166,5 @@ Other free text and markdown formatting can be used elsewhere in the document if
 ### [reshared share that is shared with a group the sharer is part of shows twice on "Share with me" page](https://github.com/owncloud/web/issues/2512)
 -   [webUISharingAcceptShares/acceptShares.feature:31](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature#L31)
 
-### [Change the file content of a received shared file](https://github.com/owncloud/web/pull/5548)
+### [Change the file content of a received shared file](https://github.com/owncloud/ocis/issues/2319)
 -   [webUIFilesActionMenu/versions.feature:88](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L88)

--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -158,7 +158,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIFilesActionMenu/versions.feature:59](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L59)
 -   [webUIFilesActionMenu/versions.feature:74](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L74)
 
-### [Change the file content of a received shared file](https://github.com/owncloud/web/pull/5548)
+### [Change the file content of a received shared file](https://github.com/owncloud/ocis/issues/2319)
 -   [webUIFilesActionMenu/versions.feature:88](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L88)
 
 ### [No occ command in ocis](https://github.com/owncloud/ocis/issues/1317)

--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -158,8 +158,8 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIFilesActionMenu/versions.feature:59](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L59)
 -   [webUIFilesActionMenu/versions.feature:74](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L74)
 
-### [Change the file content of a received shared file](https://github.com/owncloud/web/pull/5534)
--   [webUIFilesActionMenu/versions.feature:87](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L87)
+### [Change the file content of a received shared file](https://github.com/owncloud/web/pull/5548)
+-   [webUIFilesActionMenu/versions.feature:88](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L88)
 
 ### [No occ command in ocis](https://github.com/owncloud/ocis/issues/1317)
 -   [webUIRestrictSharing/restrictReSharing.feature:23](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature#L23)

--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -158,6 +158,9 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIFilesActionMenu/versions.feature:59](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L59)
 -   [webUIFilesActionMenu/versions.feature:74](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L74)
 
+### [Change the file content of a received shared file](https://github.com/owncloud/web/pull/5534)
+-   [webUIFilesActionMenu/versions.feature:87](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L87)
+
 ### [No occ command in ocis](https://github.com/owncloud/ocis/issues/1317)
 -   [webUIRestrictSharing/restrictReSharing.feature:23](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature#L23)
 -   [webUIRestrictSharing/restrictReSharing.feature:42](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature#L42)

--- a/tests/acceptance/features/webUIFilesActionMenu/versions.feature
+++ b/tests/acceptance/features/webUIFilesActionMenu/versions.feature
@@ -84,7 +84,7 @@ Feature: Versions of a file
     And the user browses to display the "versions" details of file "lorem-file.txt"
     Then the versions list should contain 0 entries
 
-  @web-pull-5548
+  @issue-ocis-2319
   Scenario: change the file content of a received shared file
     Given user "Brian" has created file "lorem.txt"
     And user "Brian" has shared file "lorem.txt" with user "Alice" with "all" permissions

--- a/tests/acceptance/features/webUIFilesActionMenu/versions.feature
+++ b/tests/acceptance/features/webUIFilesActionMenu/versions.feature
@@ -84,6 +84,7 @@ Feature: Versions of a file
     And the user browses to display the "versions" details of file "lorem-file.txt"
     Then the versions list should contain 0 entries
 
+  @web-pull-5548
   Scenario: change the file content of a received shared file
     Given user "Brian" has created file "lorem.txt"
     And user "Brian" has shared file "lorem.txt" with user "Alice" with "all" permissions

--- a/tests/acceptance/features/webUIFilesActionMenu/versions.feature
+++ b/tests/acceptance/features/webUIFilesActionMenu/versions.feature
@@ -83,3 +83,13 @@ Feature: Versions of a file
     When the user re-logs in as "Alice" using the webUI
     And the user browses to display the "versions" details of file "lorem-file.txt"
     Then the versions list should contain 0 entries
+
+  Scenario: change the file content of a received shared file
+    Given user "Brian" has created file "lorem.txt"
+    And user "Brian" has shared file "lorem.txt" with user "Alice" with "all" permissions
+    And user "Alice" has accepted the share "lorem.txt" offered by user "Brian"
+    And user "Alice" has logged in using the webUI
+    And the user has opened folder "Shares" using the webUI
+    When the user uploads overwriting file "lorem.txt" using the webUI
+    Then the versions list should contain 1 entries 
+    


### PR DESCRIPTION
## Describe the bug
A test is written that demonstrates the error. The test will work when the bug is fixed

## Steps to reproduce
Steps to reproduce the behavior:

User1 creates file and shares file to User2
User2 accepts file and try to upload file with some name
Or run test: yarn run test:acceptance:ocis tests/acceptance/features/webUIUserJourney/journey1.feature:29

## Expected behavior
Created new version

## Actual behavior
403 Forbinden

<img width="1433" alt="125840261-52e59662-0d43-4672-9dac-0c3b3cb9e72e" src="https://user-images.githubusercontent.com/84779829/126222608-93d08ac5-61e4-4a10-ada2-d0444a085ecf.png">


## Setup
Please describe how you started the server and provide a list of relevant environment variables.

OCIS_VERSION=v1.9.0 reachable at https://localhost:9200
BRANCH=v1.9.0-rc1