### PR TITLE
send cookie on manifest.json

### DIFF
--- a/changelog/unreleased/bugfix-send-cookie-manifests-json
+++ b/changelog/unreleased/bugfix-send-cookie-manifests-json
@@ -1,0 +1,5 @@
+Bugfix: Send authentication on manifests.json
+
+We've changed that requests to manifest.json will use authentication, too.
+
+https://github.com/owncloud/web/pull/5553

--- a/packages/web-container/index.html.ejs
+++ b/packages/web-container/index.html.ejs
@@ -5,7 +5,7 @@
     <meta<%- helpers.makeHtmlAttributes(m) %>>
   <% }); %>
   <title><%= data.title %></title>
-  <link rel="manifest" href="manifest.json">
+  <link rel="manifest" href="manifest.json" crossorigin="use-credentials">
   <% Object.keys(data.bundle.css).forEach((s) => { %>
     <link href="<%- data.bundle.css[s] %>" rel="stylesheet">
   <% }); %>


### PR DESCRIPTION
## Description
Requests to manifest.json are performed without any authorization / cookies.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/w3c/manifest/issues/535

## Motivation and Context
 For the ownCloud 10 to oCIS migration strategy we want to utilize cookies, to decide where to route requests. Therefore every request needs to send the cookie, also manifest.json.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: dev setup  (add a cookie and see if it was added to the manifest.json request)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...