### PR TITLE
a11y fix visible labels for screenreader

### DIFF
--- a/changelog/unreleased/enhancement-a11y-fix-visible-labels
+++ b/changelog/unreleased/enhancement-a11y-fix-visible-labels
@@ -1,0 +1,5 @@
+Enhancement: Fix visible labels for screenreader
+
+We fixed the wrong aria-labels for "Neu"/"New" and "Öffentlicher Link"/"Public Link"
+
+https://github.com/owncloud/web/issues/5394

--- a/packages/web-app-files/src/components/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar.vue
@@ -159,7 +159,7 @@ export default {
       if (tooltip) {
         return tooltip
       }
-      return this.$gettext('Add files or folders')
+      return this.$gettext('New files or folders')
     },
     currentPath() {
       const path = this.$route.params.item || ''

--- a/packages/web-app-files/src/components/FileLinkSidebar.vue
+++ b/packages/web-app-files/src/components/FileLinkSidebar.vue
@@ -18,7 +18,6 @@
             id="files-file-link-add"
             icon="add"
             variation="primary"
-            :aria-label="$_addButtonAriaLabel"
             @click="addNewLink"
           >
             <oc-icon name="add" />


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
See https://github.com/owncloud/web/issues/5394

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/5394

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
