### PR TITLE
[full-ci] feat: load only opened panels

### DIFF
--- a/changelog/unreleased/enhancement-load-only-opened-panels
+++ b/changelog/unreleased/enhancement-load-only-opened-panels
@@ -1,0 +1,6 @@
+Enhancement: load only opened panels
+
+Do not load panels in the Files extension sidebar until they are opened.
+
+https://github.com/owncloud/web/issues/5569
+https://github.com/owncloud/web/pull/5573


### PR DESCRIPTION
Do not load panels in the Files extension sidebar until they are opened.

I've chosen here a slightly different approach than via events. I would still like to use animation events listeners instead of the observer but in a separate PR.