### PR TITLE
[full-ci] Restructure context menu items

### DIFF
--- a/changelog/unreleased/enhancement-filestable-dropdown-actions
+++ b/changelog/unreleased/enhancement-filestable-dropdown-actions
@@ -1,6 +1,6 @@
 Enhancement: Dropdown actions in FilesTable
 
-Users can now access quick actions in a dropdown by clicking on 
+Users can now access quick actions in a dropdown by clicking on
 the three-dots button or right-clicking on rows in the files table.
 
 We've also bumped the ownCloud Design System to version 8.3.0
@@ -10,3 +10,5 @@ https://github.com/owncloud/web/issues/5102
 https://github.com/owncloud/web/issues/5103
 https://github.com/owncloud/web/pull/5551
 https://github.com/owncloud/web/pull/5554
+https://github.com/owncloud/web/issues/5160
+https://github.com/owncloud/web/pull/5576

--- a/packages/web-app-files/src/components/FilesList/ContextActions.vue
+++ b/packages/web-app-files/src/components/FilesList/ContextActions.vue
@@ -1,7 +1,11 @@
 <template>
   <ul id="oc-files-context-actions" class="uk-list oc-mt-s">
     <template v-for="(section, i) in menuSections">
-      <li v-for="(action, j) in section.items" :key="`section-${section.name}-action-${j}`">
+      <li
+        v-for="(action, j) in section.items"
+        :key="`section-${section.name}-action-${j}`"
+        class="oc-files-context-action"
+      >
         <component
           :is="action.componentType"
           v-bind="getComponentProps(action, item)"

--- a/packages/web-app-files/src/components/FilesList/ContextActions.vue
+++ b/packages/web-app-files/src/components/FilesList/ContextActions.vue
@@ -170,7 +170,10 @@ export default {
       const callback = () => action.handler(resource, action.handlerData)
       if (action.keepOpen) {
         return {
-          'click.stop': callback
+          click: event => {
+            event.stopPropagation()
+            callback()
+          }
         }
       }
       return {

--- a/packages/web-app-files/src/components/FilesList/ContextActions.vue
+++ b/packages/web-app-files/src/components/FilesList/ContextActions.vue
@@ -10,7 +10,7 @@
           :is="action.componentType"
           v-bind="getComponentProps(action, item)"
           :class="['oc-text-bold', action.class]"
-          @click.stop="action.handler(item, action.handlerData)"
+          v-on="getComponentListeners(action, item)"
         >
           <oc-icon :name="action.icon" size="medium" />
           <span class="oc-files-context-action-label">{{ action.label(item) }}</span>
@@ -120,7 +120,10 @@ export default {
           ...this.$_download_items,
           ...this.$_createPublicLink_items,
           ...this.$_showShares_items,
-          ...this.$_favorite_items
+          ...this.$_favorite_items.map(action => {
+            action.keepOpen = true
+            return action
+          })
         ].filter(item => item.isEnabled(this.filterParams))
       )
 
@@ -142,13 +145,13 @@ export default {
     }
   },
   methods: {
-    getComponentProps(action, target) {
+    getComponentProps(action, resource) {
       if (action.componentType === 'router-link' && action.route) {
         return {
           to: {
             name: action.route,
             params: {
-              item: target.path
+              item: resource.path
             }
           }
         }
@@ -156,6 +159,22 @@ export default {
 
       return {
         appearance: 'raw'
+      }
+    },
+
+    getComponentListeners(action, resource) {
+      if (action.handler === undefined || action.componentType !== 'oc-button') {
+        return {}
+      }
+
+      const callback = () => action.handler(resource, action.handlerData)
+      if (action.keepOpen) {
+        return {
+          'click.stop': callback
+        }
+      }
+      return {
+        click: callback
       }
     }
   }

--- a/packages/web-app-files/src/components/FilesList/ContextActions.vue
+++ b/packages/web-app-files/src/components/FilesList/ContextActions.vue
@@ -23,17 +23,34 @@
 import { mapGetters } from 'vuex'
 
 import FileActions from '../../mixins/fileActions'
-import Copy from './../../mixins/actions/copy'
-import Delete from './../../mixins/actions/delete'
+import Copy from '../../mixins/actions/copy'
+import CreatePublicLink from '../../mixins/actions/createPublicLink'
+import Delete from '../../mixins/actions/delete'
 import Download from '../../mixins/actions/download'
 import Favorite from '../../mixins/actions/favorite'
-import Move from './../../mixins/actions/move'
+import Move from '../../mixins/actions/move'
 import Navigate from '../../mixins/actions/navigate'
-import Rename from './../../mixins/actions/rename'
+import Rename from '../../mixins/actions/rename'
+import ShowActions from '../../mixins/actions/showActions'
+import ShowDetails from '../../mixins/actions/showDetails'
+import ShowShares from '../../mixins/actions/showShares'
 
 export default {
   name: 'ContextActions',
-  mixins: [FileActions, Copy, Delete, Download, Favorite, Move, Navigate, Rename],
+  mixins: [
+    FileActions,
+    Copy,
+    CreatePublicLink,
+    Delete,
+    Download,
+    Favorite,
+    Move,
+    Navigate,
+    Rename,
+    ShowActions,
+    ShowDetails,
+    ShowShares
+  ],
 
   props: {
     item: {
@@ -54,10 +71,10 @@ export default {
 
       // `open` and `open with`
       const openActions = [
-        ...this.$_navigate_items.filter(item => item.isEnabled(filterParams)),
-        ...this.$_fetch_items.filter(item => item.isEnabled(filterParams)),
-        ...this.$_fileActions_editorActions.filter(item => item.isEnabled(filterParams))
-      ]
+        ...this.$_navigate_items,
+        ...this.$_fetch_items,
+        ...this.$_fileActions_editorActions
+      ].filter(item => item.isEnabled(filterParams))
       if (openActions.length > 0) {
         menuItems.push(openActions[0])
       }
@@ -67,16 +84,18 @@ export default {
 
       // other actions
       menuItems.push(
-        ...this.$_download_items.filter(item => item.isEnabled(filterParams)),
-        // create & copy public link
-        // share
-        ...this.$_favorite_items.filter(item => item.isEnabled(filterParams)),
-        ...this.$_rename_items.filter(item => item.isEnabled(filterParams)),
-        ...this.$_move_items.filter(item => item.isEnabled(filterParams)),
-        ...this.$_copy_items.filter(item => item.isEnabled(filterParams)),
-        ...this.$_delete_items.filter(item => item.isEnabled(filterParams))
-        // all actions
-        // details
+        ...[
+          ...this.$_download_items,
+          ...this.$_createPublicLink_items,
+          ...this.$_showShares_items,
+          ...this.$_favorite_items,
+          ...this.$_rename_items,
+          ...this.$_move_items,
+          ...this.$_copy_items,
+          ...this.$_delete_items,
+          ...this.$_showActions_items,
+          ...this.$_showDetails_items
+        ].filter(item => item.isEnabled(filterParams))
       )
 
       return menuItems

--- a/packages/web-app-files/src/mixins/actions/createPublicLink.js
+++ b/packages/web-app-files/src/mixins/actions/createPublicLink.js
@@ -1,0 +1,23 @@
+import quickActions, { canShare, createPublicLink } from '../../quickActions'
+
+export default {
+  computed: {
+    $_createPublicLink_items() {
+      return [
+        {
+          icon: quickActions.publicLink.icon,
+          label: () => this.$gettext('Create & copy public link'),
+          handler: this.$_createPublicLink_trigger,
+          isEnabled: ({ resource }) => canShare(resource, this.$store),
+          componentType: 'oc-button',
+          class: 'oc-files-actions-create-public-link-trigger'
+        }
+      ]
+    }
+  },
+  methods: {
+    $_createPublicLink_trigger(resource) {
+      createPublicLink({ item: resource, client: this.$client, store: this.$store })
+    }
+  }
+}

--- a/packages/web-app-files/src/mixins/actions/download.js
+++ b/packages/web-app-files/src/mixins/actions/download.js
@@ -1,4 +1,4 @@
-import { checkRoute } from '../../helpers/route'
+import { isTrashbinRoute } from '../../helpers/route'
 
 export default {
   computed: {
@@ -11,7 +11,7 @@ export default {
             return this.$gettext('Download')
           },
           isEnabled: ({ resource }) => {
-            if (checkRoute(['files-trashbin'], this.$route.name)) {
+            if (isTrashbinRoute(this.$route)) {
               return false
             }
 

--- a/packages/web-app-files/src/mixins/actions/favorite.js
+++ b/packages/web-app-files/src/mixins/actions/favorite.js
@@ -11,9 +11,9 @@ export default {
           handler: this.$_favorite_trigger,
           label: item => {
             if (item.starred) {
-              return this.$gettext('Unmark as favorite')
+              return this.$gettext('Remove from favorites')
             }
-            return this.$gettext('Mark as favorite')
+            return this.$gettext('Add to favorites')
           },
           isEnabled: () => {
             const isRouteAllowed = checkRoute(

--- a/packages/web-app-files/src/mixins/actions/navigate.js
+++ b/packages/web-app-files/src/mixins/actions/navigate.js
@@ -1,4 +1,4 @@
-import { checkRoute } from '../../helpers/route'
+import { isTrashbinRoute } from '../../helpers/route'
 
 export default {
   computed: {
@@ -10,7 +10,7 @@ export default {
           label: () =>
             this.$pgettext('Action in the files list row to open a folder', 'Open folder'),
           isEnabled: ({ resource }) => {
-            if (checkRoute(['files-trashbin'], this.$route.name)) {
+            if (isTrashbinRoute(this.$route)) {
               return false
             }
 

--- a/packages/web-app-files/src/mixins/actions/rename.js
+++ b/packages/web-app-files/src/mixins/actions/rename.js
@@ -1,6 +1,6 @@
 import { mapActions, mapGetters } from 'vuex'
 
-import { checkRoute } from '../../helpers/route'
+import { isTrashbinRoute } from '../../helpers/route'
 
 export default {
   computed: {
@@ -15,7 +15,7 @@ export default {
           },
           handler: this.$_rename_trigger,
           isEnabled: ({ resource }) => {
-            if (checkRoute(['files-trashbin'], this.$route.name)) {
+            if (isTrashbinRoute(this.$route)) {
               return false
             }
 

--- a/packages/web-app-files/src/mixins/actions/restore.js
+++ b/packages/web-app-files/src/mixins/actions/restore.js
@@ -1,6 +1,6 @@
 import { mapActions } from 'vuex'
 
-import { checkRoute } from '../../helpers/route'
+import { isTrashbinRoute } from '../../helpers/route'
 
 export default {
   computed: {
@@ -10,7 +10,7 @@ export default {
           icon: 'restore',
           label: () => this.$gettext('Restore'),
           handler: this.$_restore_trigger,
-          isEnabled: () => checkRoute(['files-trashbin'], this.$route.name),
+          isEnabled: () => isTrashbinRoute(this.$route),
           componentType: 'oc-button',
           class: 'oc-files-actions-restore-trigger'
         }

--- a/packages/web-app-files/src/mixins/actions/showActions.js
+++ b/packages/web-app-files/src/mixins/actions/showActions.js
@@ -1,0 +1,27 @@
+import { mapActions, mapMutations } from 'vuex'
+
+export default {
+  computed: {
+    $_showActions_items() {
+      return [
+        {
+          icon: 'slideshow',
+          label: () => this.$gettext('All Actions'),
+          handler: this.$_showActions_trigger,
+          isEnabled: () => true,
+          componentType: 'oc-button',
+          class: 'oc-files-actions-show-actions-trigger'
+        }
+      ]
+    }
+  },
+  methods: {
+    ...mapMutations('Files', ['SET_APP_SIDEBAR_ACTIVE_PANEL']),
+    ...mapActions('Files', ['setHighlightedFile']),
+
+    $_showActions_trigger(resource) {
+      this.setHighlightedFile(resource)
+      this.SET_APP_SIDEBAR_ACTIVE_PANEL('actions-item')
+    }
+  }
+}

--- a/packages/web-app-files/src/mixins/actions/showDetails.js
+++ b/packages/web-app-files/src/mixins/actions/showDetails.js
@@ -1,0 +1,28 @@
+import { mapActions, mapMutations } from 'vuex'
+import { isTrashbinRoute } from '../../helpers/route'
+
+export default {
+  computed: {
+    $_showDetails_items() {
+      return [
+        {
+          icon: 'info_outline',
+          label: () => this.$gettext('Details'),
+          handler: this.$_showDetails_trigger,
+          isEnabled: () => !isTrashbinRoute(this.$route),
+          componentType: 'oc-button',
+          class: 'oc-files-actions-show-details-trigger'
+        }
+      ]
+    }
+  },
+  methods: {
+    ...mapMutations('Files', ['SET_APP_SIDEBAR_ACTIVE_PANEL']),
+    ...mapActions('Files', ['setHighlightedFile']),
+
+    $_showDetails_trigger(resource) {
+      this.setHighlightedFile(resource)
+      this.SET_APP_SIDEBAR_ACTIVE_PANEL(null)
+    }
+  }
+}

--- a/packages/web-app-files/src/mixins/actions/showShares.js
+++ b/packages/web-app-files/src/mixins/actions/showShares.js
@@ -1,0 +1,23 @@
+import quickActions, { canShare, openNewCollaboratorsPanel } from '../../quickActions'
+
+export default {
+  computed: {
+    $_showShares_items() {
+      return [
+        {
+          icon: quickActions.collaborators.icon,
+          label: () => this.$gettext('Share'),
+          handler: this.$_showShares_trigger,
+          isEnabled: ({ resource }) => canShare(resource, this.$store),
+          componentType: 'oc-button',
+          class: 'oc-files-actions-show-shares-trigger'
+        }
+      ]
+    }
+  },
+  methods: {
+    $_showShares_trigger(resource) {
+      openNewCollaboratorsPanel({ item: resource, client: this.$client, store: this.$store })
+    }
+  }
+}

--- a/packages/web-app-files/src/quickActions.js
+++ b/packages/web-app-files/src/quickActions.js
@@ -6,9 +6,9 @@ function $gettext(msg) {
   return msg
 }
 
-function createPublicLink(ctx) {
+export function createPublicLink(ctx) {
   // FIXME: Translate name
-  const params = { name: 'Quick action link', permissions: 1 }
+  const params = { name: $gettext('Quick action link'), permissions: 1 }
   const capabilities = ctx.store.state.user.capabilities
   const expirationDate = capabilities.files_sharing.public.expire_date
 
@@ -24,6 +24,7 @@ function createPublicLink(ctx) {
       ctx.store
         .dispatch('Files/addLink', { path: ctx.item.path, client: ctx.client, params })
         .then(link => {
+          ctx.store.commit('Files/SET_APP_SIDEBAR_ACTIVE_PANEL', 'links-item')
           copyToClipboard(link.url)
           ctx.store.dispatch('showMessage', {
             title: $gettext('Public link created'),
@@ -44,12 +45,12 @@ function createPublicLink(ctx) {
   })
 }
 
-function openNewCollaboratorsPanel(ctx) {
+export function openNewCollaboratorsPanel(ctx) {
   ctx.store.dispatch('Files/setHighlightedFile', ctx.item)
   ctx.store.commit('Files/SET_APP_SIDEBAR_ACTIVE_PANEL', 'sharing-item')
 }
 
-function canShare(item, store) {
+export function canShare(item, store) {
   return (
     store.state.user.capabilities.files_sharing &&
     store.state.user.capabilities.files_sharing.api_enabled &&

--- a/packages/web-app-files/tests/unit/components/FilesList/ContextActions.spec.js
+++ b/packages/web-app-files/tests/unit/components/FilesList/ContextActions.spec.js
@@ -90,6 +90,9 @@ const apps = {
   newFileHandlers: editors,
   meta
 }
+const user = {
+  capabilities: {}
+}
 
 describe('ContextActions', () => {
   function getWrapper(route, { filename = '', extension = '', type = '' }) {
@@ -120,7 +123,7 @@ describe('ContextActions', () => {
 
   const selectors = {
     actionList: '#oc-files-context-actions',
-    actionItem: 'li.oc-py-xs'
+    actionItem: 'li.oc-files-context-action'
   }
 
   describe('renders a list of actions', () => {
@@ -155,7 +158,8 @@ describe('ContextActions', () => {
 function createStore(state) {
   return new Vuex.Store({
     state: {
-      apps: apps
+      apps,
+      user
     },
     modules: {
       Files: {

--- a/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
@@ -90,7 +90,7 @@ module.exports = {
       return items
     },
     getActionsMenuItemsExceptDefaults: async function() {
-      const defaultItems = ['mark as favorite', 'copy', 'move', 'rename', 'delete']
+      const defaultItems = ['add to favorites', 'copy', 'move', 'rename', 'delete']
       const items = []
       let elements
       await this.api.elements('@panelActionsItems', function(result) {

--- a/tests/acceptance/pageObjects/FilesPageElement/fileActionsMenu.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/fileActionsMenu.js
@@ -182,11 +182,11 @@ module.exports = {
       locateStrategy: 'xpath'
     },
     favoriteButtonInAccordion: {
-      selector: '//button[normalize-space()="Mark as favorite"]',
+      selector: '//button[normalize-space()="Add to favorites"]',
       locateStrategy: 'xpath'
     },
     unmarkFavoriteButtonInAccordion: {
-      selector: '//button[normalize-space()="Unmark as favorite"]',
+      selector: '//button[normalize-space()="Remove from favorites"]',
       locateStrategy: 'xpath'
     },
     restoreButtonInAccordion: {


### PR DESCRIPTION
## Description
This PR restructures the context menu to not just list the actions from the right sidebar but instead to bring the structure that was proposed in https://github.com/owncloud/web/issues/5160

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/5160

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):
<img width="2369" alt="Screenshot 2021-07-28 at 23 29 33" src="https://user-images.githubusercontent.com/3532843/127399132-c96305a4-7447-4890-a47a-033bf68a4f48.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...