### PR TITLE
[unit-tests] Added unit tests for link actions component

### DIFF
--- a/packages/web-app-files/tests/unit/components/SideBar/Links/PublicLinks/LinkActions.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Links/PublicLinks/LinkActions.spec.js
@@ -1,0 +1,147 @@
+import LinkActions from '@files/src/components/SideBar/Links/PublicLinks/LinkActions.vue'
+import { createLocalVue, mount, shallowMount } from '@vue/test-utils'
+import GetTextPlugin from 'vue-gettext'
+import Vuex from 'vuex'
+import DesignSystem from 'owncloud-design-system'
+
+const localVue = createLocalVue()
+localVue.use(DesignSystem)
+localVue.use(Vuex)
+localVue.use(GetTextPlugin, {
+  translations: 'does-not-matter.json',
+  silent: true
+})
+
+const selectors = {
+  editActionButton: '.oc-files-file-link-edit',
+  deleteActionButton: '.oc-files-file-link-delete'
+}
+
+const storeOptions = {
+  modules: {
+    Files: {
+      namespaced: true,
+      actions: {
+        removeLink: jest.fn()
+      },
+      mutations: {
+        TRIGGER_PUBLIC_LINK_EDIT: jest.fn()
+      }
+    }
+  },
+  actions: {
+    showMessage: jest.fn(),
+    createModal: jest.fn(),
+    hideModal: jest.fn()
+  }
+}
+
+describe('LinkActions', () => {
+  describe('removal in progress', () => {
+    it('should render spinner if true', async () => {
+      const wrapper = getShallowMountedWrapper()
+      await wrapper.setData({ removalInProgress: true })
+      const spinner = wrapper.find('oc-spinner-stub')
+
+      expect(spinner.exists()).toBeTruthy()
+      expect(spinner.attributes('aria-label')).toBe('Removing public link')
+
+      const actionLinks = wrapper.findAll('oc-button-stub')
+      expect(actionLinks.length).toBe(0)
+    })
+
+    it('should not render spinner if false', async () => {
+      const wrapper = getShallowMountedWrapper()
+      await wrapper.setData({ removalInProgress: false })
+      const spinner = wrapper.find('oc-spinner-stub')
+      expect(spinner.exists()).toBeFalsy()
+
+      const actionLinks = wrapper.findAll('oc-button-stub')
+      expect(actionLinks.length).toBe(2)
+    })
+  })
+
+  describe('action buttons label', () => {
+    it('should set edit link button label', () => {
+      const wrapper = getShallowMountedWrapper()
+      const editLinkButton = wrapper.find(selectors.editActionButton)
+
+      expect(editLinkButton.attributes('aria-label')).toBe('Edit public link')
+    })
+
+    it('should set remove link button label', () => {
+      const wrapper = getShallowMountedWrapper()
+      const editLinkButton = wrapper.find(selectors.deleteActionButton)
+
+      expect(editLinkButton.attributes('aria-label')).toBe('Delete public link')
+    })
+  })
+
+  describe('link buttons function calls', () => {
+    const editLinkSpy = jest.spyOn(LinkActions.methods, 'editLink')
+    const removeLinkSpy = jest.spyOn(LinkActions.methods, '$_removeLink')
+    const triggerPublicLinkEditSpy = jest.spyOn(
+      storeOptions.modules.Files.mutations,
+      'TRIGGER_PUBLIC_LINK_EDIT'
+    )
+    const wrapper = getMountedWrapper()
+
+    it('should call "editLink" if edit link button is clicked', async () => {
+      const wrapper = getMountedWrapper()
+      const editButton = wrapper.find(selectors.editActionButton)
+      await editButton.trigger('click')
+
+      expect(editLinkSpy).toHaveBeenCalledTimes(1)
+      expect(triggerPublicLinkEditSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('should call "$_removeLink" if delete link button is clicked', async () => {
+      const deleteButton = wrapper.find(selectors.deleteActionButton)
+      await deleteButton.trigger('click')
+
+      expect(removeLinkSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+})
+
+function getMountedWrapper() {
+  return mount(LinkActions, {
+    localVue,
+    propsData: {
+      link: {}
+    },
+    provide: {
+      changeView: jest.fn()
+    },
+    store: createStore(),
+    stubs: {
+      'oc-button': false,
+      'oc-icon': true,
+      'oc-spinner': true
+    }
+  })
+}
+
+function getShallowMountedWrapper() {
+  return shallowMount(LinkActions, {
+    propsData: {
+      link: {}
+    },
+    store: createStore(),
+    provide: {
+      changeView: jest.fn()
+    },
+    directives: {
+      'oc-tooltip': jest.fn()
+    },
+    stubs: {
+      'oc-button': true,
+      'oc-icon': true,
+      'oc-spinner': true
+    }
+  })
+}
+
+function createStore() {
+  return new Vuex.Store(storeOptions)
+}


### PR DESCRIPTION
## Description
- added unit tests for `LinkActions` component from `web-app-files` package

## Related Issue
- Part of #5234 

## Motivation and Context
- unit tests coverage

## How Has This Been Tested?
- 💇🏼‍♂️ 
- 🤖 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 