### PR TITLE
[tests-only] [full-ci] Adjust invalid file and folder name tests

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,7 +1,7 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=cc8273f048e36503fd78b7e185321eb8f949bdf6
+OCIS_COMMITID=ad0e7fe38d35b85d2b762b8e403e2f62485fd3c8
 OCIS_BRANCH=master
 
 # The test runner source for API tests
-CORE_COMMITID=58c1c886f44ee727cf777c45aee1a6c0aa78d65b
+CORE_COMMITID=bd3c6d3fcd63c6ed2c32a023812e7a0de52428c5
 CORE_BRANCH=master

--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -46,7 +46,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIFilesSearch/search.feature:153](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L151)
 -   [webUIFilesSearch/search.feature:165](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L163)
 -   [webUIFilesSearch/search.feature:175](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L173)
--   [webUIRenameFiles/renameFiles.feature:249](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFiles/renameFiles.feature#L249)
+-   [webUIRenameFiles/renameFiles.feature:252](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFiles/renameFiles.feature#L252)
 -   [webUISharingInternalUsersShareWithPage/shareWithUsers.feature:118](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalUsersShareWithPage/shareWithUsers.feature#L118)
 -   [webUIResharing1/reshareUsers.feature:230](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L230)
 
@@ -54,10 +54,10 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIDeleteFilesFolders/deleteFilesFolders.feature:235](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L235)
 
 ### [file_path property is not unique for a share created with same resource name i.e already present in sharee](https://github.com/owncloud/ocis/issues/2249)
--   [webUIRenameFiles/renameFiles.feature:202](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFiles/renameFiles.feature#L202)
+-   [webUIRenameFiles/renameFiles.feature:205](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFiles/renameFiles.feature#L205)
 
 ### [when sharer renames the shared resource, sharee get the updated name](https://github.com/owncloud/ocis/issues/2256)
--   [webUIRenameFiles/renameFiles.feature:227](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFiles/renameFiles.feature#L227)
+-   [webUIRenameFiles/renameFiles.feature:230](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFiles/renameFiles.feature#L230)
 
 ### [Viewer cannot share a shared resource](https://github.com/owncloud/ocis/issues/2260)
 -   [webUISharingInternalUsers/shareWithUsers.feature:53](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature#L53)
@@ -543,9 +543,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUISharingAcceptShares/acceptShares.feature:49](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature#L49)
 -   [webUISharingAcceptShares/acceptShares.feature:144](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature#L144)
 -   [webUISharingAcceptShares/acceptShares.feature:182](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature#L182)
-
-### [[oCIS] Deleting accepted share doesn't change share status from Accepted to Declined](https://github.com/owncloud/web/issues/5532)
--   [webUISharingAcceptShares/acceptShares.feature:193](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature#L193)
 
 ### [not possible to overwrite a received shared file](https://github.com/owncloud/ocis/issues/2267)
 -   [webUISharingInternalGroups/shareWithGroups.feature:77](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature#L77)

--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -105,9 +105,9 @@ Feature: rename files
     Then file "loremz.dat" should be listed on the webUI
     And file "loremy.tad" should be listed on the webUI
 
-  @notToImplementOnOCIS
-  # these are valid file names for ocis
-  Scenario Outline: Rename a file using forbidden characters (on oc10)
+
+  # these are invalid file names on all implementations
+  Scenario Outline: Try to rename a file using forbidden characters
     When the user tries to rename file "data.zip" to "<filename>" using the webUI
     Then the error message with header 'Error while renaming "data.zip" to "<filename>"' should be displayed on the webUI
     And file "data.zip" should be listed on the webUI
@@ -116,18 +116,21 @@ Feature: rename files
       | filename  |
       | lorem\txt |
       | \\.txt    |
-      | .htaccess |
+
+  @notToImplementOnOCIS
+  # .htaccess is an invalid file name on oC10
+  Scenario: Try to rename a file to .htaccess on oC10
+    When the user tries to rename file "data.zip" to ".htaccess" using the webUI
+    Then the error message with header 'Error while renaming "data.zip" to ".htaccess"' should be displayed on the webUI
+    And file "data.zip" should be listed on the webUI
+    And file "<filename>" should not be listed on the webUI
 
   @skipOnOC10
-  Scenario Outline: Rename a file using forbidden characters (on ocis)
-    When the user renames file "data.zip" to "<filename>" using the webUI
+  # .htaccess is a valid file name on OCIS
+  Scenario: Rename a file to .htaccess on OCIS
+    When the user renames file "data.zip" to ".htaccess" using the webUI
     Then file "data.zip" should not be listed on the webUI
-    And file "<filename>" should be listed on the webUI
-    Examples:
-      | filename  |
-      | lorem\txt |
-      | \\.txt    |
-      | .htaccess |
+    And file ".htaccess" should be listed on the webUI
 
   Scenario Outline: Rename a file/folder using forward slash in its name
     When the user tries to rename file "<from_file_name>" to "<to_file_name>" using the webUI

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -96,8 +96,7 @@ Feature: rename folders
       | a normal folder       |
       | another normal folder |
 
-  @notToImplementOnOCIS
-  # These are valid file names for ocis
+  # these are invalid file names on all implementations
   Scenario Outline: Rename a folder using forbidden characters
     When the user tries to rename folder <from_name> to <to_name> using the webUI
     Then the error message with header '<alert_message>' should be displayed on the webUI
@@ -106,17 +105,19 @@ Feature: rename folders
       | from_name       | to_name           | alert_message                                             |
       | "simple-folder" | "simple\folder"   | Error while renaming "simple-folder" to "simple\folder"   |
       | "simple-folder" | "\\simple-folder" | Error while renaming "simple-folder" to "\\simple-folder" |
-      | "simple-folder" | ".htaccess"       | Error while renaming "simple-folder" to ".htaccess"       |
+
+  @notToImplementOnOCIS
+  # .htaccess is an invalid folder name on oC10
+  Scenario: Try to rename a folder to .htaccess on oC10
+    When the user tries to rename folder "simple-folder" to ".htaccess" using the webUI
+    Then the error message with header 'Error while renaming "simple-folder" to ".htaccess"' should be displayed on the webUI
+    And folder "simple-folder" should be listed on the webUI
 
   @skipOnOC10
-  Scenario Outline: Rename a folder using forbidden characters
-    When the user renames folder <from_name> to <to_name> using the webUI
-    Then folder <to_name> should be listed on the webUI
-    Examples:
-      | from_name       | to_name           |
-      | "simple-folder" | "simple\folder"   |
-      | "simple-folder" | "\\simple-folder" |
-      | "simple-folder" | ".htaccess"       |
+  # .htaccess is a valid folder name on OCIS
+  Scenario: Rename a folder to .htaccess on OCIS
+    When the user renames folder "simple-folder" to ".htaccess" using the webUI
+    Then folder ".htaccess" should be listed on the webUI
 
 
   Scenario: Rename a folder putting a name of a file which already exists


### PR DESCRIPTION
## Description
Now that https://github.com/owncloud/ocis/pull/2334 has been merged, the invalid file/folder name rules are:
- file and folder names containing a backslash `\` are invalid on both oC10 and OCIS
- .htaccess is invalid on oC10 but valid on OCIS

Sort out the acceptance test scenarios so that they test these combinations.

## Related Issue
- Fixes #5595 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
