### PR TITLE
[ocis] Used span id as selector for openid login error message

### DIFF
--- a/tests/acceptance/pageObjects/ocisLoginPage.js
+++ b/tests/acceptance/pageObjects/ocisLoginPage.js
@@ -14,8 +14,7 @@ module.exports = {
       selector: 'button[type="submit"]'
     },
     invalidCredentialsMessage: {
-      locateStrategy: 'xpath',
-      selector: '//form/h6'
+      selector: '#oc-login-error-message'
     }
   },
   commands: [


### PR DESCRIPTION
### Description
- use id as a selector for login error message in open id login page

### Related Issue
- https://github.com/owncloud/ocis/issues/2350