### PR TITLE
[unit-tests-only] Run minimum pipelines for unit tests only PRs

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -727,10 +727,16 @@ def main(ctx):
     return pipelines + deploys + checkStarlark()
 
 def beforePipelines(ctx):
-    return yarnlint() + checkForRecentBuilds(ctx) + changelog(ctx) + website(ctx) + cacheOcisPipeline(ctx)
+    if "unit-tests-only" in ctx.build.title.lower():
+        return yarnlint() + checkForRecentBuilds(ctx)
+    else:
+        return yarnlint() + checkForRecentBuilds(ctx) + changelog(ctx) + website(ctx) + cacheOcisPipeline(ctx)
 
 def stagePipelines(ctx):
     unitTestPipelines = unitTests(ctx)
+    if "unit-tests-only" in ctx.build.title.lower():
+        return unitTestPipelines
+
     acceptancePipelines = acceptance(ctx)
     if acceptancePipelines == False:
         return unitTestPipelines
@@ -1038,7 +1044,7 @@ def unitTests(ctx):
 def acceptance(ctx):
     pipelines = []
 
-    if "acceptance" not in config or "unit-tests-only" in ctx.build.title.lower():
+    if "acceptance" not in config:
         return pipelines
 
     if type(config["acceptance"]) == "bool":


### PR DESCRIPTION
## Description
if the PR title has `unit-tests-only` then only the minimum pipelines will be executed in CI

Minimum Pipelines for unit-tests-only: 
- lint-test
- stop-recent-builds
- unit-and-integration-tests
- check-starlark

## Related Issue
- Fixes https://github.com/owncloud/web/issues/5421

## Motivation and Context
Optimize the CI build duration

## How Has This Been Tested?
- test environment: CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 