### PR TITLE
[docs-only] Do not run unit and acceptance test pipelines for docs only PRs

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -727,21 +727,28 @@ def main(ctx):
     return pipelines + deploys + checkStarlark()
 
 def beforePipelines(ctx):
-    if "unit-tests-only" in ctx.build.title.lower():
+    title = ctx.build.title.lower()
+    if "docs-only" in title:
+        return checkForRecentBuilds(ctx) + website(ctx)
+    elif "unit-tests-only" in title:
         return yarnlint() + checkForRecentBuilds(ctx)
     else:
         return yarnlint() + checkForRecentBuilds(ctx) + changelog(ctx) + website(ctx) + cacheOcisPipeline(ctx)
 
 def stagePipelines(ctx):
+    title = ctx.build.title.lower()
+    if "docs-only" in title:
+        return []
+
     unitTestPipelines = unitTests(ctx)
-    if "unit-tests-only" in ctx.build.title.lower():
+    if "unit-tests-only" in title:
         return unitTestPipelines
 
     acceptancePipelines = acceptance(ctx)
     if acceptancePipelines == False:
         return unitTestPipelines
 
-    if ("acceptance-tests-only" not in ctx.build.title.lower()):
+    if ("acceptance-tests-only" not in title):
         dependsOn(unitTestPipelines, acceptancePipelines)
 
     return unitTestPipelines + acceptancePipelines

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ docs-copy:
 	git remote add origin https://github.com/owncloud/owncloud.github.io; \
 	git fetch; \
 	git checkout origin/source -f; \
+	make -C $(HUGO) theme; \
 	rsync --delete -ax ../docs/ content/$(NAME)
 
 .PHONY: docs-build


### PR DESCRIPTION
## Description
Checks for `[docs-only]` in PR title and if found, unit and acceptance test pipelines won't run

## Related Issue
- part of https://github.com/owncloud/web/issues/5637

## Motivation and Context

## How Has This Been Tested?
- test environment: CI

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 