### PR TITLE
fix stop-recent-builds for forks

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -820,8 +820,6 @@ def checkForRecentBuilds(ctx):
     return pipelines
 
 def stopRecentBuilds(ctx):
-    repo_slug = ctx.build.source_repo if ctx.build.source_repo else ctx.repo.slug
-
     return [{
         "name": "stop-recent-builds",
         "image": "drone/cli:alpine",
@@ -833,8 +831,8 @@ def stopRecentBuilds(ctx):
             },
         },
         "commands": [
-            "drone build ls %s --status running > %s/recentBuilds.txt" % (repo_slug, dir["web"]),
-            "drone build info %s ${DRONE_BUILD_NUMBER} > %s/thisBuildInfo.txt" % (repo_slug, dir["web"]),
+            "drone build ls %s --status running > %s/recentBuilds.txt" % (ctx.repo.slug, dir["web"]),
+            "drone build info %s ${DRONE_BUILD_NUMBER} > %s/thisBuildInfo.txt" % (ctx.repo.slug, dir["web"]),
             "cd %s && ./tests/acceptance/cancelBuilds.sh" % dir["web"],
         ],
         "when": {


### PR DESCRIPTION
## Description
the `stop-recent-builds` pipeline fails for forks because drone.owncloud.com doesn't know that repo (comming from `ctx.build.source_repo`). Instead we always need to use `ctx.repo.slug` since this acts as identifier for the target repo in drone.

Example
PR from fork to oCIS failed in this step:
```
alpine: Pulling from drone/cli
--
2 | Digest: sha256:29517295f5c1dd9ef78645f08afe360a47bc3e2bbac70c7dd755c61551b4202f
3 | Status: Image is up to date for drone/cli:alpine
4 | + drone build ls ishank011/ocis --status running > /drone/src/recentBuilds.txt
5 | client error 404: {"message":"Not Found"
```

## Related issues
- same as https://github.com/owncloud/ocis/pull/2368