### PR TITLE
Route into folders instead of parents in private links

### DIFF
--- a/changelog/unreleased/bugfix-resolve-private-link
+++ b/changelog/unreleased/bugfix-resolve-private-link
@@ -1,0 +1,5 @@
+Bugfix: Resolve private links
+
+Private links didn't resolve correctly anymore because the internal file path handling was changed in our api client (owncloud-sdk). We've adjusted it accordingly so that private links now resolve correctly again.
+
+https://github.com/owncloud/web/pull/5654

--- a/changelog/unreleased/enhancement-private-link-routing
+++ b/changelog/unreleased/enhancement-private-link-routing
@@ -1,0 +1,6 @@
+Enhancement: Resolve private links into folders instead of parent
+
+Private links always resolved into the parent folder of the linked file and visually highlighted the file or folder from the link. We've changed this behaviour to directly navigate into the folder in case the linked resource is a folder and only keep the previous behaviour for when the linked resource is a file.
+
+https://github.com/owncloud/web/issues/5533
+https://github.com/owncloud/web/pull/5654


### PR DESCRIPTION
## Description
For private links to a folder: route directly into the folder instead of the parent. Routing to parent is only valid for files.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/5533

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] write changelog item