### PR TITLE
[full-ci] fix: escape image name in media viewer

### DIFF
--- a/changelog/unreleased/bugfix-escape-file-path-in-media-viewer
+++ b/changelog/unreleased/bugfix-escape-file-path-in-media-viewer
@@ -1,0 +1,6 @@
+Bugfix: escape file name in Media viewer
+
+We've started escaping the file name in the Media viewer extension so that a file with special characters in the name can still be loaded.
+
+https://github.com/owncloud/web/issues/5593
+https://github.com/owncloud/web/pull/5655

--- a/packages/web-app-media-viewer/src/App.vue
+++ b/packages/web-app-media-viewer/src/App.vue
@@ -264,7 +264,7 @@ export default {
       // workaround for now: Load file as blob for images, load as signed url (if supported) for everything else.
       let promise
       if (this.isActiveMediaFileTypeImage || !this.isUrlSigningEnabled) {
-        promise = this.mediaSource(decodeURIComponent(url), 'url', null)
+        promise = this.mediaSource(url, 'url', null)
       } else {
         promise = this.$client.signUrl(url, 86400) // Timeout of the signed URL = 24 hours
       }

--- a/packages/web-app-media-viewer/src/mixins/loader.js
+++ b/packages/web-app-media-viewer/src/mixins/loader.js
@@ -68,7 +68,13 @@ export default {
     $_loader_getDavFilePath(mediaFile, query = null) {
       const queryStr = !query ? '' : queryString.stringify(query)
       if (!this.$_loader_publicContext) {
-        const path = ['..', 'dav', 'files', this.$store.getters.user.id, mediaFile.path].join('/')
+        const path = [
+          '..',
+          'dav',
+          'files',
+          this.$store.getters.user.id,
+          mediaFile.path.replace(/^\//, '')
+        ].join('/')
         return [this.$client.files.getFileUrl(path), queryStr].filter(Boolean).join('?')
       }
 


### PR DESCRIPTION
We've started escaping the file name in the Media viewer extension so that a file with special characters in the name can still be loaded.

- fixes #5593