### PR TITLE
Added unit tests for permissions helper

### DIFF
--- a/packages/web-app-files/tests/unit/helpers/permissions.spec.js
+++ b/packages/web-app-files/tests/unit/helpers/permissions.spec.js
@@ -1,0 +1,51 @@
+import { canBeMoved } from '@files/src/helpers/permissions.js'
+
+describe('permissions helper', () => {
+  describe('canBeMoved function', () => {
+    it.each([
+      { isReceivedShare: false, isMounted: false, canBeDeleted: true, parentPath: '' },
+      { isReceivedShare: false, isMounted: false, canBeDeleted: true, parentPath: 'folder' },
+      { isReceivedShare: true, isMounted: false, canBeDeleted: true, parentPath: 'folder' },
+      { isReceivedShare: false, isMounted: true, canBeDeleted: true, parentPath: 'folder' }
+    ])(
+      'should return true if the given resource can be deleted and if it is not mounted in root',
+      input => {
+        // resources are supposed to be external if it is a received share or is mounted
+        // resources are supposed to be mountedInRoot if its parentPath is an empty string and resource is external
+        expect(
+          canBeMoved(
+            {
+              isReceivedShare: () => input.isReceivedShare,
+              isMounted: () => input.isMounted,
+              canBeDeleted: () => input.canBeDeleted
+            },
+            input.parentPath
+          )
+        ).toBeTruthy()
+      }
+    )
+    it.each([
+      { isReceivedShare: false, isMounted: false, canBeDeleted: false, parentPath: '' },
+      { isReceivedShare: false, isMounted: false, canBeDeleted: false, parentPath: 'folder' },
+      { isReceivedShare: true, isMounted: false, canBeDeleted: false, parentPath: 'folder' },
+      { isReceivedShare: false, isMounted: true, canBeDeleted: false, parentPath: 'folder' },
+      { isReceivedShare: false, isMounted: true, canBeDeleted: true, parentPath: '' },
+      { isReceivedShare: true, isMounted: false, canBeDeleted: true, parentPath: '' },
+      { isReceivedShare: true, isMounted: true, canBeDeleted: true, parentPath: '' }
+    ])(
+      'should return false if the given resource cannot be deleted or if it is mounted in root',
+      input => {
+        expect(
+          canBeMoved(
+            {
+              isReceivedShare: () => input.isReceivedShare,
+              isMounted: () => input.isMounted,
+              canBeDeleted: () => input.canBeDeleted
+            },
+            input.parentPath
+          )
+        ).toBeFalsy()
+      }
+    )
+  })
+})


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Added unit tests for permissions helper

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of #5236 

## How Has This Been Tested?
🤖 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 