### PR TITLE
chore: enable live reload for changes to themes

### DIFF
--- a/changelog/unreleased/change-enable-live-reload-for-themes
+++ b/changelog/unreleased/change-enable-live-reload-for-themes
@@ -1,0 +1,6 @@
+Change: Enable live reload for changes to themes
+
+This allows live reloads to be triggered by changes to themes defined within the 'packages/web-runtime/themes/**/*' folders, to facilitate efficient WYSIWYG
+development when wanting to customise the look and feel of the frontend.
+
+https://github.com/owncloud/web/pull/5668

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -62,7 +62,7 @@ const plugins = [
   globals(),
   json(),
   copy({
-    watch: !production && './config',
+    watch: !production && ['./config', './packages/web-runtime/themes'],
     targets: [
       { src: './packages/web-container/img', dest: 'dist' },
       { src: './packages/web-container/oidc-callback.html', dest: 'dist' },


### PR DESCRIPTION
## Description
Owncloud has done a great job allowing customisations of themes without needing to make modifications directly to the **owncloud-design-system** 👍 

This PR allows you to live reload in local development mode as you go through and change any theme(s) you are working on.  (Eg. changing the colour of `swatch-brand-default`.)

My understanding for why it does not work by default is because the application will load the theme file via **fetch** at runtime from the location defined in the `config.json` which, typically, would be defined as follows (on the same domain as a relative url):
```
   "theme": "themes/aarnet/theme.json",
```

This content is generated from `packages/web-runtime/themes/<theme_name>/theme.json` and compiled by rollup into the `dist` folder, but because it's not part of the source code of the project (retrieved via **fetch** as opposed to static includes via TS/JS, rollup does not monitor changes to files in these folders.

There may be a better way to do this so open to alternatives but this is an easy way to get the intended behaviour of real-time theme customisations, which makes it a very productive way to customise the look and feel.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] 