### PR TITLE
fix: handle loading and parsing errors when loading themes

### DIFF
--- a/changelog/unreleased/bugfix-handle-errors-when-loading-themes
+++ b/changelog/unreleased/bugfix-handle-errors-when-loading-themes
@@ -1,0 +1,5 @@
+Bugfix: Handle loading and parsing errors when loading themes
+
+Adds graceful error handling of json parse errors when loading custom themes.
+
+https://github.com/owncloud/web/pull/5669

--- a/packages/web-runtime/src/helpers/theme.js
+++ b/packages/web-runtime/src/helpers/theme.js
@@ -4,20 +4,21 @@ export const loadTheme = async (location = '') => {
   const defaults = { theme: defaultTheme }
 
   if (location.split('.').pop() !== 'json') {
+    console.error(`Theme '${location}' does not specify a json file, using default theme.`)
     return defaults
   }
 
-  let response
   try {
-    response = await fetch(location)
+    const response = await fetch(location)
+    if (!response.ok) {
+      return defaults
+    }
+    const theme = await response.json()
+    return { theme }
   } catch (e) {
+    console.error(
+      `Failed to load theme '${location}' is not a valid json file, using default theme.`
+    )
     return defaults
   }
-
-  if (!response.ok) {
-    return defaults
-  }
-
-  const theme = await response.json()
-  return { theme }
 }

--- a/packages/web-runtime/tests/unit/helpers/theme.spec.js
+++ b/packages/web-runtime/tests/unit/helpers/theme.spec.js
@@ -4,7 +4,10 @@ import merge from 'lodash-es/merge'
 
 describe('theme loading and error reporting', () => {
   beforeEach(() => {
-    fetch.resetMocks()
+    global.console = { error: jest.fn() }
+  })
+  afterEach(() => {
+    jest.clearAllMocks()
   })
 
   it('should load the default theme if location is empty', async () => {
@@ -12,14 +15,21 @@ describe('theme loading and error reporting', () => {
     expect(theme).toMatchObject(defaultTheme)
   })
 
-  it('should load the default theme if location is not a json file', async () => {
+  it('should load the default theme if location is not a json file extension', async () => {
     const { theme } = await loadTheme('some_location_without_json_file_ending.xml')
     expect(theme).toMatchObject(defaultTheme)
   })
 
-  it('should load the default theme if location errors', async () => {
+  it('should load the default theme if location is not found', async () => {
     fetch.mockResponse(new Error(), { status: 404 })
     const { theme } = await loadTheme('http://www.owncloud.com/unknown.json')
+    expect(theme).toMatchObject(defaultTheme)
+  })
+
+  it('should load the default theme if location is not a valid json file', async () => {
+    const customTheme = merge({}, defaultTheme, { default: { logo: { login: 'custom.svg' } } })
+    fetch.mockResponse(JSON.stringify(customTheme) + '-invalid')
+    const { theme } = await loadTheme('http://www.owncloud.com/invalid.json')
     expect(theme).toMatchObject(defaultTheme)
   })
 


### PR DESCRIPTION
## Description
There are multiple conditions where a custom theme will fail to load eg.
1. If the file extension does not end in `.json`
2. If the file is not found
3. If there is any other error attempting to fetch the file from network
4. If the file is not a valid JSON file format

Currently only (1), (2) and (3) are handled by returning the default owncloud extension.

This fix adds error handling for (4) and also refactors the code a little.  Currently (4) will break the application with:
```
web-runtime.js:5504 SyntaxError: Unexpected token d in JSON at position 584
``` 
as there is no catch around the json parsing.

With the fix, it will show the following on the console:
```
web-runtime.js:5262 Failed to load theme 'themes/aarnet/theme.json' is not a valid JSON file, using default theme.
```

This fix also logs a console error that a custom theme load failed and the default theme is going to be used (I personally found it confusing as it failed silently to load the theme and I was unsure what had happened.)

## How Has This Been Tested?
Tested manually in the browser and have added / updated unit tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
