### PR TITLE
[CI] Fix diff calculation for drone builds

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2651,11 +2651,6 @@ def dependsOn(earlierStages, nextStages):
                 nextStage["depends_on"] = [earlierStage["name"]]
 
 def calculateDiffContainsUnitTestsOnly(ctx):
-    # Do all the pipeline steps fully on tag events. Do not try to analyze diffs
-    # and short-circuit the tests that are executed.
-    if ctx.build.event == "tag":
-        return []
-
     return [
         {
             "name": "calculate-diff",
@@ -2665,5 +2660,10 @@ def calculateDiffContainsUnitTestsOnly(ctx):
                 "bash -x tests/drone/if-diff-has-unit-tests-only.sh",
                 "ls -la",
             ],
+            "when": {
+                "event": [
+                    "pull_request",
+                ],
+            },
         },
     ]

--- a/tests/drone/if-diff-has-unit-tests-only.sh
+++ b/tests/drone/if-diff-has-unit-tests-only.sh
@@ -13,7 +13,10 @@ do
 	fi
 done
 
-if [ $CHANGED_UNIT_TESTS_ONLY == "True" ]
+if [ ! "${DIFF}" ]
+then
+	echo "no any files are changed"
+elif [ $CHANGED_UNIT_TESTS_ONLY == "True" ]
 then
 	echo "only unit tests files are changed"
 	touch runUnitTestsOnly


### PR DESCRIPTION
## Description
- do not set unit-tests mode if diff contains nothing ( used for nightly builds )
- only run diff calculation for `pull_requests` events

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- 🤖 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests