### PR TITLE
[unit-tests-only] added unit tests for files drop view

### DIFF
--- a/packages/web-app-files/tests/unit/views/FilesDrop.spec.js
+++ b/packages/web-app-files/tests/unit/views/FilesDrop.spec.js
@@ -1,0 +1,216 @@
+import FilesDrop from '@files/src/views/FilesDrop.vue'
+import { shallowMount } from '@vue/test-utils'
+import GetTextPlugin from 'vue-gettext'
+import vue2DropZone from 'vue2-dropzone'
+import { getStore, localVue } from './views.setup.js'
+
+localVue.use(vue2DropZone)
+localVue.use(GetTextPlugin, {
+  translations: 'does-not-matter.json',
+  silent: true
+})
+
+localVue.prototype.$client.publicFiles = {
+  PUBLIC_LINK_SHARE_OWNER: 'admin',
+  // function is mocked because it should return a promise with a list of resources
+  list: async () => [{ getProperty: jest.fn(val => val) }],
+  // function takes token as an argument and is mocked because it should return some public link url
+  getFileUrl: token => `http://some-url/${token}`,
+  putFileContents: jest.fn()
+}
+
+const $route = {
+  meta: {
+    title: 'page route title'
+  },
+  params: {
+    token: 'abc123def456'
+  }
+}
+
+const selectors = {
+  filesEmpty: '.files-empty',
+  loadingHeader: '.oc-login-card-title'
+}
+
+const ocSpinnerStubSelector = 'oc-spinner-stub'
+const ocTableSimpleStubSelector = 'oc-table-simple-stub'
+const ocTableRowStubSelector = 'oc-tr-stub'
+
+describe('FilesDrop', () => {
+  it('should call "resolvePublicLink" method on wrapper mount', () => {
+    const spyResolvePublicLink = jest.spyOn(FilesDrop.methods, 'resolvePublicLink')
+    getShallowWrapper()
+
+    expect(spyResolvePublicLink).toHaveBeenCalledTimes(1)
+  })
+
+  it('should show page title and configuration theme general slogan', () => {
+    const wrapper = getShallowWrapper()
+
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it('should show spinner with loading text if wrapper is loading', () => {
+    const wrapper = getShallowWrapper({ loading: true })
+
+    expect(wrapper.find(selectors.loadingHeader).exists()).toBeTruthy()
+    expect(wrapper.find(ocSpinnerStubSelector).exists()).toBeTruthy()
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  describe('when "loading" is set to false', () => {
+    const spyDropZoneFileAdded = jest.spyOn(FilesDrop.methods, 'dropZoneFileAdded')
+
+    const wrapper = getShallowWrapper()
+
+    it('should not show spinner and loading header', () => {
+      expect(wrapper.find(selectors.loadingHeader).exists()).toBeFalsy()
+      expect(wrapper.find(ocSpinnerStubSelector).exists()).toBeFalsy()
+    })
+
+    it('should show share information title', () => {
+      expect(wrapper).toMatchSnapshot()
+    })
+
+    it('should show vue drop zone with given options', () => {
+      const dropZone = wrapper.findComponent(vue2DropZone)
+
+      expect(dropZone.exists()).toBeTruthy()
+      expect(dropZone.props()).toMatchObject({
+        id: 'oc-dropzone',
+        options: {
+          // from the mocked function
+          url: 'http://some-url/abc123def456/',
+          clickable: true,
+          createImageThumbnails: false,
+          autoQueue: false,
+          previewsContainer: '#previews'
+        },
+        includeStyling: false,
+        awss3: null,
+        destroyDropzone: true,
+        duplicateCheck: false,
+        useCustomSlot: true
+      })
+    })
+
+    it('should show error message if only it has truthy value', () => {
+      const wrapper = getShallowWrapper({
+        loading: false,
+        errorMessage: 'This is a test error message'
+      })
+
+      expect(wrapper).toMatchSnapshot()
+    })
+
+    it('should not show files table if uploaded files list is empty', () => {
+      expect(wrapper.find(selectors.filesEmpty).exists()).toBeTruthy()
+      expect(wrapper.find(selectors.filesEmpty)).toMatchSnapshot()
+      expect(wrapper.find(ocTableSimpleStubSelector).exists()).toBeFalsy()
+    })
+
+    it('should show files list of uploaded files', async () => {
+      const uploadedFiles = new Map()
+      const files = [
+        { name: 'file1', size: 300, status: 'error' },
+        { name: 'file2', size: 600, status: 'done' },
+        { name: 'file3', size: 900, status: 'init' },
+        { name: 'file4', size: 1200, status: 'uploading' }
+      ]
+      uploadedFiles.set(1, files[0])
+      uploadedFiles.set(2, files[1])
+      uploadedFiles.set(3, files[2])
+      uploadedFiles.set(4, files[3])
+
+      const wrapper = shallowMount(FilesDrop, {
+        localVue,
+        store: createStore(),
+        mocks: {
+          $route
+        },
+        data() {
+          return {
+            uploadedFiles: uploadedFiles,
+            uploadedFilesChangeTracker: 1
+          }
+        }
+      })
+
+      // table is visible only after two next-ticks
+      await wrapper.vm.$nextTick()
+      await wrapper.vm.$nextTick()
+
+      const tableElement = wrapper.find(ocTableSimpleStubSelector)
+      const rows = tableElement.findAll(ocTableRowStubSelector)
+
+      expect(rows.length).toBe(4)
+
+      expect(wrapper).toMatchSnapshot()
+    })
+
+    it('should call "dropZoneFileAdded" method if "vdropzone-file-added" event is emitted', async () => {
+      const event = {
+        upload: {
+          uuid: 'abc123'
+        },
+        name: 'file1.txt',
+        size: '300'
+      }
+      const expectedMap = new Map()
+      const expectedDoneMap = expectedMap.set(event.upload.uuid, {
+        name: event.name,
+        size: event.size,
+        status: 'done'
+      })
+
+      const dropZone = wrapper.findComponent(vue2DropZone)
+
+      expect(spyDropZoneFileAdded).not.toHaveBeenCalled()
+
+      // drag and drop cannot be performed in unit tests
+      // only checking how wrapper responds when dropzone emits the event specified below
+      await dropZone.vm.$emit('vdropzone-file-added', event)
+
+      expect(spyDropZoneFileAdded).toHaveBeenCalledTimes(1)
+      expect(wrapper.vm.uploadedFilesChangeTracker).toBe(1)
+
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.vm.uploadedFilesChangeTracker).toBe(2)
+      expect(wrapper.vm.uploadedFiles).toMatchObject(expectedDoneMap)
+
+      await wrapper.vm.$nextTick()
+
+      const tableElement = wrapper.find(ocTableSimpleStubSelector)
+      const rows = tableElement.findAll(ocTableRowStubSelector)
+
+      expect(rows.length).toBe(1)
+
+      expect(wrapper).toMatchSnapshot()
+    })
+  })
+})
+
+function createStore(slogan = 'some slogan', davProperties = []) {
+  return getStore({ slogan, davProperties })
+}
+
+function getShallowWrapper({ store = createStore(), loading = false, errorMessage = null } = {}) {
+  return shallowMount(FilesDrop, {
+    localVue,
+    store,
+    mocks: {
+      $route
+    },
+    data() {
+      return {
+        loading: loading,
+        errorMessage: errorMessage,
+        share: {
+          getProperty: val => val
+        }
+      }
+    }
+  })
+}

--- a/packages/web-app-files/tests/unit/views/__snapshots__/FilesDrop.spec.js.snap
+++ b/packages/web-app-files/tests/unit/views/__snapshots__/FilesDrop.spec.js.snap
@@ -1,0 +1,240 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FilesDrop should show page title and configuration theme general slogan 1`] = `
+<div id="files-drop-container" class="uk-height-1-1 uk-flex uk-flex-column uk-flex-between">
+  <h1 class="oc-invisible-sr">page route title</h1>
+  <div class="oc-p uk-height-1-1">
+    <div class="uk-flex uk-flex-column uk-flex-middle uk-height-1-1">
+      <div class="uk-text-center uk-width-1-1 uk-width-xxlarge@m">
+        <h2>admin shared this folder with you for uploading</h2>
+        <vue-dropzone-stub id="oc-dropzone" options="[object Object]" destroydropzone="true" usecustomslot="true">
+          <div class="uk-flex uk-flex-middle uk-flex-center uk-placeholder">
+            <oc-icon-stub name="file_upload" accessiblelabel="" type="span" size="medium" variation="passive"></oc-icon-stub>
+            <translate-stub tag="span">Drop files here to upload or click to select file</translate-stub>
+          </div>
+        </vue-dropzone-stub>
+        <div id="previews" hidden="hidden"></div>
+      </div>
+      <div class="uk-flex uk-flex-center uk-overflow-auto uk-width-1-1 files-empty">
+        <!---->
+      </div>
+      <!---->
+    </div>
+  </div>
+  <div class="uk-text-center">
+    <p>some slogan</p>
+  </div>
+</div>
+`;
+
+exports[`FilesDrop should show spinner with loading text if wrapper is loading 1`] = `
+<div id="files-drop-container" class="uk-height-1-1 uk-flex uk-flex-column uk-flex-between">
+  <h1 class="oc-invisible-sr">page route title</h1>
+  <div class="oc-p uk-height-1-1">
+    <div class="uk-flex uk-flex-column uk-flex-middle">
+      <h2 class="oc-login-card-title">
+        <translate-stub tag="span">Loading public link…</translate-stub>
+      </h2>
+      <oc-spinner-stub arialabel="" size="medium" aria-hidden="true"></oc-spinner-stub>
+    </div>
+  </div>
+  <div class="uk-text-center">
+    <p>some slogan</p>
+  </div>
+</div>
+`;
+
+exports[`FilesDrop when "loading" is set to false should call "dropZoneFileAdded" method if "vdropzone-file-added" event is emitted 1`] = `
+<div id="files-drop-container" class="uk-height-1-1 uk-flex uk-flex-column uk-flex-between">
+  <h1 class="oc-invisible-sr">page route title</h1>
+  <div class="oc-p uk-height-1-1">
+    <div class="uk-flex uk-flex-column uk-flex-middle uk-height-1-1">
+      <div class="uk-text-center uk-width-1-1 uk-width-xxlarge@m">
+        <h2>admin shared this folder with you for uploading</h2>
+        <vue-dropzone-stub id="oc-dropzone" options="[object Object]" destroydropzone="true" usecustomslot="true">
+          <div class="uk-flex uk-flex-middle uk-flex-center uk-placeholder">
+            <oc-icon-stub name="file_upload" accessiblelabel="" type="span" size="medium" variation="passive"></oc-icon-stub>
+            <translate-stub tag="span">Drop files here to upload or click to select file</translate-stub>
+          </div>
+        </vue-dropzone-stub>
+        <div id="previews" hidden="hidden"></div>
+      </div>
+      <div class="uk-flex uk-flex-center uk-overflow-auto uk-width-1-1">
+        <oc-table-simple-stub class="uk-width-1-1 uk-width-xxlarge@m">
+          <oc-tbody-stub>
+            <oc-tr-stub>
+              <oc-td-stub alignh="left" alignv="middle" width="auto" class="oc-pl-rm">file1.txt</oc-td-stub>
+              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="uk-text-nowrap oc-text-muted">
+                <oc-resource-size-stub size="300"></oc-resource-size-stub>
+              </oc-td-stub>
+              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="oc-pr-rm uk-preserve-width">
+                <oc-icon-stub name="ready" accessiblelabel="" type="span" size="small" variation="success"></oc-icon-stub>
+                <!---->
+                <!---->
+              </oc-td-stub>
+            </oc-tr-stub>
+          </oc-tbody-stub>
+        </oc-table-simple-stub>
+      </div>
+      <div class="uk-text-center">
+        <h2>
+          <translate-stub tag="span">An error occurred while loading the public link</translate-stub>
+        </h2>
+        <p class="oc-m-rm">TypeError: Cannot read property 'push' of undefined</p>
+      </div>
+    </div>
+  </div>
+  <div class="uk-text-center">
+    <p>some slogan</p>
+  </div>
+</div>
+`;
+
+exports[`FilesDrop when "loading" is set to false should not show files table if uploaded files list is empty 1`] = `
+<div class="uk-flex uk-flex-center uk-overflow-auto uk-width-1-1 files-empty">
+  <!---->
+</div>
+`;
+
+exports[`FilesDrop when "loading" is set to false should show error message if only it has truthy value 1`] = `
+<div id="files-drop-container" class="uk-height-1-1 uk-flex uk-flex-column uk-flex-between">
+  <h1 class="oc-invisible-sr">page route title</h1>
+  <div class="oc-p uk-height-1-1">
+    <div class="uk-flex uk-flex-column uk-flex-middle uk-height-1-1">
+      <div class="uk-text-center uk-width-1-1 uk-width-xxlarge@m">
+        <h2>admin shared this folder with you for uploading</h2>
+        <vue-dropzone-stub id="oc-dropzone" options="[object Object]" destroydropzone="true" usecustomslot="true">
+          <div class="uk-flex uk-flex-middle uk-flex-center uk-placeholder">
+            <oc-icon-stub name="file_upload" accessiblelabel="" type="span" size="medium" variation="passive"></oc-icon-stub>
+            <translate-stub tag="span">Drop files here to upload or click to select file</translate-stub>
+          </div>
+        </vue-dropzone-stub>
+        <div id="previews" hidden="hidden"></div>
+      </div>
+      <div class="uk-flex uk-flex-center uk-overflow-auto uk-width-1-1 files-empty">
+        <!---->
+      </div>
+      <div class="uk-text-center">
+        <h2>
+          <translate-stub tag="span">An error occurred while loading the public link</translate-stub>
+        </h2>
+        <p class="oc-m-rm">This is a test error message</p>
+      </div>
+    </div>
+  </div>
+  <div class="uk-text-center">
+    <p>some slogan</p>
+  </div>
+</div>
+`;
+
+exports[`FilesDrop when "loading" is set to false should show files list of uploaded files 1`] = `
+<div id="files-drop-container" class="uk-height-1-1 uk-flex uk-flex-column uk-flex-between">
+  <h1 class="oc-invisible-sr">page route title</h1>
+  <div class="oc-p uk-height-1-1">
+    <div class="uk-flex uk-flex-column uk-flex-middle uk-height-1-1">
+      <div class="uk-text-center uk-width-1-1 uk-width-xxlarge@m">
+        <h2></h2>
+        <vue-dropzone-stub id="oc-dropzone" options="[object Object]" destroydropzone="true" usecustomslot="true">
+          <div class="uk-flex uk-flex-middle uk-flex-center uk-placeholder">
+            <oc-icon-stub name="file_upload" accessiblelabel="" type="span" size="medium" variation="passive"></oc-icon-stub>
+            <translate-stub tag="span">Drop files here to upload or click to select file</translate-stub>
+          </div>
+        </vue-dropzone-stub>
+        <div id="previews" hidden="hidden"></div>
+      </div>
+      <div class="uk-flex uk-flex-center uk-overflow-auto uk-width-1-1">
+        <oc-table-simple-stub class="uk-width-1-1 uk-width-xxlarge@m">
+          <oc-tbody-stub>
+            <oc-tr-stub>
+              <oc-td-stub alignh="left" alignv="middle" width="auto" class="oc-pl-rm">file1</oc-td-stub>
+              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="uk-text-nowrap oc-text-muted">
+                <oc-resource-size-stub size="300"></oc-resource-size-stub>
+              </oc-td-stub>
+              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="oc-pr-rm uk-preserve-width">
+                <!---->
+                <oc-icon-stub name="info" accessiblelabel="" type="span" size="small" variation="danger"></oc-icon-stub>
+                <!---->
+              </oc-td-stub>
+            </oc-tr-stub>
+            <oc-tr-stub>
+              <oc-td-stub alignh="left" alignv="middle" width="auto" class="oc-pl-rm">file2</oc-td-stub>
+              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="uk-text-nowrap oc-text-muted">
+                <oc-resource-size-stub size="600"></oc-resource-size-stub>
+              </oc-td-stub>
+              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="oc-pr-rm uk-preserve-width">
+                <oc-icon-stub name="ready" accessiblelabel="" type="span" size="small" variation="success"></oc-icon-stub>
+                <!---->
+                <!---->
+              </oc-td-stub>
+            </oc-tr-stub>
+            <oc-tr-stub>
+              <oc-td-stub alignh="left" alignv="middle" width="auto" class="oc-pl-rm">file3</oc-td-stub>
+              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="uk-text-nowrap oc-text-muted">
+                <oc-resource-size-stub size="900"></oc-resource-size-stub>
+              </oc-td-stub>
+              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="oc-pr-rm uk-preserve-width">
+                <!---->
+                <!---->
+                <oc-spinner-stub arialabel="Uploading file &quot;file3&quot;" size="small"></oc-spinner-stub>
+              </oc-td-stub>
+            </oc-tr-stub>
+            <oc-tr-stub>
+              <oc-td-stub alignh="left" alignv="middle" width="auto" class="oc-pl-rm">file4</oc-td-stub>
+              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="uk-text-nowrap oc-text-muted">
+                <oc-resource-size-stub size="1200"></oc-resource-size-stub>
+              </oc-td-stub>
+              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="oc-pr-rm uk-preserve-width">
+                <!---->
+                <!---->
+                <oc-spinner-stub arialabel="Uploading file &quot;file4&quot;" size="small"></oc-spinner-stub>
+              </oc-td-stub>
+            </oc-tr-stub>
+          </oc-tbody-stub>
+        </oc-table-simple-stub>
+      </div>
+      <div class="uk-text-center">
+        <h2>
+          <translate-stub tag="span">An error occurred while loading the public link</translate-stub>
+        </h2>
+        <p class="oc-m-rm">TypeError: Cannot read property 'push' of undefined</p>
+      </div>
+    </div>
+  </div>
+  <div class="uk-text-center">
+    <p>some slogan</p>
+  </div>
+</div>
+`;
+
+exports[`FilesDrop when "loading" is set to false should show share information title 1`] = `
+<div id="files-drop-container" class="uk-height-1-1 uk-flex uk-flex-column uk-flex-between">
+  <h1 class="oc-invisible-sr">page route title</h1>
+  <div class="oc-p uk-height-1-1">
+    <div class="uk-flex uk-flex-column uk-flex-middle uk-height-1-1">
+      <div class="uk-text-center uk-width-1-1 uk-width-xxlarge@m">
+        <h2>admin shared this folder with you for uploading</h2>
+        <vue-dropzone-stub id="oc-dropzone" options="[object Object]" destroydropzone="true" usecustomslot="true">
+          <div class="uk-flex uk-flex-middle uk-flex-center uk-placeholder">
+            <oc-icon-stub name="file_upload" accessiblelabel="" type="span" size="medium" variation="passive"></oc-icon-stub>
+            <translate-stub tag="span">Drop files here to upload or click to select file</translate-stub>
+          </div>
+        </vue-dropzone-stub>
+        <div id="previews" hidden="hidden"></div>
+      </div>
+      <div class="uk-flex uk-flex-center uk-overflow-auto uk-width-1-1 files-empty">
+        <!---->
+      </div>
+      <div class="uk-text-center">
+        <h2>
+          <translate-stub tag="span">An error occurred while loading the public link</translate-stub>
+        </h2>
+        <p class="oc-m-rm">TypeError: Cannot read property 'push' of undefined</p>
+      </div>
+    </div>
+  </div>
+  <div class="uk-text-center">
+    <p>some slogan</p>
+  </div>
+</div>
+`;

--- a/packages/web-app-files/tests/unit/views/views.setup.js
+++ b/packages/web-app-files/tests/unit/views/views.setup.js
@@ -42,7 +42,10 @@ export const getStore = function({
   selectedFiles = [],
   totalFilesSize = null,
   loginBackgroundImg = '',
-  loginLogo = ''
+  loginLogo = '',
+  davProperties = [],
+  publicLinkPassword = null,
+  slogan = null
 } = {}) {
   return createStore(Vuex.Store, {
     state: {
@@ -56,6 +59,9 @@ export const getStore = function({
           },
           logo: {
             login: loginLogo
+          },
+          general: {
+            slogan: slogan
           }
         },
         options: {
@@ -79,7 +85,10 @@ export const getStore = function({
           activeFilesCount: () => activeFilesCount,
           inProgress: () => inProgress,
           highlightedFile: () => highlightedFile,
-          currentFolder: () => currentFolder
+          currentFolder: () => currentFolder,
+          pages: () => pages,
+          davProperties: () => davProperties,
+          publicLinkPassword: () => publicLinkPassword
         },
         mutations: {
           UPDATE_RESOURCE: (state, resource) => {


### PR DESCRIPTION
## Description
- added unit tests for `FilesDrop` view in `web-app-files` package

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of #5237 


## How Has This Been Tested?
- `yarn test:unit`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
