### PR TITLE
Change signout icon

### DIFF
--- a/changelog/unreleased/enhancement-signout-icon
+++ b/changelog/unreleased/enhancement-signout-icon
@@ -1,0 +1,5 @@
+Enhancement: Signout icon
+
+We changed the icon in the personal menu nav item for signing out based on recent user feedback.
+
+https://github.com/owncloud/web/pull/5681

--- a/packages/web-runtime/src/components/UserMenu.vue
+++ b/packages/web-runtime/src/components/UserMenu.vue
@@ -74,7 +74,7 @@
             justify-content="left"
             @click="logout"
           >
-            <oc-icon name="exit_to_app" />
+            <oc-icon name="sign-out" />
             <translate>Log out</translate>
           </oc-button>
         </li>


### PR DESCRIPTION
## Description
Based on user feedback that @rpocklin received and forwarded to us, this PR changes the signout icon in the personal menu. Previous one was not clear enough. See screenshots for before and after comparison.

## Motivation and Context
UX

## How Has This Been Tested?
- CI

## Screenshots:

### Before
<img width="269" alt="Screenshot 2021-08-16 at 17 40 21" src="https://user-images.githubusercontent.com/3532843/129591218-6d704150-0dd2-4b75-822c-e4c84dd13de9.png">

### After
<img width="252" alt="Screenshot 2021-08-16 at 17 39 41" src="https://user-images.githubusercontent.com/3532843/129591232-4f1596bf-8667-4c53-b521-af80e5c88a4a.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 