### PR TITLE
[unit-tests-only] Refactored favorites spec to use helper functions and variable selectors

### DIFF
--- a/packages/web-app-files/tests/unit/views/Favorites.spec.js
+++ b/packages/web-app-files/tests/unit/views/Favorites.spec.js
@@ -1,25 +1,7 @@
-import GetTextPlugin from 'vue-gettext'
 import { mount } from '@vue/test-utils'
-import Favorites from 'packages/web-app-files/src/views/Favorites.vue'
-import { createStore } from 'vuex-extensions'
 import { createFile, localVue, getStore } from './views.setup'
-import Vuex from 'vuex'
-import VueRouter from 'vue-router'
+import Favorites from 'packages/web-app-files/src/views/Favorites.vue'
 
-localVue.use(GetTextPlugin, {
-  translations: 'does-not-matter.json',
-  silent: true
-})
-localVue.use(VueRouter)
-
-const router = new VueRouter()
-
-jest.unmock('axios')
-
-const selectors = {
-  favoritesTable: '#files-favorites-table'
-}
-const component = { ...Favorites, created: jest.fn(), mounted: jest.fn() }
 const stubs = {
   'router-link': true,
   translate: true,
@@ -29,214 +11,202 @@ const stubs = {
   'context-actions': true
 }
 
-const defaultWrapper = mount(component, {
-  store: getStore(),
-  localVue,
-  router,
-  stubs: stubs,
-  data: () => ({
-    loading: false
-  })
-})
+const selectors = {
+  noContentMessage: '#files-favorites-empty',
+  favoritesTable: '#files-favorites-table'
+}
+
+const spinnerStub = 'oc-spinner-stub'
+const filesTableStub = 'oc-table-files-stub'
+const paginationStub = 'oc-pagination-stub'
+const listInfoStub = 'list-info-stub'
+
+const defaultActiveFiles = [createFile({ id: '1233' }), createFile({ id: '1234' })]
 
 describe('Favorites component', () => {
   describe('loading indicator', () => {
     it('shows only the list-loader during loading', () => {
-      const wrapper = mount(component, {
-        store: getStore(),
-        localVue,
-        router,
-        stubs: stubs,
-        data: () => ({
-          loading: true
-        })
-      })
-      expect(wrapper.find('oc-spinner-stub').exists()).toBeTruthy()
-      expect(wrapper.find('oc-table-files-stub').exists()).toBeFalsy()
+      const wrapper = getMountedWrapper({ loading: true })
+
+      expect(wrapper.find(spinnerStub).exists()).toBeTruthy()
+      expect(wrapper.find(filesTableStub).exists()).toBeFalsy()
     })
+
     it('shows only the files table when loading is finished', () => {
-      expect(defaultWrapper.find('oc-spinner-stub').exists()).toBeFalsy()
-      expect(defaultWrapper.find('oc-table-files-stub').exists()).toBeTruthy()
+      const wrapper = getMountedWrapper()
+
+      expect(wrapper.find(spinnerStub).exists()).toBeFalsy()
+      expect(wrapper.find(filesTableStub).exists()).toBeTruthy()
     })
   })
   describe('no content message', () => {
     it('shows only the "no content" message if no resources are marked as favorite', () => {
-      const wrapper = mount(component, {
-        store: createStore(Vuex.Store, {
-          modules: {
-            Files: {
-              state: {
-                resource: null,
-                currentPage: 1
-              },
-              getters: {
-                activeFiles: () => [],
-                inProgress: () => [null]
-              },
-              mutations: {
-                UPDATE_CURRENT_PAGE: () => {},
-                SET_FILES_PAGE_LIMIT: () => {}
-              },
-              namespaced: true
-            }
-          }
-        }),
-        localVue,
-        router,
-        stubs: stubs,
-        data: () => ({
-          loading: false
-        })
-      })
-      expect(wrapper.find('#files-favorites-empty').exists()).toBeTruthy()
-      expect(wrapper.find('oc-table-files-stub').exists()).toBeFalsy()
+      const store = getStore({ activeFiles: [] })
+      const wrapper = getMountedWrapper({ store, loading: false })
+
+      expect(wrapper.find(selectors.noContentMessage).exists()).toBeTruthy()
+      expect(wrapper.find(filesTableStub).exists()).toBeFalsy()
     })
+
     it('does not show the no content message if resources are marked as favorite', () => {
-      expect(defaultWrapper.find('#files-favorites-empty').exists()).toBeFalsy()
-      expect(defaultWrapper.find('oc-table-files-stub').exists()).toBeTruthy()
+      const wrapper = getMountedWrapper()
+
+      expect(wrapper.find('#files-favorites-empty').exists()).toBeFalsy()
+      expect(wrapper.find(filesTableStub).exists()).toBeTruthy()
     })
   })
   describe('files table', () => {
     describe('no file is highlighted', () => {
       it("don't squash the table", () => {
-        const wrapper = mount(component, {
-          store: getStore({
-            sidebarClosed: true
-          }),
-          localVue,
-          router,
-          stubs: stubs,
-          data: () => ({
-            loading: false
-          })
-        })
+        const store = getStore({ sidebarClosed: true, activeFiles: defaultActiveFiles })
+        const wrapper = getMountedWrapper({ store, loading: false })
+
         expect(wrapper.find(selectors.favoritesTable).attributes('class')).not.toContain(
           'files-table-squashed'
         )
         expect(wrapper.find(selectors.favoritesTable).attributes('class')).toContain('files-table')
       })
+
       it('don\'t sets the "highlighted" attribute', () => {
-        expect(defaultWrapper.find(selectors.favoritesTable).attributes('highlighted')).toBeFalsy()
+        const wrapper = getMountedWrapper()
+
+        expect(wrapper.find(selectors.favoritesTable).attributes('highlighted')).toBeFalsy()
       })
     })
+
     describe('a file is highlighted', () => {
-      const wrapper = mount(component, {
-        store: getStore({ highlightedFile: createFile({ id: 234 }) }),
-        localVue,
-        router,
-        stubs: stubs,
-        data: () => ({
-          loading: false
-        })
+      const store = getStore({
+        highlightedFile: defaultActiveFiles[0],
+        activeFiles: defaultActiveFiles
       })
+      const wrapper = getMountedWrapper({ store })
+
       it('squash the table', () => {
         expect(wrapper.find(selectors.favoritesTable).attributes('class')).toContain(
           'files-table-squashed'
         )
       })
     })
+
     describe('previews', () => {
       it('displays previews when the "disablePreviews" config is disabled', () => {
-        const wrapper = mount(component, {
-          store: getStore({
-            configuration: {
-              options: {
-                disablePreviews: false
-              }
-            }
-          }),
-          localVue,
-          router,
-          stubs: stubs,
-          data: () => ({
-            loading: false
-          })
-        })
+        const store = getStore({ disablePreviews: false, activeFiles: defaultActiveFiles })
+        const wrapper = getMountedWrapper({ store, loading: false })
+
         expect(
           wrapper.find(selectors.favoritesTable).attributes('arethumbnailsdisplayed')
         ).toBeTruthy()
       })
+
       it('hides previews when the "disablePreviews" config is enabled', () => {
+        const store = getStore({ disablePreviews: true, activeFiles: defaultActiveFiles })
+        const wrapper = getMountedWrapper({ store, loading: false })
+
         expect(
-          defaultWrapper.find(selectors.favoritesTable).attributes('arethumbnailsdisplayed')
+          wrapper.find(selectors.favoritesTable).attributes('arethumbnailsdisplayed')
         ).toBeFalsy()
       })
     })
+
     describe('pagination', () => {
       beforeEach(() => {
         stubs['oc-table-files'] = false
       })
+
       it('sets the pages count & the current page', () => {
-        const wrapper = mount(component, {
-          store: getStore(),
-          localVue,
-          router,
-          stubs: stubs,
-          data: () => ({
-            loading: false
-          })
+        const store = getStore({
+          activeFiles: defaultActiveFiles,
+          pages: 4,
+          currentPage: 3,
+          totalFilesCount: { files: 10, folders: 10 }
         })
-        expect(wrapper.find('oc-pagination-stub').attributes('currentpage')).toEqual('3')
-        expect(wrapper.find('oc-pagination-stub').attributes('pages')).toEqual('4')
+        const wrapper = getMountedWrapper({ store, loading: false })
+
+        expect(wrapper.find(paginationStub).attributes('currentpage')).toEqual('3')
+        expect(wrapper.find(paginationStub).attributes('pages')).toEqual('4')
       })
 
       it('does not show any pagination when there is only one page', () => {
-        const wrapper = mount(component, {
-          store: getStore({ pages: 1 }),
-          localVue,
-          router,
-          stubs: stubs,
-          data: () => ({
-            loading: false
-          })
+        const store = getStore({
+          activeFiles: defaultActiveFiles,
+          pages: 1,
+          currentPage: 1,
+          totalFilesCount: { files: 10, folders: 10 }
         })
-        expect(wrapper.find('oc-pagination-stub').exists()).toBeFalsy()
+        const wrapper = getMountedWrapper({ store, loading: false })
+
+        expect(wrapper.find(paginationStub).exists()).toBeFalsy()
       })
     })
+
     describe('list-info', () => {
       beforeEach(() => {
         stubs['oc-table-files'] = false
         stubs['list-info'] = true
       })
+
       it('sets the counters and the size', () => {
-        const wrapper = mount(component, {
-          store: getStore(),
-          localVue,
-          router,
-          stubs: stubs,
-          data: () => ({
-            loading: false
-          })
+        const store = getStore({
+          activeFiles: defaultActiveFiles,
+          totalFilesCount: { files: 15, folders: 20 },
+          totalFilesSize: 1024
         })
-        expect(wrapper.find('list-info-stub').attributes('files')).toEqual('15')
-        expect(wrapper.find('list-info-stub').attributes('folders')).toEqual('20')
-        expect(wrapper.find('list-info-stub').attributes('size')).toEqual('1024')
+        const wrapper = getMountedWrapper({ store, loading: false })
+        const listInfoStubElement = wrapper.find(listInfoStub)
+
+        expect(listInfoStubElement.props()).toMatchObject({
+          files: 15,
+          folders: 20,
+          size: 1024
+        })
+        expect(listInfoStubElement.attributes()).toMatchObject({
+          files: '15',
+          folders: '20',
+          size: '1024'
+        })
       })
+
       it('shows the list info when there is only one active file', () => {
-        const wrapper = mount(component, {
-          store: getStore({ activeFiles: [createFile({ id: 3, status: 2, type: 'file' })] }),
-          localVue,
-          router,
-          stubs: stubs,
-          data: () => ({
-            loading: false
-          })
+        const store = getStore({
+          activeFiles: [createFile({ id: 3, status: 2, type: 'file' })],
+          totalFilesCount: { files: 15, folders: 20 }
         })
-        expect(wrapper.find('list-info-stub').exists()).toBeTruthy()
+        const wrapper = getMountedWrapper({ store, loading: false })
+
+        expect(wrapper.find(listInfoStub).exists()).toBeTruthy()
       })
 
       it('does not show the list info when there are no active files', () => {
-        const wrapper = mount(component, {
-          store: getStore({ activeFiles: [] }),
-          localVue,
-          router,
-          stubs: stubs,
-          data: () => ({
-            loading: false
-          })
-        })
-        expect(wrapper.find('list-info-stub').exists()).toBeFalsy()
+        const store = getStore({ activeFiles: [] })
+        const wrapper = getMountedWrapper({ store, loading: false })
+
+        expect(wrapper.find(listInfoStub).exists()).toBeFalsy()
       })
     })
   })
 })
+
+function mountOptions({
+  store = getStore({ activeFiles: defaultActiveFiles, totalFilesCount: { files: 1, folders: 1 } }),
+  loading = false
+} = {}) {
+  return {
+    localVue,
+    store,
+    stubs,
+    mocks: {
+      $route: {
+        name: 'some-route',
+        params: { page: 1 }
+      }
+    },
+    data: () => ({
+      loading: loading
+    })
+  }
+}
+
+function getMountedWrapper({ store, loading } = {}) {
+  const component = { ...Favorites, created: jest.fn(), mounted: jest.fn() }
+  return mount(component, mountOptions({ store, loading }))
+}

--- a/packages/web-app-files/tests/unit/views/views.setup.js
+++ b/packages/web-app-files/tests/unit/views/views.setup.js
@@ -3,6 +3,7 @@ import Vuex from 'vuex'
 import OwnCloud from 'owncloud-sdk'
 import { createStore } from 'vuex-extensions'
 import DesignSystem from 'owncloud-design-system'
+import GetTextPlugin from 'vue-gettext'
 
 export const createFile = ({ id, status = 1, type = 'folder' }) => ({
   id: `file-id-${id}`,
@@ -22,24 +23,35 @@ localVue.prototype.$client = new OwnCloud()
 localVue.prototype.$client.init({ baseUrl: 'http://none.de' })
 localVue.use(Vuex)
 localVue.use(DesignSystem)
+localVue.use(GetTextPlugin, {
+  translations: 'does-not-matter.json',
+  silent: true
+})
 
 export const getStore = function({
   highlightedFile = null,
-  configuration = {
-    options: {
-      disablePreviews: true
-    }
-  },
-  activeFiles = [createFile({ id: 1 }), createFile({ id: 2, status: 2 })],
-  pages = 4,
-  sidebarClosed = false
+  disablePreviews = true,
+  currentPage = null,
+  activeFiles = [],
+  pages = null,
+  sidebarClosed = false,
+  currentFolder = null,
+  activeFilesCount = null,
+  inProgress = [null],
+  totalFilesCount = null,
+  selectedFiles = [],
+  totalFilesSize = null
 } = {}) {
   return createStore(Vuex.Store, {
     state: {
       app: { quickActions: {} }
     },
     getters: {
-      configuration: () => configuration,
+      configuration: () => ({
+        options: {
+          disablePreviews: disablePreviews
+        }
+      }),
       getToken: () => '',
       isOcis: () => true,
       homeFolder: () => '/'
@@ -48,19 +60,19 @@ export const getStore = function({
       Files: {
         state: {
           resource: null,
-          currentPage: 3,
+          currentPage: currentPage,
           filesPageLimit: 100
         },
         getters: {
-          totalFilesCount: () => ({ files: 15, folders: 20 }),
-          totalFilesSize: () => 1024,
-          selectedFiles: () => [],
+          totalFilesCount: () => totalFilesCount,
+          totalFilesSize: () => totalFilesSize,
+          selectedFiles: () => selectedFiles,
           activeFiles: () => activeFiles,
-          activeFilesCount: () => ({ files: 0, folders: 1 }),
-          inProgress: () => [null],
+          activeFilesCount: () => activeFilesCount,
+          inProgress: () => inProgress,
           highlightedFile: () => highlightedFile,
           pages: () => pages,
-          currentFolder: () => '/'
+          currentFolder: () => currentFolder
         },
         mutations: {
           UPDATE_RESOURCE: (state, resource) => {


### PR DESCRIPTION
## Description
Favorites spec uses hard coded selecotors and used the `mount` method in every scenario which we can manage a little bit with a `getWrapper` helper.

WIth this PR:
- make more general `views.setup.js`
- refactored favorites spec to use helper functions and selectors from variables

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of #5237 


## How Has This Been Tested?
- 💇🏼‍♂️ 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
