### PR TITLE
add developer ssh access to continously deployed instances

### DIFF
--- a/deployments/continuous-deployment-config/ocis_web/latest.yml
+++ b/deployments/continuous-deployment-config/ocis_web/latest.yml
@@ -17,6 +17,16 @@
     - "*.ocis-web.latest.owncloud.works"
 
   vars:
+    ssh_authorized_keys:
+      - https://github.com/butonic.keys
+      - https://github.com/C0rby.keys
+      - https://github.com/fschade.keys
+      - https://github.com/kulmann.keys
+      - https://github.com/micbar.keys
+      - https://github.com/pascalwengerter.keys
+      - https://github.com/paulcod3.keys
+      - https://github.com/refs.keys
+      - https://github.com/wkloucek.keys
     docker_compose_projects:
       - name: web
         git_url: https://github.com/owncloud/web.git


### PR DESCRIPTION
## Description
This adds developer ssh access to continuously deployed instances, in this case:
`ssh admin@ocis.ocis-web.latest.owncloud.works`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Possible after https://github.com/owncloud-devops/continuous-deployment/pull/21/files
- same as https://github.com/owncloud/ocis/pull/2464

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Provide SSH access to continuously deployed instances to a wider audience to investigate, debug, ...