### PR TITLE
[unit-tests-only] Added todo unit tests for statusIndicator helper

### DIFF
--- a/packages/web-app-files/tests/unit/helpers/statusIndicator.spec.js
+++ b/packages/web-app-files/tests/unit/helpers/statusIndicator.spec.js
@@ -1,0 +1,35 @@
+describe('statusIndicator', () => {
+  describe('getIndicators', () => {
+    it.todo(
+      'should replace "=" to "" from the resource id if present and set the value as the indicator id'
+    )
+
+    describe('user share indicator', () => {
+      it.todo('should set "visible" as true if the resource is a user share')
+      it.todo('should set "visible" as false if the resource is not a user share')
+      it.todo('should set "type" as true if the resource is a direct user share')
+      it.todo('should set "type" as false if the resource is not a direct user share')
+      it.todo(
+        'should set "accessibleDescription" with direct share information if the resource is a direct user share'
+      )
+      it.todo(
+        'should set "accessibleDescription" with parent share information if the resource is not a direct user share'
+      )
+      it.todo('should set "handler" as "indicatorHandler"')
+    })
+
+    describe('link share indicator', () => {
+      it.todo('should set "visible" as true if the resource is a link share')
+      it.todo('should set "visible" as false if the resource is not a link share')
+      it.todo('should set "type" as true if the resource is a direct link share')
+      it.todo('should set "type" as false if the resource is not a direct link share')
+      it.todo(
+        'should set "accessibleDescription" with direct share information if the resource is a direct link share'
+      )
+      it.todo(
+        'should set "accessibleDescription" with parent share information if the resource is not a direct link share'
+      )
+      it.todo('should set "handler" as "indicatorHandler"')
+    })
+  })
+})


### PR DESCRIPTION
## Description
- Added todo unit tests for `statusIndicator` helper from `packages/web-app-files/helper`
- todo tests for only the exported function is  added

## Related Issue
- Part of #5236 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
