### PR TITLE
Bump core & ocis commit IDs & core node version in CI

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,7 +1,7 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=45bd133a706ea031f905a159184e6fdb63faa885
+OCIS_COMMITID=a07c1e77a0a3bcb10b109ea4b468472cea10fbb3
 OCIS_BRANCH=master
 
 # The test runner source for API tests
-CORE_COMMITID=08e27f0d73bca5352d87b42936d6d956bc0eaea5
+CORE_COMMITID=d2d63df18170e5e62dbc4d77492ba9a9156af80e
 CORE_BRANCH=master

--- a/.drone.star
+++ b/.drone.star
@@ -1505,7 +1505,7 @@ def installCore(version, db):
 
     stepDefinition = {
         "name": "install-core",
-        "image": "owncloudci/core",
+        "image": "owncloudci/core:nodejs14",
         "pull": "always",
     }
 
@@ -1553,7 +1553,7 @@ def installFederatedServer(version, db, dbSuffix = "-federated"):
 
     stepDefinition = {
         "name": "install-federated",
-        "image": "owncloudci/core",
+        "image": "owncloudci/core:nodejs14",
         "pull": "always",
     }
     if version:


### PR DESCRIPTION
## Description
@micbar @wkloucek @fschade this is now just commit-IDs & PHP-node-version