### PR TITLE
[unit-tests-only] Add unit tests for publicLinkRolesDefinition helper

### DIFF
--- a/packages/web-app-files/tests/unit/helpers/publicLinkRolesDefinition.spec.js
+++ b/packages/web-app-files/tests/unit/helpers/publicLinkRolesDefinition.spec.js
@@ -1,4 +1,42 @@
+import publicLinkRolesDefinition from '@files/src/helpers/publicLinkRolesDefinition'
+
 describe('publicLinkRolesDefinition', () => {
-  it.todo('should return viewer role for resources other than folder')
-  it.todo('should return extended roles for folder')
+  it('should return viewer role for resources other than folder', () => {
+    expect(publicLinkRolesDefinition({})).toMatchObject([
+      {
+        name: 'viewer',
+        label: 'Viewer',
+        description: 'Recipients can view and download contents.',
+        permissions: 1
+      }
+    ])
+  })
+  it('should return extended roles for folder', () => {
+    expect(publicLinkRolesDefinition({ isFolder: true })).toMatchObject([
+      {
+        name: 'viewer',
+        label: 'Viewer',
+        description: 'Recipients can view and download contents.',
+        permissions: 1
+      },
+      {
+        name: 'contributor',
+        label: 'Contributor',
+        description: 'Recipients can view, download and upload contents.',
+        permissions: 5
+      },
+      {
+        name: 'editor',
+        label: 'Editor',
+        description: 'Recipients can view, download, edit, delete and upload contents.',
+        permissions: 15
+      },
+      {
+        name: 'uploader',
+        label: 'Uploader',
+        description: 'Recipients can upload but existing contents are not revealed.',
+        permissions: 4
+      }
+    ])
+  })
 })


### PR DESCRIPTION
## Description
- added unit tests for files package helper: `publicLinkRolesDefinition.js`

## Related Issue
- Part of #5236 

## How Has This Been Tested?
- local

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
