### PR TITLE
[unit-tests-only] Implemented `todo` unit tests for route helper

### DIFF
--- a/packages/web-app-files/tests/unit/helpers/route.spec.js
+++ b/packages/web-app-files/tests/unit/helpers/route.spec.js
@@ -1,48 +1,100 @@
+import {
+  checkRoute,
+  isAnySharedWithRoute,
+  isFavoritesRoute,
+  isPersonalRoute,
+  isPublicFilesRoute,
+  isPublicPage,
+  isSharedWithMeRoute,
+  isSharedWithOthersRoute,
+  isTrashbinRoute
+} from '@files/src/helpers/route.js'
+
 describe('route', () => {
   describe('checkRoute', () => {
-    it.todo('should return "true" if given "routes" array contains given "currentRoute"')
-    it.todo('should return "false" if given "routes" array does not contains given "currentRoute"')
+    it('should return "true" if given "routes" array contains given "currentRoute"', () => {
+      expect(checkRoute(['some-route'], 'some-route')).toBe(true)
+    })
+    it('should return "false" if given "routes" array does not contains given "currentRoute"', () => {
+      expect(checkRoute(['some-route'], 'another-route')).toBe(false)
+    })
   })
 
   describe('isPersonalRoute', () => {
-    it.todo('should return "true" if given route name is "files-personal"')
-    it.todo('should return "false" if given route name is not "files-personal"')
+    it('should return "true" if given route name is "files-personal"', () => {
+      expect(isPersonalRoute({ name: 'files-personal' })).toBe(true)
+    })
+    it('should return "false" if given route name is not "files-personal"', () => {
+      expect(isPersonalRoute({ name: 'files-favorites' })).toBe(false)
+    })
   })
 
   describe('isFavoritesRoute', () => {
-    it.todo('should return "true" if given route name is "files-favorites"')
-    it.todo('should return "false" if given route name is not "files-favorites"')
+    it('should return "true" if given route name is "files-favorites"', () => {
+      expect(isFavoritesRoute({ name: 'files-favorites' })).toBe(true)
+    })
+    it('should return "false" if given route name is not "files-favorites"', () => {
+      expect(isFavoritesRoute({ name: 'files-personal' })).toBe(false)
+    })
   })
 
   describe('isTrashbinRoute', () => {
-    it.todo('should return "true" if given route name is "files-trashbin"')
-    it.todo('should return "false" if given route name is not "files-trashbin"')
+    it('should return "true" if given route name is "files-trashbin"', () => {
+      expect(isTrashbinRoute({ name: 'files-trashbin' })).toBe(true)
+    })
+    it('should return "false" if given route name is not "files-trashbin"', () => {
+      expect(isTrashbinRoute({ name: 'files-personal' })).toBe(false)
+    })
   })
 
   describe('isSharedWithMeRoute', () => {
-    it.todo('should return "true" if given route name is "files-shared-with-me"')
-    it.todo('should return "false" if given route name is not "files-shared-with-me"')
+    it('should return "true" if given route name is "files-shared-with-me"', () => {
+      expect(isSharedWithMeRoute({ name: 'files-shared-with-me' })).toBe(true)
+    })
+    it('should return "false" if given route name is not "files-shared-with-me"', () => {
+      expect(isSharedWithMeRoute({ name: 'files-personal' })).toBe(false)
+    })
   })
 
   describe('isSharedWithOthersRoute', () => {
-    it.todo('should return "true" if given route name is "files-shared-with-others"')
-    it.todo('should return "false" if given route name is not "files-shared-with-others"')
+    it('should return "true" if given route name is "files-shared-with-others"', () => {
+      expect(isSharedWithOthersRoute({ name: 'files-shared-with-others' })).toBe(true)
+    })
+    it('should return "false" if given route name is not "files-shared-with-others"', () => {
+      expect(isSharedWithOthersRoute({ name: 'files-shared-with-me' })).toBe(false)
+    })
   })
 
   describe('isAnySharedWithRoute', () => {
-    it.todo('should return "false" if given route is not "SharedWithMe" and "SharedWithOthers"')
-    it.todo('should return "true" if given route is "SharedWithMe"')
-    it.todo('should return "true" if given route is "SharedWithOthers"')
+    it('should return "false" if given route is not "SharedWithMe" and "SharedWithOthers"', () => {
+      expect(isAnySharedWithRoute({ name: 'files-personal' })).toBe(false)
+    })
+    it('should return "true" if given route is "SharedWithMe"', () => {
+      expect(isAnySharedWithRoute({ name: 'files-shared-with-me' })).toBe(true)
+    })
+    it('should return "true" if given route is "SharedWithOthers"', () => {
+      expect(isAnySharedWithRoute({ name: 'files-shared-with-others' })).toBe(true)
+    })
   })
 
   describe('isPublicFilesRoute', () => {
-    it.todo('should return "true" if given route name is "files-public-list"')
-    it.todo('should return "false" if given route name is not "files-public-list"')
+    it('should return "true" if given route name is "files-public-list"', () => {
+      expect(isPublicFilesRoute({ name: 'files-public-list' })).toBe(true)
+    })
+    it('should return "false" if given route name is not "files-public-list"', () => {
+      expect(isPublicFilesRoute({ name: 'files-shared-with-others' })).toBe(false)
+    })
   })
 
   describe('isPublicPage', () => {
-    it.todo('should return "false" if given route has no meta information')
-    it.todo('should return "false" if given route meta auth is "true"')
-    it.todo('should return "true" if given route meta auth is "false"')
+    it('should return "false" if given route has no meta information', () => {
+      expect(isPublicPage({ name: 'files-public-list' })).toBe(false)
+    })
+    it('should return "false" if given route meta auth is "true"', () => {
+      expect(isPublicPage({ meta: { auth: true } })).toBe(false)
+    })
+    it('should return "true" if given route meta auth is "false"', () => {
+      expect(isPublicPage({ meta: { auth: false } })).toBe(true)
+    })
   })
 })


### PR DESCRIPTION
## Description
- implemented `todo` unit tests for `route` helper

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #5236 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
