### PR TITLE
[full-ci][tests-only] Bump commit ids for tests

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,7 +1,7 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=0e9e6356727590bc8e18d20dbe0425903f24bece
+OCIS_COMMITID=b4f6ebe96d3bfce19699824d919f1f35008e9123
 OCIS_BRANCH=master
 
 # The test runner source for API tests
-CORE_COMMITID=e12a097b982a70247a71d6175c37dda3ff9cd236
+CORE_COMMITID=7d3b29708162facd5ba0291cd8a934eca09de6a2
 CORE_BRANCH=master


### PR DESCRIPTION
## Description
This PR bumps core  and oCIS commit ids to the latest

## Related Issue
- Part of  https://github.com/owncloud/QA/issues/689