### PR TITLE
[Tests-Only] Fix implementation for breadcrumb test step in mobile resolution

### DIFF
--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -13,6 +13,7 @@ const util = require('util')
 const { download } = require('../helpers/webdavHelper')
 const fs = require('fs')
 const sharingHelper = require('../helpers/sharingHelper')
+const appSideBar = client.page.FilesPageElement.appSideBar()
 
 let deletedElements
 let unsharedElements
@@ -731,6 +732,7 @@ const assertBreadcrumbIsDisplayedFor = async function(resource, clickable, nonCl
 
   // Try to look for a mobile breadcrumbs in case it has not been found
   if (!isBreadcrumbVisible) {
+    await appSideBar.closeSidebarIfOpen()
     const mobileBreadcrumbMobileXpath = util.format(
       client.page.personalPage().elements.breadcrumbMobile.selector,
       xpathHelper.buildXpathLiteral(resource)


### PR DESCRIPTION
## Description
This PR makes sure that the details tab in the sidebar is closed so that the breadcrumb is actually visible for mobile resolution.

## Related Issue
- https://github.com/owncloud/web/issues/5790

## Motivation and Context:
On mobile resolution, when a resource is copied into a folder, breadcrumb for the current folder is expected to be visible in the tests. But the sidebar takes all the viewport to display the details tab. The sidebar should be closed before we see the breadcrumb for the mobile resolution. However, the tests were passing until now, because the element is there in the DOM, but not visible to us. So it looked like the tests are passing even when the breadcrumb is not visible, so once the details tab is closed by the changes made in this pr, the breadcrumb is actually visible.

However, something might be done so that when the element is not actually visible, it should not pass when the visibility of the element is checked.

## How Has This Been Tested?
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...