### PR TITLE
[Tests-Only][full-ci]Adjust the element and implementations to work for mobile breadcrumb

### DIFF
--- a/tests/acceptance/features/webUIFiles/breadcrumb.feature
+++ b/tests/acceptance/features/webUIFiles/breadcrumb.feature
@@ -13,8 +13,9 @@ Feature: access breadcrumb
     And user "Alice" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user opens folder "subfolder" using the webUI
-    Then clickable breadcrumb for folder "simple-folder" should be displayed on the webUI
-    And non-clickable breadcrumb for folder "subfolder" should be displayed on the webUI
+    Then breadcrumb for folder "simple-folder" should be displayed on the webUI
+    And breadcrumb for folder "subfolder" should be displayed on the webUI
+    And non-clickable breadcrumb for folder "subfolder" should be present on the webUI
 
 
   Scenario: Select breadcrumb inside folder with problematic name
@@ -35,15 +36,15 @@ Feature: access breadcrumb
     Then no message should be displayed on the webUI
 
 
-
   Scenario: breadcrumb for double quotes
     Given user "Alice" has created folder "\'single-double quotes\""
     And user "Alice" has created folder "\'single-double quotes\"/\"inner\" double quotes"
     And user "Alice" has logged in using the webUI
     When the user opens folder "\'single-double quotes\"" using the webUI
     And the user opens folder "\"inner\" double quotes" using the webUI
-    Then clickable breadcrumb for folder "\'single-double quotes\"" should be displayed on the webUI
-    And non-clickable breadcrumb for folder "\"inner\" double quotes" should be displayed on the webUI
+    Then breadcrumb for folder "\'single-double quotes\"" should be displayed on the webUI
+    And breadcrumb for folder "\"inner\" double quotes" should be displayed on the webUI
+    And non-clickable breadcrumb for folder "\"inner\" double quotes" should be present on the webUI
 
 
   Scenario: Check breadCrumb for home folder

--- a/tests/acceptance/pageObjects/personalPage.js
+++ b/tests/acceptance/pageObjects/personalPage.js
@@ -33,7 +33,7 @@ module.exports = {
      * @param {string} resource
      */
     navigateToBreadcrumb: function(resource) {
-      const breadcrumbElement = this.elements.resourceBreadcrumbClickable
+      const breadcrumbElement = this.elements.resourceBreadcrumb
       const resourceXpath = util.format(
         breadcrumbElement.selector,
         xpathHelper.buildXpathLiteral(resource)
@@ -53,28 +53,12 @@ module.exports = {
      * @returns {null|{locateStrategy: string, selector: string}}
      */
     getBreadcrumbSelector: function(clickable, nonClickable) {
-      if (clickable && nonClickable) {
+      if (clickable) {
         return this.elements.resourceBreadcrumb
-      } else if (clickable) {
-        return this.elements.resourceBreadcrumbClickable
       } else if (nonClickable) {
         return this.elements.resourceBreadcrumbNonClickable
       }
       return null
-    },
-    /**
-     * Check if the breadcrumb element is visible or not
-     *
-     * @returns Promise
-     */
-    checkBreadcrumbVisibility: async function(resourceBreadcrumbXpath) {
-      await this.useXpath()
-        .waitForElementVisible({
-          selector: resourceBreadcrumbXpath,
-          abortOnFailure: false
-        })
-        .useCss()
-      return this
     },
     /**
      * Create a folder with the given name
@@ -369,12 +353,12 @@ module.exports = {
       selector: '//span[@class="oc-breadcrumb-drop-label-text" and text()=%s]',
       locateStrategy: 'xpath'
     },
-    resourceBreadcrumb: {
+    breadcrumbMobileReferencedToOpenSidebarButton: {
       selector:
-        '//nav[@id="files-breadcrumb"]//*[(self::a or self::span or self::button) and contains(text(),%s)]',
+        '//button[@aria-label="Open sidebar to view details"]/ancestor::div//span[@class="oc-breadcrumb-drop-label-text" and text()=%s]',
       locateStrategy: 'xpath'
     },
-    resourceBreadcrumbClickable: {
+    resourceBreadcrumb: {
       selector:
         '//nav[@id="files-breadcrumb"]//*[(self::a or self::button) and contains(text(),%s)]',
       locateStrategy: 'xpath'


### PR DESCRIPTION
## Description
This PR fixes the implementation for the types of breadcrumbs expected in the tests, so that the breadcrumb tests work as expected in mobile resolution and there is no false positive acceptance tests.

## Related Issue
- https://github.com/owncloud/web/issues/5790

## Motivation and Context
- The tests for breadcrumb in mobile resolution passed even when the sidebar covered all the viewport and the breadcrumb was not actually visible to us.
- The non-clickable breadcrumb element is not visible for just present, but still the tests passed when the non-clickable breadcrumb was expected to be visible in the webUI

These resulted in false positive acceptance tests, which needed to be fixed.

## How Has This Been Tested?
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...