### PR TITLE
[docs-only] Remove trailing commas from json snippets, add validator hint

### DIFF
--- a/docs/deployments/oc10-app.md
+++ b/docs/deployments/oc10-app.md
@@ -100,6 +100,10 @@ There are a few config values which need to be set in order for ownCloud Web to 
 }
 ```
 
+{{< hint info >}}
+If any issues arise when trying to access the new design, a good start for debugging it is to run your `config.json` file through a json validator of your choice.
+{{< /hint >}}
+
 |config parameter|explanation|
 |---|---|
 |server|ownCloud 10 server address|
@@ -117,14 +121,14 @@ It is important that you don't edit or place the `config.json` within the app fo
 {{< hint >}}
 If you use OpenID Connect you need to replace the `"auth"` part with following configuration:
 
-``` 
+```json
   "openIdConnect": {
     "metadata_url": "<fqdn-of-the-identity-provider>/.well-known/openid-configuration",
     "authority": "<fqdn-of-the-identity-provider>",
     "client_id": "<client-id-from-the-identity-provider>",
     "response_type": "code",
     "scope": "openid profile email"
-  },
+  }
 ```
 {{< /hint >}}
 
@@ -134,7 +138,7 @@ ownCloud Classic features that are not deeply integrated with the Classic UI (e.
 
 To add new elements in the app switcher, paste the following into the `applications` section of `config.json`:
 
-```
+```json
     {
       "title": {
         "en": "Custom Groups",
@@ -142,7 +146,7 @@ To add new elements in the app switcher, paste the following into the `applicati
       },
       "icon": "application",
       "url": "https://<your-owncloud-server>/settings/personal?sectionid=customgroups"
-    },
+    }
 ```
 
 {{< hint info >}}
@@ -152,7 +156,7 @@ The URL in the example might need adaptations depending on the configuration of 
 ### Add links to the user menu
 Just like adding links to the app switcher, you can also add links to the user menu.
 
-```
+```json
     {
       "icon": "application",
       "menu": "user",
@@ -162,7 +166,7 @@ Just like adding links to the app switcher, you can also add links to the user m
         "en": "Help"
       },
       "url": "https://help-link.example"
-    },
+    }
 ```
 
 This will add a link to the specified URL in the user menu. This way, the link will open in the same tab. If you instead want to open it in a new tab, just remove the line `"target": "_self",`.
@@ -177,11 +181,11 @@ To be able to use ONLYOFFICE in ownCloud Web, it is required to run
 
 Make sure that ONLYOFFICE works as expected in the Classic UI and add the following to `config.json` to make it available in ownCloud Web:
 
-```
+```json
 "external_apps": [
     {
         "id": "onlyoffice",
-        "path": "https://<your-owncloud-server>/apps/onlyoffice/js/web/onlyoffice.js",
+        "path": "https://<your-owncloud-server>/apps/onlyoffice/js/web/onlyoffice.js"
     }
 ]
 ```


### PR DESCRIPTION
## Description
This PR removes (invalid) trailing commas from json snippets in the documentation and adds a hint for using json validators if issues arise accessing ownCloud Web.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://central.owncloud.org/t/owncloud-web-4-2-white-page-with-js-typeerror/34063/8

## Motivation and Context
Reduce copy&paste induced issues

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- not needed, docs only

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 