### PR TITLE
[tests-only] Do not skip npm install when there are only unit test changes

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1590,7 +1590,7 @@ def installNPM():
         "image": "owncloudci/nodejs:14",
         "pull": "always",
         "commands": [
-            "if test -f runUnitTestsOnly || test -f runTestsForDocsChangeOnly; then echo 'skipping installNPM'; else yarn install --frozen-lockfile; fi",
+            "if test -f runTestsForDocsChangeOnly; then echo 'skipping installNPM'; else yarn install --frozen-lockfile; fi",
         ],
     }]
 


### PR DESCRIPTION
## Description
npm-install step is skipped when there are only unit tests changes
https://drone.owncloud.com/owncloud/web/19208/3/3

## Related Issue
- Fixes issue: npm install is skipped when there are only unit tests changes

## How Has This Been Tested?
- test environment:


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 