### PR TITLE
fix: change sticky header top offset to reflect actual height on page of #files-app-bar not relative height

### DIFF
--- a/packages/web-app-files/src/views/LocationPicker.vue
+++ b/packages/web-app-files/src/views/LocationPicker.vue
@@ -293,7 +293,7 @@ export default {
     adjustTableHeaderPosition() {
       this.$nextTick(() => {
         const header = document.querySelector('#files-app-bar')
-        this.headerPosition = header.getBoundingClientRect().bottom
+        this.headerPosition = header.getBoundingClientRect().height
       })
     },
 


### PR DESCRIPTION
## Description
If the implementation of **web** has a notification bar or anything else consuming space above #files-app-bar, the sticky header will be off by the exact height of anything above it.

**Before**
![image](https://user-images.githubusercontent.com/876651/134840334-9944df67-8bb1-4afb-9af2-0f3f540d95d3.png)

**After**
![image](https://user-images.githubusercontent.com/876651/134840441-ab250ca9-c99a-44d9-adf1-bc4bc7fb17f1.png)

There is one other place where `bottom` is used in place of `height` but I have not tested this so may propose this in another PR.
See https://github.com/owncloud/web/blob/a330d27b7706118d974d219d6d30776e730907ed/packages/web-app-files/src/mixins/filesListScrolling.js#L5
