### PR TITLE
Fix theme paths in docs example/drone configs

### DIFF
--- a/docs/deployments/oc10-app.md
+++ b/docs/deployments/oc10-app.md
@@ -64,7 +64,7 @@ There are a few config values which need to be set in order for ownCloud Web to 
 ```json
 {
   "server" : "https://<your-owncloud-server>",
-  "theme": "owncloud",
+  "theme": "https://<your-owncloud-server>/themes/owncloud/theme.json",
   "auth": {
     "clientId": "<client-id-from-oauth2>",
     "url": "https://<your-owncloud-server>/index.php/apps/oauth2/api/v1/token",

--- a/packages/web-runtime/tests/unit/helpers/config.spec.js
+++ b/packages/web-runtime/tests/unit/helpers/config.spec.js
@@ -2,7 +2,7 @@ import { loadConfig } from 'web-runtime/src/helpers/config'
 
 const validConfig = `{
   "server" : "http://localhost/owncloud-core",
-  "theme": "owncloud",
+  "theme": "http://localhost/themes/owncloud/theme.json",
   "version": "0.1.0",
   "auth": {
     "clientId": "bZrw9cijQ9JGf6wDcLCEuiT9iyah2OzzRycjZc30WDEkMHMRybv7VXENbYGbqy3H",

--- a/tests/drone/config-oc10-integration-app-oauth.json
+++ b/tests/drone/config-oc10-integration-app-oauth.json
@@ -1,6 +1,6 @@
 {
   "server" : "http://owncloud",
-  "theme": "owncloud",
+  "theme": "http://owncloud/themes/owncloud/theme.json",
   "auth": {
     "clientId": "Cxfj9F9ZZWQbQZps1E1M0BszMz6OOFq3lxjSuc8Uh4HLEYb9KIfyRMmgY5ibXXrU",
     "url": "http://owncloud/index.php/apps/oauth2/api/v1/token",

--- a/tests/drone/config-oc10-oauth.json
+++ b/tests/drone/config-oc10-oauth.json
@@ -1,6 +1,6 @@
 {
   "server" : "http://owncloud",
-  "theme": "owncloud",
+  "theme": "http://owncloud/themes/owncloud/theme.json",
   "version": "0.1.0",
   "auth": {
     "clientId": "Cxfj9F9ZZWQbQZps1E1M0BszMz6OOFq3lxjSuc8Uh4HLEYb9KIfyRMmgY5ibXXrU",
@@ -13,7 +13,5 @@
     "markdown-editor",
     "media-viewer",
     "search"
-  ],
-  "external_apps": [
   ]
 }

--- a/tests/drone/config-oc10-openid.json
+++ b/tests/drone/config-oc10-openid.json
@@ -1,6 +1,6 @@
 {
   "server": "http://owncloud/",
-  "theme": "owncloud",
+  "theme": "http://owncloud/themes/owncloud/theme.json",
   "version": "0.1.0",
   "openIdConnect": {
     "metadata_url": "https://idp:9130/.well-known/openid-configuration",

--- a/tests/drone/config-ocis.json
+++ b/tests/drone/config-ocis.json
@@ -1,6 +1,6 @@
 {
   "server": "https://ocis:9200",
-  "theme": "owncloud",
+  "theme": "https://ocis:9200/themes/owncloud/theme.json",
   "version": "0.1.0",
   "openIdConnect": {
     "metadata_url": "https://ocis:9200/.well-known/openid-configuration",
@@ -15,8 +15,5 @@
     "markdown-editor",
     "media-viewer",
     "search"
-  ],
-  "options": {
-    "hideSearchBar": true
-  }
+  ]
 }


### PR DESCRIPTION
## Description
When introducing theming, we changed the way themes are getting loaded to either URL- or path-based. I've recently come across a couple of outdated examples that still use a theme-name and hence fail & fall back to the `ownCloud`-default-theme. Fixing them gives dev-/admin-users a better idea of how to actually use this config option and reduces errors in the JS console