### PR TITLE
[tests-only full-ci] disable previews in tests that check sharing indicators

### DIFF
--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -126,8 +126,8 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUISharingInternalUsersExpire/shareWithUsersExpiringShares.feature:239](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalUsersExpire/shareWithUsersExpiringShares.feature#L239)
 
 ### [share indicator in files are not shown until sharing sidebar is opened](https://github.com/owncloud/web/issues/4167)
--   [webUISharingInternalUsersSharingIndicator/shareWithUsers.feature:99](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalUsersSharingIndicator/shareWithUsers.feature#L99)
--   [webUISharingInternalUsersSharingIndicator/shareWithUsers.feature:120](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalUsersSharingIndicator/shareWithUsers.feature#L120)
+-   [webUISharingInternalUsersSharingIndicator/shareWithUsers.feature:100](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalUsersSharingIndicator/shareWithUsers.feature#L100)
+-   [webUISharingInternalUsersSharingIndicator/shareWithUsers.feature:121](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalUsersSharingIndicator/shareWithUsers.feature#L121)
 -   [webUISharingPublicManagement/publicLinkIndicator.feature:12](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkIndicator.feature#L12)
 -   [webUISharingPublicManagement/publicLinkIndicator.feature:47](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkIndicator.feature#L47)
 -   [webUISharingPublicManagement/publicLinkIndicator.feature:64](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkIndicator.feature#L64)

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -1,4 +1,4 @@
-@ocis-product-issue-277 @federated-server-needed
+@ocis-product-issue-277 @federated-server-needed @disablePreviews
 Feature: Federation Sharing - sharing with users on other cloud storages
   As a user
   I want to share files with any users on other cloud storages

--- a/tests/acceptance/features/webUISharingExternalToRoot/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternalToRoot/federationSharing.feature
@@ -1,4 +1,4 @@
-@notToImplementOnOCIS
+@notToImplementOnOCIS @disablePreviews
 Feature: Federation Sharing - sharing with users on other cloud storages
   As a user
   I want to share files with any users on other cloud storages

--- a/tests/acceptance/features/webUISharingInternalGroupsSharingIndicator/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroupsSharingIndicator/shareWithGroups.feature
@@ -1,4 +1,4 @@
-@ocis-reva-issue-194
+@ocis-reva-issue-194 @disablePreviews
 Feature: Sharing files and folders with internal groups
   As a user
   I want to share files and folders with groups

--- a/tests/acceptance/features/webUISharingInternalGroupsToRootSharingIndicator/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroupsToRootSharingIndicator/shareWithGroups.feature
@@ -1,4 +1,4 @@
-@notToImplementOnOCIS
+@notToImplementOnOCIS @disablePreviews
 Feature: Sharing files and folders with internal groups
   As a user
   I want to share files and folders with groups

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -12,7 +12,7 @@ Feature: Sharing files and folders with internal users
       | Brian    |
     And user "Brian" has created folder "simple-folder"
 
-  @smokeTest @issue-ocis-2260 @ocisSmokeTest
+  @smokeTest @issue-ocis-2260 @ocisSmokeTest @disablePreviews
   Scenario Outline: share a file & folder with another internal user
     Given user "Brian" has created file "testimage.jpg"
     And user "Brian" has created file "simple-folder/lorem.txt"
@@ -53,7 +53,7 @@ Feature: Sharing files and folders with internal users
       | Editor               | Editor               | read,update,create,delete,share | read,update,share |
       | Custom permissions | Custom permissions | read                            | read              |
 
-  @issue-4102 @issue-ocis-2267
+  @issue-4102 @issue-ocis-2267 @disablePreviews
   Scenario: share a file with another internal user who overwrites and unshares the file
     Given user "Brian" has created file "lorem.txt"
     And user "Brian" has logged in using the webUI
@@ -73,7 +73,7 @@ Feature: Sharing files and folders with internal users
     # check that the original file owner can still see the file
     And as "Brian" the content of "new-lorem.txt" should be the same as the content of local file "new-lorem.txt"
 
-
+  @disablePreviews
   Scenario: share a folder with another internal user who uploads, overwrites and deletes files
     Given user "Brian" has created file "simple-folder/lorem.txt"
     And user "Brian" has created file "simple-folder/data.zip"
@@ -104,7 +104,7 @@ Feature: Sharing files and folders with internal users
     And as "Brian" the content of "simple-folder/new-lorem.txt" should be the same as the content of local file "new-lorem.txt"
     But file "data.zip" should not be listed on the webUI
 
-  @issue-product-270
+  @issue-product-270 @disablePreviews
   Scenario: share a folder with another internal user who unshares the folder
     Given user "Brian" has uploaded file with content "text file" to "simple-folder/lorem.txt"
     And user "Brian" has logged in using the webUI
@@ -122,7 +122,7 @@ Feature: Sharing files and folders with internal users
     Then folder "new-simple-folder" should be listed on the webUI
     And the content of file "new-simple-folder/lorem.txt" for user "Brian" should be "text file"
 
-  @issue-product-270
+  @issue-product-270 @disablePreviews
   Scenario: share a folder with another internal user and prohibit deleting
     Given user "Brian" has created file "simple-folder/lorem.txt"
     And user "Brian" has logged in using the webUI
@@ -133,7 +133,7 @@ Feature: Sharing files and folders with internal users
     And the user opens folder "simple-folder" using the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
-  @issue-ocis-2260
+  @issue-ocis-2260 @disablePreviews
   Scenario: user shares the file/folder with multiple internal users and delete the share with one user
     Given user "Carol" has been created with default attributes and without skeleton files
     And user "Alice" has created file "lorem.txt"
@@ -154,7 +154,7 @@ Feature: Sharing files and folders with internal users
     And as "Brian" file "Shares/lorem.txt" should not exist
     But as "Carol" file "Shares/lorem.txt" should exist
 
-
+  @disablePreviews
   Scenario: Try to share file and folder that used to exist but does not anymore
     Given user "Alice" has created folder "simple-folder"
     And user "Alice" has created file "lorem.txt"
@@ -176,7 +176,7 @@ Feature: Sharing files and folders with internal users
     And as "Alice" file "lorem.txt" should not exist
     And as "Alice" folder "simple-folder" should not exist
 
-  @issue-2897 @issue-ocis-2260
+  @issue-2897 @issue-ocis-2260 @disablePreviews
   Scenario: sharing details of items inside a shared folder
     Given user "Alice" has created folder "simple-folder"
     And user "Alice" has created folder "simple-folder/simple-empty-folder"
@@ -191,7 +191,7 @@ Feature: Sharing files and folders with internal users
     Then user "Brian Murphy" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
 
   # Share permission is not available in oCIS webUI so when setting all permissions, it is displayed as "Custom permissions" there
-  @issue-2897 @issue-ocis-2260
+  @issue-2897 @issue-ocis-2260 @disablePreviews
   Scenario: sharing details of items inside a re-shared folder
     Given user "Alice" has created folder "simple-folder"
     And user "Alice" has created folder "simple-folder/simple-empty-folder"
@@ -208,7 +208,7 @@ Feature: Sharing files and folders with internal users
     When the user opens the share dialog for file "lorem.txt" using the webUI
     Then user "Carol King" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
 
-  @skipOnOC10 @issue-2897
+  @skipOnOC10 @issue-2897 @disablePreviews
   Scenario: sharing details of items inside a re-shared folder (ocis bug demonstration)
     Given user "Alice" has created folder "simple-folder"
     And user "Alice" has created folder "simple-folder/simple-empty-folder"
@@ -225,7 +225,7 @@ Feature: Sharing files and folders with internal users
     When the user opens the share dialog for file "lorem.txt" using the webUI
     Then user "Carol King" should be listed as "Custom permissions" via "simple-folder" in the collaborators list on the webUI
 
-  @issue-2897 @issue-ocis-2260
+  @issue-2897 @issue-ocis-2260 @disablePreviews
   Scenario: sharing details of items inside a shared folder shared with multiple users
     Given user "Alice" has created folder "simple-folder"
     And user "Carol" has been created with default attributes and without skeleton files
@@ -239,7 +239,7 @@ Feature: Sharing files and folders with internal users
     Then user "Brian Murphy" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
     And user "Carol King" should be listed as "Editor" via "sub-folder" in the collaborators list on the webUI
 
-  @issue-ocis-2260
+  @issue-ocis-2260 @disablePreviews
   Scenario Outline: Share files/folders with special characters in their name
     Given user "Brian" has created folder "Sample,Folder,With,Comma"
     And user "Brian" has created file "sample,1.txt"
@@ -276,7 +276,7 @@ Feature: Sharing files and folders with internal users
       | Editor               | Editor               | read,update,create,delete,share | read,update,share |
       | Custom permissions | Custom permissions | read                            | read              |
 
-  @skipOnOC10 @ocisSmokeTest
+  @skipOnOC10 @ocisSmokeTest @disablePreviews
   #after fixing the issue delete this scenario and use the one above by deleting the @skipOnOCIS tag there
   Scenario Outline: Share files/folders with special characters in their name
     Given user "Brian" has created folder "Sample,Folder,With,Comma"
@@ -333,7 +333,7 @@ Feature: Sharing files and folders with internal users
     When the user opens folder "Shares" using the webUI
     Then the preview image of file "testavatar.jpg" should not be displayed in the file list view on the webUI
 
-  @issue-4192
+  @issue-4192 @disablePreviews
   Scenario: sharing file after renaming it is possible
     Given user "Alice" has created file "lorem.txt"
     And user "Alice" has logged in using the webUI

--- a/tests/acceptance/features/webUISharingInternalUsersSharingIndicator/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersSharingIndicator/shareWithUsers.feature
@@ -1,3 +1,4 @@
+@disablePreviews
 Feature: Sharing files and folders with internal users
   As a user
   I want to share files and folders with other users

--- a/tests/acceptance/features/webUISharingInternalUsersToRoot/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersToRoot/shareWithUsers.feature
@@ -10,7 +10,7 @@ Feature: Sharing files and folders with internal users
       | Alice    |
       | Brian    |
 
-  @smokeTest
+  @smokeTest @disablePreviews
   Scenario Outline: share a file & folder with another internal user
     Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
     And user "Brian" has created folder "simple-folder"
@@ -49,7 +49,7 @@ Feature: Sharing files and folders with internal users
       | Editor               | Editor               | read,update,create,delete,share | read,update,share |
       | Custom permissions | Custom permissions | read                            | read              |
 
-
+  @disablePreviews
   Scenario: share a file with another internal user who overwrites and unshares the file
     Given user "Brian" has created file "new-lorem.txt"
     And user "Brian" has logged in using the webUI
@@ -66,7 +66,7 @@ Feature: Sharing files and folders with internal users
     # check that the original file owner can still see the file
     And as "Brian" the content of "new-lorem.txt" should be the same as the content of local file "new-lorem.txt"
 
-
+  @disablePreviews
   Scenario: share a folder with another internal user who uploads, overwrites and deletes files
     Given user "Brian" has created folder "new-simple-folder"
     And user "Brian" has created file "new-simple-folder/lorem.txt"
@@ -95,7 +95,7 @@ Feature: Sharing files and folders with internal users
     And as "Brian" the content of "new-simple-folder/new-lorem.txt" should be the same as the content of local file "new-lorem.txt"
     But file "data.zip" should not be listed on the webUI
 
-
+  @disablePreviews
   Scenario: share a folder with another internal user who unshares the folder
     Given user "Brian" has created folder "new-simple-folder"
     And user "Brian" has uploaded file "lorem.txt" to "new-simple-folder/lorem.txt"
@@ -111,7 +111,7 @@ Feature: Sharing files and folders with internal users
     Then folder "new-simple-folder" should be listed on the webUI
     And as "Brian" the content of "new-simple-folder/lorem.txt" should be the same as the content of local file "lorem.txt"
 
-
+  @disablePreviews
   Scenario: share a folder with another internal user and prohibit deleting
     Given user "Brian" has created folder "simple-folder"
     And user "Brian" has created file "simple-folder/lorem.txt"
@@ -121,7 +121,7 @@ Feature: Sharing files and folders with internal users
     And the user opens folder "simple-folder" using the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
-
+  @disablePreviews
   Scenario: user shares the file/folder with another internal user and delete the share with user
     Given user "Alice" has created file "lorem.txt"
     And user "Alice" has logged in using the webUI
@@ -134,7 +134,7 @@ Feature: Sharing files and folders with internal users
     And file "lorem.txt" should not be listed in shared-with-others page on the webUI
     And as "Brian" file "lorem.txt" should not exist
 
-
+  @disablePreviews
   Scenario: user shares the file/folder with multiple internal users and delete the share with one user
     Given user "Carol" has been created with default attributes and without skeleton files
     And user "Alice" has created file "lorem.txt"
@@ -153,7 +153,7 @@ Feature: Sharing files and folders with internal users
     And as "Brian" file "lorem.txt" should not exist
     But as "Carol" file "lorem.txt" should exist
 
-
+  @disablePreviews
   Scenario: Try to share file and folder that used to exist but does not anymore
     Given user "Alice" has created folder "simple-folder"
     And user "Alice" has created file "lorem.txt"
@@ -175,7 +175,7 @@ Feature: Sharing files and folders with internal users
     And as "Alice" file "lorem.txt" should not exist
     And as "Alice" folder "simple-folder" should not exist
 
-  @issue-2897
+  @issue-2897 @disablePreviews
   Scenario: sharing details of items inside a shared folder
     Given user "Carol" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "simple-folder"
@@ -189,7 +189,7 @@ Feature: Sharing files and folders with internal users
     When the user opens the share dialog for file "lorem.txt" using the webUI
     Then user "Brian Murphy" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
 
-  @issue-2897
+  @issue-2897 @disablePreviews
   Scenario: sharing details of items inside a re-shared folder
     Given user "Carol" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "simple-folder"
@@ -204,7 +204,7 @@ Feature: Sharing files and folders with internal users
     When the user opens the share dialog for file "lorem.txt" using the webUI
     Then user "Carol King" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
 
-  @issue-2897
+  @issue-2897 @disablePreviews
   Scenario: sharing details of items inside a shared folder shared with multiple users
     Given user "Carol" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "simple-folder"
@@ -218,7 +218,7 @@ Feature: Sharing files and folders with internal users
     Then user "Brian Murphy" should be listed as "Editor" via "simple-folder" in the collaborators list on the webUI
     And user "Carol King" should be listed as "Editor" via "sub-folder" in the collaborators list on the webUI
 
-
+  @disablePreviews
   Scenario Outline: Share files/folders with special characters in their name
     Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
     And user "Brian" has created folder "Sample,Folder,With,Comma"
@@ -267,7 +267,7 @@ Feature: Sharing files and folders with internal users
     When user "Brian" logs in using the webUI
     Then the preview image of file "testavatar.jpg" should not be displayed in the file list view on the webUI
 
-
+  @disablePreviews
   Scenario: sharing file after renaming it is possible
     Given user "Alice" has uploaded file with content "test" to "lorem.txt"
     And user "Alice" has logged in using the webUI

--- a/tests/acceptance/features/webUISharingInternalUsersToRootSharingIndicator/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersToRootSharingIndicator/shareWithUsers.feature
@@ -1,4 +1,4 @@
-@notToImplementOnOCIS
+@notToImplementOnOCIS @disablePreviews
 Feature: Sharing files and folders with internal users
   As a user
   I want to share files and folders with other users

--- a/tests/acceptance/features/webUISharingPublicManagement/publicLinkIndicator.feature
+++ b/tests/acceptance/features/webUISharingPublicManagement/publicLinkIndicator.feature
@@ -1,4 +1,4 @@
-@public_link_share-feature-required
+@public_link_share-feature-required @disablePreviews
 Feature: Public link share indicator
   As a user
   I want to check share indicator


### PR DESCRIPTION
## Description
When the preview / thumbnail is loaded the whole row is replaced.
So if the tests check something else in the row during that time, they might crash with a `stale element` error.
For those cases disable previews.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #5660

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...