### PR TITLE
configure ldap certificate path for ci and docker-compose

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1972,6 +1972,7 @@ def ocisService():
             "PROXY_OIDC_INSECURE": "true",
             "STORAGE_HOME_DATA_SERVER_URL": "http://ocis:9155/data",
             "STORAGE_USERS_DATA_SERVER_URL": "http://ocis:9158/data",
+            "STORAGE_LDAP_CACERT": "/srv/config/drone/ldap.crt",
             "WEB_UI_CONFIG": "/srv/config/drone/config-ocis.json",
             "WEB_ASSET_PATH": "%s/dist" % dir["web"],
             "IDP_IDENTIFIER_REGISTRATION_CONF": "/srv/config/drone/identifier-registration.yml",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       OCIS_URL: ${OCIS_URL:-https://host.docker.internal:9200}
       STORAGE_HOME_DRIVER: ${STORAGE_HOME_DRIVER:-ocis}
       STORAGE_USERS_DRIVER: ${STORAGE_USERS_DRIVER:-ocis}
+      STORAGE_LDAP_CACERT: ${STORAGE_LDAP_CACERT:-/web/ldap.crt}
       PROXY_OIDC_INSECURE: "${PROXY_OIDC_INSECURE:-true}"
       WEB_UI_CONFIG: ${WEB_UI_CONFIG:-/web/config.json}
       WEB_ASSET_PATH: ${WEB_ASSET_PATH:-/web/dist}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
oCIS has a new config for the ldap certificate which defaults to the running users home directory.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It fixes the CI because the CI user doesn't have a home directory or can't write to it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Tests
