### PR TITLE
support sidecar deployment in local dev server

### DIFF
--- a/changelog/unreleased/enhancement-web-as-oc10-sidecar
+++ b/changelog/unreleased/enhancement-web-as-oc10-sidecar
@@ -1,0 +1,8 @@
+Enhancement: Run web as oc10 sidecar
+
+Running web inside docker was supported as application mode, in some cases it is needed to run it as a 'sidecar' deployment.
+This now is supported out of the box without any additional configuration.
+
+Copy config/config.json.sample-oc10 to config/config.json, run dev server build and start oc10 from the docker-compose file and open http://localhost:9100.
+
+https://github.com/owncloud/web/pull/5880

--- a/config/config.json.sample-oc10
+++ b/config/config.json.sample-oc10
@@ -3,7 +3,7 @@
   "theme": "https://localhost:9100/themes/owncloud/theme.json",
   "version": "0.1.0",
   "auth": {
-    "clientId": "",
+    "clientId": "UmCVsEIxdWmssxa6uVRRPC3txYBVN4qqxooJbsPhuuoPmHk9Pt9Oy68N4ZaKXUYy",
     "url": "http://localhost:8080/index.php/apps/oauth2/api/v1/token",
     "authUrl": "http://localhost:8080/index.php/apps/oauth2/authorize"
   },

--- a/dev/docker/oc10.entrypoint.sh
+++ b/dev/docker/oc10.entrypoint.sh
@@ -24,6 +24,13 @@ then
       M8W5mo3wQV3VHWYsaYpWhkr8dwa949i4GljCkedHhl7GWqmHMkxSeJgK2PcS0jt5 \
       sqvPYXK94tMsEEVOYORxg8Ufesi2kC4WpJJSYb0Kj1DSAYl6u2XvJZjc3VcitjDv \
       http://host.docker.internal:8080/index.php/apps/web/oidc-callback.html
+    occ oauth2:add-client \
+      web-sidecar \
+      UmCVsEIxdWmssxa6uVRRPC3txYBVN4qqxooJbsPhuuoPmHk9Pt9Oy68N4ZaKXUYy \
+      HW1fo6lbtgEERBQufBouJ4HID2QaDfngvIdc2vjDUE46qKB4JRG1YDir41LliReC \
+      http://localhost:9100/oidc-callback.html
+    occ config:system:set trusted_domains 0 --value="localhost"
+    occ config:system:set cors.allowed-domains 0 --value="http://localhost:9100"
 fi
 
 if [ -d /var/www/owncloud/apps/web/ ]


### PR DESCRIPTION
Running web inside docker was supported as application mode, in some cases it is needed to run it as a 'sidecar' deployment.
This now is supported out of the box without any additional configuration.

Copy config/config.json.sample-oc10 to config/config.json, run dev server build and start oc10 from the docker-compose file and open http://localhost:9100.