### PR TITLE
[tests-only][full-ci]Fix flaky versions test

### DIFF
--- a/tests/acceptance/helpers/webdavHelper.js
+++ b/tests/acceptance/helpers/webdavHelper.js
@@ -199,7 +199,7 @@ exports.createFile = async function(user, fileName, contents = '', waitMaxIfExis
    */
   uploadTimeStamps[user] = uploadTimeStamps[user] || {}
 
-  const pollCheck = async (retries = 0, waitFor = 100, waitMax = waitMaxIfExisting) => {
+  const pollCheck = async (retries = 0, waitFor = 1000, waitMax = waitMaxIfExisting) => {
     if (!uploadTimeStamps[user][fileName] || waitMax <= waitFor) {
       return
     } else {
@@ -216,6 +216,7 @@ exports.createFile = async function(user, fileName, contents = '', waitMaxIfExis
   await pollCheck()
 
   const davPath = exports.createDavPath(user, fileName)
+  await client.pause(1000)
   const putResponse = await httpHelper.put(davPath, user, contents)
 
   delete uploadTimeStamps[user][fileName]
@@ -225,7 +226,7 @@ exports.createFile = async function(user, fileName, contents = '', waitMaxIfExis
     `Could not create the file "${fileName}" for user "${user}".`
   )
 
-  await client.pause(500)
+  await client.pause(1000)
 
   return statusResponse.text()
 }

--- a/tests/acceptance/stepDefinitions/generalContext.js
+++ b/tests/acceptance/stepDefinitions/generalContext.js
@@ -230,15 +230,12 @@ After(async function(testCase) {
   if (!client.globals.screenshots) {
     return
   }
-  if (testCase.result.status === 'failed' && !testCase.result.retried) {
+  if (testCase.result.status === 'FAILED' && !testCase.result.retried) {
     console.log('saving screenshot of failed test')
-    const filename =
-      testCase.sourceLocation.uri
-        .replace('tests/acceptance/features/', '')
-        .replace('/', '-')
-        .replace('.', '-') +
-      '-' +
-      testCase.sourceLocation.line
+    const filename = testCase.pickle.uri
+      .replace('tests/acceptance/features/', '')
+      .replace('/', '-')
+      .replace('.', '-')
     await client.saveScreenshot('./tests/reports/screenshots/' + filename + '.png')
   }
 })


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
This PR adds a fix for failing versions tests and also updates the hook for setting screenshots for tests.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes: https://github.com/owncloud/web/issues/5853

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`webUIFilesActionMenu/versions.feature:36` was flaky and was passing on retry a lot and sometimes even failing. The behavior could only be reproduced in CI as it passed without any problem locally, even if it's run multiple times. It failed on the `And the versions list should contain 2 entries` step because it couldn't find the second version. Upon inspecting the screenshots the second version wasn't created probably because the file wasn't uploaded as this scenario requires few `put` operations for updating the versions. Upon adding a `pause` before `put` operation and increasing the `waitTime` which will eventually give enough time for the file to be uploaded, the tests pass.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally
-  https://github.com/owncloud/web/pull/5870

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...