### PR TITLE
Prioritize internal action as default

### DIFF
--- a/packages/web-app-files/src/mixins/fileActions.js
+++ b/packages/web-app-files/src/mixins/fileActions.js
@@ -158,6 +158,15 @@ export default {
       })
 
       const allDefaultActions = availableExternalAppActions.concat(actions)
+
+      // if there is an internal action rather than download, prioritize it as default
+      // ToDo: actions identifier
+      const internalAppActionExists = actions[0].icon !== 'file_download'
+      if (internalAppActionExists && availableExternalAppActions)
+        allDefaultActions.unshift(
+          allDefaultActions.splice(availableExternalAppActions.length, 1)[0]
+        )
+
       allDefaultActions[0].handler(resource, allDefaultActions[0].handlerData)
     },
 


### PR DESCRIPTION

## Description
If there is an internal action for the file (for example pdf viewer, text editor, image gallery), it is prioritized to the external apps


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

- test environment: latest web master branch (4.3.0)
- test case 1: external actions exist, internal action other than download exists--> prioritizing
- test case 2: external actions exist, no internal action other than download exists--> no prioritizing
- test case 3: no external actions exist, no internal action other than download exists--> no prioritizing
- test case 4: no external actions exist, internal action other than download exists--> no prioritizing


## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:

- Mechanism to identify if an action is other that download. Currently the only identifier is icon. Eventually "name" property for each action?