### PR TITLE
[deployment-example] fix proxy config of deployment example

### DIFF
--- a/deployments/examples/ocis_web/config/ocis/proxy-config.json
+++ b/deployments/examples/ocis_web/config/ocis/proxy-config.json
@@ -70,6 +70,10 @@
           "backend": "http://localhost:9140"
         },
         {
+          "endpoint": "/app/",
+          "backend": "http://localhost:9140"
+        },
+        {
           "endpoint": "/graph/",
           "backend": "http://localhost:9120"
         },


### PR DESCRIPTION
## Description
Requests to the app provider (`/app/open`, `/app/list`) are not working on https://ocis.ocis-wopi.latest.owncloud.works/ since the custom proxy configuration is outdated. It was updated in this PR, so that the app provider works

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Fix the app provider on this continuously deployed instance, was not fixed in https://github.com/owncloud/web/pull/5899

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- patch was manually applied on the server