### PR TITLE
Allow archive download on public links

### DIFF
--- a/packages/web-app-files/src/components/AppBar/SelectedResources/BatchActions.vue
+++ b/packages/web-app-files/src/components/AppBar/SelectedResources/BatchActions.vue
@@ -129,7 +129,7 @@ export default {
 
     canDownloadSingleFile() {
       if (
-        !checkRoute(['files-personal', 'files-favorites', 'files-public-list'], this.$route.name)
+        !checkRoute(['files-personal', 'files-public-list', 'files-favorites'], this.$route.name)
       ) {
         return false
       }
@@ -146,7 +146,9 @@ export default {
     },
 
     canDownloadAsArchive() {
-      if (!checkRoute(['files-personal', 'files-favorites'], this.$route.name)) {
+      if (
+        !checkRoute(['files-personal', 'files-public-list', 'files-favorites'], this.$route.name)
+      ) {
         return false
       }
 

--- a/packages/web-app-files/src/mixins/actions/downloadFolder.js
+++ b/packages/web-app-files/src/mixins/actions/downloadFolder.js
@@ -1,4 +1,4 @@
-import { isFavoritesRoute, isPersonalRoute } from '../../helpers/route'
+import { checkRoute } from '../../helpers/route'
 import {
   isDownloadAsArchiveAvailable,
   triggerDownloadAsArchive
@@ -15,7 +15,12 @@ export default {
             return this.$gettext('Download folder')
           },
           isEnabled: ({ resource }) => {
-            if (!isPersonalRoute(this.$route) && !isFavoritesRoute(this.$route)) {
+            if (
+              !checkRoute(
+                ['files-personal', 'files-public-list', 'files-favorites'],
+                this.$route.name
+              )
+            ) {
               return false
             }
             if (!resource.isFolder) {


### PR DESCRIPTION
## Description
This PR enables the folder download action on public links. It requires to have capabilities on public links available before it can work. In other words: this PR is as much `WIP` as you can get. But it already solves a first babystep and can be rebased and completed after we have capabilities in public links.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Works towards https://github.com/owncloud/web/issues/5862

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- unclear, until capabilities are available for public links
- [ ] write changelog