### PR TITLE
remove unit~tests~only and docs~only CI flags

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2690,7 +2690,6 @@ def skipIfUnchanged(ctx, type):
         "^docs/.*",
         "^packages/web-app-skeleton/.*",
         "^tests/smoke/.*",
-        "^.drone.star",  #TODO: remove me before merging
         "README.md",
     ]
 


### PR DESCRIPTION
## Description
remove `unit-tests-only` and `docs-only` CI flags, since PRs with a certain changeset will run automatically on a reduced CI