### PR TITLE
Export translations of search app

### DIFF
--- a/changelog/unreleased/bugfix-search-app-translations
+++ b/changelog/unreleased/bugfix-search-app-translations
@@ -1,0 +1,6 @@
+Bugfix: Use search app translations
+
+We fixed that the search app was not using its translations properly.
+
+https://github.com/owncloud/web/issues/5955
+https://github.com/owncloud/web/pull/5956

--- a/packages/web-app-draw-io/src/index.js
+++ b/packages/web-app-draw-io/src/index.js
@@ -1,4 +1,4 @@
-import translationsJson from '../l10n/translations'
+import translations from '../l10n/translations'
 import App from './App.vue'
 
 const routes = [
@@ -49,7 +49,6 @@ const appInfo = {
   ]
 }
 
-const translations = translationsJson
 export default {
   appInfo,
   routes,

--- a/packages/web-app-files/src/components/FilesList/QuickActions.vue
+++ b/packages/web-app-files/src/components/FilesList/QuickActions.vue
@@ -2,13 +2,13 @@
   <div class="uk-flex">
     <oc-button
       v-for="action in filteredActions"
-      :key="action.label"
-      v-oc-tooltip="$gettext(action.label)"
-      :aria-label="$gettext(action.label)"
+      :key="action.label($gettext)"
+      v-oc-tooltip="action.label($gettext)"
+      :aria-label="action.label($gettext)"
       appearance="raw"
       class="oc-mr-xs"
       :class="`files-quick-action-${action.id}`"
-      @click="action.handler({ item, client: $client, store: $store })"
+      @click="action.handler({ item, client: $client, store: $store, $gettext })"
     >
       <oc-icon :name="action.icon" class="uk-flex" />
     </oc-button>

--- a/packages/web-app-files/src/index.js
+++ b/packages/web-app-files/src/index.js
@@ -1,5 +1,5 @@
-import translationsJson from '../l10n/translations.json'
-import quickActionsImport from './quickActions'
+import translations from '../l10n/translations.json'
+import quickActions from './quickActions'
 import store from './store'
 import { FilterSearch, SDKSearch } from './search'
 import { bus } from 'web-pkg/src/instance'
@@ -77,11 +77,6 @@ const navItems = [
     }
   }
 ]
-
-// Prepare imported modules to be exported
-// If we do not define these constants, the export will be undefined
-const translations = translationsJson
-const quickActions = quickActionsImport
 
 export default {
   appInfo,

--- a/packages/web-app-files/src/mixins/actions/createPublicLink.js
+++ b/packages/web-app-files/src/mixins/actions/createPublicLink.js
@@ -17,7 +17,12 @@ export default {
   },
   methods: {
     $_createPublicLink_trigger(resource) {
-      createPublicLink({ item: resource, client: this.$client, store: this.$store })
+      createPublicLink({
+        item: resource,
+        client: this.$client,
+        store: this.$store,
+        $gettext: this.$gettext
+      })
     }
   }
 }

--- a/packages/web-app-files/src/quickActions.js
+++ b/packages/web-app-files/src/quickActions.js
@@ -1,14 +1,9 @@
 import { DateTime } from 'luxon'
 import copyToClipboard from 'copy-to-clipboard'
 
-// just a dummy function to trick gettext tools
-function $gettext(msg) {
-  return msg
-}
-
 export function createPublicLink(ctx) {
   // FIXME: Translate name
-  const params = { name: $gettext('Quick action link'), permissions: 1 }
+  const params = { name: ctx.$gettext('Quick action link'), permissions: 1 }
   const capabilities = ctx.store.state.user.capabilities
   const expirationDate = capabilities.files_sharing.public.expire_date
 
@@ -26,8 +21,8 @@ export function createPublicLink(ctx) {
         ctx.store.dispatch('Files/sidebar/openWithPanel', 'links-item').then(() => {
           copyToClipboard(link.url)
           ctx.store.dispatch('showMessage', {
-            title: $gettext('Public link created'),
-            desc: $gettext(
+            title: ctx.$gettext('Public link created'),
+            desc: ctx.$gettext(
               'Public link has been successfully created and copied into your clipboard.'
             ),
             status: 'success',
@@ -59,14 +54,14 @@ export function canShare(item, store) {
 export default {
   collaborators: {
     id: 'collaborators',
-    label: $gettext('Add people'),
+    label: ($gettext) => $gettext('Add people'),
     icon: 'group-add',
     handler: openNewCollaboratorsPanel,
     displayed: canShare
   },
   publicLink: {
     id: 'public-link',
-    label: $gettext('Create and copy public link'),
+    label: ($gettext) => $gettext('Create and copy public link'),
     icon: 'link-add',
     handler: createPublicLink,
     displayed: canShare

--- a/packages/web-app-files/tests/unit/components/FilesList/QuickActions.spec.js
+++ b/packages/web-app-files/tests/unit/components/FilesList/QuickActions.spec.js
@@ -8,7 +8,7 @@ const collaboratorAction = {
   handler: jest.fn(),
   icon: 'group-add',
   id: 'collaborators',
-  label: 'Add people'
+  label: () => 'Add people'
 }
 
 const publicLinkAction = {
@@ -16,7 +16,7 @@ const publicLinkAction = {
   handler: jest.fn(),
   icon: 'link-add',
   id: 'public-link',
-  label: 'Create and copy public link'
+  label: () => 'Create and copy public link'
 }
 
 const testItem = {

--- a/packages/web-app-files/tests/unit/components/FilesList/QuickActions.spec.js
+++ b/packages/web-app-files/tests/unit/components/FilesList/QuickActions.spec.js
@@ -108,9 +108,8 @@ describe('QuickActions', () => {
       const actionButton = wrapper.find('button')
       await actionButton.trigger('click')
       expect(handlerAction).toHaveBeenCalledTimes(1)
-      expect(handlerAction).toHaveBeenCalledWith({
-        item: testItem,
-        store: undefined // undefined because not provided with wrapper
+      Object.keys(testItem).forEach((key) => {
+        expect(handlerAction.mock.calls[0][0].item[key]).toBe(testItem[key])
       })
     })
   })

--- a/packages/web-app-search/src/index.ts
+++ b/packages/web-app-search/src/index.ts
@@ -6,6 +6,8 @@ import { providerStore } from './service'
 import { bus } from 'web-pkg/src/instance'
 import { SearchProvider } from './types'
 import { Component } from 'vue'
+// @ts-ignore
+import translationsJson from '../l10n/translations.json'
 
 // just a dummy function to trick gettext tools
 const $gettext = (msg) => {
@@ -39,6 +41,7 @@ export default {
       ]
     }
   ],
+  translations: translationsJson,
   mounted({
     portal
   }: {

--- a/packages/web-app-search/src/index.ts
+++ b/packages/web-app-search/src/index.ts
@@ -8,7 +8,7 @@ import { SearchProvider } from './types'
 import { Component } from 'vue'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import translationsJson from '../l10n/translations.json'
+import translations from '../l10n/translations.json'
 
 // just a dummy function to trick gettext tools
 const $gettext = (msg) => {
@@ -42,7 +42,7 @@ export default {
       ]
     }
   ],
-  translations: translationsJson,
+  translations,
   mounted({
     portal
   }: {

--- a/packages/web-app-search/src/index.ts
+++ b/packages/web-app-search/src/index.ts
@@ -6,6 +6,7 @@ import { providerStore } from './service'
 import { bus } from 'web-pkg/src/instance'
 import { SearchProvider } from './types'
 import { Component } from 'vue'
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import translationsJson from '../l10n/translations.json'
 


### PR DESCRIPTION
## Description
Fixes that the search app was not exporting its translations in the app manifest.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/5955

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
