### PR TITLE
Use default app from app provider and early returns in fileActions

### DIFF
--- a/changelog/unreleased/enhancement-app-provider-defaults
+++ b/changelog/unreleased/enhancement-app-provider-defaults
@@ -1,0 +1,6 @@
+Enhancement: Use default info from app provider
+
+The app provider returns information about the default application per mime type. This information is now respected when triggering the default action for a file.
+
+https://github.com/owncloud/web/issues/5962
+https://github.com/owncloud/web/pull/5970

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -110,8 +110,12 @@ export default {
 
     // fetch iframe params for app and file
     const configUrl = this.configuration.server
-    const appOpenUrl = this.capabilities.files.app_providers[0].open_url.replace('/app', 'app')
-    const url = configUrl + appOpenUrl + '?file_id=' + this.fileId + '&app_name=' + this.appName
+    const appOpenUrl = this.capabilities.files.app_providers[0].open_url.replace(/^\/+/, '')
+    const url =
+      configUrl +
+      appOpenUrl +
+      `?file_id=${this.fileId}` +
+      (this.appName ? `&app_name=${this.appName}` : '')
 
     const response = await fetch(url, {
       method: 'POST',

--- a/packages/web-app-external/src/index.js
+++ b/packages/web-app-external/src/index.js
@@ -15,7 +15,7 @@ const appInfo = {
 const routes = [
   {
     name: 'apps',
-    path: '/:app/:file_id',
+    path: '/:file_id/:app?',
     components: {
       app: App
     },


### PR DESCRIPTION
## Description
Switch to early returns when evaluating the default action for a file. Also use the app provider without `app` param so that the app provider can decide on its own which app to use.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/5962

## Motivation and Context
Improve default action handling for files.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] changelog item
- [x] take app provider default apps into account when https://github.com/cs3org/reva/pull/2230 is in oCIS
