### PR TITLE
Remove UiKit from codebase

### DIFF
--- a/packages/web-app-draw-io/src/App.vue
+++ b/packages/web-app-draw-io/src/App.vue
@@ -3,7 +3,7 @@
     <oc-spinner
       v-if="loading"
       :aria-label="$gettext('Loading media')"
-      class="uk-position-center"
+      class="oc-position-center"
       size="xlarge"
     />
     <iframe

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -1,8 +1,8 @@
 <template>
   <main
-    class="uk-height-viewport"
+    class="oc-height-viewport"
     :class="{
-      'uk-flex uk-flex-center uk-flex-middle': loading || loadingError
+      'oc-flex oc-flex-center oc-flex-middle': loading || loadingError
     }"
   >
     <h1 class="oc-invisible-sr" v-text="pageTitle" />
@@ -11,7 +11,7 @@
     <iframe
       v-if="appUrl && method === 'GET'"
       :src="appUrl"
-      class="uk-width-1-1 uk-height-viewport"
+      class="oc-width-1-1 oc-height-viewport"
       :title="iFrameTitle"
     />
     <div v-if="appUrl && method === 'POST' && formParameters">
@@ -21,7 +21,7 @@
           <input :name="key" :value="item" type="hidden" />
         </div>
       </form>
-      <iframe name="app-iframe" class="uk-width-1-1 uk-height-viewport" :title="iFrameTitle" />
+      <iframe name="app-iframe" class="oc-width-1-1 oc-height-viewport" :title="iFrameTitle" />
     </div>
   </main>
 </template>

--- a/packages/web-app-external/src/components/ErrorScreen.vue
+++ b/packages/web-app-external/src/components/ErrorScreen.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="uk-text-center">
+  <div class="oc-text-center">
     <oc-icon size="xxlarge" name="warning" />
     <p v-translate>Error when loading the application</p>
   </div>

--- a/packages/web-app-external/src/components/LoadingScreen.vue
+++ b/packages/web-app-external/src/components/LoadingScreen.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="uk-text-center">
+  <div class="oc-text-center">
     <oc-spinner size="xlarge" />
     <p v-translate class="oc-invisible">Loading app</p>
   </div>

--- a/packages/web-app-external/tests/unit/__snapshots__/app.spec.js.snap
+++ b/packages/web-app-external/tests/unit/__snapshots__/app.spec.js.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`The app provider extension should be able to load an iFrame via get 1`] = `
-<main class="uk-height-viewport">
+<main class="oc-height-viewport">
   <h1 class="oc-invisible-sr">"exampleApp" app page</h1>
-  <!----> <iframe src="https://example.test/d12ab86/loe009157-MzBw" title="&quot;exampleApp&quot; app content area" class="uk-width-1-1 uk-height-viewport"></iframe>
+  <!----> <iframe src="https://example.test/d12ab86/loe009157-MzBw" title="&quot;exampleApp&quot; app content area" class="oc-width-1-1 oc-height-viewport"></iframe>
   <!---->
 </main>
 `;
 
 exports[`The app provider extension should be able to load an iFrame via post 1`] = `
-<main class="uk-height-viewport">
+<main class="oc-height-viewport">
   <h1 class="oc-invisible-sr">"exampleApp" app page</h1>
   <!---->
   <!---->
@@ -17,13 +17,13 @@ exports[`The app provider extension should be able to load an iFrame via post 1`
     <form action="https://example.test/d12ab86/loe009157-MzBw" target="app-iframe" method="post"><input type="submit" class="oc-hidden" value="[object Object]">
       <div><input name="access_token" type="hidden" value="asdfsadfsadf"></div>
       <div><input name="access_token_ttl" type="hidden" value="123456"></div>
-    </form> <iframe name="app-iframe" title="&quot;exampleApp&quot; app content area" class="uk-width-1-1 uk-height-viewport"></iframe>
+    </form> <iframe name="app-iframe" title="&quot;exampleApp&quot; app content area" class="oc-width-1-1 oc-height-viewport"></iframe>
   </div>
 </main>
 `;
 
 exports[`The app provider extension should fail for unauthenticated users 1`] = `
-<main class="uk-height-viewport uk-flex uk-flex-center uk-flex-middle">
+<main class="oc-height-viewport oc-flex oc-flex-center oc-flex-middle">
   <h1 class="oc-invisible-sr">"exampleApp" app page</h1>
   <errorscreen-stub></errorscreen-stub>
   <!---->
@@ -32,7 +32,7 @@ exports[`The app provider extension should fail for unauthenticated users 1`] = 
 `;
 
 exports[`The app provider extension should show a loading spinner while loading 1`] = `
-<main class="uk-height-viewport uk-flex uk-flex-center uk-flex-middle">
+<main class="oc-height-viewport oc-flex oc-flex-center oc-flex-middle">
   <h1 class="oc-invisible-sr">"exampleApp" app page</h1>
   <loadingscreen-stub></loadingscreen-stub>
   <!---->
@@ -41,7 +41,7 @@ exports[`The app provider extension should show a loading spinner while loading 
 `;
 
 exports[`The app provider extension should show a meaningful message if an error occurs during loading 1`] = `
-<main class="uk-height-viewport uk-flex uk-flex-center uk-flex-middle">
+<main class="oc-height-viewport oc-flex oc-flex-center oc-flex-middle">
   <h1 class="oc-invisible-sr">"exampleApp" app page</h1>
   <errorscreen-stub></errorscreen-stub>
   <!---->

--- a/packages/web-app-external/tests/unit/components/__snapshots__/ErrorScreen.spec.ts.snap
+++ b/packages/web-app-external/tests/unit/components/__snapshots__/ErrorScreen.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`The external app error screen component displays an icon and a paragraph 1`] = `
-<div class="uk-text-center">
+<div class="oc-text-center">
   <ocicon-stub size="xxlarge" name="warning"></ocicon-stub>
   <p data-msgid="Error when loading the application" data-current-language="en_US">Error when loading the application</p>
 </div>

--- a/packages/web-app-external/tests/unit/components/__snapshots__/LoadingScreen.spec.ts.snap
+++ b/packages/web-app-external/tests/unit/components/__snapshots__/LoadingScreen.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`The external app loading screen component displays a spinner and a paragraph 1`] = `
-<div class="uk-text-center">
+<div class="oc-text-center">
   <ocspinner-stub size="xlarge"></ocspinner-stub>
   <p class="oc-invisible" data-msgid="Loading app" data-current-language="en_US">Loading app</p>
 </div>

--- a/packages/web-app-files/src/App.vue
+++ b/packages/web-app-files/src/App.vue
@@ -1,9 +1,9 @@
 <template>
-  <main id="files" class="uk-flex uk-height-1-1">
+  <main id="files" class="oc-flex oc-height-1-1">
     <div
       ref="filesListWrapper"
       tabindex="-1"
-      class="files-list-wrapper uk-width-expand"
+      class="files-list-wrapper oc-width-expand"
       @dragover="$_ocApp_dragOver"
     >
       <app-bar id="files-app-bar" />
@@ -15,7 +15,7 @@
       id="files-sidebar"
       ref="filesSidebar"
       tabindex="-1"
-      class="uk-width-1-1 uk-width-1-2@m uk-width-1-3@xl"
+      class="oc-width-1-1 oc-width-1-2@m oc-width-1-3@xl"
       @beforeDestroy="focusSideBar"
       @mounted="focusSideBar"
       @fileChanged="focusSideBar"

--- a/packages/web-app-files/src/components/AppBar/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar/AppBar.vue
@@ -22,7 +22,7 @@
       <div class="files-app-bar-actions">
         <div
           v-if="showActions || selectedFiles.length > 0 || isTrashbinRoute"
-          class="uk-flex-1 uk-flex uk-flex-start"
+          class="oc-flex-1 oc-flex"
         >
           <template v-if="showActions && areDefaultActionsVisible">
             <oc-button
@@ -44,7 +44,7 @@
               close-on-click
               :options="{ delayHide: 0 }"
             >
-              <ul class="uk-list">
+              <ul class="oc-list">
                 <li>
                   <file-upload
                     :path="currentPath"
@@ -70,7 +70,7 @@
                     <oc-button
                       id="new-folder-btn"
                       appearance="raw"
-                      class="uk-width-1-1"
+                      class="oc-width-1-1"
                       justify-content="left"
                       @click="showCreateResourceModal"
                     >
@@ -84,7 +84,7 @@
                     <oc-button
                       appearance="raw"
                       justify-content="left"
-                      :class="['new-file-btn-' + newFileHandler.ext, 'uk-width-1-1']"
+                      :class="['new-file-btn-' + newFileHandler.ext, 'oc-width-1-1']"
                       @click="
                         showCreateResourceModal(false, newFileHandler.ext, newFileHandler.action)
                       "
@@ -97,7 +97,7 @@
               </ul>
             </oc-drop>
           </template>
-          <size-info v-if="selectedFiles.length > 0" class="oc-mr-s uk-visible@l" />
+          <size-info v-if="selectedFiles.length > 0" class="oc-mr-s oc-visible@l" />
           <batch-actions />
         </div>
         <view-options />

--- a/packages/web-app-files/src/components/AppBar/SelectedResources/BatchActions.vue
+++ b/packages/web-app-files/src/components/AppBar/SelectedResources/BatchActions.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="uk-flex uk-flex-middle">
+  <div class="oc-flex oc-flex-middle">
     <template v-if="isTrashbinRoute">
       <oc-button
         v-if="selectedFiles.length > 0"

--- a/packages/web-app-files/src/components/AppBar/SelectedResources/SizeInfo.vue
+++ b/packages/web-app-files/src/components/AppBar/SelectedResources/SizeInfo.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="uk-flex uk-flex-middle">
+  <div class="oc-flex oc-flex-middle">
     <translate
       v-if="selectedResourcesSize !== '?'"
       key="multiple-select-info-with-size"

--- a/packages/web-app-files/src/components/AppBar/Upload/FileUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/Upload/FileUpload.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <oc-button class="uk-width-1-1" justify-content="left" appearance="raw" @click="triggerUpload">
+    <oc-button class="oc-width-1-1" justify-content="left" appearance="raw" @click="triggerUpload">
       <oc-icon name="file_upload" />
       <span id="files-file-upload-button" v-translate>Upload File</span>
     </oc-button>

--- a/packages/web-app-files/src/components/AppBar/Upload/FolderUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/Upload/FolderUpload.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <oc-button class="uk-width-1-1" justify-content="left" appearance="raw" @click="triggerUpload">
+    <oc-button class="oc-width-1-1" justify-content="left" appearance="raw" @click="triggerUpload">
       <oc-icon name="cloud_upload" />
       <span id="files-folder-upload-button" v-translate>Upload Folder</span>
     </oc-button>

--- a/packages/web-app-files/src/components/AppBar/ViewOptions.vue
+++ b/packages/web-app-files/src/components/AppBar/ViewOptions.vue
@@ -30,7 +30,7 @@
       drop-id="files-view-options-drop"
       toggle="#files-view-options-btn"
       mode="click"
-      class="uk-width-auto"
+      class="oc-width-auto"
     >
       <oc-list>
         <li class="files-view-options-list-item">

--- a/packages/web-app-files/src/components/FilesList/ContextActions.vue
+++ b/packages/web-app-files/src/components/FilesList/ContextActions.vue
@@ -4,7 +4,7 @@
       <ul
         :id="`oc-files-context-actions-${section.name}`"
         :key="`section-${section.name}-list`"
-        class="uk-list oc-mt-s oc-files-context-actions"
+        class="oc-list oc-mt-s oc-files-context-actions"
       >
         <li
           v-for="(action, j) in section.items"

--- a/packages/web-app-files/src/components/FilesList/ListInfo.vue
+++ b/packages/web-app-files/src/components/FilesList/ListInfo.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="uk-text-nowrap uk-text-center">
+  <div class="oc-text-nowrap oc-text-center">
     <p
       data-testid="files-list-footer-info"
       :data-test-items="items"

--- a/packages/web-app-files/src/components/FilesList/ListLoader.vue
+++ b/packages/web-app-files/src/components/FilesList/ListLoader.vue
@@ -1,5 +1,5 @@
 <template functional>
-  <div class="uk-flex uk-flex-middle uk-flex-center uk-height-1-1">
+  <div class="oc-flex oc-flex-middle oc-flex-center oc-height-1-1">
     <oc-spinner id="files-list-progress" size="large" :aria-hidden="true" aria-label="" />
   </div>
 </template>

--- a/packages/web-app-files/src/components/FilesList/NoContentMessage.vue
+++ b/packages/web-app-files/src/components/FilesList/NoContentMessage.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="uk-height-1-1 uk-flex uk-flex-column uk-flex-center uk-flex-middle uk-text-center">
+  <div class="oc-height-1-1 oc-flex oc-flex-column oc-flex-center oc-flex-middle oc-text-center">
     <oc-icon :name="icon" type="div" size="xxlarge" />
-    <div class="oc-text-muted uk-text-large">
+    <div class="oc-text-muted oc-text-large">
       <slot name="message" />
     </div>
     <div class="oc-text-muted">

--- a/packages/web-app-files/src/components/FilesList/NotFoundMessage.vue
+++ b/packages/web-app-files/src/components/FilesList/NotFoundMessage.vue
@@ -1,10 +1,10 @@
 <template>
   <div
     id="files-list-not-found-message"
-    class="uk-text-center uk-flex-middle uk-flex uk-flex-center uk-flex-column"
+    class="oc-text-center oc-flex-middle oc-flex oc-flex-center oc-flex-column"
   >
     <oc-icon name="cloud" type="div" size="xxlarge" />
-    <div class="oc-text-muted uk-text-large">
+    <div class="oc-text-muted oc-text-large">
       <translate>Resource not found</translate>
     </div>
     <div class="oc-text-muted">

--- a/packages/web-app-files/src/components/FilesList/Pagination.vue
+++ b/packages/web-app-files/src/components/FilesList/Pagination.vue
@@ -5,7 +5,7 @@
     :current-page="currentPage"
     :max-displayed="3"
     :current-route="$route"
-    class="files-pagination uk-flex uk-flex-center oc-my-s"
+    class="files-pagination oc-flex oc-flex-center oc-my-s"
   />
 </template>
 

--- a/packages/web-app-files/src/components/FilesList/QuickActions.vue
+++ b/packages/web-app-files/src/components/FilesList/QuickActions.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="uk-flex">
+  <div class="oc-flex">
     <oc-button
       v-for="action in filteredActions"
       :key="action.label"
@@ -10,7 +10,7 @@
       :class="`files-quick-action-${action.id}`"
       @click="action.handler({ item, client: $client, store: $store })"
     >
-      <oc-icon :name="action.icon" class="uk-flex" />
+      <oc-icon :name="action.icon" class="oc-flex" />
     </oc-button>
   </div>
 </template>

--- a/packages/web-app-files/src/components/Search/List.vue
+++ b/packages/web-app-files/src/components/Search/List.vue
@@ -25,7 +25,7 @@
         <pagination />
         <list-info
           v-if="activeFilesCurrentPage.length > 0"
-          class="uk-width-1-1 oc-my-s"
+          class="oc-width-1-1 oc-my-s"
           :files="totalFilesCount.files"
           :folders="totalFilesCount.folders"
           :size="totalFilesSize"

--- a/packages/web-app-files/src/components/SideBar/Actions/FileActions.vue
+++ b/packages/web-app-files/src/components/SideBar/Actions/FileActions.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul id="oc-files-actions-sidebar" class="uk-list oc-mt-s">
+  <ul id="oc-files-actions-sidebar" class="oc-list oc-mt-s">
     <li v-for="(action, index) in actions" :key="`action-${index}`" class="oc-py-xs">
       <component
         :is="action.componentType"

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -7,7 +7,7 @@
         :style="{
           'background-image': $asyncComputed.preview.updating ? 'none' : `url(${preview})`
         }"
-        class="details-preview uk-flex uk-flex-middle uk-flex-center oc-mb"
+        class="details-preview oc-flex oc-flex-middle oc-flex-center oc-mb"
         data-testid="preview"
       >
         <oc-spinner v-if="$asyncComputed.preview.updating" />
@@ -16,7 +16,7 @@
         v-if="showShares"
         key="file-shares"
         data-testid="sharingInfo"
-        class="uk-flex uk-flex-middle oc-my-m"
+        class="oc-flex oc-flex-middle oc-my-m"
       >
         <oc-button
           v-if="hasPeopleShares"

--- a/packages/web-app-files/src/components/SideBar/Links/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/FileLinks.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="oc-files-file-link" class="uk-position-relative">
+  <div id="oc-files-file-link" class="oc-position-relative">
     <div
       v-show="currentView === VIEW_SHOW"
       :key="VIEW_SHOW"
@@ -32,7 +32,7 @@
           v-text="noResharePermsMessage"
         />
         <transition-group
-          class="uk-list uk-list-divider uk-overflow-hidden oc-m-rm"
+          class="oc-list oc-list-divider oc-overflow-hidden oc-m-rm"
           :enter-active-class="$_transitionGroupEnter"
           :leave-active-class="$_transitionGroupLeave"
           name="custom-classes-transition"

--- a/packages/web-app-files/src/components/SideBar/Links/PrivateLinkItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/PrivateLinkItem.vue
@@ -2,8 +2,8 @@
   <div class="oc-files-private-link-item" data-testid="files-sidebar-private-link">
     <h4 v-translate class="oc-text-bold oc-m-rm oc-text-initial">Private Link</h4>
     <p v-translate class="oc-text-muted oc-my-rm">Only invited people can use this link.</p>
-    <div class="uk-width-1-1 uk-flex uk-flex-middle">
-      <a :href="link" target="_blank" class="uk-text-truncate" v-text="link" />
+    <div class="oc-width-1-1 oc-flex oc-flex-middle">
+      <a :href="link" target="_blank" class="oc-text-truncate" v-text="link" />
       <copy-to-clipboard-button
         class="oc-files-private-link-copy-url oc-ml-xs"
         :value="link"

--- a/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkActions.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkActions.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="uk-flex uk-flex-nowrap uk-flex-middle">
+  <div class="oc-flex oc-flex-nowrap oc-flex-middle">
     <oc-spinner v-if="removalInProgress" :aria-label="$gettext('Removing public link')" />
     <template v-else>
       <oc-button

--- a/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkEdit.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkEdit.vue
@@ -48,7 +48,7 @@
             <oc-button
               id="files-links-expiration-btn"
               data-testid="recipient-datepicker-btn"
-              class="uk-width-1-1 expiration-dialog-btn"
+              class="oc-width-1-1 expiration-dialog-btn"
               justify-content="space-between"
               gap-size="xsmall"
               @click="togglePopover"
@@ -95,17 +95,17 @@
       <!-- @TODO: Enable Mail API to use the following
                   ++++++++++++++++++++++++++++++++++++
         <template v-if="$_sendMailEnabled">
-            <h4 class="oc-mt-top uk-heading-divider">
+            <h4 class="oc-mt-top oc-heading-divider">
                 Send mail notification
             </h4>
             <div class="oc-mb">
-                <input type="text" class="uk-input" :placeholder="placeholder.mailTo" />
+                <input type="text" class="oc-input" :placeholder="placeholder.mailTo" />
             </div>
             <div class="oc-mb">
-                <textarea class="uk-textarea" :placeholder="placeholder.mailBody rows="4"></textarea>
+                <textarea class="oc-textarea" :placeholder="placeholder.mailBody rows="4"></textarea>
             </div>
             <div class="oc-mb">
-                <label><input type="checkbox" class="uk-checkbox oc-mr-s" v-translate>Send a copy to myself</label>
+                <label><input type="checkbox" class="oc-checkbox oc-mr-s" v-translate>Send a copy to myself</label>
             </div>
         </template>
         -->

--- a/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkInfo.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkInfo.vue
@@ -1,15 +1,15 @@
 <template>
-  <div class="uk-width-expand">
-    <div class="oc-mb-s uk-width-1-1">
+  <div class="oc-width-expand">
+    <div class="oc-mb-s oc-width-1-1">
       <h5
-        class="oc-text-bold uk-text-truncate oc-files-file-link-name oc-my-rm oc-text-initial"
+        class="oc-text-bold oc-text-truncate oc-files-file-link-name oc-my-rm oc-text-initial"
         v-text="linkName"
       />
-      <div class="uk-flex uk-flex-middle uk-width-1-1">
+      <div class="oc-flex oc-flex-middle oc-width-1-1">
         <a
           :href="link.url"
           target="_blank"
-          class="oc-files-file-link-url uk-text-truncate"
+          class="oc-files-file-link-url oc-text-truncate"
           v-text="link.url"
         />
         <copy-to-clipboard-button
@@ -50,7 +50,7 @@
           :to="viaRouterParams"
         >
           <oc-icon name="exit_to_app" />
-          <span class="uk-text-truncate files-file-links-link-via-label" v-text="viaLabel" />
+          <span class="oc-text-truncate files-file-links-link-via-label" v-text="viaLabel" />
         </oc-tag>
       </div>
     </oc-grid>

--- a/packages/web-app-files/src/components/SideBar/Links/PublicLinks/ListItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/PublicLinks/ListItem.vue
@@ -3,7 +3,7 @@
     gutter="small"
     class="
       files-file-links-link files-file-links-link-table-row-info
-      uk-flex uk-flex-top uk-flex-between
+      oc-flex oc-flex-top oc-flex-between
     "
   >
     <link-info :link="link" />

--- a/packages/web-app-files/src/components/SideBar/NoSelection.vue
+++ b/packages/web-app-files/src/components/SideBar/NoSelection.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="oc-no-selection" class="uk-text-center oc-mt-xl">
+  <div id="oc-no-selection" class="oc-text-center oc-mt-xl">
     <oc-icon size="xxlarge" name="select_items" />
     <p data-testid="selectedFilesText" v-text="selectedFilesString" />
   </div>

--- a/packages/web-app-files/src/components/SideBar/Shared/RoleItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shared/RoleItem.vue
@@ -1,6 +1,6 @@
 <template>
   <span :id="`files-role-${role.name}`" class="roles-select-role-item">
-    <span class="oc-text-bold uk-display-block uk-width-1-1" v-text="role.label" />
+    <span class="oc-text-bold oc-display-block oc-width-1-1" v-text="role.label" />
     <span class="oc-m-rm" v-text="role.description" />
   </span>
 </template>

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/AutocompleteItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/AutocompleteItem.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     :data-testid="`recipient-autocomplete-item-${item.label}`"
-    class="uk-flex uk-flex-middle oc-py-xs"
+    class="oc-flex oc-flex-middle oc-py-xs"
     :class="collaboratorClass"
   >
     <avatar-image

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/CollaboratorsEditOptions.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/CollaboratorsEditOptions.vue
@@ -45,7 +45,7 @@
     <oc-drop
       ref="customPermissionsDrop"
       data-testid="files-recipient-custom-permissions-drop"
-      class="files-recipient-custom-permissions-drop uk-width-auto"
+      class="files-recipient-custom-permissions-drop oc-width-auto"
       mode="manual"
       target="#files-collaborators-role-button"
     >

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/EditCollaborator.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/EditCollaborator.vue
@@ -21,12 +21,12 @@
     </transition>
     <p
       v-if="user.id !== collaborator.owner.name"
-      class="oc-text-muted uk-flex uk-flex-middle oc-mb-s"
+      class="oc-text-muted oc-flex oc-flex-middle oc-mb-s"
     >
       <oc-icon name="repeat" class="oc-mr-s" /> {{ collaborator.owner.displayName }}
     </p>
     <collaborator
-      class="uk-width-expand oc-mb"
+      class="oc-width-expand oc-mb"
       :collaborator="collaborator"
       :first-column="false"
     />

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ShowCollaborator.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ShowCollaborator.vue
@@ -36,7 +36,7 @@
         </div>
       </oc-td>
       <oc-td class="oc-py-rm oc-pr-s">
-        <div class="uk-flex uk-flex-column uk-flex-center" :class="collaboratorListItemClass">
+        <div class="oc-flex oc-flex-column oc-flex-center" :class="collaboratorListItemClass">
           <div class="oc-text-initial oc-mb-xs">
             <p
               class="files-collaborators-collaborator-name oc-text-bold oc-mb-rm"
@@ -91,7 +91,7 @@
               >
                 <h4 :id="`resharer-info-${shareId}`" v-translate>Shared by</h4>
                 <ul
-                  class="uk-list uk-list-divider uk-overflow-hidden oc-m-rm"
+                  class="oc-list oc-list-divider oc-overflow-hidden oc-m-rm"
                   :aria-labelledby="`resharer-info-${shareId}`"
                 >
                   <li
@@ -99,7 +99,7 @@
                     :key="resharer.name"
                     class="oc-py-rm"
                   >
-                    <div class="uk-flex uk-flex-middle uk-flex-left">
+                    <div class="oc-flex oc-flex-middle oc-flex-left">
                       <avatar-image
                         class="oc-mr-s"
                         :width="48"
@@ -153,7 +153,7 @@
               >
                 <oc-icon name="exit_to_app" />
                 <span
-                  class="uk-text-truncate files-collaborators-collaborator-via-label"
+                  class="oc-text-truncate files-collaborators-collaborator-via-label"
                   v-text="viaLabel"
                 />
               </oc-tag>
@@ -162,7 +162,7 @@
         </div>
       </oc-td>
       <oc-td width="shrink" align-v="top" class="oc-py-rm oc-pr-s">
-        <div class="uk-flex uk-flex-nowrap uk-flex-middle">
+        <div class="oc-flex oc-flex-nowrap oc-flex-middle">
           <oc-button
             v-if="$_editButtonVisible"
             v-oc-tooltip="editShareHint"
@@ -189,7 +189,7 @@
               v-else-if="$_loadingSpinnerVisible"
               :aria-label="$gettext('Removing person')"
             />
-            <oc-icon v-else name="lock" class="uk-invisible" />
+            <oc-icon v-else name="lock" class="oc-invisible" />
           </div>
         </div>
       </oc-td>

--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="oc-files-sharing-sidebar" class="uk-position-relative">
+  <div id="oc-files-sharing-sidebar" class="oc-position-relative">
     <div
       v-show="currentView === VIEW_SHOW"
       :key="VIEW_SHOW"
@@ -66,7 +66,7 @@
           <hr v-if="collaborators.length > 0" class="oc-mt-s oc-mb-s" />
           <transition-group
             id="files-collaborators-list"
-            class="uk-list uk-list-divider uk-overflow-hidden oc-m-rm"
+            class="oc-list oc-list-divider oc-overflow-hidden oc-m-rm"
             :enter-active-class="$_transitionGroupEnter"
             :leave-active-class="$_transitionGroupLeave"
             name="custom-classes-transition"

--- a/packages/web-app-files/src/components/SideBar/SideBar.vue
+++ b/packages/web-app-files/src/components/SideBar/SideBar.vue
@@ -3,7 +3,7 @@
     data-testid="files-sidebar"
     :class="{
       'has-active-sub-panel': !!activeAvailablePanelName,
-      'uk-flex uk-flex-center uk-flex-middle': loading
+      'oc-flex oc-flex-center oc-flex-middle': loading
     }"
   >
     <oc-spinner v-if="loading" />

--- a/packages/web-app-files/src/components/SideBar/Versions/FileVersions.vue
+++ b/packages/web-app-files/src/components/SideBar/Versions/FileVersions.vue
@@ -9,43 +9,39 @@
           </oc-td>
           <oc-td
             width="shrink"
-            class="oc-text-muted uk-text-nowrap"
+            class="oc-text-muted oc-text-nowrap"
             data-testid="file-versions-file-last-modified-date"
           >
             {{ formDateFromNow(item.fileInfo[DavProperty.LastModifiedDate], 'Http') }}
           </oc-td>
           <oc-td
             width="expand"
-            class="oc-text-muted uk-text-nowrap"
+            class="oc-text-muted oc-text-nowrap"
             data-testid="file-versions-file-size"
           >
             {{ getResourceSize(item.fileInfo[DavProperty.ContentLength]) }}
           </oc-td>
           <oc-td width="shrink">
-            <div class="uk-button-group">
-              <oc-button
-                v-oc-tooltip="$gettext('Restore older version')"
-                data-testid="file-versions-revert-button"
-                appearance="raw"
-                :aria-label="$gettext('Restore older version')"
-                @click="revertVersion(item)"
-              >
-                <oc-icon name="restore" />
-              </oc-button>
-            </div>
+            <oc-button
+              v-oc-tooltip="$gettext('Restore older version')"
+              data-testid="file-versions-revert-button"
+              appearance="raw"
+              :aria-label="$gettext('Restore older version')"
+              @click="revertVersion(item)"
+            >
+              <oc-icon name="restore" />
+            </oc-button>
           </oc-td>
           <oc-td width="shrink">
-            <div class="uk-button-group">
-              <oc-button
-                v-oc-tooltip="$gettext('Download older version')"
-                data-testid="file-versions-download-button"
-                appearance="raw"
-                :aria-label="$gettext('Download older version')"
-                @click="downloadVersion(item)"
-              >
-                <oc-icon name="cloud_download" />
-              </oc-button>
-            </div>
+            <oc-button
+              v-oc-tooltip="$gettext('Download older version')"
+              data-testid="file-versions-download-button"
+              appearance="raw"
+              :aria-label="$gettext('Download older version')"
+              @click="downloadVersion(item)"
+            >
+              <oc-icon name="cloud_download" />
+            </oc-button>
           </oc-td>
         </oc-tr>
       </oc-tbody>

--- a/packages/web-app-files/src/components/Upload/DetailsWidget.vue
+++ b/packages/web-app-files/src/components/Upload/DetailsWidget.vue
@@ -1,25 +1,25 @@
 <template>
-  <ul class="uk-list uk-list-divider oc-ml-rm oc-mr-rm">
+  <ul class="oc-list oc-list-divider oc-ml-rm oc-mr-rm">
     <li v-for="item in items" :key="item.id">
-      <div class="uk-flex uk-flex-middle">
+      <div class="oc-flex oc-flex-middle">
         <oc-icon name="file_copy" class="oc-mr-s" />
-        <div class="uk-width-expand">
-          <div class="uk-flex">
-            <div class="oc-text-bold uk-width-expand uk-text-truncate upload-details-item-name">
+        <div class="oc-width-expand">
+          <div class="oc-flex">
+            <div class="oc-text-bold oc-width-expand oc-text-truncate upload-details-item-name">
               {{ item.name }}
             </div>
-            <div class="uk-width-auto uk-text-nowrap upload-details-item-size">
+            <div class="oc-width-auto oc-text-nowrap upload-details-item-size">
               {{ getResourceSize(item.size) }}
             </div>
           </div>
-          <div class="oc-m-rm uk-position-relative uk-width-expand">
+          <div class="oc-m-rm oc-position-relative oc-width-expand">
             <oc-progress
               :aria-hidden="true"
               :max="100"
               :value="item.progress | toInt"
-              class="uk-width-expand oc-m-rm"
+              class="oc-width-expand oc-m-rm"
             />
-            <span :aria-hidden="true" class="uk-position-center oc-progress-text">
+            <span :aria-hidden="true" class="oc-position-center oc-progress-text">
               {{ item.progress | roundNumber }} %
             </span>
           </div>

--- a/packages/web-app-files/src/components/Upload/ProgressBar.vue
+++ b/packages/web-app-files/src/components/Upload/ProgressBar.vue
@@ -1,14 +1,14 @@
 <template>
-  <div class="files-upload-progress uk-clearfix oc-py-rm">
-    <div class="oc-m-rm uk-position-relative uk-width-expand">
+  <div class="files-upload-progress oc-py-rm">
+    <div class="oc-m-rm oc-position-relative oc-width-expand">
       <oc-progress
         ref="progressbar"
         :aria-hidden="true"
         :max="100"
         :value="totalUploadProgress"
-        class="uk-width-expand oc-m-rm"
+        class="oc-width-expand oc-m-rm"
       />
-      <span :aria-hidden="true" class="uk-position-center oc-progress-text">
+      <span :aria-hidden="true" class="oc-position-center oc-progress-text">
         {{ totalUploadProgress | roundNumber }} %
       </span>
       <oc-hidden-announcer :announcement="announcement" level="assertive" />
@@ -19,8 +19,8 @@
       :aria-label="$gettext('Click row to toggle upload progress details')"
       @click.native="$_toggleExpanded"
     >
-      <oc-icon class="uk-width-auto" :name="expanded ? 'expand_less' : 'expand_more'" />
-      <div class="uk-width-expand uk-text-truncate">
+      <oc-icon class="oc-width-auto" :name="expanded ? 'expand_less' : 'expand_more'" />
+      <div class="oc-width-expand oc-text-truncate">
         <translate
           v-if="count === 1"
           id="files-upload-progress-single"
@@ -41,7 +41,7 @@
           Uploading %{ count } item
         </translate>
       </div>
-      <div class="uk-width-auto">
+      <div class="oc-width-auto">
         <translate
           v-if="expanded"
           id="files-upload-progress-collapse-details"
@@ -63,7 +63,7 @@
     <details-widget
       v-if="expanded"
       :items="inProgress"
-      class="uk-width-expand oc-upload-details-scrollable"
+      class="oc-width-expand oc-upload-details-scrollable"
     />
   </div>
 </template>
@@ -157,7 +157,7 @@ export default {
   font-size: 0.75em;
   color: var(--oc-color-text-inverse);
 }
-.files-upload-progress .uk-progress {
+.files-upload-progress .oc-progress {
   box-shadow: 0 0 2px var(--oc-color-border);
 }
 </style>

--- a/packages/web-app-files/src/views/Favorites.vue
+++ b/packages/web-app-files/src/views/Favorites.vue
@@ -31,7 +31,7 @@
           <pagination />
           <list-info
             v-if="activeFilesCurrentPage.length > 0"
-            class="uk-width-1-1 oc-my-s"
+            class="oc-width-1-1 oc-my-s"
             :files="totalFilesCount.files"
             :folders="totalFilesCount.folders"
             :size="totalFilesSize"

--- a/packages/web-app-files/src/views/FilesDrop.vue
+++ b/packages/web-app-files/src/views/FilesDrop.vue
@@ -1,15 +1,15 @@
 <template>
-  <div id="files-drop-container" class="uk-height-1-1 uk-flex uk-flex-column uk-flex-between">
+  <div id="files-drop-container" class="oc-height-1-1 oc-flex oc-flex-column oc-flex-between">
     <h1 class="oc-invisible-sr">{{ pageTitle }}</h1>
-    <div class="oc-p uk-height-1-1">
-      <div v-if="loading" key="loading-drop" class="uk-flex uk-flex-column uk-flex-middle">
+    <div class="oc-p oc-height-1-1">
+      <div v-if="loading" key="loading-drop" class="oc-flex oc-flex-column oc-flex-middle">
         <h2 class="oc-login-card-title">
           <translate>Loading public link…</translate>
         </h2>
         <oc-spinner :aria-hidden="true" />
       </div>
-      <div v-else key="loaded-drop" class="uk-flex uk-flex-column uk-flex-middle uk-height-1-1">
-        <div class="uk-text-center uk-width-1-1 uk-width-xxlarge@m">
+      <div v-else key="loaded-drop" class="oc-flex oc-flex-column oc-flex-middle oc-height-1-1">
+        <div class="oc-text-center oc-width-1-1">
           <h2 v-text="title" />
           <vue-dropzone
             id="oc-dropzone"
@@ -18,7 +18,7 @@
             :include-styling="false"
             @vdropzone-file-added="dropZoneFileAdded"
           >
-            <div class="uk-flex uk-flex-middle uk-flex-center uk-placeholder">
+            <div class="oc-flex oc-flex-middle oc-flex-center">
               <oc-icon name="file_upload" />
               <translate>Drop files here to upload or click to select file</translate>
             </div>
@@ -26,17 +26,17 @@
           <div id="previews" hidden />
         </div>
         <div
-          class="uk-flex uk-flex-center uk-overflow-auto uk-width-1-1"
+          class="oc-flex oc-flex-center oc-overflow-auto oc-width-1-1"
           :class="{ 'files-empty': !getUploadedFiles }"
         >
-          <oc-table-simple v-if="getUploadedFiles" class="uk-width-1-1 uk-width-xxlarge@m">
+          <oc-table-simple v-if="getUploadedFiles" class="oc-width-1-1">
             <oc-tbody>
               <oc-tr v-for="(file, key) in getUploadedFiles" :key="key">
                 <oc-td class="oc-pl-rm" v-text="file.name" />
-                <oc-td width="shrink" class="uk-text-nowrap oc-text-muted">
+                <oc-td width="shrink" class="oc-text-nowrap oc-text-muted">
                   <oc-resource-size :size="file.size" />
                 </oc-td>
-                <oc-td width="shrink" class="oc-pr-rm uk-preserve-width">
+                <oc-td width="shrink" class="oc-pr-rm">
                   <oc-icon
                     v-if="file.status === 'done'"
                     name="ready"
@@ -59,7 +59,7 @@
             </oc-tbody>
           </oc-table-simple>
         </div>
-        <div v-if="errorMessage" class="uk-text-center">
+        <div v-if="errorMessage" class="oc-text-center">
           <h2>
             <translate>An error occurred while loading the public link</translate>
           </h2>
@@ -67,7 +67,7 @@
         </div>
       </div>
     </div>
-    <div class="uk-text-center">
+    <div class="oc-text-center">
       <p v-text="configuration.theme.general.slogan" />
     </div>
   </div>

--- a/packages/web-app-files/src/views/LocationPicker.vue
+++ b/packages/web-app-files/src/views/LocationPicker.vue
@@ -1,12 +1,12 @@
 <template>
-  <main id="files-location-picker" class="uk-flex uk-height-1-1">
-    <div tabindex="-1" class="files-list-wrapper uk-width-expand">
+  <main id="files-location-picker" class="oc-flex oc-height-1-1">
+    <div tabindex="-1" class="files-list-wrapper oc-width-expand">
       <div id="files-app-bar" class="oc-p-s">
         <h1 class="location-picker-selection-info oc-mb" v-text="title" />
-        <p class="oc-text-muted uk-text-meta" v-text="currentHint" />
+        <p class="oc-text-muted oc-text-meta" v-text="currentHint" />
         <hr class="oc-mt-rm" />
         <oc-breadcrumb :items="breadcrumbs" class="oc-mb-s" />
-        <oc-grid gutter="small" flex class="uk-flex-middle">
+        <oc-grid gutter="small" flex class="oc-flex-middle">
           <div>
             <oc-button
               id="location-picker-btn-cancel"
@@ -59,7 +59,7 @@
               <pagination />
               <list-info
                 v-if="activeFilesCurrentPage.length > 0"
-                class="uk-width-1-1 oc-my-s"
+                class="oc-width-1-1 oc-my-s"
                 :files="totalFilesCount.files"
                 :folders="totalFilesCount.folders"
                 :size="totalFilesSize"

--- a/packages/web-app-files/src/views/Personal.vue
+++ b/packages/web-app-files/src/views/Personal.vue
@@ -2,7 +2,7 @@
   <div>
     <list-loader v-if="loadResourcesTask.isRunning" />
     <template v-else>
-      <not-found-message v-if="folderNotFound" class="files-not-found uk-height-1-1" />
+      <not-found-message v-if="folderNotFound" class="files-not-found oc-height-1-1" />
       <no-content-message
         v-else-if="isEmpty"
         id="files-personal-empty"
@@ -46,7 +46,7 @@
           <pagination />
           <list-info
             v-if="activeFilesCurrentPage.length > 0"
-            class="uk-width-1-1 oc-my-s"
+            class="oc-width-1-1 oc-my-s"
             :files="totalFilesCount.files"
             :folders="totalFilesCount.folders"
             :size="totalFilesSize"

--- a/packages/web-app-files/src/views/PrivateLink.vue
+++ b/packages/web-app-files/src/views/PrivateLink.vue
@@ -1,11 +1,10 @@
 <template>
   <div
-    class="oc-login"
-    uk-height-viewport
+    class="oc-login oc-height-viewport"
     :style="{ backgroundImage: 'url(' + backgroundImg + ')' }"
   >
     <h1 class="oc-invisible-sr">{{ pageTitle }}</h1>
-    <div class="oc-login-card uk-position-center">
+    <div class="oc-login-card oc-position-center">
       <img class="oc-login-logo" :src="logoImg" alt="" :aria-hidden="true" />
       <div v-if="loading" class="oc-login-card-body">
         <h2 class="oc-login-card-title">

--- a/packages/web-app-files/src/views/PublicFiles.vue
+++ b/packages/web-app-files/src/views/PublicFiles.vue
@@ -2,7 +2,7 @@
   <div>
     <list-loader v-if="loadResourcesTask.isRunning" />
     <template v-else>
-      <not-found-message v-if="folderNotFound" class="files-not-found uk-height-1-1" />
+      <not-found-message v-if="folderNotFound" class="files-not-found oc-height-1-1" />
       <no-content-message
         v-else-if="isEmpty"
         id="files-public-list-empty"
@@ -36,7 +36,7 @@
           <pagination />
           <list-info
             v-if="activeFilesCurrentPage.length > 0"
-            class="uk-width-1-1 oc-my-s"
+            class="oc-width-1-1 oc-my-s"
             :files="totalFilesCount.files"
             :folders="totalFilesCount.folders"
             :size="totalFilesSize"

--- a/packages/web-app-files/src/views/PublicLink.vue
+++ b/packages/web-app-files/src/views/PublicLink.vue
@@ -1,11 +1,10 @@
 <template>
   <div
-    class="oc-login"
-    uk-height-viewport
+    class="oc-login oc-height-viewport"
     :style="{ backgroundImage: 'url(' + backgroundImg + ')' }"
   >
     <h1 class="oc-invisible-sr">{{ pageTitle }}</h1>
-    <div class="oc-login-card uk-position-center">
+    <div class="oc-login-card oc-position-center">
       <img class="oc-login-logo" :src="logoImg" alt="" :aria-hidden="true" />
       <div class="oc-login-card-body">
         <template v-if="loading">

--- a/packages/web-app-files/src/views/SharedViaLink.vue
+++ b/packages/web-app-files/src/views/SharedViaLink.vue
@@ -32,7 +32,7 @@
           <pagination />
           <list-info
             v-if="activeFilesCurrentPage.length > 0"
-            class="uk-width-1-1 oc-my-s"
+            class="oc-width-1-1 oc-my-s"
             :files="totalFilesCount.files"
             :folders="totalFilesCount.folders"
           />

--- a/packages/web-app-files/src/views/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/SharedWithMe.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="uk-flex uk-flex-column">
+  <div class="oc-flex oc-flex-column">
     <list-loader v-if="loadResourcesTask.isRunning" />
     <template v-else>
       <!-- Pending shares -->
@@ -24,7 +24,7 @@
           <template #status="{ resource }">
             <div
               :key="resource.id + resource.status"
-              class="uk-text-nowrap uk-flex uk-flex-middle uk-flex-right"
+              class="oc-text-nowrap oc-flex oc-flex-middle oc-flex-right"
             >
               <oc-button
                 size="small"
@@ -49,7 +49,7 @@
             <context-actions v-if="isHighlightedFile(resource)" :item="resource" />
           </template>
           <template v-if="pendingHasMore" #footer>
-            <div class="uk-width-1-1 uk-text-center oc-mt">
+            <div class="oc-width-1-1 oc-text-center oc-mt">
               <oc-button
                 id="files-shared-with-me-pending-show-all"
                 appearance="raw"
@@ -84,7 +84,7 @@
       <no-content-message
         v-if="!hasShares"
         id="files-shared-with-me-shares-empty"
-        class="files-empty uk-flex-stretch"
+        class="files-empty oc-flex-stretch"
         icon="group"
       >
         <template #message>
@@ -108,7 +108,7 @@
         <template #status="{ resource }">
           <div
             :key="resource.id + resource.status"
-            class="uk-text-nowrap uk-flex uk-flex-middle uk-flex-right"
+            class="oc-text-nowrap oc-flex oc-flex-middle oc-flex-right"
           >
             <oc-button
               v-if="resource.status === shareStatus.declined"
@@ -137,7 +137,7 @@
         <template #footer>
           <list-info
             v-if="hasShares"
-            class="uk-width-1-1 oc-my-s"
+            class="oc-width-1-1 oc-my-s"
             :files="sharesCountFiles"
             :folders="sharesCountFolders"
           />

--- a/packages/web-app-files/src/views/SharedWithOthers.vue
+++ b/packages/web-app-files/src/views/SharedWithOthers.vue
@@ -34,7 +34,7 @@
           <pagination />
           <list-info
             v-if="activeFilesCurrentPage.length > 0"
-            class="uk-width-1-1 oc-my-s"
+            class="oc-width-1-1 oc-my-s"
             :files="totalFilesCount.files"
             :folders="totalFilesCount.folders"
           />

--- a/packages/web-app-files/src/views/Trashbin.vue
+++ b/packages/web-app-files/src/views/Trashbin.vue
@@ -31,7 +31,7 @@
           <pagination />
           <list-info
             v-if="activeFilesCurrentPage.length > 0"
-            class="uk-width-1-1 oc-my-s"
+            class="oc-width-1-1 oc-my-s"
             :files="totalFilesCount.files"
             :folders="totalFilesCount.folders"
           />

--- a/packages/web-app-files/tests/unit/components/AppBar/AppBar.spec.js
+++ b/packages/web-app-files/tests/unit/components/AppBar/AppBar.spec.js
@@ -19,7 +19,7 @@ const elSelector = {
   sizeInfo: 'size-info-stub',
   newFileButton: '#new-file-menu-btn',
   ocDrop: 'oc-drop-stub',
-  fileMenuList: 'oc-drop-stub .uk-list > li',
+  fileMenuList: 'oc-drop-stub .oc-list > li',
   fileUpload: 'file-upload-stub',
   folderUpload: 'folder-upload-stub',
   newFolderBtn: '#new-folder-btn',

--- a/packages/web-app-files/tests/unit/components/FilesList/__snapshots__/ContextActions.spec.js.snap
+++ b/packages/web-app-files/tests/unit/components/FilesList/__snapshots__/ContextActions.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ContextActions menu items renders a list of actions for a file 1`] = `
 <div id="oc-files-context-menu">
-  <ul id="oc-files-context-actions-context" class="uk-list oc-mt-s oc-files-context-actions">
+  <ul id="oc-files-context-actions-context" class="oc-list oc-mt-s oc-files-context-actions">
     <li class="oc-files-context-action"><button class="oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-text-bold oc-files-actions-markdown-editor-trigger">
         <oc-icon-stub name="text" accessiblelabel="" type="span" size="medium" variation="passive"></oc-icon-stub>
         <!----> <span class="oc-files-context-action-label">Open in editor</span>
@@ -40,7 +40,7 @@ exports[`ContextActions menu items renders a list of actions for a file 1`] = `
       </button></li>
   </ul>
   <hr>
-  <ul id="oc-files-context-actions-actions" class="uk-list oc-mt-s oc-files-context-actions">
+  <ul id="oc-files-context-actions-actions" class="oc-list oc-mt-s oc-files-context-actions">
     <li class="oc-files-context-action"><button class="oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-text-bold oc-files-actions-rename-trigger">
         <oc-icon-stub name="edit" accessiblelabel="" type="span" size="medium" variation="passive"></oc-icon-stub>
         <!----> <span class="oc-files-context-action-label">Edit</span>
@@ -68,7 +68,7 @@ exports[`ContextActions menu items renders a list of actions for a file 1`] = `
       </button></li>
   </ul>
   <hr>
-  <ul id="oc-files-context-actions-sidebar" class="uk-list oc-mt-s oc-files-context-actions">
+  <ul id="oc-files-context-actions-sidebar" class="oc-list oc-mt-s oc-files-context-actions">
     <li class="oc-files-context-action"><button class="oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-text-bold oc-files-actions-show-details-trigger">
         <oc-icon-stub name="info_outline" accessiblelabel="" type="span" size="medium" variation="passive"></oc-icon-stub>
         <!----> <span class="oc-files-context-action-label">Details</span>
@@ -81,7 +81,7 @@ exports[`ContextActions menu items renders a list of actions for a file 1`] = `
 
 exports[`ContextActions menu items renders a list of actions for a folder 1`] = `
 <div id="oc-files-context-menu">
-  <ul id="oc-files-context-actions-context" class="uk-list oc-mt-s oc-files-context-actions">
+  <ul id="oc-files-context-actions-context" class="oc-list oc-mt-s oc-files-context-actions">
     <li class="oc-files-context-action"><button class="oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-text-bold oc-files-actions-markdown-editor-trigger">
         <oc-icon-stub name="text" accessiblelabel="" type="span" size="medium" variation="passive"></oc-icon-stub>
         <!----> <span class="oc-files-context-action-label">Open in editor</span>
@@ -119,7 +119,7 @@ exports[`ContextActions menu items renders a list of actions for a folder 1`] = 
       </button></li>
   </ul>
   <hr>
-  <ul id="oc-files-context-actions-actions" class="uk-list oc-mt-s oc-files-context-actions">
+  <ul id="oc-files-context-actions-actions" class="oc-list oc-mt-s oc-files-context-actions">
     <li class="oc-files-context-action"><button class="oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-text-bold oc-files-actions-rename-trigger">
         <oc-icon-stub name="edit" accessiblelabel="" type="span" size="medium" variation="passive"></oc-icon-stub>
         <!----> <span class="oc-files-context-action-label">Edit</span>
@@ -147,7 +147,7 @@ exports[`ContextActions menu items renders a list of actions for a folder 1`] = 
       </button></li>
   </ul>
   <hr>
-  <ul id="oc-files-context-actions-sidebar" class="uk-list oc-mt-s oc-files-context-actions">
+  <ul id="oc-files-context-actions-sidebar" class="oc-list oc-mt-s oc-files-context-actions">
     <li class="oc-files-context-action"><button class="oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-text-bold oc-files-actions-show-details-trigger">
         <oc-icon-stub name="info_outline" accessiblelabel="" type="span" size="medium" variation="passive"></oc-icon-stub>
         <!----> <span class="oc-files-context-action-label">Details</span>

--- a/packages/web-app-files/tests/unit/components/Search/__snapshots__/List.spec.js.snap
+++ b/packages/web-app-files/tests/unit/components/Search/__snapshots__/List.spec.js.snap
@@ -2,13 +2,13 @@
 
 exports[`List component when no resource is found should show no-content-message component 1`] = `
 <div class="files-search-result">
-  <div class="uk-height-1-1 uk-flex uk-flex-column uk-flex-center uk-flex-middle uk-text-center files-empty">
+  <div class="oc-height-1-1 oc-flex oc-flex-column oc-flex-center oc-flex-middle oc-text-center files-empty">
     <div class="oc-icon oc-icon-xxl oc-icon-passive"><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" version="1.0" viewBox="0 0 16 16" height="16" width="16" xmlns="http://www.w3.org/2000/svg" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" aria-hidden="true" focusable="false">
         <g xmlns="http://www.w3.org/2000/svg" transform="matrix(.86667 0 0 .86667 -172.05 -864.43)">
           <path d="m200.2 999.72c-0.28913 0-0.53125 0.2421-0.53125 0.53117v12.784c0 0.2985 0.23264 0.5312 0.53125 0.5312h15.091c0.2986 0 0.53124-0.2327 0.53124-0.5312l0.0004-10.474c0-0.2889-0.24211-0.5338-0.53124-0.5338l-7.5457 0.0005-2.3076-2.3078z"></path>
         </g>
       </svg></div>
-    <div class="oc-text-muted uk-text-large">
+    <div class="oc-text-muted oc-text-large">
       <p class="oc-text-muted"><span data-msgid="No resource found" data-current-language="en_US">No resource found</span></p>
     </div>
     <div class="oc-text-muted"></div>
@@ -18,13 +18,13 @@ exports[`List component when no resource is found should show no-content-message
 
 exports[`List component when no search term is entered should show no-content-message component 1`] = `
 <div class="files-search-result">
-  <div class="uk-height-1-1 uk-flex uk-flex-column uk-flex-center uk-flex-middle uk-text-center files-empty">
+  <div class="oc-height-1-1 oc-flex oc-flex-column oc-flex-center oc-flex-middle oc-text-center files-empty">
     <div class="oc-icon oc-icon-xxl oc-icon-passive"><svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" version="1.0" viewBox="0 0 16 16" height="16" width="16" xmlns="http://www.w3.org/2000/svg" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" aria-hidden="true" focusable="false">
         <g xmlns="http://www.w3.org/2000/svg" transform="matrix(.86667 0 0 .86667 -172.05 -864.43)">
           <path d="m200.2 999.72c-0.28913 0-0.53125 0.2421-0.53125 0.53117v12.784c0 0.2985 0.23264 0.5312 0.53125 0.5312h15.091c0.2986 0 0.53124-0.2327 0.53124-0.5312l0.0004-10.474c0-0.2889-0.24211-0.5338-0.53124-0.5338l-7.5457 0.0005-2.3076-2.3078z"></path>
         </g>
       </svg></div>
-    <div class="oc-text-muted uk-text-large">
+    <div class="oc-text-muted oc-text-large">
       <p class="oc-text-muted"><span data-msgid="No search term entered" data-current-language="en_US">No search term entered</span></p>
     </div>
     <div class="oc-text-muted"></div>

--- a/packages/web-app-files/tests/unit/views/__snapshots__/FilesDrop.spec.js.snap
+++ b/packages/web-app-files/tests/unit/views/__snapshots__/FilesDrop.spec.js.snap
@@ -1,73 +1,73 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FilesDrop should show page title and configuration theme general slogan 1`] = `
-<div id="files-drop-container" class="uk-height-1-1 uk-flex uk-flex-column uk-flex-between">
+<div id="files-drop-container" class="oc-height-1-1 oc-flex oc-flex-column oc-flex-between">
   <h1 class="oc-invisible-sr">page route title</h1>
-  <div class="oc-p uk-height-1-1">
-    <div class="uk-flex uk-flex-column uk-flex-middle uk-height-1-1">
-      <div class="uk-text-center uk-width-1-1 uk-width-xxlarge@m">
+  <div class="oc-p oc-height-1-1">
+    <div class="oc-flex oc-flex-column oc-flex-middle oc-height-1-1">
+      <div class="oc-text-center oc-width-1-1">
         <h2>admin shared this folder with you for uploading</h2>
         <vue-dropzone-stub id="oc-dropzone" options="[object Object]" destroydropzone="true" usecustomslot="true">
-          <div class="uk-flex uk-flex-middle uk-flex-center uk-placeholder">
+          <div class="oc-flex oc-flex-middle oc-flex-center">
             <oc-icon-stub name="file_upload" accessiblelabel="" type="span" size="medium" variation="passive"></oc-icon-stub>
             <translate-stub tag="span">Drop files here to upload or click to select file</translate-stub>
           </div>
         </vue-dropzone-stub>
         <div id="previews" hidden="hidden"></div>
       </div>
-      <div class="uk-flex uk-flex-center uk-overflow-auto uk-width-1-1 files-empty">
+      <div class="oc-flex oc-flex-center oc-overflow-auto oc-width-1-1 files-empty">
         <!---->
       </div>
       <!---->
     </div>
   </div>
-  <div class="uk-text-center">
+  <div class="oc-text-center">
     <p>some slogan</p>
   </div>
 </div>
 `;
 
 exports[`FilesDrop should show spinner with loading text if wrapper is loading 1`] = `
-<div id="files-drop-container" class="uk-height-1-1 uk-flex uk-flex-column uk-flex-between">
+<div id="files-drop-container" class="oc-height-1-1 oc-flex oc-flex-column oc-flex-between">
   <h1 class="oc-invisible-sr">page route title</h1>
-  <div class="oc-p uk-height-1-1">
-    <div class="uk-flex uk-flex-column uk-flex-middle">
+  <div class="oc-p oc-height-1-1">
+    <div class="oc-flex oc-flex-column oc-flex-middle">
       <h2 class="oc-login-card-title">
         <translate-stub tag="span">Loading public link…</translate-stub>
       </h2>
       <oc-spinner-stub arialabel="" size="medium" aria-hidden="true"></oc-spinner-stub>
     </div>
   </div>
-  <div class="uk-text-center">
+  <div class="oc-text-center">
     <p>some slogan</p>
   </div>
 </div>
 `;
 
 exports[`FilesDrop when "loading" is set to false should call "dropZoneFileAdded" method if "vdropzone-file-added" event is emitted 1`] = `
-<div id="files-drop-container" class="uk-height-1-1 uk-flex uk-flex-column uk-flex-between">
+<div id="files-drop-container" class="oc-height-1-1 oc-flex oc-flex-column oc-flex-between">
   <h1 class="oc-invisible-sr">page route title</h1>
-  <div class="oc-p uk-height-1-1">
-    <div class="uk-flex uk-flex-column uk-flex-middle uk-height-1-1">
-      <div class="uk-text-center uk-width-1-1 uk-width-xxlarge@m">
+  <div class="oc-p oc-height-1-1">
+    <div class="oc-flex oc-flex-column oc-flex-middle oc-height-1-1">
+      <div class="oc-text-center oc-width-1-1">
         <h2>admin shared this folder with you for uploading</h2>
         <vue-dropzone-stub id="oc-dropzone" options="[object Object]" destroydropzone="true" usecustomslot="true">
-          <div class="uk-flex uk-flex-middle uk-flex-center uk-placeholder">
+          <div class="oc-flex oc-flex-middle oc-flex-center">
             <oc-icon-stub name="file_upload" accessiblelabel="" type="span" size="medium" variation="passive"></oc-icon-stub>
             <translate-stub tag="span">Drop files here to upload or click to select file</translate-stub>
           </div>
         </vue-dropzone-stub>
         <div id="previews" hidden="hidden"></div>
       </div>
-      <div class="uk-flex uk-flex-center uk-overflow-auto uk-width-1-1">
-        <oc-table-simple-stub class="uk-width-1-1 uk-width-xxlarge@m">
+      <div class="oc-flex oc-flex-center oc-overflow-auto oc-width-1-1">
+        <oc-table-simple-stub class="oc-width-1-1">
           <oc-tbody-stub>
             <oc-tr-stub>
               <oc-td-stub alignh="left" alignv="middle" width="auto" class="oc-pl-rm">file1.txt</oc-td-stub>
-              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="uk-text-nowrap oc-text-muted">
+              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="oc-text-nowrap oc-text-muted">
                 <oc-resource-size-stub size="300"></oc-resource-size-stub>
               </oc-td-stub>
-              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="oc-pr-rm uk-preserve-width">
+              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="oc-pr-rm">
                 <oc-icon-stub name="ready" accessiblelabel="" type="span" size="small" variation="success"></oc-icon-stub>
                 <!---->
                 <!---->
@@ -76,7 +76,7 @@ exports[`FilesDrop when "loading" is set to false should call "dropZoneFileAdded
           </oc-tbody-stub>
         </oc-table-simple-stub>
       </div>
-      <div class="uk-text-center">
+      <div class="oc-text-center">
         <h2>
           <translate-stub tag="span">An error occurred while loading the public link</translate-stub>
         </h2>
@@ -84,37 +84,37 @@ exports[`FilesDrop when "loading" is set to false should call "dropZoneFileAdded
       </div>
     </div>
   </div>
-  <div class="uk-text-center">
+  <div class="oc-text-center">
     <p>some slogan</p>
   </div>
 </div>
 `;
 
 exports[`FilesDrop when "loading" is set to false should not show files table if uploaded files list is empty 1`] = `
-<div class="uk-flex uk-flex-center uk-overflow-auto uk-width-1-1 files-empty">
+<div class="oc-flex oc-flex-center oc-overflow-auto oc-width-1-1 files-empty">
   <!---->
 </div>
 `;
 
 exports[`FilesDrop when "loading" is set to false should show error message if only it has truthy value 1`] = `
-<div id="files-drop-container" class="uk-height-1-1 uk-flex uk-flex-column uk-flex-between">
+<div id="files-drop-container" class="oc-height-1-1 oc-flex oc-flex-column oc-flex-between">
   <h1 class="oc-invisible-sr">page route title</h1>
-  <div class="oc-p uk-height-1-1">
-    <div class="uk-flex uk-flex-column uk-flex-middle uk-height-1-1">
-      <div class="uk-text-center uk-width-1-1 uk-width-xxlarge@m">
+  <div class="oc-p oc-height-1-1">
+    <div class="oc-flex oc-flex-column oc-flex-middle oc-height-1-1">
+      <div class="oc-text-center oc-width-1-1">
         <h2>admin shared this folder with you for uploading</h2>
         <vue-dropzone-stub id="oc-dropzone" options="[object Object]" destroydropzone="true" usecustomslot="true">
-          <div class="uk-flex uk-flex-middle uk-flex-center uk-placeholder">
+          <div class="oc-flex oc-flex-middle oc-flex-center">
             <oc-icon-stub name="file_upload" accessiblelabel="" type="span" size="medium" variation="passive"></oc-icon-stub>
             <translate-stub tag="span">Drop files here to upload or click to select file</translate-stub>
           </div>
         </vue-dropzone-stub>
         <div id="previews" hidden="hidden"></div>
       </div>
-      <div class="uk-flex uk-flex-center uk-overflow-auto uk-width-1-1 files-empty">
+      <div class="oc-flex oc-flex-center oc-overflow-auto oc-width-1-1 files-empty">
         <!---->
       </div>
-      <div class="uk-text-center">
+      <div class="oc-text-center">
         <h2>
           <translate-stub tag="span">An error occurred while loading the public link</translate-stub>
         </h2>
@@ -122,36 +122,36 @@ exports[`FilesDrop when "loading" is set to false should show error message if o
       </div>
     </div>
   </div>
-  <div class="uk-text-center">
+  <div class="oc-text-center">
     <p>some slogan</p>
   </div>
 </div>
 `;
 
 exports[`FilesDrop when "loading" is set to false should show files list of uploaded files 1`] = `
-<div id="files-drop-container" class="uk-height-1-1 uk-flex uk-flex-column uk-flex-between">
+<div id="files-drop-container" class="oc-height-1-1 oc-flex oc-flex-column oc-flex-between">
   <h1 class="oc-invisible-sr">page route title</h1>
-  <div class="oc-p uk-height-1-1">
-    <div class="uk-flex uk-flex-column uk-flex-middle uk-height-1-1">
-      <div class="uk-text-center uk-width-1-1 uk-width-xxlarge@m">
+  <div class="oc-p oc-height-1-1">
+    <div class="oc-flex oc-flex-column oc-flex-middle oc-height-1-1">
+      <div class="oc-text-center oc-width-1-1">
         <h2></h2>
         <vue-dropzone-stub id="oc-dropzone" options="[object Object]" destroydropzone="true" usecustomslot="true">
-          <div class="uk-flex uk-flex-middle uk-flex-center uk-placeholder">
+          <div class="oc-flex oc-flex-middle oc-flex-center">
             <oc-icon-stub name="file_upload" accessiblelabel="" type="span" size="medium" variation="passive"></oc-icon-stub>
             <translate-stub tag="span">Drop files here to upload or click to select file</translate-stub>
           </div>
         </vue-dropzone-stub>
         <div id="previews" hidden="hidden"></div>
       </div>
-      <div class="uk-flex uk-flex-center uk-overflow-auto uk-width-1-1">
-        <oc-table-simple-stub class="uk-width-1-1 uk-width-xxlarge@m">
+      <div class="oc-flex oc-flex-center oc-overflow-auto oc-width-1-1">
+        <oc-table-simple-stub class="oc-width-1-1">
           <oc-tbody-stub>
             <oc-tr-stub>
               <oc-td-stub alignh="left" alignv="middle" width="auto" class="oc-pl-rm">file1</oc-td-stub>
-              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="uk-text-nowrap oc-text-muted">
+              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="oc-text-nowrap oc-text-muted">
                 <oc-resource-size-stub size="300"></oc-resource-size-stub>
               </oc-td-stub>
-              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="oc-pr-rm uk-preserve-width">
+              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="oc-pr-rm">
                 <!---->
                 <oc-icon-stub name="info" accessiblelabel="" type="span" size="small" variation="danger"></oc-icon-stub>
                 <!---->
@@ -159,10 +159,10 @@ exports[`FilesDrop when "loading" is set to false should show files list of uplo
             </oc-tr-stub>
             <oc-tr-stub>
               <oc-td-stub alignh="left" alignv="middle" width="auto" class="oc-pl-rm">file2</oc-td-stub>
-              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="uk-text-nowrap oc-text-muted">
+              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="oc-text-nowrap oc-text-muted">
                 <oc-resource-size-stub size="600"></oc-resource-size-stub>
               </oc-td-stub>
-              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="oc-pr-rm uk-preserve-width">
+              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="oc-pr-rm">
                 <oc-icon-stub name="ready" accessiblelabel="" type="span" size="small" variation="success"></oc-icon-stub>
                 <!---->
                 <!---->
@@ -170,10 +170,10 @@ exports[`FilesDrop when "loading" is set to false should show files list of uplo
             </oc-tr-stub>
             <oc-tr-stub>
               <oc-td-stub alignh="left" alignv="middle" width="auto" class="oc-pl-rm">file3</oc-td-stub>
-              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="uk-text-nowrap oc-text-muted">
+              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="oc-text-nowrap oc-text-muted">
                 <oc-resource-size-stub size="900"></oc-resource-size-stub>
               </oc-td-stub>
-              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="oc-pr-rm uk-preserve-width">
+              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="oc-pr-rm">
                 <!---->
                 <!---->
                 <oc-spinner-stub arialabel="Uploading file &quot;file3&quot;" size="small"></oc-spinner-stub>
@@ -181,10 +181,10 @@ exports[`FilesDrop when "loading" is set to false should show files list of uplo
             </oc-tr-stub>
             <oc-tr-stub>
               <oc-td-stub alignh="left" alignv="middle" width="auto" class="oc-pl-rm">file4</oc-td-stub>
-              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="uk-text-nowrap oc-text-muted">
+              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="oc-text-nowrap oc-text-muted">
                 <oc-resource-size-stub size="1200"></oc-resource-size-stub>
               </oc-td-stub>
-              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="oc-pr-rm uk-preserve-width">
+              <oc-td-stub alignh="left" alignv="middle" width="shrink" class="oc-pr-rm">
                 <!---->
                 <!---->
                 <oc-spinner-stub arialabel="Uploading file &quot;file4&quot;" size="small"></oc-spinner-stub>
@@ -193,7 +193,7 @@ exports[`FilesDrop when "loading" is set to false should show files list of uplo
           </oc-tbody-stub>
         </oc-table-simple-stub>
       </div>
-      <div class="uk-text-center">
+      <div class="oc-text-center">
         <h2>
           <translate-stub tag="span">An error occurred while loading the public link</translate-stub>
         </h2>
@@ -201,31 +201,31 @@ exports[`FilesDrop when "loading" is set to false should show files list of uplo
       </div>
     </div>
   </div>
-  <div class="uk-text-center">
+  <div class="oc-text-center">
     <p>some slogan</p>
   </div>
 </div>
 `;
 
 exports[`FilesDrop when "loading" is set to false should show share information title 1`] = `
-<div id="files-drop-container" class="uk-height-1-1 uk-flex uk-flex-column uk-flex-between">
+<div id="files-drop-container" class="oc-height-1-1 oc-flex oc-flex-column oc-flex-between">
   <h1 class="oc-invisible-sr">page route title</h1>
-  <div class="oc-p uk-height-1-1">
-    <div class="uk-flex uk-flex-column uk-flex-middle uk-height-1-1">
-      <div class="uk-text-center uk-width-1-1 uk-width-xxlarge@m">
+  <div class="oc-p oc-height-1-1">
+    <div class="oc-flex oc-flex-column oc-flex-middle oc-height-1-1">
+      <div class="oc-text-center oc-width-1-1">
         <h2>admin shared this folder with you for uploading</h2>
         <vue-dropzone-stub id="oc-dropzone" options="[object Object]" destroydropzone="true" usecustomslot="true">
-          <div class="uk-flex uk-flex-middle uk-flex-center uk-placeholder">
+          <div class="oc-flex oc-flex-middle oc-flex-center">
             <oc-icon-stub name="file_upload" accessiblelabel="" type="span" size="medium" variation="passive"></oc-icon-stub>
             <translate-stub tag="span">Drop files here to upload or click to select file</translate-stub>
           </div>
         </vue-dropzone-stub>
         <div id="previews" hidden="hidden"></div>
       </div>
-      <div class="uk-flex uk-flex-center uk-overflow-auto uk-width-1-1 files-empty">
+      <div class="oc-flex oc-flex-center oc-overflow-auto oc-width-1-1 files-empty">
         <!---->
       </div>
-      <div class="uk-text-center">
+      <div class="oc-text-center">
         <h2>
           <translate-stub tag="span">An error occurred while loading the public link</translate-stub>
         </h2>
@@ -233,7 +233,7 @@ exports[`FilesDrop when "loading" is set to false should show share information 
       </div>
     </div>
   </div>
-  <div class="uk-text-center">
+  <div class="oc-text-center">
     <p>some slogan</p>
   </div>
 </div>

--- a/packages/web-app-files/tests/unit/views/__snapshots__/PrivateLink.spec.js.snap
+++ b/packages/web-app-files/tests/unit/views/__snapshots__/PrivateLink.spec.js.snap
@@ -3,9 +3,9 @@
 exports[`PrivateLink view when the page has loaded successfully should display the page title 1`] = `<h1 class="oc-invisible-sr">Resolving private link</h1>`;
 
 exports[`PrivateLink view when the view has finished loading and there was no error should not display the loading text and the error message 1`] = `
-<div uk-height-viewport="" class="oc-login" style="background-image: url(assets/loginBackground.jpg);">
+<div class="oc-login oc-height-viewport" style="background-image: url(assets/loginBackground.jpg);">
   <h1 class="oc-invisible-sr">Resolving private link</h1>
-  <div class="oc-login-card uk-position-center"><img src="assets/logo.svg" alt="" aria-hidden="true" class="oc-login-logo">
+  <div class="oc-login-card oc-position-center"><img src="assets/logo.svg" alt="" aria-hidden="true" class="oc-login-logo">
     <!---->
     <!---->
   </div>

--- a/packages/web-app-markdown-editor/src/App.vue
+++ b/packages/web-app-markdown-editor/src/App.vue
@@ -9,20 +9,20 @@
         @close="clearLastError"
       />
     </oc-notifications>
-    <div class="uk-flex">
-      <div class="uk-container uk-width-1-2">
+    <div class="oc-flex">
+      <div class="oc-container oc-width-1-2">
         <oc-textarea
           id="markdown-editor-input"
           name="input"
           full-width
           :value="currentContent"
           :label="$gettext('Editor')"
-          class="uk-height-1-1"
+          class="oc-height-1-1"
           :rows="20"
           @input="onType"
         />
       </div>
-      <div class="uk-container uk-width-1-2">
+      <div class="oc-container oc-width-1-2">
         <!-- eslint-disable-next-line vue/no-v-html -->
         <div id="markdown-editor-preview" v-html="renderedMarkdown"></div>
       </div>

--- a/packages/web-app-markdown-editor/src/MarkdownEditorAppBar.vue
+++ b/packages/web-app-markdown-editor/src/MarkdownEditorAppBar.vue
@@ -1,16 +1,16 @@
 <template>
   <div id="markdown-editor-app-bar" class="oc-app-bar">
     <oc-grid flex gutter="small">
-      <div class="uk-width-auto">
+      <div class="oc-width-auto">
         <oc-button id="markdown-editor-controls-save" :disabled="!isTouched" @click="saveContent">
           <oc-icon name="save" />
         </oc-button>
         <oc-spinner v-if="isLoading" :aria-label="$gettext('Loading editor content')" />
       </div>
-      <div class="uk-width-expand uk-text-center">
+      <div class="oc-width-expand oc-text-center">
         <span id="markdown-editor-file-path">{{ activeFilePath }}</span>
       </div>
-      <div class="uk-width-auto uk-text-right">
+      <div class="oc-width-auto oc-text-right">
         <oc-button id="markdown-editor-controls-close" @click="closeApp">
           <oc-icon name="close" />
         </oc-button>

--- a/packages/web-app-media-viewer/src/App.vue
+++ b/packages/web-app-media-viewer/src/App.vue
@@ -16,9 +16,7 @@
       <div
         v-show="!loading && activeMediaFileCached"
         class="
-          uk-width-1-1 uk-flex uk-flex-center uk-flex-middle
-          oc-p-s
-          uk-box-shadow-medium
+          oc-width-1-1 oc-flex oc-flex-center oc-flex-middle oc-p-s oc-box-shadow-medium
           media-viewer-player
         "
       >
@@ -34,7 +32,7 @@
         />
       </div>
     </transition>
-    <div v-if="loading" class="uk-position-center">
+    <div v-if="loading" class="oc-position-center">
       <oc-spinner :aria-label="$gettext('Loading media file')" size="xlarge" />
     </div>
     <oc-icon
@@ -42,21 +40,26 @@
       name="review"
       variation="danger"
       size="xlarge"
-      class="uk-position-center uk-z-index"
+      class="oc-position-center"
       :accessible-label="$gettext('Failed to load media file')"
     />
 
-    <div class="uk-position-medium uk-position-bottom-center media-viewer-details">
+    <div class="oc-position-medium oc-position-bottom-center media-viewer-details">
       <p
-        class="oc-text-lead uk-text-center oc-text-truncate oc-p-s media-viewer-file-name"
+        class="oc-text-lead oc-text-center oc-text-truncate oc-p-s media-viewer-file-name"
         aria-hidden="true"
       >
         {{ medium.name }}
       </p>
       <div
         class="
-          oc-background-brand oc-p-s
-          uk-width-large uk-flex uk-flex-middle uk-flex-center uk-flex-around
+          oc-background-brand
+          oc-p-s
+          oc-width-large
+          oc-flex
+          oc-flex-middle
+          oc-flex-center
+          oc-flex-around
           media-viewer-controls-action-bar
         "
       >

--- a/packages/web-app-search/src/App.vue
+++ b/packages/web-app-search/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <main id="search" class="uk-flex uk-height-1-1">
+  <main id="search" class="oc-flex oc-height-1-1">
     <router-view id="search-view" />
   </main>
 </template>

--- a/packages/web-app-search/src/portals/SearchBar.vue
+++ b/packages/web-app-search/src/portals/SearchBar.vue
@@ -15,7 +15,7 @@
       @clear="resetProvider"
     />
     <div v-if="optionsVisible && term" id="files-global-search-options" ref="options">
-      <ul class="uk-list uk-list-divider">
+      <ul class="oc-list oc-list-divider">
         <li
           v-for="provider in availableProviders"
           :key="provider.id"

--- a/packages/web-app-search/src/views/List.vue
+++ b/packages/web-app-search/src/views/List.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="uk-width-1-1">
+  <div class="oc-width-1-1">
     <div
       v-if="$asyncComputed.searchResults.updating"
-      class="uk-flex uk-flex-middle uk-flex-center uk-height-1-1 uk-width-1-1"
+      class="oc-flex oc-flex-middle oc-flex-center oc-height-1-1 oc-width-1-1"
     >
       <oc-spinner size="large" :aria-hidden="true" aria-label="" />
     </div>

--- a/packages/web-runtime/.depcheckrc
+++ b/packages/web-runtime/.depcheckrc
@@ -2,10 +2,7 @@
   "ignores": [
     "web-runtime",
     "easygettext",
-    "uikit",
-    "vue-datetime",
     "webfontloader",
-    "weekstart",
     "vue-inline-svg"
   ]
 }

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -25,7 +25,6 @@
     "query-string": "^6.8.3",
     "tippy.js": "^6.3.1",
     "tus-js-client": "^1.8.0",
-    "uikit": "3.5.16",
     "v-calendar": "^2.3.2",
     "vue": "^2.6.10",
     "vue-async-computed": "^3.9.0",

--- a/packages/web-runtime/src/App.vue
+++ b/packages/web-runtime/src/App.vue
@@ -6,7 +6,7 @@
     </skip-to>
     <div
       v-if="user.isAuthenticated && !user.userReady"
-      class="loading-overlay uk-flex uk-flex-middle uk-flex-center"
+      class="loading-overlay oc-flex oc-flex-middle oc-flex-center"
       :style="{
         backgroundImage: 'url(' + configuration.theme.loginPage.backgroundImg + ')'
       }"
@@ -16,7 +16,7 @@
     <template v-else-if="!showHeader">
       <router-view name="fullscreen" />
     </template>
-    <div v-else id="web-content" key="core-content" class="uk-flex uk-flex-stretch">
+    <div v-else id="web-content" key="core-content" class="oc-flex oc-flex-stretch">
       <transition :name="appNavigationAnimation">
         <focus-trap v-if="isSidebarVisible" :active="isSidebarFixed && appNavigationVisible">
           <oc-sidebar-nav
@@ -30,7 +30,7 @@
             :class="sidebarClasses"
           >
             <template #header>
-              <div class="uk-text-center">
+              <div class="oc-text-center">
                 <oc-button
                   v-if="isSidebarFixed"
                   variation="inverse"
@@ -65,11 +65,11 @@
           </oc-sidebar-nav>
         </focus-trap>
       </transition>
-      <div class="uk-width-expand web-content-container">
+      <div class="oc-width-expand web-content-container">
         <top-bar
           v-if="!publicPage() && !$route.meta.verbose"
           id="oc-topbar"
-          class="uk-width-expand"
+          class="oc-width-expand"
           :applications-list="applicationsList"
           :active-notifications="activeNotifications"
           :user-id="user.username || user.id"
@@ -215,7 +215,7 @@ export default {
         return ''
       }
 
-      return 'uk-visible@l'
+      return 'oc-visible@l'
     },
 
     isSidebarFixed() {
@@ -403,6 +403,7 @@ html,
 body,
 #web,
 #web-content {
+  margin: 0;
   height: 100%;
   overflow-y: hidden;
 }

--- a/packages/web-runtime/src/components/ApplicationsMenu.vue
+++ b/packages/web-runtime/src/components/ApplicationsMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav :aria-label="$gettext('Main navigation')" class="uk-flex uk-flex-middle">
+  <nav :aria-label="$gettext('Main navigation')" class="oc-flex oc-flex-middle">
     <oc-button
       id="_appSwitcherButton"
       ref="menubutton"
@@ -8,7 +8,7 @@
       class="oc-topbar-menu-burger"
       :aria-label="applicationSwitcherLabel"
     >
-      <oc-icon name="apps" class="uk-flex" />
+      <oc-icon name="apps" class="oc-flex" />
     </oc-button>
     <oc-drop
       ref="menu"
@@ -16,18 +16,18 @@
       toggle="#_appSwitcherButton"
       mode="click"
       :options="{ pos: 'bottom-right', delayHide: 0 }"
-      class="uk-width-large"
+      class="oc-width-large"
       close-on-click
     >
-      <ul class="uk-grid-small uk-text-center" uk-grid>
-        <li v-for="(n, nid) in menuItems" :key="`apps-menu-${nid}`" class="uk-width-1-3">
+      <ul class="oc-list oc-text-center">
+        <li v-for="(n, nid) in menuItems" :key="`apps-menu-${nid}`" class="oc-width-1-3">
           <a v-if="n.url" key="apps-menu-external-link" :target="n.target" :href="n.url">
             <oc-icon :name="n.iconMaterial" size="xlarge" />
-            <span class="uk-display-block" v-text="$gettext(n.title)" />
+            <span class="oc-display-block" v-text="$gettext(n.title)" />
           </a>
           <router-link v-else key="apps-menu-internal-link" :to="n.path">
             <oc-icon :name="n.iconMaterial" size="xlarge" />
-            <span class="uk-display-block" v-text="$gettext(n.title)" />
+            <span class="oc-display-block" v-text="$gettext(n.title)" />
           </router-link>
         </li>
       </ul>
@@ -37,7 +37,6 @@
 
 <script>
 import NavigationMixin from '../mixins/navigationMixin'
-import UiKit from 'uikit'
 
 export default {
   mixins: [NavigationMixin],
@@ -57,14 +56,13 @@ export default {
     }
   },
   mounted() {
-    UiKit.util.on('#app-switcher-dropdown', 'shown', () => {
-      this.focusFirstLink()
-    })
-
-    UiKit.util.on('#app-switcher-dropdown', 'hidden', () => {
-      this.$emit('closed')
-      this.focusMenuButton()
-    })
+    // UiKit.util.on('#app-switcher-dropdown', 'shown', () => {
+    //   this.focusFirstLink()
+    // })
+    // UiKit.util.on('#app-switcher-dropdown', 'hidden', () => {
+    //   this.$emit('closed')
+    //   this.focusMenuButton()
+    // })
   },
   methods: {
     logout() {

--- a/packages/web-runtime/src/components/FeedbackLink.vue
+++ b/packages/web-runtime/src/components/FeedbackLink.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="uk-flex uk-flex-middle">
+  <div class="oc-flex oc-flex-middle">
     <oc-button
       v-oc-tooltip="description"
       type="a"

--- a/packages/web-runtime/src/components/MessageBar.vue
+++ b/packages/web-runtime/src/components/MessageBar.vue
@@ -7,7 +7,7 @@
         :title="$gettext(item.title)"
         :message="$gettext(item.desc)"
         :status="item.status"
-        class="uk-width-large"
+        class="oc-width-large"
         @close="deleteMessage(item)"
       />
     </transition-group>

--- a/packages/web-runtime/src/components/Notifications.vue
+++ b/packages/web-runtime/src/components/Notifications.vue
@@ -1,12 +1,12 @@
 <template>
-  <div id="oc-notification" class="uk-flex uk-flex-middle">
+  <div id="oc-notification" class="oc-flex oc-flex-middle">
     <oc-button
       id="oc-notification-bell"
       v-oc-tooltip="notificationsLabel"
       appearance="raw"
       :aria-label="notificationsLabel"
     >
-      <oc-icon class="oc-cursor-pointer uk-flex uk-flex-middle" name="bell" />
+      <oc-icon class="oc-cursor-pointer oc-flex oc-flex-middle" name="bell" />
     </oc-button>
     <oc-drop
       id="oc-notification-drop"
@@ -14,15 +14,15 @@
       toggle="#oc-notification-bell"
       mode="click"
       :options="{ pos: 'bottom-right', delayHide: 0 }"
-      class="uk-overflow-auto uk-width-3-4 uk-width-large@s"
+      class="oc-overflow-auto oc-width-3-4 oc-width-large@s"
     >
-      <div v-for="(el, index) in activeNotifications" :key="index" class="uk-width-1-1">
+      <div v-for="(el, index) in activeNotifications" :key="index" class="oc-width-1-1">
         <h4 v-text="el.subject" />
-        <p v-if="el.message" class="uk-text-small">{{ el.message }}</p>
+        <p v-if="el.message" class="oc-text-small">{{ el.message }}</p>
         <p>
-          <a v-if="el.link" :href="el.link" class="uk-link" target="_blank">{{ el.link }}</a>
+          <a v-if="el.link" :href="el.link" class="oc-link" target="_blank">{{ el.link }}</a>
         </p>
-        <div class="uk-button-group uk-width-1-1 uk-flex-right">
+        <div class="oc-width-1-1 oc-flex-right">
           <template v-if="el.actions.length !== 0">
             <oc-button
               v-for="(action, actionIndex) in el.actions"

--- a/packages/web-runtime/src/components/SidebarQuota.vue
+++ b/packages/web-runtime/src/components/SidebarQuota.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="uk-text-center">
+  <div class="oc-text-center">
     <oc-progress :value="quota.relative" :max="100" size="small" class="oc-mb-xs" />
     <translate
       class="oc-light"

--- a/packages/web-runtime/src/components/TopBar.vue
+++ b/packages/web-runtime/src/components/TopBar.vue
@@ -1,10 +1,10 @@
 <template>
   <header
-    class="oc-topbar uk-flex uk-flex-middle uk-flex-wrap oc-border-b oc-p-s"
+    class="oc-topbar oc-flex oc-flex-middle oc-flex-wrap oc-border-b oc-p-s"
     :aria-label="$gettext('Top bar')"
   >
     <oc-grid gutter="medium" flex>
-      <div class="uk-hidden@l">
+      <div class="oc-hidden@l">
         <oc-button
           appearance="raw"
           class="oc-m-s oc-app-navigation-toggle"
@@ -18,7 +18,7 @@
     <div class="portal-wrapper">
       <portal-target name="app.runtime.header" multiple></portal-target>
     </div>
-    <oc-grid flex gutter="small" class="uk-width-expand uk-flex-right oc-m-rm">
+    <oc-grid flex gutter="small" class="oc-width-expand oc-flex-right oc-m-rm">
       <feedback-link v-if="isFeedbackLinkEnabled" />
       <notifications v-if="activeNotifications.length" />
       <applications-menu v-if="applicationsList.length > 0" :applications-list="applicationsList" />

--- a/packages/web-runtime/src/components/UserMenu.vue
+++ b/packages/web-runtime/src/components/UserMenu.vue
@@ -3,14 +3,14 @@
     <oc-button
       id="_userMenuButton"
       ref="menuButton"
-      class="oc-topbar-personal uk-height-1-1 oc-pr-xs"
+      class="oc-topbar-personal oc-height-1-1 oc-pr-xs"
       appearance="raw"
       variation="passive"
       :aria-label="$gettext('User Menu')"
     >
       <oc-grid flex>
         <avatar-image
-          class="oc-topbar-personal-avatar uk-flex-inline uk-flex-center uk-flex-middle oc-px-s"
+          class="oc-topbar-personal-avatar oc-flex-inline oc-flex-center oc-flex-middle oc-px-s"
           :width="24"
           :userid="userId"
           :user-name="userDisplayName"
@@ -25,10 +25,10 @@
       mode="click"
       close-on-click
       :options="{ pos: 'bottom-right', delayHide: 0 }"
-      class="uk-width-auto"
+      class="oc-width-auto"
     >
-      <ul class="uk-list">
-        <li class="uk-text-nowrap">
+      <ul class="oc-list">
+        <li class="oc-text-nowrap">
           <oc-button
             id="oc-topbar-account-manage"
             type="router-link"

--- a/packages/web-runtime/src/pages/accessDenied.vue
+++ b/packages/web-runtime/src/pages/accessDenied.vue
@@ -1,13 +1,12 @@
 <template>
   <div
-    class="oc-login"
-    uk-height-viewport
+    class="oc-login oc-height-viewport"
     :style="{ backgroundImage: 'url(' + backgroundImg + ')' }"
   >
     <h1 class="oc-invisible-sr">{{ pageTitle }}</h1>
-    <div class="oc-login-card uk-position-center">
+    <div class="oc-login-card oc-position-center">
       <img class="oc-login-logo" :src="logoImg" alt="" :aria-hidden="true" />
-      <div class="oc-login-card-body uk-width-large">
+      <div class="oc-login-card-body oc-width-large">
         <h3 class="oc-login-card-title">
           <span v-translate>Login Error</span>
         </h3>
@@ -20,7 +19,7 @@
           this browser with your current user.
         </div>
       </div>
-      <div class="oc-login-card-footer uk-width-large">
+      <div class="oc-login-card-footer oc-width-large">
         <p>
           {{ helpDeskText }}
           <a v-if="helpDeskLink" :href="helpDeskLink" v-text="helpDeskLinkText" />

--- a/packages/web-runtime/src/pages/account.vue
+++ b/packages/web-runtime/src/pages/account.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="uk-width-1-1 uk-container oc-p">
-    <div v-if="loading" class="uk-flex uk-flex-between uk-flex-middle">
+  <div class="oc-width-1-1 oc-container oc-p">
+    <div v-if="loading" class="oc-flex oc-flex-between oc-flex-middle">
       <h1 class="oc-page-title">{{ pageTitle }}</h1>
       <oc-loader />
     </div>
     <template v-else>
-      <div class="uk-flex uk-flex-between uk-flex-middle">
+      <div class="oc-flex oc-flex-between oc-flex-middle">
         <h1 id="account-page-title" v-translate class="oc-page-title">Account</h1>
         <oc-button v-if="editUrl" variation="primary" type="a" :href="editUrl">
           <oc-icon name="edit" />
@@ -19,9 +19,9 @@
       <hr />
       <h2 v-translate class="oc-text-bold oc-text-initial oc-mb">Account Information</h2>
 
-      <dl class="account-page-info uk-flex uk-flex-wrap">
-        <div class="oc-mb uk-width-1-2@s">
-          <dt v-translate class="account-page-info-username uk-text-normal oc-text-muted">
+      <dl class="account-page-info oc-flex oc-flex-wrap">
+        <div class="oc-mb oc-width-1-2@s">
+          <dt v-translate class="account-page-info-username oc-text-normal oc-text-muted">
             Username
           </dt>
           <dd>
@@ -29,30 +29,30 @@
           </dd>
         </div>
         <div v-if="user.username && user.id">
-          <dt v-translate class="account-page-info-userid uk-text-normal oc-text-muted">User ID</dt>
+          <dt v-translate class="account-page-info-userid oc-text-normal oc-text-muted">User ID</dt>
           <dd>
             {{ user.id }}
           </dd>
         </div>
-        <div class="oc-mb uk-width-1-2@s">
-          <dt v-translate class="account-page-info-displayname uk-text-normal oc-text-muted">
+        <div class="oc-mb oc-width-1-2@s">
+          <dt v-translate class="account-page-info-displayname oc-text-normal oc-text-muted">
             Display name
           </dt>
           <dd>
             {{ user.displayname }}
           </dd>
         </div>
-        <div class="oc-mb uk-width-1-2@s">
-          <dt v-translate class="account-page-info-email uk-text-normal oc-text-muted">Email</dt>
+        <div class="oc-mb oc-width-1-2@s">
+          <dt v-translate class="account-page-info-email oc-text-normal oc-text-muted">Email</dt>
           <dd>
             <template v-if="user.email">{{ user.email }}</template>
             <span v-else v-translate>No email has been set up</span>
           </dd>
         </div>
-        <div class="oc-mb uk-width-1-2@s">
+        <div class="oc-mb oc-width-1-2@s">
           <dt
             v-translate
-            class="account-page-info-groups uk-text-normal oc-text-muted"
+            class="account-page-info-groups oc-text-normal oc-text-muted"
             @click="$_oc_settingsAccount_getGroup"
           >
             Group memberships

--- a/packages/web-runtime/src/pages/login.vue
+++ b/packages/web-runtime/src/pages/login.vue
@@ -1,12 +1,11 @@
 <template>
   <div
     v-if="initialized"
-    class="oc-login"
-    uk-height-viewport
+    class="oc-login oc-height-viewport"
     :style="{ backgroundImage: 'url(' + backgroundImg + ')' }"
   >
     <h1 class="oc-invisible-sr">{{ pageTitle }}</h1>
-    <div class="oc-login-card uk-position-center">
+    <div class="oc-login-card oc-position-center">
       <img class="oc-login-logo" :src="logoImg" alt="" :aria-hidden="true" />
       <div class="oc-login-card-body">
         <h2 class="oc-login-card-title">

--- a/packages/web-runtime/src/pages/missingOrInvalidConfig.vue
+++ b/packages/web-runtime/src/pages/missingOrInvalidConfig.vue
@@ -1,7 +1,7 @@
 <template>
-  <div id="Web" class="uk-height-1-1" :style="{ backgroundImage: 'url(' + backgroundImg + ')' }">
-    <div class="oc-login" uk-height-viewport>
-      <div class="oc-login-card uk-position-center">
+  <div id="Web" class="oc-height-1-1" :style="{ backgroundImage: 'url(' + backgroundImg + ')' }">
+    <div class="oc-login oc-height-viewport">
+      <div class="oc-login-card oc-position-center">
         <img class="oc-login-logo" :src="logoImg" alt="" :aria-hidden="true" />
         <div class="oc-login-card-body">
           <h1 v-translate class="oc-login-card-title">Missing or invalid config</h1>

--- a/packages/web-runtime/src/pages/oidcCallback.vue
+++ b/packages/web-runtime/src/pages/oidcCallback.vue
@@ -1,11 +1,10 @@
 <template>
   <div
-    class="oc-login"
+    class="oc-login oc-height-viewport"
     :style="{ backgroundImage: 'url(' + backgroundImg + ')' }"
-    uk-height-viewport
   >
     <h1 class="oc-invisible-sr">{{ pageTitle }}</h1>
-    <div class="oc-login-card uk-position-center">
+    <div class="oc-login-card oc-position-center">
       <img class="oc-login-logo" :src="logoImg" alt="" :aria-hidden="true" />
       <div v-show="error" class="oc-login-card-body">
         <h2 v-translate class="oc-login-card-title">Authentication failed</h2>

--- a/packages/web-runtime/tests/unit/components/Notification.spec.js
+++ b/packages/web-runtime/tests/unit/components/Notification.spec.js
@@ -10,9 +10,9 @@ const testData = {
     ocIconStub: 'oc-icon-stub',
     actionButton: '.oc-ml-s',
     resolveNotificationButton: '#resolve-notification-button',
-    link: '.uk-link',
+    link: '.oc-link',
     subject: 'h4',
-    message: '.uk-text-small'
+    message: '.oc-text-small'
   },
   notifications: {
     emptyActions: [

--- a/packages/web-runtime/tests/unit/components/__snapshots__/ApplicationsMenu.spec.js.snap
+++ b/packages/web-runtime/tests/unit/components/__snapshots__/ApplicationsMenu.spec.js.snap
@@ -2,20 +2,20 @@
 
 exports[`ApplicationsMenu component shoud set aria-label prop on switcher button 1`] = `
 <oc-button-stub type="button" size="medium" arialabel="Application Switcher" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" id="_appSwitcherButton" class="oc-topbar-menu-burger">
-  <oc-icon-stub name="apps" accessiblelabel="" type="span" size="medium" variation="passive" class="uk-flex"></oc-icon-stub>
+  <oc-icon-stub name="apps" accessiblelabel="" type="span" size="medium" variation="passive" class="oc-flex"></oc-icon-stub>
 </oc-button-stub>
 `;
 
 exports[`ApplicationsMenu component should show app menus 1`] = `
-<oc-drop-stub dropid="app-switcher-dropdown" toggle="#_appSwitcherButton" position="bottom-start" mode="click" closeonclick="true" options="[object Object]" class="uk-width-large">
-  <ul uk-grid="" class="uk-grid-small uk-text-center">
-    <li class="uk-width-1-3">
+<oc-drop-stub dropid="app-switcher-dropdown" toggle="#_appSwitcherButton" position="bottom-start" mode="click" closeonclick="true" options="[object Object]" class="oc-width-large">
+  <ul class="oc-list oc-text-center">
+    <li class="oc-width-1-3">
       <router-link-stub to="/files" tag="a" ariacurrentvalue="page" event="click">
-        <oc-icon-stub name="folder" accessiblelabel="" type="span" size="xlarge" variation="passive"></oc-icon-stub> <span class="uk-display-block">Files</span>
+        <oc-icon-stub name="folder" accessiblelabel="" type="span" size="xlarge" variation="passive"></oc-icon-stub> <span class="oc-display-block">Files</span>
       </router-link-stub>
     </li>
-    <li class="uk-width-1-3"><a target="_blank" href="http://some.org">
-        <oc-icon-stub name="some-icon" accessiblelabel="" type="span" size="xlarge" variation="passive"></oc-icon-stub> <span class="uk-display-block">External</span>
+    <li class="oc-width-1-3"><a target="_blank" href="http://some.org">
+        <oc-icon-stub name="some-icon" accessiblelabel="" type="span" size="xlarge" variation="passive"></oc-icon-stub> <span class="oc-display-block">External</span>
       </a></li>
   </ul>
 </oc-drop-stub>

--- a/packages/web-runtime/tests/unit/components/__snapshots__/FeedbackLink.spec.js.snap
+++ b/packages/web-runtime/tests/unit/components/__snapshots__/FeedbackLink.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FeedbackLink component has no accessibility violations 1`] = `
-<div class="uk-flex uk-flex-middle"><a aria-label="ownCloud feedback survey" href="https://owncloud.com/web-design-feedback" class="oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" target="_blank" aria-describedby="oc-feedback-link-description"><span class="oc-icon oc-icon-m oc-icon-passive"><svg height="24" width="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"> <path xmlns="http://www.w3.org/2000/svg" d="M20 2H4c-1.1 0-1.99.9-1.99 2L2 22l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-7 12h-2v-2h2v2zm0-4h-2V6h2v4z"></path> </svg></span></a>
+<div class="oc-flex oc-flex-middle"><a aria-label="ownCloud feedback survey" href="https://owncloud.com/web-design-feedback" class="oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" target="_blank" aria-describedby="oc-feedback-link-description"><span class="oc-icon oc-icon-m oc-icon-passive"><svg height="24" width="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"> <path xmlns="http://www.w3.org/2000/svg" d="M20 2H4c-1.1 0-1.99.9-1.99 2L2 22l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-7 12h-2v-2h2v2zm0-4h-2V6h2v4z"></path> </svg></span></a>
   <p id="oc-feedback-link-description" class="oc-invisible-sr">Provide your feedback: We'd like to improve the web design and would be happy to hear your feedback. Thank you! Your ownCloud team.</p>
 </div>
 `;

--- a/packages/web-runtime/tests/unit/components/__snapshots__/TopBar.spec.js.snap
+++ b/packages/web-runtime/tests/unit/components/__snapshots__/TopBar.spec.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Top Bar component Displays applications menu 1`] = `
-<header aria-label="Top bar" class="oc-topbar uk-flex uk-flex-middle uk-flex-wrap oc-border-b oc-p-s">
+<header aria-label="Top bar" class="oc-topbar oc-flex oc-flex-middle oc-flex-wrap oc-border-b oc-p-s">
   <oc-grid-stub gutter="medium" flex="">
-    <div class="uk-hidden@l">
+    <div class="oc-hidden@l">
       <oc-button-stub appearance="raw" aria-label="Open navigation menu" class="oc-m-s oc-app-navigation-toggle">
         <oc-icon-stub name="menu"></oc-icon-stub>
       </oc-button-stub>
@@ -12,7 +12,7 @@ exports[`Top Bar component Displays applications menu 1`] = `
   <div class="portal-wrapper">
     <portal-target-stub name="app.runtime.header" multiple=""></portal-target-stub>
   </div>
-  <oc-grid-stub flex="" gutter="small" class="uk-width-expand uk-flex-right oc-m-rm">
+  <oc-grid-stub flex="" gutter="small" class="oc-width-expand oc-flex-right oc-m-rm">
     <feedback-link-stub></feedback-link-stub>
     <!---->
     <applications-menu-stub applicationslist="testApp"></applications-menu-stub>

--- a/tests/acceptance/pageObjects/personalPage.js
+++ b/tests/acceptance/pageObjects/personalPage.js
@@ -399,7 +399,7 @@ module.exports = {
       selector: '#copy-selected-btn'
     },
     editorCloseBtn: {
-      selector: '#markdown-editor-app-bar .uk-text-right .oc-button'
+      selector: '#markdown-editor-app-bar .oc-text-right .oc-button'
     },
     clearSelectionBtn: {
       selector: '#files-clear-selection'

--- a/tests/acceptance/pageObjects/publicLinkPasswordPage.js
+++ b/tests/acceptance/pageObjects/publicLinkPasswordPage.js
@@ -58,7 +58,7 @@ module.exports = {
       locateStrategy: 'xpath'
     },
     loadingPublicLink: {
-      selector: "//div[@class='oc-login-card uk-position-center']//span[.='Loading public link…']",
+      selector: "//div[@class='oc-login-card oc-position-center']//span[.='Loading public link…']",
       locateStrategy: 'xpath'
     },
     loginCardDialogBox: {

--- a/tests/acceptance/pageObjects/webPage.js
+++ b/tests/acceptance/pageObjects/webPage.js
@@ -236,11 +236,11 @@ module.exports = {
   elements: {
     message: {
       selector:
-        '//*[contains(@class, "uk-notification-message")]/div/div[contains(@class, "oc-notification-message-title")]',
+        '//*[contains(@class, "oc-notification-message")]/div/div[contains(@class, "oc-notification-message-title")]',
       locateStrategy: 'xpath'
     },
     messages: {
-      selector: '//*[contains(@class, "uk-notification-message")]',
+      selector: '//*[contains(@class, "oc-notification-message")]',
       locateStrategy: 'xpath'
     },
     clearErrorMessage: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14912,13 +14912,6 @@ typescript@^4.3.2:
   languageName: node
   linkType: hard
 
-"uikit@npm:3.5.16":
-  version: 3.5.16
-  resolution: "uikit@npm:3.5.16"
-  checksum: 25ad7958567666c82b7e876af34ba56747e2649d296efcfe845560c871a36af4c6ea3adde5e7f2cb588efe62b92fa34fced68989c1aa3a3be3981249d5ad8a2e
-  languageName: node
-  linkType: hard
-
 "unbox-primitive@npm:^1.0.1":
   version: 1.0.1
   resolution: "unbox-primitive@npm:1.0.1"
@@ -15524,7 +15517,6 @@ typescript@^4.3.2:
     query-string: ^6.8.3
     tippy.js: ^6.3.1
     tus-js-client: ^1.8.0
-    uikit: 3.5.16
     v-calendar: ^2.3.2
     vue: ^2.6.10
     vue-async-computed: ^3.9.0


### PR DESCRIPTION
## Description
This PR goes hand-in-hand with https://github.com/owncloud/owncloud-design-system/pull/1658

## Issues
- [ ] Could be that it fixes #5431 since it removes UiKits animation classes
- [ ] Fixes #6103

## Types of changes
- [X] Technical debt

## Checklist:
- [X] Code changes
- [X] Unit tests updated

## Open tasks:
- [ ] Decide what to do with `uk-animation-**` stuff
- [ ] Refactor focus management in ApplicationsMenu component (which was using UiKit utils) 
