### PR TITLE
[tests-only] Do not retry failed acceptance tests in cron nightly

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1223,7 +1223,7 @@ def acceptance(ctx):
                         steps += copyFilesForUpload()
 
                         # run the acceptance tests
-                        steps += runWebuiAcceptanceTests(suite, alternateSuiteName, params["filterTags"], params["extraEnvironment"], browser, params["visualTesting"], params["screenShots"])
+                        steps += runWebuiAcceptanceTests(ctx, suite, alternateSuiteName, params["filterTags"], params["extraEnvironment"], browser, params["visualTesting"], params["screenShots"])
 
                         # capture the screenshots from visual regression testing (only runs on failure)
                         if (params["visualTesting"]):
@@ -2115,7 +2115,7 @@ def copyFilesForUpload():
         ],
     }]
 
-def runWebuiAcceptanceTests(suite, alternateSuiteName, filterTags, extraEnvironment, browser, visualTesting, screenShots):
+def runWebuiAcceptanceTests(ctx, suite, alternateSuiteName, filterTags, extraEnvironment, browser, visualTesting, screenShots):
     environment = {}
     if (filterTags != ""):
         environment["TEST_TAGS"] = filterTags
@@ -2140,6 +2140,8 @@ def runWebuiAcceptanceTests(suite, alternateSuiteName, filterTags, extraEnvironm
             "from_secret": "sauce_access_key",
         }
 
+    if ctx.build.event == "cron":
+        environment["RERUN_FAILED_WEBUI_SCENARIOS"] = "false"
     if (visualTesting):
         environment["VISUAL_TEST"] = "true"
     if (screenShots):

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -35,6 +35,12 @@ do
 	shift
 done
 
+# Default to retrying failing tests
+if [ -z "${RERUN_FAILED_WEBUI_SCENARIOS}" ]
+then
+	RERUN_FAILED_WEBUI_SCENARIOS=true
+fi
+
 # An array of the suites that were run. Each value is a string like:
 # webUILogin
 # webUIPrivateLinks
@@ -161,7 +167,16 @@ then
 	TEST_PATHS+=( "${FEATURES_DIR}" )
 fi
 
-RUN_ACCEPTANCE_TESTS="cucumber-js --retry 1 --require-module @babel/register --require-module @babel/polyfill --require setup.js --require stepDefinitions --format @cucumber/pretty-formatter"
+if [ "${RERUN_FAILED_WEBUI_SCENARIOS}" = true ]
+then
+	RETRY_OPTION="--retry 1"
+	echo "Failing tests will be automatically retried once"
+else
+	RETRY_OPTION=" "
+	echo "Failing tests will not be retried"
+fi
+
+RUN_ACCEPTANCE_TESTS="cucumber-js ${RETRY_OPTION} --require-module @babel/register --require-module @babel/polyfill --require setup.js --require stepDefinitions --format @cucumber/pretty-formatter"
 
 if [ -z "${TEST_TAGS}" ]
 then


### PR DESCRIPTION
## Description
PR #5409 tries to report failed scenarios to RocketChat when a scenario fails and has to be rerun. That would be useful in the nightly CI run, because in that case there is no PR to post a comment to on GitHub. But that had difficulty getting a flexible message to be posted (rather than just a pass/fail kind of message)

Rather than keep trying to achieve individual RocketChat notifications for each failed test, this PR simply runs the nightly CI without the `--retry 1` parameter. Any test scenario(s) that fails will cause the drone pipeline to fail. When the whole nightly job finishes it reports overall success or failure to RocketChat already. (That is like what all the other nightly jobs do in other repos). When we see a nightly failure in RocketChat it has a link to drone. We can follow that link and easily see which pipelines failed, and which test scenario(s) failed in the pipeline.

We will get failure for any test that fails the first time. And we want to know about those possibly intermittent tests so that we can work to improve them.

## How Has This Been Tested?
I ran PR #5978 with the retry logic on and ff to check that both work.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
