### PR TITLE
A11y fix logical keyboard order

### DIFF
--- a/packages/web-app-files/src/components/PublicLinksSidebar/EditPublicLink.vue
+++ b/packages/web-app-files/src/components/PublicLinksSidebar/EditPublicLink.vue
@@ -39,7 +39,7 @@
               id="oc-files-file-link-expire-date-delete"
               class="oc-mt-s"
               appearance="raw"
-              @click="expireDate = null"
+              @click="focusDatepicker"
               v-text="$gettext('Remove expiration date')"
             />
           </div>
@@ -282,6 +282,14 @@ export default {
     ...mapActions('Files', ['addLink', 'updateLink']),
     ...mapMutations('Files', ['SET_APP_SIDEBAR_ACCORDION_CONTEXT']),
 
+    focusDatepicker() {
+      this.expireDate = null
+      this.$nextTick(() => {
+        console.log('DATEPICKER: ', this.$refs.datepicker)
+        document.getElementById('oc-files-file-link-expire-date').click()
+      })
+    },
+
     setRole() {
       const permissions = parseInt(this.publicLinkInEdit.permissions, 10)
 
@@ -364,6 +372,7 @@ export default {
         })
     },
 
+    // TODO: Focus button with id editButtonLabel
     $_closeForm() {
       this.SET_APP_SIDEBAR_ACCORDION_CONTEXT('showLinks')
     },

--- a/packages/web-app-files/src/components/PublicLinksSidebar/LinkActions.vue
+++ b/packages/web-app-files/src/components/PublicLinksSidebar/LinkActions.vue
@@ -9,7 +9,7 @@
         class="oc-files-file-link-edit oc-mr-xs"
         @click="editLink"
       >
-        <oc-icon name="edit" />
+        <oc-icon id="editButtonLabel" name="edit" />
       </oc-button>
       <oc-button
         v-oc-tooltip="deleteButtonLabel"


### PR DESCRIPTION
## Description
Focus certain elements when clicking certain buttons (more detailed info in related issue).

## Related Issue
- Works towards https://github.com/owncloud/web/issues/5392

## How Has This Been Tested?
- Works in Chrome, Firefox, Safari and Edge

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- Need help to focus "Bearbeite öffentlichen Link" button. Problem: Focus only works on `svg`element inside of `OcIcon` component, not sure how to target it. Also focussing via focus() method won't trigger the tooltip.
- Need help to focus "Neu" button. Problem: Focussing it with `document.getElementById('new-file-menu-btn').focus()`doesn't have any effect, althoug `document.getElementById('new-file-menu-btn').click()` is working.
