### PR TITLE
Reduce sidebar width in files app

### DIFF
--- a/changelog/unreleased/enhancement-files-sidebar-reduced-width
+++ b/changelog/unreleased/enhancement-files-sidebar-reduced-width
@@ -1,0 +1,6 @@
+Enhancement: Reduced sidebar width
+
+We reduced the sidebar width to give the files list more horizontal room, especially on medium sized screens.
+
+https://github.com/owncloud/web/issues/5981
+https://github.com/owncloud/web/pull/5983

--- a/packages/web-app-files/src/App.vue
+++ b/packages/web-app-files/src/App.vue
@@ -15,7 +15,7 @@
       id="files-sidebar"
       ref="filesSidebar"
       tabindex="-1"
-      class="uk-width-1-1 uk-width-1-2@m uk-width-1-3@xl"
+      class="uk-width-1-1 uk-width-1-3@m uk-width-1-4@xl"
       @beforeDestroy="focusSideBar"
       @mounted="focusSideBar"
       @fileChanged="focusSideBar"

--- a/packages/web-app-files/src/components/SideBar/FileInfo.vue
+++ b/packages/web-app-files/src/components/SideBar/FileInfo.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="file_info">
     <oc-icon :name="file.icon" size="large" class="file_info__icon" />
-    <div class="file_info__body">
+    <div class="file_info__body oc-text-overflow">
       <h3 tabindex="-1">
         <oc-resource-name
           :name="file.name"


### PR DESCRIPTION
## Description
The right sidebar now only takes 1/3 of the width on medium and large
viewports and 1/4 of the width on extra large viewports. It doesn't need
more horizontal space. See screenshots.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/5981

## Screenshots
<img width="1603" alt="Screenshot 2021-11-05 at 14 26 31" src="https://user-images.githubusercontent.com/3532843/140518744-0091b048-b953-42d1-ad33-eafe764ce7c5.png">
<img width="1345" alt="Screenshot 2021-11-05 at 14 28 50" src="https://user-images.githubusercontent.com/3532843/140518757-676b620e-1c99-4544-992d-5f48f230c4b4.png">
<img width="1204" alt="Screenshot 2021-11-05 at 14 29 06" src="https://user-images.githubusercontent.com/3532843/140518762-b1263ff5-b1f3-42ff-a0a7-e105396250cc.png">
<img width="973" alt="Screenshot 2021-11-05 at 14 29 25" src="https://user-images.githubusercontent.com/3532843/140518763-8c87efcf-48a2-49a6-ae9f-5872055301c2.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
