### PR TITLE
Performance improvements

### DIFF
--- a/packages/web-app-files/src/views/Personal.vue
+++ b/packages/web-app-files/src/views/Personal.vue
@@ -165,9 +165,12 @@ export default {
         })
 
         // Load quota
-        const user = yield ref.$client.users.getUser(ref.user.id)
-
-        ref.SET_QUOTA(user.quota)
+        const promiseUser = ref.$client.users.getUser(ref.user.id)
+        // The semicolon is important to separate from the previous statement
+        ;(async () => {
+          const user = await promiseUser
+          ref.SET_QUOTA(user.quota)
+        })()
       } catch (error) {
         ref.SET_CURRENT_FOLDER(null)
         console.error(error)

--- a/packages/web-container/index.html.ejs
+++ b/packages/web-container/index.html.ejs
@@ -7,9 +7,14 @@
   <title><%= data.title %></title>
   <link rel="manifest" href="manifest.json" crossorigin="use-credentials">
   <% Object.keys(data.bundle.css).forEach((s) => { %>
-    <link href="<%- data.bundle.css[s] %>" rel="stylesheet">
+    <link href="<%- data.bundle.css[s] %>?<%= data.compilationTimestamp %>" rel="stylesheet">
   <% }); %>
-  <script src="js/require.js"></script>
+  <% if (data.config.cdn) { %>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"></script>
+  <script>if (typeof requirejs === 'undefined') { document.write('<script src="js/require.js?<%= data.compilationTimestamp %>">\x3C/script>') }</script>
+  <% } else { %>
+  <script src="js/require.js?<%= data.compilationTimestamp %>"></script>
+  <% } %>
   <style>
     .splash-banner {
       display: flex;

--- a/packages/web-container/index.html.ejs
+++ b/packages/web-container/index.html.ejs
@@ -68,7 +68,8 @@
     } else {
       requirejs.config({
         baseUrl: <%- JSON.stringify(data.roots.js) %>,
-        paths: <%- JSON.stringify(data.bundle.js) %>
+        paths: <%- JSON.stringify(data.bundle.js) %>,
+        ...<%- JSON.stringify(data.config.requirejs) %>
       })
 
       requirejs(['web-runtime'], function (runtime) {

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -71,16 +71,20 @@ export const announceStore = async ({
  *
  * @param runtimeConfiguration
  */
-export const announceClient = async (runtimeConfiguration: RuntimeConfiguration): Promise<void> => {
+export const announceClient = (runtimeConfiguration: RuntimeConfiguration): Promise<void> => {
   const { openIdConnect = {} } = runtimeConfiguration
 
   if (!openIdConnect.dynamic) {
     return
   }
 
-  const { client_id: clientId, client_secret: clientSecret } = await registerClient(openIdConnect)
-  openIdConnect.client_id = clientId
-  openIdConnect.client_secret = clientSecret
+  const promiseRegistration = registerClient(openIdConnect)
+
+  promiseRegistration.then(({ client_id: clientId, client_secret: clientSecret }) => {
+    openIdConnect.client_id = clientId
+    openIdConnect.client_secret = clientSecret
+  })
+  return promiseRegistration
 }
 
 /**
@@ -95,7 +99,7 @@ export const announceClient = async (runtimeConfiguration: RuntimeConfiguration)
  * @param translations
  * @param supportedLanguages
  */
-export const announceApplications = async ({
+export const announceApplications = ({
   runtimeConfiguration,
   store,
   router,
@@ -107,7 +111,7 @@ export const announceApplications = async ({
   router: VueRouter
   translations: unknown
   supportedLanguages: { [key: string]: string }
-}): Promise<void> => {
+}): Promise<any> => {
   const { apps: internalApplications = [], external_apps: externalApplications = [] } =
     runtimeConfiguration
 
@@ -116,31 +120,31 @@ export const announceApplications = async ({
     ...externalApplications.map((application) => application.path)
   ].filter(Boolean)
 
-  const applicationResults = await Promise.allSettled(
-    applicationPaths.map((applicationPath) =>
-      buildApplication({
-        applicationPath,
-        store,
-        supportedLanguages,
-        router,
-        translations
+  const registerApp = (applicationPath) => {
+    const promiseBuild = buildApplication({
+      applicationPath,
+      store,
+      supportedLanguages,
+      router,
+      translations
+    })
+
+    promiseBuild
+      .then((application) => {
+        application.initialize().then(() => {
+          application.ready()
+        })
       })
-    )
-  )
+      .catch((reason) => {
+        console.error(reason)
+      })
 
-  const applications = applicationResults.reduce<NextApplication[]>((acc, applicationResult) => {
-    // we don't want to fail hard with the full system when one specific application can't get loaded. only log the error.
-    if (applicationResult.status !== 'fulfilled') {
-      console.error(applicationResult.reason)
-    } else {
-      acc.push(applicationResult.value)
-    }
+    return promiseBuild
+  }
 
-    return acc
-  }, [])
+  const promiseInternalApps = applicationPaths.map(registerApp)
 
-  await Promise.all(applications.map((application) => application.initialize()))
-  await Promise.all(applications.map((application) => application.ready()))
+  return Promise.allSettled(promiseInternalApps)
 }
 
 /**
@@ -152,7 +156,7 @@ export const announceApplications = async ({
  * @param vue
  * @param designSystem
  */
-export const announceTheme = async ({
+export const announceTheme = ({
   store,
   vue,
   designSystem,
@@ -163,13 +167,15 @@ export const announceTheme = async ({
   designSystem: any
   runtimeConfiguration?: RuntimeConfiguration
 }): Promise<void> => {
-  const { theme } = await loadTheme(runtimeConfiguration?.theme)
-  await store.dispatch('loadThemes', { theme })
-  await store.dispatch('loadTheme', { theme: theme.default })
-
-  vue.use(designSystem, {
-    tokens: store.getters.theme.designTokens
+  const promiseLoad = loadTheme(runtimeConfiguration?.theme)
+  promiseLoad.then(async ({ theme }) => {
+    await store.dispatch('loadThemes', { theme })
+    await store.dispatch('loadTheme', { theme: theme.default })
+    vue.use(designSystem, {
+      tokens: store.getters.theme.designTokens
+    })
   })
+  return promiseLoad
 }
 
 /**

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -22,18 +22,22 @@ import {
 
 export const bootstrap = async (configurationPath: string): Promise<void> => {
   const runtimeConfiguration = await requestConfiguration(configurationPath)
-  announceOwncloudSDK({ vue: Vue, runtimeConfiguration })
-  await announceClient(runtimeConfiguration)
-  await announceStore({ vue: Vue, store, runtimeConfiguration })
-  await announceApplications({
+  const promiseOcSDK = announceOwncloudSDK({ vue: Vue, runtimeConfiguration }) // vue.$client
+  const promiseClient = announceClient(runtimeConfiguration) // oidc client
+  const promiseTheme = announceTheme({ store, vue: Vue, designSystem, runtimeConfiguration })
+  await promiseOcSDK
+  await promiseClient
+  await announceStore({ vue: Vue, store, runtimeConfiguration }) // REQUIRES $client and oidc
+  const promiseApplications = announceApplications({
     runtimeConfiguration,
     store,
     supportedLanguages,
     router,
     translations
   })
+  await promiseTheme
+  await promiseApplications
   announceTranslations({ vue: Vue, supportedLanguages, translations })
-  await announceTheme({ store, vue: Vue, designSystem, runtimeConfiguration })
   announceDefaults({ store, router })
 }
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,6 +26,13 @@ const production = !process.env.ROLLUP_WATCH
 const sourcemap = process.env.SOURCE_MAP === 'true'
 const { version } = require('./package.json')
 
+const config = {
+  requirejs: {}
+}
+if (process.env.REQUIRE_TIMEOUT) {
+  config.requirejs.waitSeconds = parseInt(process.env.REQUIRE_TIMEOUT)
+}
+
 const plugins = [
   del({
     runOnce: true,
@@ -146,7 +153,8 @@ const plugins = [
               roots: {
                 css: 'css',
                 js: 'js'
-              }
+              },
+              config: config
             }
           },
           {},

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,9 +25,11 @@ import inject from '@rollup/plugin-inject'
 const production = !process.env.ROLLUP_WATCH
 const sourcemap = process.env.SOURCE_MAP === 'true'
 const { version } = require('./package.json')
+const compilationTimestamp = new Date().getTime()
 
 const config = {
-  requirejs: {}
+  requirejs: {},
+  cdn: process.env.CDN === 'true'
 }
 if (process.env.REQUIRE_TIMEOUT) {
   config.requirejs.waitSeconds = parseInt(process.env.REQUIRE_TIMEOUT)
@@ -154,7 +156,8 @@ const plugins = [
                 css: 'css',
                 js: 'js'
               },
-              config: config
+              config: config,
+              compilationTimestamp: compilationTimestamp
             }
           },
           {},


### PR DESCRIPTION
I'm not very knowledgeable on these things, so please let me know if I'm messing this up...

We had massive performance issues with CERNBox. One of the first things we did was to serve the web behind nginx with caching headers for all these files (this needs to be implemented in `ocis-web`, which for now just has a "TODO" in the code). Since the extensions already have the hash in their name, this works perfectly. I don't know if we can do the same for the css file? For now I just appended the timestamp of the build to ensure the update is properly handled by the browser.

(The second thing we did was to finally separate all our extensions from the fork... They were there for convenience, but the dependencies created a huuuge chunks file. This was our fault, so nothing to fix here :) )

One of the issues our users saw was the browser timing out when loading the chunks file, so we increased the timeout of requirejs. This doesn't seem necessary anymore, as the file is now smaller, but I think it can still be kept.

On the subject of requirejs, we've used a CDN instead of the one copied locally. This, besides potentially being cached already, is a minimized version. If the CDN is not available (running locally without connectivity?), We still fallback to the local one.

The rest of the changes were essentially to parallelize the calls to the backend. Since you await everything immediately, even things without dependencies between themselves, this means that the requests will be sequential. This speeds ups the first loading. So: load early, await when really needed.
When loading the apps, we distinguish between internal and external: we never wait for the externals to be loaded and continue the run, as they will be registered eventually. Please confirm wether this is acceptable or not.

~~When opening for the first time, instead of waiting for everything to load before redirecting to the idp, we just abort the loading and redirect. We've seen errors in the console because there were things trying to use methods that were not available yet... So this is more an idea of what we think needs to be done, but the implementation details still need to be tuned.~~ (removed this after the latest upstream changes messed with it)

Lastly, when PROPFINDING, we decided to show the result as soon as the response arrives, and load the shares information after. But I guess that this info will come with the PROPFIND soon so this fix won't be necessary.

This was just a first attempt but we're quite happy with the performance now. But I guess there are still many improvements that can be done and some issues that were reported and need to be fixed (multiple repeated requests, for example). On this last topic: https://github.com/owncloud/owncloud-sdk/pull/933