### PR TITLE
rename _chunks folder to chunks folder

### DIFF
--- a/changelog/unreleased/enhancement-chunks-folder
+++ b/changelog/unreleased/enhancement-chunks-folder
@@ -1,0 +1,5 @@
+Enhancement: Rename `_chunks` folder to `chunks`
+
+We've renamed the `_chunks` folder to `chunks` in the ownCloud Web build output in order to make it more easily embedable with the Go embed directive.
+
+https://github.com/owncloud/web/pull/5988

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -197,7 +197,7 @@ export default {
   output: {
     dir: 'dist',
     format: 'amd',
-    chunkFileNames: path.join('js', '_chunks', production ? '[name]-[hash].js' : '[name].js'),
+    chunkFileNames: path.join('js', 'chunks', production ? '[name]-[hash].js' : '[name].js'),
     entryFileNames: path.join('js', production ? '[name]-[hash].js' : '[name].js')
   },
   manualChunks: id => {


### PR DESCRIPTION
## Description
oCIS uses Go embedd directives to include oC Web into it's binary.
Go embed ignores dot files and files starting with a underscore by default. You can also include them by using a `*` but that is only valid for the current path segment (not for subfolders).

oC Web has  a `_chunks` folder which will not be embedded in this case by default. Therefore we have the extra `assets/js/*` rule.

https://github.com/owncloud/ocis/blob/2c4bd9005ec26cddabefeb63af7e841d67bbd2f9/web/web.go#L7-L9

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/pull/2730

## Motivation and Context
I there is no reasoning / convention behind the name of the `_chunks` folder, I would like to rename it to `chunks` and simplify the Go embed rule on the oCIS side.

## How Has This Been Tested?
- CI