### PR TITLE
Remove vue-axe to reduce bundle size

### DIFF
--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -29,7 +29,6 @@
     "v-calendar": "^2.3.2",
     "vue": "^2.6.10",
     "vue-async-computed": "^3.9.0",
-    "vue-axe": "^2.4.4",
     "vue-concurrency": "^2.2.1",
     "vue-drag-drop": "^1.1.4",
     "vue-events": "^3.1.0",

--- a/packages/web-runtime/src/defaults/vue.js
+++ b/packages/web-runtime/src/defaults/vue.js
@@ -15,7 +15,6 @@ import Vue2TouchEvents from 'vue2-touch-events'
 import PortalVue from 'portal-vue'
 import AsyncComputed from 'vue-async-computed'
 import { Drag, Drop } from 'vue-drag-drop'
-import VueAxe from 'vue-axe'
 import VueRouter from 'vue-router'
 import Vuex from 'vuex'
 import VueCompositionAPI from '@vue/composition-api'
@@ -35,12 +34,6 @@ Vue.use(ChunkedUpload)
 Vue.use(Vue2TouchEvents)
 Vue.use(PortalVue)
 Vue.use(AsyncComputed)
-
-if (process.env.NODE_ENV === 'development') {
-  Vue.use(VueAxe, {
-    allowConsoleClears: false
-  })
-}
 
 Vue.component('drag', Drag)
 Vue.component('drop', Drop)

--- a/yarn.lock
+++ b/yarn.lock
@@ -15235,15 +15235,6 @@ typescript@^4.3.2:
   languageName: node
   linkType: hard
 
-"vue-axe@npm:^2.4.4":
-  version: 2.4.4
-  resolution: "vue-axe@npm:2.4.4"
-  peerDependencies:
-    axe-core: 3.x || 4.x
-  checksum: 6e078ad12a8bbc970fcc574d197650528fbad627301c3301b442f3cd8ed410b312085de045dda379b54e937f06ee254d7dee1d77fba16f6f3c25bcb64f4e65db
-  languageName: node
-  linkType: hard
-
 "vue-concurrency@npm:^2.2.1":
   version: 2.2.1
   resolution: "vue-concurrency@npm:2.2.1"
@@ -15528,7 +15519,6 @@ typescript@^4.3.2:
     v-calendar: ^2.3.2
     vue: ^2.6.10
     vue-async-computed: ^3.9.0
-    vue-axe: ^2.4.4
     vue-concurrency: ^2.2.1
     vue-drag-drop: ^1.1.4
     vue-events: ^3.1.0


### PR DESCRIPTION
## Description
We used vue-axe for the accessibility audit (where it was helpful) but can't omit it from the production bundle (and it's not that much of a help currently) hence we'll remove it for now

## Related Issue
- Fixes #5342

## Motivation and Context
Reduce bundle size

