### PR TITLE
Automatically show oC10 apps in app switcher menu

### DIFF
--- a/changelog/unreleased/enhancement-oc10-apps-in-app-switcher
+++ b/changelog/unreleased/enhancement-oc10-apps-in-app-switcher
@@ -1,0 +1,4 @@
+Enhancement: Automatically show oC 10 apps in the app switcher menu
+
+https://github.com/owncloud/web/issues/5980
+https://github.com/owncloud/web/pull/5996

--- a/changelog/unreleased/enhancement-oc10-apps-in-app-switcher
+++ b/changelog/unreleased/enhancement-oc10-apps-in-app-switcher
@@ -1,4 +1,6 @@
 Enhancement: Automatically show oC 10 apps in the app switcher menu
 
+When using the ownCloud 10 app of web the configuration automatically gets augmented with all menu items / apps from the classic UI. They open in a new tab in the classic UI and have a generic icon.
+
 https://github.com/owncloud/web/issues/5980
 https://github.com/owncloud/web/pull/5996

--- a/changelog/unreleased/enhancement-update-ods
+++ b/changelog/unreleased/enhancement-update-ods
@@ -1,11 +1,13 @@
-Enhancement: Update ODS to v11.2.1
+Enhancement: Update ODS to v11.2.2
 
-We updated the ownCloud Design System to version 11.2.1. Please refer to the full changelog in the ODS release (linked) for more details. Summary:
+We updated the ownCloud Design System to version 11.2.2. Please refer to the full changelog in the ODS release (linked) for more details. Summary:
 
 - Bugfix - Limit select event in OcTableFiles: https://github.com/owncloud/owncloud-design-system/pull/1753
 - Bugfix - Add word-break rule to OcNotificationMessage component: https://github.com/owncloud/owncloud-design-system/issues/1712
 - Bugfix - OcTable sorting case sensitivity: https://github.com/owncloud/owncloud-design-system/issues/1698
 - Bugfix - Drag and Drop triggers wrong actions: https://github.com/owncloud/web/issues/5808
+- Bugfix - Fix files table event: https://github.com/owncloud/web/issues/1777
+- Bugfix - Fix extension icon rendering: https://github.com/owncloud/web/issues/1779
 - Enhancement - Make OcDatepicker themable: https://github.com/owncloud/owncloud-design-system/issues/1679
 - Enhancement - Streamline OcTextInput: https://github.com/owncloud/owncloud-design-system/pull/1636
 - Enhancement - Add accentuated class for OcTable: https://github.com/owncloud/owncloud-design-system/pull/5967
@@ -15,4 +17,4 @@ We updated the ownCloud Design System to version 11.2.1. Please refer to the ful
 - Enhancement - Reduce filename text weight: https://github.com/owncloud/owncloud-design-system/pull/1759
 
 https://github.com/owncloud/web/pull/6009
-https://github.com/owncloud/owncloud-design-system/releases/tag/v11.2.1
+https://github.com/owncloud/owncloud-design-system/releases/tag/v11.2.2

--- a/docs/deployments/oc10-app.md
+++ b/docs/deployments/oc10-app.md
@@ -138,7 +138,11 @@ If you use OpenID Connect you need to replace the `"auth"` part with following c
 
 ## Integrate ownCloud Classic features in ownCloud Web
 ### Add links to the app switcher
-ownCloud Classic features that are not deeply integrated with the Classic UI (e.g., full screen apps) can be added to the ownCloud Web app switcher so that users can easily access them from ownCloud Web. You can use the following example and customize it according to your needs. 
+ownCloud Classic features that are not deeply integrated with the Classic UI (e.g., full screen apps) can be added to the ownCloud Web app switcher so that users can easily access them from ownCloud Web. You can use the following example and customize it according to your needs.
+
+{{< hint info >}}
+All apps that are listed in the ownCloud Classic app switcher will be added as links to the app switcher of the new ownCloud Web automatically. All of those links will open in a new browser tab on click.
+{{< /hint >}}
 
 To add new elements in the app switcher, paste the following into the `applications` section of `config.json`:
 

--- a/packages/web-integration-oc10/lib/Controller/ConfigController.php
+++ b/packages/web-integration-oc10/lib/Controller/ConfigController.php
@@ -22,7 +22,6 @@
 namespace OCA\Web\Controller;
 
 use OC\AppFramework\Http;
-use OC\NavigationManager;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
@@ -42,11 +41,6 @@ class ConfigController extends Controller {
     private $logger;
 
     /**
-     * @var NavigationManager
-     */
-    private $navigationManager;
-
-    /**
      * @var IAppManager
      */
     private $appManager;
@@ -57,13 +51,11 @@ class ConfigController extends Controller {
      * @param string $appName
      * @param IRequest $request
      * @param ILogger $logger
-     * @param NavigationManager $navigationManager
      * @param IAppManager $appManager
      */
-    public function __construct(string $appName, IRequest $request, ILogger $logger, NavigationManager $navigationManager, IAppManager $appManager) {
+    public function __construct(string $appName, IRequest $request, ILogger $logger, IAppManager $appManager) {
         parent::__construct($appName, $request);
         $this->logger = $logger;
-        $this->navigationManager = $navigationManager;
         $this->appManager = $appManager;
     }
 
@@ -102,7 +94,7 @@ class ConfigController extends Controller {
      */
     private function addAppsToConfig(array $config): array {
         $apps = $config['applications'] ?? [];
-        $oc10NavigationEntries = $this->navigationManager->getAll();
+        $oc10NavigationEntries = \OC::$server->getNavigationManager()->getAll();
         $ignoredApps = ['files', 'web'];
         $appsToAdd = [];
         $serverUrl = $this->request->getServerProtocol() . '://' . $this->request->getServerHost();

--- a/packages/web-integration-oc10/lib/Controller/ConfigController.php
+++ b/packages/web-integration-oc10/lib/Controller/ConfigController.php
@@ -93,14 +93,13 @@ class ConfigController extends Controller {
      * @return array
      */
     private function addAppsToConfig(array $config): array {
-        $appsInConfig = $config['applications'] ?? [];
+        $apps = $config['applications'] ?? [];
 
         $oc10NavigationEntries = \OC::$server->getNavigationManager()->getAll();
         $serverUrl = $this->request->getServerProtocol() . '://' . $this->request->getServerHost();
 
         $ignoredApps = ['files', 'web'];
         $supportedLanguages = ['en', 'fr', 'de', 'es', 'it', 'cs', 'gl'];
-        $appsToAdd = [];
 
         foreach ($oc10NavigationEntries as $navigationEntry) {
             if (\in_array($navigationEntry['id'], $ignoredApps)) {
@@ -115,15 +114,14 @@ class ConfigController extends Controller {
                 $titles[$lang] = $l10n->t($appInfo['name']);
             }
 
-            $appsToAdd[] = [
+            $apps[] = [
                 'title' => $titles,
                 'url' => $serverUrl . $navigationEntry['href'],
                 'icon' => 'extension',
             ];
         }
 
-        // apps in config.json have higher prio
-        $config['applications'] = \array_merge($appsToAdd, $appsInConfig);
+        $config['applications'] = $apps;
         return $config;
     }
 }

--- a/packages/web-integration-oc10/lib/Controller/ConfigController.php
+++ b/packages/web-integration-oc10/lib/Controller/ConfigController.php
@@ -72,7 +72,7 @@ class ConfigController extends Controller {
             $configFile = \OC::$SERVERROOT . '/config/config.json';
             $configContent = \file_get_contents($configFile);
             $configAssoc = \json_decode($configContent, true);
-            $extendedConfig = $this->addAppsToConfig($configAssoc);
+            $extendedConfig = $this->addOC10AppsToConfig($configAssoc);
             $response = new JSONResponse($extendedConfig);
 			$response->addHeader('Cache-Control', 'max-age=0, no-cache, no-store, must-revalidate');
 			$response->addHeader('Pragma', 'no-cache');
@@ -92,7 +92,7 @@ class ConfigController extends Controller {
      * @param array $config
      * @return array
      */
-    private function addAppsToConfig(array $config): array {
+    private function addOC10AppsToConfig(array $config): array {
         $apps = $config['applications'] ?? [];
 
         $oc10NavigationEntries = \OC::$server->getNavigationManager()->getAll();

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -14,7 +14,7 @@
     "lodash-es": "^4.17.21",
     "luxon": "^2.0.0",
     "oidc-client": "1.11.5",
-    "owncloud-design-system": "^11.2.1",
+    "owncloud-design-system": "^11.2.2",
     "owncloud-sdk": "1.0.0-2296",
     "p-queue": "^6.1.1",
     "popper-max-size-modifier": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10945,9 +10945,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"owncloud-design-system@npm:^11.2.1":
-  version: 11.2.1
-  resolution: "owncloud-design-system@npm:11.2.1"
+"owncloud-design-system@npm:^11.2.2":
+  version: 11.2.2
+  resolution: "owncloud-design-system@npm:11.2.2"
   peerDependencies:
     "@popperjs/core": ^2.4.0
     filesize: ^8.0.0
@@ -10957,14 +10957,14 @@ __metadata:
     luxon: ^2.0.2
     postcss-import: ^12.0.1
     postcss-url: ^9.0.0
-    tippy.js: ^6.3.1
+    tippy.js: ^6.3.7
     uikit: 3.5.16
     v-calendar: ^2.3.2
     vue: ^2.6.11
     vue-inline-svg: ^2.0.0
     vue-select: ^3.12.0
     webfontloader: ^1.6.28
-  checksum: 00cc424a2f8bd3611cc5263bae73e099f0ffebd0bd5c26c69c4119837a2ffc2a17b8907b07e069591c7ffffc701c7bbddeb4bec09b7c5939008f3984baf2fdcd
+  checksum: be4730cbc76c49ee9fa9b90d3155211cfdbf0c5564eaaee2ce0b6185b4ef50348a768fbc5f65dccb411c658551c7a9c7062c8b261de899de1982fca9158cb778
   languageName: node
   linkType: hard
 
@@ -15290,7 +15290,7 @@ typescript@^4.3.2:
     lodash-es: ^4.17.21
     luxon: ^2.0.0
     oidc-client: 1.11.5
-    owncloud-design-system: ^11.2.1
+    owncloud-design-system: ^11.2.2
     owncloud-sdk: 1.0.0-2296
     p-queue: ^6.1.1
     popper-max-size-modifier: ^0.2.0


### PR DESCRIPTION
With this change, oC10 apps will be listed in the app switcher menu.

2 things that are not so good with the current approach:

* ~We only have full URLs to the icons. The config on the other hand expects a string to load the icons. Therefore the `application` icon is the default for now.~ -> we use the [extension icon](https://fonts.google.com/icons?selected=Material+Icons:extension:) 
* ~The app name we get from `\OC::$server->getNavigationManager()->getAll()` is already translated. To overcome this, we currently load the app + 3 different l10n instances to provide proper solutions based on the original name... super ugly. Is there a way to use the already translated string for OC web?~ -> That's okay for now.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/5980

## Screenshots:
![image](https://user-images.githubusercontent.com/50302941/140751636-eb2ca2b4-fdc6-49ba-b366-c4c5a7cf8351.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
