### PR TITLE
use `OCIS_INSECURE` flag after owncloud/ocis#2745

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=5aeb76f6c8aee574fdd2710f9e883efe0c8166f8
+OCIS_COMMITID=45c3b072fbb6267a11d1de264fe2d64d18d56c73
 OCIS_BRANCH=master

--- a/.drone.star
+++ b/.drone.star
@@ -1976,7 +1976,7 @@ def ocisService():
             "STORAGE_USERS_DRIVER_OCIS_ROOT": "/srv/app/tmp/ocis/storage/users",
             "STORAGE_METADATA_DRIVER_OCIS_ROOT": "/srv/app/tmp/ocis/storage/metadata",
             "STORAGE_SHARING_USER_JSON_FILE": "/srv/app/tmp/ocis/shares.json",
-            "PROXY_OIDC_INSECURE": "true",
+            "OCIS_INSECURE": "true",
             "WEB_UI_CONFIG": "/srv/config/drone/config-ocis.json",
             "WEB_ASSET_PATH": "%s/dist" % dir["web"],
             "IDP_IDENTIFIER_REGISTRATION_CONF": "/srv/config/drone/identifier-registration.yml",

--- a/deployments/examples/ocis_web/docker-compose.yml
+++ b/deployments/examples/ocis_web/docker-compose.yml
@@ -57,7 +57,6 @@ services:
       OCIS_URL: https://${OCIS_DOMAIN:-ocis.owncloud.test}
       OCIS_DOMAIN: ${OCIS_DOMAIN:-ocis.owncloud.test}
       OCIS_LOG_LEVEL: ${OCIS_LOG_LEVEL:-error} # make oCIS less verbose
-      PROXY_OIDC_INSECURE: "${INSECURE:-false}" # needed if Traefik is using self generated certificates
       PROXY_TLS: "false" # do not use SSL between Traefik and oCIS
       # change default secrets
       IDP_LDAP_BIND_PASSWORD: ${IDP_LDAP_BIND_PASSWORD:-idp}
@@ -70,6 +69,8 @@ services:
       STORAGE_GATEWAY_GRPC_ADDR: 0.0.0.0:9142 # make the REVA gateway accessible to the app drivers
       # proxy
       PROXY_CONFIG_FILE: "/var/tmp/ocis/proxy-config/config.json"
+      # INSECURE: needed if oCIS / Traefik is using self generated certificates
+      OCIS_INSECURE: "${INSECURE:-false}"
     volumes:
       - ./config/ocis/entrypoint-override.sh:/entrypoint-override.sh
       - ./config/ocis/proxy-config.json:/var/tmp/ocis/proxy-config/config.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       OCIS_URL: ${OCIS_URL:-https://host.docker.internal:9200}
       STORAGE_HOME_DRIVER: ${STORAGE_HOME_DRIVER:-ocis}
       STORAGE_USERS_DRIVER: ${STORAGE_USERS_DRIVER:-ocis}
-      PROXY_OIDC_INSECURE: "${PROXY_OIDC_INSECURE:-true}"
+      OCIS_INSECURE: "${OCIS_INSECURE:-true}"
       WEB_UI_CONFIG: ${WEB_UI_CONFIG:-/web/config.json}
       WEB_ASSET_PATH: ${WEB_ASSET_PATH:-/web/dist}
       IDP_IDENTIFIER_REGISTRATION_CONF: ${IDP_IDENTIFIER_REGISTRATION_CONF:-/web/identifier-registration.yml}


### PR DESCRIPTION
## Description
use `OCIS_INSECURE` flag after owncloud/ocis#2745. oCIS has a breaking change in that PR where all insecure options default to false. But there is one new flag to set them all to true.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Caused by  owncloud/ocis#2745

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
