### PR TITLE
add archiver route to deployment examples

### DIFF
--- a/deployments/examples/ocis_web/config/ocis/proxy-config.json
+++ b/deployments/examples/ocis_web/config/ocis/proxy-config.json
@@ -74,6 +74,10 @@
           "backend": "http://localhost:9140"
         },
         {
+          "endpoint": "/archiver",
+          "backend": "http://localhost:9140"
+        },
+        {
           "endpoint": "/graph/",
           "backend": "http://localhost:9120"
         },


### PR DESCRIPTION
## Description
The archiver does not work on https://ocis.ocis-web.latest.owncloud.works due the missing `/archiver` route.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/6026
