### PR TITLE
Add tooltips with absolute dates to relative dates

### DIFF
--- a/changelog/unreleased/enhancement-relative-date-tooltips
+++ b/changelog/unreleased/enhancement-relative-date-tooltips
@@ -1,6 +1,6 @@
 Enhancement: Add tooltips to relative dates
 
-Relative dates like "1 day ago" now have a tooltip that shows the absolute date. This tooltip is a11y-compliant and can be reached via tab.
+Relative dates like "1 day ago" now have a tooltip that shows the absolute date.
 
 https://github.com/owncloud/web/pull/6037
 https://github.com/owncloud/web/issues/5672

--- a/changelog/unreleased/enhancement-relative-date-tooltips
+++ b/changelog/unreleased/enhancement-relative-date-tooltips
@@ -1,0 +1,6 @@
+Enhancement: Add tooltips to relative dates
+
+Relative dates like "1 day ago" now have a tooltip that shows the absolute date. This tooltip is a11y-compliant and can be reached via tab.
+
+https://github.com/owncloud/web/pull/6037
+https://github.com/owncloud/web/issues/5672

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -211,7 +211,7 @@ export default {
       return this.hasAnyShares && !this.isPublicPage
     },
     displayShareDate() {
-      const date = this.formDateFromNow(new Date(this.sharedTime * 1000), 'JSDate')
+      const date = this.formRelativeDateFromJSDate(new Date(this.sharedTime * 1000))
       return upperFirst(date)
     },
     detailSharingInformation() {
@@ -273,13 +273,9 @@ export default {
     capitalizedTimestamp() {
       let displayDate = ''
       if (this.file.mdate) {
-        displayDate = DateTime.fromRFC2822(this.file.mdate)
-          .setLocale(this.$language.current)
-          .toLocaleString(DateTime.DATETIME_FULL)
+        displayDate = this.formDateFromRFC(this.file.mdate)
       } else {
-        displayDate = DateTime.fromRFC2822(this.file.sdate)
-          .setLocale(this.$language.current)
-          .toLocaleString(DateTime.DATETIME_FULL)
+        displayDate = this.formDateFromRFC(this.file.sdate)
       }
       return upperFirst(displayDate)
     },

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -167,11 +167,6 @@ export default {
     sharedViaLabel() {
       return this.$gettext('Shared via:')
     },
-    shareDateTooltip() {
-      return DateTime.fromSeconds(parseInt(this.sharedTime))
-        .setLocale(this.$language.current)
-        .toLocaleString(DateTime.DATETIME_FULL)
-    },
     sharedViaTooltip() {
       return this.$gettextInterpolate(
         this.$gettext("Navigate to '%{folder}'"),

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -58,7 +58,12 @@
         <tr v-if="showShareDate" data-testid="shared-date">
           <th scope="col" class="oc-pr-s" v-text="shareDateLabel" />
           <td>
-            <span v-oc-tooltip="shareDateTooltip" tabindex="0" v-text="displayShareDate" />
+            <span
+              v-oc-tooltip="shareDateTooltip"
+              tabindex="0"
+              :aria-label="displayShareDate + ' (' + shareDateTooltip + ')'"
+              v-text="displayShareDate"
+            />
           </td>
         </tr>
         <tr v-if="showSharedVia" data-testid="shared-via">

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -119,7 +119,6 @@ import { loadPreview } from '../../../helpers/resource'
 import intersection from 'lodash-es/intersection'
 import upperFirst from 'lodash-es/upperFirst'
 import path from 'path'
-import { DateTime } from 'luxon'
 
 export default {
   name: 'FileDetails',

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -58,7 +58,7 @@
         <tr v-if="showShareDate" data-testid="shared-date">
           <th scope="col" class="oc-pr-s" v-text="shareDateLabel" />
           <td>
-            <span v-oc-tooltip="shareDateTooltip" v-text="displayShareDate" />
+            <span v-oc-tooltip="shareDateTooltip" tabindex="0" v-text="displayShareDate" />
           </td>
         </tr>
         <tr v-if="showSharedVia" data-testid="shared-via">
@@ -275,11 +275,11 @@ export default {
       if (this.file.mdate) {
         displayDate = DateTime.fromRFC2822(this.file.mdate)
           .setLocale(this.$language.current)
-          .toLocaleString(DateTime.DATETIME_SHORT)
+          .toLocaleString(DateTime.DATETIME_FULL)
       } else {
         displayDate = DateTime.fromRFC2822(this.file.sdate)
           .setLocale(this.$language.current)
-          .toLocaleString(DateTime.DATETIME_SHORT)
+          .toLocaleString(DateTime.DATETIME_FULL)
       }
       return upperFirst(displayDate)
     },

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -273,9 +273,13 @@ export default {
     capitalizedTimestamp() {
       let displayDate = ''
       if (this.file.mdate) {
-        displayDate = this.formDateFromNow(this.file.mdate, 'Http')
+        displayDate = DateTime.fromRFC2822(this.file.mdate)
+          .setLocale(this.$language.current)
+          .toLocaleString(DateTime.DATETIME_SHORT)
       } else {
-        displayDate = this.formDateFromNow(this.file.sdate, 'Http')
+        displayDate = DateTime.fromRFC2822(this.file.sdate)
+          .setLocale(this.$language.current)
+          .toLocaleString(DateTime.DATETIME_SHORT)
       }
       return upperFirst(displayDate)
     },

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -58,12 +58,7 @@
         <tr v-if="showShareDate" data-testid="shared-date">
           <th scope="col" class="oc-pr-s" v-text="shareDateLabel" />
           <td>
-            <span
-              v-oc-tooltip="shareDateTooltip"
-              tabindex="0"
-              :aria-label="displayShareDate + ' (' + shareDateTooltip + ')'"
-              v-text="displayShareDate"
-            />
+            <span v-text="displayShareDate" />
           </td>
         </tr>
         <tr v-if="showSharedVia" data-testid="shared-via">
@@ -216,7 +211,7 @@ export default {
       return this.hasAnyShares && !this.isPublicPage
     },
     displayShareDate() {
-      const date = this.formRelativeDateFromJSDate(new Date(this.sharedTime * 1000))
+      const date = this.formDateFromJSDate(new Date(this.sharedTime * 1000))
       return upperFirst(date)
     },
     detailSharingInformation() {
@@ -278,9 +273,9 @@ export default {
     capitalizedTimestamp() {
       let displayDate = ''
       if (this.file.mdate) {
-        displayDate = this.formDateFromRFC(this.file.mdate)
+        displayDate = this.formDateFromHTTP(this.file.mdate)
       } else {
-        displayDate = this.formDateFromRFC(this.file.sdate)
+        displayDate = this.formDateFromHTTP(this.file.sdate)
       }
       return upperFirst(displayDate)
     },

--- a/packages/web-app-files/src/components/SideBar/FileInfo.vue
+++ b/packages/web-app-files/src/components/SideBar/FileInfo.vue
@@ -13,9 +13,13 @@
       </h3>
       <p class="oc-my-rm">
         <template v-if="file.size > -1">{{ getResourceSize(file.size) }},</template>
-        <span v-oc-tooltip="modificationTime" data-testid="files-info-mdate" tabindex="0">{{
-          modificationTimeRelative
-        }}</span>
+        <span
+          v-oc-tooltip="modificationTime"
+          data-testid="files-info-mdate"
+          tabindex="0"
+          :aria-label="modificationTimeRelative + ' (' + modificationTime + ')'"
+          >{{ modificationTimeRelative }}</span
+        >
       </p>
     </div>
     <oc-button

--- a/packages/web-app-files/src/components/SideBar/FileInfo.vue
+++ b/packages/web-app-files/src/components/SideBar/FileInfo.vue
@@ -2,7 +2,7 @@
   <div class="file_info">
     <oc-icon :name="file.icon" size="large" class="file_info__icon" />
     <div class="file_info__body oc-text-overflow">
-      <h3>
+      <h3 data-testid="files-info-name">
         <oc-resource-name
           :name="file.name"
           :extension="file.extension"
@@ -13,7 +13,9 @@
       </h3>
       <p class="oc-my-rm">
         <template v-if="file.size > -1">{{ getResourceSize(file.size) }},</template>
-        <span v-oc-tooltip="modificationTime" tabindex="0">{{ modificationTimeRelative }}</span>
+        <span v-oc-tooltip="modificationTime" data-testid="files-info-mdate" tabindex="0">{{
+          modificationTimeRelative
+        }}</span>
       </p>
     </div>
     <oc-button

--- a/packages/web-app-files/src/components/SideBar/FileInfo.vue
+++ b/packages/web-app-files/src/components/SideBar/FileInfo.vue
@@ -55,12 +55,12 @@ export default {
       if (this.isTrashbinRoute) {
         return DateTime.fromRFC2822(this.file.mdate)
           .setLocale(this.$language.current)
-          .toLocaleString(DateTime.DATETIME_SHORT)
+          .toLocaleString(DateTime.DATETIME_FULL)
       }
 
       return DateTime.fromHTTP(this.file.mdate)
         .setLocale(this.$language.current)
-        .toLocaleString(DateTime.DATETIME_SHORT)
+        .toLocaleString(DateTime.DATETIME_FULL)
     },
     modificationTimeRelative() {
       if (this.isTrashbinRoute) {

--- a/packages/web-app-files/src/components/SideBar/FileInfo.vue
+++ b/packages/web-app-files/src/components/SideBar/FileInfo.vue
@@ -2,7 +2,7 @@
   <div class="file_info">
     <oc-icon :name="file.icon" size="large" class="file_info__icon" />
     <div class="file_info__body oc-text-overflow">
-      <h3 tabindex="-1">
+      <h3>
         <oc-resource-name
           :name="file.name"
           :extension="file.extension"
@@ -13,7 +13,7 @@
       </h3>
       <p class="oc-my-rm">
         <template v-if="file.size > -1">{{ getResourceSize(file.size) }},</template>
-        {{ modificationTime }}
+        <span v-oc-tooltip="modificationTime" tabindex="0">{{ modificationTimeRelative }}</span>
       </p>
     </div>
     <oc-button
@@ -37,6 +37,7 @@ import { mapGetters, mapActions } from 'vuex'
 import Mixins from '../../mixins'
 import MixinResources from '../../mixins/resources'
 import MixinRoutes from '../../mixins/routes'
+import { DateTime } from 'luxon'
 
 export default {
   name: 'FileInfo',
@@ -51,6 +52,17 @@ export default {
   computed: {
     ...mapGetters(['capabilities']),
     modificationTime() {
+      if (this.isTrashbinRoute) {
+        return DateTime.fromRFC2822(this.file.mdate)
+          .setLocale(this.$language.current)
+          .toLocaleString(DateTime.DATETIME_SHORT)
+      }
+
+      return DateTime.fromHTTP(this.file.mdate)
+        .setLocale(this.$language.current)
+        .toLocaleString(DateTime.DATETIME_SHORT)
+    },
+    modificationTimeRelative() {
       if (this.isTrashbinRoute) {
         return this.formDateFromNow(this.file.ddate, 'RFC')
       }

--- a/packages/web-app-files/src/components/SideBar/FileInfo.vue
+++ b/packages/web-app-files/src/components/SideBar/FileInfo.vue
@@ -39,7 +39,6 @@ import { mapGetters, mapActions } from 'vuex'
 import Mixins from '../../mixins'
 import MixinResources from '../../mixins/resources'
 import MixinRoutes from '../../mixins/routes'
-import { DateTime } from 'luxon'
 
 export default {
   name: 'FileInfo',
@@ -55,21 +54,17 @@ export default {
     ...mapGetters(['capabilities']),
     modificationTime() {
       if (this.isTrashbinRoute) {
-        return DateTime.fromRFC2822(this.file.mdate)
-          .setLocale(this.$language.current)
-          .toLocaleString(DateTime.DATETIME_FULL)
+        return this.formDateFromRFC(this.file.ddate)
       }
 
-      return DateTime.fromHTTP(this.file.mdate)
-        .setLocale(this.$language.current)
-        .toLocaleString(DateTime.DATETIME_FULL)
+      return this.formDateFromHTTP(this.file.mdate)
     },
     modificationTimeRelative() {
       if (this.isTrashbinRoute) {
-        return this.formDateFromNow(this.file.ddate, 'RFC')
+        return this.formRelativeDateFromRFC(this.file.ddate)
       }
 
-      return this.formDateFromNow(this.file.mdate, 'Http')
+      return this.formRelativeDateFromHTTP(this.file.mdate)
     },
     isFavoritesEnabled() {
       return (

--- a/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkInfo.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkInfo.vue
@@ -31,7 +31,7 @@
       <div v-if="link.expiration">
         <oc-tag v-oc-tooltip="expirationDate" tabindex="0" class="oc-files-public-link-expires">
           <oc-icon name="text-calendar" />
-          <translate :translate-params="{ expires: formDateFromNow(link.expiration, 'ISO') }">
+          <translate :translate-params="{ expires: formRelativeDateFromISO(link.expiration) }">
             Expires %{expires}
           </translate>
         </oc-tag>

--- a/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkInfo.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkInfo.vue
@@ -138,7 +138,7 @@ export default {
     expirationDate() {
       return DateTime.fromISO(this.link.expiration)
         .setLocale(this.$language.current)
-        .toLocaleString(DateTime.DATETIME_SHORT)
+        .toLocaleString(DateTime.DATETIME_FULL)
     }
   },
 

--- a/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkInfo.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkInfo.vue
@@ -29,7 +29,7 @@
         </oc-tag>
       </div>
       <div v-if="link.expiration">
-        <oc-tag class="oc-files-public-link-expires">
+        <oc-tag v-oc-tooltip="expirationDate" tabindex="0" class="oc-files-public-link-expires">
           <oc-icon name="text-calendar" />
           <translate :translate-params="{ expires: formDateFromNow(link.expiration, 'ISO') }">
             Expires %{expires}
@@ -61,6 +61,7 @@
 import { basename, dirname } from 'path'
 import Mixins from '../../../../mixins'
 import CopyToClipboardButton from '../CopyToClipboardButton.vue'
+import { DateTime } from 'luxon'
 
 export default {
   name: 'LinkInfo',
@@ -132,6 +133,12 @@ export default {
 
     copyToClipboardSuccessMsgTitle() {
       return this.$gettext('Public link copied')
+    },
+
+    expirationDate() {
+      return DateTime.fromISO(this.link.expiration)
+        .setLocale(this.$language.current)
+        .toLocaleString(DateTime.DATETIME_SHORT)
     }
   },
 

--- a/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkInfo.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkInfo.vue
@@ -30,10 +30,12 @@
       </div>
       <div v-if="link.expiration">
         <oc-tag
-          v-oc-tooltip="expirationDate"
+          v-oc-tooltip="formDateFromISO(link.expiration)"
           tabindex="0"
           class="oc-files-public-link-expires"
-          :aria-label="formRelativeDateFromISO(link.expiration) + ' (' + expirationDate + ')'"
+          :aria-label="
+            formRelativeDateFromISO(link.expiration) + ' (' + formDateFromISO(link.expiration) + ')'
+          "
         >
           <oc-icon name="text-calendar" />
           <translate :translate-params="{ expires: formRelativeDateFromISO(link.expiration) }">
@@ -66,7 +68,6 @@
 import { basename, dirname } from 'path'
 import Mixins from '../../../../mixins'
 import CopyToClipboardButton from '../CopyToClipboardButton.vue'
-import { DateTime } from 'luxon'
 
 export default {
   name: 'LinkInfo',
@@ -138,12 +139,6 @@ export default {
 
     copyToClipboardSuccessMsgTitle() {
       return this.$gettext('Public link copied')
-    },
-
-    expirationDate() {
-      return DateTime.fromISO(this.link.expiration)
-        .setLocale(this.$language.current)
-        .toLocaleString(DateTime.DATETIME_FULL)
     }
   },
 

--- a/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkInfo.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkInfo.vue
@@ -29,7 +29,12 @@
         </oc-tag>
       </div>
       <div v-if="link.expiration">
-        <oc-tag v-oc-tooltip="expirationDate" tabindex="0" class="oc-files-public-link-expires">
+        <oc-tag
+          v-oc-tooltip="expirationDate"
+          tabindex="0"
+          class="oc-files-public-link-expires"
+          :aria-label="formRelativeDateFromISO(link.expiration) + ' (' + expirationDate + ')'"
+        >
           <oc-icon name="text-calendar" />
           <translate :translate-params="{ expires: formRelativeDateFromISO(link.expiration) }">
             Expires %{expires}

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ShowCollaborator.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ShowCollaborator.vue
@@ -137,6 +137,7 @@
                 v-oc-tooltip="expirationDate"
                 data-testid="recipient-info-expiration-date"
                 class="files-collaborators-collaborator-expires"
+                tabindex="0"
                 :aria-label="expirationDateRelative + ' (' + expirationDate + ')'"
               >
                 <oc-icon name="text-calendar" />

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ShowCollaborator.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ShowCollaborator.vue
@@ -134,11 +134,13 @@
             </li>
             <li v-if="collaborator.expires" class="oc-py-rm">
               <oc-tag
+                v-oc-tooltip="expirationDate"
                 data-testid="recipient-info-expiration-date"
                 class="files-collaborators-collaborator-expires"
+                :aria-label="expirationDateRelative + ' (' + expirationDate + ')'"
               >
                 <oc-icon name="text-calendar" />
-                <translate :translate-params="{ expires: expirationDate }">
+                <translate :translate-params="{ expires: expirationDateRelative }">
                   Expires %{expires}
                 </translate>
               </oc-tag>
@@ -340,6 +342,13 @@ export default {
     },
 
     expirationDate() {
+      return DateTime.fromJSDate(this.collaborator.expires)
+        .endOf('day')
+        .setLocale(this.$language.current)
+        .toLocaleString(DateTime.DATETIME_FULL)
+    },
+
+    expirationDateRelative() {
       return DateTime.fromJSDate(this.collaborator.expires)
         .endOf('day')
         .setLocale(this.$language.current)

--- a/packages/web-app-files/src/components/SideBar/Versions/FileVersions.vue
+++ b/packages/web-app-files/src/components/SideBar/Versions/FileVersions.vue
@@ -12,7 +12,7 @@
             class="oc-text-muted uk-text-nowrap"
             data-testid="file-versions-file-last-modified-date"
           >
-            {{ formDateFromNow(item.fileInfo[DavProperty.LastModifiedDate], 'Http') }}
+            {{ formRelativeDateFromHTTP(item.fileInfo[DavProperty.LastModifiedDate]) }}
           </oc-td>
           <oc-td
             width="expand"

--- a/packages/web-app-files/src/mixins.js
+++ b/packages/web-app-files/src/mixins.js
@@ -32,20 +32,29 @@ export default {
     ]),
     ...mapActions(['showMessage', 'createModal', 'hideModal']),
 
-    formDateFromNow(date, type) {
-      // TODO: Refactor those into their own functions a.k.a relDateFromJSDate() etc
-      if (type === 'JSDate') {
-        return DateTime.fromJSDate(date).setLocale(this.$language.current).toRelative()
-      }
-      if (type === 'Http') {
-        return DateTime.fromHTTP(date).setLocale(this.$language.current).toRelative()
-      }
-      if (type === 'ISO') {
-        return DateTime.fromISO(date).setLocale(this.$language.current).toRelative()
-      }
-      if (type === 'RFC') {
-        return DateTime.fromRFC2822(date).setLocale(this.$language.current).toRelative()
-      }
+    formDateFromJSDate(date, format = DateTime.DATETIME_FULL) {
+      return DateTime.fromJSDate(date).setLocale(this.$language.current).toLocaleString(format)
+    },
+    formDateFromHTTP(date, format = DateTime.DATETIME_FULL) {
+      return DateTime.fromHTTP(date).setLocale(this.$language.current).toLocaleString(format)
+    },
+    formDateFromISO(date, format = DateTime.DATETIME_FULL) {
+      return DateTime.fromISO(date).setLocale(this.$language.current).toLocaleString(format)
+    },
+    formDateFromRFC(date, format = DateTime.DATETIME_FULL) {
+      return DateTime.fromRFC2822(date).setLocale(this.$language.current).toLocaleString(format)
+    },
+    formRelativeDateFromJSDate(date) {
+      return DateTime.fromJSDate(date).setLocale(this.$language.current).toRelative()
+    },
+    formRelativeDateFromHTTP(date) {
+      return DateTime.fromHTTP(date).setLocale(this.$language.current).toRelative()
+    },
+    formRelativeDateFromISO(date) {
+      return DateTime.fromISO(date).setLocale(this.$language.current).toRelative()
+    },
+    formRelativeDateFromRFC(date) {
+      return DateTime.fromRFC2822(date).setLocale(this.$language.current).toRelative()
     },
     delayForScreenreader(func, delay = 500) {
       /*

--- a/packages/web-app-files/tests/unit/components/SideBar/FileInfo.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/FileInfo.spec.js
@@ -1,0 +1,84 @@
+import { shallowMount, createLocalVue } from '@vue/test-utils'
+import Vuex from 'vuex'
+import GetTextPlugin from 'vue-gettext'
+import AsyncComputed from 'vue-async-computed'
+
+import stubs from '@/tests/unit/stubs'
+
+import FileInfo from '@files/src/components/SideBar/FileInfo.vue'
+
+const simpleOwnFile = {
+  type: 'file',
+  ownerId: 'marie',
+  ownerDisplayName: 'Marie',
+  mdate: 'Wed, 21 Oct 2015 07:28:00 GMT',
+  size: '740'
+}
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
+localVue.use(AsyncComputed)
+localVue.use(GetTextPlugin, {
+  translations: 'does-not-matter.json',
+  silent: true
+})
+
+const selectors = {
+  name: '[data-testid="files-info-name"]',
+  mdate: '[data-testid="files-info-mdate"]'
+}
+
+describe('FileInfo', () => {
+  it('shows file info', () => {
+    const tooltipStub = jest.fn()
+    const wrapper = createWrapper(simpleOwnFile, tooltipStub)
+    expect(wrapper.find(selectors.name).exists()).toBeTruthy()
+    expect(wrapper.find(selectors.mdate).exists()).toBeTruthy()
+  })
+
+  it('shows modify date tooltip', () => {
+    const tooltipStub = jest.fn()
+    createWrapper(simpleOwnFile, tooltipStub)
+    expect(tooltipStub).toHaveBeenCalledTimes(1)
+  })
+})
+
+function createWrapper(testResource, tooltipStub) {
+  return shallowMount(FileInfo, {
+    store: new Vuex.Store({
+      getters: {
+        user: function () {
+          return { id: 'marie' }
+        },
+        capabilities: jest.fn(() => ({}))
+      },
+      modules: {
+        Files: {
+          namespaced: true,
+          getters: {
+            highlightedFile: function () {
+              return testResource
+            }
+          }
+        }
+      }
+    }),
+    localVue,
+    stubs: stubs,
+    directives: {
+      OcTooltip: tooltipStub
+    },
+    mocks: {
+      $route: {
+        name: 'some-route',
+        query: { page: 1 }
+      },
+      publicPage: () => false
+    },
+    provide: {
+      displayedItem: {
+        value: testResource
+      }
+    }
+  })
+}

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -14,7 +14,7 @@
     "lodash-es": "^4.17.21",
     "luxon": "^2.0.0",
     "oidc-client": "1.11.5",
-    "owncloud-design-system": "^11.3.0-rc2",
+    "owncloud-design-system": "^11.3.0-rc3",
     "owncloud-sdk": "1.0.0-2296",
     "p-queue": "^6.1.1",
     "popper-max-size-modifier": "^0.2.0",

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -14,7 +14,7 @@
     "lodash-es": "^4.17.21",
     "luxon": "^2.0.0",
     "oidc-client": "1.11.5",
-    "owncloud-design-system": "^11.3.0-rc1",
+    "owncloud-design-system": "^11.3.0-rc2",
     "owncloud-sdk": "1.0.0-2296",
     "p-queue": "^6.1.1",
     "popper-max-size-modifier": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10602,9 +10602,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"owncloud-design-system@npm:^11.3.0-rc1":
-  version: 11.3.0-rc1
-  resolution: "owncloud-design-system@npm:11.3.0-rc1"
+"owncloud-design-system@npm:^11.3.0-rc2":
+  version: 11.3.0-rc2
+  resolution: "owncloud-design-system@npm:11.3.0-rc2"
   peerDependencies:
     "@popperjs/core": ^2.4.0
     filesize: ^8.0.0
@@ -10621,7 +10621,7 @@ __metadata:
     vue-inline-svg: ^2.0.0
     vue-select: ^3.12.0
     webfontloader: ^1.6.28
-  checksum: a5149838389182c673e10fc6e10fc797e194d2823337b82e8abed3eea71bc2ade3852dac0e1b896795ea8ae775d65d0fbd3b1ca6b77e87fd66f3d6af62087f8f
+  checksum: 2f1892863f730fc8a96d3a285176fa0662140ba45aa479639ee42a6f3702b3ecc5bb00cab217d0d0e00f964748b4a9eef81790b52ad203f87a322eac26cf782d
   languageName: node
   linkType: hard
 
@@ -14953,7 +14953,7 @@ typescript@^4.3.2:
     lodash-es: ^4.17.21
     luxon: ^2.0.0
     oidc-client: 1.11.5
-    owncloud-design-system: ^11.3.0-rc1
+    owncloud-design-system: ^11.3.0-rc2
     owncloud-sdk: 1.0.0-2296
     p-queue: ^6.1.1
     popper-max-size-modifier: ^0.2.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -10602,9 +10602,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"owncloud-design-system@npm:^11.3.0-rc2":
-  version: 11.3.0-rc2
-  resolution: "owncloud-design-system@npm:11.3.0-rc2"
+"owncloud-design-system@npm:^11.3.0-rc3":
+  version: 11.3.0-rc3
+  resolution: "owncloud-design-system@npm:11.3.0-rc3"
   peerDependencies:
     "@popperjs/core": ^2.4.0
     filesize: ^8.0.0
@@ -10621,7 +10621,7 @@ __metadata:
     vue-inline-svg: ^2.0.0
     vue-select: ^3.12.0
     webfontloader: ^1.6.28
-  checksum: 2f1892863f730fc8a96d3a285176fa0662140ba45aa479639ee42a6f3702b3ecc5bb00cab217d0d0e00f964748b4a9eef81790b52ad203f87a322eac26cf782d
+  checksum: a7f132e0ad382942175434a0ce87ff4d5659a42ab001eb8badff5cb037dc0b569d8218335ff3b60d610f6f6af021b9b1bc313a77aa4fea99fbbe1d23ebe78765
   languageName: node
   linkType: hard
 
@@ -14953,7 +14953,7 @@ typescript@^4.3.2:
     lodash-es: ^4.17.21
     luxon: ^2.0.0
     oidc-client: 1.11.5
-    owncloud-design-system: ^11.3.0-rc2
+    owncloud-design-system: ^11.3.0-rc3
     owncloud-sdk: 1.0.0-2296
     p-queue: ^6.1.1
     popper-max-size-modifier: ^0.2.0


### PR DESCRIPTION
## Description
* Add tooltips with absolute dates to relative dates
* Make tooltips a11y compliant
* Use absolute date in sidebar file infos

Also see https://github.com/owncloud/owncloud-design-system/pull/1787 for the related changed in the files table.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/5672

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/50302941/142389747-e0bbf31e-d1d5-4dfc-a44d-c9baace33b04.png)

![image](https://user-images.githubusercontent.com/50302941/142389807-a071c77b-8c39-42ec-9c7d-ef3fb4532918.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
