### PR TITLE
Implement breadcrumb context menu

### DIFF
--- a/changelog/unreleased/enhancement-breadcrumb-context-menu
+++ b/changelog/unreleased/enhancement-breadcrumb-context-menu
@@ -1,0 +1,6 @@
+Enhancement: Implement breadcrumb context menu
+
+The last element of the breadcrumb now has a context menu which gives the user the possibility to perform actions on the current folder.
+
+https://github.com/owncloud/web/pull/6044
+https://github.com/owncloud/web/issues/6030

--- a/packages/web-app-files/src/components/AppBar/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar/AppBar.vue
@@ -19,7 +19,7 @@
         :show-contextmenu="true"
         :items="breadcrumbs"
       >
-        <template v-if="currentFolder" v-slot:contextMenu>
+        <template v-if="currentFolder" #contextMenu>
           <context-actions :items="[currentFolder]" />
         </template>
       </oc-breadcrumb>

--- a/packages/web-app-files/src/components/AppBar/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar/AppBar.vue
@@ -16,8 +16,13 @@
         id="files-breadcrumb"
         data-testid="files-breadcrumbs"
         class="oc-p-s"
+        :show-contextmenu="true"
         :items="breadcrumbs"
-      />
+      >
+        <template v-if="currentFolder" v-slot:contextMenu>
+          <context-actions :item="currentFolder" />
+        </template>
+      </oc-breadcrumb>
       <h1 class="oc-invisible-sr" v-text="pageTitle" />
       <div class="files-app-bar-actions">
         <div
@@ -126,6 +131,7 @@ import FolderUpload from './Upload/FolderUpload.vue'
 import SizeInfo from './SelectedResources/SizeInfo.vue'
 import ViewOptions from './ViewOptions.vue'
 import { DavProperties, DavProperty } from 'web-pkg/src/constants'
+import ContextActions from '../FilesList/ContextActions.vue'
 
 export default {
   components: {
@@ -134,7 +140,8 @@ export default {
     FileUpload,
     FolderUpload,
     SizeInfo,
-    ViewOptions
+    ViewOptions,
+    ContextActions
   },
   mixins: [Mixins, MixinFileActions, MixinRoutes, MixinScrollToResource],
   data: () => ({

--- a/packages/web-app-files/src/components/AppBar/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar/AppBar.vue
@@ -19,7 +19,10 @@
         :items="breadcrumbs"
       >
         <template #contextMenu>
-          <context-actions v-if="currentFolder" :items="[currentFolder]" />
+          <context-actions
+            v-if="currentFolder && showBreadcrumbContextMenu"
+            :items="[currentFolder]"
+          />
         </template>
       </oc-breadcrumb>
       <h1 class="oc-invisible-sr" v-text="pageTitle" />
@@ -300,6 +303,10 @@ export default {
         this.selectedFiles.length
       )
       return this.$gettextInterpolate(translated, { amount: this.selectedFiles.length })
+    },
+
+    showBreadcrumbContextMenu() {
+      return this.currentPathSegments.length > 0
     }
   },
 

--- a/packages/web-app-files/src/components/AppBar/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar/AppBar.vue
@@ -16,11 +16,10 @@
         id="files-breadcrumb"
         data-testid="files-breadcrumbs"
         class="oc-p-s"
-        :show-contextmenu="true"
         :items="breadcrumbs"
       >
-        <template v-if="currentFolder" #contextMenu>
-          <context-actions :items="[currentFolder]" />
+        <template #contextMenu>
+          <context-actions v-if="currentFolder" :items="[currentFolder]" />
         </template>
       </oc-breadcrumb>
       <h1 class="oc-invisible-sr" v-text="pageTitle" />

--- a/packages/web-app-files/src/components/AppBar/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar/AppBar.vue
@@ -20,7 +20,7 @@
         :items="breadcrumbs"
       >
         <template v-if="currentFolder" v-slot:contextMenu>
-          <context-actions :item="currentFolder" />
+          <context-actions :items="[currentFolder]" />
         </template>
       </oc-breadcrumb>
       <h1 class="oc-invisible-sr" v-text="pageTitle" />

--- a/packages/web-app-files/src/mixins/actions/delete.js
+++ b/packages/web-app-files/src/mixins/actions/delete.js
@@ -1,7 +1,6 @@
 import MixinDeleteResources from '../../mixins/deleteResources'
 import { isPersonalRoute, isPublicFilesRoute, isTrashbinRoute } from '../../helpers/route'
 import { mapState } from 'vuex'
-import { isSameResource } from '../../helpers/resource'
 
 export default {
   mixins: [MixinDeleteResources],
@@ -23,9 +22,6 @@ export default {
             }
 
             const deleteDisabled = resources.some((resource) => {
-              if (isSameResource(resource, this.currentFolder)) {
-                return true
-              }
               return !resource.canBeDeleted()
             })
             return !deleteDisabled

--- a/packages/web-app-files/src/mixins/actions/rename.js
+++ b/packages/web-app-files/src/mixins/actions/rename.js
@@ -47,7 +47,7 @@ export default {
     ...mapActions('Files', ['renameFile']),
 
     async $_rename_trigger({ resources }) {
-      let parentResources;
+      let parentResources
       if (isSameResource(resources[0], this.currentFolder)) {
         const parentPaths = getParentPaths(resources[0].path, false)
         const promise = this.$client.files.list(parentPaths[0], 1)

--- a/packages/web-app-files/src/mixins/actions/rename.js
+++ b/packages/web-app-files/src/mixins/actions/rename.js
@@ -42,6 +42,7 @@ export default {
       'createModal',
       'hideModal',
       'setModalInputErrorMessage',
+      'showMessage',
       'toggleModalConfirmButton'
     ]),
     ...mapActions('Files', ['renameFile']),

--- a/packages/web-app-files/src/mixins/actions/rename.js
+++ b/packages/web-app-files/src/mixins/actions/rename.js
@@ -51,8 +51,7 @@ export default {
       let parentResources
       if (isSameResource(resources[0], this.currentFolder)) {
         const parentPaths = getParentPaths(resources[0].path, false)
-        const promise = this.$client.files.list(parentPaths[0], 1)
-        parentResources = await promise
+        parentResources = await this.$client.files.list(parentPaths[0], 1)
         parentResources = parentResources.map(buildResource)
       }
 

--- a/packages/web-app-files/src/mixins/deleteResources.js
+++ b/packages/web-app-files/src/mixins/deleteResources.js
@@ -1,5 +1,6 @@
 import { mapGetters, mapActions, mapMutations } from 'vuex'
 import { cloneStateObject } from '../helpers/store'
+import { isSameResource } from '../helpers/resource'
 import { isTrashbinRoute } from '../helpers/route'
 import PQueue from 'p-queue'
 
@@ -161,16 +162,18 @@ export default {
         this.SET_QUOTA(user.quota)
 
         let parentFolderPath;
-        if (this.resourcesToDelete.length) {
+        if (this.resourcesToDelete.length && isSameResource(this.resourcesToDelete[0], this.currentFolder)) {
           const resourcePath = this.resourcesToDelete[0].path
           parentFolderPath = resourcePath.substr(1, resourcePath.lastIndexOf('/'))
         }
 
-        this.$router.push({
-          params: {
-            item: parentFolderPath || '/'
-          },
-        })
+        if (parentFolderPath !== undefined) {
+          this.$router.push({
+            params: {
+              item: parentFolderPath
+            },
+          })
+        }
       })
     },
 

--- a/packages/web-app-files/src/mixins/deleteResources.js
+++ b/packages/web-app-files/src/mixins/deleteResources.js
@@ -159,6 +159,18 @@ export default {
         const user = await this.$client.users.getUser(this.user.id)
 
         this.SET_QUOTA(user.quota)
+
+        let parentFolderPath;
+        if (this.resourcesToDelete.length) {
+          const resourcePath = this.resourcesToDelete[0].path
+          parentFolderPath = resourcePath.substr(1, resourcePath.lastIndexOf('/'))
+        }
+
+        this.$router.push({
+          params: {
+            item: parentFolderPath || '/'
+          },
+        })
       })
     },
 

--- a/packages/web-app-files/src/mixins/deleteResources.js
+++ b/packages/web-app-files/src/mixins/deleteResources.js
@@ -161,8 +161,11 @@ export default {
 
         this.SET_QUOTA(user.quota)
 
-        let parentFolderPath;
-        if (this.resourcesToDelete.length && isSameResource(this.resourcesToDelete[0], this.currentFolder)) {
+        let parentFolderPath
+        if (
+          this.resourcesToDelete.length &&
+          isSameResource(this.resourcesToDelete[0], this.currentFolder)
+        ) {
           const resourcePath = this.resourcesToDelete[0].path
           parentFolderPath = resourcePath.substr(1, resourcePath.lastIndexOf('/'))
         }
@@ -171,7 +174,7 @@ export default {
           this.$router.push({
             params: {
               item: parentFolderPath
-            },
+            }
           })
         }
       })

--- a/packages/web-app-files/src/store/actions.js
+++ b/packages/web-app-files/src/store/actions.js
@@ -122,18 +122,22 @@ export default {
       context.commit('REMOVE_FILE_FROM_SEARCHED', file)
     }
   },
-  renameFile(context, { file, newValue, client, publicPage }) {
+  renameFile(context, { file, newValue, client, publicPage, isSameResource }) {
     if (file !== undefined && newValue !== undefined && newValue !== file.name) {
       const newPath = file.path.substr(1, file.path.lastIndexOf('/'))
       if (publicPage) {
         return client.publicFiles
           .move(file.path, newPath + newValue, context.getters.publicLinkPassword)
           .then(() => {
-            context.commit('RENAME_FILE', { file, newValue, newPath })
+            if (!isSameResource) {
+              context.commit('RENAME_FILE', { file, newValue, newPath })
+            }
           })
       }
       return client.files.move(file.path, newPath + newValue).then(() => {
-        context.commit('RENAME_FILE', { file, newValue, newPath })
+        if (!isSameResource) {
+          context.commit('RENAME_FILE', { file, newValue, newPath })
+        }
       })
     }
   },

--- a/packages/web-app-files/tests/unit/mixins/actions/delete.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/actions/delete.spec.js
@@ -1,5 +1,4 @@
 import Vuex from 'vuex'
-import { createStore } from 'vuex-extensions'
 import { mount, createLocalVue } from '@vue/test-utils'
 import Delete from '@files/src/mixins/actions/delete.js'
 
@@ -19,33 +18,8 @@ describe('delete', () => {
         $route: {
           name: 'files-personal'
         },
-        $router: [],
-        $client: { files: { list: jest.fn(() => []) } },
-        $gettextInterpolate: () => 'title',
-        publicPage: () => false
-      },
-      store: createStore(Vuex.Store, {
-        modules: {
-          Files: {
-            namespaced: true,
-            getters: {
-              currentFolder: () => {
-                return { id: 1, path: '/folder' }
-              },
-              files: () => [{ name: 'file1' }]
-            },
-            actions: {
-              deleteFile: jest.fn(() => {})
-            }
-          }
-        },
-        actions: {
-          createModal: jest.fn(),
-          hideModal: jest.fn(),
-          toggleModalConfirmButton: jest.fn(),
-          showMessage: jest.fn()
-        }
-      })
+        $router: []
+      }
     })
   }
 

--- a/packages/web-app-files/tests/unit/mixins/actions/delete.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/actions/delete.spec.js
@@ -1,0 +1,64 @@
+import Vuex from 'vuex'
+import { createStore } from 'vuex-extensions'
+import { mount, createLocalVue } from '@vue/test-utils'
+import Delete from '@files/src/mixins/actions/delete.js'
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
+
+describe('delete', () => {
+  const Component = {
+    render() {},
+    mixins: [Delete]
+  }
+
+  function getWrapper() {
+    return mount(Component, {
+      localVue,
+      mocks: {
+        $route: {
+          name: 'files-personal'
+        },
+        $router: [],
+        $client: { files: { list: jest.fn(() => []) } },
+        $gettextInterpolate: () => 'title',
+        publicPage: () => false
+      },
+      store: createStore(Vuex.Store, {
+        modules: {
+          Files: {
+            namespaced: true,
+            getters: {
+              currentFolder: () => {
+                return { id: 1, path: '/folder' }
+              },
+              files: () => [{ name: 'file1' }]
+            },
+            actions: {
+              deleteFile: jest.fn(() => {})
+            }
+          }
+        },
+        actions: {
+          createModal: jest.fn(),
+          hideModal: jest.fn(),
+          toggleModalConfirmButton: jest.fn(),
+          showMessage: jest.fn()
+        }
+      })
+    })
+  }
+
+  describe('computed property "$_delete_items"', () => {
+    describe('isEnabled property of returned element', () => {
+      it.each([
+        { resources: [{ canBeDeleted: () => true }], expectedStatus: true },
+        { resources: [{ canBeDeleted: () => false }], expectedStatus: false }
+      ])('should be set correctly', (inputData) => {
+        const wrapper = getWrapper()
+        const resources = inputData.resources
+        expect(wrapper.vm.$_delete_items[0].isEnabled({ resources })).toBe(inputData.expectedStatus)
+      })
+    })
+  })
+})

--- a/packages/web-app-files/tests/unit/mixins/actions/rename.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/actions/rename.spec.js
@@ -6,6 +6,11 @@ import rename from '@files/src/mixins/actions/rename.js'
 const localVue = createLocalVue()
 localVue.use(Vuex)
 
+const currentFolder = {
+  id: 1,
+  path: '/folder'
+}
+
 describe('rename', () => {
   const Component = {
     render() {},
@@ -31,9 +36,7 @@ describe('rename', () => {
           Files: {
             namespaced: true,
             getters: {
-              currentFolder: () => {
-                return { id: 1, path: '/folder' }
-              },
+              currentFolder: () => currentFolder,
               files: () => [{ name: 'file1' }]
             },
             actions: {
@@ -142,8 +145,7 @@ describe('rename', () => {
 
       const wrapper = getWrapper(promise)
       const spyHideModalStub = jest.spyOn(wrapper.vm, 'hideModal')
-      const resource = { id: 1, path: 'folder' }
-      wrapper.vm.$_rename_renameResource(resource, 'new name')
+      wrapper.vm.$_rename_renameResource(currentFolder, 'new name')
       await wrapper.vm.$nextTick()
       expect(wrapper.vm.$router.length).toBeGreaterThanOrEqual(1)
       expect(spyHideModalStub).toHaveBeenCalledTimes(1)
@@ -157,8 +159,7 @@ describe('rename', () => {
       const wrapper = getWrapper(promise)
       const spyHideModalStub = jest.spyOn(wrapper.vm, 'hideModal')
       const spyShowMessageStub = jest.spyOn(wrapper.vm, 'showMessage')
-      const resource = { id: 2, path: 'folder' }
-      wrapper.vm.$_rename_renameResource(resource, 'new name')
+      wrapper.vm.$_rename_renameResource(currentFolder, 'new name')
       await wrapper.vm.$nextTick()
       await wrapper.vm.$nextTick()
       expect(spyHideModalStub).toHaveBeenCalledTimes(0)

--- a/packages/web-app-files/tests/unit/mixins/actions/rename.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/actions/rename.spec.js
@@ -47,7 +47,8 @@ describe('rename', () => {
           createModal: jest.fn(),
           hideModal: jest.fn(),
           toggleModalConfirmButton: jest.fn(),
-          showMessage: jest.fn()
+          showMessage: jest.fn(),
+          setModalInputErrorMessage: jest.fn()
         }
       })
     })

--- a/packages/web-app-files/tests/unit/mixins/actions/rename.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/actions/rename.spec.js
@@ -1,0 +1,124 @@
+import Vuex from 'vuex'
+import { createStore } from 'vuex-extensions'
+import { mount, createLocalVue } from '@vue/test-utils'
+import rename from '@files/src/mixins/actions/rename.js'
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
+
+describe('rename', () => {
+  const Component = {
+    render() {},
+    mixins: [rename]
+  }
+
+  function getWrapper(renameFilePromise) {
+    return mount(Component, {
+      localVue,
+      mocks: {
+        $route: {
+          name: 'files-personal'
+        },
+        $router: [],
+        $client: { files: { list: jest.fn(() => []) } },
+        $gettextInterpolate: () => 'title',
+        publicPage: () => false
+      },
+      store: createStore(Vuex.Store, {
+        modules: {
+          Files: {
+            namespaced: true,
+            getters: {
+              currentFolder: () => {
+                return { id: 1, path: '/folder' }
+              },
+              files: () => [{ name: 'file1' }]
+            },
+            actions: {
+              renameFile: jest.fn(() => {
+                return renameFilePromise
+              })
+            }
+          }
+        },
+        actions: {
+          createModal: jest.fn(),
+          hideModal: jest.fn(),
+          toggleModalConfirmButton: jest.fn(),
+          showMessage: jest.fn()
+        }
+      })
+    })
+  }
+
+  describe('computed property "$_rename_items"', () => {
+    describe('isEnabled property of returned element', () => {
+      it.each([
+        { resources: [{ canRename: () => true }], expectedStatus: true },
+        { resources: [{ canRename: () => false }], expectedStatus: false },
+        { resources: [{ canRename: () => true }, { canRename: () => true }], expectedStatus: false }
+      ])('should be set correctly', (inputData) => {
+        const wrapper = getWrapper()
+        const resources = inputData.resources
+        expect(wrapper.vm.$_rename_items[0].isEnabled({ resources })).toBe(inputData.expectedStatus)
+      })
+    })
+  })
+
+  describe('method "$_rename_trigger"', () => {
+    it('should trigger the rename modal window', async () => {
+      const wrapper = getWrapper()
+      const spyCreateModalStub = jest.spyOn(wrapper.vm, 'createModal')
+      const resources = [{ id: 1 }]
+      await wrapper.vm.$_rename_trigger({ resources })
+      expect(spyCreateModalStub).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('method "$_rename_renameResource"', () => {
+    it('should call the rename action on a resource in the file list', async () => {
+      const promise = new Promise((resolve) => {
+        resolve()
+      })
+
+      const wrapper = getWrapper(promise)
+      const spyHideModalStub = jest.spyOn(wrapper.vm, 'hideModal')
+      const resource = { id: 2, path: 'folder' }
+      wrapper.vm.$_rename_renameResource(resource, 'new name')
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.vm.$router.length).toBeGreaterThanOrEqual(0)
+      expect(spyHideModalStub).toHaveBeenCalledTimes(1)
+    })
+
+    it('should call the rename action on the current folder', async () => {
+      const promise = new Promise((resolve) => {
+        resolve()
+      })
+
+      const wrapper = getWrapper(promise)
+      const spyHideModalStub = jest.spyOn(wrapper.vm, 'hideModal')
+      const resource = { id: 1, path: 'folder' }
+      wrapper.vm.$_rename_renameResource(resource, 'new name')
+      await wrapper.vm.$nextTick()
+      expect(wrapper.vm.$router.length).toBeGreaterThanOrEqual(1)
+      expect(spyHideModalStub).toHaveBeenCalledTimes(1)
+    })
+
+    it('should handle errors properly', async () => {
+      const promise = new Promise((resolve, reject) => {
+        reject(new Error())
+      })
+
+      const wrapper = getWrapper(promise)
+      const spyHideModalStub = jest.spyOn(wrapper.vm, 'hideModal')
+      const spyShowMessageStub = jest.spyOn(wrapper.vm, 'showMessage')
+      const resource = { id: 2, path: 'folder' }
+      wrapper.vm.$_rename_renameResource(resource, 'new name')
+      await wrapper.vm.$nextTick()
+      await wrapper.vm.$nextTick()
+      expect(spyHideModalStub).toHaveBeenCalledTimes(0)
+      expect(spyShowMessageStub).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/packages/web-app-files/tests/unit/mixins/deleteResources.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/deleteResources.spec.js
@@ -11,6 +11,11 @@ const user = {
   quota: 1
 }
 
+const currentFolder = {
+  id: 1,
+  path: '/folder'
+}
+
 describe('deleteResources', () => {
   const Component = {
     render() {},
@@ -31,7 +36,7 @@ describe('deleteResources', () => {
           }
         },
         publicPage: () => false,
-        currentFolder: { id: 1, path: '/folder' }
+        currentFolder: currentFolder
       },
       data: () => {
         return { resourcesToDelete: resourcesToDelete }
@@ -78,8 +83,8 @@ describe('deleteResources', () => {
       expect(spyHideModalStub).toHaveBeenCalledTimes(1)
     })
 
-    it('should call the folder itself', async () => {
-      const resourcesToDelete = [{ id: 1, path: '/folder' }]
+    it('should call the delete action on the current folder', async () => {
+      const resourcesToDelete = [currentFolder]
       const wrapper = getWrapper(resourcesToDelete)
       const spyHideModalStub = jest.spyOn(wrapper.vm, 'hideModal')
       await wrapper.vm.$_deleteResources_filesList_delete()

--- a/packages/web-app-files/tests/unit/mixins/deleteResources.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/deleteResources.spec.js
@@ -1,0 +1,91 @@
+import Vuex from 'vuex'
+import { createStore } from 'vuex-extensions'
+import { mount, createLocalVue } from '@vue/test-utils'
+import deleteResources from '@files/src/mixins/deleteResources.js'
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
+
+const user = {
+  id: 1,
+  quota: 1
+}
+
+describe('deleteResources', () => {
+  const Component = {
+    render() {},
+    mixins: [deleteResources]
+  }
+
+  function getWrapper(resourcesToDelete) {
+    return mount(Component, {
+      localVue,
+      mocks: {
+        $route: {
+          name: 'files-personal'
+        },
+        $router: [],
+        $client: {
+          users: {
+            getUser: jest.fn(() => user)
+          }
+        },
+        publicPage: () => false,
+        currentFolder: { id: 1, path: '/folder' }
+      },
+      data: () => {
+        return { resourcesToDelete: resourcesToDelete }
+      },
+      store: createStore(Vuex.Store, {
+        getters: {
+          user: () => {
+            return { id: 'marie' }
+          }
+        },
+        modules: {
+          Files: {
+            namespaced: true,
+            actions: {
+              deleteFiles: jest.fn(
+                () =>
+                  new Promise((resolve) => {
+                    resolve()
+                  })
+              )
+            }
+          }
+        },
+        mutations: {
+          SET_QUOTA: () => {}
+        },
+        actions: {
+          createModal: jest.fn(),
+          hideModal: jest.fn(),
+          toggleModalConfirmButton: jest.fn()
+        }
+      })
+    })
+  }
+
+  describe('method "$_deleteResources_filesList_delete"', () => {
+    it('should call the delete action on a resource in the file list', async () => {
+      const resourcesToDelete = [{ id: 2, path: '/' }]
+      const wrapper = getWrapper(resourcesToDelete)
+      const spyHideModalStub = jest.spyOn(wrapper.vm, 'hideModal')
+      await wrapper.vm.$_deleteResources_filesList_delete()
+      await wrapper.vm.$nextTick()
+      expect(wrapper.vm.$router.length).toBeGreaterThanOrEqual(0)
+      expect(spyHideModalStub).toHaveBeenCalledTimes(1)
+    })
+
+    it('should call the folder itself', async () => {
+      const resourcesToDelete = [{ id: 1, path: '/folder' }]
+      const wrapper = getWrapper(resourcesToDelete)
+      const spyHideModalStub = jest.spyOn(wrapper.vm, 'hideModal')
+      await wrapper.vm.$_deleteResources_filesList_delete()
+      await wrapper.vm.$nextTick()
+      expect(wrapper.vm.$router.length).toBeGreaterThanOrEqual(1)
+      expect(spyHideModalStub).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -14,7 +14,7 @@
     "lodash-es": "^4.17.21",
     "luxon": "^2.0.0",
     "oidc-client": "1.11.5",
-    "owncloud-design-system": "^11.2.2",
+    "owncloud-design-system": "^11.3.0-rc1",
     "owncloud-sdk": "1.0.0-2296",
     "p-queue": "^6.1.1",
     "popper-max-size-modifier": "^0.2.0",

--- a/packages/web-runtime/tests/unit/components/__snapshots__/ApplicationsMenu.spec.js.snap
+++ b/packages/web-runtime/tests/unit/components/__snapshots__/ApplicationsMenu.spec.js.snap
@@ -7,7 +7,7 @@ exports[`ApplicationsMenu component shoud set aria-label prop on switcher button
 `;
 
 exports[`ApplicationsMenu component should show app menus 1`] = `
-<oc-drop-stub dropid="app-switcher-dropdown" toggle="#_appSwitcherButton" position="bottom-start" mode="click" closeonclick="true" options="[object Object]" class="uk-width-large">
+<oc-drop-stub dropid="app-switcher-dropdown" toggle="#_appSwitcherButton" position="bottom-start" mode="click" closeonclick="true" paddingsize="medium" options="[object Object]" class="uk-width-large">
   <ul uk-grid="" class="uk-grid-small uk-text-center">
     <li class="uk-width-1-3">
       <router-link-stub to="/files" tag="a" ariacurrentvalue="page" event="click">

--- a/yarn.lock
+++ b/yarn.lock
@@ -10602,9 +10602,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"owncloud-design-system@npm:^11.2.2":
-  version: 11.2.2
-  resolution: "owncloud-design-system@npm:11.2.2"
+"owncloud-design-system@npm:^11.3.0-rc1":
+  version: 11.3.0-rc1
+  resolution: "owncloud-design-system@npm:11.3.0-rc1"
   peerDependencies:
     "@popperjs/core": ^2.4.0
     filesize: ^8.0.0
@@ -10621,7 +10621,7 @@ __metadata:
     vue-inline-svg: ^2.0.0
     vue-select: ^3.12.0
     webfontloader: ^1.6.28
-  checksum: be4730cbc76c49ee9fa9b90d3155211cfdbf0c5564eaaee2ce0b6185b4ef50348a768fbc5f65dccb411c658551c7a9c7062c8b261de899de1982fca9158cb778
+  checksum: a5149838389182c673e10fc6e10fc797e194d2823337b82e8abed3eea71bc2ade3852dac0e1b896795ea8ae775d65d0fbd3b1ca6b77e87fd66f3d6af62087f8f
   languageName: node
   linkType: hard
 
@@ -14953,7 +14953,7 @@ typescript@^4.3.2:
     lodash-es: ^4.17.21
     luxon: ^2.0.0
     oidc-client: 1.11.5
-    owncloud-design-system: ^11.2.2
+    owncloud-design-system: ^11.3.0-rc1
     owncloud-sdk: 1.0.0-2296
     p-queue: ^6.1.1
     popper-max-size-modifier: ^0.2.0


### PR DESCRIPTION
## Description
The last element of the breadcrumb now has a context menu which gives the user the possibility to perform actions on the current folder.

Requires https://github.com/owncloud/owncloud-design-system/pull/1786 to work.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/6030

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/50302941/142850661-e3f54889-28cb-4933-a217-f5f59cbf6b3d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
