### PR TITLE
[deployment examples] rename app provider environment variables

### DIFF
--- a/deployments/examples/ocis_web/docker-compose.yml
+++ b/deployments/examples/ocis_web/docker-compose.yml
@@ -105,8 +105,8 @@ services:
     #command: storage-app-provider server
     environment:
       REVA_GATEWAY: ${REVA_GATEWAY:-ocis:9142}
-      APP_PROVIDER_BASIC_GRPC_ADDR: 0.0.0.0:9164
-      APP_PROVIDER_BASIC_EXTERNAL_ADDR: ocis-appdriver-collabora:9164
+      APP_PROVIDER_GRPC_ADDR: 0.0.0.0:9164
+      APP_PROVIDER_EXTERNAL_ADDR: ocis-appdriver-collabora:9164
       OCIS_JWT_SECRET: ${OCIS_JWT_SECRET:-Pive-Fumkiu4}
       OCIS_MACHINE_AUTH_API_KEY: ${OCIS_MACHINE_AUTH_API_KEY:-change-me-please}
       APP_PROVIDER_DRIVER: wopi
@@ -133,8 +133,8 @@ services:
     #command: storage-app-provider server
     environment:
       REVA_GATEWAY: ${REVA_GATEWAY:-ocis:9142}
-      APP_PROVIDER_BASIC_GRPC_ADDR: 0.0.0.0:9164
-      APP_PROVIDER_BASIC_EXTERNAL_ADDR: ocis-appdriver-onlyoffice:9164
+      APP_PROVIDER_GRPC_ADDR: 0.0.0.0:9164
+      APP_PROVIDER_EXTERNAL_ADDR: ocis-appdriver-onlyoffice:9164
       OCIS_JWT_SECRET: ${OCIS_JWT_SECRET:-Pive-Fumkiu4}
       OCIS_MACHINE_AUTH_API_KEY: ${OCIS_MACHINE_AUTH_API_KEY:-change-me-please}
       APP_PROVIDER_DRIVER: wopi
@@ -161,8 +161,8 @@ services:
     #command: storage-app-provider server
     environment:
       REVA_GATEWAY: ${REVA_GATEWAY:-ocis:9142}
-      APP_PROVIDER_BASIC_GRPC_ADDR: 0.0.0.0:9164
-      APP_PROVIDER_BASIC_EXTERNAL_ADDR: ocis-appdriver-codimd:9164
+      APP_PROVIDER_GRPC_ADDR: 0.0.0.0:9164
+      APP_PROVIDER_EXTERNAL_ADDR: ocis-appdriver-codimd:9164
       OCIS_JWT_SECRET: ${OCIS_JWT_SECRET:-Pive-Fumkiu4}
       OCIS_MACHINE_AUTH_API_KEY: ${OCIS_MACHINE_AUTH_API_KEY:-change-me-please}
       APP_PROVIDER_DRIVER: wopi


### PR DESCRIPTION
## Description
This PR switches to the new configuration environment variable for the app provider

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- needs owncloud/ocis#2811 first
- is needed after owncloud/ocis#2812

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Make the app provider in the deployment example work after owncloud/ocis#2812

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->

