### PR TITLE
Fix pagination on page 2 and following

### DIFF
--- a/changelog/unreleased/bugfix-pagination
+++ b/changelog/unreleased/bugfix-pagination
@@ -1,0 +1,5 @@
+Bugfix: Pagination
+
+We fixed the pagination as it was slicing the items wrong on pages after the first one.
+
+https://github.com/owncloud/web/pull/6056

--- a/packages/web-app-files/src/store/modules/pagination.js
+++ b/packages/web-app-files/src/store/modules/pagination.js
@@ -6,7 +6,7 @@ export default {
   }),
   mutations: {
     SET_ITEMS_PER_PAGE(state, limit) {
-      state.itemsPerPage = limit
+      state.itemsPerPage = parseInt(limit)
 
       window.localStorage.setItem('oc_filesPageLimit', limit)
     },
@@ -16,7 +16,7 @@ export default {
   },
   getters: {
     pages: (state, getters, rootState, rootGetters) => {
-      if (!parseInt(state.itemsPerPage)) {
+      if (!state.itemsPerPage) {
         return 1
       }
 


### PR DESCRIPTION
## Description
Pagination was broken on page 2 and following because the `items per page` were referenced as strings. `firstElementIndex + itemsPerPage` for `firstElementIndex=0` and `itemsPerPage="100"` resulted in `0100`.

## Motivation and Context
Bugfix

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
