### PR TITLE
[tests-only] Shorten pipeline names

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -82,7 +82,7 @@ config = {
                     "webUISharingExpirationDate",
                 ],
                 "webUIResharingToRoot": "oC10ResharingToRoot",
-                "oC10SharingFilePermission": [
+                "oC10SharingFilePerm": [
                     "webUISharingFilePermissionMultipleUsers",
                     "webUISharingFilePermissionsGroups",
                 ],
@@ -92,42 +92,42 @@ config = {
                     "webUISharingFolderPermissionMultipleUsers",
                     "webUISharingFolderPermissionsGroups",
                 ],
-                "oC10SharingInternalGroups": [
+                "oC10SharingIntGroups": [
                     "webUISharingInternalGroups",
                     "webUISharingInternalGroupsEdgeCases",
                 ],
-                "oC10SharingInternalGroupsToRoot": [
+                "oC10SharingIntGroupsToRoot": [
                     "webUISharingInternalGroupsToRoot",
                     "webUISharingInternalGroupsToRootEdgeCases",
                 ],
-                "oC10SharingInternalGroupsSharingInd": [
+                "oC10SharingIntGroupsSharingInd": [
                     "webUISharingInternalGroupsSharingIndicator",
                     "webUISharingInternalGroupsToRootSharingIndicator",
                 ],
-                "oC10SharingInternalUsers": [
+                "oC10SharingIntUsers": [
                     "webUISharingInternalUsers",
                     "webUISharingInternalUsersCollaborator",
                     "webUISharingInternalUsersShareWithPage",
                 ],
-                "webUISharingInternalUsersBlacklisted": "oC10SharingInternalUsersBlacklisted",
-                "oC10SharingInternalUsersSharingInd": [
+                "webUISharingInternalUsersBlacklisted": "oC10SharingIntUsersBlacklisted",
+                "oC10SharingIntUsersSharingInd": [
                     "webUISharingInternalUsersSharingIndicator",
                     "webUISharingInternalUsersToRootSharingIndicator",
                 ],
-                "oC10SharingInternalUsersRoot1": [
+                "oC10SharingIntUsersRoot1": [
                     "webUISharingInternalUsersToRoot",
                     "webUISharingInternalUsersToRootBlacklisted",
                 ],
-                "oC10SharingInternalUsersRoot2": [
+                "oC10SharingIntUsersRoot2": [
                     "webUISharingInternalUsersToRootCollaborator",
                     "webUISharingInternalUsersToRootPreviews",
                     "webUISharingInternalUsersToRootShareWithPage",
                 ],
-                "webUISharingPermissionsUsers": "oC10SharingPermissionsUsers",
-                "webUISharingPermissionToRoot": "oC10SharingPermissionToRoot",
+                "webUISharingPermissionsUsers": "oC10SharingPermUsers",
+                "webUISharingPermissionToRoot": "oC10SharingPermToRoot",
                 "webUISharingPublicBasic": "oC10SharingPublicBasic",
                 "webUISharingPublicManagement": "oC10SharingPublicManagement",
-                "oC10SharingPublicExpireAndRoles": [
+                "oC10SharingPubExpAndRoles": [
                     "webUISharingPublicDifferentRoles",
                     "webUISharingPublicExpire",
                 ],
@@ -408,31 +408,31 @@ config = {
                     "webUIFilesDetails",
                     "webUIFilesSearch",
                 ],
-                "oCISSharingInternalGroups": [
+                "oCISSharingIntGroups": [
                     "webUISharingInternalGroups",
                     "webUISharingInternalGroupsEdgeCases",
                     "webUISharingInternalGroupsSharingIndicator",
                 ],
-                "oCISSharingInternalUsers1": [
+                "oCISSharingIntUsers1": [
                     "webUISharingInternalUsers",
                     "webUISharingAutocompletion",
                     "webUISharingExpirationDate",
                 ],
-                "oCISSharingInternalUsers2": [
+                "oCISSharingIntUsers2": [
                     "webUISharingInternalUsersBlacklisted",
                     "webUISharingInternalUsersCollaborator",
                     "webUISharingInternalUsersShareWithPage",
                     "webUISharingInternalUsersSharingIndicator",
                 ],
-                "oCISSharingPermissions1": [
+                "oCISSharingPerm1": [
                     "webUISharingPermissionsUsers",
                     "webUISharingFilePermissionsGroups",
                 ],
-                "oCISSharingPermissions2": [
+                "oCISSharingPerm2": [
                     "webUISharingFolderPermissionsGroups",
                     "webUISharingFolderAdvancedPermissionsGroups",
                 ],
-                "oCISSharingPermissions3": [
+                "oCISSharingPerm3": [
                     "webUISharingFilePermissionMultipleUsers",
                     "webUISharingFolderPermissionMultipleUsers",
                     "webUISharingFolderAdvancedPermissionMultipleUsers",
@@ -445,7 +445,7 @@ config = {
                     "webUISharingPublicBasic",
                     "webUISharingPublicManagement",
                 ],
-                "oCISSharingPublicExpireAndRoles": [
+                "oCISSharingPubExpAndRoles": [
                     "webUISharingPublicDifferentRoles",
                     "webUISharingPublicExpire",
                 ],


### PR DESCRIPTION
## Description
PR #6063 test against the `10.9.0-beta1` oC10 tarball. That name is longer than when we test against `latest`. The names of the acceptance test pipelines include the oC10 system-version-under-test. Pipeline names in drone are limited to 50 characters. Some generated pipeline names exceeded this limit, for example:
```
$ drone starlark
Error: generated stage name of length 51 is not supported. The maximum length is 50. oC10SharingInternalGroupsToRoot-chrome-10.9.0-beta1
2021/11/27 17:32:20 starlark evaluation error:
Traceback (most recent call last):
  .drone.star:716:47: in main
  .drone.star:757:38: in stagePipelines
  .drone.star:1251:17: in acceptance
```

This PR reduces the longer names so that we can avoid this annoying limit for most future test runs.


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
