### PR TITLE
[tests-only][full-ci]Fix failing expiration dates tests

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/expirationDatePicker.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/expirationDatePicker.js
@@ -98,8 +98,26 @@ module.exports = {
      */
     isExpiryDateDisabled: async function (pastDate) {
       let disabled = false
-
       const yearSelector = this.getSelectorExpiryDateYear(pastDate)
+      const month = pastDate.toLocaleString('default', { month: 'long' })
+      const monthSelector = this.getSelectorExpiryDateMonth(pastDate)
+      const daySelector = this.getSelectorExpiryDateDay(pastDate)
+
+      if (month === 'December') {
+        await this.waitForElementVisible(daySelector).getAttribute(
+          daySelector,
+          'class',
+          (result) => {
+            if (result.value.includes('is-disabled') === true) {
+              disabled = true
+            }
+          }
+        )
+        if (disabled) {
+          return disabled
+        } else return false
+      }
+
       await this.waitForElementVisible('@datepickerTitle')
         .click('@datepickerTitle')
         .waitForElementVisible('@datepickerMonthAndYearTitle', 500)
@@ -115,7 +133,6 @@ module.exports = {
         return disabled
       }
 
-      const monthSelector = this.getSelectorExpiryDateMonth(pastDate)
       await this.waitForElementVisible(yearSelector)
         .click(yearSelector)
         .waitForElementVisible(monthSelector)
@@ -129,7 +146,6 @@ module.exports = {
         return disabled
       }
 
-      const daySelector = this.getSelectorExpiryDateDay(pastDate)
       await this.waitForElementVisible(monthSelector)
         .click(monthSelector)
         .waitForElementVisible(daySelector)
@@ -162,6 +178,11 @@ module.exports = {
           )
           return false
         }
+      }
+      const month = dateToSet.toLocaleString('default', { month: 'long' })
+      if (month === 'December') {
+        await this.setExpiryDateMonth(dateToSet).setExpiryDateDay(dateToSet)
+        return true
       }
       await this.setExpiryDateYear(dateToSet)
         .setExpiryDateMonth(dateToSet)


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR fixes the expiration-related tests that were failing because it's almost end of the year and the `selecting this year 2021` button is disabled in the UI. The PR check if the month of the expiration date is `December` directly day of the expiration is selected and this fixes the issue

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes : https://github.com/owncloud/web/issues/6071

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
