### PR TITLE
[full-ci] Fix inconsistencies in share expiry dates

### DIFF
--- a/changelog/unreleased/bugfix-expiry-date-inconsistencies
+++ b/changelog/unreleased/bugfix-expiry-date-inconsistencies
@@ -1,0 +1,7 @@
+Bugfix: Inconsistencies in share expiry dates
+
+* Share expiry dates now always refer to the end of the given day. This change allows users to select the current day as expiry date.
+* Displayed expiry dates have been aligned to ensure their consistency.
+* We now use the Luxon `DateTime` object more consistently across the code base (replacing JavaScript's `new Date()).
+
+https://github.com/owncloud/web/pull/6084

--- a/changelog/unreleased/bugfix-expiry-date-inconsistencies
+++ b/changelog/unreleased/bugfix-expiry-date-inconsistencies
@@ -2,6 +2,7 @@ Bugfix: Inconsistencies in share expiry dates
 
 * Share expiry dates now always refer to the end of the given day. This change allows users to select the current day as expiry date.
 * Displayed expiry dates have been aligned to ensure their consistency.
+* Existing expiry dates for public links can now be removed again.
 * We now use the Luxon `DateTime` object more consistently across the code base (replacing JavaScript's `new Date()).
 
 https://github.com/owncloud/web/pull/6084

--- a/packages/web-app-files/src/components/SideBar/Links/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/FileLinks.vue
@@ -18,6 +18,7 @@
             id="files-file-link-add"
             icon="add"
             variation="primary"
+            data-testid="files-file-link-add-btn"
             :aria-label="$_addButtonAriaLabel"
             @click="addNewLink"
           >
@@ -33,13 +34,14 @@
         />
         <transition-group
           class="uk-list uk-list-divider uk-overflow-hidden oc-m-rm"
+          data-testid="file-links-list"
           :enter-active-class="$_transitionGroupEnter"
           :leave-active-class="$_transitionGroupLeave"
           name="custom-classes-transition"
           tag="ul"
         >
           <li v-for="link in links" :key="link.key">
-            <list-item :link="link" />
+            <list-item :data-testid="`files-link-id-${link.id}`" :link="link" />
           </li>
         </transition-group>
         <p

--- a/packages/web-app-files/src/components/SideBar/Links/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/FileLinks.vue
@@ -18,7 +18,7 @@
             id="files-file-link-add"
             icon="add"
             variation="primary"
-            data-testid="files-file-link-add-btn"
+            data-testid="files-link-add-btn"
             :aria-label="$_addButtonAriaLabel"
             @click="addNewLink"
           >
@@ -34,7 +34,6 @@
         />
         <transition-group
           class="uk-list uk-list-divider uk-overflow-hidden oc-m-rm"
-          data-testid="file-links-list"
           :enter-active-class="$_transitionGroupEnter"
           :leave-active-class="$_transitionGroupLeave"
           name="custom-classes-transition"

--- a/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkActions.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkActions.vue
@@ -5,6 +5,7 @@
       <oc-button
         v-oc-tooltip="editButtonLabel"
         :aria-label="editButtonLabel"
+        :data-testid="`files-link-id-${link.id}-btn-edit`"
         appearance="raw"
         class="oc-files-file-link-edit oc-mr-xs"
         @click="editLink"

--- a/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkEdit.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkEdit.vue
@@ -166,7 +166,6 @@ import { mapGetters, mapActions, mapState } from 'vuex'
 import mixins from '../../../../mixins'
 import { DateTime } from 'luxon'
 import publicLinkRoles from '../../../../helpers/publicLinkRolesDefinition'
-import { addDays } from 'web-runtime/src/helpers/date'
 
 import RoleItem from '../../Shared/RoleItem.vue'
 
@@ -247,7 +246,7 @@ export default {
     },
 
     minExpirationDate() {
-      return addDays(new Date(), 1)
+      return DateTime.now().setLocale(this.$language.current).toJSDate()
     },
 
     maxExpirationDate() {
@@ -256,8 +255,7 @@ export default {
       }
 
       const days = parseInt(this.$_expirationDate.days, 10)
-
-      return addDays(new Date(), days)
+      return DateTime.now().setLocale(this.$language.current).plus({ days: days }).toJSDate()
     },
 
     $_expirationIsValid() {
@@ -324,7 +322,8 @@ export default {
         return null
       }
 
-      return addDays(new Date(), parseInt(this.$_expirationDate.days))
+      const days = parseInt(this.$_expirationDate.days)
+      return DateTime.now().setLocale(this.$language.current).plus({ days: days }).toJSDate()
     }
   },
   created() {
@@ -364,7 +363,10 @@ export default {
       this.saving = true
 
       const params = {
-        expireDate: DateTime.fromJSDate(this.expireDate).endOf('day').toISODate(),
+        expireDate: DateTime.fromJSDate(this.expireDate)
+          .setLocale(this.$language.current)
+          .endOf('day')
+          .toFormat("yyyy-MM-dd'T'HH:mm:ssZZZ"),
         permissions: this.selectedRole.permissions,
         name: this.name
       }
@@ -394,7 +396,10 @@ export default {
       this.saving = true
 
       const params = {
-        expireDate: DateTime.fromJSDate(this.expireDate).endOf('day').toISODate(),
+        expireDate: DateTime.fromJSDate(this.expireDate)
+          .setLocale(this.$language.current)
+          .endOf('day')
+          .toFormat("yyyy-MM-dd'T'HH:mm:ssZZZ"),
         permissions: this.selectedRole.permissions,
         name: this.name
       }

--- a/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkEdit.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkEdit.vue
@@ -127,11 +127,15 @@
           >
             <template v-if="$_isNew">
               <oc-spinner :aria-label="$gettext('Creating Public Link')" size="small" />
-              <span v-translate data-testid="file-link-being-created" :aria-hidden="true">Creating</span>
+              <span v-translate data-testid="file-link-being-created" :aria-hidden="true"
+                >Creating</span
+              >
             </template>
             <template v-else>
               <oc-spinner :aria-label="$gettext('Saving Public Link')" size="small" />
-              <span v-translate data-testid="file-link-being-saved" :aria-hidden="true">Saving</span>
+              <span v-translate data-testid="file-link-being-saved" :aria-hidden="true"
+                >Saving</span
+              >
             </template>
           </oc-button>
           <template v-else>

--- a/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkEdit.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkEdit.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="oc-files-edit-public-link oc-files-file-link-form" data-testid="new-file-link">
+  <div class="oc-files-edit-public-link oc-files-file-link-form" data-testid="new-files-link">
     <form @submit.prevent>
       <transition
         enter-active-class="uk-animation-slide-top-small"
@@ -72,7 +72,7 @@
           id="oc-files-file-link-expire-date-delete"
           class="oc-mt-s"
           appearance="raw"
-          data-testid="file-link-remove-expiration-date"
+          data-testid="files-link-remove-expiration-date"
           @click="expireDate = null"
           v-text="$gettext('Remove expiration date')"
         />
@@ -127,13 +127,13 @@
           >
             <template v-if="$_isNew">
               <oc-spinner :aria-label="$gettext('Creating Public Link')" size="small" />
-              <span v-translate data-testid="file-link-being-created" :aria-hidden="true"
+              <span v-translate data-testid="files-link-being-created" :aria-hidden="true"
                 >Creating</span
               >
             </template>
             <template v-else>
               <oc-spinner :aria-label="$gettext('Saving Public Link')" size="small" />
-              <span v-translate data-testid="file-link-being-saved" :aria-hidden="true"
+              <span v-translate data-testid="files-link-being-saved" :aria-hidden="true"
                 >Saving</span
               >
             </template>
@@ -142,7 +142,7 @@
             <oc-button
               v-if="$_isNew"
               id="oc-files-file-link-create"
-              data-testid="new-file-link-btn"
+              data-testid="new-files-link-btn"
               :disabled="!$_isValid"
               variation="primary"
               appearance="filled"
@@ -153,7 +153,7 @@
             <oc-button
               v-else
               id="oc-files-file-link-save"
-              data-testid="save-file-link-btn"
+              data-testid="save-files-link-btn"
               :disabled="!$_isValid || !$_hasChanges"
               variation="primary"
               appearance="filled"

--- a/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkEdit.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkEdit.vue
@@ -255,7 +255,7 @@ export default {
       }
 
       const days = parseInt(this.$_expirationDate.days, 10)
-      return DateTime.now().setLocale(this.$language.current).plus({ days: days }).toJSDate()
+      return DateTime.now().setLocale(this.$language.current).plus({ days }).toJSDate()
     },
 
     $_expirationIsValid() {
@@ -323,7 +323,7 @@ export default {
       }
 
       const days = parseInt(this.$_expirationDate.days)
-      return DateTime.now().setLocale(this.$language.current).plus({ days: days }).toJSDate()
+      return DateTime.now().setLocale(this.$language.current).plus({ days }).toJSDate()
     }
   },
   created() {
@@ -362,11 +362,12 @@ export default {
     $_addLink() {
       this.saving = true
 
+      const expireDate = DateTime.fromJSDate(this.expireDate)
+        .setLocale(this.$language.current)
+        .endOf('day')
+
       const params = {
-        expireDate: DateTime.fromJSDate(this.expireDate)
-          .setLocale(this.$language.current)
-          .endOf('day')
-          .toFormat("yyyy-MM-dd'T'HH:mm:ssZZZ"),
+        expireDate: expireDate.isValid ? expireDate.toFormat("yyyy-MM-dd'T'HH:mm:ssZZZ") : '',
         permissions: this.selectedRole.permissions,
         name: this.name
       }
@@ -395,11 +396,12 @@ export default {
     $_updateLink() {
       this.saving = true
 
+      const expireDate = DateTime.fromJSDate(this.expireDate)
+        .setLocale(this.$language.current)
+        .endOf('day')
+
       const params = {
-        expireDate: DateTime.fromJSDate(this.expireDate)
-          .setLocale(this.$language.current)
-          .endOf('day')
-          .toFormat("yyyy-MM-dd'T'HH:mm:ssZZZ"),
+        expireDate: expireDate.isValid ? expireDate.toFormat("yyyy-MM-dd'T'HH:mm:ssZZZ") : '',
         permissions: this.selectedRole.permissions,
         name: this.name
       }

--- a/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkEdit.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkEdit.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="oc-files-edit-public-link oc-files-file-link-form">
+  <div class="oc-files-edit-public-link oc-files-file-link-form" data-testid="new-file-link">
     <form @submit.prevent>
       <transition
         enter-active-class="uk-animation-slide-top-small"
@@ -72,6 +72,7 @@
           id="oc-files-file-link-expire-date-delete"
           class="oc-mt-s"
           appearance="raw"
+          data-testid="file-link-remove-expiration-date"
           @click="expireDate = null"
           v-text="$gettext('Remove expiration date')"
         />
@@ -126,17 +127,18 @@
           >
             <template v-if="$_isNew">
               <oc-spinner :aria-label="$gettext('Creating Public Link')" size="small" />
-              <span v-translate :aria-hidden="true">Creating</span>
+              <span v-translate data-testid="file-link-being-created" :aria-hidden="true">Creating</span>
             </template>
             <template v-else>
               <oc-spinner :aria-label="$gettext('Saving Public Link')" size="small" />
-              <span v-translate :aria-hidden="true">Saving</span>
+              <span v-translate data-testid="file-link-being-saved" :aria-hidden="true">Saving</span>
             </template>
           </oc-button>
           <template v-else>
             <oc-button
               v-if="$_isNew"
               id="oc-files-file-link-create"
+              data-testid="new-file-link-btn"
               :disabled="!$_isValid"
               variation="primary"
               appearance="filled"
@@ -147,6 +149,7 @@
             <oc-button
               v-else
               id="oc-files-file-link-save"
+              data-testid="save-file-link-btn"
               :disabled="!$_isValid || !$_hasChanges"
               variation="primary"
               appearance="filled"

--- a/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkInfo.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkInfo.vue
@@ -30,15 +30,13 @@
       </div>
       <div v-if="link.expiration">
         <oc-tag
-          v-oc-tooltip="formDateFromISO(link.expiration)"
+          v-oc-tooltip="expirationDate"
           tabindex="0"
           class="oc-files-public-link-expires"
-          :aria-label="
-            formRelativeDateFromISO(link.expiration) + ' (' + formDateFromISO(link.expiration) + ')'
-          "
+          :aria-label="expirationDateRelative + ' (' + expirationDate + ')'"
         >
           <oc-icon name="text-calendar" />
-          <translate :translate-params="{ expires: formRelativeDateFromISO(link.expiration) }">
+          <translate :translate-params="{ expires: expirationDateRelative }">
             Expires %{expires}
           </translate>
         </oc-tag>
@@ -68,6 +66,7 @@
 import { basename, dirname } from 'path'
 import Mixins from '../../../../mixins'
 import CopyToClipboardButton from '../CopyToClipboardButton.vue'
+import { DateTime } from 'luxon'
 
 export default {
   name: 'LinkInfo',
@@ -139,6 +138,20 @@ export default {
 
     copyToClipboardSuccessMsgTitle() {
       return this.$gettext('Public link copied')
+    },
+
+    expirationDate() {
+      return DateTime.fromISO(this.link.expiration)
+        .setLocale(this.$language.current)
+        .endOf('day')
+        .toLocaleString(DateTime.DATETIME_FULL)
+    },
+
+    expirationDateRelative() {
+      return DateTime.fromISO(this.link.expiration)
+        .setLocale(this.$language.current)
+        .endOf('day')
+        .toRelative()
     }
   },
 

--- a/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkInfo.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkInfo.vue
@@ -33,6 +33,7 @@
           v-oc-tooltip="expirationDate"
           tabindex="0"
           class="oc-files-public-link-expires"
+          :data-testid="`files-link-id-${link.id}-expiration-date`"
           :aria-label="expirationDateRelative + ' (' + expirationDate + ')'"
         >
           <oc-icon name="text-calendar" />

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/CollaboratorsEditOptions.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/CollaboratorsEditOptions.vue
@@ -259,7 +259,7 @@ export default {
         days = userMaxExpirationDays || groupMaxExpirationDays
       }
 
-      return DateTime.now().setLocale(this.$language.current).plus({ days: days }).toJSDate()
+      return DateTime.now().setLocale(this.$language.current).plus({ days }).toJSDate()
     },
 
     expirationDateEnforced() {
@@ -350,12 +350,16 @@ export default {
     },
 
     publishChange() {
+      const expirationDate = DateTime.fromJSDate(this.enteredExpirationDate)
+        .setLocale(this.$language.current)
+        .endOf('day')
+
       this.$emit('optionChange', {
         role: this.selectedRole,
         permissions: this.customPermissions,
-        expirationDate: DateTime.fromJSDate(this.enteredExpirationDate)
-          .endOf('day')
-          .toFormat("yyyy-MM-dd'T'HH:mm:ssZZZ")
+        expirationDate: expirationDate.isValid
+          ? expirationDate.toFormat("yyyy-MM-dd'T'HH:mm:ssZZZ")
+          : null
       })
     },
 

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/CollaboratorsEditOptions.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/CollaboratorsEditOptions.vue
@@ -259,9 +259,7 @@ export default {
         days = userMaxExpirationDays || groupMaxExpirationDays
       }
 
-      const date = new Date()
-      date.setDate(new Date().getDate() + days)
-      return date
+      return DateTime.now().setLocale(this.$language.current).plus({ days: days }).toJSDate()
     },
 
     expirationDateEnforced() {
@@ -285,11 +283,7 @@ export default {
     },
 
     minExpirationDate() {
-      const date = new Date()
-
-      date.setDate(new Date().getDate() + 1)
-
-      return date
+      return DateTime.now().setLocale(this.$language.current).toJSDate()
     },
 
     isAdvancedRoleSelected() {
@@ -359,7 +353,9 @@ export default {
       this.$emit('optionChange', {
         role: this.selectedRole,
         permissions: this.customPermissions,
-        expirationDate: DateTime.fromJSDate(this.enteredExpirationDate).endOf('day').toISO()
+        expirationDate: DateTime.fromJSDate(this.enteredExpirationDate)
+          .endOf('day')
+          .toFormat("yyyy-MM-dd'T'HH:mm:ssZZZ")
       })
     },
 

--- a/packages/web-app-files/src/helpers/resources.js
+++ b/packages/web-app-files/src/helpers/resources.js
@@ -262,7 +262,7 @@ function _buildLink(link) {
     password: !!(link.share_with && link.share_with_displayname),
     expiration:
       typeof link.expiration === 'string'
-        ? DateTime.fromFormat(link.expiration, 'yyyy-MM-dd HH:mm:ss').toFormat('yyyy-MM-dd') // @ TODO refactor this?
+        ? DateTime.fromFormat(link.expiration, 'yyyy-MM-dd HH:mm:ss').toFormat('yyyy-MM-dd')
         : null,
     itemSource: link.item_source,
     file: {

--- a/packages/web-app-files/src/helpers/resources.js
+++ b/packages/web-app-files/src/helpers/resources.js
@@ -262,7 +262,7 @@ function _buildLink(link) {
     password: !!(link.share_with && link.share_with_displayname),
     expiration:
       typeof link.expiration === 'string'
-        ? DateTime.fromFormat(link.expiration, 'yyyy-MM-dd HH:mm:ss').toFormat('yyyy-MM-dd')
+        ? DateTime.fromFormat(link.expiration, 'yyyy-MM-dd HH:mm:ss').toFormat('yyyy-MM-dd') // @ TODO refactor this?
         : null,
     itemSource: link.item_source,
     file: {

--- a/packages/web-app-files/tests/integration/helpers/date.js
+++ b/packages/web-app-files/tests/integration/helpers/date.js
@@ -1,3 +1,5 @@
+import userEvent from '@testing-library/user-event'
+
 /**
  * Adds a given number of days to the current date
  * @param {number} days number of days to be added to the current date
@@ -9,4 +11,42 @@ export function getDateInFuture(days) {
   date.setDate(new Date().getDate() + days)
 
   return date
+}
+
+export async function navigateToDate(date, component, direction = 'right') {
+  const formatDate = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }
+
+  if (['right', 'left'].indexOf(direction) < 0) {
+    return Promise.reject(new Error('invalid value for direction. Please use "left" or "right"'))
+  }
+  const { queryByText, baseElement, findByText } = component
+
+  while (true) {
+    const dateHeader = await queryByText(
+      date.toLocaleString('en', { month: 'long', year: 'numeric' })
+    )
+
+    if (!dateHeader) {
+      const nextMonthBtn = baseElement.querySelector(`.vc-arrow.is-${direction}`)
+      await userEvent.click(nextMonthBtn)
+    } else {
+      break
+    }
+  }
+
+  const dateSelector = document.evaluate(
+    `//span[contains(@class, "vc-day-content vc-focusable") and @tabindex="-1" and @aria-label="${date.toLocaleDateString(
+      'en',
+      formatDate
+    )}" and text()="${date.getDate()}"]`,
+    baseElement,
+    null,
+    XPathResult.FIRST_ORDERED_NODE_TYPE,
+    null
+  ).singleNodeValue
+
+  expect(
+    await findByText(date.toLocaleString('en', { month: 'long', year: 'numeric' }))
+  ).toBeVisible()
+  await userEvent.click(dateSelector)
 }

--- a/packages/web-app-files/tests/integration/specs/linkExpirationDate.spec.js
+++ b/packages/web-app-files/tests/integration/specs/linkExpirationDate.spec.js
@@ -47,11 +47,11 @@ describe('Users can set expiration date when sharing via public link', () => {
   test('user can set a new expiration date', async () => {
     const component = renderComponent()
     const { findByTestId, baseElement, getByTestId, findByText, queryByTestId } = component
-    const addBtn = await findByTestId('files-file-link-add-btn')
+    const addBtn = await findByTestId('files-link-add-btn')
 
     expect(addBtn).toBeVisible()
     await fireEvent.click(addBtn)
-    expect(await findByTestId('new-file-link')).toBeVisible()
+    expect(await findByTestId('new-files-link')).toBeVisible()
     await fireEvent.update(baseElement.querySelector('#oc-files-file-link-name'), 'Public link')
 
     expect(getByTestId('recipient-datepicker')).toBeVisible()
@@ -62,11 +62,11 @@ describe('Users can set expiration date when sharing via public link', () => {
 
     expect(await findByText('Expires in 2 days')).toBeVisible()
 
-    const shareBtn = getByTestId('new-file-link-btn')
+    const shareBtn = getByTestId('new-files-link-btn')
     expect(shareBtn).toBeVisible()
     await fireEvent.click(shareBtn)
     await waitFor(() => {
-      return expect(queryByTestId('file-link-being-created')).toBe(null)
+      return expect(queryByTestId('files-link-being-created')).toBe(null)
     })
 
     const link = await findByTestId('files-link-id-1')
@@ -106,11 +106,11 @@ describe('Users can set expiration date when sharing via public link', () => {
 
     expect(await findByText('Expires in 4 days')).toBeVisible()
 
-    const shareBtn = getByTestId('save-file-link-btn')
+    const shareBtn = getByTestId('save-files-link-btn')
     expect(shareBtn).toBeVisible()
     await fireEvent.click(shareBtn)
     await waitFor(() => {
-      return expect(queryByTestId('file-link-being-saved')).toBe(null)
+      return expect(queryByTestId('files-link-being-saved')).toBe(null)
     })
 
     expect(
@@ -139,15 +139,15 @@ describe('Users can set expiration date when sharing via public link', () => {
     expect(editBtn).toBeVisible()
     await fireEvent.click(editBtn)
 
-    const removeExpiryDateBtn = getByTestId('file-link-remove-expiration-date')
+    const removeExpiryDateBtn = getByTestId('files-link-remove-expiration-date')
     expect(removeExpiryDateBtn).toBeVisible()
     await fireEvent.click(removeExpiryDateBtn)
 
-    const shareBtn = getByTestId('save-file-link-btn')
+    const shareBtn = getByTestId('save-files-link-btn')
     expect(shareBtn).toBeVisible()
     await fireEvent.click(shareBtn)
     await waitFor(() => {
-      return expect(queryByTestId('file-link-being-saved')).toBe(null)
+      return expect(queryByTestId('files-link-being-saved')).toBe(null)
     })
 
     expect(within(link).queryByTestId('files-link-id-1-expiration-date')).toBe(null)

--- a/packages/web-app-files/tests/integration/specs/linkExpirationDate.spec.js
+++ b/packages/web-app-files/tests/integration/specs/linkExpirationDate.spec.js
@@ -1,0 +1,248 @@
+import '@testing-library/jest-dom'
+import { render, fireEvent, waitFor, within } from '@testing-library/vue'
+import merge from 'lodash-es/merge'
+import StoreFiles from '@files/src/store'
+import Store from '@runtime/src/store'
+import routes from '@files/src/routes'
+import fileSideBars from '@files/src/fileSideBars'
+import { getDateInFuture, navigateToDate } from '../helpers/date'
+// eslint-disable-next-line jest/no-mocks-import
+import sdkMock from '@/__mocks__/sdk'
+import { DateTime } from 'luxon'
+import FileLinks from '@files/src/components/SideBar/Links/FileLinks.vue'
+
+const existingShares = [
+  {
+    shareInfo: {
+      id: 1,
+      share_type: 3,
+      uid_owner: 'alice',
+      displayname_owner: 'alice',
+      permissions: 16,
+      stime: new Date().getTime(),
+      expiration: DateTime.fromJSDate(getDateInFuture(2)).toFormat('yyyy-MM-dd HH:mm:ss'),
+      uid_file_owner: 'alice',
+      displayname_file_owner: 'alice',
+      path: '/Documents',
+      item_type: 'folder',
+      item_source: 10,
+      file_source: 10,
+      file_parent: 6,
+      file_target: '/Documents',
+      share_with: 'bob',
+      share_with_displayname: 'bob',
+      token: 'token',
+      url: 'url',
+      name: 'Public link'
+    }
+  }
+]
+
+describe('Users can set expiration date when sharing via public link', () => {
+  afterEach(() => {
+    jest.resetModules()
+    jest.restoreAllMocks()
+    window.sessionStorage.clear()
+  })
+  test('user can set a new expiration date', async () => {
+    const component = renderComponent()
+    const { findByTestId, baseElement, getByTestId, findByText, queryByTestId } = component
+    const addBtn = await findByTestId('files-file-link-add-btn')
+
+    expect(addBtn).toBeVisible()
+    await fireEvent.click(addBtn)
+    expect(await findByTestId('new-file-link')).toBeVisible()
+    await fireEvent.update(baseElement.querySelector('#oc-files-file-link-name'), 'Public link')
+
+    expect(getByTestId('recipient-datepicker')).toBeVisible()
+    await fireEvent.click(getByTestId('recipient-datepicker-btn'))
+
+    const newDate = getDateInFuture(2)
+    await navigateToDate(newDate, component)
+
+    expect(await findByText('Expires in 2 days')).toBeVisible()
+
+    const shareBtn = getByTestId('new-file-link-btn')
+    expect(shareBtn).toBeVisible()
+    await fireEvent.click(shareBtn)
+    await waitFor(() => {
+      return expect(queryByTestId('file-link-being-created')).toBe(null)
+    })
+
+    const link = await findByTestId('files-link-id-1')
+    expect(link).toBeVisible()
+
+    expect(
+      within(getByTestId('files-link-id-1-expiration-date')).getByText('Expires in 2 days')
+    ).toBeVisible()
+  })
+
+  test('user can edit an existing expiration date', async () => {
+    const component = renderComponent({
+      mocks: {
+        $client: {
+          ...sdkMock,
+          shares: {
+            ...sdkMock.shares,
+            getShares: jest.fn().mockImplementation(() => Promise.resolve(existingShares))
+          }
+        }
+      }
+    })
+    const { findByTestId, getByTestId, findByText, queryByTestId } = component
+
+    const link = await findByTestId('files-link-id-1')
+    expect(link).toBeVisible()
+
+    const editBtn = getByTestId('files-link-id-1-btn-edit')
+    expect(editBtn).toBeVisible()
+    await fireEvent.click(editBtn)
+
+    expect(getByTestId('recipient-datepicker')).toBeVisible()
+    await fireEvent.click(getByTestId('recipient-datepicker-btn'))
+
+    const newDate = getDateInFuture(4)
+    await navigateToDate(newDate, component)
+
+    expect(await findByText('Expires in 4 days')).toBeVisible()
+
+    const shareBtn = getByTestId('save-file-link-btn')
+    expect(shareBtn).toBeVisible()
+    await fireEvent.click(shareBtn)
+    await waitFor(() => {
+      return expect(queryByTestId('file-link-being-saved')).toBe(null)
+    })
+
+    expect(
+      within(getByTestId('files-link-id-1-expiration-date')).getByText('Expires in 4 days')
+    ).toBeVisible()
+  })
+
+  test('user can remove an existing expiration date', async () => {
+    const component = renderComponent({
+      mocks: {
+        $client: {
+          ...sdkMock,
+          shares: {
+            ...sdkMock.shares,
+            getShares: jest.fn().mockImplementation(() => Promise.resolve(existingShares))
+          }
+        }
+      }
+    })
+    const { findByTestId, getByTestId, queryByTestId } = component
+
+    const link = await findByTestId('files-link-id-1')
+    expect(link).toBeVisible()
+
+    const editBtn = getByTestId('files-link-id-1-btn-edit')
+    expect(editBtn).toBeVisible()
+    await fireEvent.click(editBtn)
+
+    const removeExpiryDateBtn = getByTestId('file-link-remove-expiration-date')
+    expect(removeExpiryDateBtn).toBeVisible()
+    await fireEvent.click(removeExpiryDateBtn)
+
+    const shareBtn = getByTestId('save-file-link-btn')
+    expect(shareBtn).toBeVisible()
+    await fireEvent.click(shareBtn)
+    await waitFor(() => {
+      return expect(queryByTestId('file-link-being-saved')).toBe(null)
+    })
+
+    expect(within(link).queryByTestId('files-link-id-1-expiration-date')).toBe(null)
+  })
+})
+
+const getTestFolder = () => ({
+  type: 'folder',
+  ownerId: 'alice',
+  ownerDisplayName: 'alice',
+  mdate: 'Wed, 21 Oct 2015 07:28:00 GMT',
+  size: '740',
+  isMounted: jest.fn(() => true),
+  name: 'lorem.txt',
+  privateLink: 'some-link',
+  canShare: jest.fn(() => true),
+  path: '/documents'
+})
+
+function createStore(store) {
+  return merge(
+    {},
+    Store,
+    {
+      modules: {
+        user: {
+          state: {
+            id: 'alice',
+            capabilities: {
+              files: {
+                privateLinks: true
+              },
+              files_sharing: {
+                public: {
+                  enabled: true,
+                  expire_date: {
+                    enabled: false,
+                    enforced: false
+                  },
+                  password: {
+                    enforced_for: {
+                      read_only: '0',
+                      upload_only: '0',
+                      read_write: '0'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        apps: {
+          ...Store.modules.apps,
+          state: {
+            ...Store.modules.apps.state,
+            fileSideBars
+          }
+        },
+        Files: {
+          ...StoreFiles,
+          getters: {
+            ...StoreFiles.getters,
+            highlightedFile: () => getTestFolder(),
+            currentFileOutgoingSharesLoading: () => false,
+            sharesTreeLoading: () => false
+          },
+          actions: {
+            ...StoreFiles.actions,
+            loadSharesTree: jest.fn
+          }
+        }
+      }
+    },
+    store
+  )
+}
+
+function renderComponent({ store, mocks } = {}) {
+  return render(
+    FileLinks,
+    {
+      store: createStore(store),
+      stubs: {
+        'avatar-image': true
+      },
+      provide: {
+        displayedItem: {
+          value: getTestFolder()
+        }
+      },
+      routes,
+      mocks
+    },
+    (vue, store, router) => {
+      router.push({ name: 'personal' })
+    }
+  )
+}

--- a/packages/web-app-files/tests/integration/specs/peopleExpirationDate.spec.js
+++ b/packages/web-app-files/tests/integration/specs/peopleExpirationDate.spec.js
@@ -6,13 +6,11 @@ import merge from 'lodash-es/merge'
 import StoreFiles from '@files/src/store'
 import Store from '@runtime/src/store'
 import routes from '@files/src/routes'
-import { getDateInFuture } from '../helpers/date'
+import { getDateInFuture, navigateToDate } from '../helpers/date'
 // eslint-disable-next-line jest/no-mocks-import
 import sdkMock from '@/__mocks__/sdk'
 
 import FileShares from '@files/src/components/SideBar/Shares/FileShares.vue'
-
-const formatDate = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }
 
 const existingShares = [
   {
@@ -471,42 +469,6 @@ function createStore(store) {
     },
     store
   )
-}
-
-async function navigateToDate(date, component, direction = 'right') {
-  if (['right', 'left'].indexOf(direction) < 0) {
-    return Promise.reject(new Error('invalid value for direction. Please use "left" or "right"'))
-  }
-  const { queryByText, baseElement, findByText } = component
-
-  while (true) {
-    const dateHeader = await queryByText(
-      date.toLocaleString('en', { month: 'long', year: 'numeric' })
-    )
-
-    if (!dateHeader) {
-      const nextMonthBtn = baseElement.querySelector(`.vc-arrow.is-${direction}`)
-      await userEvent.click(nextMonthBtn)
-    } else {
-      break
-    }
-  }
-
-  const dateSelector = document.evaluate(
-    `//span[contains(@class, "vc-day-content vc-focusable") and @tabindex="-1" and @aria-label="${date.toLocaleDateString(
-      'en',
-      formatDate
-    )}" and text()="${date.getDate()}"]`,
-    baseElement,
-    null,
-    XPathResult.FIRST_ORDERED_NODE_TYPE,
-    null
-  ).singleNodeValue
-
-  expect(
-    await findByText(date.toLocaleString('en', { month: 'long', year: 'numeric' }))
-  ).toBeVisible()
-  await userEvent.click(dateSelector)
 }
 
 function renderComponent({ store, mocks } = {}) {

--- a/packages/web-app-files/tests/unit/components/SideBar/Links/PublicLinks/LinkEdit.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Links/PublicLinks/LinkEdit.spec.js
@@ -82,11 +82,10 @@ describe('LinkEdit', () => {
       })
     })
 
-    it('should have min-datetime attribute with the value one day ahead from provided day', () => {
+    it('should have min-datetime attribute with the value now', () => {
       const wrapper = getShallowMountedWrapper()
       const expirationDatePickerElement = wrapper.find('#oc-files-file-link-expire-date')
       const expectedDate = new Date()
-      expectedDate.setDate(new Date().getDate() + 1)
       expect(expirationDatePickerElement.attributes()['min-date']).toEqual(expectedDate.toString())
     })
 
@@ -105,9 +104,7 @@ describe('LinkEdit', () => {
       )
       const expirationDatePickerFieldElement = wrapper.find(selectors.linkExpireDatePicker)
 
-      expect(expirationDatePickerFieldElement.attributes()['min-date']).toEqual(
-        expectedDate.toString()
-      )
+      expect(expirationDatePickerFieldElement.attributes().value).toEqual(expectedDate.toString())
     })
   })
 

--- a/packages/web-app-files/tests/unit/components/SideBar/Links/PublicLinks/LinkInfo.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Links/PublicLinks/LinkInfo.spec.js
@@ -164,7 +164,7 @@ describe('LinkInfo', () => {
 
       expect(linkExpiration.exists()).toBeTruthy()
       expect(linkExpiration.find('translate-stub').props().translateParams).toMatchObject({
-        expires: 'in 23 hours'
+        expires: 'in 1 day'
       })
     })
     it('should not be present if link does not have expiration', () => {


### PR DESCRIPTION
## Description

* Share expiry dates now always refer to the end of the given day. This change allows users to select the current day as expiry date.
* Displayed expiry dates have been aligned to ensure their consistency.
* Existing expiry dates for public links can now be removed again.
* We now use the Luxon `DateTime` object more consistently across the code base (replacing JavaScript's `new Date()`).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
