### PR TITLE
[tests-only] Reduce flakyness in smoke tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1340,6 +1340,10 @@ def acceptance(ctx):
                         # Copy files for upload
                         steps += copyFilesForUpload()
 
+                        # Wait for test-related services to be up
+                        steps += waitForBrowserService()
+                        steps += waitForMiddlewareService()
+
                         # run the acceptance tests
                         steps += runWebuiAcceptanceTests(ctx, suite, alternateSuiteName, params["filterTags"], params["extraEnvironment"], browser, params["visualTesting"], params["screenShots"])
 
@@ -1543,6 +1547,15 @@ def browserService(alternateSuiteName, browser):
         }]
 
     return []
+
+def waitForBrowserService():
+    return [{
+        "name": "wait-for-browser-service",
+        "image": OC_CI_WAIT_FOR,
+        "commands": [
+            "wait-for -it selenium:4444 -t 300",
+        ],
+    }]
 
 def owncloudService():
     return [{
@@ -2875,6 +2888,15 @@ def middlewareService(ocis = False):
             "name": "gopath",
             "path": "/srv/app",
         }],
+    }]
+
+def waitForMiddlewareService():
+    return [{
+        "name": "wait-for-middleware-service",
+        "image": OC_CI_WAIT_FOR,
+        "commands": [
+            "wait-for -it middleware:3000 -t 300",
+        ],
     }]
 
 def pipelineDependsOn(pipeline, dependant_pipelines):

--- a/tests/smoke/features/shareFileJourney.feature
+++ b/tests/smoke/features/shareFileJourney.feature
@@ -1,8 +1,6 @@
-Feature: share folder with file, share file
-  Alice shares the folder with file to Brian with the "editor" role.
-  I want to check that Brian can accept folder, download, move, copy and rename the shared file
+Feature: share file
   Alice shares file with Brian
-  I want to check that Brian can open file in Mediaviewer, copy, download the file.
+  I want to check that Brian can copy, download the file.
   I also want to check that Alice can change the role to the share and can delete share
 
   Background:
@@ -11,50 +9,6 @@ Feature: share folder with file, share file
       | Brian |
     And admin set the default folder for received shares to "Shares"
     And admin disables auto accepting of the shares
-
-  Scenario: Alice shares folder with file to Brian
-    Given "Alice" has logged in
-    When "Alice" opens the "files" app
-    And "Alice" navigates to the files page
-    And "Alice" creates the following folder
-      | folder_to_shared |
-    And "Alice" uploads the following resource
-      | resource  | to               |
-      | lorem.txt | folder_to_shared |
-    Then "Alice" ensures that the following resource exist
-      | folder_to_shared/lorem.txt |
-    And "Alice" shares the following resource via the sidebar panel
-      | resource         | user  | role   |
-      | folder_to_shared | Brian | editor |
-    Given "Brian" has logged in
-    When "Brian" opens the "files" app
-    And "Brian" accepts the following resource
-      | folder_to_shared |
-    And "Brian" renames the following resource
-      | resource                          | as            |
-      | Shares/folder_to_shared/lorem.txt | lorem_new.txt |
-    And "Brian" uploads the following resource
-      | resource   | to                      |
-      | simple.pdf | Shares/folder_to_shared |
-    And "Brian" copies the following resource
-      | resource                | to       |
-      | Shares/folder_to_shared | All files |
-    When "Alice" opens the "files" app
-    Then "Alice" ensures that the following resources exist
-      | folder_to_shared/lorem_new.txt |
-      | folder_to_shared/simple.pdf    |
-    When "Alice" creates new version of the following files
-      | resource   | to               |
-      | simple.pdf | folder_to_shared |
-    Then "Alice" ensures that the resource "folder_to_shared/simple.pdf" has 1 version
-    When "Alice" deletes the following resources
-      | folder_to_shared/lorem_new.txt |
-      | folder_to_shared               |
-    And "Alice" has logged out
-    When "Brian" opens the "files" app
-    Then "Brian" ensures that the following resource does not exist
-      | Shares/folder_to_shared |
-    And "Brian" has logged out
 
   Scenario: Alice shares file to Brian
     Given "Alice" has logged in

--- a/tests/smoke/features/shareFolderJourney.feature
+++ b/tests/smoke/features/shareFolderJourney.feature
@@ -1,0 +1,55 @@
+Feature: share folder with file
+  Alice shares the folder with file to Brian with the "editor" role.
+  I want to check that Brian can accept folder, download, move, copy and rename the shared file
+
+  Background:
+    Given following users have been created
+      | Alice |
+      | Brian |
+    And admin set the default folder for received shares to "Shares"
+    And admin disables auto accepting of the shares
+
+  Scenario: Alice shares folder with file to Brian
+    Given "Alice" has logged in
+    When "Alice" opens the "files" app
+    And "Alice" navigates to the files page
+    And "Alice" creates the following folder
+      | folder_to_shared |
+    And "Alice" uploads the following resource
+      | resource  | to               |
+      | lorem.txt | folder_to_shared |
+    Then "Alice" ensures that the following resource exist
+      | folder_to_shared/lorem.txt |
+    And "Alice" shares the following resource via the sidebar panel
+      | resource         | user  | role   |
+      | folder_to_shared | Brian | editor |
+    Given "Brian" has logged in
+    When "Brian" opens the "files" app
+    And "Brian" accepts the following resource
+      | folder_to_shared |
+    And "Brian" renames the following resource
+      | resource                          | as            |
+      | Shares/folder_to_shared/lorem.txt | lorem_new.txt |
+    And "Brian" uploads the following resource
+      | resource   | to                      |
+      | simple.pdf | Shares/folder_to_shared |
+    And "Brian" copies the following resource
+      | resource                | to       |
+      | Shares/folder_to_shared | All files |
+    When "Alice" opens the "files" app
+    Then "Alice" ensures that the following resources exist
+      | folder_to_shared/lorem_new.txt |
+      | folder_to_shared/simple.pdf    |
+    When "Alice" creates new version of the following files
+      | resource   | to               |
+      | simple.pdf | folder_to_shared |
+    Then "Alice" ensures that the resource "folder_to_shared/simple.pdf" has 1 version
+    When "Alice" deletes the following resources
+      | folder_to_shared/lorem_new.txt |
+      | folder_to_shared               |
+    And "Alice" has logged out
+    When "Brian" opens the "files" app
+    Then "Brian" ensures that the following resource does not exist
+      | Shares/folder_to_shared |
+    And "Brian" has logged out
+    

--- a/tests/smoke/support/page/files/allFiles.ts
+++ b/tests/smoke/support/page/files/allFiles.ts
@@ -64,7 +64,11 @@ export class AllFilesPage {
     )
 
     if (newVersion) {
-      await page.click('.oc-modal-body-actions-confirm')
+      const fileName = files.map((file) => path.basename(file.name))
+      await Promise.all([
+        page.waitForResponse((resp) => resp.url().endsWith(fileName[0]) && resp.status() === 204),
+        page.click('.oc-modal-body-actions-confirm')
+      ])
     }
 
     await cta.files.waitForResources({
@@ -245,6 +249,7 @@ export class AllFilesPage {
     await cta.files.sidebar.open({ page: page, resource: resouceName })
     await cta.files.sidebar.openPanel({ page: page, name: 'versions' })
 
+    await page.waitForSelector('//*[@id="oc-file-versions-sidebar"]')
     const elements = await page.$$('//*[@id="oc-file-versions-sidebar"]/table/tbody/tr')
     return elements.length
   }


### PR DESCRIPTION

## Description

- Added a check that a new version has been created. Added waitForControl before my "favorite" flaky methods "page.$" or "page.$$". 

- ~~Added retry 1 to CI **to unlock CI**~~

- I continue to watch, identify, and fix flaky places



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
