### PR TITLE
fix deployment example

### DIFF
--- a/deployments/examples/ocis_web/docker-compose.yml
+++ b/deployments/examples/ocis_web/docker-compose.yml
@@ -65,17 +65,15 @@ services:
       OCIS_MACHINE_AUTH_API_KEY: ${OCIS_MACHINE_AUTH_API_KEY:-change-me-please}
       OCIS_TRANSFER_SECRET: ${STORAGE_TRANSFER_SECRET:-replace-me-with-a-transfer-secret}
       # app registry
-      STORAGE_APP_REGISTRY_MIMETYPES_JSON: /var/tmp/ocis/app-config/mimetypes.json
       STORAGE_GATEWAY_GRPC_ADDR: 0.0.0.0:9142 # make the REVA gateway accessible to the app drivers
-      # proxy
-      PROXY_CONFIG_FILE: "/var/tmp/ocis/proxy-config/config.json"
+      STORAGE_APP_REGISTRY_MIMETYPES_JSON: /var/tmp/ocis/app-config/mimetypes.json
       # INSECURE: needed if oCIS / Traefik is using self generated certificates
       OCIS_INSECURE: "${INSECURE:-false}"
     volumes:
       - ./config/ocis/entrypoint-override.sh:/entrypoint-override.sh
-      - ./config/ocis/proxy-config.json:/var/tmp/ocis/proxy-config/config.json
+      - ./config/ocis/proxy.json:/etc/ocis/proxy.json
       - ./config/ocis/mimetypes.json:/var/tmp/ocis/app-config/mimetypes.json
-      - ocis-data:/var/tmp/ocis
+      - ocis-data:/var/lib/ocis
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.ocis.entrypoints=https"


### PR DESCRIPTION
## Description
The proxy config was no longer picked up after https://github.com/owncloud/ocis/pull/2708. It will now picked up automatically from `/etc/ocis/proxy.json`.

(Also the persistent volume /var/tmp/ocis did change some time ago)
