### PR TITLE
[tests-only] Playwright cache is not needed in nightwatch test pipelines

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1281,7 +1281,6 @@ def acceptance(ctx):
                         steps += skipIfUnchanged(ctx, "acceptance-tests")
 
                         steps += restoreBuildArtifactCache(ctx, "yarn", ".yarn")
-                        steps += restoreBuildArtifactCache(ctx, "playwright", ".playwright")
                         steps += restoreBuildArtifactCache(ctx, "tests-yarn", "tests/acceptance/.yarn")
                         steps += yarnInstallTests()
 


### PR DESCRIPTION
## Description
`restoreBuildArtifactCache(ctx, "playwright", ".playwright")` was being dome as a step in the nightwatch acceptance tests. That uses some time and is not needed. This PR removes it.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
