### PR TITLE
relocate oc-table-files from ods to web-app-files

### DIFF
--- a/changelog/unreleased/change-adopt-oc-table-files
+++ b/changelog/unreleased/change-adopt-oc-table-files
@@ -1,0 +1,6 @@
+Change: Adopt oc-table-files from ods
+
+ods oc-table-files always contained concrete web-app-files logic, to make development more agile and keep things close
+oc-table-files was renamed to resource-table and relocated to live in web-app-files from now on.
+
+https://github.com/owncloud/web/pull/6106

--- a/changelog/unreleased/enhancement-adopt-oc-table-files
+++ b/changelog/unreleased/enhancement-adopt-oc-table-files
@@ -1,6 +1,7 @@
-Change: Adopt oc-table-files from ods
+Enhancement: Adopt oc-table-files from ods
 
 ods oc-table-files always contained concrete web-app-files logic, to make development more agile and keep things close
 oc-table-files was renamed to resource-table and relocated to live in web-app-files from now on.
 
 https://github.com/owncloud/web/pull/6106
+https://github.com/owncloud/owncloud-design-system/pull/1817

--- a/changelog/unreleased/enhancement-update-ods
+++ b/changelog/unreleased/enhancement-update-ods
@@ -1,0 +1,9 @@
+Enhancement: Update ODS to v12.0.0-alpha1
+
+We updated the ownCloud Design System to version 12.0.0-alpha1. Please refer to the full changelog in the ODS release (linked) for more details. Summary:
+
+- Change - Remove oc-table-files from ods: https://github.com/owncloud/owncloud-design-system/pull/1817
+- Change - Remove unused props for unstyled components: https://github.com/owncloud/owncloud-design-system/pull/1795
+
+https://github.com/owncloud/web/pull/6106
+https://github.com/owncloud/owncloud-design-system/releases/tag/v12.0.0-alpha1

--- a/packages/web-app-files/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceTable.vue
@@ -1,0 +1,583 @@
+<template>
+  <oc-table
+    :data="resources"
+    :fields="fields"
+    :highlighted="selectedIds"
+    :disabled="disabled"
+    :sticky="true"
+    :header-position="headerPosition"
+    :drag-drop="dragDrop"
+    :hover="hover"
+    :item-dom-selector="resourceDomSelector"
+    :selection="selection"
+    @highlight="fileClicked"
+    @rowMounted="rowMounted"
+    @contextmenuClicked="showContextMenu"
+    @itemDropped="fileDropped"
+    @itemDragged="fileDragged"
+  >
+    <template #selectHeader>
+      <div class="resource-table-select-all">
+        <oc-checkbox
+          id="resource-table-select-all"
+          :label="allResourcesCheckboxLabel"
+          :hide-label="true"
+          :value="areAllResourcesSelected"
+          @input="toggleSelectionAll"
+        />
+      </div>
+    </template>
+    <template #select="{ item }">
+      <oc-checkbox
+        :id="`resource-table-select-${resourceDomSelector(item)}`"
+        :label="getResourceCheckboxLabel(item)"
+        :hide-label="true"
+        size="large"
+        :value="selection"
+        :option="item"
+        @input="emitSelect"
+        @click.native.stop
+      />
+    </template>
+    <template #name="{ item }">
+      <oc-resource
+        :key="`${item.path}-${resourceDomSelector(item)}-${item.thumbnail}`"
+        :resource="item"
+        :is-path-displayed="arePathsDisplayed"
+        :is-thumbnail-displayed="areThumbnailsDisplayed"
+        :target-route="targetRoute"
+        :is-resource-clickable="isResourceClickable(item.id)"
+        @click="emitFileClick(item)"
+      />
+    </template>
+    <template #status="{ item }">
+      <!-- @slot Status column -->
+      <slot name="status" :resource="item" />
+    </template>
+    <template #sharedWith="{ item }">
+      <oc-avatars
+        class="resource-table-people"
+        :items="item.sharedWith"
+        :stacked="true"
+        :max-displayed="3"
+        :is-tooltip-displayed="true"
+        :accessible-description="getSharedWithAvatarDescription(item)"
+      />
+    </template>
+    <template #size="{ item }">
+      <oc-resource-size :size="item.size" />
+    </template>
+    <template #mdate="{ item }">
+      <span
+        v-oc-tooltip="formatDate(item.mdate)"
+        tabindex="0"
+        v-text="formatDateRelative(item.mdate)"
+      />
+    </template>
+    <template #sdate="{ item }">
+      <span
+        v-oc-tooltip="formatDate(item.sdate)"
+        tabindex="0"
+        v-text="formatDateRelative(item.sdate)"
+      />
+    </template>
+    <template #ddate="{ item }">
+      <span
+        v-oc-tooltip="formatDate(item.ddate)"
+        tabindex="0"
+        v-text="formatDateRelative(item.ddate)"
+      />
+    </template>
+    <template #owner="{ item }">
+      <oc-avatars
+        class="resource-table-people"
+        :items="item.owner"
+        :is-tooltip-displayed="true"
+        :accessible-description="getOwnerAvatarDescription(item)"
+      />
+    </template>
+    <template #actions="{ item }">
+      <div class="resource-table-actions">
+        <!-- @slot Add quick actions before the `context-menu / three dot` button in the actions column -->
+        <slot name="quickActions" :resource="item" />
+        <oc-button
+          :id="`context-menu-trigger-${resourceDomSelector(item)}`"
+          v-oc-tooltip="contextMenuLabel"
+          :aria-label="contextMenuLabel"
+          class="resource-table-btn-action-dropdown"
+          appearance="raw"
+          @click.stop.prevent="
+            resetDropPosition(`context-menu-drop-ref-${resourceDomSelector(item)}`, $event, item)
+          "
+        >
+          <oc-icon name="more_vert" />
+        </oc-button>
+        <oc-drop
+          :ref="`context-menu-drop-ref-${resourceDomSelector(item)}`"
+          :drop-id="`context-menu-drop-${resourceDomSelector(item)}`"
+          :toggle="`#context-menu-trigger-${resourceDomSelector(item)}`"
+          :popper-options="popperOptions"
+          mode="click"
+          close-on-click
+          padding-size="remove"
+          @click.native.stop.prevent
+        >
+          <!-- @slot Add context actions that open in a dropdown when clicking on the "three dots" button -->
+          <slot name="contextMenu" :resource="item" />
+        </oc-drop>
+      </div>
+    </template>
+    <template v-if="$slots.footer" #footer>
+      <!-- @slot Footer of the files table -->
+      <slot name="footer" />
+    </template>
+  </oc-table>
+</template>
+
+<script>
+import { DateTime } from 'luxon'
+import maxSize from 'popper-max-size-modifier'
+import { EVENT_TROW_MOUNTED, EVENT_FILE_DROPPED } from '../../constants'
+
+export default {
+  model: {
+    prop: 'selection',
+    event: 'select'
+  },
+  props: {
+    /**
+     * Resources to be displayed in the table.
+     * Required fields:
+     * - name: The name of the resource containing the file extension in case of a file
+     * - path: The full path of the resource
+     * - type: The type of the resource. Can be `file` or `folder`
+     * Optional fields:
+     * - thumbnail
+     * - size: The size of the resource
+     * - modificationDate: The date of the last modification of the resource
+     * - shareDate: The date when the share was created
+     * - deletionDate: The date when the resource has been deleted
+     * - status: The status of the share. Contains also actions to accept/decline the share
+     * - opensInNewWindow: Open the link in a new window
+     */
+    resources: {
+      type: Array,
+      required: true
+    },
+    /**
+     * Closure function to mutate the resource id into a valid DOM selector.
+     */
+    resourceDomSelector: {
+      type: Function,
+      required: false,
+      default: (resource) => resource.id.replace(/[^A-Za-z0-9\-_]/g, '')
+    },
+    /**
+     * Asserts whether resources path should be shown in the resource name
+     */
+    arePathsDisplayed: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    /**
+     * Asserts whether icons should be replaced with thumbnails for resources which provide them
+     */
+    areThumbnailsDisplayed: {
+      type: Boolean,
+      required: false,
+      default: true
+    },
+    /**
+     * V-model for the selection
+     */
+    selection: {
+      type: Array,
+      default: () => []
+    },
+    /**
+     * Asserts whether actions are available
+     */
+    hasActions: {
+      type: Boolean,
+      required: false,
+      default: true
+    },
+    /**
+     * Target route path used to build the link when navigating into a resource
+     */
+    targetRoute: {
+      type: Object,
+      required: false,
+      default: null
+    },
+    /**
+     * Asserts whether clicking on the resource name triggers any action
+     */
+    areResourcesClickable: {
+      type: Boolean,
+      required: false,
+      default: true
+    },
+    /**
+     * Top position of header used when the header is sticky in pixels
+     */
+    headerPosition: {
+      type: Number,
+      required: false,
+      default: 0
+    },
+    /**
+     * Asserts whether resources in the table can be selected
+     */
+    isSelectable: {
+      type: Boolean,
+      required: false,
+      default: true
+    },
+    /**
+     * The ids of disabled resources. Null or an empty string/array for no disabled resources.
+     */
+    disabled: {
+      type: [String, Array],
+      required: false,
+      default: null
+    },
+    /**
+     * Sets the padding size for x axis
+     * @values xsmall, small, medium, large, xlarge
+     */
+    paddingX: {
+      type: String,
+      required: false,
+      default: 'small',
+      validator: (size) => /(xsmall|small|medium|large|xlarge)/.test(size)
+    },
+    /**
+     * Enable Drag & Drop events
+     */
+    dragDrop: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    /**
+     * Enable hover effect
+     */
+    hover: {
+      type: Boolean,
+      required: false,
+      default: false
+    }
+  },
+  data() {
+    return {
+      constants: {
+        EVENT_TROW_MOUNTED
+      }
+    }
+  },
+  computed: {
+    popperOptions() {
+      return {
+        modifiers: [
+          maxSize,
+          {
+            name: 'applyMaxSize',
+            enabled: true,
+            phase: 'beforeWrite',
+            requires: ['maxSize'],
+            fn({ state }) {
+              const { height } = state.modifiersData.maxSize
+              state.styles.popper.overflowY = `auto`
+              state.styles.popper.maxHeight = `${height - 5}px`
+            }
+          }
+        ]
+      }
+    },
+    fields() {
+      if (this.resources.length === 0) {
+        return []
+      }
+      const firstResource = this.resources[0]
+      const fields = []
+      if (this.isSelectable) {
+        fields.push({
+          name: 'select',
+          title: '',
+          type: 'slot',
+          headerType: 'slot',
+          width: 'shrink'
+        })
+      }
+      fields.push(
+        ...[
+          {
+            name: 'name',
+            title: this.$gettext('Name'), // How do we get the translations here?
+            type: 'slot',
+            width: 'expand',
+            wrap: 'truncate',
+            sortable: true
+          },
+          {
+            name: 'size',
+            title: this.$gettext('Size'),
+            type: 'slot',
+            alignH: 'right',
+            wrap: 'nowrap',
+            sortable: true
+          },
+          {
+            name: 'sharedWith',
+            title: this.$gettext('Shared with'),
+            type: 'slot',
+            alignH: 'right',
+            wrap: 'nowrap',
+            sortable: true
+          },
+          {
+            name: 'status',
+            title: this.$gettext('Status'),
+            type: 'slot',
+            alignH: 'right',
+            wrap: 'nowrap',
+            sortable: true
+          },
+          {
+            name: 'owner',
+            title: this.$gettext('Share owner'),
+            type: 'slot',
+            alignH: 'right',
+            wrap: 'nowrap',
+            sortable: 'displayName'
+          },
+          {
+            name: 'mdate',
+            title: this.$gettext('Modified'),
+            type: 'slot',
+            alignH: 'right',
+            wrap: 'nowrap',
+            sortable: (date) => this.unixDate(date),
+            accessibleLabelCallback: (item) =>
+              this.formatDateRelative(item.mdate) + ' (' + this.formatDate(item.mdate) + ')'
+          },
+          {
+            name: 'sdate',
+            title: this.$gettext('Shared on'),
+            type: 'slot',
+            alignH: 'right',
+            wrap: 'nowrap',
+            sortable: (date) => this.unixDate(date),
+            accessibleLabelCallback: (item) =>
+              this.formatDateRelative(item.sdate) + ' (' + this.formatDate(item.sdate) + ')'
+          },
+          {
+            name: 'ddate',
+            title: this.$gettext('Deleted'),
+            type: 'slot',
+            alignH: 'right',
+            wrap: 'nowrap',
+            sortable: (date) => this.unixDate(date),
+            accessibleLabelCallback: (item) =>
+              this.formatDateRelative(item.ddate) + ' (' + this.formatDate(item.ddate) + ')'
+          }
+        ].filter((field) => Object.prototype.hasOwnProperty.call(firstResource, field.name))
+      )
+      if (this.hasActions) {
+        fields.push({
+          name: 'actions',
+          title: this.$gettext('Actions'),
+          type: 'slot',
+          alignH: 'right',
+          wrap: 'nowrap'
+        })
+      }
+      return fields
+    },
+    areAllResourcesSelected() {
+      return this.selection.length === this.resources.length
+    },
+    selectedIds() {
+      return this.selection.map((r) => r.id)
+    },
+    allResourcesCheckboxLabel() {
+      return this.$gettext('Select all resources')
+    },
+    contextMenuLabel() {
+      return this.$gettext('Show context menu')
+    },
+    currentLanguage() {
+      return (this.$language?.current || '').split('_')[0]
+    }
+  },
+  methods: {
+    fileDragged(file) {
+      this.addSelectedResource(file)
+    },
+    fileDropped(fileId) {
+      this.$emit(EVENT_FILE_DROPPED, fileId)
+    },
+    addSelectedResource(file) {
+      const isSelected = this.selection.some((e) => e.id === file.id)
+      if (!isSelected) {
+        this.$emit('select', this.selection.concat([file]))
+      } else {
+        this.$emit('select', this.selection)
+      }
+    },
+    resetDropPosition(id, event, item) {
+      const instance = this.$refs[id].tippy
+      if (instance === undefined) return
+      if (!this.selection.includes(item)) {
+        this.emitSelect([item])
+      }
+      this.displayPositionedDropdown(instance, event)
+    },
+    showContextMenu(row, event, item) {
+      event.preventDefault()
+      const instance = row.$el.getElementsByClassName('resource-table-btn-action-dropdown')[0]
+      if (instance === undefined) return
+      if (!this.selection.includes(item)) {
+        this.emitSelect([item])
+      }
+      this.displayPositionedDropdown(instance._tippy, event)
+    },
+    displayPositionedDropdown(dropdown, event) {
+      dropdown.setProps({
+        getReferenceClientRect: () => ({
+          width: 0,
+          height: 0,
+          top: event.clientY,
+          bottom: event.clientY,
+          left: event.clientX,
+          right: event.clientX
+        })
+      })
+      dropdown.show()
+    },
+    rowMounted(resource, component) {
+      /**
+       * Triggered whenever a row is mounted
+       * @property {object} resource The resource which was mounted as table row
+       * @property {object} component The table row component
+       */
+      this.$emit('rowMounted', resource, component)
+    },
+    fileClicked(resource) {
+      /**
+       * Triggered when the file row is clicked
+       * @property {object} resource The resource for which the event is triggered
+       */
+      this.emitSelect([resource])
+    },
+    formatDate(date) {
+      return DateTime.fromJSDate(new Date(date))
+        .setLocale(this.currentLanguage)
+        .toLocaleString(DateTime.DATETIME_FULL)
+    },
+    formatDateRelative(date) {
+      return DateTime.fromJSDate(new Date(date)).setLocale(this.currentLanguage).toRelative()
+    },
+    unixDate(date) {
+      return DateTime.fromJSDate(new Date(date)).setLocale(this.currentLanguage).valueOf()
+    },
+    emitSelect(resources) {
+      /**
+       * Triggered when a checkbox for selecting a resource or the checkbox for selecting all resources is clicked
+       * @property {array} resources The selected resources
+       */
+      this.$emit('select', resources)
+    },
+    toggleSelectionAll() {
+      if (this.areAllResourcesSelected) {
+        return this.emitSelect([])
+      }
+      this.emitSelect(this.resources)
+    },
+    emitFileClick(resource) {
+      /**
+       * Triggered when a default action is triggered on a file
+       * @property {object} resource resource for which the event is triggered
+       */
+      this.$emit('fileClick', resource)
+    },
+    isResourceClickable(resourceId) {
+      if (!this.areResourcesClickable) {
+        return false
+      }
+      return Array.isArray(this.disabled)
+        ? !this.disabled.includes(resourceId)
+        : this.disabled !== resourceId
+    },
+    getResourceCheckboxLabel(resource) {
+      if (resource.type === 'folder') {
+        return this.$gettext('Select folder')
+      }
+      return this.$gettext('Select file')
+    },
+    getSharedWithAvatarDescription(resource) {
+      const resourceType =
+        resource.type === 'folder' ? this.$gettext('folder') : this.$gettext('file')
+      const shareCount = resource.sharedWith.filter((u) => !u.link).length
+      const linkCount = resource.sharedWith.filter((u) => !!u.link).length
+      const shareText =
+        shareCount > 0
+          ? this.$ngettext(
+              'This %{ resourceType } is shared via %{ shareCount } invite',
+              'This %{ resourceType } is shared via %{ shareCount } invites',
+              shareCount
+            )
+          : ''
+      const linkText =
+        linkCount > 0
+          ? this.$ngettext(
+              'This %{ resourceType } is shared via %{ linkCount } link',
+              'This %{ resourceType } is shared via %{ linkCount } links',
+              linkCount
+            )
+          : ''
+      const description = [shareText, linkText].join(' ')
+      const translated = this.$gettextInterpolate(description, {
+        resourceType,
+        shareCount,
+        linkCount
+      })
+      return translated
+    },
+    getOwnerAvatarDescription(resource) {
+      const translated = this.$gettext('This %{ resourceType } is owned by %{ ownerName }')
+      const resourceType =
+        resource.type === 'folder' ? this.$gettext('folder') : this.$gettext('file')
+      const description = this.$gettextInterpolate(translated, {
+        resourceType,
+        ownerName: resource.owner[0].displayName
+      })
+      return description
+    }
+  }
+}
+</script>
+<style lang="scss">
+.resource-table {
+  &-people {
+    position: absolute;
+    right: var(--oc-space-xsmall);
+    top: 50%;
+    transform: translateY(-50%);
+  }
+  &-actions {
+    align-items: center;
+    display: flex;
+    flex-flow: row wrap;
+    gap: var(--oc-space-xsmall);
+    justify-content: flex-end;
+  }
+  &-select-all {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+  }
+}
+</style>

--- a/packages/web-app-files/src/components/Search/List.vue
+++ b/packages/web-app-files/src/components/Search/List.vue
@@ -8,7 +8,7 @@
         </p>
       </template>
     </no-content-message>
-    <oc-table-files
+    <resource-table
       v-else
       class="files-table"
       :class="{ 'files-table-squashed': false }"
@@ -31,7 +31,7 @@
           :size="totalFilesSize"
         />
       </template>
-    </oc-table-files>
+    </resource-table>
   </div>
 </template>
 
@@ -40,6 +40,7 @@ import { useStore, useRouteQuery, usePagination, useDefaults } from '../../compo
 import { VisibilityObserver } from 'web-pkg/src/observer'
 import { ImageType, ImageDimension } from '../../constants'
 import NoContentMessage from '../FilesList/NoContentMessage.vue'
+import ResourceTable from '../FilesList/ResourceTable.vue'
 import debounce from 'lodash-es/debounce'
 import { mapMutations, mapGetters, mapActions } from 'vuex'
 import { computed } from '@vue/composition-api'
@@ -52,7 +53,7 @@ import MixinFilesListScrolling from '../../mixins/filesListScrolling'
 const visibilityObserver = new VisibilityObserver()
 
 export default {
-  components: { ListInfo, Pagination, NoContentMessage },
+  components: { ListInfo, Pagination, NoContentMessage, ResourceTable },
   mixins: [MixinFileActions, MixinFilesListFilter, MixinFilesListScrolling],
   props: {
     searchResults: {

--- a/packages/web-app-files/src/constants.ts
+++ b/packages/web-app-files/src/constants.ts
@@ -1,3 +1,6 @@
+export const EVENT_TROW_MOUNTED = 'rowMounted'
+export const EVENT_FILE_DROPPED = 'fileDropped'
+
 export abstract class ImageDimension {
   static readonly Thumbnail: [number, number] = [36, 36]
   static readonly Preview: [number, number] = [1200, 1200]

--- a/packages/web-app-files/src/views/Favorites.vue
+++ b/packages/web-app-files/src/views/Favorites.vue
@@ -7,7 +7,7 @@
           <span v-translate>There are no resources marked as favorite</span>
         </template>
       </no-content-message>
-      <oc-table-files
+      <resource-table
         v-else
         id="files-favorites-table"
         v-model="selected"
@@ -37,7 +37,7 @@
             :size="totalFilesSize"
           />
         </template>
-      </oc-table-files>
+      </resource-table>
     </template>
   </div>
 </template>
@@ -45,6 +45,7 @@
 <script>
 import { mapGetters, mapState, mapActions, mapMutations } from 'vuex'
 import { computed } from '@vue/composition-api'
+import ResourceTable from '../components/FilesList/ResourceTable.vue'
 
 import { buildResource } from '../helpers/resources'
 import FileActions from '../mixins/fileActions'
@@ -74,6 +75,7 @@ const visibilityObserver = new VisibilityObserver()
 
 export default {
   components: {
+    ResourceTable,
     QuickActions,
     ListLoader,
     Pagination,

--- a/packages/web-app-files/src/views/LocationPicker.vue
+++ b/packages/web-app-files/src/views/LocationPicker.vue
@@ -43,7 +43,7 @@
               <span v-translate>There are no resources in this folder.</span>
             </template>
           </no-content-message>
-          <oc-table-files
+          <resource-table
             v-else
             id="files-location-picker-table"
             class="files-table"
@@ -65,7 +65,7 @@
                 :size="totalFilesSize"
               />
             </template>
-          </oc-table-files>
+          </resource-table>
         </template>
       </div>
     </div>
@@ -77,6 +77,7 @@ import { mapMutations, mapState, mapActions, mapGetters } from 'vuex'
 import { computed } from '@vue/composition-api'
 
 import { basename, join } from 'path'
+import ResourceTable from '../components/FilesList/ResourceTable.vue'
 import { batchActions } from '../helpers/batchActions'
 import { cloneStateObject } from '../helpers/store'
 import MixinsGeneral from '../mixins'
@@ -105,6 +106,7 @@ export default {
   },
 
   components: {
+    ResourceTable,
     NoContentMessage,
     ListLoader,
     ListInfo,

--- a/packages/web-app-files/src/views/Personal.vue
+++ b/packages/web-app-files/src/views/Personal.vue
@@ -16,7 +16,7 @@
           <span v-translate>Drag files and folders here or use the "+ New" button to upload</span>
         </template>
       </no-content-message>
-      <oc-table-files
+      <resource-table
         v-else
         id="files-personal-table"
         v-model="selected"
@@ -52,7 +52,7 @@
             :size="totalFilesSize"
           />
         </template>
-      </oc-table-files>
+      </resource-table>
     </template>
   </div>
 </template>
@@ -81,6 +81,7 @@ import {
 } from '../composables'
 import { bus } from 'web-pkg/src/instance'
 
+import ResourceTable from '../components/FilesList/ResourceTable.vue'
 import QuickActions from '../components/FilesList/QuickActions.vue'
 import ListLoader from '../components/FilesList/ListLoader.vue'
 import NoContentMessage from '../components/FilesList/NoContentMessage.vue'
@@ -98,6 +99,7 @@ const visibilityObserver = new VisibilityObserver()
 
 export default {
   components: {
+    ResourceTable,
     QuickActions,
     ListLoader,
     NoContentMessage,

--- a/packages/web-app-files/src/views/PublicFiles.vue
+++ b/packages/web-app-files/src/views/PublicFiles.vue
@@ -16,7 +16,7 @@
           <span v-translate>Drag files and folders here or use the "+ New" button to upload</span>
         </template>
       </no-content-message>
-      <oc-table-files
+      <resource-table
         v-else
         id="files-public-files-table"
         v-model="selected"
@@ -42,13 +42,14 @@
             :size="totalFilesSize"
           />
         </template>
-      </oc-table-files>
+      </resource-table>
     </template>
   </div>
 </template>
 
 <script>
 import { mapGetters, mapActions, mapMutations, mapState } from 'vuex'
+import ResourceTable from '../components/FilesList/ResourceTable.vue'
 import {
   useMutationSubscription,
   useFileListHeaderPosition,
@@ -118,6 +119,7 @@ const unauthenticatedUserReady = async (router, store) => {
 const visibilityObserver = new VisibilityObserver()
 export default {
   components: {
+    ResourceTable,
     ListInfo,
     Pagination,
     ListLoader,

--- a/packages/web-app-files/src/views/SharedViaLink.vue
+++ b/packages/web-app-files/src/views/SharedViaLink.vue
@@ -12,7 +12,7 @@
           <span v-translate>There are no resources with a public link at the moment</span>
         </template>
       </no-content-message>
-      <oc-table-files
+      <resource-table
         v-else
         id="files-shared-via-link-table"
         v-model="selected"
@@ -37,13 +37,14 @@
             :folders="totalFilesCount.folders"
           />
         </template>
-      </oc-table-files>
+      </resource-table>
     </template>
   </div>
 </template>
 
 <script>
 import { mapGetters, mapState, mapActions, mapMutations } from 'vuex'
+import ResourceTable from '../components/FilesList/ResourceTable.vue'
 import {
   useFileListHeaderPosition,
   useStore,
@@ -72,7 +73,7 @@ import ContextActions from '../components/FilesList/ContextActions.vue'
 const visibilityObserver = new VisibilityObserver()
 
 export default {
-  components: { ListLoader, NoContentMessage, ListInfo, Pagination, ContextActions },
+  components: { ResourceTable, ListLoader, NoContentMessage, ListInfo, Pagination, ContextActions },
 
   mixins: [FileActions, MixinResources, MixinMountSideBar, MixinFilesListFilter],
 

--- a/packages/web-app-files/src/views/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/SharedWithMe.vue
@@ -9,7 +9,7 @@
           <span class="oc-text-initial">({{ pendingCount }})</span>
         </h2>
 
-        <oc-table-files
+        <resource-table
           id="files-shared-with-me-pending-table"
           v-model="pendingSelected"
           :data-test-share-status="shareStatus.pending"
@@ -66,7 +66,7 @@
               </oc-button>
             </div>
           </template>
-        </oc-table-files>
+        </resource-table>
       </div>
 
       <!-- Accepted or declined shares -->
@@ -94,7 +94,7 @@
           <span>{{ sharesEmptyMessage }}</span>
         </template>
       </no-content-message>
-      <oc-table-files
+      <resource-table
         v-else
         id="files-shared-with-me-shares-table"
         v-model="sharesSelected"
@@ -145,13 +145,14 @@
             :folders="sharesCountFolders"
           />
         </template>
-      </oc-table-files>
+      </resource-table>
     </template>
   </div>
 </template>
 
 <script>
 import { mapGetters, mapState, mapActions, mapMutations } from 'vuex'
+import ResourceTable from '../components/FilesList/ResourceTable.vue'
 import { shareStatus } from '../helpers/shareStatus'
 import { aggregateResourceShares } from '../helpers/resources'
 import FileActions from '../mixins/fileActions'
@@ -174,6 +175,7 @@ const visibilityObserver = new VisibilityObserver()
 
 export default {
   components: {
+    ResourceTable,
     ListLoader,
     NoContentMessage,
     ListInfo,

--- a/packages/web-app-files/src/views/SharedWithOthers.vue
+++ b/packages/web-app-files/src/views/SharedWithOthers.vue
@@ -14,7 +14,7 @@
           </span>
         </template>
       </no-content-message>
-      <oc-table-files
+      <resource-table
         v-else
         id="files-shared-with-others-table"
         v-model="selected"
@@ -39,7 +39,7 @@
             :folders="totalFilesCount.folders"
           />
         </template>
-      </oc-table-files>
+      </resource-table>
     </template>
   </div>
 </template>
@@ -47,6 +47,7 @@
 <script>
 import { mapGetters, mapState, mapActions, mapMutations } from 'vuex'
 import { computed } from '@vue/composition-api'
+import ResourceTable from '../components/FilesList/ResourceTable.vue'
 
 import { aggregateResourceShares } from '../helpers/resources'
 import FileActions from '../mixins/fileActions'
@@ -74,7 +75,7 @@ import ContextActions from '../components/FilesList/ContextActions.vue'
 const visibilityObserver = new VisibilityObserver()
 
 export default {
-  components: { ListLoader, NoContentMessage, ListInfo, Pagination, ContextActions },
+  components: { ResourceTable, ListLoader, NoContentMessage, ListInfo, Pagination, ContextActions },
 
   mixins: [FileActions, MixinResources, MixinMountSideBar, MixinFilesListFilter],
 

--- a/packages/web-app-files/src/views/Trashbin.vue
+++ b/packages/web-app-files/src/views/Trashbin.vue
@@ -12,7 +12,7 @@
           <span v-translate>You have no deleted files</span>
         </template>
       </no-content-message>
-      <oc-table-files
+      <resource-table
         v-else
         id="files-trashbin-table"
         v-model="selected"
@@ -36,7 +36,7 @@
             :folders="totalFilesCount.folders"
           />
         </template>
-      </oc-table-files>
+      </resource-table>
     </template>
   </div>
 </template>
@@ -44,6 +44,7 @@
 <script>
 import { mapGetters, mapMutations, mapState } from 'vuex'
 import { computed } from '@vue/composition-api'
+import ResourceTable from '../components/FilesList/ResourceTable.vue'
 
 import { buildDeletedResource, buildResource } from '../helpers/resources'
 import MixinFilesListFilter from '../mixins/filesListFilter'
@@ -66,7 +67,7 @@ import ContextActions from '../components/FilesList/ContextActions.vue'
 import { DavProperties } from 'web-pkg/src/constants'
 
 export default {
-  components: { ListLoader, NoContentMessage, ListInfo, Pagination, ContextActions },
+  components: { ResourceTable, ListLoader, NoContentMessage, ListInfo, Pagination, ContextActions },
 
   mixins: [MixinResources, MixinMountSideBar, MixinFilesListFilter],
 

--- a/packages/web-app-files/tests/unit/components/FilesList/ResourceTable.spec.js
+++ b/packages/web-app-files/tests/unit/components/FilesList/ResourceTable.spec.js
@@ -1,0 +1,265 @@
+import _ from 'lodash'
+import { mount, createLocalVue } from '@vue/test-utils'
+import { DateTime } from 'luxon'
+import DesignSystem from 'owncloud-design-system'
+
+import ResourceTable from '../../../../src/components/FilesList/ResourceTable.vue'
+
+const getCurrentDate = () => {
+  return DateTime.fromJSDate(new Date()).minus({ days: 1 }).toFormat('EEE, dd MMM yyyy HH:mm:ss')
+}
+
+const fields = ['name', 'size', 'mdate', 'sdate', 'ddate', 'actions', 'owner', 'sharedWith']
+
+const sharedWith = [
+  {
+    id: 'bob',
+    username: 'bob',
+    displayName: 'Bob',
+    avatar:
+      'https://images.unsplash.com/photo-1610216705422-caa3fcb6d158?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTB8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60'
+  },
+  {
+    id: 'marie',
+    username: 'marie',
+    displayName: 'Marie',
+    avatar:
+      'https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60'
+  },
+  {
+    id: 'john',
+    username: 'john',
+    displayName: 'John Richards Emperor of long names'
+  }
+]
+
+const owner = [
+  {
+    id: 'bob',
+    username: 'bob',
+    displayName: 'Bob',
+    avatar:
+      'https://images.unsplash.com/photo-1610216705422-caa3fcb6d158?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTB8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60'
+  }
+]
+
+const indicators = [
+  {
+    id: 'files-sharing',
+    label: 'Shared with other people',
+    visible: true,
+    icon: 'group',
+    handler: (resource, indicatorId) =>
+      alert(`Resource: ${resource.name}, indicator: ${indicatorId}`)
+  },
+  {
+    id: 'file-link',
+    label: 'Shared via link',
+    visible: true,
+    icon: 'link'
+  }
+]
+
+const resourcesWithAllFields = [
+  {
+    id: 'forest',
+    name: 'forest.jpg',
+    path: 'images/nature/forest.jpg',
+    thumbnail: 'https://cdn.pixabay.com/photo/2015/09/09/16/05/forest-931706_960_720.jpg',
+    indicators,
+    type: 'file',
+    size: '111000234',
+    mdate: getCurrentDate(),
+    sdate: getCurrentDate(),
+    ddate: getCurrentDate(),
+    owner,
+    sharedWith
+  },
+  {
+    id: 'notes',
+    name: 'notes.txt',
+    path: '/Documents/notes.txt',
+    icon: 'text',
+    indicators,
+    type: 'file',
+    size: 'big',
+    mdate: getCurrentDate(),
+    sdate: getCurrentDate(),
+    ddate: getCurrentDate(),
+    sharedWith,
+    owner
+  },
+  {
+    id: 'documents',
+    name: 'Documents',
+    path: '/Documents',
+    icon: 'folder',
+    indicators,
+    type: 'folder',
+    size: '-1',
+    mdate: getCurrentDate(),
+    sdate: getCurrentDate(),
+    ddate: getCurrentDate(),
+    sharedWith,
+    owner
+  },
+  {
+    id: 'another-one==',
+    name: 'Another one',
+    path: '/Another one',
+    icon: 'folder',
+    indicators,
+    type: 'folder',
+    size: '237895',
+    mdate: getCurrentDate(),
+    sdate: getCurrentDate(),
+    ddate: getCurrentDate(),
+    sharedWith,
+    owner
+  }
+]
+
+function getMountedWrapper(options = {}) {
+  const localVue = createLocalVue()
+  localVue.use(DesignSystem)
+  localVue.prototype.$gettextInterpolate = jest.fn()
+  localVue.prototype.$ngettext = jest.fn()
+
+  return mount(
+    ResourceTable,
+    _.merge(
+      {
+        propsData: {
+          resources: resourcesWithAllFields,
+          selection: [],
+          slots: {
+            status: "<div class='status-slot'>Hello world!</div>"
+          },
+          hover: false
+        },
+        stubs: {
+          'router-link': true
+        },
+        localVue
+      },
+      options
+    )
+  )
+}
+
+describe('ResourceTable', () => {
+  const spyDisplayPositionedDropdown = jest
+    .spyOn(ResourceTable.methods, 'displayPositionedDropdown')
+    .mockImplementation()
+
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = getMountedWrapper()
+    jest.clearAllMocks()
+  })
+
+  it('displays all known fields of the resources', () => {
+    for (const field of fields) {
+      expect(wrapper.findAll('.oc-table-header-cell-' + field).length).toEqual(1)
+      expect(wrapper.findAll('.oc-table-data-cell-' + field).length).toEqual(
+        resourcesWithAllFields.length
+      )
+    }
+  })
+
+  it('accepts resourceDomId closure', () => {
+    const wrapper = getMountedWrapper({
+      propsData: {
+        resourceDomSelector: (resource) => ['custom', resource.id.replace(/=+/, '')].join('-')
+      }
+    })
+    resourcesWithAllFields.forEach((resource) => {
+      ;['.oc-tbody-tr', '#resource-table-select', '#context-menu-drop'].forEach((baseSelector) => {
+        expect(
+          wrapper.find([baseSelector, 'custom', resource.id.replace(/=+/, '')].join('-')).exists()
+        ).toBeTruthy()
+      })
+    })
+  })
+
+  it('formats the resource size to a human readable format', () => {
+    expect(wrapper.find('.oc-tbody-tr-forest .oc-table-data-cell-size').text()).toEqual('111 MB')
+    expect(wrapper.find('.oc-tbody-tr-documents .oc-table-data-cell-size').text()).toEqual('--')
+    expect(wrapper.find('.oc-tbody-tr-notes .oc-table-data-cell-size').text()).toEqual('?')
+  })
+
+  describe('resource selection', () => {
+    it('adds resources to selection model via checkboxes', () => {
+      wrapper.find('.resource-table-select-all .oc-checkbox').setChecked()
+      wrapper.find('.oc-tbody-tr-documents .oc-checkbox').setChecked()
+      expect(wrapper.emitted().select.length).toBe(2)
+    })
+
+    describe('all rows already selected', () => {
+      it('de-selects all resources via the select-all checkbox', async () => {
+        const wrapperSelected = getMountedWrapper({
+          propsData: {
+            selection: resourcesWithAllFields.map((resource) => resource.id)
+          }
+        })
+
+        await wrapperSelected.find('.resource-table-select-all .oc-checkbox').setChecked(false)
+        expect(wrapperSelected.emitted().select[0][0].length).toBe(0)
+      })
+    })
+  })
+
+  describe('resource activation', () => {
+    it('emits fileClick upon clicking on a resource name', () => {
+      wrapper.find('.oc-tbody-tr-forest .oc-resource-name').trigger('click')
+
+      expect(wrapper.emitted().fileClick[0][0].name).toMatch('forest.jpg')
+    })
+  })
+
+  describe('resource details', () => {
+    it('emits select event when clicking on the row', async () => {
+      const tableRow = await wrapper.find('.oc-tbody-tr .oc-table-data-cell-size')
+      await tableRow.trigger('click')
+      expect(wrapper.emitted().select).toBeTruthy()
+    })
+  })
+
+  describe('context menu', () => {
+    it('emits select event on contextmenu click', async () => {
+      await wrapper.find('.oc-tbody-tr').trigger('contextmenu')
+      expect(wrapper.emitted().select.length).toBe(1)
+      expect(spyDisplayPositionedDropdown).toHaveBeenCalledTimes(1)
+    })
+
+    it('emits select event on clicking the three-dot icon in table row', async () => {
+      await wrapper
+        .find('.oc-table-data-cell-actions .resource-table-btn-action-dropdown')
+        .trigger('click')
+      expect(wrapper.emitted().select.length).toBe(1)
+      expect(spyDisplayPositionedDropdown).toHaveBeenCalledTimes(1)
+    })
+
+    it('removes invalid chars from item ids for usage in html template', async () => {
+      const contextMenuTriggers = await wrapper.findAll('.resource-table-btn-action-dropdown')
+      for (let i = 0; i < contextMenuTriggers.length; i++) {
+        const id = contextMenuTriggers.at(i).attributes().id
+        expect(id).not.toBeUndefined()
+        expect(id).toEqual(expect.not.stringContaining('='))
+      }
+    })
+  })
+
+  describe('hover effect', () => {
+    it('is disabled by default', () => {
+      const wrapper = getMountedWrapper({ propsData: { hover: false } })
+      expect(wrapper.classes()).not.toContain('oc-table-hover')
+    })
+
+    it('can be enabled', () => {
+      const wrapper = getMountedWrapper({ propsData: { hover: true } })
+      expect(wrapper.classes()).toContain('oc-table-hover')
+    })
+  })
+})

--- a/packages/web-app-files/tests/unit/components/FilesList/ResourceTableSort.spec.js
+++ b/packages/web-app-files/tests/unit/components/FilesList/ResourceTableSort.spec.js
@@ -1,0 +1,339 @@
+import { mount, createLocalVue } from '@vue/test-utils'
+import DesignSystem from 'owncloud-design-system'
+import ResourceTable from '../../../../src/components/FilesList/ResourceTable.vue'
+
+const ASC = 'ascending'
+const DESC = 'descending'
+const NONE = 'none'
+
+const sharedWithOne = [
+  {
+    id: 'bob',
+    username: 'bob',
+    displayName: 'Bob'
+  }
+]
+
+const sharedWithTwo = [
+  {
+    id: 'marie',
+    username: 'marie',
+    displayName: 'Marie'
+  },
+  {
+    id: 'john',
+    username: 'john',
+    displayName: 'John Richards Emperor of long names'
+  }
+]
+
+const sharedWithThree = [
+  {
+    id: 'bob',
+    username: 'bob',
+    displayName: 'Bob'
+  },
+  {
+    id: 'marie',
+    username: 'marie',
+    displayName: 'Marie'
+  },
+  {
+    id: 'john',
+    username: 'john',
+    displayName: 'John Richards Emperor of long names'
+  }
+]
+
+const firstOwner = sharedWithOne
+const secondOwner = []
+secondOwner[0] = sharedWithTwo[0]
+
+const indicators = [
+  {
+    id: 'files-sharing',
+    label: 'Shared with other people',
+    visible: true,
+    icon: 'group',
+    handler: (resource, indicatorId) =>
+      alert(`Resource: ${resource.name}, indicator: ${indicatorId}`)
+  },
+  {
+    id: 'file-link',
+    label: 'Shared via link',
+    visible: true,
+    icon: 'link'
+  }
+]
+
+const resourcesWithAllFields = [
+  {
+    id: 'forest',
+    name: 'forest.jpg',
+    path: 'images/nature/forest.jpg',
+    thumbnail: 'https://cdn.pixabay.com/photo/2015/09/09/16/05/forest-931706_960_720.jpg',
+    indicators,
+    type: 'file',
+    size: '111000234',
+    mdate: 'Thu, 01 Jul 2021 08:34:04 GMT',
+    owner: firstOwner,
+    sharedWith: sharedWithOne
+  },
+  {
+    id: 'notes',
+    name: 'notes.txt',
+    path: '/Documents/notes.txt',
+    icon: 'text',
+    indicators,
+    type: 'file',
+    size: '1245',
+    mdate: 'Thu, 01 Jul 2021 08:45:04 GMT',
+    owner: secondOwner,
+    sharedWith: sharedWithTwo
+  },
+  {
+    id: 'documents',
+    name: 'Documents',
+    path: '/Documents',
+    icon: 'folder',
+    indicators,
+    type: 'folder',
+    size: '5324435',
+    mdate: 'Sat, 09 Jan 2021 14:34:04 GMT',
+    owner: firstOwner,
+    sharedWith: sharedWithThree
+  },
+  {
+    id: 'pdfs',
+    name: 'pdfs',
+    path: '/pdfs',
+    icon: 'folder',
+    indicators,
+    type: 'folder',
+    size: '53244',
+    mdate: 'Sat, 09 Jan 2021 14:34:04 GMT',
+    owner: firstOwner,
+    sharedWith: sharedWithThree
+  },
+  {
+    id: 'Prints',
+    name: 'Prints',
+    path: '/Prints',
+    icon: 'folder',
+    indicators,
+    type: 'folder',
+    size: '53244',
+    mdate: 'Sat, 09 Jan 2021 14:34:04 GMT',
+    owner: firstOwner,
+    sharedWith: sharedWithThree
+  }
+]
+
+describe('ResourceTable.sort', () => {
+  function getWrapperWithProps(props = {}) {
+    const localVue = createLocalVue()
+    localVue.use(DesignSystem)
+    localVue.prototype.$gettextInterpolate = jest.fn()
+    localVue.prototype.$ngettext = jest.fn()
+
+    return mount(ResourceTable, {
+      propsData: {
+        resources: resourcesWithAllFields,
+        ...props
+      },
+      localVue,
+      stubs: {
+        'router-link': true
+      }
+    })
+  }
+
+  function getHeaders(wrapper) {
+    return wrapper.findAll('thead th')
+  }
+
+  function getSortByName(wrapper) {
+    return getHeaders(wrapper).at(1)
+  }
+
+  function getSortBySize(wrapper) {
+    return getHeaders(wrapper).at(2)
+  }
+
+  function getSortBySharedWith(wrapper) {
+    return getHeaders(wrapper).at(3)
+  }
+
+  function getSortByOwner(wrapper) {
+    return getHeaders(wrapper).at(4)
+  }
+
+  function getSortByMdate(wrapper) {
+    return getHeaders(wrapper).at(5)
+  }
+
+  it('renders all sorting table headers correctly', () => {
+    expect(getWrapperWithProps().findAll('[aria-sort]').length).toBe(5)
+  })
+
+  it('displays all fields in order of first sortable field', () => {
+    const resources = getWrapperWithProps().findAll('.oc-resource-name')
+
+    expect(resources.at(0).attributes('data-test-resource-name')).toBe('Documents')
+    expect(resources.at(1).attributes('data-test-resource-name')).toBe('pdfs')
+    expect(resources.at(2).attributes('data-test-resource-name')).toBe('Prints')
+    expect(resources.at(3).attributes('data-test-resource-name')).toBe('forest.jpg')
+    expect(resources.at(4).attributes('data-test-resource-name')).toBe('notes.txt')
+  })
+
+  it('sorts by name on click', async () => {
+    const wrapper = getWrapperWithProps()
+    const sortByName = getSortByName(wrapper)
+    const sortBySize = getSortBySize(wrapper)
+
+    await sortByName.trigger('click')
+
+    expect(sortByName.attributes('aria-sort')).toBe(ASC)
+    expect(sortBySize.attributes('aria-sort')).toBe(NONE)
+
+    const resourcesOne = wrapper.findAll('.oc-resource-name')
+
+    expect(resourcesOne.at(0).attributes('data-test-resource-name')).toBe('notes.txt')
+    expect(resourcesOne.at(1).attributes('data-test-resource-name')).toBe('forest.jpg')
+    expect(resourcesOne.at(2).attributes('data-test-resource-name')).toBe('Prints')
+    expect(resourcesOne.at(3).attributes('data-test-resource-name')).toBe('pdfs')
+    expect(resourcesOne.at(4).attributes('data-test-resource-name')).toBe('Documents')
+
+    await sortByName.trigger('click')
+
+    expect(sortByName.attributes('aria-sort')).toBe(DESC)
+
+    const resourcesTwo = wrapper.findAll('.oc-resource-name')
+
+    expect(resourcesTwo.at(0).attributes('data-test-resource-name')).toBe('Documents')
+    expect(resourcesTwo.at(1).attributes('data-test-resource-name')).toBe('pdfs')
+    expect(resourcesTwo.at(2).attributes('data-test-resource-name')).toBe('Prints')
+    expect(resourcesTwo.at(3).attributes('data-test-resource-name')).toBe('forest.jpg')
+    expect(resourcesTwo.at(4).attributes('data-test-resource-name')).toBe('notes.txt')
+  })
+
+  it('sorts by size', async () => {
+    const wrapper = getWrapperWithProps()
+    const sortByName = getSortByName(wrapper)
+    const sortBySize = getSortBySize(wrapper)
+
+    await sortBySize.trigger('click')
+
+    expect(sortByName.attributes('aria-sort')).toBe(NONE)
+    expect(sortBySize.attributes('aria-sort')).toBe(DESC)
+
+    const resourcesOne = wrapper.findAll('.oc-resource-name')
+
+    expect(resourcesOne.at(0).attributes('data-test-resource-name')).toBe('notes.txt')
+    expect(resourcesOne.at(1).attributes('data-test-resource-name')).toBe('pdfs')
+    expect(resourcesOne.at(2).attributes('data-test-resource-name')).toBe('Prints')
+    expect(resourcesOne.at(3).attributes('data-test-resource-name')).toBe('Documents')
+    expect(resourcesOne.at(4).attributes('data-test-resource-name')).toBe('forest.jpg')
+
+    await sortBySize.trigger('click')
+
+    expect(sortBySize.attributes('aria-sort')).toBe(ASC)
+
+    const resourcesTwo = wrapper.findAll('.oc-resource-name')
+
+    expect(resourcesTwo.at(0).attributes('data-test-resource-name')).toBe('forest.jpg')
+    expect(resourcesTwo.at(1).attributes('data-test-resource-name')).toBe('Documents')
+    expect(resourcesTwo.at(2).attributes('data-test-resource-name')).toBe('pdfs')
+    expect(resourcesTwo.at(3).attributes('data-test-resource-name')).toBe('Prints')
+    expect(resourcesTwo.at(4).attributes('data-test-resource-name')).toBe('notes.txt')
+  })
+
+  it('sorts by modification date', async () => {
+    const wrapper = getWrapperWithProps()
+    const sortByMdate = getSortByMdate(wrapper)
+    const sortBySize = getSortBySize(wrapper)
+
+    await sortByMdate.trigger('click')
+
+    expect(sortByMdate.attributes('aria-sort')).toBe(DESC)
+    expect(sortBySize.attributes('aria-sort')).toBe(NONE)
+
+    const resourcesOne = wrapper.findAll('.oc-resource-name')
+
+    expect(resourcesOne.at(0).attributes('data-test-resource-name')).toBe('Documents')
+    expect(resourcesOne.at(1).attributes('data-test-resource-name')).toBe('pdfs')
+    expect(resourcesOne.at(2).attributes('data-test-resource-name')).toBe('Prints')
+    expect(resourcesOne.at(3).attributes('data-test-resource-name')).toBe('forest.jpg')
+    expect(resourcesOne.at(4).attributes('data-test-resource-name')).toBe('notes.txt')
+
+    await sortByMdate.trigger('click')
+
+    expect(sortByMdate.attributes('aria-sort')).toBe(ASC)
+
+    const resourcesTwo = wrapper.findAll('.oc-resource-name')
+
+    expect(resourcesTwo.at(0).attributes('data-test-resource-name')).toBe('notes.txt')
+    expect(resourcesTwo.at(1).attributes('data-test-resource-name')).toBe('forest.jpg')
+    expect(resourcesTwo.at(2).attributes('data-test-resource-name')).toBe('Documents')
+  })
+
+  it('sorts by owner', async () => {
+    const wrapper = getWrapperWithProps()
+    const sortByMdate = getSortByMdate(wrapper)
+    const sortByOwner = getSortByOwner(wrapper)
+
+    await sortByOwner.trigger('click')
+
+    expect(sortByOwner.attributes('aria-sort')).toBe(DESC)
+    expect(sortByMdate.attributes('aria-sort')).toBe(NONE)
+
+    const resourcesOne = wrapper.findAll('.oc-resource-name')
+
+    expect(resourcesOne.at(0).attributes('data-test-resource-name')).toBe('forest.jpg')
+    expect(resourcesOne.at(1).attributes('data-test-resource-name')).toBe('Documents')
+    expect(resourcesOne.at(2).attributes('data-test-resource-name')).toBe('pdfs')
+    expect(resourcesOne.at(3).attributes('data-test-resource-name')).toBe('Prints')
+    expect(resourcesOne.at(4).attributes('data-test-resource-name')).toBe('notes.txt')
+
+    await sortByOwner.trigger('click')
+
+    expect(sortByOwner.attributes('aria-sort')).toBe(ASC)
+
+    const resourcesTwo = wrapper.findAll('.oc-resource-name')
+
+    expect(resourcesTwo.at(0).attributes('data-test-resource-name')).toBe('notes.txt')
+    expect(resourcesTwo.at(1).attributes('data-test-resource-name')).toBe('forest.jpg')
+    expect(resourcesTwo.at(2).attributes('data-test-resource-name')).toBe('Documents')
+    expect(resourcesTwo.at(3).attributes('data-test-resource-name')).toBe('pdfs')
+    expect(resourcesTwo.at(4).attributes('data-test-resource-name')).toBe('Prints')
+  })
+
+  it('sorts by shares', async () => {
+    const wrapper = getWrapperWithProps()
+    const sortBySharedWith = getSortBySharedWith(wrapper)
+    const sortByOwner = getSortByOwner(wrapper)
+
+    await sortBySharedWith.trigger('click')
+
+    expect(sortBySharedWith.attributes('aria-sort')).toBe(DESC)
+    expect(sortByOwner.attributes('aria-sort')).toBe(NONE)
+
+    const resourcesOne = wrapper.findAll('.oc-resource-name')
+
+    expect(resourcesOne.at(0).attributes('data-test-resource-name')).toBe('forest.jpg')
+    expect(resourcesOne.at(1).attributes('data-test-resource-name')).toBe('notes.txt')
+    expect(resourcesOne.at(2).attributes('data-test-resource-name')).toBe('Documents')
+
+    await sortBySharedWith.trigger('click')
+
+    expect(sortBySharedWith.attributes('aria-sort')).toBe(ASC)
+
+    const resourcesTwo = wrapper.findAll('.oc-resource-name')
+
+    expect(resourcesTwo.at(0).attributes('data-test-resource-name')).toBe('Documents')
+    expect(resourcesTwo.at(1).attributes('data-test-resource-name')).toBe('pdfs')
+    expect(resourcesTwo.at(2).attributes('data-test-resource-name')).toBe('Prints')
+    expect(resourcesTwo.at(3).attributes('data-test-resource-name')).toBe('notes.txt')
+    expect(resourcesTwo.at(4).attributes('data-test-resource-name')).toBe('forest.jpg')
+  })
+})

--- a/packages/web-app-files/tests/unit/components/Search/List.spec.js
+++ b/packages/web-app-files/tests/unit/components/Search/List.spec.js
@@ -19,7 +19,7 @@ localVue.use(GetTextPlugin, {
 
 const stubs = {
   'no-content-message': false,
-  'oc-table-files': false,
+  'resource-table': false,
   pagination: true,
   'list-info': true
 }

--- a/packages/web-app-files/tests/unit/views/Favorites.spec.js
+++ b/packages/web-app-files/tests/unit/views/Favorites.spec.js
@@ -9,7 +9,7 @@ const stubs = {
   'router-link': true,
   translate: true,
   'oc-pagination': true,
-  'oc-table-files': true,
+  'resource-table': true,
   'oc-spinner': true,
   'context-actions': true
 }
@@ -20,7 +20,7 @@ const selectors = {
 }
 
 const spinnerStub = 'oc-spinner-stub'
-const filesTableStub = 'oc-table-files-stub'
+const resourceTableStub = 'resource-table-stub'
 const paginationStub = 'oc-pagination-stub'
 const listInfoStub = 'list-info-stub'
 
@@ -32,7 +32,7 @@ describe('Favorites component', () => {
       const wrapper = getMountedWrapper({ loading: true })
 
       expect(wrapper.find(spinnerStub).exists()).toBeTruthy()
-      expect(wrapper.find(filesTableStub).exists()).toBeFalsy()
+      expect(wrapper.find(resourceTableStub).exists()).toBeFalsy()
     })
 
     it('shows only the files table when loading is finished', () => {
@@ -45,7 +45,7 @@ describe('Favorites component', () => {
       })
 
       expect(wrapper.find(spinnerStub).exists()).toBeFalsy()
-      expect(wrapper.find(filesTableStub).exists()).toBeTruthy()
+      expect(wrapper.find(resourceTableStub).exists()).toBeTruthy()
     })
   })
   describe('no content message', () => {
@@ -54,7 +54,7 @@ describe('Favorites component', () => {
       const wrapper = getMountedWrapper({ store, loading: false })
 
       expect(wrapper.find(selectors.noContentMessage).exists()).toBeTruthy()
-      expect(wrapper.find(filesTableStub).exists()).toBeFalsy()
+      expect(wrapper.find(resourceTableStub).exists()).toBeFalsy()
     })
 
     it('does not show the no content message if resources are marked as favorite', () => {
@@ -67,7 +67,7 @@ describe('Favorites component', () => {
       })
 
       expect(wrapper.find('#files-favorites-empty').exists()).toBeFalsy()
-      expect(wrapper.find(filesTableStub).exists()).toBeTruthy()
+      expect(wrapper.find(resourceTableStub).exists()).toBeTruthy()
     })
   })
   describe('files table', () => {
@@ -165,7 +165,7 @@ describe('Favorites component', () => {
 
     describe('pagination', () => {
       beforeEach(() => {
-        stubs['oc-table-files'] = false
+        stubs['resource-table'] = false
       })
 
       it('does not show any pagination when there is only one page', () => {
@@ -183,7 +183,7 @@ describe('Favorites component', () => {
 
     describe('list-info', () => {
       beforeEach(() => {
-        stubs['oc-table-files'] = false
+        stubs['resource-table'] = false
         stubs['list-info'] = true
       })
 

--- a/packages/web-app-files/tests/unit/views/Personal.spec.js
+++ b/packages/web-app-files/tests/unit/views/Personal.spec.js
@@ -49,7 +49,7 @@ const stubs = {
   translate: true,
   'oc-pagination': true,
   'list-loader': true,
-  'oc-table-files': true,
+  'resource-table': true,
   'not-found-message': true,
   'quick-actions': true,
   'list-info': true

--- a/packages/web-app-files/tests/unit/views/SharedViaLink.spec.js
+++ b/packages/web-app-files/tests/unit/views/SharedViaLink.spec.js
@@ -13,12 +13,12 @@ describe('SharedViaLink view', () => {
 
     describe('when there are no files to be displayed', () => {
       it.todo('should show no-content-message component')
-      it.todo('should not show oc-table-files component')
+      it.todo('should not show resource-table component')
     })
 
     describe('when there are one or more files to be displayed', () => {
       it.todo('should not show no-content-message component')
-      it.todo('should show oc-table-files component with props')
+      it.todo('should show resource-table component with props')
       it.todo('should set props on context-actions component')
       it.todo('should set props on list-info component')
       it.todo('should trigger showing the sidebar when a "showDetails" event gets emitted')

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -14,7 +14,7 @@
     "lodash-es": "^4.17.21",
     "luxon": "^2.0.0",
     "oidc-client": "1.11.5",
-    "owncloud-design-system": "^11.3.0",
+    "owncloud-design-system": "12.0.0-alpha1",
     "owncloud-sdk": "1.0.0-2296",
     "p-queue": "^6.1.1",
     "popper-max-size-modifier": "^0.2.0",

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -662,7 +662,7 @@ module.exports = {
       locateStrategy: 'xpath'
     },
     contextBtnInFileRow: {
-      selector: '//button[contains(@class, "oc-table-files-btn-action-dropdown")]',
+      selector: '//button[contains(@class, "resource-table-btn-action-dropdown")]',
       locateStrategy: 'xpath'
     },
     contextMenuPanel: {
@@ -690,7 +690,7 @@ module.exports = {
       locateStrategy: 'xpath'
     },
     checkBoxAllFiles: {
-      selector: '#oc-table-files-select-all'
+      selector: '#resource-table-select-all'
     },
     checkboxInFileRow: {
       selector: '//input[@type="checkbox"]',

--- a/tests/acceptance/pageObjects/sharedWithOthersPage.js
+++ b/tests/acceptance/pageObjects/sharedWithOthersPage.js
@@ -44,7 +44,7 @@ module.exports = {
   elements: {
     collaboratorsInFileRow: {
       selector:
-        '//span[contains(@class, "oc-table-files-people")]/span[contains(@class, "oc-avatars")]/span[contains(@class, "oc-avatar")]',
+        '//span[contains(@class, "resource-table-people")]/span[contains(@class, "oc-avatars")]/span[contains(@class, "oc-avatar")]',
       locateStrategy: 'xpath'
     }
   }

--- a/tests/smoke/support/cta/files/sidebar.ts
+++ b/tests/smoke/support/cta/files/sidebar.ts
@@ -2,7 +2,7 @@ import { Page } from 'playwright'
 
 export const open = async ({ page, resource }: { page: Page; resource: string }): Promise<void> => {
   await page.click(
-    `//span[@data-test-resource-name="${resource}"]/ancestor::tr[contains(@class, "oc-tbody-tr")]//button[contains(@class, "oc-table-files-btn-action-dropdown")]`
+    `//span[@data-test-resource-name="${resource}"]/ancestor::tr[contains(@class, "oc-tbody-tr")]//button[contains(@class, "resource-table-btn-action-dropdown")]`
   )
   await page.waitForSelector('//*[@id="oc-files-context-menu"]')
   await page.click('.oc-files-actions-show-details-trigger')

--- a/yarn.lock
+++ b/yarn.lock
@@ -10602,9 +10602,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"owncloud-design-system@npm:^11.3.0":
-  version: 11.3.1
-  resolution: "owncloud-design-system@npm:11.3.1"
+"owncloud-design-system@npm:12.0.0-alpha1":
+  version: 12.0.0-alpha1
+  resolution: "owncloud-design-system@npm:12.0.0-alpha1"
   peerDependencies:
     "@popperjs/core": ^2.4.0
     filesize: ^8.0.0
@@ -10621,7 +10621,7 @@ __metadata:
     vue-inline-svg: ^2.0.0
     vue-select: ^3.12.0
     webfontloader: ^1.6.28
-  checksum: 659556a4aef76dcf155f35ffeeffc50ee8c3825c002d071f68d185b9e0fa407e8f8414210c4bb570485b82fd8d54ca593f49bb3222c02f9ae5289b3ac84a292c
+  checksum: 6df97479a7204ff856134c56f66f483f087c5cc5d30c8e8898c43747318bcc88917c747b883a985aa0d453977d6a52a7df49ba45408312f4ce79e901c255a84a
   languageName: node
   linkType: hard
 
@@ -14953,7 +14953,7 @@ typescript@^4.3.2:
     lodash-es: ^4.17.21
     luxon: ^2.0.0
     oidc-client: 1.11.5
-    owncloud-design-system: ^11.3.0
+    owncloud-design-system: 12.0.0-alpha1
     owncloud-sdk: 1.0.0-2296
     p-queue: ^6.1.1
     popper-max-size-modifier: ^0.2.0


### PR DESCRIPTION
## Description
ods oc-table-files always contained concrete web-app-files logic, to make development more agile and keep things close
oc-table-files was renamed to resource-table and relocated to live in web-app-files from now on.

## Related Issue
- https://github.com/owncloud/owncloud-design-system/pull/1817

## Motivation and Context
its unnecessarily much work if oc-table-files live in ODS, to have it relocated makes development easier

## How Has This Been Tested?
- unit tests
- integration tests
- acceptance tests

## Types of changes
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Technical debt

## Checklist:
- [X] Code changes
- [X] Unit tests added
- [X] Acceptance tests added

## Open tasks:
- [x] remove oc-table-files from ODS
