### PR TITLE
[full-ci] Fix #4893: Make sure filenames (and extensions) are properly updated in file list and sidebar after rename

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=a2681cb6545a155d1ccf9cd4c38aa0a780424904
+OCIS_COMMITID=2856bcdef2f66297b548797cc31cc3c34c47cce2
 OCIS_BRANCH=master

--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=0d34ed55f0b0b72516b65a463e86f55792e94b2c
+OCIS_COMMITID=a2681cb6545a155d1ccf9cd4c38aa0a780424904
 OCIS_BRANCH=master

--- a/changelog/unreleased/bugfix-contextmenu-public-links
+++ b/changelog/unreleased/bugfix-contextmenu-public-links
@@ -1,0 +1,5 @@
+Bugfix: Contextmenu on public links
+
+We fixed an issue of the contextmenu not being displayed for the files table on public links.
+
+https://github.com/owncloud/web/issues/6123

--- a/changelog/unreleased/bugfix-file-rename
+++ b/changelog/unreleased/bugfix-file-rename
@@ -1,0 +1,6 @@
+Bugfix: File renaming
+
+We fixed the displayed file name not being properly updated in files list and sidebar after renaming.
+
+https://github.com/owncloud/web/issues/4893
+https://github.com/owncloud/web/pull/6114

--- a/packages/web-app-files/src/components/SideBar/SideBar.vue
+++ b/packages/web-app-files/src/components/SideBar/SideBar.vue
@@ -93,7 +93,7 @@ import { DavProperties } from 'web-pkg/src/constants'
 import MixinRoutes from '../../mixins/routes'
 import { buildResource } from '../../helpers/resources'
 import { isTrashbinRoute } from '../../helpers/route'
-
+import { computed } from '@vue/composition-api'
 import FileInfo from './FileInfo.vue'
 
 let visibilityObserver
@@ -104,14 +104,9 @@ export default {
   mixins: [MixinRoutes],
 
   provide() {
-    const displayedItem = {}
-
-    Object.defineProperty(displayedItem, 'value', {
-      enumerable: true,
-      get: () => this.selectedFile
-    })
-
-    return { displayedItem }
+    return {
+      displayedItem: computed(() => this.selectedFile)
+    }
   },
 
   data() {

--- a/packages/web-app-files/src/components/SideBar/SideBar.vue
+++ b/packages/web-app-files/src/components/SideBar/SideBar.vue
@@ -214,9 +214,7 @@ export default {
         return
       }
 
-      if (newFile.id !== oldFile?.id) {
-        this.fetchFileInfo()
-      }
+      this.fetchFileInfo()
     },
 
     highlightedFileThumbnail(thumbnail) {

--- a/packages/web-app-files/src/helpers/resources.js
+++ b/packages/web-app-files/src/helpers/resources.js
@@ -36,6 +36,8 @@ export function renameResource(resource, newName, newPath) {
   resource.name = newName
   resource.path = '/' + newPath + newName
   resource.extension = isFolder ? '' : extension
+
+  return resource
 }
 
 export function buildResource(resource) {

--- a/packages/web-app-files/src/helpers/resources.js
+++ b/packages/web-app-files/src/helpers/resources.js
@@ -29,6 +29,15 @@ function _getFileExtension(name) {
   return extension.replace(/^(.)/, '')
 }
 
+export function renameResource(resource, newName, newPath) {
+  const isFolder = resource.type === 'dir'
+  const extension = _getFileExtension(newName)
+
+  resource.name = newName
+  resource.path = '/' + newPath + newName
+  resource.extension = isFolder ? '' : extension
+}
+
 export function buildResource(resource) {
   const isFolder = resource.type === 'dir'
   const extension = _getFileExtension(resource.name)

--- a/packages/web-app-files/src/store/mutations.js
+++ b/packages/web-app-files/src/store/mutations.js
@@ -3,6 +3,7 @@ import pickBy from 'lodash-es/pickBy'
 import { DateTime } from 'luxon'
 import { set, has } from 'lodash-es'
 import { getIndicators } from '../helpers/statusIndicators'
+import { renameResource } from '../helpers/resources'
 
 export default {
   UPDATE_FILE_PROGRESS(state, file) {
@@ -114,8 +115,7 @@ export default {
       return f.id === file.id
     })
 
-    resources[fileIndex].name = newValue
-    resources[fileIndex].path = '/' + newPath + newValue
+    renameResource(resources[fileIndex], newValue, newPath)
 
     state.files = resources
   },

--- a/packages/web-app-files/src/views/PublicFiles.vue
+++ b/packages/web-app-files/src/views/PublicFiles.vue
@@ -30,7 +30,7 @@
         @rowMounted="rowMounted"
       >
         <template #contextMenu="{ resource }">
-          <context-actions v-if="isResourceInSelection(resource)" :items="[resource]" />
+          <context-actions v-if="isResourceInSelection(resource)" :items="selected" />
         </template>
         <template #footer>
           <pagination :pages="paginationPages" :current-page="paginationPage" />

--- a/packages/web-app-files/tests/unit/components/SideBar/SideBar.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/SideBar.spec.js
@@ -1,4 +1,5 @@
 import { mount, createLocalVue } from '@vue/test-utils'
+import VueCompositionAPI from '@vue/composition-api'
 import Vuex from 'vuex'
 import VueRouter from 'vue-router'
 import GetTextPlugin from 'vue-gettext'
@@ -20,6 +21,7 @@ const simpleOwnFolder = {
 function createWrapper({ item, selectedItems, mocks }) {
   const localVue = createLocalVue()
   localVue.use(Vuex)
+  localVue.use(VueCompositionAPI)
   localVue.use(VueRouter)
   localVue.use(GetTextPlugin, {
     translations: 'does-not-matter.json',

--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -107,8 +107,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 ### [share indicator in files are not shown until sharing sidebar is opened](https://github.com/owncloud/web/issues/4167)
 -   [webUISharingInternalUsersSharingIndicator/shareWithUsers.feature:100](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalUsersSharingIndicator/shareWithUsers.feature#L100)
 -   [webUISharingInternalUsersSharingIndicator/shareWithUsers.feature:121](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalUsersSharingIndicator/shareWithUsers.feature#L121)
--   [webUISharingPublicManagement/publicLinkIndicator.feature:12](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkIndicator.feature#L12)
--   [webUISharingPublicManagement/publicLinkIndicator.feature:47](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkIndicator.feature#L47)
 -   [webUISharingPublicManagement/publicLinkIndicator.feature:64](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkIndicator.feature#L64)
 -   [webUISharingPublicManagement/publicLinkIndicator.feature:81](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkIndicator.feature#L81)
 -   [webUISharingPublicManagement/publicLinkIndicator.feature:98](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkIndicator.feature#L98)

--- a/tests/acceptance/features/webUIFilesCopy/copy.feature
+++ b/tests/acceptance/features/webUIFilesCopy/copy.feature
@@ -35,7 +35,7 @@ Feature: copy files and folders
   @smokeTest @ocisSmokeTest
   Scenario: Copy multiple files at once
     Given user "Alice" has uploaded file "data.zip" to "data.zip"
-    And user "Alice" has created file "lorem.txt"
+    And user "Alice" has uploaded file "lorem.txt" to "lorem.txt"
     And user "Alice" has uploaded file "new-data.zip" to "testapp.zip"
     And user "Alice" has created folder "simple-empty-folder"
     And user "Alice" has logged in using the webUI

--- a/tests/acceptance/features/webUIFilesCopy/copy.feature
+++ b/tests/acceptance/features/webUIFilesCopy/copy.feature
@@ -54,7 +54,7 @@ Feature: copy files and folders
 
 
   Scenario Outline: copy a file into a folder (problematic characters)
-    Given user "Alice" has created file "lorem.txt"
+    Given user "Alice" has uploaded file "lorem.txt" to "lorem.txt"
     And user "Alice" has created folder "simple-empty-folder"
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page

--- a/tests/smoke/support/cta/files/sidebar.ts
+++ b/tests/smoke/support/cta/files/sidebar.ts
@@ -25,7 +25,7 @@ export const openPanel = async ({
     await backElement.click()
   }
 
-  const panelOpenElement = await page.$(`#sidebar-panel-${name}-item-select`)
+  const panelOpenElement = await page.locator(`#sidebar-panel-${name}-item-select`)
   if (panelOpenElement) {
     await panelOpenElement.click()
   }

--- a/tests/smoke/support/page/files/allFiles.ts
+++ b/tests/smoke/support/page/files/allFiles.ts
@@ -95,7 +95,7 @@ export class AllFilesPage {
 
       const [download] = await Promise.all([
         page.waitForEvent('download'),
-        page.click('.oc-files-actions-download-file-trigger')
+        page.click('#oc-files-actions-sidebar .oc-files-actions-download-file-trigger')
       ])
 
       await cta.files.sidebar.close({ page: page })


### PR DESCRIPTION
## Description
Make sure filenames (and extensions) are properly updated in file list and sidebar after rename.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #4893 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
