### PR TITLE
Use webdav email for user store initialization

### DIFF
--- a/changelog/unreleased/bugfix-user-email-initialization
+++ b/changelog/unreleased/bugfix-user-email-initialization
@@ -1,0 +1,6 @@
+Bugfix: User email attribute initialization
+
+Until now, the user email would only be set if the user used it instead of a username in the login form.
+It now can also be set from the user webdav response as a fallback.
+
+https://github.com/owncloud/web/pull/6118

--- a/packages/web-runtime/src/store/user.js
+++ b/packages/web-runtime/src/store/user.js
@@ -101,11 +101,18 @@ const actions = {
         const userGroups = await client.users.getUserGroups(login.id)
         const user = await client.users.getUser(login.id)
 
+        let userEmail = ''
+        if (login && login.email) {
+          userEmail = login.email
+        } else if (user && user.email) {
+          userEmail = user.email
+        }
+
         context.commit('SET_USER', {
           id: login.id,
           username: login.username,
           displayname: login.displayname || login['display-name'],
-          email: !Object.keys(login.email).length ? '' : login.email,
+          email: userEmail,
           token,
           isAuthenticated: true,
           groups: userGroups


### PR DESCRIPTION
## Description
Stumbled upon this in #1749 and figured it's worth adding the quick fix.

## Motivation and Context
User should see their email address (if set) in the accounts page even if they used their username in the login form.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] Code changes
