### PR TITLE
Drawio improvements

### DIFF
--- a/changelog/unreleased/enhancement-drawio
+++ b/changelog/unreleased/enhancement-drawio
@@ -1,0 +1,6 @@
+Enhancement: Drawio improvements
+
+- Honor the autosave configuration, and actually save
+- Show error messages to the user, currently all failures are silent
+
+https://github.com/owncloud/web/pull/6125


### PR DESCRIPTION
A couple of improvements to Drawio:

- Honor the autosave configuration, and actually _save_
- Show error messages to the user, currently all failures are silent
- Enable opening from public links without being authenticated

Let me know if this strategy for public links is ok. I was thinking of applying the same logic into the app provider/external app, as this is also not working properly with public links.
Maybe the mixin `fileAcess` that I created here can be moved somewhere else and re-used? Where do you suggest? `web-pkg`?