### PR TITLE
oCIS: Fix share date and share owner in shared-with-me sidebar

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -225,13 +225,10 @@ export default {
       return this.$gettext('Shared by:')
     },
     hasTimestamp() {
-      return this.file.mdate?.length > 0 || this.file.sdate?.length > 0
+      return this.file.mdate?.length > 0
     },
     timestampTitle() {
-      if (this.file.mdate) {
-        return this.$gettext('Last modified:')
-      }
-      return this.$gettext('Shared:')
+      return this.$gettext('Last modified:')
     },
     ownerTitle() {
       return this.$gettext('Owner:')
@@ -265,12 +262,7 @@ export default {
       return this.$gettext('See all versions')
     },
     capitalizedTimestamp() {
-      let displayDate = ''
-      if (this.file.mdate) {
-        displayDate = this.formDateFromHTTP(this.file.mdate)
-      } else {
-        displayDate = this.formDateFromHTTP(this.file.sdate)
-      }
+      const displayDate = this.formDateFromHTTP(this.file.mdate)
       return upperFirst(displayDate)
     },
     hasAnyShares() {

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -366,7 +366,9 @@ export default {
       let currentPath = childPath
       while (currentPath !== '/') {
         const share = shares[currentPath]
-        if (share !== undefined && share[0] !== undefined) return currentPath
+        if (share !== undefined && share[0] !== undefined) {
+          return currentPath
+        }
         currentPath = path.dirname(currentPath)
       }
       return null

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -306,15 +306,20 @@ export default {
       this.loadData()
       this.refreshShareDetailsTree()
     },
-    sharesTreeLoading(current) {
+    sharesTree() {
       this.sharedItem = null
-      if (current !== false) return
+
       const sharePathParentOrCurrent = this.getParentSharePath(this.file.path, this.sharesTree)
-      if (sharePathParentOrCurrent === null) return
+      if (sharePathParentOrCurrent === null) {
+        return
+      }
       const userShares = this.sharesTree[sharePathParentOrCurrent]?.filter((s) =>
         userShareTypes.includes(s.shareType)
       )
-      if (userShares.length === 0) return
+      if (userShares.length === 0) {
+        return
+      }
+
       this.sharedItem = userShares[0]
       this.sharedByName = this.sharedItem.owner?.name
       this.sharedByDisplayName = this.sharedItem.owner?.displayName

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -299,6 +299,7 @@ export default {
       this.refreshShareDetailsTree()
     },
     sharesTree() {
+      // missing early return
       this.sharedItem = null
 
       const sharePathParentOrCurrent = this.getParentSharePath(this.file.path, this.sharesTree)
@@ -356,6 +357,9 @@ export default {
     },
     getParentSharePath(childPath, shares) {
       let currentPath = childPath
+      if (!currentPath) {
+        return null
+      }
       while (currentPath !== '/') {
         const share = shares[currentPath]
         if (share !== undefined && share[0] !== undefined) {

--- a/packages/web-app-files/src/helpers/store.ts
+++ b/packages/web-app-files/src/helpers/store.ts
@@ -6,5 +6,8 @@
  * @return {Object} Copied object
  */
 export function cloneStateObject(state: unknown): any {
+  if (state === undefined) {
+    throw new Error('cloneStateObject: cannot clone "undefined"')
+  }
   return JSON.parse(JSON.stringify(state))
 }

--- a/packages/web-app-files/src/store/mutations.js
+++ b/packages/web-app-files/src/store/mutations.js
@@ -186,7 +186,7 @@ export default {
     }
   },
   SHARESTREE_ADD(state, sharesTree) {
-    Object.assign(state.sharesTree, sharesTree)
+    state.sharesTree = Object.assign({}, state.sharesTree, sharesTree)
   },
   SHARESTREE_ERROR(state, error) {
     state.sharesTreeError = error

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.js
@@ -14,19 +14,6 @@ localVue.use(GetTextPlugin, {
 })
 const OcTooltip = jest.fn()
 
-const selectors = {
-  noContentText: '[data-testid="noContentText"]',
-  timestamp: '[data-testid="timestamp"]',
-  ownerName: '[data-testid="ownerDisplayName"]',
-  sharingInfo: '[data-testid="sharingInfo"]',
-  sizeInfo: '[data-testid="sizeInfo"]',
-  versionsInfo: '[data-testid="versionsInfo"]',
-  previewImgContainer: '[data-testid="preview"]',
-  sharedBy: '[data-testid="shared-by"]',
-  sharedVia: '[data-testid="shared-via"]',
-  sharedDate: '[data-testid="shared-date"]'
-}
-
 const simpleOwnFolder = {
   type: 'folder',
   ownerId: 'marie',
@@ -63,45 +50,29 @@ const sharedFile = {
   shareTypes: [0]
 }
 
+const formDateFromJSDate = jest.fn().mockImplementation(() => 'ABSOLUTE_TIME')
+const formDateFromHTTP = jest.fn().mockImplementation(() => 'ABSOLUTE_TIME')
+beforeEach(() => {
+  formDateFromJSDate.mockClear()
+  formDateFromHTTP.mockClear()
+})
+
 describe('Details SideBar Panel', () => {
   describe('displays a resource of type folder', () => {
     describe('on a private page', () => {
       it('with timestamp, size info and (me) as owner', () => {
         const wrapper = createWrapper(simpleOwnFolder)
-        expect(wrapper.find(selectors.noContentText).exists()).toBeFalsy()
-        expect(wrapper.find(selectors.timestamp).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.ownerName).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.ownerName).text()).toContain('(me)')
-        expect(wrapper.find(selectors.sizeInfo).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.sharingInfo).exists()).toBeFalsy()
-        expect(wrapper.find(selectors.versionsInfo).exists()).toBeFalsy()
-        expect(wrapper.find(selectors.previewImgContainer).exists()).toBeFalsy()
+        expect(wrapper).toMatchSnapshot()
       })
       it('with timestamp, size info, share info and share date', () => {
         const wrapper = createWrapper(sharedFolder)
-        expect(wrapper.find(selectors.noContentText).exists()).toBeFalsy()
-        expect(wrapper.find(selectors.timestamp).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.ownerName).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.ownerName).text()).not.toContain('(me)')
-        expect(wrapper.find(selectors.sizeInfo).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.sharingInfo).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.versionsInfo).exists()).toBeFalsy()
-        expect(wrapper.find(selectors.previewImgContainer).exists()).toBeFalsy()
+        expect(wrapper).toMatchSnapshot()
       })
     })
     describe('on a public page', () => {
       it('with owner, timestamp, size info and no share info', () => {
         const wrapper = createWrapper(sharedFolder, [], null, true)
-        expect(wrapper.find(selectors.noContentText).exists()).toBeFalsy()
-        expect(wrapper.find(selectors.timestamp).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.ownerName).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.ownerName).text()).not.toContain('(me)')
-        expect(wrapper.find(selectors.sizeInfo).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.sharingInfo).exists()).toBeFalsy()
-        expect(wrapper.find(selectors.versionsInfo).exists()).toBeFalsy()
-        expect(wrapper.find(selectors.previewImgContainer).exists()).toBeFalsy()
-        expect(wrapper.find(selectors.sharedBy).exists()).toBeFalsy()
-        expect(wrapper.find(selectors.sharedDate).exists()).toBeFalsy()
+        expect(wrapper).toMatchSnapshot()
       })
     })
   })
@@ -109,49 +80,21 @@ describe('Details SideBar Panel', () => {
     describe('on a private page', () => {
       it('with timestamp, size info and (me) as owner', () => {
         const wrapper = createWrapper(simpleOwnFile)
-        expect(wrapper.find(selectors.noContentText).exists()).toBeFalsy()
-        expect(wrapper.find(selectors.timestamp).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.ownerName).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.ownerName).text()).toContain('(me)')
-        expect(wrapper.find(selectors.sizeInfo).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.sharingInfo).exists()).toBeFalsy()
-        expect(wrapper.find(selectors.versionsInfo).exists()).toBeFalsy()
-        expect(wrapper.find(selectors.previewImgContainer).exists()).toBeFalsy()
+        expect(wrapper).toMatchSnapshot()
       })
       it('with timestamp, size info, share info, share date and preview', () => {
         const wrapper = createWrapper(sharedFile)
-        expect(wrapper.find(selectors.noContentText).exists()).toBeFalsy()
-        expect(wrapper.find(selectors.timestamp).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.ownerName).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.ownerName).text()).not.toContain('(me)')
-        expect(wrapper.find(selectors.sizeInfo).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.sharingInfo).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.versionsInfo).exists()).toBeFalsy()
-        expect(wrapper.find(selectors.previewImgContainer).exists()).toBeTruthy()
+        expect(wrapper).toMatchSnapshot()
       })
     })
     describe('on a public page', () => {
       it('with owner, timestap, size info, no share info and preview', () => {
         const wrapper = createWrapper(sharedFile, [], null, true)
-        expect(wrapper.find(selectors.noContentText).exists()).toBeFalsy()
-        expect(wrapper.find(selectors.timestamp).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.ownerName).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.ownerName).text()).not.toContain('(me)')
-        expect(wrapper.find(selectors.sizeInfo).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.sharingInfo).exists()).toBeFalsy()
-        expect(wrapper.find(selectors.versionsInfo).exists()).toBeFalsy()
-        expect(wrapper.find(selectors.previewImgContainer).exists()).toBeTruthy()
+        expect(wrapper).toMatchSnapshot()
       })
       it('with owner, timestamp, size info, no share info and preview', () => {
         const wrapper = createWrapper(sharedFile, [], null, true)
-        expect(wrapper.find(selectors.noContentText).exists()).toBeFalsy()
-        expect(wrapper.find(selectors.timestamp).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.ownerName).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.ownerName).text()).not.toContain('(me)')
-        expect(wrapper.find(selectors.sizeInfo).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.sharingInfo).exists()).toBeFalsy()
-        expect(wrapper.find(selectors.versionsInfo).exists()).toBeFalsy()
-        expect(wrapper.find(selectors.previewImgContainer).exists()).toBeTruthy()
+        expect(wrapper).toMatchSnapshot()
       })
     })
   })
@@ -168,6 +111,9 @@ function createWrapper(testResource, testVersions = [], testPreview, publicRoute
       modules: {
         Files: {
           namespaced: true,
+          state: {
+            sharesTree: {}
+          },
           getters: {
             highlightedFile: function () {
               return testResource
@@ -177,6 +123,9 @@ function createWrapper(testResource, testVersions = [], testPreview, publicRoute
             },
             sharesTreeLoading: function () {
               return false
+            },
+            sharesTree: function (state) {
+              return state.sharesTree
             }
           },
           actions: {
@@ -196,6 +145,14 @@ function createWrapper(testResource, testVersions = [], testPreview, publicRoute
     directives: {
       OcTooltip
     },
+    mixins: [
+      {
+        methods: {
+          formDateFromJSDate,
+          formDateFromHTTP
+        }
+      }
+    ],
     mocks: {
       $route: {
         meta: {

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.js
@@ -26,7 +26,7 @@ const sharedFolder = {
   type: 'folder',
   ownerId: 'einstein',
   ownerDisplayName: 'Einstein',
-  sdate: 'Wed, 21 Oct 2015 07:28:00 GMT',
+  mdate: 'Wed, 21 Oct 2015 07:28:00 GMT',
   size: '740',
   shareTypes: [0]
 }
@@ -46,7 +46,7 @@ const sharedFile = {
   ownerDisplayName: 'Einstein',
   preview: 'example.com/image',
   thumbnail: 'example.com/image',
-  sdate: 'Wed, 21 Oct 2015 07:28:00 GMT',
+  mdate: 'Tue, 20 Oct 2015 06:15:00 GMT',
   size: '740',
   shareTypes: [0]
 }

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.js.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.js.snap
@@ -1,0 +1,256 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Details SideBar Panel displays a resource of type file on a private page with timestamp, size info and (me) as owner 1`] = `
+<div id="oc-file-details-sidebar">
+  <div>
+    <!---->
+    <!---->
+    <table aria-label="Overview of the information about the selected file" class="details-table">
+      <tr data-testid="timestamp">
+        <th scope="col" class="oc-pr-s">Last modified:</th>
+        <td><span>ABSOLUTE_TIME</span></td>
+      </tr>
+      <!---->
+      <!---->
+      <!---->
+      <tr data-testid="ownerDisplayName">
+        <th scope="col" class="oc-pr-s">Owner:</th>
+        <td>
+          <p class="oc-m-rm">
+            Marie
+            <span data-msgid="(me)" data-current-language="en_US">(me)</span>
+            <!---->
+          </p>
+        </td>
+      </tr>
+      <tr data-testid="sizeInfo">
+        <th scope="col" class="oc-pr-s">Size:</th>
+        <td>740 B</td>
+      </tr>
+      <!---->
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Details SideBar Panel displays a resource of type file on a private page with timestamp, size info, share info, share date and preview 1`] = `
+<div id="oc-file-details-sidebar">
+  <div>
+    <div data-testid="preview" class="details-preview uk-flex uk-flex-middle uk-flex-center oc-mb" style="background-image: none;">
+      <oc-spinner-stub></oc-spinner-stub>
+    </div>
+    <div data-testid="sharingInfo" class="uk-flex uk-flex-middle oc-my-m">
+      <oc-button-stub appearance="raw" aria-label="Show invited people" class="oc-mr-xs">
+        <oc-icon-stub name="group"></oc-icon-stub>
+      </oc-button-stub>
+      <!---->
+      <p class="oc-my-rm oc-mx-s">This file has been shared.</p>
+    </div>
+    <table aria-label="Overview of the information about the selected file" class="details-table">
+      <tr data-testid="timestamp">
+        <th scope="col" class="oc-pr-s">Shared:</th>
+        <td><span>ABSOLUTE_TIME</span></td>
+      </tr>
+      <tr data-testid="shared-date">
+        <th scope="col" class="oc-pr-s">Shared:</th>
+        <td><span>ABSOLUTE_TIME</span></td>
+      </tr>
+      <!---->
+      <!---->
+      <tr data-testid="ownerDisplayName">
+        <th scope="col" class="oc-pr-s">Owner:</th>
+        <td>
+          <p class="oc-m-rm">
+            Einstein
+            <!---->
+            <!---->
+          </p>
+        </td>
+      </tr>
+      <tr data-testid="sizeInfo">
+        <th scope="col" class="oc-pr-s">Size:</th>
+        <td>740 B</td>
+      </tr>
+      <!---->
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Details SideBar Panel displays a resource of type file on a public page with owner, timestamp, size info, no share info and preview 1`] = `
+<div id="oc-file-details-sidebar">
+  <div>
+    <div data-testid="preview" class="details-preview uk-flex uk-flex-middle uk-flex-center oc-mb" style="background-image: none;">
+      <oc-spinner-stub></oc-spinner-stub>
+    </div>
+    <!---->
+    <table aria-label="Overview of the information about the selected file" class="details-table">
+      <tr data-testid="timestamp">
+        <th scope="col" class="oc-pr-s">Shared:</th>
+        <td><span>ABSOLUTE_TIME</span></td>
+      </tr>
+      <!---->
+      <!---->
+      <!---->
+      <tr data-testid="ownerDisplayName">
+        <th scope="col" class="oc-pr-s">Owner:</th>
+        <td>
+          <p class="oc-m-rm">
+            Einstein
+            <!---->
+            <!---->
+          </p>
+        </td>
+      </tr>
+      <tr data-testid="sizeInfo">
+        <th scope="col" class="oc-pr-s">Size:</th>
+        <td>740 B</td>
+      </tr>
+      <!---->
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Details SideBar Panel displays a resource of type file on a public page with owner, timestap, size info, no share info and preview 1`] = `
+<div id="oc-file-details-sidebar">
+  <div>
+    <div data-testid="preview" class="details-preview uk-flex uk-flex-middle uk-flex-center oc-mb" style="background-image: none;">
+      <oc-spinner-stub></oc-spinner-stub>
+    </div>
+    <!---->
+    <table aria-label="Overview of the information about the selected file" class="details-table">
+      <tr data-testid="timestamp">
+        <th scope="col" class="oc-pr-s">Shared:</th>
+        <td><span>ABSOLUTE_TIME</span></td>
+      </tr>
+      <!---->
+      <!---->
+      <!---->
+      <tr data-testid="ownerDisplayName">
+        <th scope="col" class="oc-pr-s">Owner:</th>
+        <td>
+          <p class="oc-m-rm">
+            Einstein
+            <!---->
+            <!---->
+          </p>
+        </td>
+      </tr>
+      <tr data-testid="sizeInfo">
+        <th scope="col" class="oc-pr-s">Size:</th>
+        <td>740 B</td>
+      </tr>
+      <!---->
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Details SideBar Panel displays a resource of type folder on a private page with timestamp, size info and (me) as owner 1`] = `
+<div id="oc-file-details-sidebar">
+  <div>
+    <!---->
+    <!---->
+    <table aria-label="Overview of the information about the selected file" class="details-table">
+      <tr data-testid="timestamp">
+        <th scope="col" class="oc-pr-s">Last modified:</th>
+        <td><span>ABSOLUTE_TIME</span></td>
+      </tr>
+      <!---->
+      <!---->
+      <!---->
+      <tr data-testid="ownerDisplayName">
+        <th scope="col" class="oc-pr-s">Owner:</th>
+        <td>
+          <p class="oc-m-rm">
+            Marie
+            <span data-msgid="(me)" data-current-language="en_US">(me)</span>
+            <!---->
+          </p>
+        </td>
+      </tr>
+      <tr data-testid="sizeInfo">
+        <th scope="col" class="oc-pr-s">Size:</th>
+        <td>740 B</td>
+      </tr>
+      <!---->
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Details SideBar Panel displays a resource of type folder on a private page with timestamp, size info, share info and share date 1`] = `
+<div id="oc-file-details-sidebar">
+  <div>
+    <!---->
+    <div data-testid="sharingInfo" class="uk-flex uk-flex-middle oc-my-m">
+      <oc-button-stub appearance="raw" aria-label="Show invited people" class="oc-mr-xs">
+        <oc-icon-stub name="group"></oc-icon-stub>
+      </oc-button-stub>
+      <!---->
+      <p class="oc-my-rm oc-mx-s">This folder has been shared.</p>
+    </div>
+    <table aria-label="Overview of the information about the selected file" class="details-table">
+      <tr data-testid="timestamp">
+        <th scope="col" class="oc-pr-s">Shared:</th>
+        <td><span>ABSOLUTE_TIME</span></td>
+      </tr>
+      <tr data-testid="shared-date">
+        <th scope="col" class="oc-pr-s">Shared:</th>
+        <td><span>ABSOLUTE_TIME</span></td>
+      </tr>
+      <!---->
+      <!---->
+      <tr data-testid="ownerDisplayName">
+        <th scope="col" class="oc-pr-s">Owner:</th>
+        <td>
+          <p class="oc-m-rm">
+            Einstein
+            <!---->
+            <!---->
+          </p>
+        </td>
+      </tr>
+      <tr data-testid="sizeInfo">
+        <th scope="col" class="oc-pr-s">Size:</th>
+        <td>740 B</td>
+      </tr>
+      <!---->
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Details SideBar Panel displays a resource of type folder on a public page with owner, timestamp, size info and no share info 1`] = `
+<div id="oc-file-details-sidebar">
+  <div>
+    <!---->
+    <!---->
+    <table aria-label="Overview of the information about the selected file" class="details-table">
+      <tr data-testid="timestamp">
+        <th scope="col" class="oc-pr-s">Shared:</th>
+        <td><span>ABSOLUTE_TIME</span></td>
+      </tr>
+      <!---->
+      <!---->
+      <!---->
+      <tr data-testid="ownerDisplayName">
+        <th scope="col" class="oc-pr-s">Owner:</th>
+        <td>
+          <p class="oc-m-rm">
+            Einstein
+            <!---->
+            <!---->
+          </p>
+        </td>
+      </tr>
+      <tr data-testid="sizeInfo">
+        <th scope="col" class="oc-pr-s">Size:</th>
+        <td>740 B</td>
+      </tr>
+      <!---->
+    </table>
+  </div>
+</div>
+`;

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.js.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.js.snap
@@ -15,7 +15,7 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
     </div>
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Shared:</th>
+        <th scope="col" class="oc-pr-s">Last modified:</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <tr data-testid="shared-date">
@@ -59,7 +59,7 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
     </div>
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Shared:</th>
+        <th scope="col" class="oc-pr-s">Last modified:</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <tr data-testid="shared-date">
@@ -139,7 +139,7 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
     </div>
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Shared:</th>
+        <th scope="col" class="oc-pr-s">Last modified:</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <tr data-testid="shared-date">
@@ -177,7 +177,7 @@ exports[`Details SideBar Panel displays a resource of type file on a public page
     <!---->
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Shared:</th>
+        <th scope="col" class="oc-pr-s">Last modified:</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <!---->
@@ -212,7 +212,7 @@ exports[`Details SideBar Panel displays a resource of type file on a public page
     <!---->
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Shared:</th>
+        <th scope="col" class="oc-pr-s">Last modified:</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <!---->
@@ -284,7 +284,7 @@ exports[`Details SideBar Panel displays a resource of type folder on a private p
     </div>
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Shared:</th>
+        <th scope="col" class="oc-pr-s">Last modified:</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <tr data-testid="shared-date">
@@ -320,7 +320,7 @@ exports[`Details SideBar Panel displays a resource of type folder on a public pa
     <!---->
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Shared:</th>
+        <th scope="col" class="oc-pr-s">Last modified:</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <!---->

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.js.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.js.snap
@@ -1,5 +1,96 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Details SideBar Panel displays a resource of type file on a private page updates when the shareTree updates 1`] = `
+<div id="oc-file-details-sidebar">
+  <div>
+    <div data-testid="preview" class="details-preview uk-flex uk-flex-middle uk-flex-center oc-mb" style="background-image: none;">
+      <oc-spinner-stub></oc-spinner-stub>
+    </div>
+    <div data-testid="sharingInfo" class="uk-flex uk-flex-middle oc-my-m">
+      <oc-button-stub appearance="raw" aria-label="Show invited people" class="oc-mr-xs">
+        <oc-icon-stub name="group"></oc-icon-stub>
+      </oc-button-stub>
+      <!---->
+      <p class="oc-my-rm oc-mx-s">This file has been shared.</p>
+    </div>
+    <table aria-label="Overview of the information about the selected file" class="details-table">
+      <tr data-testid="timestamp">
+        <th scope="col" class="oc-pr-s">Shared:</th>
+        <td><span>ABSOLUTE_TIME</span></td>
+      </tr>
+      <tr data-testid="shared-date">
+        <th scope="col" class="oc-pr-s">Shared:</th>
+        <td><span>ABSOLUTE_TIME</span></td>
+      </tr>
+      <!---->
+      <!---->
+      <tr data-testid="ownerDisplayName">
+        <th scope="col" class="oc-pr-s">Owner:</th>
+        <td>
+          <p class="oc-m-rm">
+            Einstein
+            <!---->
+            <!---->
+          </p>
+        </td>
+      </tr>
+      <tr data-testid="sizeInfo">
+        <th scope="col" class="oc-pr-s">Size:</th>
+        <td>740 B</td>
+      </tr>
+      <!---->
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Details SideBar Panel displays a resource of type file on a private page updates when the shareTree updates 2`] = `
+<div id="oc-file-details-sidebar">
+  <div>
+    <div data-testid="preview" class="details-preview uk-flex uk-flex-middle uk-flex-center oc-mb" style="background-image: none;">
+      <oc-spinner-stub></oc-spinner-stub>
+    </div>
+    <div data-testid="sharingInfo" class="uk-flex uk-flex-middle oc-my-m">
+      <oc-button-stub appearance="raw" aria-label="Show invited people" class="oc-mr-xs">
+        <oc-icon-stub name="group"></oc-icon-stub>
+      </oc-button-stub>
+      <!---->
+      <p class="oc-my-rm oc-mx-s">This file has been shared.</p>
+    </div>
+    <table aria-label="Overview of the information about the selected file" class="details-table">
+      <tr data-testid="timestamp">
+        <th scope="col" class="oc-pr-s">Shared:</th>
+        <td><span>ABSOLUTE_TIME</span></td>
+      </tr>
+      <tr data-testid="shared-date">
+        <th scope="col" class="oc-pr-s">Shared:</th>
+        <td><span>ABSOLUTE_TIME</span></td>
+      </tr>
+      <!---->
+      <tr data-testid="shared-by">
+        <th scope="col" class="oc-pr-s">Shared by:</th>
+        <td><span>Marie Curie</span></td>
+      </tr>
+      <tr data-testid="ownerDisplayName">
+        <th scope="col" class="oc-pr-s">Owner:</th>
+        <td>
+          <p class="oc-m-rm">
+            Einstein
+            <!---->
+            <!---->
+          </p>
+        </td>
+      </tr>
+      <tr data-testid="sizeInfo">
+        <th scope="col" class="oc-pr-s">Size:</th>
+        <td>740 B</td>
+      </tr>
+      <!---->
+    </table>
+  </div>
+</div>
+`;
+
 exports[`Details SideBar Panel displays a resource of type file on a private page with timestamp, size info and (me) as owner 1`] = `
 <div id="oc-file-details-sidebar">
   <div>

--- a/packages/web-app-files/tests/unit/components/SideBar/FileInfo.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/FileInfo.spec.js
@@ -109,10 +109,14 @@ function createWrapper(testResource, tooltipStub, routeName) {
     directives: {
       OcTooltip: tooltipStub
     },
-    methods: {
-      formDateFromRFC,
-      formRelativeDateFromRFC
-    },
+    mixins: [
+      {
+        methods: {
+          formDateFromRFC,
+          formRelativeDateFromRFC
+        }
+      }
+    ],
     mocks: {
       $route: {
         name: routeName || 'some-route',

--- a/packages/web-app-files/tests/unit/helpers/store.spec.ts
+++ b/packages/web-app-files/tests/unit/helpers/store.spec.ts
@@ -12,4 +12,14 @@ describe('cloneStateObject', () => {
     expect(cloned.id).toBe('1')
     expect(cloned.frozen).toBe('updated')
   })
+
+  it('clones null', () => {
+    expect(cloneStateObject(null)).toStrictEqual(null)
+  })
+
+  it('throws an error when "undefined" is cloned', () => {
+    expect(() => {
+      cloneStateObject(undefined)
+    }).toThrowError('cloneStateObject: cannot clone "undefined"')
+  })
 })

--- a/packages/web-app-files/tests/unit/store/mutations.spec.js
+++ b/packages/web-app-files/tests/unit/store/mutations.spec.js
@@ -59,6 +59,22 @@ describe('vuex store mutations', () => {
     })
   })
 
+  describe('SHARESTREE_ADD', () => {
+    it('adds sharesTrees', () => {
+      const state = { sharesTree: {} }
+      mutations.SHARESTREE_ADD(state, { '/Shares': {} })
+      const sharesTreeBefore = state.sharesTree
+      mutations.SHARESTREE_ADD(state, { '/Shares/123.png': {} })
+      expect(state.sharesTree).toEqual({
+        '/Shares': {},
+        '/Shares/123.png': {}
+      })
+
+      // TODO: find a better way to test reactivity
+      expect(state.sharesTree).not.toStrictEqual(sharesTreeBefore)
+    })
+  })
+
   it('SET_HIDDEN_FILES_VISIBILITY', () => {
     const state = { areHiddenFilesShown: true }
     const { SET_HIDDEN_FILES_VISIBILITY } = mutations


### PR DESCRIPTION
## Steps to reproduce issue:

- go to shared with me
- select a file
- open sidebar

with oc10 backend:
- see correct share date
- see share owner

with oCIS backend:
- see share date being unix timestamp 0
- see no owner

## Description
The store did not mutate the `sharesTree` state in a reactive way.
The FileDetails (maybe for that reason) watched the `sharesTreeLoading` state, which is not a good event source as mutiple loading processes can be started simultaneously and do not trigger multiple watch runs (when they set loading to false one after another).
For that reason I fixed the store mutation and made the FileDetails watch the sharesTree itself instead.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- No issue as I noticed this while working on another bug

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Without this fix:
![Screenshot_20211209_135038](https://user-images.githubusercontent.com/448487/145591681-8842d648-aa05-44ca-9ca7-30487a79a79f.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
