### PR TITLE
Fix #4615: Use downloadUrl for 'Open in browser' on public files

### DIFF
--- a/changelog/unreleased/bugfix-open-in-browser-on-public-files
+++ b/changelog/unreleased/bugfix-open-in-browser-on-public-files
@@ -1,0 +1,7 @@
+Bugfix: Open in browser for public files
+
+We fixed opening publicly shared files in the browser.
+
+
+https://github.com/owncloud/web/issues/4615
+https://github.com/owncloud/web/pull/6133

--- a/packages/web-app-files/src/mixins/actions/fetch.js
+++ b/packages/web-app-files/src/mixins/actions/fetch.js
@@ -36,18 +36,15 @@ export default {
   },
   methods: {
     $_fetch_trigger({ resources, mimeType, isPublicFile }) {
-      if (isPublicFile) {
-        const url = resources[0].downloadURL
-        window.open(url, '_blank')
-        return
-      }
-
-      // FIXME: use presigned URL instead
-      const url = this.$client.helpers._webdavUrl + resources[0].path
+      let url
       const headers = new Headers()
-
-      headers.append('Authorization', 'Bearer ' + this.getToken)
-      headers.append('X-Requested-With', 'XMLHttpRequest')
+      if (isPublicFile) {
+        url = resources[0].downloadURL
+      } else {
+        url = this.$client.helpers._webdavUrl + resources[0].path
+        headers.append('Authorization', 'Bearer ' + this.getToken)
+        headers.append('X-Requested-With', 'XMLHttpRequest')
+      }
 
       fetch(url, {
         method: 'GET',


### PR DESCRIPTION
## Description
When #4615 was created, using "open in browser" on public links indeed resulted in the described behavior.
In https://github.com/owncloud/web/pull/4689 the behavior was changed to open the download url in a new tab, that in turn did not open the file in the browser (for me, Chromium 95) but instead downloaded it with a random/hash filename. 

The code path for private files achieves the correct result: it opens the file in a new tab and displays it.
We can align the behavior for public files with that by simply using the downloadUrl in the XHR download.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #4615
- Fixes #6128

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes


## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
