### PR TITLE
Ensure route config is honored for new file handlers

### DIFF
--- a/changelog/unreleased/bugfix-new-file-handler
+++ b/changelog/unreleased/bugfix-new-file-handler
@@ -1,0 +1,5 @@
+Bugfix: Ensure route config is honored for new file handlers
+
+Only display the new file entries for the routes it belongs to.
+
+https://github.com/owncloud/web/pull/6135

--- a/packages/web-app-files/src/components/AppBar/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar/AppBar.vue
@@ -88,7 +88,7 @@
                     </oc-button>
                   </div>
                 </li>
-                <li v-for="(newFileHandler, key) in newFileHandlers" :key="key">
+                <li v-for="(newFileHandler, key) in newFileHandlersForRoute" :key="key">
                   <div>
                     <oc-button
                       appearance="raw"
@@ -123,6 +123,7 @@ import isEmpty from 'lodash-es/isEmpty'
 import Mixins from '../../mixins'
 import MixinFileActions, { EDITOR_MODE_CREATE } from '../../mixins/fileActions'
 import MixinRoutes from '../../mixins/routes'
+import { checkRoute } from '../../helpers/route'
 import MixinScrollToResource from '../../mixins/filesListScrolling'
 import { buildResource } from '../../helpers/resources'
 import { bus } from 'web-pkg/src/instance'
@@ -302,6 +303,10 @@ export default {
 
     showBreadcrumbContextMenu() {
       return this.currentPathSegments.length > 0
+    },
+
+    newFileHandlersForRoute() {
+      return this.newFileHandlers.filter((handler) => checkRoute(handler.routes, this.$route.name))
     }
   },
 

--- a/packages/web-app-files/src/helpers/route.js
+++ b/packages/web-app-files/src/helpers/route.js
@@ -5,7 +5,7 @@
  * @returns {Boolean}
  */
 export function checkRoute(routes, currentRoute) {
-  return routes.indexOf(currentRoute) > -1
+  return routes ? routes.indexOf(currentRoute) > -1 : true
 }
 
 export function isPersonalRoute(route) {

--- a/packages/web-runtime/src/store/apps.js
+++ b/packages/web-runtime/src/store/apps.js
@@ -58,6 +58,7 @@ const mutations = {
     if (extension.newFileMenu) {
       extension.newFileMenu.ext = extension.extension
       extension.newFileMenu.action = editor
+      extension.newFileMenu.routes = extension.routes
       state.newFileHandlers.push(extension.newFileMenu)
     }
   },


### PR DESCRIPTION
If we have more than one new file handler in the extensions, we never check the routes associated with them.
If, for example, we need different routes in order to distinguish internal and public links (i.e #6125), without this fix we would see both entries in the "new" menu.

In the past I only added a single "new handler" to avoid seeing 2 entries, but then when I create a new file, the opening action will match the route it belongs to.