### PR TITLE
[tests-only] Reduce smoke test flakiness by waiting for action responses

### DIFF
--- a/tests/smoke/support/cta/files/misc.ts
+++ b/tests/smoke/support/cta/files/misc.ts
@@ -8,9 +8,12 @@ export const navigateToFolder = async ({
   path: string
 }): Promise<void> => {
   const paths = path.split('/')
-
   for (const name of paths) {
-    await page.click(`[data-test-resource-name="${name}"]`)
+    const resource = page.locator(`[data-test-resource-name="${name}"]`)
+    await resource.click()
+    await page.waitForResponse(
+      (resp) => resp.url().includes(encodeURIComponent(name)) && resp.status() === 200
+    )
   }
 }
 
@@ -32,7 +35,6 @@ export const resourceExists = async ({
   timeout?: number
 }): Promise<boolean> => {
   let exist = true
-
   await page.waitForSelector(`[data-test-resource-name="${name}"]`, { timeout }).catch((e) => {
     if (!(e instanceof errors.TimeoutError)) {
       throw e

--- a/tests/smoke/support/page/files/allFiles.ts
+++ b/tests/smoke/support/page/files/allFiles.ts
@@ -271,6 +271,9 @@ export class AllFilesPage {
     }
     await page.click('button.oc-files-actions-delete-trigger')
     await page.click('.oc-modal-body-actions-confirm')
+    await page.waitForResponse(
+      (resp) => resp.url().includes(encodeURIComponent(resouceName)) && resp.status() === 204
+    )
 
     await page.goto(startUrl)
   }

--- a/tests/smoke/support/page/files/sharedWithMe.ts
+++ b/tests/smoke/support/page/files/sharedWithMe.ts
@@ -14,21 +14,21 @@ export class SharedWithMePage {
 
   async acceptShare({ name }: { name: string }): Promise<void> {
     const { page } = this.actor
+    const acceptShareButton = page.locator(
+      `//*[@data-test-resource-name="${name}"]/ancestor::tr//button[contains(@class, "file-row-share-status-accept")]`
+    )
 
-    await page
-      .locator(
-        `//*[@data-test-resource-name="${name}"]/ancestor::tr//button[contains(@class, "file-row-share-status-accept")]`
-      )
-      .click()
+    await acceptShareButton.click()
+    await page.waitForResponse((resp) => resp.url().includes('shares') && resp.status() === 200)
   }
 
   async declineShare({ name }: { name: string }): Promise<void> {
     const { page } = this.actor
+    const declineShareButton = page.locator(
+      `//*[@data-test-resource-name="${name}"]/ancestor::tr//button[contains(@class, "file-row-share-decline")]`
+    )
 
-    await page
-      .locator(
-        `//*[@data-test-resource-name="${name}"]/ancestor::tr//button[contains(@class, "file-row-share-decline")]`
-      )
-      .click()
+    await declineShareButton.click()
+    await page.waitForResponse((resp) => resp.url().includes('shares') && resp.status() === 200)
   }
 }


### PR DESCRIPTION
## Description
as title says, wait for responses before move forward.

## Related Issue
- (Temporarily, hopefully for quite a while) Fixes https://github.com/owncloud/web/issues/6082

## Motivation and Context
trust!

## How Has This Been Tested?
- test smoke tests
