### PR TITLE
Separate public route for external apps

### DIFF
--- a/changelog/unreleased/bugfix-authenticate-app-provider
+++ b/changelog/unreleased/bugfix-authenticate-app-provider
@@ -1,0 +1,8 @@
+Bugfix: Separate public route for external apps 
+
+Ensures that users are redirected to the idp to authenticate, whever trying
+to open a non public link file via the app provider
+
+https://github.com/owncloud/web/issues/6069
+https://github.com/owncloud/web/issues/6045
+https://github.com/owncloud/web/pull/6151

--- a/packages/web-app-external/src/index.js
+++ b/packages/web-app-external/src/index.js
@@ -15,7 +15,17 @@ const appInfo = {
 const routes = [
   {
     name: 'apps',
-    path: '/:file_id/:app?',
+    path: '/edit/:file_id/:app?',
+    components: {
+      app: App
+    },
+    meta: {
+      title: $gettext('External app')
+    }
+  },
+  {
+    name: 'apps-public',
+    path: '/public/:file_id/:app?',
     components: {
       app: App
     },

--- a/packages/web-app-files/src/mixins/fileActions.js
+++ b/packages/web-app-files/src/mixins/fileActions.js
@@ -1,7 +1,7 @@
 import get from 'lodash-es/get'
 import { mapGetters, mapActions, mapState } from 'vuex'
 
-import { isAuthenticatedRoute, isLocationActive } from '../router'
+import { isAuthenticatedRoute, isLocationActive, isLocationPublicActive } from '../router' 
 import AcceptShare from './actions/acceptShare'
 import Copy from './actions/copy'
 import DeclineShare from './actions/declineShare'
@@ -243,8 +243,9 @@ export default {
     },
 
     $_fileActions_openLink(appName, resourceId) {
+      const isPublic = isLocationPublicActive(this.$router, 'files-public-files')
       const routeData = this.$router.resolve({
-        name: 'external-apps',
+        name: 'external-apps' + (isPublic ? '-public' : ''),
         params: {
           file_id: resourceId,
           app: appName


### PR DESCRIPTION
Quick fix to ensure that we redirect users to the idp when trying to open files with external apps that are not from public links.

Fixes #6069
Potentially fixes #6045