### PR TITLE
[tests-only] do not run acceptance tests if only smoke tests changed

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1119,7 +1119,7 @@ def smokeTests(ctx):
     services = databaseService(db) + owncloudService() + webService()
 
     stepsClassic = \
-        skipIfUnchanged(ctx, "unit-tests") + \
+        skipIfUnchanged(ctx, "smoke-tests") + \
         restoreBuildArtifactCache(ctx, "yarn", ".yarn") + \
         restoreBuildArtifactCache(ctx, "playwright", ".playwright") + \
         installYarn() + \
@@ -1135,7 +1135,7 @@ def smokeTests(ctx):
         smoke_test_occ
 
     stepsInfinite = \
-        skipIfUnchanged(ctx, "unit-tests") + \
+        skipIfUnchanged(ctx, "smoke-tests") + \
         restoreBuildArtifactCache(ctx, "yarn", ".yarn") + \
         restoreBuildArtifactCache(ctx, "playwright", ".playwright") + \
         restoreBuildArtifactCache(ctx, "web-dist", "dist") + \
@@ -2959,10 +2959,25 @@ def skipIfUnchanged(ctx, type):
             "^__mocks__/.*",
             "^packages/.*/tests/.*",
             "^tests/integration/.*",
+            "^tests/smoke/.*",
             "^tests/unit/.*",
         ]
         skip_step["settings"] = {
             "ALLOW_SKIP_CHANGED": base_skip_steps + acceptance_skip_steps,
+        }
+        return [skip_step]
+
+    if type == "smoke-tests":
+        smoke_skip_steps = [
+            "^__fixtures__/.*",
+            "^__mocks__/.*",
+            "^packages/.*/tests/.*",
+            "^tests/acceptance/.*",
+            "^tests/integration/.*",
+            "^tests/unit/.*",
+        ]
+        skip_step["settings"] = {
+            "ALLOW_SKIP_CHANGED": base_skip_steps + smoke_skip_steps,
         }
         return [skip_step]
 


### PR DESCRIPTION
## Description
If only smoke test code in `tests/smoke` has changed, then acceptance tests will not be run.

If only acceptance test code in `tests/acceptance` has changed, then smoke tests will not be run.

## Related Issue
- Fixes #6150 

## How Has This Been Tested?
See demo in #6154 and #6155


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
