### PR TITLE
[tests-only] Touch some files in the smoke tests to demonstrate 6153

### DIFF
--- a/tests/smoke/features/kindergarten.feature
+++ b/tests/smoke/features/kindergarten.feature
@@ -3,6 +3,7 @@ Feature: Kindergarten can use web to organize a day
   As a kindergarten operator named Alice
   I want to manage all file related operations by using ownCloud WEB
   So that i'm sure all parents are informed and have the latest information in a easy and secure way
+  Touch some files in the smoke tests to demonstrate 6153
 
   Background:
     Given following users have been created
@@ -32,7 +33,7 @@ Feature: Kindergarten can use web to organize a day
       | lorem.txt         | groups/Teddy Bear Daycare/meal plan  |
       | lorem-big.txt     | groups/Teddy Bear Daycare/meal plan  |
     # Implementation of sharing with different roles is currently broken
-    # since we switched to bulk creating of shares with a single dropdown 
+    # since we switched to bulk creating of shares with a single dropdown
     Then "Alice" shares the following resources via the sidebar panel
       | resource                             | user  | role   |
       | groups/Pre-Schools Pirates/meal plan | Brian | editor |

--- a/tests/smoke/support/page/login/oc10.ts
+++ b/tests/smoke/support/page/login/oc10.ts
@@ -2,6 +2,7 @@ import { Actor, User } from '../../types'
 /* eslint-disable-next-line */
 import type {LoginAdapter} from './index'
 
+// Touch some files in the smoke tests to demonstrate 6153
 export class Oc10LoginAdapter implements LoginAdapter {
   private readonly actor: Actor
 


### PR DESCRIPTION
https://drone.owncloud.com/owncloud/web/21067/14/7
```
latest: Pulling from owncloudci/drone-skip-pipeline
Digest: sha256:57cd847707c8b89e3a4c3e2374ddd4e448167c72b8d410f9ffc2ef894e221f55
Status: Image is up to date for owncloudci/drone-skip-pipeline:latest
DRONE_COMMIT_BEFORE:  ea04af4f09017b8ad246ebe10af9f2908631cb98
DRONE_COMMIT_AFTER:  09e236c70185c8026fe1e1b2e9900ce98ea2b487
### changed files ###
 tests/smoke/features/kindergarten.feature | 3 ++-
 tests/smoke/support/page/login/oc10.ts | 1 +
### check if changed files are on allowed skip list ###
 - all changed files are allowed to be skipped
```

That's good - acceptance test pipelines were skipped because only smoke-test files were changed.

See #6153 