### PR TITLE
set visible month to requested month in expiry date-picker

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/expirationDatePicker.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/expirationDatePicker.js
@@ -169,6 +169,11 @@ module.exports = {
         return this.click('@publicLinkDeleteExpirationDateButton')
       }
       const dateToSet = new Date(Date.parse(value))
+      client.execute(
+        `document.querySelector('#oc-files-file-link-expire-date').__vue__.$refs.calendar.move(new Date(Date.parse('${value}')))`,
+        []
+      )
+
       if (shareType === 'collaborator' || shareType === 'link') {
         const disabled = await this.isExpiryDateDisabled(dateToSet)
         if (disabled) {


### PR DESCRIPTION
## Description
as described in https://github.com/owncloud/web/issues/6158 it is problematic to select a date if the month of date is not in focus, this is fixed by using (hacking) the vue dom api and request the datepicker to focus on given date. Lets see iof this works in future and is a final solution

## Related Issue
- Fixes #6158
- needed #6160

## Motivation and Context
...