### PR TITLE
[unit-tests] make use of mocked router rather using vue router

### DIFF
--- a/packages/web-app-files/tests/unit/views/Personal.spec.js
+++ b/packages/web-app-files/tests/unit/views/Personal.spec.js
@@ -1,5 +1,4 @@
 import Vuex from 'vuex'
-import VueRouter from 'vue-router'
 import GetTextPlugin from 'vue-gettext'
 import { mount } from '@vue/test-utils'
 import { localVue } from './views.setup'
@@ -12,7 +11,6 @@ localVue.use(GetTextPlugin, {
   translations: 'does-not-matter.json',
   silent: true
 })
-localVue.use(VueRouter)
 
 const configuration = {
   options: {
@@ -33,15 +31,6 @@ localVue.prototype.$client = {
     getUser: jest.fn(() => user)
   }
 }
-
-const router = new VueRouter({
-  routes: [
-    {
-      path: '/',
-      name: 'files-personal'
-    }
-  ]
-})
 
 jest.unmock('axios')
 
@@ -222,7 +211,10 @@ function createWrapper(selectedFiles = [resourceForestJpg]) {
       }
     }),
     localVue,
-    router,
+    mocks: {
+      $route: {},
+      $router: {}
+    },
     stubs: stubs
   })
 }

--- a/packages/web-app-files/tests/unit/views/Personal.spec.js
+++ b/packages/web-app-files/tests/unit/views/Personal.spec.js
@@ -1,8 +1,6 @@
-import Vuex from 'vuex'
 import GetTextPlugin from 'vue-gettext'
 import { mount } from '@vue/test-utils'
-import { localVue } from './views.setup'
-import { createStore } from 'vuex-extensions'
+import { getStore, localVue } from './views.setup'
 import Personal from '@files/src/views/Personal.vue'
 import MixinAccessibleBreadcrumb from '@files/src/mixins/accessibleBreadcrumb'
 import { accentuatesTableRowTest } from './views.shared'
@@ -12,11 +10,6 @@ localVue.use(GetTextPlugin, {
   silent: true
 })
 
-const configuration = {
-  options: {
-    disablePreviews: true
-  }
-}
 const user = {
   id: 1,
   quota: 1
@@ -157,58 +150,11 @@ function createWrapper(selectedFiles = [resourceForestJpg]) {
     })
   }
   return mount(component, {
-    store: createStore(Vuex.Store, {
-      state: {
-        app: { quickActions: {} }
-      },
-      getters: {
-        configuration: () => configuration,
-        homeFolder: () => '/',
-        user: () => user
-      },
-      mutations: {
-        SET_QUOTA: () => {}
-      },
-      actions: {
-        showMessage: () => {}
-      },
-      modules: {
-        Files: {
-          modules: {
-            sidebar: {
-              state: {
-                closed: false
-              },
-              namespaced: true
-            }
-          },
-          state: {
-            resource: null,
-            currentPage: 1
-          },
-          getters: {
-            inProgress: () => [null],
-            currentFolder: () => '/',
-            pages: () => 4,
-            selectedFiles: () => [...selectedFiles],
-            highlightedFile: () => resourceForestJpg
-          },
-          actions: {
-            loadIndicators: () => {}
-          },
-          mutations: {
-            SET_FILES_PAGE_LIMIT: () => {},
-            CLEAR_FILES_SEARCHED: () => {},
-            SET_CURRENT_FOLDER: () => {},
-            LOAD_FILES: () => {},
-            CLEAR_CURRENT_FILES_LIST: () => {},
-            REMOVE_FILE: () => {},
-            REMOVE_FILE_FROM_SEARCHED: () => {},
-            REMOVE_FILE_SELECTION: () => {}
-          },
-          namespaced: true
-        }
-      }
+    store: getStore({
+      selectedFiles: [...selectedFiles],
+      highlightedFile: resourceForestJpg,
+      pages: 4,
+      inProgress: [null]
     }),
     localVue,
     mocks: {

--- a/packages/web-app-files/tests/unit/views/PublicFiles.spec.ts
+++ b/packages/web-app-files/tests/unit/views/PublicFiles.spec.ts
@@ -2,17 +2,6 @@ import { accentuatesTableRowTest } from './views.shared'
 import PublicFiles from '@files/src/views/PublicFiles.vue'
 import { localVue } from './views.setup'
 
-/**
- * FixMe:
- * localVue is shared, no isolated testing is happening.
- * if VueRouter is applied multipleTimes it fails (as expected).
- * as temporary workaround apply it here too.
- *
- * create a localVue factory to guarantee isolation
- */
-import VueRouter from 'vue-router'
-localVue.use(VueRouter)
-
 describe('PublicFiles view', () => {
   describe('accentuate new files and folders', () => {
     // eslint-disable-next-line jest/expect-expect

--- a/packages/web-app-files/tests/unit/views/views.setup.js
+++ b/packages/web-app-files/tests/unit/views/views.setup.js
@@ -58,7 +58,8 @@ export const getStore = function ({
   loginLogo = '',
   davProperties = [],
   publicLinkPassword = null,
-  slogan = null
+  slogan = null,
+  user = null
 } = {}) {
   return createStore(Vuex.Store, {
     state: {
@@ -83,20 +84,28 @@ export const getStore = function ({
       }),
       getToken: () => '',
       isOcis: () => true,
-      homeFolder: () => '/'
+      homeFolder: () => '/',
+      user: () => user
+    },
+    mutations: {
+      SET_QUOTA: () => {}
+    },
+    actions: {
+      showMessage: () => {}
     },
     modules: {
       Files: {
         state: {
           resource: null,
           filesPageLimit: 100,
-          files: []
+          files: [],
+          activeFiles: activeFiles
         },
         getters: {
           totalFilesCount: () => totalFilesCount,
           totalFilesSize: () => totalFilesSize,
           selectedFiles: () => selectedFiles,
-          activeFiles: () => activeFiles,
+          activeFiles: (state) => state.activeFiles,
           inProgress: () => inProgress,
           highlightedFile: () => highlightedFile,
           currentFolder: () => currentFolder,
@@ -108,9 +117,20 @@ export const getStore = function ({
           UPDATE_RESOURCE: (state, resource) => {
             state.resource = resource
           },
+          UPSERT_RESOURCE: (state, resource) => {
+            state.activeFiles.push(resource)
+          },
           CLEAR_FILES_SEARCHED: () => {},
           CLEAR_CURRENT_FILES_LIST: () => {},
-          LOAD_FILES: () => {}
+          LOAD_FILES: () => {},
+          SET_FILES_PAGE_LIMIT: () => {},
+          SET_CURRENT_FOLDER: () => {},
+          REMOVE_FILE: () => {},
+          REMOVE_FILE_FROM_SEARCHED: () => {},
+          REMOVE_FILE_SELECTION: () => {}
+        },
+        actions: {
+          loadIndicators: () => {}
         },
         namespaced: true,
         modules: {

--- a/packages/web-app-files/tests/unit/views/views.shared.ts
+++ b/packages/web-app-files/tests/unit/views/views.shared.ts
@@ -4,14 +4,28 @@ import VueRouter from 'vue-router'
 import { mount, VueClass } from '@vue/test-utils'
 import { localVue } from './views.setup'
 
-const router = new VueRouter({
-  routes: [
-    {
-      path: '/',
-      name: 'files-personal'
-    }
-  ]
-})
+const $route = {
+  name: 'files-personal',
+  params: { page: 1 }
+}
+
+const $router = {
+  afterEach: jest.fn(),
+  currentRoute: {
+    query: {}
+  }
+}
+
+const stubs = {
+  'list-loader': true,
+  'not-found-message': true,
+  'no-content-message': true,
+  'quick-actions': true,
+  'oc-resource': true,
+  'context-actions': true,
+  pagination: true,
+  'list-info': true
+}
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {}
@@ -70,18 +84,13 @@ export const accentuatesTableRowTest = async <V extends Vue>(
     {
       attachTo: document.body,
       localVue,
-      router,
       store,
-      stubs: {
-        'list-loader': true,
-        'not-found-message': true,
-        'no-content-message': true,
-        'quick-actions': true,
-        'oc-resource': true,
-        'context-actions': true,
-        pagination: true,
-        'list-info': true
+      mocks: {
+        $route,
+        $router
       },
+
+      stubs: stubs,
       computed: {
         displayThumbnails: () => false,
         folderNotFound: () => false,

--- a/packages/web-app-files/tests/unit/views/views.shared.ts
+++ b/packages/web-app-files/tests/unit/views/views.shared.ts
@@ -1,8 +1,6 @@
-import Vuex from 'vuex'
 import Vue from 'vue'
-import VueRouter from 'vue-router'
 import { mount, VueClass } from '@vue/test-utils'
-import { localVue } from './views.setup'
+import { localVue, getStore } from './views.setup'
 
 const $route = {
   name: 'files-personal',
@@ -27,6 +25,16 @@ const stubs = {
   'list-info': true
 }
 
+const forestJpg = {
+  id: 'forest',
+  name: 'forest.jpg',
+  path: 'images/nature/forest.jpg',
+  thumbnail: 'https://cdn.pixabay.com/photo/2015/09/09/16/05/forest-931706_960_720.jpg',
+  type: 'file',
+  size: '111000234',
+  mdate: 'Thu, 01 Jul 2021 08:34:04 GMT'
+}
+
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {}
 
@@ -36,41 +44,13 @@ export const accentuatesTableRowTest = async <V extends Vue>(
 ): Promise<void> => {
   jest.useFakeTimers()
 
-  const store = new Vuex.Store({
-    modules: {
-      Files: {
-        modules: {
-          sidebar: {
-            state: {
-              closed: false
-            },
-            namespaced: true
-          }
-        },
-        state: {
-          activeFiles: [
-            {
-              id: 'forest',
-              name: 'forest.jpg',
-              path: 'images/nature/forest.jpg',
-              thumbnail: 'https://cdn.pixabay.com/photo/2015/09/09/16/05/forest-931706_960_720.jpg',
-              type: 'file',
-              size: '111000234',
-              mdate: 'Thu, 01 Jul 2021 08:34:04 GMT'
-            }
-          ]
-        },
-        mutations: {
-          UPSERT_RESOURCE: (state, resource) => {
-            state.activeFiles.push(resource)
-          }
-        },
-        getters: {
-          inProgress: () => 0,
-          activeFiles: (state) => state.activeFiles
-        },
-        namespaced: true
-      }
+  const store = getStore({
+    inProgress: 0,
+    activeFiles: [forestJpg],
+    totalFilesSize: 0,
+    totalFilesCount: {
+      files: 1,
+      folders: 0
     }
   })
   const wrapper = mount(
@@ -89,21 +69,11 @@ export const accentuatesTableRowTest = async <V extends Vue>(
         $route,
         $router
       },
-
       stubs: stubs,
       computed: {
         displayThumbnails: () => false,
         folderNotFound: () => false,
-        isEmpty: () => false,
-        selected: () => [],
-        totalFilesSize: () => 0,
-        app: () => ({
-          quickActions: {}
-        }),
-        totalFilesCount: () => ({
-          files: 1,
-          folders: 0
-        })
+        isEmpty: () => false
       },
       mixins: [
         {


### PR DESCRIPTION
## Description
Some unit tests for `views` were using `VueRouter` for mounting.
- VueRouter is complex to integrate
- Uses external library for the tests

With this PR,
- `VueRouter` usages are replaced with the mocked `route` and `router`
- Also, `getStore` method from `view.setup.js` is used to get the store

## Related Issue
- #5237 

## Motivation and Context


## How Has This Been Tested?
- :robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
