### PR TITLE
[tests-only][full-ci] Remove unused step definitions from generalContext

### DIFF
--- a/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
@@ -234,7 +234,7 @@ Feature: deleting files and folders
 
   @issue-5435
   Scenario: Delete a file and folder from shared with me page
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And user "Brian" has been created with default attributes and without skeleton files in the server
     And user "Brian" has created folder "simple-folder" in the server
     And user "Brian" has created file "lorem.txt" in the server

--- a/tests/acceptance/features/webUIFiles/batchAction.feature
+++ b/tests/acceptance/features/webUIFiles/batchAction.feature
@@ -60,7 +60,7 @@ Feature: Visibility of the batch actions menu
 
 
   Scenario: View batch action menu for a folder on the shared with me page (Pending Share)
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And user "Alice" has shared folder "simple-folder" with user "Brian" in the server
     And user "Brian" has logged in using the webUI
@@ -73,7 +73,7 @@ Feature: Visibility of the batch actions menu
 
 
   Scenario: View batch action menu for a folder on the shared with me page (Accepted Share)
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And user "Alice" has shared folder "simple-folder" with user "Brian" in the server
     And user "Brian" has accepted the share "Shares/simple-folder" offered by user "Alice" in the server

--- a/tests/acceptance/features/webUIFilesActionMenu/versions.feature
+++ b/tests/acceptance/features/webUIFilesActionMenu/versions.feature
@@ -39,7 +39,7 @@ Feature: Versions of a file
     And user "user0" has uploaded file with content "lorem" to "lorem-file.txt" in the server
     And user "user0" has uploaded file with content "new lorem content" to "lorem-file.txt" in the server
     And user "user0" has logged in using the webUI
-    And the administrator has cleared the versions for user "user0"
+    And the administrator has cleared the versions for user "user0" in the server
     When the user browses to display the "versions" details of file "lorem-file.txt"
     Then the versions list should contain 0 entries
 
@@ -51,7 +51,7 @@ Feature: Versions of a file
     And user "Alice" has uploaded file with content "lorem content" to "lorem-file.txt" in the server
     And user "Alice" has uploaded file with content "lorem" to "lorem-file.txt" in the server
     And user "user0" has logged in using the webUI
-    And the administrator has cleared the versions for user "user0"
+    And the administrator has cleared the versions for user "user0" in the server
     When the user browses to display the "versions" details of file "lorem-file.txt"
     Then the versions list should contain 0 entries
     When the user re-logs in as "Alice" using the webUI
@@ -66,7 +66,7 @@ Feature: Versions of a file
     And user "Alice" has uploaded file with content "lorem content" to "/lorem-file.txt" in the server
     And user "Alice" has uploaded file with content "lorem" to "/lorem-file.txt" in the server
     And user "user0" has logged in using the webUI
-    And the administrator has cleared the versions for all users
+    And the administrator has cleared the versions for all users in the server
     When the user browses to display the "versions" details of file "lorem-file.txt"
     Then the versions list should contain 0 entries
     When the user re-logs in as "Alice" using the webUI
@@ -75,7 +75,7 @@ Feature: Versions of a file
 
   @issue-ocis-2319
   Scenario: change the file content of a received shared file
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And user "Brian" has been created with default attributes and without skeleton files in the server
     And user "Brian" has created folder "simple-folder" in the server
@@ -91,7 +91,7 @@ Feature: Versions of a file
 
   @issue-ocis-1328 @disablePreviews
   Scenario: sharee can see the versions of a file
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes" in the server
     And user "user0" has uploaded file with content "lorem content" to "lorem-file.txt" in the server
     And user "user0" has uploaded file with content "lorem" to "lorem-file.txt" in the server
     And user "user0" has uploaded file with content "new lorem content" to "lorem-file.txt" in the server

--- a/tests/acceptance/features/webUIFilesCopy/copy.feature
+++ b/tests/acceptance/features/webUIFilesCopy/copy.feature
@@ -4,7 +4,7 @@ Feature: copy files and folders
   So that I can work safely on a copy without changing the original
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And user "Alice" has been created with default attributes and without skeleton files in the server
 

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -137,7 +137,7 @@ Feature: move files
 
   @issue-ocis-873
   Scenario: sharee moves a file shared by sharer into another folder
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And user "Brian" has been created with default attributes and without skeleton files in the server
     And user "Alice" has uploaded file with content "test content" to "simple-folder/testFile.txt" in the server

--- a/tests/acceptance/features/webUIOperationsWithFolderShares/accessToSharesFolder.feature
+++ b/tests/acceptance/features/webUIOperationsWithFolderShares/accessToSharesFolder.feature
@@ -5,7 +5,7 @@ Feature: Upload into a folder Shares
   The folder "Shares" in ownCloud10 is a folder in which you can download or save files
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And user "Alice" has been created with default attributes and without skeleton files in the server
     And user "Brian" has been created with default attributes and without skeleton files in the server

--- a/tests/acceptance/features/webUIResharing1/reshareUsers.feature
+++ b/tests/acceptance/features/webUIResharing1/reshareUsers.feature
@@ -5,7 +5,7 @@ Feature: Resharing shared files with different permissions
   So that I can control the access on those files/folders by other collaborators
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And these users have been created with default attributes and without skeleton files in the server:
       | username |

--- a/tests/acceptance/features/webUIResharing2/reshareUsers.feature
+++ b/tests/acceptance/features/webUIResharing2/reshareUsers.feature
@@ -5,7 +5,7 @@ Feature: Resharing shared files with different permissions
   So that I can control the access on those files/folders by other collaborators
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And these users have been created with default attributes and without skeleton files in the server:
       | username |

--- a/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
@@ -5,7 +5,7 @@ Feature: disable sharing
   So that users cannot share files
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And user "Alice" has been created with default attributes and without skeleton files in the server
     And user "Alice" has created folder "simple-folder" in the server
@@ -14,13 +14,13 @@ Feature: disable sharing
 
   @smokeTest
   Scenario: Users tries to share via WebUI when Sharing is disabled
-    Given the setting "shareapi_enabled" of app "core" has been set to "no"
+    Given the setting "shareapi_enabled" of app "core" has been set to "no" in the server
     When user "Alice" logs in using the webUI
     Then it should not be possible to share folder "simple-folder" using the webUI
 
 
   Scenario: Users tries to share from favorites page when sharing is disabled
-    Given the setting "shareapi_enabled" of app "core" has been set to "no"
+    Given the setting "shareapi_enabled" of app "core" has been set to "no" in the server
     And user "Alice" has favorited element "lorem.txt" in the server
     And user "Alice" has favorited element "simple-folder" in the server
     And user "Alice" has logged in using the webUI
@@ -35,7 +35,7 @@ Feature: disable sharing
     And user "Brian" has accepted the share "Shares/lorem.txt" offered by user "Alice" in the server
     And user "Alice" has shared folder "simple-folder" with user "Brian" in the server
     And user "Brian" has accepted the share "Shares/simple-folder" offered by user "Alice" in the server
-    And the setting "shareapi_enabled" of app "core" has been set to "no"
+    And the setting "shareapi_enabled" of app "core" has been set to "no" in the server
     When user "Brian" logs in using the webUI
     And the user opens folder "Shares" using the webUI
     Then file "lorem.txt" should be listed on the webUI
@@ -50,7 +50,7 @@ Feature: disable sharing
     Given user "Brian" has been created with default attributes and without skeleton files in the server
     And user "Alice" has shared file "lorem.txt" with user "Brian" in the server
     And user "Alice" has shared folder "simple-folder" with user "Brian" in the server
-    And the setting "shareapi_enabled" of app "core" has been set to "no"
+    And the setting "shareapi_enabled" of app "core" has been set to "no" in the server
     When user "Alice" logs in using the webUI
     #    Then the link for "shared-with-others" page should not be available in files page menu
     And the user browses to the shared-with-others page

--- a/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
@@ -6,7 +6,7 @@ Feature: restrict resharing
   I want to be able to forbid a user that received a share from me to share it further
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And these users have been created with default attributes and without skeleton files in the server:
       | username |
@@ -21,7 +21,7 @@ Feature: restrict resharing
 
   @smokeTest @issue-2447
   Scenario: disable resharing and check if the received resource can be reshared
-    Given the setting "shareapi_allow_resharing" of app "core" has been set to "no"
+    Given the setting "shareapi_allow_resharing" of app "core" has been set to "no" in the server
     And user "Brian" has created folder "simple-folder" in the server
     And user "Brian" has uploaded file "lorem.txt" to "simple-folder/lorem.txt" in the server
     And user "Brian" has shared folder "simple-folder" with user "Alice" in the server
@@ -40,8 +40,8 @@ Feature: restrict resharing
 
   @smokeTest
   Scenario: disable resharing and check if the received resource from group share can be reshared
-    Given the setting "shareapi_allow_resharing" of app "core" has been set to "no"
-    And user "Carol" has uploaded file "lorem.txt" to "lorem.txt" in the server 
+    Given the setting "shareapi_allow_resharing" of app "core" has been set to "no" in the server
+    And user "Carol" has uploaded file "lorem.txt" to "lorem.txt" in the server
     And user "Carol" has shared file "lorem.txt" with group "grp1" in the server
     And user "Alice" has accepted the share "Shares/lorem.txt" offered by user "Carol" in the server
     And user "Brian" has accepted the share "Shares/lorem.txt" offered by user "Carol" in the server

--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -5,7 +5,7 @@ Feature: restrict Sharing
   So that users can only share files with specific users and groups
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And these users have been created with default attributes and without skeleton files in the server:
       | username |
@@ -29,7 +29,7 @@ Feature: restrict Sharing
 
   @smokeTest
   Scenario: Restrict users to only share with users in their groups
-    Given the setting "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
+    Given the setting "shareapi_only_share_with_group_members" of app "core" has been set to "yes" in the server
     When the user opens the share dialog for folder "simple-folder" using the webUI
 
     And the user types "Ali" in the share-with-field
@@ -38,7 +38,7 @@ Feature: restrict Sharing
 
   @smokeTest
   Scenario: Restrict users to only share with groups they are member of
-    Given the setting "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
+    Given the setting "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes" in the server
     When the user opens the share dialog for folder "simple-folder" using the webUI
 
     And the user types "grp" in the share-with-field
@@ -47,14 +47,14 @@ Feature: restrict Sharing
 
 
   Scenario: Do not restrict users to only share with groups they are member of
-    Given the setting "shareapi_only_share_with_membership_groups" of app "core" has been set to "no"
+    Given the setting "shareapi_only_share_with_membership_groups" of app "core" has been set to "no" in the server
     When the user shares folder "simple-folder" with group "grp2" as "Viewer" using the webUI
     And user "Carol" accepts the share "Shares/simple-folder" offered by user "Brian" using the sharing API in the server
     Then as "Carol" folder "/Shares/simple-folder" should exist in the server
 
   @smokeTest
   Scenario: Forbid sharing with groups
-    Given the setting "shareapi_allow_group_sharing" of app "core" has been set to "no"
+    Given the setting "shareapi_allow_group_sharing" of app "core" has been set to "no" in the server
     When the user opens the share dialog for folder "simple-folder" using the webUI
 
     And the user types "grp" in the share-with-field

--- a/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
@@ -4,7 +4,7 @@ Feature: accept/decline shares coming from internal users
   So that I can keep my file system clean
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And these users have been created with default attributes and without skeleton files in the server:
       | username |

--- a/tests/acceptance/features/webUISharingAcceptSharesToRoot/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingAcceptSharesToRoot/acceptShares.feature
@@ -12,7 +12,7 @@ Feature: accept/decline shares coming from internal users
     And user "Brian" has logged in using the webUI
 
   Scenario: reject a share that you received as user and as group member
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And user "Alice" has created folder "/simple-folder" in the server
     And these groups have been created in the server:
       | groupname |
@@ -29,7 +29,7 @@ Feature: accept/decline shares coming from internal users
 
   @issue-2512
   Scenario: reshare a share that you received to a group that you are member of
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And user "Alice" has created folder "/simple-folder" in the server
     And user "Brian" has created folder "/simple-folder" in the server
     And these groups have been created in the server:
@@ -48,7 +48,7 @@ Feature: accept/decline shares coming from internal users
 
   @smokeTest
   Scenario: unshare an accepted share on the "All files" page
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And user "Alice" has created folder "/simple-folder" in the server
     And user "Alice" has uploaded file "testavatar.jpg" to "/testimage.jpg" in the server
     And these groups have been created in the server:
@@ -70,7 +70,7 @@ Feature: accept/decline shares coming from internal users
 
   @smokeTest
   Scenario: Auto-accept shares
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes" in the server
     And user "Alice" has created folder "/simple-folder" in the server
     And user "Alice" has uploaded file "testavatar.jpg" to "/testimage.jpg" in the server
     And these groups have been created in the server:
@@ -87,7 +87,7 @@ Feature: accept/decline shares coming from internal users
     And file "testimage.jpg" shared by "Alice Hansen" should be in "Accepted" state on the webUI
 
   Scenario: decline auto-accepted shares
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes" in the server
     And user "Alice" has created folder "/simple-folder" in the server
     And user "Alice" has uploaded file "testavatar.jpg" to "/testimage.jpg" in the server
     And these groups have been created in the server:
@@ -106,7 +106,7 @@ Feature: accept/decline shares coming from internal users
     And file "testimage.jpg" shared by "Alice Hansen" should be in "Declined" state on the webUI
 
   Scenario: unshare auto-accepted shares
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes" in the server
     And user "Alice" has created folder "/simple-folder" in the server
     And user "Alice" has uploaded file "testavatar.jpg" to "/testimage.jpg" in the server
     And these groups have been created in the server:
@@ -126,7 +126,7 @@ Feature: accept/decline shares coming from internal users
     And file "testimage.jpg" shared by "Alice Hansen" should be in "Declined" state on the webUI
 
   Scenario: unshare renamed shares
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes" in the server
     And user "Alice" has created folder "/simple-folder" in the server
     And user "Alice" has shared folder "simple-folder" with user "Brian" with "create, read, share, update" permissions in the server
     And user "Brian" has renamed folder "simple-folder" to "simple-folder-renamed" in the server
@@ -137,7 +137,7 @@ Feature: accept/decline shares coming from internal users
     Then folder "simple-folder-renamed" shared by "Alice Hansen" should be in "Declined" state on the webUI
 
   Scenario: unshare moved shares
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes" in the server
     And user "Alice" has created folder "/simple-folder" in the server
     And user "Brian" has created folder "/simple-folder" in the server
     And user "Brian" has created folder "/simple-folder/shared" in the server
@@ -151,7 +151,7 @@ Feature: accept/decline shares coming from internal users
     Then folder "shared" shared by "Alice Hansen" should be in "Declined" state on the webUI
 
   Scenario: unshare renamed shares, accept it again
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes" in the server
     And user "Alice" has created folder "/simple-folder" in the server
     And user "Alice" has shared folder "/simple-folder" with user "Brian" in the server
     And user "Brian" has renamed folder "/simple-folder" to "/simple-folder-renamed" in the server
@@ -165,7 +165,7 @@ Feature: accept/decline shares coming from internal users
     Then folder "simple-folder-renamed" should be listed on the webUI
 
   Scenario: User receives files when auto accept share is disabled
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And user "Alice" has created file "lorem.txt" in the server
     And user "Alice" has shared file "lorem.txt" with user "Brian" in the server
     When the user browses to the shared-with-me page
@@ -174,7 +174,7 @@ Feature: accept/decline shares coming from internal users
     Then file "lorem.txt" should not be listed on the webUI
 
   Scenario: shared file is in pending state when the Automatically accept incoming shares is disabled
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And user "Alice" has created file "lorem.txt" in the server
     And user "Alice" has shared file "lorem.txt" with user "Brian" in the server
     When the user browses to the shared-with-me page
@@ -184,7 +184,7 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: receive shares with same name from different users
     Given user "Carol" has been created with default attributes and without skeleton files in the server
-    And the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And user "Alice" has created file "lorem.txt" in the server
     And user "Carol" has created file "lorem.txt" in the server
     And user "Carol" has shared file "lorem.txt" with user "Brian" in the server
@@ -194,7 +194,7 @@ Feature: accept/decline shares coming from internal users
     And file "lorem.txt" shared by "Carol King" should be in "Pending" state on the webUI
 
   Scenario: decline an offered (pending) share
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And user "Alice" has created file "lorem.txt" in the server
     And user "Alice" has created file "testimage.jpg" in the server
     And user "Alice" has shared file "lorem.txt" with user "Brian" in the server
@@ -209,7 +209,7 @@ Feature: accept/decline shares coming from internal users
     And file "testimage.jpg" should not be listed on the webUI
 
   Scenario: accept an offered (pending) share
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And user "Alice" has created file "lorem.txt" in the server
     And user "Alice" has created file "testimage.jpg" in the server
     And user "Alice" has shared file "lorem.txt" with user "Brian" in the server
@@ -223,7 +223,7 @@ Feature: accept/decline shares coming from internal users
     And file "testimage.jpg" should not be listed on the webUI
 
   Scenario: accept a previously declined share
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And user "Alice" has created file "lorem.txt" in the server
     And user "Alice" has created file "testimage.jpg" in the server
     And user "Alice" has shared file "lorem.txt" with user "Brian" in the server
@@ -239,7 +239,7 @@ Feature: accept/decline shares coming from internal users
     And file "testimage.jpg" should not be listed on the webUI
 
   Scenario: delete an accepted share
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And user "Alice" has created file "lorem.txt" in the server
     And user "Alice" has created file "testimage.jpg" in the server
     And user "Alice" has shared file "lorem.txt" with user "Brian" in the server
@@ -256,7 +256,7 @@ Feature: accept/decline shares coming from internal users
 
   @issue-3101
   Scenario: Decline multiple accepted shares at once from shared with me page
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And user "Alice" has been created with default attributes and without skeleton files in the server
     And user "Alice" has created file "lorem.txt" in the server
     And user "Alice" has created file "data.zip" in the server
@@ -300,7 +300,7 @@ Feature: accept/decline shares coming from internal users
     Then file "lorem.txt" should be listed on the webUI
 
   Scenario: receive shares with same name from different users, accept one by one
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And user "Carol" has been created with default attributes and without skeleton files in the server
     And user "Carol" has created folder "/simple-folder" in the server
     And user "Carol" has created folder "/simple-folder/from_Carol" in the server
@@ -317,7 +317,7 @@ Feature: accept/decline shares coming from internal users
     And as "Brian" folder "from_Carol" should exist inside folder "/simple-folder (2)" in the server
 
   Scenario: accept a share that you received as user and as group member
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And  user "Alice" has created folder "/simple-folder" in the server
     And these groups have been created in the server:
       | groupname |

--- a/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature
@@ -4,7 +4,7 @@ Feature: Autocompletion of share-with names
   So that I can efficiently share my files with other users or groups
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     # Users that are in the special known users already
     And these users have been created with default attributes and without skeleton files in the server but not initialized:

--- a/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletionSpecialChars.feature
+++ b/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletionSpecialChars.feature
@@ -4,7 +4,7 @@ Feature: Autocompletion of share-with names
   So that I can efficiently share my files with other users or groups
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And these users have been created with default attributes and without skeleton files in the server but not initialized:
       | username    |
@@ -17,7 +17,7 @@ Feature: Autocompletion of share-with names
       | groupname |
       | finance1  |
       | finance2  |
-    And the setting "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "no"
+    And the setting "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "no" in the server
 
   @issue-ocis-1417
   Scenario Outline: autocompletion of user having special characters in their usernames

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -7,7 +7,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
   Background:
     Given app "notifications" has been "enabled" in the server
     And the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "no" on remote server
-    And the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
+    And the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "no" in the server
     And the setting "shareapi_auto_accept_share" of app "core" has been set to "no" on remote server
     And the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" on remote server

--- a/tests/acceptance/features/webUISharingExternalToRoot/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternalToRoot/federationSharing.feature
@@ -71,7 +71,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-2510
   Scenario: automatically accept a federation share when it is allowed by the config
-    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes" in the server
     And user "Alice" has created folder "simple-folder" on remote server
     And user "Alice" has created file "simple-folder/lorem.txt" on remote server
     And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server in the server
@@ -109,7 +109,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-3309
   Scenario: overwrite a file in a received share - remote server shares - local server receives
-    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes" in the server
     And user "Alice" has created folder "simple-folder" on remote server
     And user "Alice" has created file "simple-folder/lorem.txt" on remote server
     And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server in the server
@@ -120,7 +120,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-3309
   Scenario: upload a new file in a received share - remote server shares - local server receives
-    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes" in the server
     And user "Alice" has created folder "simple-folder" on remote server
     And user "Alice" has created file "simple-folder/lorem.txt" on remote server
     And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server in the server
@@ -131,7 +131,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-3309
   Scenario: rename a file in a received share - remote server shares - local server receives
-    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes" in the server
     And user "Alice" has created folder "simple-folder" on remote server
     And user "Alice" has created file "simple-folder/lorem.txt" on remote server
     And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server in the server
@@ -143,7 +143,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @issue-3309
   Scenario: delete a file in a received share - remote server shares - local server receives
-    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes" in the server
     And user "Alice" has created folder "simple-folder" on remote server
     And user "Alice" has created file "simple-folder/lorem.txt" on remote server
     And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server in the server
@@ -154,7 +154,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
 
   Scenario: unshare a federation share
-    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes" in the server
     And user "Alice" has created file "lorem.txt" on remote server
     And user "Alice" from remote server has shared "lorem.txt" with user "Alice" from local server in the server
     When the user reloads the current page of the webUI
@@ -178,7 +178,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
 
   Scenario: test resharing folder with "Viewer" role
-    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes" in the server
     And user "Brian" has been created with default attributes and without skeleton files in the server
     And user "Alice" has created folder "simple-folder" on remote server
     And user "Alice" has created file "simple-folder/lorem.txt" on remote server
@@ -195,7 +195,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
 
   Scenario: test resharing a federated server to remote again
-    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes" in the server
     And user "Brian" has been created with default attributes and without skeleton files on remote server
     And user "Alice" has created folder "simple-folder" on remote server
     And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server with "read, share" permissions in the server
@@ -211,7 +211,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
 
   Scenario: try resharing a folder with read-only permissions
-    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes" in the server
     And user "Alice" has created folder "simple-folder" on remote server
     And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server with "read" permissions in the server
     When the user reloads the current page of the webUI
@@ -226,7 +226,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
 
   Scenario: sharee should be able to access the files/folders inside other folder
-    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes" in the server
     And user "Alice" has created folder "'single'quotes" on remote server
     And user "Alice" has created folder "'single'quotes/simple-empty-folder" on remote server
     And user "Alice" has uploaded file "lorem.txt" to "'single'quotes/lorem.txt" on remote server
@@ -249,7 +249,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
 
   Scenario: uploading a file inside a folder of a folder
-    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes" in the server
     And user "Alice" has created folder "simple-folder" on remote server
     And user "Alice" has created folder "simple-folder/simple-empty-folder" on remote server
     And user "Alice" from remote server has shared "simple-folder" with user "Alice" from local server in the server
@@ -261,7 +261,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
 
   Scenario: rename a file in a folder inside a shared folder
-    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes" in the server
     And user "Alice" has created folder "'single'quotes" on remote server
     And user "Alice" has created folder "'single'quotes/simple-empty-folder" on remote server
     And user "Alice" has created file "'single'quotes/simple-empty-folder/for-git-commit" on remote server
@@ -277,7 +277,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
 
   Scenario: delete a file in a folder inside a shared folder
-    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    Given the setting "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes" in the server
     And user "Alice" has created folder "'single'quotes" on remote server
     And user "Alice" has created folder "'single'quotes/simple-empty-folder" on remote server
     And user "Alice" has created file "'single'quotes/simple-empty-folder/for-git-commit" on remote server

--- a/tests/acceptance/features/webUISharingFilePermissionMultipleUsers/shareFileWithMultipleUsers.feature
+++ b/tests/acceptance/features/webUISharingFilePermissionMultipleUsers/shareFileWithMultipleUsers.feature
@@ -4,7 +4,7 @@ Feature: Sharing files with multiple internal users with different permissions
   So that I can control the access on those files by other collaborators
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And these users have been created with default attributes and without skeleton files in the server:
       | username |

--- a/tests/acceptance/features/webUISharingFilePermissionsGroups/sharePermissionsGroup.feature
+++ b/tests/acceptance/features/webUISharingFilePermissionsGroups/sharePermissionsGroup.feature
@@ -5,7 +5,7 @@ Feature: Sharing files with internal groups with permissions
   So that I can control the access on those files by other users on the group
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And these users have been created with default attributes and without skeleton files in the server:
       | username |

--- a/tests/acceptance/features/webUISharingFolderAdvancedPermissionMultipleUsers/sharedFolderWithMultipleUsersAdvancedPermissions.feature
+++ b/tests/acceptance/features/webUISharingFolderAdvancedPermissionMultipleUsers/sharedFolderWithMultipleUsersAdvancedPermissions.feature
@@ -4,7 +4,7 @@ Feature: Sharing folders with multiple internal users using advanced permissions
   So that I can control the access on those folders by other collaborators
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And these users have been created with default attributes and without skeleton files in the server:
       | username |

--- a/tests/acceptance/features/webUISharingFolderAdvancedPermissionsGroups/shareAdvancePermissionsGroup.feature
+++ b/tests/acceptance/features/webUISharingFolderAdvancedPermissionsGroups/shareAdvancePermissionsGroup.feature
@@ -5,7 +5,7 @@ Feature: Sharing folders with internal groups with role as advanced permissions
   So that I can control the access on those folders by other users on the group
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And these users have been created with default attributes and without skeleton files in the server:
       | username |

--- a/tests/acceptance/features/webUISharingFolderPermissionMultipleUsers/shareFolderWithMultipleUsers.feature
+++ b/tests/acceptance/features/webUISharingFolderPermissionMultipleUsers/shareFolderWithMultipleUsers.feature
@@ -5,7 +5,7 @@ Feature: Sharing folders with multiple internal users with different permissions
   So that I can control the access on those folders by other collaborators
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And these users have been created with default attributes and without skeleton files in the server:
       | username |

--- a/tests/acceptance/features/webUISharingFolderPermissionsGroups/sharePermissionsGroup.feature
+++ b/tests/acceptance/features/webUISharingFolderPermissionsGroups/sharePermissionsGroup.feature
@@ -5,7 +5,7 @@ Feature: Sharing folders with internal groups with different roles and permissio
   So that I can control the access on those folders by other users on the group
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And these users have been created with default attributes and without skeleton files in the server:
       | username |

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -4,7 +4,7 @@ Feature: Sharing files and folders with internal groups
   So that those groups can access the files and folders
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And these users have been created with default attributes and without skeleton files in the server:
       | username |
@@ -275,8 +275,8 @@ Feature: Sharing files and folders with internal groups
 
   @issue-ocis-1317 @issue-ocis-1250
   Scenario: share a resource with another internal group with default expiration date
-    Given the setting "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
-    And the setting "shareapi_expire_after_n_days_group_share" of app "core" has been set to "42"
+    Given the setting "shareapi_default_expire_date_group_share" of app "core" has been set to "yes" in the server
+    And the setting "shareapi_expire_after_n_days_group_share" of app "core" has been set to "42" in the server
     And user "Carol" has created file "lorem.txt" in the server
     And user "Carol" has logged in using the webUI
     When the user shares folder "lorem.txt" with group "grp1" as "Viewer" using the webUI
@@ -294,9 +294,9 @@ Feature: Sharing files and folders with internal groups
 
   @issue-ocis-1250
   Scenario Outline: share a resource with another internal group with expiration date beyond maximum enforced expiration date
-    Given the setting "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
-    And the setting "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
-    And the setting "shareapi_expire_after_n_days_group_share" of app "core" has been set to "5"
+    Given the setting "shareapi_default_expire_date_group_share" of app "core" has been set to "yes" in the server
+    And the setting "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes" in the server
+    And the setting "shareapi_expire_after_n_days_group_share" of app "core" has been set to "5" in the server
     And user "Carol" has created file "lorem.txt" in the server
     And user "Carol" has created folder "simple-folder" in the server
     And user "Carol" has logged in using the webUI

--- a/tests/acceptance/features/webUISharingInternalGroupsEdgeCases/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroupsEdgeCases/shareWithGroupsEdgeCases.feature
@@ -5,7 +5,7 @@ Feature: Sharing files and folders with internal groups
   So that those groups can access the files and folders
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And these users have been created with default attributes and without skeleton files in the server:
       | username |

--- a/tests/acceptance/features/webUISharingInternalGroupsSharingIndicator/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroupsSharingIndicator/shareWithGroups.feature
@@ -5,7 +5,7 @@ Feature: Sharing files and folders with internal groups
   So that those groups can access the files and folders
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And these users have been created with default attributes and without skeleton files in the server:
       | username |

--- a/tests/acceptance/features/webUISharingInternalGroupsToRoot/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroupsToRoot/shareWithGroups.feature
@@ -247,8 +247,8 @@ Feature: Sharing files and folders with internal groups
 
 
   Scenario: share a resource with another internal group with default expiration date
-    Given the setting "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
-    And the setting "shareapi_expire_after_n_days_group_share" of app "core" has been set to "42"
+    Given the setting "shareapi_default_expire_date_group_share" of app "core" has been set to "yes" in the server
+    And the setting "shareapi_expire_after_n_days_group_share" of app "core" has been set to "42" in the server
     And user "Carol" has created file "lorem.txt" in the server
     And user "Carol" has logged in using the webUI
     When the user shares file "lorem.txt" with group "grp1" as "Viewer" using the webUI
@@ -264,9 +264,9 @@ Feature: Sharing files and folders with internal groups
 
 
   Scenario Outline: share a resource with another internal group with expiration date beyond maximum enforced expiration date
-    Given the setting "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
-    And the setting "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
-    And the setting "shareapi_expire_after_n_days_group_share" of app "core" has been set to "5"
+    Given the setting "shareapi_default_expire_date_group_share" of app "core" has been set to "yes" in the server
+    And the setting "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes" in the server
+    And the setting "shareapi_expire_after_n_days_group_share" of app "core" has been set to "5" in the server
     And user "Carol" has created <element> "<shared-resource>" in the server
     And user "Carol" has logged in using the webUI
     When the user tries to share resource "<shared-resource>" with group "grp1" which expires in "+6" days using the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -4,7 +4,7 @@ Feature: Sharing files and folders with internal users
   So that those users can access the files and folders
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And these users have been created with default attributes and without skeleton files in the server:
       | username |

--- a/tests/acceptance/features/webUISharingInternalUsersBlacklisted/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersBlacklisted/shareWithUsers.feature
@@ -5,7 +5,7 @@ Feature: Sharing files and folders with internal users
   So that those users can access the files and folders
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And these users have been created with default attributes and without skeleton files in the server:
       | username |

--- a/tests/acceptance/features/webUISharingInternalUsersCollaborator/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersCollaborator/shareWithUsers.feature
@@ -4,7 +4,7 @@ Feature: Shares collaborator list
   So that I can know the collaborators of a shared resource
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And these users have been created with default attributes and without skeleton files in the server:
       | username |

--- a/tests/acceptance/features/webUISharingInternalUsersShareWithPage/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersShareWithPage/shareWithUsers.feature
@@ -4,7 +4,7 @@ Feature: Shares in share-with pages
   So that I can know what is shared with me and by me
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And these users have been created with default attributes and without skeleton files in the server:
       | username |
@@ -145,7 +145,7 @@ Feature: Shares in share-with pages
 
   @issue-ocis-1328
   Scenario Outline: collaborators list contains additional info when enabled
-    Given the setting "user_additional_info_field" of app "core" has been set to "<additional-info-field>"
+    Given the setting "user_additional_info_field" of app "core" has been set to "<additional-info-field>" in the server
     And user "Alice" has created folder "simple-folder" in the server
     And user "Alice" has shared folder "simple-folder" with user "Brian" in the server
     When user "Alice" has logged in using the webUI
@@ -158,7 +158,7 @@ Feature: Shares in share-with pages
 
   @issue-ocis-1328
   Scenario: collaborators list does not contain additional info when disabled
-    Given the setting "user_additional_info_field" of app "core" has been set to ""
+    Given the setting "user_additional_info_field" of app "core" has been set to "" in the server
     And user "Alice" has created folder "simple-folder" in the server
     And user "Alice" has shared folder "simple-folder" with user "Brian" in the server
     When user "Alice" has logged in using the webUI

--- a/tests/acceptance/features/webUISharingInternalUsersSharingIndicator/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersSharingIndicator/shareWithUsers.feature
@@ -5,7 +5,7 @@ Feature: Sharing files and folders with internal users
   So that those users can access the files and folders
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And these users have been created with default attributes and without skeleton files in the server:
       | username |

--- a/tests/acceptance/features/webUISharingInternalUsersToRoot/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersToRoot/shareWithUsers.feature
@@ -12,7 +12,7 @@ Feature: Sharing files and folders with internal users
 
   @smokeTest @disablePreviews
   Scenario Outline: share a file & folder with another internal user
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes" in the server
     And user "Brian" has created folder "simple-folder" in the server
     And user "Brian" has created file "simple-folder/lorem.txt" in the server
     And user "Brian" has uploaded file "testavatar.jpg" to "testimage.jpg" in the server
@@ -221,7 +221,7 @@ Feature: Sharing files and folders with internal users
 
   @disablePreviews
   Scenario Outline: Share files/folders with special characters in their name
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes" in the server
     And user "Brian" has created folder "Sample,Folder,With,Comma" in the server
     And user "Brian" has created file "sample,1.txt" in the server
     And user "Brian" has logged in using the webUI

--- a/tests/acceptance/features/webUISharingInternalUsersToRootBlacklisted/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersToRootBlacklisted/shareWithUsers.feature
@@ -12,7 +12,7 @@ Feature: Sharing files and folders with internal users
 
 
   Scenario: member of a blacklisted from sharing group tries to re-share a file or folder received as a share
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes" in the server
     And user "Carol" has been created with default attributes and without skeleton files in the server
     And user "Carol" has created folder "simple-folder" in the server
     And user "Carol" has uploaded file "testavatar.jpg" to "testimage.jpg" in the server

--- a/tests/acceptance/features/webUISharingInternalUsersToRootCollaborator/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersToRootCollaborator/shareWithUsers.feature
@@ -64,7 +64,7 @@ Feature: Shares collaborator list
 
 
   Scenario Outline: collaborators list contains additional info when enabled
-    Given the setting "user_additional_info_field" of app "core" has been set to "<additional-info-field>"
+    Given the setting "user_additional_info_field" of app "core" has been set to "<additional-info-field>" in the server
     And user "Alice" has shared folder "simple-folder" with user "Brian" in the server
     When user "Alice" has logged in using the webUI
     And the user opens the share dialog for folder "simple-folder" using the webUI
@@ -76,7 +76,7 @@ Feature: Shares collaborator list
 
 
   Scenario: collaborators list does not contain additional info when disabled
-    Given the setting "user_additional_info_field" of app "core" has been set to ""
+    Given the setting "user_additional_info_field" of app "core" has been set to "" in the server
     And user "Alice" has shared folder "simple-folder" with user "Brian" in the server
     When user "Alice" has logged in using the webUI
     And the user opens the share dialog for folder "simple-folder" using the webUI
@@ -107,7 +107,7 @@ Feature: Shares collaborator list
 
 
   Scenario: share a file with another internal user via collaborators quick action
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes" in the server
     And user "Alice" has logged in using the webUI
     When the user shares resource "simple-folder" with user "Brian Murphy" using the quick action on the webUI
     Then user "Brian Murphy" should be listed as "Viewer" in the collaborators list for folder "simple-folder" on the webUI

--- a/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
+++ b/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
@@ -6,7 +6,7 @@ Feature: Display notifications when receiving a share and follow embedded links
 
   Background:
     Given app "notifications" has been "enabled" in the server
-    And the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And these users have been created with default attributes and without skeleton files in the server:
       | username |

--- a/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
@@ -5,7 +5,7 @@ Feature: Sharing files and folders with internal groups
   So that those groups can access the files and folders
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And app "notifications" has been "enabled" in the server
     And these users have been created with default attributes and without skeleton files in the server:

--- a/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
@@ -5,7 +5,7 @@ Feature: Sharing files and folders with internal users
   So that those users can access the files and folders
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And app "notifications" has been "enabled" in the server
     And these users have been created with default attributes and without skeleton files in the server:

--- a/tests/acceptance/features/webUISharingNotificationsToRoot/notificationLink.feature
+++ b/tests/acceptance/features/webUISharingNotificationsToRoot/notificationLink.feature
@@ -6,7 +6,7 @@ Feature: Display notifications when receiving a share and follow embedded links
 
   Background:
     Given app "notifications" has been "enabled" in the server
-    And the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And these users have been created with default attributes and without skeleton files in the server:
       | username |
       | Alice    |

--- a/tests/acceptance/features/webUISharingNotificationsToRoot/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingNotificationsToRoot/shareWithGroups.feature
@@ -22,7 +22,7 @@ Feature: Sharing files and folders with internal groups
     And user "Carol" has uploaded file "lorem.txt" to "simple-folder/lorem.txt" in the server
 
   Scenario: notifications about new share is displayed
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And user "Carol" has shared folder "/simple-folder" with group "grp1" in the server
     And user "Carol" has shared folder "/data.zip" with group "grp1" in the server
     When the user reloads the current page of the webUI

--- a/tests/acceptance/features/webUISharingNotificationsToRoot/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingNotificationsToRoot/shareWithUsers.feature
@@ -17,7 +17,7 @@ Feature: Sharing files and folders with internal users
 
   @smokeTest
   Scenario: notifications about new share is displayed when auto-accepting is disabled
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And user "Alice" has shared folder "simple-folder" with user "Brian" in the server
     And user "Alice" has shared folder "data.zip" with user "Brian" in the server
     When user "Brian" logs in using the webUI
@@ -29,7 +29,7 @@ Feature: Sharing files and folders with internal users
 
   @smokeTest
   Scenario: Notification is gone after accepting a share
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And user "Alice" has shared folder "simple-folder" with user "Brian" in the server
     And user "Alice" has shared folder "simple-empty-folder" with user "Brian" in the server
     When user "Brian" logs in using the webUI
@@ -38,7 +38,7 @@ Feature: Sharing files and folders with internal users
 
   @smokeTest
   Scenario: accept an offered share
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And user "Alice" has shared folder "simple-folder" with user "Brian" in the server
     And user "Alice" has shared folder "simple-empty-folder" with user "Brian" in the server
     When user "Brian" logs in using the webUI
@@ -51,7 +51,7 @@ Feature: Sharing files and folders with internal users
 
   @smokeTest
   Scenario: reject an offered share
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And user "Alice" has shared folder "simple-folder" with user "Brian" in the server
     And user "Alice" has shared folder "simple-empty-folder" with user "Brian" in the server
     When user "Brian" logs in using the webUI

--- a/tests/acceptance/features/webUISharingPermissionsUsers/sharePermissionsUsers.feature
+++ b/tests/acceptance/features/webUISharingPermissionsUsers/sharePermissionsUsers.feature
@@ -4,7 +4,7 @@ Feature: Sharing files and folders with internal users with different permission
   So that I can control the access on those files/folders by other collaborators
 
   Background:
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And these users have been created with default attributes and without skeleton files in the server:
       | username |

--- a/tests/acceptance/features/webUISharingPublicBasic/publicLinkCreate.feature
+++ b/tests/acceptance/features/webUISharingPublicBasic/publicLinkCreate.feature
@@ -188,7 +188,7 @@ Feature: Create public link shares
 
 
   Scenario: Sharing the share_folder as public link is not possible
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And user "Brian" has been created with default attributes and without skeleton files in the server
     And user "Brian" has created folder "simple-folder" in the server

--- a/tests/acceptance/features/webUISharingPublicBasic/publicLinkEdit.feature
+++ b/tests/acceptance/features/webUISharingPublicBasic/publicLinkEdit.feature
@@ -9,7 +9,7 @@ Feature: Edit public link shares
 
   @issue-ocis-1328
   Scenario Outline: user tries to change the role of an existing public link role without entering share password while enforce password for that role is enforced
-    Given the setting "<setting-name>" of app "core" has been set to "yes"
+    Given the setting "<setting-name>" of app "core" has been set to "yes" in the server
     And user "Alice" has created folder "simple-folder" in the server
     And user "Alice" has created a public link with following settings in the server
       | path        | simple-folder         |
@@ -34,7 +34,7 @@ Feature: Edit public link shares
 
   @issue-ocis-1328
   Scenario Outline: user tries to delete the password of an existing public link role while enforce password for that role is enforced
-    Given the setting "<setting-name>" of app "core" has been set to "yes"
+    Given the setting "<setting-name>" of app "core" has been set to "yes" in the server
     And user "Alice" has created folder "simple-folder" in the server
     And user "Alice" has created a public link with following settings in the server
       | path        | simple-folder         |
@@ -60,7 +60,7 @@ Feature: Edit public link shares
 
   @issue-ocis-1328
   Scenario Outline: user changes the role of an existing public link role without entering share password while enforce password for the original role is enforced
-    Given the setting "<setting-name>" of app "core" has been set to "yes"
+    Given the setting "<setting-name>" of app "core" has been set to "yes" in the server
     And user "Alice" has created folder "simple-folder" in the server
     And user "Alice" has created a public link with following settings in the server
       | path        | simple-folder         |
@@ -86,7 +86,7 @@ Feature: Edit public link shares
 
   @issue-ocis-1328
   Scenario: user edits a public link and does not save the changes
-    Given the setting "shareapi_allow_public_notification" of app "core" has been set to "yes"
+    Given the setting "shareapi_allow_public_notification" of app "core" has been set to "yes" in the server
     And user "Alice" has created folder "simple-folder" in the server
     And user "Alice" has created a public link with following settings in the server
       | path     | simple-folder    |

--- a/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature
+++ b/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature
@@ -276,7 +276,7 @@ Feature: Share by public link with different roles
 
   @issue-ocis-1328
   Scenario: user tries to create a public link with Viewer role without entering share password while enforce password on read only public share is enforced
-    Given the setting "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
+    Given the setting "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes" in the server
     And user "Alice" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI
     Then the user should see an error message on the public link share dialog saying "Passwords are enforced for link shares"
@@ -284,7 +284,7 @@ Feature: Share by public link with different roles
 
   @issue-ocis-1328
   Scenario: user tries to create a public link with Contributor role without entering share password while enforce password on read-write public share is enforced
-    Given the setting "shareapi_enforce_links_password_read_write" of app "core" has been set to "yes"
+    Given the setting "shareapi_enforce_links_password_read_write" of app "core" has been set to "yes" in the server
     And user "Alice" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | role | Contributor |
@@ -293,7 +293,7 @@ Feature: Share by public link with different roles
 
   @issue-ocis-1328
   Scenario: user tries to create a public link with Editor Role without entering share password while enforce password on read-write public share is enforced
-    Given the setting "shareapi_enforce_links_password_read_write_delete" of app "core" has been set to "yes"
+    Given the setting "shareapi_enforce_links_password_read_write_delete" of app "core" has been set to "yes" in the server
     And user "Alice" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | role | Editor |
@@ -302,7 +302,7 @@ Feature: Share by public link with different roles
 
   @issue-ocis-1328
   Scenario: user tries to create a public link with Uploader role without entering share password while enforce password on write only public share is enforced
-    Given the setting "shareapi_enforce_links_password_write_only" of app "core" has been set to "yes"
+    Given the setting "shareapi_enforce_links_password_write_only" of app "core" has been set to "yes" in the server
     And user "Alice" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | role | Uploader |
@@ -311,7 +311,7 @@ Feature: Share by public link with different roles
 
   @issue-ocis-1328
   Scenario: user creates a public link with Contributor Role without entering share password while enforce password on read only public share is enforced
-    Given the setting "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
+    Given the setting "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes" in the server
     And user "Alice" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | role | Contributor |

--- a/tests/acceptance/features/webUISharingPublicExpire/shareByPublicLinkExpiringLinks.feature
+++ b/tests/acceptance/features/webUISharingPublicExpire/shareByPublicLinkExpiringLinks.feature
@@ -34,7 +34,7 @@ Feature: Share by public link
 
   @issue-ocis-1328
   Scenario Outline: auto set expiration date on public link (with default amount of expiry days)
-    Given the setting "shareapi_default_expire_date" of app "core" has been set to "yes"
+    Given the setting "shareapi_default_expire_date" of app "core" has been set to "yes" in the server
     And user "Alice" has created <element> "<shared-resource>" in the server
     And user "Alice" has logged in using the webUI
     When the user creates a new public link for resource "<shared-resource>" using the webUI
@@ -53,8 +53,8 @@ Feature: Share by public link
 
   @issue-ocis-1328
   Scenario Outline: auto set expiration date on public link (with set amount expiry days)
-    Given the setting "shareapi_default_expire_date" of app "core" has been set to "yes"
-    And the setting "shareapi_expire_after_n_days" of app "core" has been set to "42"
+    Given the setting "shareapi_default_expire_date" of app "core" has been set to "yes" in the server
+    And the setting "shareapi_expire_after_n_days" of app "core" has been set to "42" in the server
     And user "Alice" has created <element> "<shared-resource>" in the server
     And user "Alice" has logged in using the webUI
     When the user creates a new public link for resource "<shared-resource>" using the webUI
@@ -73,9 +73,9 @@ Feature: Share by public link
 
   @issue-ocis-1328
   Scenario: expiry date is set to enforced max expiry date when creating a public link to a date that is past the enforced max expiry date
-    Given the setting "shareapi_default_expire_date" of app "core" has been set to "yes"
-    And the setting "shareapi_expire_after_n_days" of app "core" has been set to "7"
-    And the setting "shareapi_enforce_expire_date" of app "core" has been set to "yes"
+    Given the setting "shareapi_default_expire_date" of app "core" has been set to "yes" in the server
+    And the setting "shareapi_expire_after_n_days" of app "core" has been set to "7" in the server
+    And the setting "shareapi_enforce_expire_date" of app "core" has been set to "yes" in the server
     And user "Alice" has created folder "simple-folder" in the server
     And user "Alice" has logged in using the webUI
     When the user tries to create a new public link for resource "simple-folder" which expires in "+15" days using the webUI
@@ -84,8 +84,8 @@ Feature: Share by public link
 
   @issue-ocis-1328
   Scenario: user cannot change the expiry date of an existing public link to a date that is past the enforced max expiry date
-    Given the setting "shareapi_default_expire_date" of app "core" has been set to "yes"
-    And the setting "shareapi_enforce_expire_date" of app "core" has been set to "yes"
+    Given the setting "shareapi_default_expire_date" of app "core" has been set to "yes" in the server
+    And the setting "shareapi_enforce_expire_date" of app "core" has been set to "yes" in the server
     And user "Alice" has created file "lorem.txt" in the server
     And user "Alice" has created a public link with following settings in the server
       | path       | lorem.txt   |
@@ -104,16 +104,16 @@ Feature: Share by public link
 
   @issue-ocis-1328
   Scenario: user cannot change the expiry date on existing public link to a date past the enforced max expiry date once max expiry date is changed
-    Given the setting "shareapi_default_expire_date" of app "core" has been set to "yes"
-    And the setting "shareapi_expire_after_n_days" of app "core" has been set to "16"
-    And the setting "shareapi_enforce_expire_date" of app "core" has been set to "yes"
+    Given the setting "shareapi_default_expire_date" of app "core" has been set to "yes" in the server
+    And the setting "shareapi_expire_after_n_days" of app "core" has been set to "16" in the server
+    And the setting "shareapi_enforce_expire_date" of app "core" has been set to "yes" in the server
     And user "Alice" has created file "lorem.txt" in the server
     And user "Alice" has created a public link with following settings in the server
       | path       | lorem.txt   |
       | name       | Public link |
       | expireDate | +16         |
     And user "Alice" has logged in using the webUI
-    And the setting "shareapi_expire_after_n_days" of app "core" has been set to "7"
+    And the setting "shareapi_expire_after_n_days" of app "core" has been set to "7" in the server
     When the user edits the public link named "Public link" of file "lorem.txt" changing following
       | expireDate | +15 |
     Then the user should see an error message on the public link share dialog saying "Cannot set expiration date more than 7 days in the future"
@@ -128,8 +128,8 @@ Feature: Share by public link
 
   @issue-ocis-1328
   Scenario: user can set an expiry date when creating a public link to a date that is before the enforced max expiry date
-    Given the setting "shareapi_default_expire_date" of app "core" has been set to "yes"
-    And the setting "shareapi_enforce_expire_date" of app "core" has been set to "yes"
+    Given the setting "shareapi_default_expire_date" of app "core" has been set to "yes" in the server
+    And the setting "shareapi_enforce_expire_date" of app "core" has been set to "yes" in the server
     And user "Alice" has created file "lorem.txt" in the server
     And user "Alice" has logged in using the webUI
     When the user creates a new public link for resource "lorem.txt" using the webUI with
@@ -145,8 +145,8 @@ Feature: Share by public link
 
   @issue-ocis-1328
   Scenario: user can change the expiry date of an existing public link to a date that is before the enforced max expiry date
-    Given the setting "shareapi_default_expire_date" of app "core" has been set to "yes"
-    And the setting "shareapi_enforce_expire_date" of app "core" has been set to "yes"
+    Given the setting "shareapi_default_expire_date" of app "core" has been set to "yes" in the server
+    And the setting "shareapi_enforce_expire_date" of app "core" has been set to "yes" in the server
     And user "Alice" has created file "lorem.txt" in the server
     And user "Alice" has created a public link with following settings in the server
       | path       | lorem.txt   |

--- a/tests/acceptance/features/webUISharingPublicManagement/publicLinkShareByEmail.feature
+++ b/tests/acceptance/features/webUISharingPublicManagement/publicLinkShareByEmail.feature
@@ -7,7 +7,7 @@ Feature: Share public link shares via email
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files in the server
     And user "Alice" has created folder "/simple-folder" in the server
-    And the setting "shareapi_allow_public_notification" of app "core" has been set to "yes"
+    And the setting "shareapi_allow_public_notification" of app "core" has been set to "yes" in the server
     And user "Alice" has logged in using the webUI
     And the user reloads the current page of the webUI
 

--- a/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature
@@ -47,7 +47,7 @@ Feature: Public link share management
 
   @issue-ocis-1328
   Scenario: user shares a file through public link and then it appears in a shared-with-others page
-    Given the setting "shareapi_allow_public_notification" of app "core" has been set to "yes"
+    Given the setting "shareapi_allow_public_notification" of app "core" has been set to "yes" in the server
     And user "Alice" has created a public link with following settings in the server
       | path        | simple-folder                |
       | name        | link-editor                  |

--- a/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
@@ -258,7 +258,7 @@ Feature: Restore deleted files/folders
 
   @issue-ocis-1124
   Scenario: delete and restore a file inside a received shared folder
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no"
+    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
     And the administrator has set the default folder for received shares to "Shares" in the server
     And user "Carol" has been created with default attributes and without skeleton files in the server
     And user "Carol" has created folder "folder-to-share" in the server

--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -118,7 +118,7 @@ Feature: File Upload
 
   @smokeTest @disablePreviews @issue-ocis-reva-54
   Scenario: overwrite an existing file when versioning is disabled
-    Given the app "files_versions" has been disabled
+    Given the app "files_versions" has been disabled in the server
     When the user uploads overwriting file "lorem.txt" using the webUI
     Then no message should be displayed on the webUI
     And file "lorem.txt" should be listed on the webUI

--- a/tests/acceptance/stepDefinitions/generalContext.js
+++ b/tests/acceptance/stepDefinitions/generalContext.js
@@ -2,8 +2,8 @@ const { client } = require('nightwatch-api')
 const { After, Before, Given, Then, When } = require('@cucumber/cucumber')
 const httpHelper = require('../helpers/httpHelper')
 const assert = require('assert')
-const path = require('path')
 const fs = require('fs')
+const path = require('path')
 const occHelper = require('../helpers/occHelper')
 
 let initialConfigJsonSettings
@@ -119,46 +119,6 @@ Then('no message should be displayed on the webUI', async function () {
   const hasMessage = await client.page.webPage().hasErrorMessage(false)
   assert.strictEqual(hasMessage, false, 'Expected no messages but a message is displayed.')
   return this
-})
-
-Given(
-  'the setting {string} of app {string} has been set to {string}',
-  function (setting, app, value) {
-    if (client.globals.ocis) {
-      // TODO: decide if we fail on OCIS when a scenario even tries to use this given step
-      return
-    }
-    return occHelper.runOcc(['config:app:set', app, setting, '--value=' + value])
-  }
-)
-
-Given('the administrator has cleared the versions for user {string}', function (userId) {
-  if (client.globals.ocis) {
-    // TODO: decide if we fail on OCIS when a scenario even tries to use this given step
-    return
-  }
-  return occHelper.runOcc(['versions:cleanup', userId])
-})
-
-Given('the administrator has cleared the versions for all users', function () {
-  if (client.globals.ocis) {
-    // TODO: decide if we fail on OCIS when a scenario even tries to use this given step
-    return
-  }
-  return occHelper.runOcc(['versions:cleanup'])
-})
-
-const setTrustedServer = function (url) {
-  const body = new URLSearchParams()
-  body.append('url', url)
-  const postUrl = 'apps/testing/api/v1/trustedservers'
-  return httpHelper.postOCS(postUrl, 'admin', body).then((res) => {
-    return httpHelper.checkStatus(res)
-  })
-}
-
-Given('server {code} has been added as trusted server', function (server) {
-  return setTrustedServer(server)
 })
 
 const getCurrentScenario = function (testCase) {
@@ -294,22 +254,4 @@ After(function () {
   if (initialConfigJsonSettings) {
     fs.writeFileSync(this.fullPathOfConfigFile, JSON.stringify(initialConfigJsonSettings, null, 4))
   }
-})
-
-Given('the app {string} has been disabled', function (app) {
-  if (client.globals.ocis) {
-    // TODO: decide if we fail on OCIS when a scenario even tries to use this given step
-    return
-  }
-  return occHelper.runOcc(['app:disable', app])
-})
-
-Given('default expiration date for users is set to {int} day/days', function (days) {
-  if (client.globals.ocis) {
-    // TODO: decide if we fail on OCIS when a scenario even tries to use this given step
-    return
-  }
-  occHelper.runOcc([`config:app:set --value ${days} core shareapi_expire_after_n_days_user_share`])
-
-  return this
 })


### PR DESCRIPTION
## Description
- use the server's app configuration steps from the middleware
- remove unused step definitions from the general context

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- part of #6111 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests