### PR TITLE
Show version numbers

### DIFF
--- a/changelog/unreleased/enhancement-print-version
+++ b/changelog/unreleased/enhancement-print-version
@@ -1,0 +1,6 @@
+Enhancement: Print version numbers
+
+The package version of the web UI and the version of the backend (if available) now get printed to the browser console and get set as meta generator tag in the html head. This makes it possible to easily reference versions in bug reports.
+
+https://github.com/owncloud/web/issues/5954
+https://github.com/owncloud/web/pull/6190

--- a/packages/web-runtime/src/App.vue
+++ b/packages/web-runtime/src/App.vue
@@ -117,6 +117,7 @@ import TopBar from './components/TopBar.vue'
 import MessageBar from './components/MessageBar.vue'
 import SkipTo from './components/SkipTo.vue'
 import { FocusTrap } from 'focus-trap-vue'
+import { getBackendVersion, getWebVersion } from './container/versions'
 
 export default {
   components: {
@@ -304,6 +305,13 @@ export default {
     if (this.favicon) {
       metaInfo.link = [{ rel: 'icon', href: this.favicon }]
     }
+    const metaGenerator = {
+      name: 'generator',
+      content: [getWebVersion(), getBackendVersion({ store: this.$store })]
+        .filter(Boolean)
+        .join(', ')
+    }
+    metaInfo.meta = [metaGenerator]
     return metaInfo
   },
 

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -9,6 +9,7 @@ import OwnCloud from 'owncloud-sdk'
 import { sync as routerSync } from 'vuex-router-sync'
 import getTextPlugin from 'vue-gettext'
 import set from 'lodash-es/set'
+import { getBackendVersion, getWebVersion } from './versions'
 
 /**
  * fetch runtime configuration, this step is optional, all later steps can use a static
@@ -238,4 +239,19 @@ export const announceDefaults = ({
   ])
 
   routerSync(store, router)
+}
+
+/**
+ * announce some version numbers
+ *
+ * @param store
+ */
+export const announceVersions = ({ store }: { store: Store<unknown> }): void => {
+  const versions = [getWebVersion(), getBackendVersion({ store })].filter(Boolean)
+  versions.forEach((version) => {
+    console.log(
+      `%c ${version} `,
+      'background-color: #041E42; color: #FFFFFF; font-weight: bold; border: 1px solid #FFFFFF; padding: 5px;'
+    )
+  })
 }

--- a/packages/web-runtime/src/container/versions.ts
+++ b/packages/web-runtime/src/container/versions.ts
@@ -1,0 +1,17 @@
+import { Store } from 'vuex'
+
+export const getWebVersion = (): string => {
+  const version = process.env.PACKAGE_VERSION
+  return `ownCloud Web UI ${version}`
+}
+
+export const getBackendVersion = ({ store }: { store: Store<unknown> }): string => {
+  const backendVersion = store.getters.user.version
+  if (!backendVersion || !backendVersion.string) {
+    return undefined
+  }
+  const product = backendVersion.product || 'ownCloud'
+  const version = backendVersion.string
+  const edition = backendVersion.edition
+  return `${product} ${version} ${edition}`
+}

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -16,6 +16,7 @@ import {
   announceStore,
   announceTheme,
   announceTranslations,
+  announceVersions,
   applicationStore
 } from './container'
 
@@ -37,6 +38,7 @@ export const bootstrap = async (configurationPath: string): Promise<void> => {
 }
 
 export const renderSuccess = (): void => {
+  announceVersions({ store })
   const applications = Array.from(applicationStore.values())
   const instance = new Vue({
     el: '#owncloud',
@@ -64,6 +66,7 @@ export const renderSuccess = (): void => {
 }
 
 export const renderFailure = async (err: Error): Promise<void> => {
+  announceVersions({ store })
   await announceTranslations({ vue: Vue, supportedLanguages, translations })
   await announceTheme({ store, vue: Vue, designSystem })
   console.error(err)

--- a/packages/web-runtime/src/pages/missingOrInvalidConfig.vue
+++ b/packages/web-runtime/src/pages/missingOrInvalidConfig.vue
@@ -23,6 +23,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import { getBackendVersion, getWebVersion } from '../container/versions'
 
 export default {
   name: 'MissingConfigPage',
@@ -36,7 +37,26 @@ export default {
 
     logoImg() {
       return this.configuration.theme.logo.login
+    },
+
+    favicon() {
+      return this.configuration.theme.logo.favicon
     }
+  },
+
+  metaInfo() {
+    const metaInfo = {}
+    if (this.favicon) {
+      metaInfo.link = [{ rel: 'icon', href: this.favicon }]
+    }
+    const metaGenerator = {
+      name: 'generator',
+      content: [getWebVersion(), getBackendVersion({ store: this.$store })]
+        .filter(Boolean)
+        .join(', ')
+    }
+    metaInfo.meta = [metaGenerator]
+    return metaInfo
   }
 }
 </script>

--- a/packages/web-runtime/tests/unit/container/versions.spec.ts
+++ b/packages/web-runtime/tests/unit/container/versions.spec.ts
@@ -1,0 +1,52 @@
+import { getBackendVersion, getWebVersion } from '../../../src/container/versions'
+import Vuex, { Store } from 'vuex'
+import Vue from 'vue'
+
+Vue.use(Vuex)
+
+describe('collect version information', () => {
+  describe('web version', () => {
+    beforeEach(() => {
+      process.env.PACKAGE_VERSION = '4.7.0'
+    })
+    it('provides the web version with a static string without exceptions', () => {
+      expect(getWebVersion()).toBe('ownCloud Web UI 4.7.0')
+    })
+  })
+  describe('backend version', () => {
+    it('returns undefined when the backend version object is not available', () => {
+      const store = versionStore(undefined)
+      expect(getBackendVersion({ store })).toBeUndefined()
+    })
+    it('returns undefined when the backend version object has no "string" field', () => {
+      const store = versionStore({
+        product: 'ownCloud',
+        string: undefined
+      })
+      expect(getBackendVersion({ store })).toBeUndefined()
+    })
+    it('falls back to "ownCloud" as a product when none is defined', () => {
+      const store = versionStore({
+        string: '10.8.0',
+        edition: 'Community'
+      })
+      expect(getBackendVersion({ store })).toBe('ownCloud 10.8.0 Community')
+    })
+    it('provides the backend version as concatenation of product, version and edition', () => {
+      const store = versionStore({
+        product: 'oCIS',
+        string: '1.16.0',
+        edition: 'Reva'
+      })
+      expect(getBackendVersion({ store })).toBe('oCIS 1.16.0 Reva')
+    })
+  })
+})
+
+const versionStore = (version: any): Store<any> => {
+  return new Vuex.Store({
+    getters: {
+      user: jest.fn(() => ({ version }))
+    }
+  })
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,6 +23,7 @@ import ts from 'rollup-plugin-ts'
 
 const production = !process.env.ROLLUP_WATCH
 const sourcemap = process.env.SOURCE_MAP === 'true'
+const { version } = require('./package.json')
 
 const plugins = [
   del({
@@ -53,6 +54,7 @@ const plugins = [
   }),
   modify({
     'process.env.NODE_ENV': JSON.stringify(production ? 'production' : 'development'),
+    'process.env.PACKAGE_VERSION': JSON.stringify(version),
     // todo: owncloud-sdk _makeOCSrequest has no catch
     // this is required if a network error for example 'blocked by CORS' happened
     'l(o.instance+p,{method:e,body:d.body,headers:h})':
@@ -83,7 +85,7 @@ const plugins = [
     ]
   }),
   html({
-    title: process.env.TITLE || "ownCloud",
+    title: process.env.TITLE || 'ownCloud',
     attributes: {
       html: { lang: 'en' },
       link: [],
@@ -124,7 +126,7 @@ const plugins = [
                 if (!Object.hasOwnProperty.call(acc, c)) {
                   acc[c] = {}
                 }
-                files[c].forEach(f => {
+                files[c].forEach((f) => {
                   const fp = path.parse(f.fileName)
                   acc[c][
                     production ? fp.name.substr(0, fp.name.lastIndexOf('-')) || fp.name : fp.name
@@ -203,12 +205,12 @@ export default {
     chunkFileNames: path.join('js', 'chunks', production ? '[name]-[hash].js' : '[name].js'),
     entryFileNames: path.join('js', production ? '[name]-[hash].js' : '[name].js')
   },
-  manualChunks: id => {
+  manualChunks: (id) => {
     if (id.includes('node_modules')) {
       return 'vendor'
     }
   },
-  onwarn: warning => {
+  onwarn: (warning) => {
     if (warning.code !== 'CIRCULAR_DEPENDENCY') {
       console.error(`(!) ${warning.message}`)
     }


### PR DESCRIPTION
## Description
With this PR the web ui prints the package version and the backend version (if available) to the javascript console and sets them as meta generator tag in the html head. See screenshots below. There are some (known) situations where the backend version is not available. Those need to be fixed separately, this PR just makes use of the information. Only consequence is that the backend doesn't show up, so it's not an issue to fix it separately. The version of the web ui always gets shown, as it is included in the bundling process.

The `product` key in the version doesn't exist, yet, so for now it'll always fall back to `ownCloud`. I'll provide an oCIS PR so that oCIS will announce itself as `product: "oCIS"` in the future. For ownCloud 10 we don't need to change anything as the fallback is correct there.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/5954

## Motivation and Context
Make debugging and bug reports easier.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- manually + with unit tests

## Screenshots (if appropriate):
<img width="749" alt="Screenshot 2021-12-23 at 14 16 58" src="https://user-images.githubusercontent.com/3532843/147258368-5a8c8ec8-b2fc-4749-be77-e8ec0a4b4fcf.png">

<img width="2246" alt="Screenshot 2021-12-23 at 14 14 10" src="https://user-images.githubusercontent.com/3532843/147258351-681d6598-85f3-4559-90c1-b39c6a30738d.png">
<img width="2251" alt="Screenshot 2021-12-23 at 14 16 32" src="https://user-images.githubusercontent.com/3532843/147258365-72a75643-9c17-4932-bdfd-49dd8d06f65c.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
