### PR TITLE
[full-ci] enable lazy table cells and fix tests

### DIFF
--- a/changelog/unreleased/enhancement-lazy-resource-table
+++ b/changelog/unreleased/enhancement-lazy-resource-table
@@ -1,0 +1,6 @@
+Enhancement: Lazy resource table cells
+
+ODS introduced lazy loadable table cells, this feature is now also part of web and enabled by default.
+To disable the feature set the displayResourcesLazy option to false.
+
+https://github.com/owncloud/web/pull/6204

--- a/dev/docker/oc10.web.config.json
+++ b/dev/docker/oc10.web.config.json
@@ -12,7 +12,8 @@
     "search"
   ],
   "options": {
-    "disablePreviews": true
+    "disablePreviews": true,
+    "displayResourcesLazy": false
   },
   "applications": [
     {

--- a/dev/docker/ocis.web.config.json
+++ b/dev/docker/ocis.web.config.json
@@ -11,7 +11,8 @@
   },
   "options": {
     "hideSearchBar": true,
-    "disablePreviews": true
+    "disablePreviews": true,
+    "displayResourcesLazy": false
   },
   "apps": [
     "files",

--- a/packages/web-app-files/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceTable.vue
@@ -140,6 +140,7 @@
 <script>
 import { DateTime } from 'luxon'
 import maxSize from 'popper-max-size-modifier'
+import { mapGetters } from 'vuex'
 import { EVENT_TROW_MOUNTED, EVENT_FILE_DROPPED } from '../../constants'
 import { SortDir } from '../../composables'
 
@@ -354,6 +355,7 @@ export default {
     }
   },
   computed: {
+    ...mapGetters(['configuration']),
     popperOptions() {
       return {
         modifiers: [
@@ -474,6 +476,17 @@ export default {
           wrap: 'nowrap'
         })
       }
+
+      if (this.configuration?.options?.displayResourcesLazy) {
+        fields.forEach((field) =>
+          Object.assign(field, {
+            lazy: {
+              delay: 250
+            }
+          })
+        )
+      }
+
       return fields
     },
     areAllResourcesSelected() {
@@ -647,6 +660,7 @@ export default {
     top: 50%;
     transform: translateY(-50%);
   }
+
   &-actions {
     align-items: center;
     display: flex;
@@ -654,6 +668,7 @@ export default {
     gap: var(--oc-space-xsmall);
     justify-content: flex-end;
   }
+
   &-select-all {
     align-items: center;
     display: flex;

--- a/packages/web-app-files/tests/integration/specs/pagination.spec.js
+++ b/packages/web-app-files/tests/integration/specs/pagination.spec.js
@@ -64,6 +64,15 @@ describe('User can navigate in files list using pagination', () => {
     window.localStorage.setItem('oc_filesPageLimit', '2')
     store = merge({}, Store, {
       modules: {
+        config: {
+          getters: {
+            configuration: () => ({
+              options: {
+                disablePreviews: true
+              }
+            })
+          }
+        },
         user: {
           state: {
             id: 'alice'
@@ -72,7 +81,6 @@ describe('User can navigate in files list using pagination', () => {
         Files: StoreFiles
       }
     })
-
     const appBar = document.createElement('div')
     const breadcrumbs = document.createElement('div')
     const breadcrumbItem = document.createElement('div')

--- a/packages/web-app-files/tests/unit/components/FilesList/ResourceTable.spec.js
+++ b/packages/web-app-files/tests/unit/components/FilesList/ResourceTable.spec.js
@@ -1,10 +1,11 @@
 import merge from 'lodash-es/merge'
 import { mount, createLocalVue } from '@vue/test-utils'
-import VueCompositionAPI from '@vue/composition-api'
 import { DateTime } from 'luxon'
 import DesignSystem from 'owncloud-design-system'
-
+import VueCompositionAPI from '@vue/composition-api'
 import ResourceTable from '../../../../src/components/FilesList/ResourceTable.vue'
+import { createStore } from 'vuex-extensions'
+import Vuex from 'vuex'
 
 const getCurrentDate = () => {
   return DateTime.fromJSDate(new Date()).minus({ days: 1 }).toFormat('EEE, dd MMM yyyy HH:mm:ss')
@@ -240,6 +241,7 @@ describe('ResourceTable', () => {
 function getMountedWrapper(options = {}) {
   const localVue = createLocalVue()
   localVue.use(DesignSystem)
+  localVue.use(Vuex)
   localVue.use(VueCompositionAPI)
   localVue.prototype.$gettextInterpolate = jest.fn()
   localVue.prototype.$ngettext = jest.fn()
@@ -248,6 +250,11 @@ function getMountedWrapper(options = {}) {
     ResourceTable,
     merge(
       {
+        store: createStore(Vuex.Store, {
+          getters: {
+            configuration: () => {}
+          }
+        }),
         propsData: {
           resources: resourcesWithAllFields,
           selection: [],

--- a/packages/web-app-files/tests/unit/views/views.setup.js
+++ b/packages/web-app-files/tests/unit/views/views.setup.js
@@ -45,6 +45,7 @@ export const getRouter = ({ query = {} }) => ({
 export const getStore = function ({
   highlightedFile = null,
   disablePreviews = true,
+
   currentPage = null,
   activeFiles = [],
   pages = null,

--- a/packages/web-runtime/src/store/config.js
+++ b/packages/web-runtime/src/store/config.js
@@ -38,6 +38,7 @@ const state = {
     defaultExtension: 'files',
     homeFolder: '',
     disablePreviews: false,
+    displayResourcesLazy: true,
     previewFileExtensions: [],
     sharingRecipientsPerPage: 200
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -43,6 +43,7 @@ const plugins = [
   builtins({ crypto: true }),
   resolve({
     include: 'node_modules/**',
+    dedupe: ['@vue/composition-api'],
     browser: true,
     preferBuiltins: false
   }),

--- a/tests/drone/config-oc10-integration-app-oauth.json
+++ b/tests/drone/config-oc10-integration-app-oauth.json
@@ -13,7 +13,8 @@
     "search"
   ],
   "options": {
-    "disablePreviews": true
+    "disablePreviews": true,
+    "displayResourcesLazy": false
   },
   "applications" : [
     {

--- a/tests/drone/config-oc10-oauth.json
+++ b/tests/drone/config-oc10-oauth.json
@@ -7,6 +7,9 @@
     "url": "http://owncloud/index.php/apps/oauth2/api/v1/token",
     "authUrl": "http://owncloud/index.php/apps/oauth2/authorize"
   },
+  "options": {
+    "displayResourcesLazy": false
+  },
   "apps": [
     "files",
     "draw-io",

--- a/tests/drone/config-oc10-openid.json
+++ b/tests/drone/config-oc10-openid.json
@@ -9,6 +9,9 @@
     "response_type": "code",
     "scope": "openid profile email"
   },
+  "options": {
+    "displayResourcesLazy": false
+  },
   "apps": [
     "files",
     "draw-io",

--- a/tests/drone/config-ocis.json
+++ b/tests/drone/config-ocis.json
@@ -10,7 +10,8 @@
     "scope": "openid profile email"
   },
   "options": {
-    "disablePreviews": true
+    "disablePreviews": true,
+    "displayResourcesLazy": false
   },
   "apps": [
     "files",

--- a/tests/unit/config/jest.config.js
+++ b/tests/unit/config/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
     '\\.(css|less)$': '<rootDir>/tests/unit/stubs/empty.js',
     '^@/(.*)$': '<rootDir>/$1',
     '^@files/(.*)$': '<rootDir>/packages/web-app-files/$1',
+    '@vue/composition-api': '<rootDir>/node_modules/@vue/composition-api',
     'core-js': '<rootDir>/node_modules/core-js'
   },
   transformIgnorePatterns: ['<rootDir>/node_modules/(?!lodash-es)'],


### PR DESCRIPTION
## Description
since lazy table cell rendering has landed in ODS we also should use it in web. the feature is enabled by default, but can be disabled via the configuration (`"resourceTableLazy": false`). 

## Related Issue
- part of https://github.com/owncloud/web/issues/6046, store needs further optimization

## Motivation and Context
as written in linked issue, current views kinda slow and should be snappy instead. This is just one piece of it and wiill need further investigation.

## How Has This Been Tested?
- local installation, unit tests and integration tests.

## Types of changes
- [X] New feature (non-breaking change which adds functionality)
- [X] Technical debt
- [X] Tests

## Checklist:
- [X] Code changes
- [ ] Unit tests added
