### PR TITLE
[full-ci] Don't highlight created folders and files anymore

### DIFF
--- a/changelog/unreleased/enhancement-file-selection
+++ b/changelog/unreleased/enhancement-file-selection
@@ -1,0 +1,6 @@
+Enhancement: File selection simplification
+
+When creating a file or folder the created item is neither selected nor scrolled to anymore. This enhances usability because the selection model doesn't get altered to a single item selection anymore and allows to create items and adding them to a preselected set of resources. It also fixes an accessibility violation as the selection model (and with it the current page in it's entirety) is not altered anymore without announcement.
+
+https://github.com/owncloud/web/issues/5967
+https://github.com/owncloud/web/pull/6208

--- a/packages/web-app-files/src/components/AppBar/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar/AppBar.vue
@@ -122,7 +122,6 @@ import { useRouter } from '../../composables'
 
 import Mixins from '../../mixins'
 import MixinFileActions, { EDITOR_MODE_CREATE } from '../../mixins/fileActions'
-import MixinScrollToResource from '../../mixins/filesListScrolling'
 import { buildResource } from '../../helpers/resources'
 import { bus } from 'web-pkg/src/instance'
 import { isLocationActive, isLocationPublicActive, isLocationSpacesActive } from '../../router'
@@ -146,7 +145,7 @@ export default {
     ViewOptions,
     ContextActions
   },
-  mixins: [Mixins, MixinFileActions, MixinScrollToResource],
+  mixins: [Mixins, MixinFileActions],
   setup() {
     const router = useRouter()
     return {
@@ -309,12 +308,7 @@ export default {
   },
 
   methods: {
-    ...mapActions('Files', [
-      'updateFileProgress',
-      'removeFilesFromTrashbin',
-      'loadIndicators',
-      'setFileSelection'
-    ]),
+    ...mapActions('Files', ['updateFileProgress', 'removeFilesFromTrashbin', 'loadIndicators']),
     ...mapActions(['openFile', 'showMessage', 'createModal', 'setModalInputErrorMessage']),
     ...mapMutations('Files', ['UPSERT_RESOURCE', 'SET_HIDDEN_FILES_VISIBILITY']),
     ...mapMutations(['SET_QUOTA']),
@@ -387,14 +381,18 @@ export default {
           })
         }
 
-        setTimeout(() => {
-          this.setFileSelection([resource])
-          this.scrollToResource(resource)
+        this.showMessage({
+          title: this.$gettextInterpolate(
+            this.$gettext('"%{folderName}" was created successfully'),
+            {
+              folderName
+            }
+          )
         })
       } catch (error) {
+        console.error(error)
         this.showMessage({
-          title: this.$gettext('Creating folder failed…'),
-          desc: error,
+          title: this.$gettext('Failed to create folder'),
           status: 'danger'
         })
       }
@@ -476,14 +474,15 @@ export default {
           })
         }
 
-        setTimeout(() => {
-          this.setFileSelection([resource])
-          this.scrollToResource(resource)
+        this.showMessage({
+          title: this.$gettextInterpolate(this.$gettext('"%{fileName}" was created successfully'), {
+            fileName
+          })
         })
       } catch (error) {
+        console.error(error)
         this.showMessage({
-          title: this.$gettext('Creating file failed…'),
-          desc: error,
+          title: this.$gettext('Failed to create file'),
           status: 'danger'
         })
       }
@@ -558,9 +557,9 @@ export default {
     },
 
     onFileError(error) {
+      console.error(error)
       this.showMessage({
-        title: this.$gettext('File upload failed…'),
-        desc: error.message,
+        title: this.$gettext('Failed to upload'),
         status: 'danger'
       })
     },

--- a/packages/web-app-files/src/components/SideBar/Links/CopyToClipboardButton.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/CopyToClipboardButton.vue
@@ -61,11 +61,7 @@ export default {
       this.clipboardSuccessHandler()
       this.showMessage({
         title: this.successMsgTitle,
-        desc: this.successMsgText,
-        status: 'success',
-        autoClose: {
-          enabled: true
-        }
+        desc: this.successMsgText
       })
     },
     clipboardSuccessHandler() {

--- a/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkActions.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkActions.vue
@@ -84,10 +84,7 @@ export default {
       this.removeLink({ client, share, resource })
 
       this.showMessage({
-        title: this.$gettext('Public link was successfully deleted'),
-        autoClose: {
-          enabled: true
-        }
+        title: this.$gettext('Public link was deleted successfully')
       })
     },
 

--- a/packages/web-app-files/src/mixins.js
+++ b/packages/web-app-files/src/mixins.js
@@ -24,12 +24,7 @@ export default {
     ...mapGetters(['getToken', 'capabilities', 'configuration'])
   },
   methods: {
-    ...mapActions('Files', [
-      'resetSearch',
-      'addFileToProgress',
-      'removeFileSelection',
-      'removeFileFromProgress'
-    ]),
+    ...mapActions('Files', ['resetSearch', 'addFileToProgress', 'removeFileFromProgress']),
     ...mapActions(['showMessage', 'createModal', 'hideModal']),
 
     formDateFromJSDate(date, format = DateTime.DATETIME_FULL) {
@@ -122,13 +117,13 @@ export default {
     },
 
     displayOverwriteDialog() {
-      const translated = this.$gettext('File %{file} already exists')
+      const translated = this.$gettext('File "%{file}" already exists')
       const isVersioningEnabled =
         !this.publicPage() && this.capabilities.files && this.capabilities.files.versioning
       // TODO: Handle properly case of multiple existing files
       const title =
         this.existingResources.length > 1
-          ? this.$gettext('Multiple files already exists')
+          ? this.$gettext('Multiple files already exist')
           : this.$gettextInterpolate(
               translated,
               { file: this.existingResources[0].file.name },
@@ -169,14 +164,11 @@ export default {
           if (exists) {
             this.showMessage({
               title: this.$gettextInterpolate(
-                this.$gettext('Folder %{folder} already exists.'),
+                this.$gettext('Folder "%{folder}" already exists.'),
                 { folder: item.name },
                 true
               ),
-              status: 'danger',
-              autoClose: {
-                enabled: true
-              }
+              status: 'danger'
             })
 
             continue
@@ -245,12 +237,9 @@ export default {
     $_ocUpload_addDirectoryToQueue(e) {
       if (this.isIE11()) {
         this.showMessage({
-          title: this.$gettext('Upload failed'),
+          title: this.$gettext('Failed to upload'),
           desc: this.$gettext('Upload of a folder is not supported in Internet Explorer.'),
-          status: 'danger',
-          autoClose: {
-            enabled: true
-          }
+          status: 'danger'
         })
         return
       }
@@ -266,14 +255,11 @@ export default {
       if (directoryExists) {
         this.showMessage({
           title: this.$gettextInterpolate(
-            this.$gettext('Folder %{folder} already exists.'),
+            this.$gettext('Folder "%{folder}" already exists.'),
             { folder: directoryName },
             true
           ),
-          status: 'danger',
-          autoClose: {
-            enabled: true
-          }
+          status: 'danger'
         })
       } else {
         // Get folder structure

--- a/packages/web-app-files/src/mixins/actions/acceptShare.js
+++ b/packages/web-app-files/src/mixins/actions/acceptShare.js
@@ -72,8 +72,8 @@ export default {
 
       this.showMessage({
         title: this.$ngettext(
-          'Error while accepting the selected share.',
-          'Error while accepting selected shares.',
+          'Failed to accept the selected share.',
+          'Failed to accept selected shares.',
           resources.length
         ),
         status: 'danger'

--- a/packages/web-app-files/src/mixins/actions/declineShare.js
+++ b/packages/web-app-files/src/mixins/actions/declineShare.js
@@ -71,8 +71,8 @@ export default {
 
       this.showMessage({
         title: this.$ngettext(
-          'Error while declining the selected share.',
-          'Error while declining selected shares.',
+          'Failed to decline the selected share.',
+          'Failed to decline selected shares.',
           resources.length
         ),
         status: 'danger'

--- a/packages/web-app-files/src/mixins/actions/downloadArchive.js
+++ b/packages/web-app-files/src/mixins/actions/downloadArchive.js
@@ -59,8 +59,8 @@ export default {
         console.error(e)
         this.showMessage({
           title: this.$ngettext(
-            'Error downloading the selected folder.', // on single selection only available for folders
-            'Error downloading the selected files.', // on multi selection available for files+folders
+            'Failed to download the selected folder.', // on single selection only available for folders
+            'Failed to download the selected files.', // on multi selection available for files+folders
             this.selectedFiles.length
           ),
           status: 'danger'

--- a/packages/web-app-files/src/mixins/actions/emptyTrashBin.js
+++ b/packages/web-app-files/src/mixins/actions/emptyTrashBin.js
@@ -41,7 +41,10 @@ export default {
         .catch((error) => {
           console.error(error)
           this.showMessage({
-            title: this.$gettext('Could not delete files'),
+            title: this.$pgettext(
+              'Error message in case clearing the trash bin fails',
+              'Failed to delete all files permanently'
+            ),
             status: 'danger'
           })
         })

--- a/packages/web-app-files/src/mixins/actions/favorite.js
+++ b/packages/web-app-files/src/mixins/actions/favorite.js
@@ -52,14 +52,11 @@ export default {
           }
         })
         .catch(() => {
-          const translated = this.$gettext('Error while starring "%{file}"')
+          const translated = this.$gettext('Failed to change favorite state of "%{file}"')
           const title = this.$gettextInterpolate(translated, { file: resources[0].name }, true)
           this.showMessage({
             title: title,
-            status: 'danger',
-            autoClose: {
-              enabled: true
-            }
+            status: 'danger'
           })
         })
     }

--- a/packages/web-app-files/src/mixins/actions/rename.js
+++ b/packages/web-app-files/src/mixins/actions/rename.js
@@ -161,15 +161,15 @@ export default {
         })
         .catch((error) => {
           this.toggleModalConfirmButton()
-          let translated = this.$gettext('Error while renaming "%{file}" to "%{newName}"')
+          let translated = this.$gettext('Failed to rename "%{file}" to "%{newName}"')
           if (error.statusCode === 423) {
             translated = this.$gettext(
-              'Error while renaming "%{file}" to "%{newName}" - the file is locked'
+              'Failed to rename "%{file}" to "%{newName}" - the file is locked'
             )
           }
           const title = this.$gettextInterpolate(translated, { file: resource.name, newName }, true)
           this.showMessage({
-            title: title,
+            title,
             status: 'danger'
           })
         })

--- a/packages/web-app-files/src/mixins/actions/restore.js
+++ b/packages/web-app-files/src/mixins/actions/restore.js
@@ -68,7 +68,7 @@ export default {
         let translated
         const translateParams = {}
         if (failedResources.length === 1) {
-          translated = this.$gettext('Failed to restore %{resource}')
+          translated = this.$gettext('Failed to restore "%{resource}"')
           translateParams.resource = failedResources[0].name
         } else {
           translated = this.$gettext('Failed to restore %{resourceCount} files')

--- a/packages/web-app-files/src/mixins/deleteResources.js
+++ b/packages/web-app-files/src/mixins/deleteResources.js
@@ -99,12 +99,9 @@ export default {
         .clearTrashBin(resource.id)
         .then(() => {
           this.removeFilesFromTrashbin([resource])
-          const translated = this.$gettext('%{file} was successfully deleted')
+          const translated = this.$gettext('"%{file}" was deleted successfully')
           this.showMessage({
-            title: this.$gettextInterpolate(translated, { file: resource.name }, true),
-            autoClose: {
-              enabled: true
-            }
+            title: this.$gettextInterpolate(translated, { file: resource.name }, true)
           })
         })
         .catch((error) => {
@@ -117,14 +114,11 @@ export default {
             return
           }
 
-          const translated = this.$gettext('Deletion of %{file} failed')
+          const translated = this.$gettext('Failed to delete "%{file}"')
           this.showMessage({
             title: this.$gettextInterpolate(translated, { file: resource.name }, true),
             desc: error.message,
-            status: 'danger',
-            autoClose: {
-              enabled: true
-            }
+            status: 'danger'
           })
         })
     },

--- a/packages/web-app-files/src/quickActions.js
+++ b/packages/web-app-files/src/quickActions.js
@@ -23,12 +23,8 @@ export function createPublicLink(ctx) {
           ctx.store.dispatch('showMessage', {
             title: ctx.$gettext('Public link created'),
             desc: ctx.$gettext(
-              'Public link has been successfully created and copied into your clipboard.'
-            ),
-            status: 'success',
-            autoClose: {
-              enabled: true
-            }
+              'Public link was created successfully and copied into your clipboard.'
+            )
           })
         })
         resolve()

--- a/packages/web-app-files/src/store/actions.js
+++ b/packages/web-app-files/src/store/actions.js
@@ -28,15 +28,6 @@ export default {
     files = files.map(buildResource)
     context.commit('LOAD_FILES', { currentFolder, files })
   },
-  setFileSelection(context, files) {
-    context.commit('SET_FILE_SELECTION', files)
-  },
-  addFileSelection(context, file) {
-    context.commit('ADD_FILE_SELECTION', file)
-  },
-  removeFileSelection(context, file) {
-    context.commit('REMOVE_FILE_SELECTION', file)
-  },
   toggleFileSelection(context, file) {
     if (context.state.selectedIds.includes(file.id)) {
       context.commit('REMOVE_FILE_SELECTION', file)
@@ -78,7 +69,7 @@ export default {
           context.commit('REMOVE_FILE_FROM_SEARCHED', file)
         })
         .catch((error) => {
-          let translated = $gettext('Error while deleting "%{file}"')
+          let translated = $gettext('Failed to delete "%{file}"')
           if (error.statusCode === 423) {
             if (firstRun) {
               return context.dispatch('deleteFiles', {
@@ -89,17 +80,14 @@ export default {
               })
             }
 
-            translated = $gettext('Error while deleting "%{file}" - the file is locked')
+            translated = $gettext('Failed to delete "%{file}" - the file is locked')
           }
           const title = $gettextInterpolate(translated, { file: file.name }, true)
           context.dispatch(
             'showMessage',
             {
               title: title,
-              status: 'danger',
-              autoClose: {
-                enabled: true
-              }
+              status: 'danger'
             },
             { root: true }
           )
@@ -261,10 +249,7 @@ export default {
             {
               title: $gettext('Error while sharing.'),
               desc: e,
-              status: 'danger',
-              autoClose: {
-                enabled: true
-              }
+              status: 'danger'
             },
             { root: true }
           )
@@ -297,10 +282,7 @@ export default {
           {
             title: $gettext('Error while sharing.'),
             desc: e,
-            status: 'danger',
-            autoClose: {
-              enabled: true
-            }
+            status: 'danger'
           },
           { root: true }
         )

--- a/packages/web-app-files/src/views/LocationPicker.vue
+++ b/packages/web-app-files/src/views/LocationPicker.vue
@@ -422,15 +422,14 @@ export default {
 
       // Display error messages
       let title = ''
-      let desc = ''
       if (errors.length === 1) {
         switch (this.currentAction) {
           case batchActions.move: {
-            title = this.$gettext('An error occurred while moving %{resource}')
+            title = this.$gettext('Failed to move "%{resourceName}"')
             break
           }
           case batchActions.copy: {
-            title = this.$gettext('An error occurred while copying %{resource}')
+            title = this.$gettext('Failed to copy "%{resourceName}"')
             break
           }
           default:
@@ -438,8 +437,7 @@ export default {
         }
 
         this.showMessage({
-          title: this.$gettextInterpolate(title, { resource: errors[0].resource }, true),
-          desc: errors[0].message,
+          title: this.$gettextInterpolate(title, { resourceName: errors[0].resource }, true),
           status: 'danger'
         })
 
@@ -448,21 +446,11 @@ export default {
 
       switch (this.currentAction) {
         case batchActions.move: {
-          title = this.$gettext('An error occurred while moving several resources')
-          desc = this.$ngettext(
-            '%{count} resource could not be moved',
-            '%{count} resources could not be moved',
-            errors.length
-          )
+          title = this.$gettext('Failed to move %{count} resources')
           break
         }
         case batchActions.copy: {
-          title = this.$gettext('An error occurred while copying several resources')
-          desc = this.$ngettext(
-            '%{count} resource could not be copied',
-            '%{count} resources could not be copied',
-            errors.length
-          )
+          title = this.$gettext('Failed to copy %{count} resources')
           break
         }
         default:
@@ -470,8 +458,7 @@ export default {
       }
 
       this.showMessage({
-        title,
-        desc: this.$gettextInterpolate(desc, { count: errors.length }, false),
+        title: this.$gettextInterpolate(title, { count: errors.length }),
         status: 'danger'
       })
     }

--- a/packages/web-app-files/src/views/Personal.vue
+++ b/packages/web-app-files/src/views/Personal.vue
@@ -350,8 +350,8 @@ export default {
       if (errors.length === 0) {
         const count = selected.length
         title = this.$ngettext(
-          'Successfully moved %{count} item',
-          'Successfully moved %{count} items',
+          '%{count} item was moved successfully',
+          '%{count} items were moved successfully',
           count
         )
         this.showMessage({
@@ -362,24 +362,17 @@ export default {
       }
 
       if (errors.length === 1) {
-        title = this.$gettext('An error occurred while moving %{resource}')
+        title = this.$gettext('Failed to move "%{resourceName}"')
         this.showMessage({
-          title: this.$gettextInterpolate(title, { resource: errors[0].resourceName }, true),
-          desc: errors[0].message,
+          title: this.$gettextInterpolate(title, { resourceName: errors[0].resourceName }, true),
           status: 'danger'
         })
         return
       }
 
-      title = this.$gettext('An error occurred while moving several resources')
-      const desc = this.$ngettext(
-        '%{count} resource could not be moved',
-        '%{count} resources could not be moved',
-        errors.length
-      )
+      title = this.$gettext('Failed to move %{count} resources')
       this.showMessage({
-        title,
-        desc: this.$gettextInterpolate(desc, { count: errors.length }, false),
+        title: this.$gettextInterpolate(title, { count: errors.length }),
         status: 'danger'
       })
     },

--- a/packages/web-runtime/src/plugins/upload.js
+++ b/packages/web-runtime/src/plugins/upload.js
@@ -44,7 +44,7 @@ export default {
               },
 
               onSuccess: () => {
-                resolve(`File ${upload.file.name} was successfully uploaded`)
+                resolve(`File ${upload.file.name} was uploaded successfully`)
               }
             })
 

--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -316,7 +316,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUITrashbinRestore/trashbinRestore.feature:138](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature#L138)
 
 ### [Conflict / overwrite issues with TUS](https://github.com/owncloud/ocis/issues/1294)
--   [webUIUpload/uploadEdgecases.feature:109](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/uploadEdgecases.feature#L109)
 -   [webUIUpload/uploadFileGreaterThanQuotaSize.feature:12](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature#L12)
 
 ### [restoring a file deleted from a received shared folder is not possible](https://github.com/owncloud/ocis/issues/1124)

--- a/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
@@ -245,10 +245,10 @@ Feature: deleting files and folders
       | lorem.txt     |
       | simple-folder |
     When the user deletes file "lorem.txt" using the webUI
-    Then the error message with header 'Error while deleting "lorem.txt"' should be displayed on the webUI
+    Then the error message with header 'Failed to delete "lorem.txt"' should be displayed on the webUI
     When the user clears all error message from the webUI
     And the user deletes folder "simple-folder" using the webUI
-    Then the error message with header 'Error while deleting "simple-folder"' should be displayed on the webUI
+    Then the error message with header 'Failed to delete "simple-folder"' should be displayed on the webUI
     When the user reloads the current page of the webUI
     Then file "lorem.txt" should not be listed on the webUI
     And folder "simple-folder" should not be listed on the webUI

--- a/tests/acceptance/features/webUIFavorites/favoritesFile.feature
+++ b/tests/acceptance/features/webUIFavorites/favoritesFile.feature
@@ -117,11 +117,11 @@ Feature: Mark file as favorite
       | lorem.txt     |
       | simple-folder |
     When the user marks file "lorem.txt" as favorite using the webUI
-    Then the error message with header 'Error while starring "lorem.txt"' should be displayed on the webUI
+    Then the error message with header 'Failed to change favorite state of "lorem.txt"' should be displayed on the webUI
     And file "lorem.txt" should not be marked as favorite on the webUI
     When the user clears all error message from the webUI
     And the user marks folder "simple-folder" as favorite using the webUI
-    Then the error message with header 'Error while starring "simple-folder"' should be displayed on the webUI
+    Then the error message with header 'Failed to change favorite state of "simple-folder"' should be displayed on the webUI
     And folder "simple-folder" should not be marked as favorite on the webUI
     And as "Alice" file "lorem.txt" should not exist
     And as "Alice" folder "simple-folder" should not exist

--- a/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
+++ b/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
@@ -113,11 +113,11 @@ Feature: Unmark file/folder as favorite
       | lorem.txt     |
       | simple-folder |
     When the user unmarks the favorited file "lorem.txt" using the webUI
-    Then the error message with header 'Error while starring "lorem.txt"' should be displayed on the webUI
+    Then the error message with header 'Failed to change favorite state of "lorem.txt"' should be displayed on the webUI
     And file "lorem.txt" should be marked as favorite on the webUI
     When the user clears all error message from the webUI
     And the user unmarks the favorited folder "simple-folder" using the webUI
-    Then the error message with header 'Error while starring "simple-folder"' should be displayed on the webUI
+    Then the error message with header 'Failed to change favorite state of "simple-folder"' should be displayed on the webUI
     And folder "simple-folder" should be marked as favorite on the webUI
     And as "Alice" file "lorem.txt" should not exist
     And as "Alice" folder "simple-folder" should not exist

--- a/tests/acceptance/features/webUIFilesCopy/copy.feature
+++ b/tests/acceptance/features/webUIFilesCopy/copy.feature
@@ -32,7 +32,7 @@ Feature: copy files and folders
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
     When the user tries to copy file "strängé filename (duplicate #2 &).txt" into folder "strängé नेपाली folder" using the webUI
-    Then the error message with header 'An error occurred while copying strängé filename (duplicate #2 &).txt' should be displayed on the webUI
+    Then the error message with header 'Failed to copy "strängé filename (duplicate #2 &).txt"' should be displayed on the webUI
 
   @smokeTest @ocisSmokeTest
   Scenario: Copy multiple files at once
@@ -113,7 +113,7 @@ Feature: copy files and folders
     Given user "Alice" has created folder "simple-empty-folder"
     And user "Alice" has logged in using the webUI
     When the user tries to copy folder "simple-empty-folder" into folder "simple-empty-folder" using the webUI
-    Then the error message with header 'An error occurred while copying simple-empty-folder' should be displayed on the webUI
+    Then the error message with header 'Failed to copy "simple-empty-folder"' should be displayed on the webUI
     And as "Alice" file "simple-empty-folder/simple-empty-folder" should not exist
 
 

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -45,7 +45,7 @@ Feature: move files
     And user "Alice" has uploaded file "lorem.txt" to "simple-folder/lorem.txt"
     And the user has browsed to the files page
     When the user tries to move file "lorem.txt" into folder "simple-folder" using the webUI
-    Then the error message with header 'An error occurred while moving lorem.txt' should be displayed on the webUI
+    Then the error message with header 'Failed to move "lorem.txt"' should be displayed on the webUI
 
    @smokeTest @ocisSmokeTest  @disablePreviews
   Scenario: Move multiple files at once

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
@@ -35,7 +35,7 @@ Feature: move folders
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
     When the user tries to move folder "simple-empty-folder" into folder "simple-folder" using the webUI
-    Then the error message with header 'An error occurred while moving simple-empty-folder' should be displayed on the webUI
+    Then the error message with header 'Failed to move "simple-empty-folder"' should be displayed on the webUI
 
   @smokeTest
   Scenario: Move multiple folders at once
@@ -81,7 +81,7 @@ Feature: move folders
   Scenario: move a folder into the same folder
     Given user "Alice" has logged in using the webUI
     When the user tries to move folder "simple-empty-folder" into folder "simple-empty-folder" using the webUI
-    Then the error message with header 'An error occurred while moving simple-empty-folder' should be displayed on the webUI
+    Then the error message with header 'Failed to move "simple-empty-folder"' should be displayed on the webUI
     And as "Alice" folder "simple-empty-folder/simple-empty-folder" should not exist
 
 

--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -109,7 +109,7 @@ Feature: rename files
   # these are invalid file names on all implementations
   Scenario Outline: Try to rename a file using forbidden characters
     When the user tries to rename file "data.zip" to "<filename>" using the webUI
-    Then the error message with header 'Error while renaming "data.zip" to "<filename>"' should be displayed on the webUI
+    Then the error message with header 'Failed to rename "data.zip" to "<filename>"' should be displayed on the webUI
     And file "data.zip" should be listed on the webUI
     And file "<filename>" should not be listed on the webUI
     Examples:
@@ -121,7 +121,7 @@ Feature: rename files
   # .htaccess is an invalid file name on oC10
   Scenario: Try to rename a file to .htaccess on oC10
     When the user tries to rename file "data.zip" to ".htaccess" using the webUI
-    Then the error message with header 'Error while renaming "data.zip" to ".htaccess"' should be displayed on the webUI
+    Then the error message with header 'Failed to rename "data.zip" to ".htaccess"' should be displayed on the webUI
     And file "data.zip" should be listed on the webUI
     And file "<filename>" should not be listed on the webUI
 
@@ -172,7 +172,7 @@ Feature: rename files
   # This is valid file name for ocis
   Scenario: Rename a file to .part (on oc10)
     When the user tries to rename file "data.zip" to "data.part" using the webUI
-    Then the error message with header 'Error while renaming "data.zip" to "data.part"' should be displayed on the webUI
+    Then the error message with header 'Failed to rename "data.zip" to "data.part"' should be displayed on the webUI
 
   @skipOnOC10
   Scenario: Rename a file to .part
@@ -260,7 +260,7 @@ Feature: rename files
       | name      |
       | lorem.txt |
     When the user tries to rename file "lorem.txt" to "new-lorem.txt" using the webUI
-    Then the error message with header 'Error while renaming "lorem.txt" to "new-lorem.txt"' should be displayed on the webUI
+    Then the error message with header 'Failed to rename "lorem.txt" to "new-lorem.txt"' should be displayed on the webUI
     When the user reloads the current page of the webUI
     Then file "lorem.txt" should not be listed on the webUI
     And file "new-lorem.txt" should not be listed on the webUI

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -102,15 +102,15 @@ Feature: rename folders
     Then the error message with header '<alert_message>' should be displayed on the webUI
     And folder "simple-folder" should be listed on the webUI
     Examples:
-      | from_name       | to_name           | alert_message                                             |
-      | "simple-folder" | "simple\folder"   | Error while renaming "simple-folder" to "simple\folder"   |
-      | "simple-folder" | "\\simple-folder" | Error while renaming "simple-folder" to "\\simple-folder" |
+      | from_name       | to_name           | alert_message                                         |
+      | "simple-folder" | "simple\folder"   | Failed to rename "simple-folder" to "simple\folder"   |
+      | "simple-folder" | "\\simple-folder" | Failed to rename "simple-folder" to "\\simple-folder" |
 
   @notToImplementOnOCIS
   # .htaccess is an invalid folder name on oC10
   Scenario: Try to rename a folder to .htaccess on oC10
     When the user tries to rename folder "simple-folder" to ".htaccess" using the webUI
-    Then the error message with header 'Error while renaming "simple-folder" to ".htaccess"' should be displayed on the webUI
+    Then the error message with header 'Failed to rename "simple-folder" to ".htaccess"' should be displayed on the webUI
     And folder "simple-folder" should be listed on the webUI
 
 
@@ -132,7 +132,7 @@ Feature: rename folders
   # This is valid file name for ocis
   Scenario: Rename a folder to .part (on oc10)
     When the user tries to rename folder "simple-folder" to "simple.part" using the webUI
-    Then the error message with header 'Error while renaming "simple-folder" to "simple.part"' should be displayed on the webUI
+    Then the error message with header 'Failed to rename "simple-folder" to "simple.part"' should be displayed on the webUI
 
   @skipOnOC10
   Scenario: Rename a folder to .part (on ocis)
@@ -145,7 +145,7 @@ Feature: rename folders
       | name          |
       | simple-folder |
     When the user tries to rename folder "simple-folder" to "new-simple-folder" using the webUI
-    Then the error message with header 'Error while renaming "simple-folder" to "new-simple-folder"' should be displayed on the webUI
+    Then the error message with header 'Failed to rename "simple-folder" to "new-simple-folder"' should be displayed on the webUI
     When the user reloads the current page of the webUI
     Then folder "simple-folder" should not be listed on the webUI
     And folder "new-simple-folder" should not be listed on the webUI

--- a/tests/acceptance/features/webUISharingPublicBasic/publicLinkCreate.feature
+++ b/tests/acceptance/features/webUISharingPublicBasic/publicLinkCreate.feature
@@ -183,7 +183,7 @@ Feature: Create public link shares
     And the following success message should be displayed on the webUI
       """
       Public link created
-      Public link has been successfully created and copied into your clipboard.
+      Public link was created successfully and copied into your clipboard.
       """
 
 

--- a/tests/acceptance/features/webUITrashbinDelete/trashbinDelete.feature
+++ b/tests/acceptance/features/webUITrashbinDelete/trashbinDelete.feature
@@ -48,7 +48,7 @@ Feature: files and folders can be deleted from the trashbin
   # after the issue is fixed delete this scenario and use the one above
   Scenario: Delete folders and check that they are gone (ocis bug demonstration)
     When the user deletes folder "simple-folder" using the webUI
-    Then the error message with header "Deletion of simple-folder failed" should be displayed on the webUI
+    Then the error message with header 'Failed to delete "simple-folder"' should be displayed on the webUI
     And folder "simple-folder" should be listed on the webUI
     When the user deletes folder "Folder,With,Comma" using the webUI
     Then folder "Folder,With,Comma" should not be listed on the webUI

--- a/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
@@ -146,7 +146,7 @@ Feature: Restore deleted files/folders
     And the user restores file "simple-folder/file-to-delete-and-restore" from the trashbin using the webUI
     Then the following error message should be displayed on the webUI
      """
-     Failed to restore file-to-delete-and-restore
+     Failed to restore "file-to-delete-and-restore"
      """
     #And a success message "file-to-delete-and-restore was restored successfully" should be displayed on the webUI
     #And as "Alice" the file with original path "simple-folder/file-to-delete-and-restore" should not exist in the trashbin
@@ -168,7 +168,7 @@ Feature: Restore deleted files/folders
     And the user restores file "simple-folder/file-to-delete-and-restore" from the trashbin using the webUI
     Then the following error message should be displayed on the webUI
       """
-      Failed to restore file-to-delete-and-restore
+      Failed to restore "file-to-delete-and-restore"
       """
     #And a success message "file-to-delete-and-restore was restored successfully" should be displayed on the webUI
     #And as "Alice" the file with original path "simple-folder/file-to-delete-and-restore" should not exist in the trashbin
@@ -189,7 +189,7 @@ Feature: Restore deleted files/folders
     And the user restores file "simple-folder/file-to-delete-and-restore" from the trashbin using the webUI
     Then the following error message should be displayed on the webUI
      """
-     Failed to restore file-to-delete-and-restore
+     Failed to restore "file-to-delete-and-restore"
      """
     #And a success message "file-to-delete-and-restore was restored successfully" should be displayed on the webUI
     #And as "Alice" the file with original path "simple-folder/file-to-delete-and-restore" should not exist in the trashbin
@@ -210,7 +210,7 @@ Feature: Restore deleted files/folders
     And the user restores file "simple-folder/file-to-delete-and-restore" from the trashbin using the webUI
     Then the following error message should be displayed on the webUI
       """
-      Failed to restore file-to-delete-and-restore
+      Failed to restore "file-to-delete-and-restore"
       """
     #And a success message "file-to-delete-and-restore was restored successfully" should be displayed on the webUI
     #And as "Alice" the file with original path "simple-folder/file-to-delete-and-restore" should not exist in the trashbin

--- a/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
+++ b/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
@@ -112,13 +112,13 @@ Feature: File Upload
     When the user uploads overwriting file "new-lorem.txt" using the webUI
     Then the following error message should be displayed on the webUI
       """
-      File upload failed…
-      PUT is not allowed on non-files.
+      Failed to upload
       """
     # Then the following error message should be displayed on the webUI
     #   """
     #   (Any nice error message)
     #   """
+
 
   # When this issue is fixed merge with the scenario above
   @issue-3015 @skipOnOC10 @issue-ocis-reva-200
@@ -128,8 +128,7 @@ Feature: File Upload
     When the user uploads overwriting file "new-lorem.txt" using the webUI
     Then the following error message should be displayed on the webUI
       """
-      File upload failed…
-      Unknown error
+      Failed to upload
       """
     # Then the following error message should be displayed on the webUI
     #   """

--- a/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
+++ b/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
@@ -15,6 +15,6 @@ Feature: Upload a file
     And a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
     When the user uploads a created file "big-video.mp4" using the webUI
     Then file "big-video.mp4" should not be listed on the webUI
-    And the error message with header 'File upload failed…' should be displayed on the webUI
+    And the error message with header 'Failed to upload' should be displayed on the webUI
     #And a error message should be displayed on the webUI with the text matching
     #  | /^Not enough free space, you are uploading (\d+(.\d+)?) MB but only (\d+(.\d+)?) MB is left$/ |

--- a/tests/acceptance/features/webUIWebdavLockProtection/delete.feature
+++ b/tests/acceptance/features/webUIWebdavLockProtection/delete.feature
@@ -21,7 +21,7 @@ Feature: Locks
     When the user tries to delete folder "lorem.txt" using the webUI
     Then notifications should be displayed on the webUI with the text
       """
-      Error while deleting "lorem.txt" - the file is locked
+      Failed to delete "lorem.txt" - the file is locked
       """
     When the user reloads the current page of the webUI
     Then file "lorem.txt" should be listed on the webUI
@@ -41,7 +41,7 @@ Feature: Locks
     When the user tries to delete folder "lorem.txt" using the webUI
     Then notifications should be displayed on the webUI with the text
       """
-      Error while deleting "lorem.txt" - the file is locked
+      Failed to delete "lorem.txt" - the file is locked
       """
     When the user reloads the current page of the webUI
     Then file "lorem.txt" should be listed on the webUI
@@ -64,7 +64,7 @@ Feature: Locks
     And the user tries to delete folder "lorem.txt" using the webUI
     Then notifications should be displayed on the webUI with the text
       """
-      Error while deleting "lorem.txt" - the file is locked
+      Failed to delete "lorem.txt" - the file is locked
       """
     When the user reloads the current page of the webUI
     Then file "lorem.txt" should be listed on the webUI

--- a/tests/acceptance/features/webUIWebdavLockProtection/move.feature
+++ b/tests/acceptance/features/webUIWebdavLockProtection/move.feature
@@ -22,7 +22,7 @@ Feature: Locks
     When the user tries to move file "lorem.txt" into folder "simple-empty-folder" using the webUI
     Then notifications should be displayed on the webUI with the text
       """
-      An error occurred while moving lorem.txt
+      Failed to move "lorem.txt"
       """
     When the user browses to the files page
     Then file "lorem.txt" should be listed on the webUI
@@ -43,7 +43,7 @@ Feature: Locks
     When the user tries to move file "lorem.txt" into folder "simple-folder" using the webUI
     Then notifications should be displayed on the webUI with the text
       """
-      An error occurred while moving lorem.txt
+      Failed to move "lorem.txt"
       """
     When the user browses to the files page
     Then file "lorem.txt" should be listed on the webUI
@@ -65,7 +65,7 @@ Feature: Locks
     When the user tries to move file "lorem.txt" into folder "simple-empty-folder" using the webUI
     Then notifications should be displayed on the webUI with the text
       """
-      An error occurred while moving lorem.txt
+      Failed to move "lorem.txt"
       """
     When the user browses to the files page
     Then file "lorem.txt" should be listed on the webUI
@@ -87,7 +87,7 @@ Feature: Locks
     When the user tries to rename file "lorem.txt" to "a-renamed-file.txt" using the webUI
     Then notifications should be displayed on the webUI with the text
       """
-      Error while renaming "lorem.txt" to "a-renamed-file.txt" - the file is locked
+      Failed to move "lorem.txt" to "a-renamed-file.txt" - the file is locked
       """
     When the user closes rename dialog
     And the user reloads the current page of the webUI
@@ -112,7 +112,7 @@ Feature: Locks
     And the user tries to rename file "lorem.txt" to "a-renamed-file.txt" using the webUI
     Then notifications should be displayed on the webUI with the text
       """
-      Error while renaming "lorem.txt" to "a-renamed-file.txt" - the file is locked
+      Failed to rename "lorem.txt" to "a-renamed-file.txt" - the file is locked
       """
     When the user closes rename dialog
     And the user reloads the current page of the webUI
@@ -135,7 +135,7 @@ Feature: Locks
     And the user tries to move file "lorem.txt" into folder "simple-empty-folder" using the webUI
     Then notifications should be displayed on the webUI with the text
       """
-      An error occurred while moving lorem.txt
+      Failed to move "lorem.txt"
       """
     When the user browses to the files page
     Then file "lorem.txt" should be listed on the webUI

--- a/tests/acceptance/features/webUIWebdavLocks/locks.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/locks.feature
@@ -340,12 +340,12 @@ Feature: Locks
     And the user deletes file "lorem (2).txt" using the webUI
     Then notifications should be displayed on the webUI with the text
       """
-      Error while deleting "lorem (2).txt" - the file is locked
+      Failed to delete "lorem (2).txt" - the file is locked
       """
     When the user deletes folder "simple-folder (2)" using the webUI
     Then notifications should be displayed on the webUI with the text
       """
-      Error while deleting "simple-folder (2)" - the file is locked
+      Failed to delete "simple-folder (2)" - the file is locked
       """
     And file "lorem (2).txt" should be listed on the webUI
     And folder "simple-folder (2)" should be listed on the webUI


### PR DESCRIPTION
## Description
When creating a file or folder the created item is neither selected nor scrolled to anymore. This enhances usability because the selection model doesn't get altered to a single item selection anymore and allows to create items and adding them to a preselected set of resources. It also fixes an accessibility violation as the selection model (and with it the current page in it's entirety) is not altered anymore without announcement.

This PR also cleans up toasts (their messages, their status and their unneeded autoClose) in general. Will need retranslations on transifex though. My guidelines during message changes:
- don't show technical errors to the user, only log them to the console
- put double quotes around file names, e.g. `Failed to delete "%{fileName}"`
- use the schema `Failed to xyz` for errors
- use the schema `Files were deleted successfully` (successfully at the end)
- no `has been` phrases for actions that are already completed, as `has been` implies that it's still ongoing.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/5967

## Motivation and Context
UX and A11Y hardening.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 