### PR TITLE
[full-ci][tests-only] Add trace error to github comment

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1141,7 +1141,7 @@ def e2eTests(ctx):
         waitForOwncloudService() + \
         copyFilesForUpload() + \
         e2e_test_occ + \
-        uploadTracingResult() + \
+        uploadTracingResult(ctx) + \
         publishTracingResult("e2e-tests oC10") + \
         githubComment("e2e-tests oC10")
 
@@ -1157,7 +1157,7 @@ def e2eTests(ctx):
         getSkeletonFiles() + \
         copyFilesForUpload() + \
         e2e_test_ocis + \
-        uploadTracingResult() + \
+        uploadTracingResult(ctx) + \
         publishTracingResult("e2e-tests oCIS") + \
         githubComment("e2e-tests oCIS")
 
@@ -3169,7 +3169,11 @@ def pipelineSanityChecks(ctx, pipelines):
     for image in images.keys():
         print(" %sx\t%s" % (images[image], image))
 
-def uploadTracingResult():
+def uploadTracingResult(ctx):
+    status = ["failure",]
+    if ("with-tracing" in ctx.build.title.lower()):
+        status = ["failure", "success",]
+        
     return [{
         "name": "upload-tracing-result",
         "image": "plugins/s3",
@@ -3193,10 +3197,7 @@ def uploadTracingResult():
             },
         },
         "when": {
-            "status": [
-                "failure",
-                "success",
-            ],
+            "status": status,
             "event": [
                 "pull_request",
             ],
@@ -3209,7 +3210,7 @@ def publishTracingResult(suite):
         "image": OC_UBUNTU,
         "commands": [
             "cd %s/reports/e2e/playwright/tracing/" % dir["web"],
-            'echo "<details><summary>:boom: The e2e tests failed. Please open an error trace in console ...</summary>\\n\\n<p>\\n\\n" >> %s/comments.file' % dir["web"],
+            'echo "<details><summary>:boom: To see the trace, please open the link in the console ...</summary>\\n\\n<p>\\n\\n" >> %s/comments.file' % dir["web"],
             'for f in *.zip; do echo "#### npx playwright show-trace https://cache.owncloud.com/owncloud/web/tracing/${DRONE_BUILD_NUMBER}/$f \n" >> %s/comments.file; done' % dir["web"],
             'echo "\n</p></details>" >> %s/comments.file' % dir["web"],
             "more %s/comments.file" % dir["web"],

--- a/.drone.star
+++ b/.drone.star
@@ -1151,7 +1151,6 @@ def e2eTests(ctx):
         setUpOauth2(True, True) + \
         fixPermissions() + \
         waitForOwncloudService() + \
-        copyFilesForUpload() + \
         waitForMiddlewareService() + \
         e2e_test_occ + \
         uploadTracingResult(ctx) + \
@@ -1168,7 +1167,6 @@ def e2eTests(ctx):
         getOcis() + \
         ocisService() + \
         getSkeletonFiles() + \
-        copyFilesForUpload() + \
         waitForMiddlewareService() + \
         e2e_test_ocis + \
         uploadTracingResult(ctx) + \

--- a/.drone.star
+++ b/.drone.star
@@ -3170,10 +3170,10 @@ def pipelineSanityChecks(ctx, pipelines):
         print(" %sx\t%s" % (images[image], image))
 
 def uploadTracingResult(ctx):
-    status = ["failure",]
+    status = ["failure"]
     if ("with-tracing" in ctx.build.title.lower()):
-        status = ["failure", "success",]
-        
+        status = ["failure", "success"]
+
     return [{
         "name": "upload-tracing-result",
         "image": "plugins/s3",

--- a/.drone.star
+++ b/.drone.star
@@ -1142,7 +1142,7 @@ def e2eTests(ctx):
         copyFilesForUpload() + \
         e2e_test_occ + \
         uploadTracingResult(ctx) + \
-        publishTracingResult("e2e-tests oC10") + \
+        publishTracingResult(ctx, "e2e-tests oC10") + \
         githubComment("e2e-tests oC10")
 
     stepsInfinite = \
@@ -1158,7 +1158,7 @@ def e2eTests(ctx):
         copyFilesForUpload() + \
         e2e_test_ocis + \
         uploadTracingResult(ctx) + \
-        publishTracingResult("e2e-tests oCIS") + \
+        publishTracingResult(ctx, "e2e-tests oCIS") + \
         githubComment("e2e-tests oCIS")
 
     e2e_trigger = {
@@ -3204,7 +3204,11 @@ def uploadTracingResult(ctx):
         },
     }]
 
-def publishTracingResult(suite):
+def publishTracingResult(ctx, suite):
+    status = ["failure"]
+    if ("with-tracing" in ctx.build.title.lower()):
+        status = ["failure", "success"]
+
     return [{
         "name": "publish-tracing-result",
         "image": OC_UBUNTU,
@@ -3222,10 +3226,7 @@ def publishTracingResult(suite):
             },
         },
         "when": {
-            "status": [
-                "failure",
-                "success",
-            ],
+            "status": status,
             "event": [
                 "pull_request",
             ],

--- a/.drone.star
+++ b/.drone.star
@@ -1074,6 +1074,10 @@ def unitTests(ctx):
 def e2eTests(ctx):
     db = "mysql:5.5"
     logLevel = "2"
+    reportTracing = "false"
+
+    if ("with-tracing" in ctx.build.title.lower()):
+        reportTracing = "true"
 
     e2e_workspace = {
         "base": dir["base"],
@@ -1099,6 +1103,7 @@ def e2eTests(ctx):
             "HEADLESS": "true",
             "OCIS": "true",
             "RETRY": "1",
+            "REPORT_TRACING": reportTracing,
         },
         "commands": [
             "sleep 10 && yarn test:e2e:cucumber tests/e2e/cucumber/",
@@ -1112,6 +1117,7 @@ def e2eTests(ctx):
             "BASE_URL_OCC": "owncloud",
             "HEADLESS": "true",
             "RETRY": "1",
+            "REPORT_TRACING": reportTracing,
         },
         "commands": [
             "sleep 10 && yarn test:e2e:cucumber tests/e2e/cucumber/",
@@ -1134,7 +1140,10 @@ def e2eTests(ctx):
         fixPermissions() + \
         waitForOwncloudService() + \
         copyFilesForUpload() + \
-        e2e_test_occ
+        e2e_test_occ + \
+        uploadTracingResult() + \
+        publishTracingResult("e2e-tests oC10") + \
+        githubComment("e2e-tests oC10")
 
     stepsInfinite = \
         skipIfUnchanged(ctx, "e2e-tests") + \
@@ -1147,7 +1156,10 @@ def e2eTests(ctx):
         ocisService() + \
         getSkeletonFiles() + \
         copyFilesForUpload() + \
-        e2e_test_ocis
+        e2e_test_ocis + \
+        uploadTracingResult() + \
+        publishTracingResult("e2e-tests oCIS") + \
+        githubComment("e2e-tests oCIS")
 
     e2e_trigger = {
         "ref": [
@@ -1156,10 +1168,6 @@ def e2eTests(ctx):
             "refs/pull/**",
         ],
     }
-
-    if ("with-tracing" in ctx.build.title.lower()):
-        stepsInfinite += uploadTracingResult() + publishTracingResult("e2e-tests oCIS") + githubComment("e2e-tests oCIS")
-        stepsClassic += uploadTracingResult() + publishTracingResult("e2e-tests oC10") + githubComment("e2e-tests oC10")
 
     return [
         {
@@ -3187,6 +3195,7 @@ def uploadTracingResult():
         "when": {
             "status": [
                 "failure",
+                "success",
             ],
             "event": [
                 "pull_request",
@@ -3214,6 +3223,7 @@ def publishTracingResult(suite):
         "when": {
             "status": [
                 "failure",
+                "success",
             ],
             "event": [
                 "pull_request",

--- a/.drone.star
+++ b/.drone.star
@@ -1105,7 +1105,7 @@ def e2eTests(ctx):
             "RETRY": "1",
             "MIDDLEWARE_HOST": "http://middleware:3000",
             "REMOTE_UPLOAD_DIR": "/usr/src/app/filesForUpload",
-            "REPORT_TRACING": reportTracing,    
+            "REPORT_TRACING": reportTracing,
         },
         "commands": [
             "sleep 10 && yarn test:e2e:cucumber tests/e2e/cucumber/",

--- a/Makefile
+++ b/Makefile
@@ -66,3 +66,7 @@ l10n-read: node_modules
 .PHONY: l10n-write
 l10n-write: node_modules
 	make -C packages/web-runtime/l10n translations
+
+.PHONY: ci-format
+ci-format: $(BUILDIFIER)
+	$(BUILDIFIER) --mode=fix .drone.star

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,3 @@ l10n-read: node_modules
 .PHONY: l10n-write
 l10n-write: node_modules
 	make -C packages/web-runtime/l10n translations
-
-.PHONY: ci-format
-ci-format: $(BUILDIFIER)
-	$(BUILDIFIER) --mode=fix .drone.star

--- a/tests/e2e/cucumber/shareFolderJourney.feature
+++ b/tests/e2e/cucumber/shareFolderJourney.feature
@@ -19,7 +19,7 @@ Feature: share folder with file
       | resource  | to               |
       | lorem.txt | folder_to_shared |
     Then "Alice" should see the following resource
-      | folder_to_shared/lorem.txt |
+      | folder_to_shared/lorem1.txt |
     When "Alice" shares the following resource via the sidebar panel
       | resource         | user  | role   |
       | folder_to_shared | Brian | editor |

--- a/tests/e2e/cucumber/shareFolderJourney.feature
+++ b/tests/e2e/cucumber/shareFolderJourney.feature
@@ -19,7 +19,7 @@ Feature: share folder with file
       | resource  | to               |
       | lorem.txt | folder_to_shared |
     Then "Alice" should see the following resource
-      | folder_to_shared/lorem1.txt |
+      | folder_to_shared/lorem.txt |
     When "Alice" shares the following resource via the sidebar panel
       | resource         | user  | role   |
       | folder_to_shared | Brian | editor |

--- a/tests/e2e/support/cta/files/sidebar.ts
+++ b/tests/e2e/support/cta/files/sidebar.ts
@@ -37,10 +37,10 @@ export const openPanel = async ({
   const panelSelector = page.locator(`#sidebar-panel-${name}-item-select`)
   const nextPanel = page.locator(`#sidebar-panel-${name}-item`)
   if (await panelSelector.count()) {
-    await panelSelector.click()
     await Promise.all([
       locatorUtils.waitForEvent(nextPanel, 'focus'),
-      locatorUtils.waitForEvent(nextPanel, 'transitionend')
+      locatorUtils.waitForEvent(nextPanel, 'transitionend'),
+      panelSelector.click()
     ])
   }
 }


### PR DESCRIPTION
I added the display of error trace in the github comments. 

The trace, in my opinion, gives a very good understanding of the cause of the error. You can see all the steps, the console and the network. 

Trace can be open in Trace Viewer in two ways:
- download zip file. and open file in console `npx playwright show-trace Downloads/file.zip`
- copy link to console (without downloading zip file): `npx playwright show-trace https://cache.owncloud.com/owncloud/web/tracing/file.zip`

I did not upload a video or har so as not to make the message too big. It might make sense to include video via headers

