### PR TITLE
Fix open folder file action

### DIFF
--- a/changelog/unreleased/bugfix-open-folder-context-menu
+++ b/changelog/unreleased/bugfix-open-folder-context-menu
@@ -1,0 +1,6 @@
+Bugfix: Open folder from context menu
+
+We fixed a bug in the context menu that prevented correct folder navigation ("Open folder").
+
+https://github.com/owncloud/web/issues/6187
+https://github.com/owncloud/web/pull/6232

--- a/packages/web-app-files/src/components/ActionMenuItem.vue
+++ b/packages/web-app-files/src/components/ActionMenuItem.vue
@@ -34,8 +34,6 @@
 </template>
 
 <script>
-import merge from 'lodash-es/merge'
-
 export default {
   name: 'ActionMenuItem',
   props: {
@@ -63,11 +61,7 @@ export default {
     getComponentProps(action, resources) {
       if (action.componentType === 'router-link' && action.route) {
         return {
-          to: merge({}, action.route, {
-            params: {
-              item: resources.map((resource) => resource.path)
-            }
-          })
+          to: action.route({ resources })
         }
       }
 

--- a/packages/web-app-files/src/mixins/actions/navigate.js
+++ b/packages/web-app-files/src/mixins/actions/navigate.js
@@ -8,6 +8,7 @@ import {
   isLocationSharesActive
 } from '../../router'
 import { ShareStatus } from '../../helpers/share'
+import merge from 'lodash-es/merge'
 
 export default {
   computed: {
@@ -46,15 +47,21 @@ export default {
           },
           canBeDefault: true,
           componentType: 'router-link',
-          route: this.route,
+          route: ({ resources }) => {
+            return merge({}, this.routeName, {
+              params: {
+                item: resources[0].path
+              }
+            })
+          },
           class: 'oc-files-actions-navigate-trigger'
         }
       ]
     },
-    route() {
+    routeName() {
       return isLocationPublicActive(this.$router, 'files-public-files')
-        ? createLocationSpaces('files-spaces-personal-home')
-        : createLocationPublic('files-public-files')
+        ? createLocationPublic('files-public-files')
+        : createLocationSpaces('files-spaces-personal-home')
     }
   }
 }

--- a/packages/web-app-files/tests/__fixtures__/fileActions.js
+++ b/packages/web-app-files/tests/__fixtures__/fileActions.js
@@ -154,7 +154,7 @@ const fileActions = {
   navigate: {
     name: 'navigate',
     icon: 'folder-open',
-    route: 'files-personal',
+    route: () => ({ name: 'files-personal' }),
     label: () => 'Open Folder',
     componentType: 'router-link',
     class: 'oc-files-actions-navigate-trigger',


### PR DESCRIPTION
## Description
- public and personal route were flipped, fixed that
- route was not correctly created in the context menu
- moved logic for creating the full route into the file action instead
  of building the route in the component (make components dumb again)

## Related Issue
- Fixes https://github.com/owncloud/web/issues/6187

## Motivation and Context
Fix context action for opening folders

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 