### PR TITLE
[tests-only] [full-ci] allow only one space before "in the server"

### DIFF
--- a/tests/acceptance/features/webUIFiles/batchAction.feature
+++ b/tests/acceptance/features/webUIFiles/batchAction.feature
@@ -8,7 +8,7 @@ Feature: Visibility of the batch actions menu
       | username |
       | Alice    |
       | Brian    |
-    And user "Alice" has created folder "simple-folder"  in the server
+    And user "Alice" has created folder "simple-folder" in the server
 
 
   Scenario: View batch action menu for a folder on the all files page
@@ -22,7 +22,7 @@ Feature: Visibility of the batch actions menu
 
 
   Scenario: View batch action menu for a file on the all files page
-    Given user "Alice" has created file "lorem.txt"  in the server
+    Given user "Alice" has created file "lorem.txt" in the server
     And user "Alice" has logged in using the webUI
     When the user marks the file "lorem.txt" using the webUI
     Then the following batch action buttons should be visible
@@ -34,7 +34,7 @@ Feature: Visibility of the batch actions menu
 
 
   Scenario: View batch action menu when selecting both file and folder on the all files page
-    Given user "Alice" has created file "lorem.txt"  in the server
+    Given user "Alice" has created file "lorem.txt" in the server
     And user "Alice" has logged in using the webUI
     When the user marks these files for batch action using the webUI
       | name          |
@@ -111,7 +111,7 @@ Feature: Visibility of the batch actions menu
 
 
   Scenario: View batch action menu for a folder on the trashbin page
-    Given the following folders have been deleted by user "Alice"  in the server
+    Given the following folders have been deleted by user "Alice" in the server
       | name          |
       | simple-folder |
     And user "Alice" has logged in using the webUI

--- a/tests/acceptance/stepDefinitions/middlewareContext.js
+++ b/tests/acceptance/stepDefinitions/middlewareContext.js
@@ -63,16 +63,16 @@ After(function () {
   })
 })
 
-Given(/^((?:(?!these|following).)*)(in the server|on remote server)(.*)$/, (st1, st2, st3) => {
+Given(/^((?:(?!these|following).)*\S)\s(in the server|on remote server)(.*)$/, (st1, st2, st3) => {
   if (st2 === 'on remote server') {
-    st1 = st1 + st2
+    st1 = st1 + ' ' + st2
   }
   return handler(st1, st3)
 })
 
-Given(/^(.*(?=these|following).*)(in the server|on remote server)(.*)$/, (st1, st2, st3, table) => {
+Given(/^(.*(?=these|following).*\S)\s(in the server|on remote server)(.*)$/, (st1, st2, st3, table) => {
   if (st2 === 'on remote server') {
-    st1 = st1 + st2
+    st1 = st1 + ' ' + st2
   }
   return handler(st1, st3, table.raw())
 })

--- a/tests/acceptance/stepDefinitions/middlewareContext.js
+++ b/tests/acceptance/stepDefinitions/middlewareContext.js
@@ -70,9 +70,12 @@ Given(/^((?:(?!these|following).)*\S)\s(in the server|on remote server)(.*)$/, (
   return handler(st1, st3)
 })
 
-Given(/^(.*(?=these|following).*\S)\s(in the server|on remote server)(.*)$/, (st1, st2, st3, table) => {
-  if (st2 === 'on remote server') {
-    st1 = st1 + ' ' + st2
+Given(
+  /^(.*(?=these|following).*\S)\s(in the server|on remote server)(.*)$/,
+  (st1, st2, st3, table) => {
+    if (st2 === 'on remote server') {
+      st1 = st1 + ' ' + st2
+    }
+    return handler(st1, st3, table.raw())
   }
-  return handler(st1, st3, table.raw())
-})
+)


### PR DESCRIPTION
## Description
PR #6105 wrote a step in a scenario:
`And user "Alice" has created folder "simple-folder"  in the server`
notice that it has 2 spaces before "in the server"

This PR changes the regex for such steps so that there must be only a single space, and removes excess space from test steps.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
