### PR TITLE
[tests-only][full-ci]Bump the commit id for tests

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=e31d986e1a86b58e5cad7e43166a98f858a9ebe4
+OCIS_COMMITID=e57008f6c3e24f67f8f9815c96e43759726a6fbd
 OCIS_BRANCH=master

--- a/.drone.star
+++ b/.drone.star
@@ -473,6 +473,7 @@ config = {
             "runningOnOCIS": True,
             "visualTesting": False,
             "filterTags": "not @skip and not @skipOnOCIS and not @notToImplementOnOCIS",
+            "screenShots": True,
         },
         "webUI-notifications-oc10-integration": {
             "type": NOTIFICATIONS,

--- a/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
+++ b/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
@@ -36,7 +36,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIFilesDetails/fileDetails.feature:153](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesDetails/fileDetails.feature#L153)
 
 ### [Tags page not implemented yet](https://github.com/owncloud/web/issues/5017)
--   [webUIDeleteFilesFolders/deleteFilesFolders.feature:131](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L131)
+-   [webUIDeleteFilesFolders/deleteFilesFolders.feature:136](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L136)
 -   [webUIFilesSearch/search.feature:63](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L63)
 -   [webUIFilesSearch/search.feature:71](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L71)
 -   [webUIFilesSearch/search.feature:84](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L84)

--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -122,8 +122,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIRestrictSharing/restrictSharing.feature:56](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature#L56)
 
 ### [First request with a recreated user returns a 401 error](https://github.com/owncloud/ocis/issues/1675)
--   [webUISharingAutocompletion/shareAutocompletion.feature:56](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature#L56)
--   [webUISharingAutocompletion/shareAutocompletion.feature:66](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature#L66)
 -   [webUISharingAutocompletion/shareAutocompletion.feature:128](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature#L128)
 -   [webUISharingAutocompletion/shareAutocompletion.feature:141](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletion.feature#L141)
 
@@ -200,7 +198,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIFilesActionMenu/versions.feature:93](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L93)
 
 ### [Accepting different shares with same filename from different users overwrites one file](https://github.com/owncloud/ocis/issues/713)
--   [webUISharingAcceptShares/acceptShares.feature:212](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature#L212)
+-   [webUISharingAcceptShares/acceptShares.feature:228](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature#L228)
 
 ### [Deletion of a selected user/group as a collaborator has unusual behavior in UI](https://github.com/owncloud/web/issues/5857)
 -   [webUISharingFolderAdvancedPermissionsGroups/shareAdvancePermissionsGroup.feature:63](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingFolderAdvancedPermissionsGroups/shareAdvancePermissionsGroup.feature#L63)
@@ -375,7 +373,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUITrashbinDelete/trashbinDelete.feature:48](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITrashbinDelete/trashbinDelete.feature#L48)
 
 ### [Tags page not implemented yet](https://github.com/owncloud/web/issues/5017)
--   [webUIDeleteFilesFolders/deleteFilesFolders.feature:131](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L131)
+-   [webUIDeleteFilesFolders/deleteFilesFolders.feature:136](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L136)
 -   [webUIFilesSearch/search.feature:63](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L63)
 -   [webUIFilesSearch/search.feature:71](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L71)
 -   [webUIFilesSearch/search.feature:84](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L84)
@@ -500,8 +498,8 @@ Other free text and markdown formatting can be used elsewhere in the document if
 
 ### [[oCIS] Received share cannot be deleted/unshared if not shared with full permissions](https://github.com/owncloud/web/issues/5531)
 -   [webUISharingAcceptShares/acceptShares.feature:50](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature#L50)
--   [webUISharingAcceptShares/acceptShares.feature:146](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature#L146)
--   [webUISharingAcceptShares/acceptShares.feature:185](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature#L185)
+-   [webUISharingAcceptShares/acceptShares.feature:162](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature#L162)
+-   [webUISharingAcceptShares/acceptShares.feature:201](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature#L201)
 
 ### [not possible to overwrite a received shared file](https://github.com/owncloud/ocis/issues/2267)
 -   [webUISharingInternalGroups/shareWithGroups.feature:77](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature#L77)
@@ -509,3 +507,9 @@ Other free text and markdown formatting can be used elsewhere in the document if
 
 ### [shares are not listed with full paths](https://github.com/owncloud/ocis/issues/2462)
 -   [webUISharingPublicBasic/publicLinkCreate.feature:88](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicBasic/publicLinkCreate.feature#L88)
+
+### [web config update is not properly reflected after the ocis start](https://github.com/owncloud/ocis/issues/2944)
+-   [webUIFiles/breadcrumb.feature:50](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFiles/breadcrumb.feature#L50)
+
+### [Selecting delete all](https://github.com/owncloud/web/issues/6305)
+-  [webUIDeleteFilesFolders/deleteFilesFolders.feature:77](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L77)

--- a/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
@@ -89,6 +89,8 @@ Feature: deleting files and folders
   Scenario: Delete all except for a few files at once
     Given user "Alice" has uploaded file "data.zip" to "data.zip" in the server
     And user "Alice" has created file "lorem.txt" in the server
+    And user "Alice" has created file "fileToDelete.txt" in the server
+    And user "Alice" has created folder "folderToDelete" in the server
     And user "Alice" has created folder "simple-folder" in the server
     And the user has reloaded the current page of the webUI
     When the user marks all files for batch action using the webUI
@@ -96,15 +98,18 @@ Feature: deleting files and folders
       | name          |
       | lorem.txt     |
       | simple-folder |
+      | Shares        |
     And the user batch deletes the marked files using the webUI
     Then as "Alice" file "lorem.txt" should exist in the server
     And as "Alice" folder "simple-folder" should exist in the server
     And folder "simple-folder" should be listed on the webUI
+    And folder "Shares" should be listed on the webUI
     And file "lorem.txt" should be listed on the webUI
-    # Check just an example of a file that should not exist any more
     But as "Alice" file "data.zip" should not exist in the server
+    And as "Alice" file "fileToDelete.txt" should not exist in the server
+    And as "Alice" folder "folderToDelete" should not exist in the server
     And file "data.zip" should not be listed on the webUI
-    And the count of files and folders shown on the webUI should be 2
+    And the count of files and folders shown on the webUI should be 4
     And no message should be displayed on the webUI
 
   @ocis-reva-issue-106

--- a/tests/acceptance/features/webUIOperationsWithFolderShares/accessToSharesFolder.feature
+++ b/tests/acceptance/features/webUIOperationsWithFolderShares/accessToSharesFolder.feature
@@ -10,14 +10,19 @@ Feature: Upload into a folder Shares
     And user "Alice" has been created with default attributes and without skeleton files in the server
     And user "Brian" has been created with default attributes and without skeleton files in the server
 
-  @issue-ocis-2322
+  @issue-ocis-2322 @notToImplementOnOCIS
   Scenario: the Shares folder does not exist if no share has been accepted
     Given user "Brian" has created file "lorem.txt" in the server
     And user "Brian" has shared file "lorem.txt" with user "Alice" with "all" permissions in the server
     When user "Alice" logs in using the webUI
     Then folder "Shares" should not be listed on the webUI
 
-  @issue-ocis-2322
+  @issue-ocis-2322 @notToImplementOnOC10
+  Scenario: the Shares folder should be listed even without any share
+    When user "Alice" logs in using the webUI
+    Then folder "Shares" should be listed on the webUI
+
+
   Scenario: the Shares folder exists after accepting the first shared file
     Given user "Brian" has created file "lorem.txt" in the server
     And user "Brian" has shared file "lorem.txt" with user "Alice" with "all" permissions in the server

--- a/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
@@ -68,8 +68,8 @@ Feature: accept/decline shares coming from internal users
     Then folder "simple-folder" shared by "Alice Hansen" should be in "Declined" state on the webUI
     And file "testimage.jpg" shared by "Alice Hansen" should be in "Declined" state on the webUI
 
-
-  Scenario: User receives files when auto accept share is disabled
+  @skipOnOCIS
+  Scenario: User receives files when auto accept share is disabled - oC10 behavior
     Given user "Alice" has created file "toshare.txt" in the server
     And user "Alice" has uploaded file with content "test" to "toshare.txt" in the server
     And user "Alice" has shared file "toshare.txt" with user "Brian" in the server
@@ -77,7 +77,23 @@ Feature: accept/decline shares coming from internal users
     Then file "toshare.txt" shared by "Alice Hansen" should be in "Pending" state on the webUI
     When the user browses to the files page
     Then file "toshare.txt" should not be listed on the webUI
+    # On oC10, the Shares folder only appears after there is a received shared
+    # resource. So it should not exist at this point.
     And folder "Shares" should not be listed on the webUI
+
+  @skipOnOC10
+  Scenario: User receives files when auto accept share is disabled - oCIS behavior
+    Given user "Alice" has created file "toshare.txt" in the server
+    And user "Alice" has uploaded file with content "test" to "toshare.txt" in the server
+    And user "Alice" has shared file "toshare.txt" with user "Brian" in the server
+    When the user browses to the shared-with-me page
+    Then file "toshare.txt" shared by "Alice Hansen" should be in "Pending" state on the webUI
+    When the user browses to the files page
+    Then file "toshare.txt" should not be listed on the webUI
+    # The Shares folder always exists on oCIS, check inside it to see that the
+    # received shared file is not listed, because the share is pending.
+    When the user opens folder "Shares" using the webUI
+    Then file "toshare.txt" should not be listed on the webUI
 
 
   Scenario: receive shares with same name from different users

--- a/tests/acceptance/stepDefinitions/previewContext.js
+++ b/tests/acceptance/stepDefinitions/previewContext.js
@@ -14,8 +14,9 @@ Given(
 
 When(
   'the user/public views the file {string} in the media viewer using the webUI',
-  function (fileName) {
-    return mediaViewerPage.openMediaViewer(fileName)
+  async function (fileName) {
+    await mediaViewerPage.openMediaViewer(fileName)
+    return mediaViewerPage.waitForMediaViewerLoaded(fileName)
   }
 )
 


### PR DESCRIPTION
## Description
Test scenarios are adjusted to take into account that the `Shares` folder is always displayed when running on oCIS, even before a user has received any incoming share.

This also means  that test scenarios that try to "select all" and then "delete all" at the top (root) level a a user's file system do not pass. The `Shares` folder gets selected, but it cannot be deleted. See issue #6305 for discussion of this.

Also, the media viewer test code has been enhanced to `waitForMediaViewerLoaded` to help be sure that the resource has been properly loaded at each point in the test steps.

## How Has This Been Tested?
- CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
