### PR TITLE
Add default sorting to the spaces list

### DIFF
--- a/changelog/unreleased/enhancement-spaces-default-sorting
+++ b/changelog/unreleased/enhancement-spaces-default-sorting
@@ -1,0 +1,6 @@
+Enhancement: Add default sorting to the spaces list
+
+Spaces will now be sorted by their name by default.
+
+https://github.com/owncloud/web/pull/6262
+https://github.com/owncloud/web/issues/6253

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -65,7 +65,9 @@ export default {
 
     const loadSpacesTask = useTask(function* () {
       const response = yield graph.drives.listMyDrives()
-      spaces.value = (response.data?.value || []).filter((drive) => drive.driveType === 'project')
+      spaces.value = (response.data?.value || [])
+        .filter((drive) => drive.driveType === 'project')
+        .sort((a, b) => a.name.localeCompare(b.name))
     })
 
     loadSpacesTask.perform()


### PR DESCRIPTION
## Description
Spaces will now be sorted by their name by default. This is only temporary. Later, spaces will be sorted via API.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/6253

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 