### PR TITLE
[do-not-merge] ocis shows the Shares folder always

### DIFF
--- a/tests/acceptance/features/webUIOperationsWithFolderShares/accessToSharesFolder.feature
+++ b/tests/acceptance/features/webUIOperationsWithFolderShares/accessToSharesFolder.feature
@@ -10,14 +10,19 @@ Feature: Upload into a folder Shares
     And user "Alice" has been created with default attributes and without skeleton files in the server
     And user "Brian" has been created with default attributes and without skeleton files in the server
 
-  @issue-ocis-2322 
+  @issue-ocis-2322 @notToImplementOnOCIS
   Scenario: the Shares folder does not exist if no share has been accepted
     Given user "Brian" has created file "lorem.txt"
     And user "Brian" has shared file "lorem.txt" with user "Alice" with "all" permissions
     When user "Alice" logs in using the webUI
     Then folder "Shares" should not be listed on the webUI
 
-  @issue-ocis-2322 
+  @notToImplementOnOC10
+  Scenario: the Shares folder should be listed even without any share
+    When user "Alice" logs in using the webUI
+    Then folder "Shares" should be listed on the webUI
+
+  @issue-ocis-2322 @notToImplementOnOCIS
   Scenario: the Shares folder exists after accepting the first shared file
     Given user "Brian" has created file "lorem.txt"
     And user "Brian" has shared file "lorem.txt" with user "Alice" with "all" permissions


### PR DESCRIPTION
## Description
ocis shows the Shares always, also when no Share was given or accepted
We usually only bump the commit id of web in ocis when releasing a new web version, but here a change in ocis has triggered a change in the web behavior.

I cannot see any other way to make the tests work correctly except of having a other branch maintained till a new version of web is released in ocis

this commit has also to come to the web master, best probably in #6257

PR to run the tests in ocis using this branch https://github.com/owncloud/ocis/pull/3007