### PR TITLE
Reduce notification to github 

### DIFF
--- a/tests/e2e/cucumber/environment/index.ts
+++ b/tests/e2e/cucumber/environment/index.ts
@@ -100,7 +100,7 @@ After(async function (this: World, { result }: ITestCaseHookParameter) {
       config.reportHar = true
       config.reportTracing = true
       retryCounter += 1
-    } 
+    }
   } else {
     config.reportHar = false
     config.reportTracing = false
@@ -108,7 +108,6 @@ After(async function (this: World, { result }: ITestCaseHookParameter) {
   }
   await this.actorsEnvironment.close()
 })
-
 
 AfterAll(() => state.browser && state.browser.close())
 

--- a/tests/e2e/cucumber/environment/index.ts
+++ b/tests/e2e/cucumber/environment/index.ts
@@ -39,7 +39,6 @@ BeforeAll(async function () {
 
 Before(function (this: World, { pickle }: ITestCaseHookParameter) {
   this.feature = pickle
-  console.log('featureName', this.feature.name)
   this.actorsEnvironment.on('console', async (actorId, message): Promise<void> => {
     const msg = {
       actor: actorId,

--- a/tests/e2e/cucumber/step_definitions/session.ts
+++ b/tests/e2e/cucumber/step_definitions/session.ts
@@ -2,10 +2,17 @@ import { Given, When } from '@cucumber/cucumber'
 import { World } from '../environment'
 import { config } from '../../config'
 import { LoginPage, RuntimePage } from '../../support'
+import { DateTime } from 'luxon'
+import { kebabCase } from 'lodash'
 
 async function LogInUser(this: World, stepUser: string): Promise<void> {
   const user = this.usersEnvironment.getUser({ id: stepUser })
-  const actor = await this.actorsEnvironment.createActor({ id: stepUser })
+  const actor = await this.actorsEnvironment.createActor({
+    id: stepUser,
+    namespace: kebabCase(
+      [this.feature.name, stepUser, DateTime.now().toFormat('yyyy-M-d-hh-mm-ss')].join('-')
+    )
+  })
   const loginPage = new LoginPage({ actor })
 
   await actor.page.goto(config.frontendUrl)

--- a/tests/e2e/support/environment/actor/actor.ts
+++ b/tests/e2e/support/environment/actor/actor.ts
@@ -17,7 +17,7 @@ export class ActorEnvironment extends EventEmitter implements Actor {
 
   constructor(options: ActorOptions) {
     super()
-    this.uuid = [DateTime.now().toFormat('yyyy-M-d-hh-mm-ss'), "feature.name", options.id].join('-')
+    this.uuid = [DateTime.now().toFormat('yyyy-M-d-hh-mm-ss'), 'feature.name', options.id].join('-')
     this.options = options
   }
 

--- a/tests/e2e/support/environment/actor/actor.ts
+++ b/tests/e2e/support/environment/actor/actor.ts
@@ -17,7 +17,7 @@ export class ActorEnvironment extends EventEmitter implements Actor {
 
   constructor(options: ActorOptions) {
     super()
-    this.uuid = [DateTime.now().toFormat('yyyy-M-d-hh-mm-ss'), options.id].join('-')
+    this.uuid = [DateTime.now().toFormat('yyyy-M-d-hh-mm-ss'), "feature.name", options.id].join('-')
     this.options = options
   }
 

--- a/tests/e2e/support/environment/actor/actor.ts
+++ b/tests/e2e/support/environment/actor/actor.ts
@@ -1,7 +1,6 @@
 import { Actor } from '../../types'
 import { ActorOptions, buildBrowserContextOptions } from './shared'
 import { BrowserContext, Page } from 'playwright'
-import { DateTime } from 'luxon'
 import path from 'path'
 import EventEmitter from 'events'
 
@@ -10,21 +9,17 @@ export declare interface ActorEnvironment {
 }
 
 export class ActorEnvironment extends EventEmitter implements Actor {
-  private readonly uuid: string
   private readonly options: ActorOptions
   public context: BrowserContext
   public page: Page
 
   constructor(options: ActorOptions) {
     super()
-    this.uuid = [DateTime.now().toFormat('yyyy-M-d-hh-mm-ss'), 'feature.name', options.id].join('-')
     this.options = options
   }
 
   async setup(): Promise<void> {
-    this.context = await this.options.browser.newContext(
-      buildBrowserContextOptions(this.uuid, this.options.context)
-    )
+    this.context = await this.options.browser.newContext(buildBrowserContextOptions(this.options))
 
     if (this.options.context.reportTracing) {
       await this.context.tracing.start({ screenshots: true, snapshots: true, sources: true })
@@ -36,7 +31,12 @@ export class ActorEnvironment extends EventEmitter implements Actor {
   async close(): Promise<void> {
     if (this.options.context.reportTracing) {
       await this.context?.tracing.stop({
-        path: path.join(this.options.context.reportDir, 'playwright', 'tracing', `${this.uuid}.zip`)
+        path: path.join(
+          this.options.context.reportDir,
+          'playwright',
+          'tracing',
+          `${this.options.namespace}.zip`
+        )
       })
     }
 

--- a/tests/e2e/support/environment/actor/actors.ts
+++ b/tests/e2e/support/environment/actor/actors.ts
@@ -26,12 +26,12 @@ export class ActorsEnvironment extends EventEmitter {
     return this.store.get(id)
   }
 
-  public async createActor({ id }: { id: string }): Promise<Actor> {
+  public async createActor({ id, namespace }: { id: string; namespace: string }): Promise<Actor> {
     if (this.store.has(id)) {
       return this.getActor({ id })
     }
 
-    const actor = new ActorEnvironment({ id, ...this.options })
+    const actor = new ActorEnvironment({ id, namespace, ...this.options })
     await actor.setup()
     actor.on('closed', () => this.store.delete(id))
     actor.page.on('console', (message) => {

--- a/tests/e2e/support/environment/actor/shared.ts
+++ b/tests/e2e/support/environment/actor/shared.ts
@@ -14,26 +14,24 @@ export interface ActorsOptions {
 
 export interface ActorOptions extends ActorsOptions {
   id: string
+  namespace: string
 }
 
-export const buildBrowserContextOptions = (
-  uuid: string,
-  options: ActorOptions['context']
-): BrowserContextOptions => {
+export const buildBrowserContextOptions = (options: ActorOptions): BrowserContextOptions => {
   const contextOptions: BrowserContextOptions = {
-    acceptDownloads: options.acceptDownloads,
+    acceptDownloads: options.context.acceptDownloads,
     ignoreHTTPSErrors: true
   }
 
-  if (options.reportVideo) {
+  if (options.context.reportVideo) {
     contextOptions.recordVideo = {
-      dir: path.join(options.reportDir, 'playwright', 'video')
+      dir: path.join(options.context.reportDir, 'playwright', 'video')
     }
   }
 
-  if (options.reportHar) {
+  if (options.context.reportHar) {
     contextOptions.recordHar = {
-      path: path.join(options.reportDir, 'playwright', 'har', `${uuid}.har`)
+      path: path.join(options.context.reportDir, 'playwright', 'har', `${options.namespace}.har`)
     }
   }
 


### PR DESCRIPTION
Step 1:
**reduce traces**

The following logic used to work:
- if the test fails and is retry=n, then trace is enabled. 
- Tracing records the next test run (is correct) but continues on the next tests as well

I changed this by adding retry counter. 
logic:
- first test run does not record trace
- after the test falls and Retry = n, in the "After" function enables trace recording for the next run
- trace records for the next run (regardless of whether test passes or falls)
- after all attempts, the recording is turned off

see block diagram: 

![image](https://user-images.githubusercontent.com/84779829/150524807-b8a77b76-c76c-490a-9afd-fd6a8e796489.png)

Step 2:
**add more details to github comments:**

our trace look like: `npx playwright show-trace https://cache.owncloud.com/owncloud/web/tracing/21580/2022-1-5-09-24-50-Alice.zip` 

- add feature name in drone.star is difficult. We know {DRONE_BUILD_LINK}/${DRONE_JOB_NUMBER}${DRONE_STAGE_NUMBER} but to fall in and get the featureName is too difficult
- we have another, easier way. add  featureName to zip file name. like: `2022-1-5-09-24-50-Kindergarten-can-use-web-to-organize-a-day-Alice.zip`. But the name would be too long. What do you think @fschade ?

 If easer way is okay, I need your help to add `this.feature.name` from `tests/e2e/cucumber/environment/index.ts` correctly to `tests/e2e/support/environment/actor/actor.ts `
