### PR TITLE
Fix #6296: Make app config available to app again

### DIFF
--- a/changelog/unreleased/bugfix-application-config
+++ b/changelog/unreleased/bugfix-application-config
@@ -1,0 +1,6 @@
+Bugfix: Application config not available to application
+
+We fixed a bug in providing config to external apps like draw-io.
+
+https://github.com/owncloud/web/issues/6296
+https://github.com/owncloud/web/pull/6298

--- a/packages/web-runtime/src/store/apps.js
+++ b/packages/web-runtime/src/store/apps.js
@@ -52,7 +52,8 @@ const mutations = {
       routes: extension.routes || [],
       extension: extension.extension,
       handler: extension.handler,
-      canBeDefault: extension.canBeDefault !== false
+      canBeDefault: extension.canBeDefault !== false,
+      config: (state.fileEditorConfigs || {})[app]
     }
 
     state.fileEditors.push(editor)
@@ -98,7 +99,8 @@ const mutations = {
       name: appInfo.name || appInfo.id,
       id: appInfo.id,
       icon: appInfo.icon || 'check_box_outline_blank',
-      img: appInfo.img || null
+      img: appInfo.img || null,
+      config: (state.fileEditorConfigs || {})[appInfo.id]
     }
     state.meta[app.id] = app
   },
@@ -107,21 +109,9 @@ const mutations = {
   },
 
   LOAD_EXTENSION_CONFIG(state, { id, config }) {
-    // make available in editors
-    const editors = [...state.fileEditors]
-    for (const editor of editors) {
-      if (editor.app === id) {
-        editor.config = config
-      }
-    }
-    state.fileEditors = editors
-
-    // make available in meta
-    if (state.meta[id]) {
-      const meta = { ...state.meta }
-      meta[id].config = config
-      state.meta = meta
-    }
+    const fileEditorConfigs = { ...state.fileEditorConfigs }
+    fileEditorConfigs[id] = config
+    state.fileEditorConfigs = fileEditorConfigs
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #6296 

## Motivation and Context
The config is loaded before the actual app, so when the old code tried to persist the setting inside the application object inside the store it was not available. That's why we now cache the config and copy it into the app object, once it becomes available. This should be a true drop in change and I don't expect any side effects as we did not change the internal structure of the object in the store.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
