### PR TITLE
Fix publicLinkPassword in apps

### DIFF
--- a/packages/web-pkg/src/composables/useAppDefaults/index.ts
+++ b/packages/web-pkg/src/composables/useAppDefaults/index.ts
@@ -40,10 +40,6 @@ export function useAppDefaults(options: AppDefaultsOptions): AppDefaultsResult {
   })
 
   const publicLinkPassword = computed(() => {
-    if (!store.getters.Files) {
-      return null
-    }
-
     return store.getters['Files/publicLinkPassword']
   })
 

--- a/packages/web-pkg/src/composables/useAppDefaults/useAppFileHandling.ts
+++ b/packages/web-pkg/src/composables/useAppDefaults/useAppFileHandling.ts
@@ -51,7 +51,7 @@ export function useAppFileHandling(options: AppFileHandlingOptions): AppFileHand
 
     // Since the pre-signed url contains query parameters and the caller of this method
     // can also provide query parameters we have to combine them.
-    const combinedQuery = [queryStr, encodeURIComponent(signedQuery)].filter(Boolean).join('&')
+    const combinedQuery = [queryStr, signedQuery].filter(Boolean).join('&')
     return [url, combinedQuery].filter(Boolean).join('?')
   }
 


### PR DESCRIPTION
## Description
Removes a nonsense check from `publicLinkPassword` computed.
The code was just introduced and never released, so we don't need a changelog entry imho.

The second change is unrelated but I stumbled upon this while debugging why files could not be shown in mediaviewer...
It seemed to still work even with the double encoding, so I'm not even sure how to use it to break something, so again no changelog needed imho.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
