### PR TITLE
[tests-only][full-ci] Fix version download acceptance test

### DIFF
--- a/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
+++ b/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
@@ -192,6 +192,3 @@ Other free text and markdown formatting can be used elsewhere in the document if
 - [webUISharingFilePermissionsGroups/sharePermissionsGroup.feature:65](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingFilePermissionsGroups/sharePermissionsGroup.feature#L65)
 - [webUISharingFilePermissionsGroups/sharePermissionsGroup.feature:66](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingFilePermissionsGroups/sharePermissionsGroup.feature#L66)
 - [webUISharingPermissionToRoot/shareFileWithMultipleUsers.feature:66](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPermissionToRoot/shareFileWithMultipleUsers.feature#L66)
-
-### [downloading an old version of a file returns 501](https://github.com/owncloud/ocis/issues/2261)
--   [webUIFilesActionMenu/versions.feature:107](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L107)

--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -112,7 +112,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIFilesActionMenu/versions.feature:63](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L63)
 
 ### [downloading an old version of a file returns 501](https://github.com/owncloud/ocis/issues/2261)
--   [webUIFilesActionMenu/versions.feature:107](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L107)
+-   [webUIFilesActionMenu/versions.feature:105](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L105)
 
 ### [No occ command in ocis](https://github.com/owncloud/ocis/issues/1317)
 -   [webUIRestrictSharing/restrictReSharing.feature:23](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature#L23)
@@ -197,7 +197,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:313](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L313)
 -   [webUIMoveFilesFolders/moveFiles.feature:97](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature#L97)
 -   [webUIMoveFilesFolders/moveFolders.feature:72](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature#L72)
--   [webUIFilesActionMenu/versions.feature:94](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L94)
+-   [webUIFilesActionMenu/versions.feature:93](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesActionMenu/versions.feature#L93)
 
 ### [Accepting different shares with same filename from different users overwrites one file](https://github.com/owncloud/ocis/issues/713)
 -   [webUISharingAcceptShares/acceptShares.feature:212](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature#L212)

--- a/tests/acceptance/features/webUIFilesActionMenu/versions.feature
+++ b/tests/acceptance/features/webUIFilesActionMenu/versions.feature
@@ -89,7 +89,6 @@ Feature: Versions of a file
     And the user browses to display the "versions" details of file "lorem.txt"
     Then the versions list should contain 1 entries
 
-
   @issue-ocis-1328 @disablePreviews
   Scenario: sharee can see the versions of a file
     Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes"
@@ -103,11 +102,10 @@ Feature: Versions of a file
     And the versions list should contain 2 entries
 
 
-  @issue-ocis-2261
   Scenario: user downloads a previous version of the file
     Given user "Alice" has uploaded file with content "lorem" to "lorem.txt" in the server
     And user "Alice" has uploaded file with content "lorem content" to "lorem.txt" in the server
     And user "Alice" has logged in using the webUI
     And the user browses to display the "versions" details of file "lorem.txt"
     When the user downloads a previous version of the file using the webUI
-    Then as "Alice" the content of "lorem.txt" should be the same as the content of local file "lorem.txt"
+    Then no message should be displayed on the webUI

--- a/tests/acceptance/pageObjects/webPage.js
+++ b/tests/acceptance/pageObjects/webPage.js
@@ -231,6 +231,26 @@ module.exports = {
         })
       })
       return messages
+    },
+    hasErrorMessage: async function (expectedVisible = true) {
+      let visible = false
+      let timeout = 5000
+      if (!expectedVisible) {
+        timeout = 500
+      }
+
+      const selector = {
+        selector: this.elements.message.selector,
+        locateStrategy: this.elements.message.locateStrategy
+      }
+
+      await this.isVisible(
+        { ...selector, suppressNotFoundErrors: !expectedVisible, timeout },
+        function ({ value }) {
+          visible = value === true
+        }
+      )
+      return visible
     }
   },
   elements: {

--- a/tests/acceptance/stepDefinitions/generalContext.js
+++ b/tests/acceptance/stepDefinitions/generalContext.js
@@ -128,8 +128,10 @@ When('the user clears all error message from the webUI', function () {
   return client.page.webPage().clearAllErrorMessages()
 })
 
-Then('no message should be displayed on the webUI', function () {
-  return client.page.webPage().expect.element('@message').to.not.be.present
+Then('no message should be displayed on the webUI', async function () {
+  const hasMessage = await client.page.webPage().hasErrorMessage(false)
+  assert.strictEqual(hasMessage, false, 'Expected no messages but a message is displayed.')
+  return this
 })
 
 Then(


### PR DESCRIPTION
## Description
Scenario `user downloads a previous version of the file` works for `oC10` server. 
`Then as "Alice" the content of "lorem.txt" should be the same as the content of local file "lorem.txt"` step is not relevant for that scenario.
I have removed that step and implemented a step that checks for error popup which is done for other download scenarios:
```
...
When the user downloads file "sample.txt" using the webUI
Then no message should be displayed on the webUI
```

## Related Issue

## How Has This Been Tested?
- test environment: local & CI

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
