### PR TITLE
[tests-only][full-ci] Bump middleware image from 1.2.0 to 1.2.1

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -9,7 +9,7 @@ OC_CI_GOLANG = "owncloudci/golang:1.17"
 OC_CI_NODEJS = "owncloudci/nodejs:14"
 OC_CI_PHP = "owncloudci/php:7.4"
 OC_CI_WAIT_FOR = "owncloudci/wait-for:latest"
-OC_TESTING_MIDDLEWARE = "owncloud/owncloud-test-middleware:1.2.0"
+OC_TESTING_MIDDLEWARE = "owncloud/owncloud-test-middleware:1.2.1"
 OC_UBUNTU = "owncloud/ubuntu:20.04"
 
 OC10_VERSION = "latest"


### PR DESCRIPTION
## Description
Bump middleware docker image from 1.2.0 to 1.2.1 for tests

## Related Issue

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
