### PR TITLE
Context route auth redirect

### DIFF
--- a/changelog/unreleased/enhancement-context-route-auth-redirect
+++ b/changelog/unreleased/enhancement-context-route-auth-redirect
@@ -1,0 +1,7 @@
+Enhancement: Redirect to IDP when opening apps from bookmark
+
+We've expanded the check for authentication requirements to the referrer of the current URL. As a result an app that doesn't necessarily require authentication can still require authentication based on the file context it was opened in. This is especially important for situations where an app is opened for a file from a bookmark, so that we cannot rely on the user already having an authenticated session.
+
+https://github.com/owncloud/web/issues/6045
+https://github.com/owncloud/web/issues/6069
+https://github.com/owncloud/web/pull/6314

--- a/packages/web-app-external/src/components/LoadingScreen.vue
+++ b/packages/web-app-external/src/components/LoadingScreen.vue
@@ -4,3 +4,9 @@
     <p v-translate class="oc-invisible">Loading app</p>
   </div>
 </template>
+
+<script>
+export default {
+  name: 'LoadingScreen'
+}
+</script>

--- a/packages/web-app-external/src/index.js
+++ b/packages/web-app-external/src/index.js
@@ -15,13 +15,13 @@ const appInfo = {
 const routes = [
   {
     name: 'apps',
-    path: '/:file_id/:app?',
+    path: '/:contextRouteName/:file_id/:app?',
     components: {
       app: App
     },
     meta: {
-      title: $gettext('External app'),
-      auth: false
+      auth: false,
+      title: $gettext('External app')
     }
   }
 ]

--- a/packages/web-app-files/src/mixins/fileActions.js
+++ b/packages/web-app-files/src/mixins/fileActions.js
@@ -241,6 +241,7 @@ export default {
       const routeData = this.$router.resolve({
         name: 'external-apps',
         params: {
+          contextRouteName: this.$route.name,
           file_id: resourceId,
           app: appName
         },


### PR DESCRIPTION
## Description
This PR includes the contextRoute of the next route when checking if authentication is required.

In the (hopefully very near) future this can be expanded to public links with password protection. But for now this simple PR solves the case of bookmarks to editors having a file open from a private context.

## Related Issue
- Fixes #6045
- Fixes #6069

## How Has This Been Tested?
- manually... I don't see much room for tests in the current state of the implementation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
