### PR TITLE
[deployment-examples] fix basic auth and remove proxy restart

### DIFF
--- a/deployments/examples/ocis_web/config/ocis/entrypoint-override.sh
+++ b/deployments/examples/ocis_web/config/ocis/entrypoint-override.sh
@@ -21,8 +21,4 @@ ocis accounts update --password $STORAGE_LDAP_BIND_PASSWORD $REVA_USER_UUID
 echo "default secrets changed"
 echo "##################################################"
 
-ocis kill proxy
-sleep 10
-ocis proxy server # workaround for loading proxy configuration
-
 wait # wait for oCIS to exit

--- a/deployments/examples/ocis_web/docker-compose.yml
+++ b/deployments/examples/ocis_web/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - "certs:/certs"
     labels:
       - "traefik.enable=${TRAEFIK_DASHBOARD:-false}"
-      - "traefik.http.middlewares.traefik-auth.basicauth.users=${TRAEFIK_BASIC_AUTH_USERS:-admin:$apr1$4vqie50r$YQAmQdtmz5n9rEALhxJ4l.}" # defaults to admin:admin
+      - "traefik.http.middlewares.traefik-auth.basicauth.users=${TRAEFIK_BASIC_AUTH_USERS:-admin:$$apr1$$4vqie50r$$YQAmQdtmz5n9rEALhxJ4l.}" # defaults to admin:admin
       - "traefik.http.routers.traefik.entrypoints=https"
       - "traefik.http.routers.traefik.rule=Host(`${TRAEFIK_DOMAIN:-traefik.owncloud.test}`)"
       - "traefik.http.routers.traefik.middlewares=traefik-auth"


### PR DESCRIPTION
## Description
fix basic auth escaping and remove proxy restart workaround (since no longer needed)

## Motivation and Context
sometimes only the proxy started on the continuously deployed server

