### PR TITLE
[tests-only] [full-ci] Adjust test to avoid issue 6305

### DIFF
--- a/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
+++ b/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
@@ -36,7 +36,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIFilesDetails/fileDetails.feature:153](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesDetails/fileDetails.feature#L153)
 
 ### [Tags page not implemented yet](https://github.com/owncloud/web/issues/5017)
--   [webUIDeleteFilesFolders/deleteFilesFolders.feature:136](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L136)
+-   [webUIDeleteFilesFolders/deleteFilesFolders.feature:145](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L145)
 -   [webUIFilesSearch/search.feature:63](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L63)
 -   [webUIFilesSearch/search.feature:71](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L71)
 -   [webUIFilesSearch/search.feature:84](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L84)

--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -373,7 +373,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUITrashbinDelete/trashbinDelete.feature:48](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITrashbinDelete/trashbinDelete.feature#L48)
 
 ### [Tags page not implemented yet](https://github.com/owncloud/web/issues/5017)
--   [webUIDeleteFilesFolders/deleteFilesFolders.feature:136](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L136)
+-   [webUIDeleteFilesFolders/deleteFilesFolders.feature:145](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L145)
 -   [webUIFilesSearch/search.feature:63](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L63)
 -   [webUIFilesSearch/search.feature:71](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L71)
 -   [webUIFilesSearch/search.feature:84](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L84)
@@ -510,6 +510,3 @@ Other free text and markdown formatting can be used elsewhere in the document if
 
 ### [web config update is not properly reflected after the ocis start](https://github.com/owncloud/ocis/issues/2944)
 -   [webUIFiles/breadcrumb.feature:50](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFiles/breadcrumb.feature#L50)
-
-### [Selecting delete all](https://github.com/owncloud/web/issues/6305)
--  [webUIDeleteFilesFolders/deleteFilesFolders.feature:77](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L77)

--- a/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
@@ -74,15 +74,24 @@ Feature: deleting files and folders
     And no message should be displayed on the webUI
 
   @skipOnOC10 @issue-4582
-  Scenario: Delete all files at once
+  Scenario: Delete all files at once at the root level
     Given user "Alice" has uploaded file "data.zip" to "data.zip" in the server
     And user "Alice" has created file "lorem.txt" in the server
     And user "Alice" has created folder "simple-folder" in the server
     And the user has browsed to the files page
     When the user marks all files for batch action using the webUI
+    # Shares is a special folder that cannot be deleted on oCIS
+    # The user has to unmark it in order to "delete all" the rest of the items
+    # See discussion in web issue 6305.
+    And the user unmarks these files for batch action using the webUI
+      | name          |
+      | Shares        |
     And the user batch deletes the marked files using the webUI
-    And there should be no resources listed on the webUI
-    And there should be no resources listed on the webUI after a page reload
+    Then as "Alice" file "data.zip" should not exist in the server
+    And as "Alice" file "lorem.txt" should not exist in the server
+    And as "Alice" folder "simple-folder" should not exist in the server
+    And file "data.zip" should not be listed on the webUI
+    And the count of files and folders shown on the webUI should be 2
     And no message should be displayed on the webUI
 
   @ocis-reva-issue-106 @ocis-reve-issue-442 @skipOnOC10 @issue-4582


### PR DESCRIPTION
## Description
Adjust the test for "delete all" batch action to take into account that the `Shares` folder cannot be deleted.
The test workflow now does "select all" and then unselects the `Shares` folder, then deletes the remaining items.

See issue comment https://github.com/owncloud/web/issues/6305#issuecomment-1022217793 and the other discussion in the issue.

## Related Issue
#6305 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
