### PR TITLE
Fix update of favorite star in right sidebar after click

### DIFF
--- a/changelog/unreleased/bugfix-favorite-action
+++ b/changelog/unreleased/bugfix-favorite-action
@@ -1,0 +1,8 @@
+Bugfix: Add and remove to/from favorites
+
+We've fixed bugs related to adding and removing files to/from favorites:
+- "favorite" star button in the right sidebar of the files app was not being updated when the favorite-state was modified through a click on the star icon
+- toggling the favorites state of the current folder was broken (via both context menu on current folder and right sidebar without a file selection)
+
+https://github.com/owncloud/web/issues/6328
+https://github.com/owncloud/web/pull/6330

--- a/changelog/unreleased/bugfix-favorite-star-sidebar
+++ b/changelog/unreleased/bugfix-favorite-star-sidebar
@@ -1,0 +1,6 @@
+Bugfix: Favorite-star in right sidebar
+
+We've fixed a bug that caused the "favorite" star in the right sidebar of the files app not to be updated when the favorite-state was modified through a click on the star icon.
+
+https://github.com/owncloud/web/issues/6328
+https://github.com/owncloud/web/pull/6330

--- a/changelog/unreleased/bugfix-favorite-star-sidebar
+++ b/changelog/unreleased/bugfix-favorite-star-sidebar
@@ -1,6 +1,0 @@
-Bugfix: Favorite-star in right sidebar
-
-We've fixed a bug that caused the "favorite" star in the right sidebar of the files app not to be updated when the favorite-state was modified through a click on the star icon.
-
-https://github.com/owncloud/web/issues/6328
-https://github.com/owncloud/web/pull/6330

--- a/packages/web-app-files/src/components/SideBar/FileInfo.vue
+++ b/packages/web-app-files/src/components/SideBar/FileInfo.vue
@@ -23,15 +23,11 @@
       </p>
     </div>
     <oc-button
-      v-if="!publicPage() && isFavoritesEnabled"
-      :aria-label="
-        file.starred
-          ? $gettext('Click to remove this file from your favorites')
-          : $gettext('Click to mark this file as favorite')
-      "
+      v-if="favoriteAction.isEnabled({ resources: [file] })"
+      :aria-label="favoriteAction.label({ resources: [file] })"
       appearance="raw"
       class="file_info__favorite"
-      @click.native.stop="toggleFileFavorite(file)"
+      @click="$_favorite_trigger({ resources: [file] })"
     >
       <oc-icon :class="file.starred ? 'oc-star-shining' : 'oc-star-dimm'" name="star" />
     </oc-button>
@@ -39,14 +35,14 @@
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex'
 import Mixins from '../../mixins'
 import MixinResources from '../../mixins/resources'
-import { isLocationCommonActive, isLocationSharesActive } from '../../router'
+import MixinFavorite from '../../mixins/actions/favorite'
+import { isLocationCommonActive } from '../../router'
 
 export default {
   name: 'FileInfo',
-  mixins: [Mixins, MixinResources],
+  mixins: [Mixins, MixinResources, MixinFavorite],
   inject: ['displayedItem'],
   props: {
     isContentDisplayed: {
@@ -55,7 +51,6 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(['capabilities']),
     timeData() {
       const interpolate = (obj) => {
         obj.time = this.formDateFromRFC(obj.sourceTime)
@@ -89,29 +84,13 @@ export default {
         )
       })
     },
-    isFavoritesEnabled() {
-      return (
-        this.capabilities.files &&
-        this.capabilities.files.favorites &&
-        this.isContentDisplayed &&
-        !isLocationSharesActive(this.$router, 'files-shares-with-me', 'files-shares-with-others') &&
-        !isLocationCommonActive(this.$router, 'files-common-trash')
-      )
+
+    favoriteAction() {
+      return this.$_favorite_items[0]
     },
 
     file() {
       return this.displayedItem.value
-    }
-  },
-  methods: {
-    ...mapActions('Files', ['markFavorite']),
-    toggleFileFavorite(file) {
-      this.markFavorite({
-        client: this.$client,
-        file: file
-      }).then(() => {
-        this.$set(this.file, 'starred', !this.file.starred)
-      })
     }
   }
 }

--- a/packages/web-app-files/src/components/SideBar/SideBar.vue
+++ b/packages/web-app-files/src/components/SideBar/SideBar.vue
@@ -191,6 +191,9 @@ export default {
     },
     highlightedFileThumbnail() {
       return this.highlightedFile?.thumbnail
+    },
+    highlightedFileFavorite() {
+      return this.highlightedFile?.starred
     }
   },
   watch: {
@@ -212,6 +215,10 @@ export default {
 
     highlightedFileThumbnail(thumbnail) {
       this.$set(this.selectedFile, 'thumbnail', thumbnail)
+    },
+
+    highlightedFileFavorite(starred) {
+      this.$set(this.selectedFile, 'starred', starred)
     }
   },
 

--- a/packages/web-app-files/src/mixins/actions/favorite.js
+++ b/packages/web-app-files/src/mixins/actions/favorite.js
@@ -3,7 +3,6 @@ import { mapActions } from 'vuex'
 import { isLocationCommonActive, isLocationSpacesActive } from '../../router'
 
 export default {
-  inject: { displayedItem: { default: null } },
   computed: {
     $_favorite_items() {
       return [
@@ -45,20 +44,14 @@ export default {
       this.markFavorite({
         client: this.$client,
         file: resources[0]
+      }).catch(() => {
+        const translated = this.$gettext('Failed to change favorite state of "%{file}"')
+        const title = this.$gettextInterpolate(translated, { file: resources[0].name }, true)
+        this.showMessage({
+          title: title,
+          status: 'danger'
+        })
       })
-        .then(() => {
-          if (this.displayedItem) {
-            this.displayedItem.value.starred = !this.displayedItem.value.starred
-          }
-        })
-        .catch(() => {
-          const translated = this.$gettext('Failed to change favorite state of "%{file}"')
-          const title = this.$gettextInterpolate(translated, { file: resources[0].name }, true)
-          this.showMessage({
-            title: title,
-            status: 'danger'
-          })
-        })
     }
   }
 }

--- a/packages/web-app-files/src/mixins/fileActions.js
+++ b/packages/web-app-files/src/mixins/fileActions.js
@@ -52,7 +52,6 @@ export default {
   computed: {
     ...mapState(['apps']),
     ...mapGetters('Files', ['highlightedFile', 'currentFolder']),
-    ...mapGetters('External', ['mimeTypes']),
     ...mapGetters(['capabilities', 'configuration']),
 
     $_fileActions_systemActions() {
@@ -206,15 +205,16 @@ export default {
       }
 
       const { mimeType, fileId } = resources[0]
+      const mimeTypes = this.$store.getters['External/mimeTypes'] || []
       if (
         mimeType === undefined ||
         !get(this, 'capabilities.files.app_providers') ||
-        !get(this, 'mimeTypes', []).length
+        !mimeTypes.length
       ) {
         return []
       }
 
-      const filteredMimeTypes = this.mimeTypes.find((t) => t.mime_type === mimeType)
+      const filteredMimeTypes = mimeTypes.find((t) => t.mime_type === mimeType)
       if (filteredMimeTypes === undefined) {
         return []
       }

--- a/packages/web-app-files/src/store/actions.js
+++ b/packages/web-app-files/src/store/actions.js
@@ -46,7 +46,11 @@ export default {
     return client.files
       .favorite(file.path, newValue)
       .then(() => {
-        context.commit('FAVORITE_FILE', file)
+        context.commit('UPDATE_RESOURCE_FIELD', {
+          id: file.id,
+          field: 'starred',
+          value: newValue
+        })
       })
       .catch((error) => {
         throw new Error(error)

--- a/packages/web-app-files/src/store/mutations.js
+++ b/packages/web-app-files/src/store/mutations.js
@@ -300,10 +300,15 @@ export default {
    * @param params.value the value that will be attached to the key
    */
   UPDATE_RESOURCE_FIELD(state, params) {
-    const fileSource = state.filesSearched || state.files
-    const index = fileSource.findIndex((r) => r.id === params.id)
+    let fileSource = state.filesSearched || state.files
+    let index = fileSource.findIndex((r) => r.id === params.id)
     if (index < 0) {
-      return
+      if (state.currentFolder?.id === params.id) {
+        fileSource = [state.currentFolder]
+        index = 0
+      } else {
+        return
+      }
     }
 
     const resource = fileSource[index]

--- a/packages/web-app-files/src/store/mutations.js
+++ b/packages/web-app-files/src/store/mutations.js
@@ -98,14 +98,6 @@ export default {
   RESET_SELECTION(state) {
     state.selectedIds = []
   },
-  FAVORITE_FILE(state, item) {
-    const files = [...state.files]
-    const fileIndex = files.findIndex((f) => {
-      return f.id === item.id
-    })
-    files[fileIndex].starred = !item.starred
-    state.files = files
-  },
   REMOVE_FILE(state, removedFile) {
     state.files = [...state.files].filter((file) => file.id !== removedFile.id)
   },


### PR DESCRIPTION
## Description
The favorite star in the right sidebar caused an error on click and didn't update itself then. This PR fixes that. Used to chance to clean up some code fragments on the way.

## Related Issue
- Fixes #6328

## Motivation and Context
Hardening

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
