### PR TITLE
[full-ci] Context Route Params

### DIFF
--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -82,10 +82,10 @@ export default {
       })
     },
     appName() {
-      return this.$route.params.app
+      return this.$route.params.appName
     },
     fileId() {
-      return this.$route.params.file_id
+      return this.$route.params.fileId
     }
   },
   async created() {

--- a/packages/web-app-external/src/index.js
+++ b/packages/web-app-external/src/index.js
@@ -15,7 +15,7 @@ const appInfo = {
 const routes = [
   {
     name: 'apps',
-    path: '/:contextRouteName/:file_id/:app?',
+    path: '/:contextRouteName/:fileId/:appName?',
     components: {
       app: App
     },

--- a/packages/web-app-external/tests/unit/app.spec.js
+++ b/packages/web-app-external/tests/unit/app.spec.js
@@ -21,8 +21,8 @@ const $route = {
     'public-token': 'a-token'
   },
   params: {
-    app: 'exampleApp',
-    file_id: '2147491323'
+    appName: 'exampleApp',
+    fileId: '2147491323'
   }
 }
 

--- a/packages/web-app-files/src/mixins/fileActions.js
+++ b/packages/web-app-files/src/mixins/fileActions.js
@@ -114,7 +114,6 @@ export default {
 
     $_fileActions__routeOpts(app, filePath, fileId, mode) {
       const route = this.$route
-      const { item, ...params } = route.params
 
       return {
         name: app.routeName || app.app,
@@ -124,8 +123,7 @@ export default {
           mode,
           contextRouteName: this.$route.name
         },
-        query: convertRouteParamsToContextQuery(params)
-        }
+        query: convertRouteParamsToContextQuery(route.params)
       }
     },
 

--- a/packages/web-app-files/src/mixins/fileActions.js
+++ b/packages/web-app-files/src/mixins/fileActions.js
@@ -256,12 +256,7 @@ export default {
         undefined
       )
 
-      routeOpts.params = {
-        ...routeOpts.params,
-        app: appName,
-        // FIXME: remove file_id fallback when we are sure noone is using it anymore
-        file_id: routeOpts.params.fileId
-      }
+      routeOpts.params.appName = appName
 
       routeOpts.query = {
         ...routeOpts.query,

--- a/packages/web-pkg/src/composables/appDefaults/index.ts
+++ b/packages/web-pkg/src/composables/appDefaults/index.ts
@@ -1,62 +1,6 @@
-import { computed, unref, Ref } from '@vue/composition-api'
-import { useRouter } from '../router'
-import { useStore } from '../store'
-import { ClientService, clientService as defaultClientService } from '../../services'
-
-import { FileContext } from './types'
-import { useAppNavigation, AppNavigationResult } from './useAppNavigation'
-import { useAppConfig, AppConfigResult } from './useAppConfig'
-import { useAppFileHandling, AppFileHandlingResult } from './useAppFileHandling'
-import { useAppFolderHandling, AppFolderHandlingResult } from './useAppFolderHandling'
-
-// TODO: this file/folder contains file/folder loading logic extracted from mediaviewer and drawio extensions
-// Discussion how to progress from here can be found in this issue:
-// https://github.com/owncloud/web/issues/3301
-
-interface AppDefaultsOptions {
-  applicationName: string
-  clientService?: ClientService
-}
-
-type AppDefaultsResult = AppConfigResult &
-  AppNavigationResult &
-  AppFileHandlingResult &
-  AppFolderHandlingResult & {
-    isPublicLinkContext: Ref<boolean>
-    currentFileContext: Ref<FileContext>
-  }
-
-export function useAppDefaults(options: AppDefaultsOptions): AppDefaultsResult {
-  const router = useRouter()
-  const store = useStore()
-  const clientService = options.clientService || defaultClientService
-
-  const currentRoute = computed(() => {
-    return router.currentRoute
-  })
-
-  const isPublicLinkContext = computed(() => {
-    return unref(currentRoute).params.contextRouteName === 'files-public-files'
-  })
-
-  const publicLinkPassword = computed(() => {
-    return store.getters['Files/publicLinkPassword']
-  })
-
-  const currentFileContext = computed((): FileContext => {
-    return {
-      routeName: unref(currentRoute).params.contextRouteName,
-      path: `/${unref(currentRoute).params.filePath.split('/').filter(Boolean).join('/')}`
-    }
-  })
-
-  return {
-    isPublicLinkContext,
-    currentFileContext,
-
-    ...useAppConfig({ store, ...options }),
-    ...useAppNavigation({ router, currentFileContext }),
-    ...useAppFileHandling({ clientService, store, isPublicLinkContext, publicLinkPassword }),
-    ...useAppFolderHandling({ clientService, store, isPublicLinkContext, publicLinkPassword })
-  }
-}
+export * from './types'
+export * from './useAppConfig'
+export * from './useAppDefaults'
+export * from './useAppFileHandling'
+export * from './useAppFolderHandling'
+export * from './useAppNavigation'

--- a/packages/web-pkg/src/composables/appDefaults/types.ts
+++ b/packages/web-pkg/src/composables/appDefaults/types.ts
@@ -1,6 +1,7 @@
 import { MaybeRef } from '../../utils'
-
+import { LocationParams } from '../router'
 export interface FileContext {
   path: MaybeRef<string>
   routeName: MaybeRef<string>
+  routeParams: MaybeRef<LocationParams>
 }

--- a/packages/web-pkg/src/composables/appDefaults/useAppDefaults.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppDefaults.ts
@@ -1,0 +1,67 @@
+import { computed, unref, Ref } from '@vue/composition-api'
+import { useRouter } from '../router'
+import { useStore } from '../store'
+import { ClientService, clientService as defaultClientService } from '../../services'
+
+import { FileContext } from './types'
+import {
+  useAppNavigation,
+  AppNavigationResult,
+  convertContextQueryToRouteParams
+} from './useAppNavigation'
+import { useAppConfig, AppConfigResult } from './useAppConfig'
+import { useAppFileHandling, AppFileHandlingResult } from './useAppFileHandling'
+import { useAppFolderHandling, AppFolderHandlingResult } from './useAppFolderHandling'
+
+// TODO: this file/folder contains file/folder loading logic extracted from mediaviewer and drawio extensions
+// Discussion how to progress from here can be found in this issue:
+// https://github.com/owncloud/web/issues/3301
+
+interface AppDefaultsOptions {
+  applicationName: string
+  clientService?: ClientService
+}
+
+type AppDefaultsResult = AppConfigResult &
+  AppNavigationResult &
+  AppFileHandlingResult &
+  AppFolderHandlingResult & {
+    isPublicLinkContext: Ref<boolean>
+    currentFileContext: Ref<FileContext>
+  }
+
+export function useAppDefaults(options: AppDefaultsOptions): AppDefaultsResult {
+  const router = useRouter()
+  const store = useStore()
+  const clientService = options.clientService || defaultClientService
+
+  const currentRoute = computed(() => {
+    return router.currentRoute
+  })
+
+  const isPublicLinkContext = computed(() => {
+    return unref(currentRoute).params.contextRouteName === 'files-public-files'
+  })
+
+  const publicLinkPassword = computed(() => {
+    return store.getters['Files/publicLinkPassword']
+  })
+
+  const currentFileContext = computed((): FileContext => {
+    return {
+      path: `/${unref(currentRoute).params.filePath.split('/').filter(Boolean).join('/')}`,
+      routeName: unref(currentRoute).params.contextRouteName,
+      routeParams: convertContextQueryToRouteParams(unref(currentRoute).query)
+    }
+  })
+
+  return {
+    isPublicLinkContext,
+    currentFileContext,
+
+    ...useAppConfig({ store, ...options }),
+    ...useAppNavigation({ router, currentFileContext }),
+    ...useAppFileHandling({ clientService, store, isPublicLinkContext, publicLinkPassword }),
+    ...useAppFolderHandling({ clientService, store, isPublicLinkContext, publicLinkPassword })
+  }
+}

--- a/packages/web-pkg/src/composables/appDefaults/useAppNavigation.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppNavigation.ts
@@ -4,6 +4,7 @@ import VueRouter from 'vue-router'
 
 import { MaybeRef } from '../../utils'
 import { FileContext } from './types'
+import { LocationQuery, LocationParams } from '../router'
 
 interface AppNavigationOptions {
   router: VueRouter
@@ -14,20 +15,46 @@ export interface AppNavigationResult {
   closeApp(): void
 }
 
+const paramsKey = 'params'
+
+export const convertRouteParamsToContextQuery = (routeParams: LocationParams): LocationQuery => {
+  const query = {}
+  Object.keys(routeParams).forEach((key) => {
+    query[`${paramsKey}[${key}]`] = routeParams[key]
+  })
+  return query
+}
+
+export const convertContextQueryToRouteParams = (query: LocationQuery): LocationParams => {
+  const routeParams = {}
+  const paramRegexp = new RegExp(`${paramsKey}\\[(.*)\\]`)
+  Object.keys(query).forEach((paramName) => {
+    const routeParamName = (paramName.match(paramRegexp) || [] )[1]
+    if (routeParamName) {
+      routeParams[routeParamName] = query[paramName]
+    }
+  })
+  return routeParams
+}
+
 export function useAppNavigation(options: AppNavigationOptions): AppNavigationResult {
   const navigateToContext = (context: MaybeRef<FileContext>) => {
     const router = options.router
 
-    const { path, routeName } = unref(context)
-    return router.push({
+    const { path, routeName, routeParams } = unref(context)
+
+    const pushOpts = {
       name: unref(routeName),
       params: {
-        item: dirname(unref(path)) || '/'
+        item: dirname(unref(path)) || '/',
+        ...unref(routeParams)
       },
       query: {
         scrollTo: basename(unref(path))
       }
-    })
+    }
+
+    return router.push(pushOpts)
   }
 
   const closeApp = () => {

--- a/packages/web-pkg/src/composables/appDefaults/useAppNavigation.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppNavigation.ts
@@ -45,10 +45,7 @@ export function useAppNavigation(options: AppNavigationOptions): AppNavigationRe
 
     const pushOpts = {
       name: unref(routeName),
-      params: {
-        item: dirname(unref(path)) || '/',
-        ...unref(routeParams)
-      },
+      params: unref(routeParams),
       query: {
         scrollTo: basename(unref(path))
       }

--- a/packages/web-pkg/src/composables/appDefaults/useAppNavigation.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppNavigation.ts
@@ -1,5 +1,5 @@
 import { unref } from '@vue/composition-api'
-import { basename, dirname } from 'path'
+import { basename } from 'path'
 import VueRouter from 'vue-router'
 
 import { MaybeRef } from '../../utils'
@@ -15,7 +15,7 @@ export interface AppNavigationResult {
   closeApp(): void
 }
 
-const paramsKey = 'params'
+const paramsKey = 'contextRouteParams'
 
 export const convertRouteParamsToContextQuery = (routeParams: LocationParams): LocationQuery => {
   const query = {}
@@ -29,7 +29,7 @@ export const convertContextQueryToRouteParams = (query: LocationQuery): Location
   const routeParams = {}
   const paramRegexp = new RegExp(`${paramsKey}\\[(.*)\\]`)
   Object.keys(query).forEach((paramName) => {
-    const routeParamName = (paramName.match(paramRegexp) || [] )[1]
+    const routeParamName = (paramName.match(paramRegexp) || [])[1]
     if (routeParamName) {
       routeParams[routeParamName] = query[paramName]
     }

--- a/packages/web-pkg/src/composables/appDefaults/useAppNavigation.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppNavigation.ts
@@ -43,15 +43,13 @@ export function useAppNavigation(options: AppNavigationOptions): AppNavigationRe
 
     const { path, routeName, routeParams } = unref(context)
 
-    const pushOpts = {
+    return router.push({
       name: unref(routeName),
       params: unref(routeParams),
       query: {
         scrollTo: basename(unref(path))
       }
-    }
-
-    return router.push(pushOpts)
+    })
   }
 
   const closeApp = () => {

--- a/packages/web-pkg/src/composables/router/index.ts
+++ b/packages/web-pkg/src/composables/router/index.ts
@@ -1,3 +1,4 @@
+export * from './types'
 export * from './useRouteName'
 export * from './useRouteQuery'
 export * from './useRouteQueryPersisted'

--- a/packages/web-pkg/src/composables/router/types.ts
+++ b/packages/web-pkg/src/composables/router/types.ts
@@ -1,0 +1,8 @@
+
+type Dictionary<T> = { [key: string]: T }
+
+export type QueryValue = string | (string | null)[]
+export type LocationQuery = Dictionary<QueryValue>
+
+export type ParamValue = string
+export type LocationParams = Dictionary<ParamValue>

--- a/packages/web-pkg/src/composables/router/types.ts
+++ b/packages/web-pkg/src/composables/router/types.ts
@@ -1,4 +1,3 @@
-
 type Dictionary<T> = { [key: string]: T }
 
 export type QueryValue = string | (string | null)[]

--- a/packages/web-pkg/src/composables/router/useRouteQuery.ts
+++ b/packages/web-pkg/src/composables/router/useRouteQuery.ts
@@ -1,7 +1,6 @@
 import { customRef, Ref } from '@vue/composition-api'
 import { useRouter } from './useRouter'
-
-export type QueryValue = string | (string | null)[]
+import { QueryValue } from './types'
 
 export const useRouteQuery = (name: string, defaultValue?: QueryValue): Ref<QueryValue> => {
   const router = useRouter()

--- a/packages/web-pkg/src/composables/router/useRouteQueryPersisted.ts
+++ b/packages/web-pkg/src/composables/router/useRouteQueryPersisted.ts
@@ -1,5 +1,6 @@
 import { Ref, watch, unref } from '@vue/composition-api'
-import { QueryValue, useRouteQuery } from './useRouteQuery'
+import { useRouteQuery } from './useRouteQuery'
+import { QueryValue } from './types'
 import { useLocalStorage } from '../localStorage'
 
 export interface RouteQueryPersistedOptions {

--- a/tests/acceptance/features/webUICreateFilesFolders/createFile.feature
+++ b/tests/acceptance/features/webUICreateFilesFolders/createFile.feature
@@ -35,5 +35,5 @@ Feature: create files
     Then there should be no resources listed on the webUI
     When the user creates a markdown file with the name "sample.md" using the webUI
     And the user closes the text editor using the webUI
-    Then the user should be in the root directory on the webUI
-    # Then breadcrumb for folder "parent-folder" should be displayed on the webUI
+    Then breadcrumb for folder "parent-folder" should be displayed on the webUI
+    And file "sample.md" should be listed on the webUI


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This adds `params` of the source context route to the `query` of app routes and converts them back to params when routing back to the origin.

For example, if I open `/Memes/itssomething.jpg` in my personal files in the mediaviewer, the URL will look like this:
`https://host.docker.internal:9200/#/mediaviewer/files-spaces-personal-home/Memes/itssomething.jpg?params%5Bstorage%5D=home&params%5Bitem%5D=Memes`

Unfortunately there does not seem to be a built-in way for `vue-router` to handle maps in `query`, that makes everything a bit ugly and especially it does not allow us to *not* *escape* `[]`. We could potentially implement [parseQuery/stringifyQuery](https://router.vuejs.org/api/#parsequery-stringifyquery) to make the handling code less awkward and to allow a url like:
`https://host.docker.internal:9200/#/mediaviewer/files-spaces-personal-home/Memes/itssomething.jpg?params[storage]=home&params[item]=Memes`

Getting that right might not be completely trivial and we probably want to rely on a library for that. As the `query-string` library we're using does not support that either, we might want to switch to https://www.npmjs.com/package/qs which seems to support this.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
We need the `params[storage]=home` information to properly route back to personal view. It becomes even more important as soon as we support more spaces.
Moreover, we have the very same issue when opening a file from search.

In my first commit I explicitly excluded the `item` query param because we handled that already in `useAppNavigation` but that was always a hack and it seems like a way better idea to just pass in what the route currently has instead of losing that information and then trying to be smart afterwards. The only downside is a slightly longer URL, that's why I kept it in a separate commit so it's easily individually revertable in case you disagree with that change.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- tested with mediaviewer and personal files
- *NOT* *TESTED* with `external-apps`. Could anyone check WOPI setups are still working e.g.?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
