### PR TITLE
[tests-only] Refactor local file involving steps

### DIFF
--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -62,16 +62,16 @@ Feature: Sharing files and folders with internal users
     And user "Alice" has accepted the share "Shares/new-lorem.txt" offered by user "Brian" in the server
     When the user re-logs in as "Alice" using the webUI
     And the user opens folder "Shares" using the webUI
-    Then as "Alice" the content of "Shares/new-lorem.txt" should not be the same as the content of local file "new-lorem.txt" in the server
+    Then as "Alice" the content of "Shares/new-lorem.txt" in the server should not be the same as the content of local file "new-lorem.txt"
     # overwrite the received shared file
     When the user uploads overwriting file "new-lorem.txt" using the webUI
     Then file "new-lorem.txt" should be listed on the webUI
-    And as "Alice" the content of "Shares/new-lorem.txt" should be the same as the content of local file "new-lorem.txt" in the server
+    And as "Alice" the content of "Shares/new-lorem.txt" in the server should be the same as the content of local file "new-lorem.txt"
     # unshare the received shared file
     When the user deletes file "new-lorem.txt" using the webUI
     Then file "new-lorem.txt" should not be listed on the webUI
     # check that the original file owner can still see the file
-    And as "Brian" the content of "new-lorem.txt" should be the same as the content of local file "new-lorem.txt" in the server
+    And as "Brian" the content of "new-lorem.txt" in the server should be the same as the content of local file "new-lorem.txt"
 
   @disablePreviews
   Scenario: share a folder with another internal user who uploads, overwrites and deletes files
@@ -84,14 +84,14 @@ Feature: Sharing files and folders with internal users
     And the user browses to the folder "Shares" on the files page
     And the user reloads the current page of the webUI
     And the user opens folder "simple-folder" using the webUI
-    Then as "Alice" the content of "Shares/simple-folder/lorem.txt" should not be the same as the content of local file "lorem.txt" in the server
+    Then as "Alice" the content of "Shares/simple-folder/lorem.txt" in the server should not be the same as the content of local file "lorem.txt"
     # overwrite an existing file in the received share
     When the user uploads overwriting file "lorem.txt" using the webUI
     Then file "lorem.txt" should be listed on the webUI
-    And as "Alice" the content of "Shares/simple-folder/lorem.txt" should be the same as the content of local file "lorem.txt" in the server
+    And as "Alice" the content of "Shares/simple-folder/lorem.txt" in the server should be the same as the content of local file "lorem.txt"
     # upload a new file into the received share
     When the user uploads file "new-lorem.txt" using the webUI
-    Then as "Alice" the content of "Shares/simple-folder/new-lorem.txt" should be the same as the content of local file "new-lorem.txt" in the server
+    Then as "Alice" the content of "Shares/simple-folder/new-lorem.txt" in the server should be the same as the content of local file "new-lorem.txt"
     # delete a file in the received share
     When the user deletes file "data.zip" using the webUI
     Then file "data.zip" should not be listed on the webUI
@@ -99,9 +99,9 @@ Feature: Sharing files and folders with internal users
     When the user re-logs in as "Brian" using the webUI
     And the user opens folder "simple-folder" using the webUI
     Then file "lorem.txt" should be listed on the webUI
-    And as "Brian" the content of "simple-folder/lorem.txt" should be the same as the content of local file "lorem.txt" in the server
+    And as "Brian" the content of "simple-folder/lorem.txt" in the server should be the same as the content of local file "lorem.txt"
     And file "new-lorem.txt" should be listed on the webUI
-    And as "Brian" the content of "simple-folder/new-lorem.txt" should be the same as the content of local file "new-lorem.txt" in the server
+    And as "Brian" the content of "simple-folder/new-lorem.txt" in the server should be the same as the content of local file "new-lorem.txt"
     But file "data.zip" should not be listed on the webUI
 
   @issue-product-270 @disablePreviews

--- a/tests/acceptance/features/webUISharingInternalUsersToRoot/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersToRoot/shareWithUsers.feature
@@ -55,16 +55,16 @@ Feature: Sharing files and folders with internal users
     And user "Brian" has logged in using the webUI
     And user "Brian" has shared file "new-lorem.txt" with user "Alice" with "all" permissions in the server
     When the user re-logs in as "Alice" using the webUI
-    Then as "Alice" the content of "new-lorem.txt" should not be the same as the content of local file "new-lorem.txt" in the server
+    Then as "Alice" the content of "new-lorem.txt" in the server should not be the same as the content of local file "new-lorem.txt"
     # overwrite the received shared file
     When the user uploads overwriting file "new-lorem.txt" using the webUI
     Then file "new-lorem.txt" should be listed on the webUI
-    And as "Alice" the content of "new-lorem.txt" should be the same as the content of local file "new-lorem.txt" in the server
+    And as "Alice" the content of "new-lorem.txt" in the server should be the same as the content of local file "new-lorem.txt"
     # unshare the received shared file
     When the user deletes file "new-lorem.txt" using the webUI
     Then file "new-lorem.txt" should not be listed on the webUI
     # check that the original file owner can still see the file
-    And as "Brian" the content of "new-lorem.txt" should be the same as the content of local file "new-lorem.txt" in the server
+    And as "Brian" the content of "new-lorem.txt" in the server should be the same as the content of local file "new-lorem.txt"
 
   @disablePreviews
   Scenario: share a folder with another internal user who uploads, overwrites and deletes files
@@ -75,14 +75,14 @@ Feature: Sharing files and folders with internal users
     When the user shares folder "new-simple-folder" with user "Alice Hansen" as "Editor" using the webUI
     And the user re-logs in as "Alice" using the webUI
     And the user opens folder "new-simple-folder" using the webUI
-    Then as "Alice" the content of "new-simple-folder/lorem.txt" should not be the same as the content of local file "lorem.txt" in the server
+    Then as "Alice" the content of "new-simple-folder/lorem.txt" in the server should not be the same as the content of local file "lorem.txt"
     # overwrite an existing file in the received share
     When the user uploads overwriting file "lorem.txt" using the webUI
     Then file "lorem.txt" should be listed on the webUI
-    And as "Alice" the content of "new-simple-folder/lorem.txt" should be the same as the content of local file "lorem.txt" in the server
+    And as "Alice" the content of "new-simple-folder/lorem.txt" in the server should be the same as the content of local file "lorem.txt"
     # upload a new file into the received share
     When the user uploads file "new-lorem.txt" using the webUI
-    Then as "Alice" the content of "new-simple-folder/new-lorem.txt" should be the same as the content of local file "new-lorem.txt" in the server
+    Then as "Alice" the content of "new-simple-folder/new-lorem.txt" in the server should be the same as the content of local file "new-lorem.txt"
     # delete a file in the received share
     When the user deletes file "data.zip" using the webUI
     Then file "data.zip" should not be listed on the webUI
@@ -90,9 +90,9 @@ Feature: Sharing files and folders with internal users
     When the user re-logs in as "Brian" using the webUI
     And the user opens folder "new-simple-folder" using the webUI
     Then file "lorem.txt" should be listed on the webUI
-    And as "Brian" the content of "new-simple-folder/lorem.txt" should be the same as the content of local file "lorem.txt" in the server
+    And as "Brian" the content of "new-simple-folder/lorem.txt" in the server should be the same as the content of local file "lorem.txt"
     And file "new-lorem.txt" should be listed on the webUI
-    And as "Brian" the content of "new-simple-folder/new-lorem.txt" should be the same as the content of local file "new-lorem.txt" in the server
+    And as "Brian" the content of "new-simple-folder/new-lorem.txt" in the server should be the same as the content of local file "new-lorem.txt"
     But file "data.zip" should not be listed on the webUI
 
   @disablePreviews
@@ -109,7 +109,7 @@ Feature: Sharing files and folders with internal users
     # check that the folder is still visible for the share owner
     When the user re-logs in as "Brian" using the webUI
     Then folder "new-simple-folder" should be listed on the webUI
-    And as "Brian" the content of "new-simple-folder/lorem.txt" should be the same as the content of local file "lorem.txt" in the server
+    And as "Brian" the content of "new-simple-folder/lorem.txt" in the server should be the same as the content of local file "lorem.txt"
 
   @disablePreviews
   Scenario: share a folder with another internal user and prohibit deleting

--- a/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature
+++ b/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature
@@ -241,8 +241,8 @@ Feature: Share by public link with different roles
     Then the following files should be listed on the files-drop page:
       | 'single'quotes.txt |
       | new-lorem.txt      |
-    And as "Alice" the content of "simple-folder/'single'quotes.txt" should be the same as the content of local file "'single'quotes.txt" in the server
-    And as "Alice" the content of "simple-folder/new-lorem.txt" should be the same as the content of local file "new-lorem.txt" in the server
+    And as "Alice" the content of "simple-folder/'single'quotes.txt" in the server should be the same as the content of local file "'single'quotes.txt"
+    And as "Alice" the content of "simple-folder/new-lorem.txt" in the server should be the same as the content of local file "new-lorem.txt"
 
   @issue-2443
   Scenario: creating a public link with "Uploader" role makes it possible to upload a folder
@@ -260,7 +260,7 @@ Feature: Share by public link with different roles
     And the public uploads file "'single'quotes.txt" in files-drop page
     Then the following files should be listed on the files-drop page:
       | 'single'quotes.txt |
-    And as "Alice" the content of "simple-folder/'single'quotes.txt" should be the same as the content of local file "'single'quotes.txt" in the server
+    And as "Alice" the content of "simple-folder/'single'quotes.txt" in the server should be the same as the content of local file "'single'quotes.txt"
 
   @issue-ocis-723
   Scenario: creating a public link with "Uploader" role makes it possible to upload multiple files via files-drop page even with password set
@@ -271,8 +271,8 @@ Feature: Share by public link with different roles
     Then the following files should be listed on the files-drop page:
       | 'single'quotes.txt |
       | new-lorem.txt      |
-    And as "Alice" the content of "simple-folder/'single'quotes.txt" should be the same as the content of local file "'single'quotes.txt" in the server
-    And as "Alice" the content of "simple-folder/new-lorem.txt" should be the same as the content of local file "new-lorem.txt" in the server
+    And as "Alice" the content of "simple-folder/'single'quotes.txt" in the server should be the same as the content of local file "'single'quotes.txt"
+    And as "Alice" the content of "simple-folder/new-lorem.txt" in the server should be the same as the content of local file "new-lorem.txt"
 
   @issue-ocis-1328
   Scenario: user tries to create a public link with Viewer role without entering share password while enforce password on read only public share is enforced

--- a/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature
@@ -43,7 +43,7 @@ Feature: Public link share management
     And the content of file "simple-folder/lorem.txt" for user "Brian" should be "Alice file" in the server
     When the user uploads overwriting file "lorem.txt" using the webUI
     Then file "lorem.txt" should be listed on the webUI
-    And as "Brian" the content of "simple-folder/lorem.txt" should be the same as the content of local file "lorem.txt"
+    And as "Brian" the content of "simple-folder/lorem.txt" in the server should be the same as the content of local file "lorem.txt"
 
   @issue-ocis-1328
   Scenario: user shares a file through public link and then it appears in a shared-with-others page

--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -65,20 +65,20 @@ Feature: File Upload
 
   @smokeTest @ocisSmokeTest
   Scenario: uploading a big file (when chunking is implemented this upload should be chunked)
-    Given a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally in the server
+    Given a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally in the middleware
     When the user uploads a created file "big-video.mp4" using the webUI
     Then no message should be displayed on the webUI
     And file "big-video.mp4" should be listed on the webUI
-    And as "Alice" the content of "big-video.mp4" should be the same as the content of local file "big-video.mp4" in the server
+    And as "Alice" the content of "big-video.mp4" in the server should be the same as the content of local file "big-video.mp4"
 
   @skipOnFIREFOX
   Scenario: conflict with a big file (when chunking is implemented this upload should be chunked)
-    Given a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally in the server
+    Given a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally in the middleware
     When the user renames file "lorem.txt" to "big-video.mp4" using the webUI
     And the user reloads the current page of the webUI
     And the user uploads a created file "big-video.mp4" with overwrite using the webUI
     Then file "big-video.mp4" should be listed on the webUI
-    And as "Alice" the content of "big-video.mp4" should be the same as the content of local file "big-video.mp4" in the server
+    And as "Alice" the content of "big-video.mp4" in the server should be the same as the content of local file "big-video.mp4"
 
 
   Scenario: upload a new file into a sub folder
@@ -86,14 +86,14 @@ Feature: File Upload
     And the user uploads file "new-lorem.txt" using the webUI
     Then no message should be displayed on the webUI
     And file "new-lorem.txt" should be listed on the webUI
-    And as "Alice" the content of "simple-folder/new-lorem.txt" should be the same as the content of local file "new-lorem.txt" in the server
+    And as "Alice" the content of "simple-folder/new-lorem.txt" in the server should be the same as the content of local file "new-lorem.txt"
 
   @smokeTest @disablePreviews
   Scenario: overwrite an existing file
     When the user uploads overwriting file "lorem.txt" using the webUI
     Then no message should be displayed on the webUI
     And file "lorem.txt" should be listed on the webUI
-    And as "Alice" the content of "lorem.txt" should be the same as the content of local file "lorem.txt" in the server
+    And as "Alice" the content of "lorem.txt" in the server should be the same as the content of local file "lorem.txt"
     And the versions list for resource "lorem.txt" should contain 1 entry
     But file "lorem (2).txt" should not be listed on the webUI
 
@@ -103,7 +103,7 @@ Feature: File Upload
     When the user uploads overwriting file "lorem.txt" using the webUI
     Then no message should be displayed on the webUI
     And file "lorem.txt" should be listed on the webUI
-    And as "Alice" the content of "lorem.txt" should be the same as the content of local file "lorem.txt" in the server
+    And as "Alice" the content of "lorem.txt" in the server should be the same as the content of local file "lorem.txt"
     But file "lorem (2).txt" should not be listed on the webUI
 
   @issue-5106
@@ -117,7 +117,7 @@ Feature: File Upload
     And file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should not have changed in the server
     And file "lorem (2).txt" should be listed on the webUI
-    And as "Alice" the content of "lorem (2).txt" should be the same as the content of local file "lorem.txt" in the server
+    And as "Alice" the content of "lorem (2).txt" in the server should be the same as the content of local file "lorem.txt"
 
   @issue-5106
   Scenario: cancel conflict dialog
@@ -134,7 +134,7 @@ Feature: File Upload
     When the user opens folder "simple-folder" using the webUI
     And the user uploads overwriting file "lorem.txt" using the webUI
     Then file "lorem.txt" should be listed on the webUI
-    And as "Alice" the content of "simple-folder/lorem.txt" should be the same as the content of local file "lorem.txt" in the server
+    And as "Alice" the content of "simple-folder/lorem.txt" in the server should be the same as the content of local file "lorem.txt"
 
   @issue-5106
   Scenario: keep new and existing file in a sub-folder
@@ -148,7 +148,7 @@ Feature: File Upload
     And file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should not have changed in the server
     And file "lorem (2).txt" should be listed on the webUI
-    And as "Alice" the content of "lorem (2).txt" should be the same as the content of local file "lorem.txt" in the server
+    And as "Alice" the content of "lorem (2).txt" in the server should be the same as the content of local file "lorem.txt"
 
   @issue-ocis-2258 @disablePreviews
   Scenario: upload overwriting a file into a public share
@@ -156,14 +156,14 @@ Feature: File Upload
     When the public uses the webUI to access the last public link created by user "Alice" with password "pass123"
     And the user uploads overwriting file "lorem.txt" using the webUI
     Then file "lorem.txt" should be listed on the webUI
-    And as "Alice" the content of "simple-folder/lorem.txt" should be the same as the content of local file "lorem.txt" in the server
+    And as "Alice" the content of "simple-folder/lorem.txt" in the server should be the same as the content of local file "lorem.txt"
 
 
   Scenario: upload a file with comma in the filename
     When the user uploads file "file,with,comma,.txt" using the webUI
     Then no message should be displayed on the webUI
     And file "file,with,comma,.txt" should be listed on the webUI
-    And as "Alice" the content of "file,with,comma,.txt" should be the same as the content of local file "file,with,comma,.txt" in the server
+    And as "Alice" the content of "file,with,comma,.txt" should be the same in the server as the content of local file "file,with,comma,.txt"
 
 
   Scenario: simple upload of a folder, with comma in its name, that does not exist before

--- a/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
+++ b/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
@@ -15,34 +15,34 @@ Feature: File Upload
   Scenario: simple upload of a file that does not exist before
     When the user uploads file "new-'single'quotes.txt" using the webUI
     Then file "new-'single'quotes.txt" should be listed on the webUI
-    And as "Alice" the content of "new-'single'quotes.txt" should be the same as the content of local file "new-'single'quotes.txt" in the server
+    And as "Alice" the content of "new-'single'quotes.txt" in the server should be the same as the content of local file "new-'single'quotes.txt"
 
     When the user uploads file "new-strängé filename (duplicate #2 &).txt" using the webUI
     Then file "new-strängé filename (duplicate #2 &).txt" should be listed on the webUI
-    And as "Alice" the content of "new-strängé filename (duplicate #2 &).txt" should be the same as the content of local file "new-strängé filename (duplicate #2 &).txt" in the server
+    And as "Alice" the content of "new-strängé filename (duplicate #2 &).txt" in the server should be the same as the content of local file "new-strängé filename (duplicate #2 &).txt"
 
     When the user uploads file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" using the webUI
     Then file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be listed on the webUI
-    And as "Alice" the content of "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be the same as the content of local file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" in the server
+    And as "Alice" the content of "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" in the server should be the same as the content of local file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt"
 
   @smokeTest @ocisSmokeTest
   Scenario Outline: upload a new file into a sub folder
     Given user "Alice" has created folder "<folder-to-upload-to>" in the server
     And the user has reloaded the current page of the webUI
-    And a file with the size of "3000" bytes and the name "0" has been created locally in the server
+    And a file with the size of "3000" bytes and the name "0" has been created locally in the middleware
     When the user opens folder "<folder-to-upload-to>" using the webUI
     And the user uploads a created file "0" using the webUI
     Then file "0" should be listed on the webUI
-    And as "Alice" the content of "<folder-to-upload-to>/0" should be the same as the content of local file "0" in the server
+    And as "Alice" the content of "<folder-to-upload-to>/0" in the server should be the same as the content of local file "0"
     When the user uploads file "new-'single'quotes.txt" using the webUI
     Then file "new-'single'quotes.txt" should be listed on the webUI
-    And as "Alice" the content of "<folder-to-upload-to>/new-'single'quotes.txt" should be the same as the content of local file "new-'single'quotes.txt" in the server
+    And as "Alice" the content of "<folder-to-upload-to>/new-'single'quotes.txt" in the server should be the same as the content of local file "new-'single'quotes.txt"
     When the user uploads file "new-strängé filename (duplicate #2 &).txt" using the webUI
     Then file "new-strängé filename (duplicate #2 &).txt" should be listed on the webUI
-    And as "Alice" the content of "<folder-to-upload-to>/new-strängé filename (duplicate #2 &).txt" should be the same as the content of local file "new-strängé filename (duplicate #2 &).txt" in the server
+    And as "Alice" the content of "<folder-to-upload-to>/new-strängé filename (duplicate #2 &).txt" in the server should be the same as the content of local file "new-strängé filename (duplicate #2 &).txt"
     When the user uploads file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" using the webUI
     Then file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be listed on the webUI
-    And as "Alice" the content of "<folder-to-upload-to>/zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be the same as the content of local file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" in the server
+    And as "Alice" the content of "<folder-to-upload-to>/zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" in the server should be the same as the content of local file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt"
     Examples:
       | folder-to-upload-to   |
       | 0                     |
@@ -53,15 +53,15 @@ Feature: File Upload
   Scenario: overwrite an existing file
     When the user uploads overwriting file "'single'quotes.txt" using the webUI
     Then file "'single'quotes.txt" should be listed on the webUI
-    And as "Alice" the content of "'single'quotes.txt" should be the same as the content of local file "'single'quotes.txt" in the server
+    And as "Alice" the content of "'single'quotes.txt" in the server should be the same as the content of local file "'single'quotes.txt"
 
     When the user uploads overwriting file "strängé filename (duplicate #2 &).txt" using the webUI
     Then file "strängé filename (duplicate #2 &).txt" should be listed on the webUI
-    And as "Alice" the content of "strängé filename (duplicate #2 &).txt" should be the same as the content of local file "strängé filename (duplicate #2 &).txt" in the server
+    And as "Alice" the content of "strängé filename (duplicate #2 &).txt" in the server should be the same as the content of local file "strängé filename (duplicate #2 &).txt"
 
     When the user uploads overwriting file "zzzz-must-be-last-file-in-folder.txt" using the webUI
     Then file "zzzz-must-be-last-file-in-folder.txt" should be listed on the webUI
-    And as "Alice" the content of "zzzz-must-be-last-file-in-folder.txt" should be the same as the content of local file "zzzz-must-be-last-file-in-folder.txt" in the server
+    And as "Alice" the content of "zzzz-must-be-last-file-in-folder.txt" in the server should be the same as the content of local file "zzzz-must-be-last-file-in-folder.txt"
 
   @issue-5106
   Scenario: keep new and existing file
@@ -69,26 +69,26 @@ Feature: File Upload
     Then file "'single'quotes.txt" should be listed on the webUI
     And the content of "'single'quotes.txt" should not have changed in the server
     And file "'single'quotes (2).txt" should be listed on the webUI
-    And as "Alice" the content of "'single'quotes (2).txt" should be the same as the content of local file "'single'quotes.txt"
+    And as "Alice" the content of "'single'quotes (2).txt" in the server should be the same as the content of local file "'single'quotes.txt"
 
     When the user uploads file "strängé filename (duplicate #2 &).txt" keeping both new and existing files using the webUI
     Then file "strängé filename (duplicate #2 &).txt" should be listed on the webUI
     And the content of "strängé filename (duplicate #2 &).txt" should not have changed in the server
     And file "strängé filename (duplicate #2 &) (2).txt" should be listed on the webUI
-    And as "Alice" the content of "strängé filename (duplicate #2 &) (2).txt" should be the same as the content of local file "strängé filename (duplicate #2 &).txt"
+    And as "Alice" the content of "strängé filename (duplicate #2 &) (2).txt" in the server should be the same as the content of local file "strängé filename (duplicate #2 &).txt"
 
     When the user uploads file "zzzz-must-be-last-file-in-folder.txt" keeping both new and existing files using the webUI
     Then file "zzzz-must-be-last-file-in-folder.txt" should be listed on the webUI
     And the content of "zzzz-must-be-last-file-in-folder.txt" should not have changed in the server
     And file "zzzz-must-be-last-file-in-folder (2).txt" should be listed on the webUI
-    And as "Alice" the content of "zzzz-must-be-last-file-in-folder (2).txt" should be the same as the content of local file "zzzz-must-be-last-file-in-folder.txt"
+    And as "Alice" the content of "zzzz-must-be-last-file-in-folder (2).txt" in the server should be the same as the content of local file "zzzz-must-be-last-file-in-folder.txt"
 
 
   Scenario Outline: upload a big file using difficult names (when chunking in implemented that upload should be chunked)
-    Given a file with the size of "30000000" bytes and the name <file-name> has been created locally in the server
+    Given a file with the size of "30000000" bytes and the name <file-name> has been created locally in the middleware
     When the user uploads a created file <file-name> using the webUI
     Then file <file-name> should be listed on the webUI
-    And as "Alice" the content of <file-name> should be the same as the content of local file <file-name> in the server
+    And as "Alice" the content of <file-name> in the server should be the same as the content of local file <file-name>
     Examples:
       | file-name |
       | "&#"      |
@@ -99,11 +99,11 @@ Feature: File Upload
   Scenario: Upload a big file called "0" (when chunking in implemented that upload should be chunked)
     Given user "Alice" has created folder "simple-folder" in the server
     And the user has browsed to the files page
-    And a file with the size of "30000000" bytes and the name "0" has been created locally in the server
+    And a file with the size of "30000000" bytes and the name "0" has been created locally in the middleware
     When the user opens folder "simple-folder" using the webUI
     And the user uploads a created file "0" using the webUI
     Then file "0" should be listed on the webUI
-    And as "Alice" the content of "simple-folder/0" should be the same as the content of local file "0" in the server
+    And as "Alice" the content of "simple-folder/0" in the server should be the same as the content of local file "0"
 
   @issue-3015 @issue-ocis-reva-200
   Scenario: Upload a file with the same name as already existing folder

--- a/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
+++ b/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
@@ -12,7 +12,7 @@ Feature: Upload a file
   Scenario: simple upload of a file with the size greater than the size of quota
     Given the quota of user "Alice" has been set to "10 MB" in the server
     And user "Alice" has logged in using the webUI
-    And a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally in the server
+    And a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally in the middleware
     When the user uploads a created file "big-video.mp4" using the webUI
     Then file "big-video.mp4" should not be listed on the webUI
     And the error message with header 'Failed to upload' should be displayed on the webUI

--- a/tests/acceptance/features/webUIUserJourney/journey1.feature
+++ b/tests/acceptance/features/webUIUserJourney/journey1.feature
@@ -13,7 +13,7 @@ Feature: User Journey 1
     And the user uploads file "new-lorem.txt" using the webUI
     Then no message should be displayed on the webUI
     And file "new-lorem.txt" should be listed on the webUI
-    And as "Alice" the content of "new-lorem.txt" should be the same as the content of local file "new-lorem.txt" in the server
+    And as "Alice" the content of "new-lorem.txt" in the server should be the same as the content of local file "new-lorem.txt"
     When the user browses to the files page
     And the user downloads file "new-lorem.txt" using the webUI
     Then no message should be displayed on the webUI

--- a/tests/acceptance/stepDefinitions/middlewareContext.js
+++ b/tests/acceptance/stepDefinitions/middlewareContext.js
@@ -71,7 +71,7 @@ Given(/^((?:(?!these|following).)*\S)\s(in the server|on remote server)(.*)$/, (
 })
 
 Given(
-  /^(.*(?=these|following).*\S)\s(in the server|on remote server)(.*)$/,
+  /^(.*(?=these|following).*\S)\s(in the server|on remote server|in the middleware)(.*)$/,
   (st1, st2, st3, table) => {
     if (st2 === 'on remote server') {
       st1 = st1 + ' ' + st2

--- a/tests/acceptance/stepDefinitions/middlewareContext.js
+++ b/tests/acceptance/stepDefinitions/middlewareContext.js
@@ -63,15 +63,18 @@ After(function () {
   })
 })
 
-Given(/^((?:(?!these|following).)*\S)\s(in the server|on remote server)(.*)$/, (st1, st2, st3) => {
-  if (st2 === 'on remote server') {
-    st1 = st1 + ' ' + st2
+Given(
+  /^((?:(?!these|following).)*\S)\s(in the server|on remote server|in the middleware)(.*)$/,
+  (st1, st2, st3) => {
+    if (st2 === 'on remote server') {
+      st1 = st1 + ' ' + st2
+    }
+    return handler(st1, st3)
   }
-  return handler(st1, st3)
-})
+)
 
 Given(
-  /^(.*(?=these|following).*\S)\s(in the server|on remote server|in the middleware)(.*)$/,
+  /^(.*(?=these|following).*\S)\s(in the server|on remote server)(.*)$/,
   (st1, st2, st3, table) => {
     if (st2 === 'on remote server') {
       st1 = st1 + ' ' + st2


### PR DESCRIPTION
## Description
- added `in the middleware` as middleware capture string for gherkin steps
- refactored content assertion steps including local files and files from the server

## Related Issue
- Fixes https://github.com/owncloud/owncloud-test-middleware/issues/96

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- :robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
