### PR TITLE
[tests-only] Update local file create scenario using v1.3.1 middleware

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -9,7 +9,7 @@ OC_CI_GOLANG = "owncloudci/golang:1.17"
 OC_CI_NODEJS = "owncloudci/nodejs:14"
 OC_CI_PHP = "owncloudci/php:7.4"
 OC_CI_WAIT_FOR = "owncloudci/wait-for:latest"
-OC_TESTING_MIDDLEWARE = "owncloud/owncloud-test-middleware:1.3.0"
+OC_TESTING_MIDDLEWARE = "owncloud/owncloud-test-middleware:1.3.1"
 OC_UBUNTU = "owncloud/ubuntu:20.04"
 
 OC10_VERSION = "latest"

--- a/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
+++ b/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
@@ -133,9 +133,9 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIWebdavLockProtection/upload.feature:91](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIWebdavLockProtection/upload.feature#L91)
 
 ### [Uploading a file with a name that already exists is confusing](https://github.com/owncloud/web/issues/5106)
--   [webUIUpload/upload.feature:110](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/upload.feature#L110)
--   [webUIUpload/upload.feature:123](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/upload.feature#L123)
--   [webUIUpload/upload.feature:140](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/upload.feature#L140)
+-   [webUIUpload/upload.feature:129](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/upload.feature#L129)
+-   [webUIUpload/upload.feature:142](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/upload.feature#L142)
+-   [webUIUpload/upload.feature:159](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/upload.feature#L159)
 -   [webUIUpload/uploadEdgecases.feature:67](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/uploadEdgecases.feature#L67)
 
 ### [Federated shares not showing in shared with me page](https://github.com/owncloud/web/issues/2510)
@@ -192,3 +192,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 - [webUISharingFilePermissionsGroups/sharePermissionsGroup.feature:65](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingFilePermissionsGroups/sharePermissionsGroup.feature#L65)
 - [webUISharingFilePermissionsGroups/sharePermissionsGroup.feature:66](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingFilePermissionsGroups/sharePermissionsGroup.feature#L66)
 - [webUISharingPermissionToRoot/shareFileWithMultipleUsers.feature:66](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPermissionToRoot/shareFileWithMultipleUsers.feature#L66)
+
+### [empty subfolder inside a folder to be uploaded is not created on the server](https://github.com/owncloud/web/issues/6348)
+- [webUIUpload/upload.feature:42](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/upload.feature#L42)

--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -480,9 +480,9 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUISharingExternal/federationSharing.feature:166](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingExternal/federationSharing.feature#L166)
 
 ### [Uploading a file with a name that already exists is confusing](https://github.com/owncloud/web/issues/5106)
--   [webUIUpload/upload.feature:110](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/upload.feature#L110)
--   [webUIUpload/upload.feature:123](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/upload.feature#L123)
--   [webUIUpload/upload.feature:140](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/upload.feature#L140)
+-   [webUIUpload/upload.feature:129](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/upload.feature#L129)
+-   [webUIUpload/upload.feature:142](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/upload.feature#L142)
+-   [webUIUpload/upload.feature:159](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/upload.feature#L159)
 -   [webUIUpload/uploadEdgecases.feature:67](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/uploadEdgecases.feature#L67)
 
 ### [browsing directly to a details 'tab' is not possible](https://github.com/owncloud/web/issues/5464)
@@ -510,3 +510,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 
 ### [web config update is not properly reflected after the ocis start](https://github.com/owncloud/ocis/issues/2944)
 -   [webUIFiles/breadcrumb.feature:50](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFiles/breadcrumb.feature#L50)
+
+### [empty subfolder inside a folder to be uploaded is not created on the server](https://github.com/owncloud/web/issues/6348)
+-   [webUIUpload/upload.feature:42](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/upload.feature#L42)

--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -20,17 +20,36 @@ Feature: File Upload
 
   @smokeTest @ocisSmokeTest
   Scenario: simple upload of a folder that does not exist before
-    Given a folder "CUSTOM" has been created with the following files in separate sub-folders in the server
-      | lorem.txt     |
-      | new-lorem.txt |
+    Given a folder "CUSTOM" has been created with the following files in separate sub-folders in the middleware
+      | subFolder | file          |
+      |           | lorem.txt     |
+      | sub1      | lorem.txt     |
+      | sub1      | new-lorem.txt |
+      | sub2/sub3 | new-lorem.txt |
     When the user uploads folder "CUSTOM" using the webUI
     Then no message should be displayed on the webUI
     And folder "CUSTOM" should be listed on the webUI
     And as "Alice" folder "CUSTOM" should exist in the server
     And as "Alice" file "CUSTOM/lorem.txt" should exist in the server
-    And as "Alice" file "CUSTOM/new-lorem.txt" should exist in the server
+    And as "Alice" file "CUSTOM/sub1/lorem.txt" should exist in the server
+    And as "Alice" file "CUSTOM/sub1/new-lorem.txt" should exist in the server
+    And as "Alice" file "CUSTOM/sub2/sub3/new-lorem.txt" should exist in the server
     And as "Alice" the content of "CUSTOM/lorem.txt" in the server should be the same as the content of local file "CUSTOM/lorem.txt"
-    And as "Alice" the content of "CUSTOM/new-lorem.txt" in the server should be the same as the content of local file "CUSTOM/new-lorem.txt"
+    And as "Alice" the content of "CUSTOM/sub1/lorem.txt" in the server should be the same as the content of local file "CUSTOM/sub1/lorem.txt"
+    And as "Alice" the content of "CUSTOM/sub1/new-lorem.txt" in the server should be the same as the content of local file "CUSTOM/sub1/new-lorem.txt"
+    And as "Alice" the content of "CUSTOM/sub2/sub3/new-lorem.txt" in the server should be the same as the content of local file "CUSTOM/sub2/sub3/new-lorem.txt"
+
+  Scenario: simple upload of a folder that does not exist before with empty sub-folders
+    Given a folder "CUSTOM" has been created with the following files in separate sub-folders in the middleware
+      | subFolder      | file |
+      | sub4           |      |
+      | sub5/sub6/sub7 |      |
+    When the user uploads folder "CUSTOM" using the webUI
+    Then no message should be displayed on the webUI
+    And folder "CUSTOM" should be listed on the webUI
+    And as "Alice" folder "CUSTOM" should exist in the server
+    And as "Alice" folder "CUSTOM/sub4" should exist in the server
+    And as "Alice" folder "CUSTOM/sub5/sub6/sub7" should exist in the server
 
   @smokeTest @ocisSmokeTest
   Scenario: simple upload of a folder with subfolders that does not exist before

--- a/tests/acceptance/stepDefinitions/middlewareContext.js
+++ b/tests/acceptance/stepDefinitions/middlewareContext.js
@@ -74,7 +74,7 @@ Given(
 )
 
 Given(
-  /^(.*(?=these|following).*\S)\s(in the server|on remote server)(.*)$/,
+  /^(.*(?=these|following).*\S)\s(in the server|on remote server|in the middleware)(.*)$/,
   (st1, st2, st3, table) => {
     if (st2 === 'on remote server') {
       st1 = st1 + ' ' + st2


### PR DESCRIPTION
### Description
Fix local file creating & uploading scenario with sub-folders
- added simple passing scenario involving all non-empty subfolders
- added a failing scenario involving empty subfolders

### Related
- part of https://github.com/owncloud/owncloud-test-middleware/issues/97
- reported https://github.com/owncloud/web/issues/6348