### PR TITLE
resolve docs build error by referencing building.md with a relative path

### DIFF
--- a/docs/backend-oc10.md
+++ b/docs/backend-oc10.md
@@ -61,11 +61,10 @@ In the local Web checkout, copy the `config/config.json.sample-oc10` file to `co
 
 ## Running Web
 
-- if running from source, make sure to [build Web]({{< ref "building.md" >}}) first
+- if running from source, make sure to [build Web]({{< ref "./building.md" >}}) first
 - run by launching a rollup dev server `yarn serve`
 - when working on the Web code, rollup will recompile the code automatically
 
 ## Running acceptance tests
 
 For testing, please refer to the [testing docs]({{< ref "testing/_index.md" >}})
-

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@ geekdocFilePath: getting-started.md
 
 ### Docker
 
-Make sure to have Docker, Docker-Compose, Node.js and Yarn installed. 
+Make sure to have Docker, Docker-Compose, Node.js and Yarn installed.
 
 {{< hint info >}}
 This setup currently doesn't work on Windows out of the box.
@@ -34,7 +34,7 @@ The bundled frontend code automatically gets mounted into the Docker containers,
 ### Source code
 
 The source code is hosted at [https://github.com/owncloud/web](https://github.com/owncloud/web).
-Please refer to the [build documentation for Web]({{< ref "building.md" >}}).
+Please refer to the [build documentation for Web]({{< ref "./building.md" >}}).
 
 ## Configuration
 
@@ -42,9 +42,9 @@ Depending on the backend you are using, there are sample config files provided i
 
 #### Options
 - `options.hideSearchBar` Lets you hide the search bar at the top of the screen for all users.
-- `options.homeFolder` You can specify a folder that is used when the user navigates `home`. Navigating home gets triggered by clicking on the `All files` 
-menu item. The user will not be jailed in that directory. It simply serves as a default location. You can either provide a static location, or you can use 
-variables of the user object to come up with a user specific home path. This uses twig template variable style and allows you to pick a value or a 
+- `options.homeFolder` You can specify a folder that is used when the user navigates `home`. Navigating home gets triggered by clicking on the `All files`
+menu item. The user will not be jailed in that directory. It simply serves as a default location. You can either provide a static location, or you can use
+variables of the user object to come up with a user specific home path. This uses twig template variable style and allows you to pick a value or a
 substring of a value of the authenticated user. Examples are `/Shares`, `/{{.Id}}` and `/{{substr 0 3 .Id}}/{{.Id}`.
 - `options.disablePreviews` Set this option to `true` to disable previews in all the different file listing views. The only list view that is not affected
   by this is the trash bin, as that doesn't allow showing previews at all.
@@ -65,4 +65,3 @@ Depending which one you chose, please check the matching section:
 
 - [Running with ownCloud as backend]({{< ref "backend-oc10.md#running-web" >}})
 - [Running with oCIS as backend]({{< ref "backend-ocis.md#running-web" >}})
-

--- a/docs/testing/acceptance-tests-all.md
+++ b/docs/testing/acceptance-tests-all.md
@@ -60,7 +60,7 @@ When running a standalone Selenium server, make sure to set the environment vari
 
 ## Setup ownCloud Web
 
-- [build Web]({{< ref "building.md" >}})
+- [build Web]({{< ref "../building.md" >}})
 - [start the Web server]({{< ref "backend-oc10.md#running-web" >}})
 - if you are running web against the oCIS backend, clone the testing app `git clone git@github.com:owncloud/testing.git tests/testing-app`
 
@@ -175,7 +175,7 @@ In order to check if new tests are compatible with oCIS, after changing the comm
 
 ### 2. oCIS Repo
 
-We follow the same approach in the `owncloud/ocis` repo too. In order to run the UI tests in CI we use commit IDs from web which can be changed in the `.drone.env` file. 
+We follow the same approach in the `owncloud/ocis` repo too. In order to run the UI tests in CI we use commit IDs from web which can be changed in the `.drone.env` file.
 
 ```
   # The test runner source for UI tests


### PR DESCRIPTION
## Description
This fixes the currently broken docs build / publish process (https://drone.owncloud.com/owncloud/owncloud.github.io/2667/1/4), because referencing the file "building.md" is ambiguous (comes also from another repo). Therefore we reference this file with relative paths to make it unambiguous.