### PR TITLE
Add grouping functionality for tables

### DIFF
--- a/packages/web-app-files/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceTable.vue
@@ -1,6 +1,7 @@
 <template>
   <oc-table
     :data="resources"
+    :grouping-settings="groupingSettings"
     :fields="fields"
     :highlighted="selectedIds"
     :disabled="disabled"
@@ -221,6 +222,17 @@ export default {
     resources: {
       type: Array,
       required: true
+    },
+    /**
+     * Grouping settings for the table. Following settings are possible:<br />
+     * -**groupingFunctions**: Object with keys as grouping options names and functions that get a table data row and return a group name for that row. The names of the functions are used as grouping options.
+     * -**groupingBy**: must be either one of the keys in groupingFunctions or 'None'. If not set, default grouping will be 'None'.<br />
+     * -**ShowGroupingOptions**:  boolean value for showing or hinding the select element with grouping options above the table. <br />
+     * -**PreviewAmount**: Integer value that is used to show only the first n data rows of the table.
+     */
+    groupingSettings: {
+      type: Object,
+      required: false,
     },
     /**
      * Closure function to mutate the resource id into a valid DOM selector.

--- a/packages/web-app-files/src/views/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/SharedWithMe.vue
@@ -113,6 +113,7 @@
         :header-position="fileListHeaderY"
         :sort-by="sharesSortBy"
         :sort-dir="sharesSortDir"
+        :grouping-settings="groupingSettings"
         @fileClick="$_fileActions_triggerDefaultAction"
         @rowMounted="rowMounted"
         @sort="sharesHandleSort"
@@ -297,6 +298,53 @@ export default {
     ...mapGetters(['isOcis', 'configuration', 'getToken']),
     ...mapState('Files/sidebar', { sidebarClosed: 'closed' }),
 
+    groupingSettings() {
+      return {
+        groupingBy: 'Last modified',
+        showGroupingOptions: true,
+        groupingFunctions: {
+          'Name alphabetically': function (row) {
+            let result
+            if (!isNaN(row.name.charAt(0))) result = '#'
+            if (row.name.charAt(0) === '.') result = row.name.charAt(1).toLowerCase()
+            result = row.name.charAt(0).toLowerCase()
+            console.log('result', result)
+            return result
+          },
+          'Last modified': function (row) {
+            const recently = Date.now() - 604800000
+            const lastMonth = Date.now() - 2592000000
+            if (Date.parse(row.sdate) < lastMonth) return 'Older'
+            if (Date.parse(row.sdate) >= recently) return 'Recently'
+            else return 'Last month'
+          }
+        },
+        sortGroups: {
+          'Name alphabetically': function (groups) {
+            // sort in alphabetical order by group name
+            return groups.sort(function (a, b) {
+              if (a.name < b.name) {
+                return -1
+              }
+              if (a.name > b.name) {
+                return 1
+              }
+              return 0
+            })
+          },
+          'Last modified': function (groups) {
+            // sort in order: 1-Recently, 2-Last month, 3-Older
+            const sortedGroups = []
+            const options = ['Recently', 'Last month', 'Older']
+            for (const o of options) {
+              const found = groups.find((el) => el.name.toLowerCase() === o.toLowerCase())
+              if (found) sortedGroups.push(found)
+            }
+            return sortedGroups
+          }
+        }
+      }
+    },
     // pending shares
     pendingSelected: {
       get() {

--- a/packages/web-app-files/src/views/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/SharedWithMe.vue
@@ -299,19 +299,17 @@ export default {
     ...mapState('Files/sidebar', { sidebarClosed: 'closed' }),
 
     groupingSettings() {
+      const that = this
       return {
-        groupingBy: 'Last modified',
+        groupingBy: 'Shared on',
         showGroupingOptions: true,
         groupingFunctions: {
           'Name alphabetically': function (row) {
-            let result
-            if (!isNaN(row.name.charAt(0))) result = '#'
-            if (row.name.charAt(0) === '.') result = row.name.charAt(1).toLowerCase()
-            result = row.name.charAt(0).toLowerCase()
-            console.log('result', result)
-            return result
+            if (!isNaN(row.name.charAt(0))) return '#'
+            if (row.name.charAt(0) === '.') return row.name.charAt(1).toLowerCase()
+            return row.name.charAt(0).toLowerCase()
           },
-          'Last modified': function (row) {
+          'Shared on': function (row) {
             const recently = Date.now() - 604800000
             const lastMonth = Date.now() - 2592000000
             if (Date.parse(row.sdate) < lastMonth) return 'Older'
@@ -322,7 +320,7 @@ export default {
         sortGroups: {
           'Name alphabetically': function (groups) {
             // sort in alphabetical order by group name
-            return groups.sort(function (a, b) {
+            const sortedGroups = groups.sort(function (a, b) {
               if (a.name < b.name) {
                 return -1
               }
@@ -331,8 +329,12 @@ export default {
               }
               return 0
             })
+            // if sorting is done by name, reverse groups depending on asc/desc
+            if (that.sharesSortBy === 'name' && that.sharesSortDir === 'desc')
+              sortedGroups.reverse()
+            return sortedGroups
           },
-          'Last modified': function (groups) {
+          'Shared on': function (groups) {
             // sort in order: 1-Recently, 2-Last month, 3-Older
             const sortedGroups = []
             const options = ['Recently', 'Last month', 'Older']
@@ -340,6 +342,9 @@ export default {
               const found = groups.find((el) => el.name.toLowerCase() === o.toLowerCase())
               if (found) sortedGroups.push(found)
             }
+            // if sorting is done by sdate, reverse groups depending on asc/desc
+            if (that.sharesSortBy === 'sdate' && that.sharesSortDir === 'asc')
+              sortedGroups.reverse()
             return sortedGroups
           }
         }

--- a/packages/web-app-files/src/views/SharedWithOthers.vue
+++ b/packages/web-app-files/src/views/SharedWithOthers.vue
@@ -27,6 +27,7 @@
         :header-position="fileListHeaderY"
         :sort-by="sortBy"
         :sort-dir="sortDir"
+        :grouping-settings="groupingSettings"
         @fileClick="$_fileActions_triggerDefaultAction"
         @rowMounted="rowMounted"
         @sort="handleSort"
@@ -146,6 +147,54 @@ export default {
     ...mapGetters('Files', ['highlightedFile', 'selectedFiles', 'totalFilesCount']),
     ...mapGetters(['isOcis', 'configuration', 'getToken', 'user']),
     ...mapState('Files/sidebar', { sidebarClosed: 'closed' }),
+
+    groupingSettings() {
+      return {
+        groupingBy: 'Last modified',
+        showGroupingOptions: true,
+        groupingFunctions: {
+          'Name alphabetically': function (row) {
+            let result
+            if (!isNaN(row.name.charAt(0))) result = '#'
+            if (row.name.charAt(0) === '.') result = row.name.charAt(1).toLowerCase()
+            result = row.name.charAt(0).toLowerCase()
+            console.log('result', result)
+            return result
+          },
+          'Last modified': function (row) {
+            const recently = Date.now() - 604800000
+            const lastMonth = Date.now() - 2592000000
+            if (Date.parse(row.sdate) < lastMonth) return 'Older'
+            if (Date.parse(row.sdate) >= recently) return 'Recently'
+            else return 'Last month'
+          }
+        },
+        sortGroups: {
+          'Name alphabetically': function (groups) {
+            // sort in alphabetical order by group name
+            return groups.sort(function (a, b) {
+              if (a.name < b.name) {
+                return -1
+              }
+              if (a.name > b.name) {
+                return 1
+              }
+              return 0
+            })
+          },
+          'Last modified': function (groups) {
+            // sort in order: 1-Recently, 2-Last month, 3-Older
+            const sortedGroups = []
+            const options = ['Recently', 'Last month', 'Older']
+            for (const o of options) {
+              const found = groups.find((el) => el.name.toLowerCase() === o.toLowerCase())
+              if (found) sortedGroups.push(found)
+            }
+            return sortedGroups
+          }
+        }
+      }
+    },
 
     selected: {
       get() {

--- a/packages/web-app-files/src/views/SharedWithOthers.vue
+++ b/packages/web-app-files/src/views/SharedWithOthers.vue
@@ -149,19 +149,17 @@ export default {
     ...mapState('Files/sidebar', { sidebarClosed: 'closed' }),
 
     groupingSettings() {
+      const that = this
       return {
-        groupingBy: 'Last modified',
+        groupingBy: 'Shared on',
         showGroupingOptions: true,
         groupingFunctions: {
           'Name alphabetically': function (row) {
-            let result
-            if (!isNaN(row.name.charAt(0))) result = '#'
-            if (row.name.charAt(0) === '.') result = row.name.charAt(1).toLowerCase()
-            result = row.name.charAt(0).toLowerCase()
-            console.log('result', result)
-            return result
+            if (!isNaN(row.name.charAt(0))) return '#'
+            if (row.name.charAt(0) === '.') return row.name.charAt(1).toLowerCase()
+            return row.name.charAt(0).toLowerCase()
           },
-          'Last modified': function (row) {
+          'Shared on': function (row) {
             const recently = Date.now() - 604800000
             const lastMonth = Date.now() - 2592000000
             if (Date.parse(row.sdate) < lastMonth) return 'Older'
@@ -172,7 +170,7 @@ export default {
         sortGroups: {
           'Name alphabetically': function (groups) {
             // sort in alphabetical order by group name
-            return groups.sort(function (a, b) {
+            const sortedGroups = groups.sort(function (a, b) {
               if (a.name < b.name) {
                 return -1
               }
@@ -181,8 +179,11 @@ export default {
               }
               return 0
             })
+            // if sorting is done by name, reverse groups depending on asc/desc
+            if (that.sortBy === 'name' && that.sortDir === 'desc') sortedGroups.reverse()
+            return sortedGroups
           },
-          'Last modified': function (groups) {
+          'Shared on': function (groups) {
             // sort in order: 1-Recently, 2-Last month, 3-Older
             const sortedGroups = []
             const options = ['Recently', 'Last month', 'Older']
@@ -190,6 +191,8 @@ export default {
               const found = groups.find((el) => el.name.toLowerCase() === o.toLowerCase())
               if (found) sortedGroups.push(found)
             }
+            // if sorting is done by sdate, reverse groups depending on asc/desc
+            if (that.sortBy === 'sdate' && that.sortDir === 'asc') sortedGroups.reverse()
             return sortedGroups
           }
         }


### PR DESCRIPTION
## Description
Grouping as well as preview functionality for the tables, web part
ODS part: https://github.com/owncloud/owncloud-design-system/pull/1838
Replacement of https://github.com/owncloud/web/pull/6165

Setup is done with the property "groupingSettings" . Following settings are possible:
- groupingFunctions: Object with keys as grouping options names and functions that get a table data row and return a group name for that row. The names of the functions are used as grouping options. 

- groupingBy: must be either one of the keys in groupingFunctions or 'None'. If not set, default grouping will be 'None'.
- ShowGroupingOptions: boolean value for showing or hinding the select element with grouping options above the table.
- sortGroups: Object with keys as grouping options names and as values functions that get an array of groups and return a sorted array of groups.


![Screenshot from 2021-09-08 10-47-39](https://user-images.githubusercontent.com/7430156/132478203-38f7ef88-78a8-4591-a7cf-7ede8356a436.png)


## Related Issue


## Motivation and Context
UX-friendly option for better overviews of table contents



## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- Tests


