### PR TITLE
[tests-only] Removed duplicated volume from middleware start script

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2398,7 +2398,6 @@ def runWebuiAcceptanceTests(ctx, suite, alternateSuiteName, filterTags, extraEnv
         "image": OC_CI_NODEJS,
         "environment": environment,
         "commands": [
-            "ls /usr/src/app/filesForUpload",
             "cd %s/tests/acceptance && ./run.sh" % dir["web"],
         ],
         "volumes": [{
@@ -2407,9 +2406,6 @@ def runWebuiAcceptanceTests(ctx, suite, alternateSuiteName, filterTags, extraEnv
         }, {
             "name": "configs",
             "path": "/srv/config",
-        }, {
-            "name": "uploads",
-            "path": "/usr/src/app/filesForUpload",
         }],
     }]
 
@@ -2904,7 +2900,7 @@ def middlewareService(ocis = False, federatedServer = False):
         "BACKEND_HOST": "https://ocis:9200" if ocis else "http://owncloud",
         "OCIS_REVA_DATA_ROOT": "/srv/app/tmp/ocis/storage/owncloud/",
         "RUN_ON_OCIS": "true" if ocis else "false",
-        "REMOTE_UPLOAD_DIR": "/usr/src/app/filesForUpload",
+        "REMOTE_UPLOAD_DIR": "/uploads",
         "NODE_TLS_REJECT_UNAUTHORIZED": "0",
         "MIDDLEWARE_HOST": "middleware",
     }
@@ -2921,7 +2917,7 @@ def middlewareService(ocis = False, federatedServer = False):
             "path": "/srv/app",
         }, {
             "name": "uploads",
-            "path": "/usr/src/app/filesForUpload",
+            "path": "/uploads",
         }],
     }]
 

--- a/.drone.star
+++ b/.drone.star
@@ -2917,9 +2917,6 @@ def middlewareService(ocis = False, federatedServer = False):
         "image": OC_TESTING_MIDDLEWARE,
         "environment": environment,
         "volumes": [{
-            "name": "uploads",
-            "path": "/filesForUpload",
-        }, {
             "name": "gopath",
             "path": "/srv/app",
         }, {


### PR DESCRIPTION
### Description

Owncloud Test Middleware's default entry point assumes the container to be run with a docker volume `uploads`. In this directory, all the files necessary for uploading jobs are copied. Also, the local files to be created during the test runs are also uploaded to this one by the middleware.

With this PR:
- middleware will use the shared vol. directory as a directory for `REMOTE_UPLOAD_DIR`