### PR TITLE
Ignore routes whitelist and reduce console noise

### DIFF
--- a/changelog/unreleased/change-drop-editor-routes-whitelist
+++ b/changelog/unreleased/change-drop-editor-routes-whitelist
@@ -1,0 +1,5 @@
+Change: Dropped editor route whitelist
+
+We've dropped the `routes` key from file extension handlers defined by editor apps. This was used as a whitelist for being rendered as available editor in the files app. The only usage of this was for disabling editors in the trashbin. We've moved that part of the business logic to the files app itself and from now on ignore the `routes` key from editors.
+
+https://github.com/owncloud/web/pull/6381

--- a/packages/web-app-draw-io/src/index.js
+++ b/packages/web-app-draw-io/src/index.js
@@ -16,14 +16,6 @@ const routes = [
   }
 ]
 
-const routesForFileExtensions = [
-  'files-spaces-storage',
-  'files-common-favorites',
-  'files-shares-with-others',
-  'files-shares-with-me',
-  'files-public-files'
-]
-
 const appInfo = {
   name: 'Draw.io',
   id: 'draw-io',
@@ -37,14 +29,12 @@ const appInfo = {
         menuTitle($gettext) {
           return $gettext('New draw.io document…')
         }
-      },
-      routes: routesForFileExtensions
+      }
     },
     {
       extension: 'vsdx',
       newTab: true,
-      routeName: 'draw-io',
-      routes: routesForFileExtensions
+      routeName: 'draw-io'
     }
   ]
 }

--- a/packages/web-app-external/src/store/index.ts
+++ b/packages/web-app-external/src/store/index.ts
@@ -1,6 +1,24 @@
 import { Commit } from 'vuex'
+
+interface AppProvider {
+  icon: string
+  name: string
+}
+
+/* eslint-disable camelcase */
+interface MimeType {
+  allow_creation?: boolean
+  app_providers: Array<AppProvider>
+  default_application?: string
+  description?: string
+  ext?: string
+  mime_type: string
+  name?: string
+}
+/* eslint-enable camelcase */
+
 const State = {
-  mimeTypes: {}
+  mimeTypes: []
 }
 
 const actions = {
@@ -25,23 +43,18 @@ const actions = {
     }
 
     const { 'mime-types': mimeTypes } = await response.json()
-
     commit('SET_MIME_TYPES', mimeTypes)
   }
 }
 
 const getters = {
-  mimeTypes: (
-    state: typeof State
-  ): {
-    [key: string]: string
-  } => {
+  mimeTypes: (state: typeof State): Array<MimeType> => {
     return state.mimeTypes
   }
 }
 
 const mutations = {
-  SET_MIME_TYPES(state: typeof State, mimeTypes: { [key: string]: string }): void {
+  SET_MIME_TYPES(state: typeof State, mimeTypes: Array<MimeType>): void {
     state.mimeTypes = mimeTypes
   }
 }

--- a/packages/web-app-files/src/components/AppBar/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar/AppBar.vue
@@ -134,7 +134,6 @@
 <script>
 import { mapActions, mapGetters, mapState, mapMutations } from 'vuex'
 import pathUtil from 'path'
-import get from 'lodash-es/get'
 
 import Mixins from '../../mixins'
 import MixinFileActions, { EDITOR_MODE_CREATE } from '../../mixins/fileActions'
@@ -179,7 +178,6 @@ export default {
     fileFolderCreationLoading: false
   }),
   computed: {
-    ...mapGetters('External', ['mimeTypes']),
     ...mapGetters([
       'getToken',
       'capabilities',
@@ -192,10 +190,12 @@ export default {
     ...mapState('Files', ['areHiddenFilesShown']),
 
     mimetypesAllowedForCreation() {
-      if (!get(this, 'mimeTypes', []).length) {
+      // we can't use `mapGetters` here because the External app doesn't exist in all deployments
+      const mimeTypes = this.$store.getters['External/mimeTypes']
+      if (!mimeTypes) {
         return []
       }
-      return this.mimeTypes.filter((mimetype) => mimetype.allow_creation) || []
+      return mimeTypes.filter((mimetype) => mimetype.allow_creation) || []
     },
     newButtonTooltip() {
       if (!this.canUpload) {

--- a/packages/web-app-files/src/mixins/fileActions.js
+++ b/packages/web-app-files/src/mixins/fileActions.js
@@ -1,7 +1,7 @@
 import get from 'lodash-es/get'
 import { mapGetters, mapActions, mapState } from 'vuex'
 
-import { isAuthenticatedRoute, isLocationActive } from '../router'
+import { isAuthenticatedRoute, isLocationCommonActive } from '../router'
 import AcceptShare from './actions/acceptShare'
 import Copy from './actions/copy'
 import DeclineShare from './actions/declineShare'
@@ -61,6 +61,9 @@ export default {
     },
 
     $_fileActions_editorActions() {
+      if (isLocationCommonActive(this.$router, 'files-common-trash')) {
+        return []
+      }
       return this.apps.fileEditors
         .map((editor) => {
           return {
@@ -83,12 +86,6 @@ export default {
               ),
             isEnabled: ({ resources }) => {
               if (resources.length !== 1) {
-                return false
-              }
-              if (
-                Array.isArray(editor.routes) &&
-                !isLocationActive(this.$router, ...editor.routes.map((name) => ({ name })))
-              ) {
                 return false
               }
 
@@ -199,6 +196,10 @@ export default {
     // to open a resource with a specific mimeType
     // FIXME: filesApp should not know anything about any other app, dont cross the line!!! BAD
     $_fileActions_loadExternalAppActions(resources) {
+      if (isLocationCommonActive(this.$router, 'files-common-trash')) {
+        return []
+      }
+
       // we don't support external apps as batch action as of now
       if (resources.length > 1) {
         return []

--- a/packages/web-app-markdown-editor/src/index.js
+++ b/packages/web-app-markdown-editor/src/index.js
@@ -15,14 +15,7 @@ const routes = [
 ]
 
 const fileExtensionConfig = {
-  canBeDefault: true,
-  routes: [
-    'files-spaces-storage',
-    'files-common-favorites',
-    'files-shares-with-others',
-    'files-shares-with-me',
-    'files-public-files'
-  ]
+  canBeDefault: true
 }
 
 const appInfo = {

--- a/packages/web-app-media-viewer/src/index.js
+++ b/packages/web-app-media-viewer/src/index.js
@@ -23,18 +23,9 @@ const routes = [
 
 const routeName = 'mediaviewer-media'
 
-const routesForFileExtensions = [
-  'files-spaces-storage',
-  'files-common-favorites',
-  'files-shares-with-others',
-  'files-shares-with-me',
-  'files-public-files'
-]
-
 const fileExtensionConfig = {
   canBeDefault: true,
-  routeName,
-  routes: routesForFileExtensions
+  routeName
 }
 
 const appInfo = {

--- a/packages/web-app-skeleton/src/app.js
+++ b/packages/web-app-skeleton/src/app.js
@@ -19,14 +19,7 @@ const injectExtensions = async (api) => {
       menuTitle($gettext) {
         return $gettext('Extension from skeleton')
       }
-    },
-    routes: [
-      'files-spaces-storage',
-      'files-common-favorites',
-      'files-shares-with-others',
-      'files-shares-with-me',
-      'files-public-files'
-    ]
+    }
   })
 }
 

--- a/packages/web-runtime/src/container/api.ts
+++ b/packages/web-runtime/src/container/api.ts
@@ -26,35 +26,38 @@ const announceRoutes = (applicationId: string, router: VueRouter, routes: RouteC
   const namespaceRouteName = (name: string) => {
     return name.startsWith(`${applicationId}-`) ? name : `${applicationId}-${name}`
   }
-  const applicationRoutes = routes.map((applicationRoute) => {
-    if (!isObject(applicationRoute)) {
-      throw new ApiError("route can't be blank", applicationRoute)
-    }
+  routes
+    .map((applicationRoute) => {
+      if (!isObject(applicationRoute)) {
+        throw new ApiError("route can't be blank", applicationRoute)
+      }
 
-    const route = clone(applicationRoute)
-    if (route.name) {
-      route.name = applicationId === route.name ? route.name : namespaceRouteName(route.name)
-    }
+      const route = clone(applicationRoute)
+      if (route.name) {
+        route.name = applicationId === route.name ? route.name : namespaceRouteName(route.name)
+      }
 
-    route.path = `/${encodeURI(applicationId)}${route.path}`
+      route.path = `/${encodeURI(applicationId)}${route.path}`
 
-    if (route.children) {
-      route.children = route.children.map((childRoute) => {
-        if (!isObject(applicationRoute)) {
-          throw new ApiError("route children can't be blank", applicationRoute, childRoute)
-        }
+      if (route.children) {
+        route.children = route.children.map((childRoute) => {
+          if (!isObject(applicationRoute)) {
+            throw new ApiError("route children can't be blank", applicationRoute, childRoute)
+          }
 
-        const r = clone(childRoute)
-        if (childRoute.name) {
-          r.name = namespaceRouteName(childRoute.name)
-        }
-        return r
-      })
-    }
+          const r = clone(childRoute)
+          if (childRoute.name) {
+            r.name = namespaceRouteName(childRoute.name)
+          }
+          return r
+        })
+      }
 
-    return route
-  })
-  router.addRoutes(applicationRoutes)
+      return route
+    })
+    .forEach((route) => {
+      router.addRoute(route)
+    })
 }
 
 /**

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -242,9 +242,10 @@ export const announceDefaults = ({
     defaultExtensionId = appIds[0]
   }
 
-  router.addRoutes([
-    { path: '/', redirect: () => store.getters.getNavItemsByExtension(defaultExtensionId)[0].route }
-  ])
+  router.addRoute({
+    path: '/',
+    redirect: () => store.getters.getNavItemsByExtension(defaultExtensionId)[0].route
+  })
 
   routerSync(store, router)
 }


### PR DESCRIPTION
## Description
This PR kills the `routes` key from the editor app manifests. It has only ever been used as a weird way to disable editors in the trashbin view. Since that logic belongs in the files app, not in the editors, I've converted this to a hardcoded check in the fileActions mixin (all the file actions do hardcoded route checks anyways). This gets us rid of the hassle to update a route whitelist in all applications out there (and internally). Which is the case for the upcoming spaces feature already (i.e. no apps being available in spaces folder listings, which is unnecessary effort).

Also used the chance to get rid of some console noise, namely:
- vue router deprecation warnings of `addRoutes` (use `addRoute` instead)
- warnings about a non-existing `files-spaces-storage` route name (deleted as not needed anymore)
- warning about vuex `mapGetter` usage for the `External/mimeTypes` getter, which only exists if the `external` app is loaded. Which is not always the case.

## Motivation and Context
Improve developer experience.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
