### PR TITLE
add fontawesome-free attributions console message

### DIFF
--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -45,6 +45,7 @@
     "webfontloader": "^1.6.28"
   },
   "devDependencies": {
+    "@fortawesome/fontawesome-free": "^6.0.0",
     "@types/luxon": "^2.0.8"
   }
 }

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -4,6 +4,7 @@
   "description": "ownCloud web runtime",
   "license": "AGPL-3.0",
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.15.4",
     "@popperjs/core": "^2.4.0",
     "@vue/composition-api": "^1.4.4",
     "easygettext": "^2.16.1",
@@ -45,7 +46,6 @@
     "webfontloader": "^1.6.28"
   },
   "devDependencies": {
-    "@fortawesome/fontawesome-free": "^6.0.0",
     "@types/luxon": "^2.0.8"
   }
 }

--- a/packages/web-runtime/src/defaults/index.ts
+++ b/packages/web-runtime/src/defaults/index.ts
@@ -6,10 +6,13 @@ import Store from '../store'
 import { coreTranslations, odsTranslations } from './json'
 import { createStore } from 'vuex-extensions'
 import Vuex from 'vuex'
+
+// fontawesome-free attributions console message
+import '@fortawesome/fontawesome-free/attribution'
+
 export { default as Vue } from './vue'
 export { default as DesignSystem } from 'owncloud-design-system'
 export { default as Router } from '../router'
-
 export const store = createStore(Vuex.Store, { ...Store })
 export const pages = { success: App, failure: missingOrInvalidConfigPage }
 export const translations = merge({}, coreTranslations, odsTranslations)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1584,6 +1584,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@fortawesome/fontawesome-free@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@fortawesome/fontawesome-free@npm:6.0.0"
+  checksum: 138e352ba6e9ecdd711899943919d4020704ddf22dc6a7de14d0dbfb5222c60738fcded6ca39a3fcd6fa8eaf9b83033e44dd25625d9e0118a9cea1d4585b36de
+  languageName: node
+  linkType: hard
+
 "@gar/promisify@npm:^1.0.1":
   version: 1.1.2
   resolution: "@gar/promisify@npm:1.1.2"
@@ -13379,6 +13386,7 @@ typescript@^4.3.2:
   version: 0.0.0-use.local
   resolution: "web-runtime@workspace:packages/web-runtime"
   dependencies:
+    "@fortawesome/fontawesome-free": ^6.0.0
     "@popperjs/core": ^2.4.0
     "@types/luxon": ^2.0.8
     "@vue/composition-api": ^1.4.4

--- a/yarn.lock
+++ b/yarn.lock
@@ -1584,10 +1584,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fortawesome/fontawesome-free@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "@fortawesome/fontawesome-free@npm:6.0.0"
-  checksum: 138e352ba6e9ecdd711899943919d4020704ddf22dc6a7de14d0dbfb5222c60738fcded6ca39a3fcd6fa8eaf9b83033e44dd25625d9e0118a9cea1d4585b36de
+"@fortawesome/fontawesome-free@npm:^5.15.4":
+  version: 5.15.4
+  resolution: "@fortawesome/fontawesome-free@npm:5.15.4"
+  checksum: 32281c3df4075290d9a96dfc22f72fadb3da7055d4117e48d34046b8c98032a55fa260ae351b0af5d6f6fb57a2f5d79a4abe52af456da35195f7cb7dda27b4a2
   languageName: node
   linkType: hard
 
@@ -13386,7 +13386,7 @@ typescript@^4.3.2:
   version: 0.0.0-use.local
   resolution: "web-runtime@workspace:packages/web-runtime"
   dependencies:
-    "@fortawesome/fontawesome-free": ^6.0.0
+    "@fortawesome/fontawesome-free": ^5.15.4
     "@popperjs/core": ^2.4.0
     "@types/luxon": ^2.0.8
     "@vue/composition-api": ^1.4.4


### PR DESCRIPTION
## Description
print fontawesome-free attributions to browser console. This is a quick workaround and should be moved to ODS in one of the next releasees.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/6369