### PR TITLE
Move the watchActiveLocation helper to a useActiveLocation composable

### DIFF
--- a/packages/web-app-files/src/components/AppBar/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar/AppBar.vue
@@ -139,12 +139,8 @@ import Mixins from '../../mixins'
 import MixinFileActions, { EDITOR_MODE_CREATE } from '../../mixins/fileActions'
 import { buildResource, buildWebDavFilesPath, buildWebDavSpacesPath } from '../../helpers/resources'
 import { bus } from 'web-pkg/src/instance'
-import {
-  isLocationActive,
-  isLocationPublicActive,
-  isLocationSpacesActive,
-  watchActiveLocation
-} from '../../router'
+import { isLocationActive, isLocationPublicActive, isLocationSpacesActive } from '../../router'
+import { useActiveLocation } from '../../composables'
 
 import BatchActions from './SelectedResources/BatchActions.vue'
 import FileDrop from './Upload/FileDrop.vue'
@@ -168,13 +164,9 @@ export default {
   mixins: [Mixins, MixinFileActions],
   setup() {
     return {
-      isPersonalLocation: watchActiveLocation(isLocationSpacesActive, 'files-spaces-personal-home'),
-      isPublicLocation: watchActiveLocation(isLocationPublicActive, 'files-public-files'),
-      isSpacesProjectsLocation: watchActiveLocation(
-        isLocationSpacesActive,
-        'files-spaces-projects'
-      ),
-      isSpacesProjectLocation: watchActiveLocation(isLocationSpacesActive, 'files-spaces-project')
+      isPersonalLocation: useActiveLocation(isLocationSpacesActive, 'files-spaces-personal-home'),
+      isPublicLocation: useActiveLocation(isLocationPublicActive, 'files-public-files'),
+      isSpacesProjectsLocation: useActiveLocation(isLocationSpacesActive, 'files-spaces-projects')
     }
   },
   data: () => ({

--- a/packages/web-app-files/src/composables/index.ts
+++ b/packages/web-app-files/src/composables/index.ts
@@ -1,5 +1,6 @@
 export * from './fileListHeaderPosition'
 export * from './pagination'
+export * from './router'
 export * from './sort'
 
 declare module 'vue/types/vue' {

--- a/packages/web-app-files/src/composables/router/index.ts
+++ b/packages/web-app-files/src/composables/router/index.ts
@@ -1,0 +1,1 @@
+export * from './useActiveLocation'

--- a/packages/web-app-files/src/composables/router/useActiveLocation.ts
+++ b/packages/web-app-files/src/composables/router/useActiveLocation.ts
@@ -1,0 +1,27 @@
+import { ref, Ref, watch } from '@vue/composition-api'
+import { useRoute, useRouter } from 'web-pkg/src/composables'
+import { ActiveRouteDirectorFunc } from '../../router'
+
+/**
+ * watches the current route and re-evaluates the provided active location director
+ * on each route name update.
+ *
+ * @param director
+ * @param comparatives
+ */
+export const useActiveLocation = <T extends string>(
+  director: ActiveRouteDirectorFunc<T>,
+  ...comparatives: T[]
+): Ref<boolean> => {
+  const value = ref(false)
+  const router = useRouter()
+  const currentRoute = useRoute()
+  watch(
+    currentRoute,
+    () => {
+      value.value = director(router, ...comparatives)
+    },
+    { immediate: true }
+  )
+  return value
+}

--- a/packages/web-app-files/src/router/index.ts
+++ b/packages/web-app-files/src/router/index.ts
@@ -23,7 +23,7 @@ import {
   isLocationCommonActive,
   createLocationCommon
 } from './common'
-import { isAuthenticatedRoute, watchActiveLocation } from './utils'
+import { isAuthenticatedRoute, ActiveRouteDirectorFunc } from './utils'
 import { buildRoutes as buildDeprecatedRoutes, isLocationActive } from './deprecated'
 import { RouteComponents } from './router'
 import { RouteConfig } from 'vue-router'
@@ -56,6 +56,6 @@ export {
   isLocationPublicActive,
   isLocationActive,
   isAuthenticatedRoute,
-  watchActiveLocation,
-  buildRoutes
+  buildRoutes,
+  ActiveRouteDirectorFunc
 }

--- a/packages/web-app-files/src/router/utils.ts
+++ b/packages/web-app-files/src/router/utils.ts
@@ -2,8 +2,6 @@ import VueRouter, { Location } from 'vue-router'
 import merge from 'lodash-es/merge'
 import get from 'lodash-es/get'
 import { RouteMeta } from 'vue-router/types/router'
-import { ref, Ref, watch } from '@vue/composition-api'
-import { useRouter, useCurrentRoute } from 'web-pkg/src/composables'
 
 export interface ActiveRouteDirectorFunc<T extends string> {
   (router: VueRouter, ...comparatives: T[]): boolean
@@ -58,30 +56,6 @@ export const isLocationActiveDirector = <T extends string>(
 
     return isLocationActive(router, first, ...rest)
   }
-}
-
-/**
- * watches the current route and re-evaluates the provided active location director
- * on each route name update.
- *
- * @param director
- * @param comparatives
- */
-export const watchActiveLocation = <T extends string>(
-  director: ActiveRouteDirectorFunc<T>,
-  ...comparatives: T[]
-): Ref<boolean> => {
-  const value = ref(false)
-  const router = useRouter()
-  const currentRoute = useCurrentRoute()
-  watch(
-    currentRoute,
-    () => {
-      value.value = director(router, ...comparatives)
-    },
-    { immediate: true }
-  )
-  return value
 }
 
 /**

--- a/packages/web-pkg/src/composables/router/index.ts
+++ b/packages/web-pkg/src/composables/router/index.ts
@@ -1,5 +1,5 @@
 export * from './types'
-export * from './useCurrentRoute'
+export * from './useRoute'
 export * from './useRouteName'
 export * from './useRouteQuery'
 export * from './useRouteQueryPersisted'

--- a/packages/web-pkg/src/composables/router/useRoute.ts
+++ b/packages/web-pkg/src/composables/router/useRoute.ts
@@ -2,9 +2,10 @@ import { ref, Ref, readonly } from '@vue/composition-api'
 import { useRouter } from './useRouter'
 import { Route } from 'vue-router'
 
-export const useCurrentRoute = (): Ref<Route> => {
+export const useRoute = (): Ref<Route> => {
   const router = useRouter()
   const currentRoute = ref()
+  currentRoute.value = router.currentRoute
   router.afterEach((to) => (currentRoute.value = { ...to }))
 
   return readonly(currentRoute)

--- a/packages/web-pkg/src/composables/router/useRouteName.ts
+++ b/packages/web-pkg/src/composables/router/useRouteName.ts
@@ -1,15 +1,9 @@
-import { useRouter } from './useRouter'
-import { Ref, ref, watch } from '@vue/composition-api'
+import { computed, ComputedRef, unref } from '@vue/composition-api'
+import { useRoute } from './useRoute'
 
-export const useRouteName = (): Ref<string> => {
-  const router = useRouter()
-  const routeName = ref('')
-  watch(
-    () => router.currentRoute,
-    (currentRoute) => {
-      routeName.value = currentRoute?.name
-    },
-    { immediate: true }
-  )
-  return routeName
+export const useRouteName = (): ComputedRef<string> => {
+  const route = useRoute()
+  return computed(() => {
+    return unref(route).name
+  })
 }


### PR DESCRIPTION
## Description
Moved the `watchActiveLocation` helper to a `useActiveLocation` composable to make clearer that it is to be used in context of composition API only.

Also renamed the useCurrentRoute composable to useRoute to stay
consistent with naming and refactored the useRouteName composable to use
the new useRoute composable internally, which reduces code complexity
and actually makes it reactive.

## Motivation and Context
Clean code...

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
