### PR TITLE
[tests-only][full-ci] Create report directory if not exists

### DIFF
--- a/tests/acceptance/setup.js
+++ b/tests/acceptance/setup.js
@@ -6,6 +6,7 @@ const {
   startWebDriver,
   stopWebDriver
 } = require('nightwatch-api')
+const fs = require('fs')
 const { rollbackConfigs, cacheConfigs } = require('./helpers/config')
 const { getAllLogsWithDateTime } = require('./helpers/browserConsole.js')
 const { runOcc } = require('./helpers/occHelper')
@@ -23,6 +24,12 @@ setDefaultTimeout(CUCUMBER_TIMEOUT)
 
 let env = RUNNING_ON_CI ? 'drone' : 'local'
 env = RUNNING_ON_SAUCELABS ? 'saucelabs' : env
+
+// create report dir if not exists
+const reportDir = 'report'
+if (!fs.existsSync(reportDir)) {
+  fs.mkdirSync(reportDir)
+}
 
 defineParameterType({
   name: 'code',


### PR DESCRIPTION
## Description
While running acceptance tests using scripts from package.json file, the command will fail because `report` dir will not be available.
This PR creates `report` folder if not exists before tests run.

**Or we can remove `-f json:report/cucumber_report.json` from the command. (I don't know how we are using `cucumber_report.json`)**

## Related Issue
- Fixes https://github.com/owncloud/web/issues/6388

## How Has This Been Tested?
- test environment: local

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 