### PR TITLE
[tests-only] mock setModalInputErrorMessage in Projects.spec.js

### DIFF
--- a/packages/web-app-files/tests/unit/views/spaces/Projects.spec.js
+++ b/packages/web-app-files/tests/unit/views/spaces/Projects.spec.js
@@ -79,6 +79,7 @@ describe('Spaces component', () => {
     })
     const wrapper = getMountedWrapper()
     await wrapper.vm.loadSpacesTask.last
+    wrapper.vm.setModalInputErrorMessage = jest.fn()
 
     const spyInputErrorMessageStub = jest.spyOn(wrapper.vm, 'setModalInputErrorMessage')
     wrapper.vm.checkSpaceName('')


### PR DESCRIPTION
## Description
mock `setModalInputErrorMessage` so that it does not show an error while running the unit tests

<!--- Describe your changes in detail -->

## Related Issue
- part of #6337

## Motivation and Context
get rid of this log output
```
  console.error
    [vuex] unknown action type: setModalInputErrorMessage

      at Store.dispatch (node_modules/vuex/dist/vuex.common.js:499:15)
      at Store.boundDispatch [as dispatch] (node_modules/vuex/dist/vuex.common.js:408:21)
      at VueComponent.mappedAction (node_modules/vuex/dist/vuex.common.js:1066:20)

```

## How Has This Been Tested?
:robot:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
