### PR TITLE
[full-ci] Enforce extensions to always display the ui-header

### DIFF
--- a/changelog/unreleased/change-enforce-ui-header
+++ b/changelog/unreleased/change-enforce-ui-header
@@ -1,0 +1,6 @@
+Change: Enforce extensions to always display the ui-header
+
+We've enforced the ui to always render the header for third party extensions.
+From now on extensions are not able to disable the header anymore.
+
+https://github.com/owncloud/web/pull/6401

--- a/packages/web-app-draw-io/src/App.vue
+++ b/packages/web-app-draw-io/src/App.vue
@@ -250,11 +250,6 @@ export default {
 </script>
 <style scoped>
 #drawio-editor {
-  position: fixed;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
   width: 100%;
   height: 100%;
   border: none;

--- a/packages/web-app-draw-io/src/index.js
+++ b/packages/web-app-draw-io/src/index.js
@@ -5,12 +5,9 @@ const routes = [
   {
     name: 'draw-io',
     path: '/:contextRouteName/:filePath*',
-    components: {
-      fullscreen: App
-    },
+    component: App,
     meta: {
       auth: false,
-      hideHeadbar: true,
       patchCleanPath: true
     }
   }

--- a/packages/web-app-external/src/index.js
+++ b/packages/web-app-external/src/index.js
@@ -16,9 +16,7 @@ const routes = [
   {
     name: 'apps',
     path: '/:contextRouteName/:fileId/:appName?',
-    components: {
-      app: App
-    },
+    component: App,
     meta: {
       auth: false,
       title: $gettext('External app')

--- a/packages/web-app-files/src/App.vue
+++ b/packages/web-app-files/src/App.vue
@@ -104,7 +104,6 @@ export default {
 main {
   height: 100%;
   max-height: 100%;
-  overflow: hidden;
 }
 
 .files-list-wrapper {

--- a/packages/web-app-files/src/components/AppBar/Upload/FileDrop.vue
+++ b/packages/web-app-files/src/components/AppBar/Upload/FileDrop.vue
@@ -103,8 +103,8 @@ export default {
 }
 @media only screen and (min-width: 640px) {
   .oc-dropzone-navigation-collapsed > .oc-dropzone-container {
-    left: calc(67px + var(--oc-space-small));
-    width: calc(100% - 67px - (2 * var(--oc-space-small)));
+    left: calc(64px + var(--oc-space-small));
+    width: calc(100% - 64px - (2 * var(--oc-space-small)));
   }
   .oc-dropzone-navigation-expanded > .oc-dropzone-container {
     left: calc(250px + var(--oc-space-small));

--- a/packages/web-app-files/src/router/common.ts
+++ b/packages/web-app-files/src/router/common.ts
@@ -18,9 +18,7 @@ export const isLocationCommonActive = isLocationActiveDirector<commonTypes>(
 export const buildRoutes = (components: RouteComponents): RouteConfig[] => [
   {
     path: '/trash',
-    components: {
-      app: components.App
-    },
+    component: components.App,
     children: [
       {
         name: locationTrash.name,
@@ -36,9 +34,7 @@ export const buildRoutes = (components: RouteComponents): RouteConfig[] => [
   },
   {
     path: '/favorites',
-    components: {
-      app: components.App
-    },
+    component: components.App,
     children: [
       {
         name: locationFavorites.name,

--- a/packages/web-app-files/src/router/operations.ts
+++ b/packages/web-app-files/src/router/operations.ts
@@ -26,9 +26,7 @@ export const buildRoutes = (components: RouteComponents): RouteConfig[] => [
   {
     name: locationLocationPicker.name,
     path: '/ops/location-picker/:context/:action/:item*',
-    components: {
-      app: components.LocationPicker
-    },
+    component: components.LocationPicker,
     meta: {
       verbose: true,
       auth: false,
@@ -38,21 +36,16 @@ export const buildRoutes = (components: RouteComponents): RouteConfig[] => [
   {
     name: locationResolverPublicLink.name,
     path: '/ops/resolver/public-link/:token',
-    components: {
-      fullscreen: components.PublicLink
-    },
+    component: components.PublicLink,
     meta: {
       auth: false,
-      hideHeadbar: true,
       title: $gettext('Resolving public link')
     }
   },
   {
     name: locationResolverPrivateLink.name,
     path: '/ops/resolver/private-link/:fileId',
-    components: {
-      fullscreen: components.PrivateLink
-    },
-    meta: { hideHeadbar: true, title: $gettext('Resolving private link') }
+    component: components.PrivateLink,
+    meta: { title: $gettext('Resolving private link') }
   }
 ]

--- a/packages/web-app-files/src/router/public.ts
+++ b/packages/web-app-files/src/router/public.ts
@@ -18,9 +18,7 @@ export const isLocationPublicActive = isLocationActiveDirector<shareTypes>(
 export const buildRoutes = (components: RouteComponents): RouteConfig[] => [
   {
     path: '/public',
-    components: {
-      app: components.App
-    },
+    component: components.App,
     meta: {
       auth: false
     },
@@ -41,9 +39,7 @@ export const buildRoutes = (components: RouteComponents): RouteConfig[] => [
   {
     name: locationPublicDrop.name,
     path: '/public/drop/:token',
-    components: {
-      app: components.FilesDrop
-    },
+    component: components.FilesDrop,
     meta: { auth: false, title: $gettext('Public file upload') }
   }
 ]

--- a/packages/web-app-files/src/router/shares.ts
+++ b/packages/web-app-files/src/router/shares.ts
@@ -20,9 +20,7 @@ export const isLocationSharesActive = isLocationActiveDirector<shareTypes>(
 export const buildRoutes = (components: RouteComponents): RouteConfig[] => [
   {
     path: '/shares',
-    components: {
-      app: components.App
-    },
+    component: components.App,
     redirect: locationSharesWithMe,
     children: [
       {

--- a/packages/web-app-files/src/router/spaces.ts
+++ b/packages/web-app-files/src/router/spaces.ts
@@ -28,9 +28,7 @@ export const isLocationSpacesActive = isLocationActiveDirector<spaceTypes>(
 export const buildRoutes = (components: RouteComponents): RouteConfig[] => [
   {
     path: '/spaces',
-    components: {
-      app: components.App
-    },
+    component: components.App,
     children: [
       {
         path: 'projects',

--- a/packages/web-app-files/src/views/PrivateLink.vue
+++ b/packages/web-app-files/src/views/PrivateLink.vue
@@ -1,22 +1,31 @@
 <template>
-  <div
-    class="oc-login oc-height-viewport"
-    :style="{ backgroundImage: 'url(' + backgroundImg + ')' }"
-  >
+  <div class="oc-height-1-1">
     <h1 class="oc-invisible-sr">{{ pageTitle }}</h1>
-    <div class="oc-login-card oc-position-center">
-      <img class="oc-login-logo" :src="logoImg" alt="" :aria-hidden="true" />
-      <div v-if="loading" class="oc-login-card-body">
-        <h2 class="oc-login-card-title">
-          <translate>Resolving private link…</translate>
-        </h2>
-        <oc-spinner :aria-hidden="true" />
-      </div>
-      <div v-if="errorMessage" class="oc-login-card-body">
-        <h2 class="oc-login-card-title">
-          <translate>An error occurred while resolving the private link</translate>
-        </h2>
-        <span>{{ errorMessage }}</span>
+    <div class="oc-card oc-border oc-rounded oc-position-center oc-text-center oc-width-large">
+      <template v-if="loading">
+        <div class="oc-card-header">
+          <h2>
+            <translate>Resolving private link…</translate>
+          </h2>
+        </div>
+        <div class="oc-card-body">
+          <oc-spinner :aria-hidden="true" />
+        </div>
+      </template>
+      <template v-else-if="errorMessage">
+        <div class="oc-card-header">
+          <h2>
+            <translate>An error occurred while resolving the private link</translate>
+          </h2>
+        </div>
+        <div class="oc-card-body oc-link-resolve-error">
+          <p class="oc-text-lead">{{ errorMessage }}</p>
+        </div>
+      </template>
+      <div class="oc-card-footer">
+        <p>
+          {{ configuration.currentTheme.general.slogan }}
+        </p>
       </div>
     </div>
   </div>
@@ -38,14 +47,6 @@ export default {
 
     pageTitle() {
       return this.$gettext(this.$route.meta.title)
-    },
-
-    backgroundImg() {
-      return this.configuration.currentTheme.loginPage.backgroundImg
-    },
-
-    logoImg() {
-      return this.configuration.currentTheme.logo.login
     }
   },
   mounted() {
@@ -77,3 +78,10 @@ export default {
   }
 }
 </script>
+
+<style lang="scss">
+.oc-card-header h2,
+.oc-card-footer p {
+  margin: 0;
+}
+</style>

--- a/packages/web-app-files/src/views/PrivateLink.vue
+++ b/packages/web-app-files/src/views/PrivateLink.vue
@@ -4,7 +4,7 @@
     <div class="oc-card oc-border oc-rounded oc-position-center oc-text-center oc-width-large">
       <template v-if="loading">
         <div class="oc-card-header">
-          <h2>
+          <h2 key="private-link-loading">
             <translate>Resolving private link…</translate>
           </h2>
         </div>
@@ -13,12 +13,12 @@
         </div>
       </template>
       <template v-else-if="errorMessage">
-        <div class="oc-card-header">
-          <h2>
+        <div class="oc-card-header oc-link-resolve-error-title">
+          <h2 key="private-link-error">
             <translate>An error occurred while resolving the private link</translate>
           </h2>
         </div>
-        <div class="oc-card-body oc-link-resolve-error">
+        <div class="oc-card-body oc-link-resolve-error-message">
           <p class="oc-text-lead">{{ errorMessage }}</p>
         </div>
       </template>

--- a/packages/web-app-files/src/views/PublicLink.vue
+++ b/packages/web-app-files/src/views/PublicLink.vue
@@ -1,29 +1,35 @@
 <template>
-  <div
-    class="oc-login oc-height-viewport"
-    :style="{ backgroundImage: 'url(' + backgroundImg + ')' }"
-  >
+  <div class="oc-height-1-1">
     <h1 class="oc-invisible-sr">{{ pageTitle }}</h1>
-    <div class="oc-login-card oc-position-center">
-      <img class="oc-login-logo" :src="logoImg" alt="" :aria-hidden="true" />
-      <div class="oc-login-card-body">
-        <template v-if="loading">
-          <h2 class="oc-login-card-title">
+    <div class="oc-card oc-border oc-rounded oc-position-center oc-text-center oc-width-large">
+      <template v-if="loading">
+        <div class="oc-card-header">
+          <h2>
             <translate>Loading public link…</translate>
           </h2>
+        </div>
+        <div class="oc-card-body">
           <oc-spinner :aria-hidden="true" />
-        </template>
-        <template v-else-if="errorMessage">
-          <h2 class="oc-login-card-title oc-login-card-error">
+        </div>
+      </template>
+      <template v-else-if="errorMessage">
+        <div class="oc-card-header">
+          <h2>
             <translate>An error occurred while loading the public link</translate>
           </h2>
+        </div>
+        <div class="oc-card-body oc-link-resolve-error">
           <p class="oc-text-lead">{{ errorMessage }}</p>
-        </template>
-        <template v-else-if="passwordRequired">
-          <form @submit.prevent="resolvePublicLink">
-            <h2 class="oc-login-card-title">
-              <translate>This resource is password-protected.</translate>
+        </div>
+      </template>
+      <template v-else-if="passwordRequired">
+        <form @submit.prevent="resolvePublicLink">
+          <div class="oc-card-header">
+            <h2>
+              <translate>This resource is password-protected</translate>
             </h2>
+          </div>
+          <div class="oc-card-body">
             <oc-text-input
               ref="passwordInput"
               v-model="password"
@@ -31,7 +37,7 @@
               :label="passwordFieldLabel"
               type="password"
               class="oc-mb-s"
-            ></oc-text-input>
+            />
             <oc-button
               variation="primary"
               appearance="filled"
@@ -40,10 +46,10 @@
             >
               <translate>Continue</translate>
             </oc-button>
-          </form>
-        </template>
-      </div>
-      <div class="oc-login-card-footer">
+          </div>
+        </form>
+      </template>
+      <div class="oc-card-footer">
         <p>
           {{ configuration.currentTheme.general.slogan }}
         </p>
@@ -80,14 +86,6 @@ export default {
 
     passwordFieldLabel() {
       return this.$gettext('Enter password for public link')
-    },
-
-    backgroundImg() {
-      return this.configuration.currentTheme.loginPage.backgroundImg
-    },
-
-    logoImg() {
-      return this.configuration.currentTheme.logo.login
     }
   },
   mounted() {
@@ -141,3 +139,13 @@ export default {
   }
 }
 </script>
+
+<style lang="scss">
+.oc-text-input-message {
+  justify-content: center;
+}
+.oc-card-header h2,
+.oc-card-footer p {
+  margin: 0;
+}
+</style>

--- a/packages/web-app-files/src/views/PublicLink.vue
+++ b/packages/web-app-files/src/views/PublicLink.vue
@@ -4,7 +4,7 @@
     <div class="oc-card oc-border oc-rounded oc-position-center oc-text-center oc-width-large">
       <template v-if="loading">
         <div class="oc-card-header">
-          <h2>
+          <h2 key="public-link-loading">
             <translate>Loading public link…</translate>
           </h2>
         </div>
@@ -13,12 +13,12 @@
         </div>
       </template>
       <template v-else-if="errorMessage">
-        <div class="oc-card-header">
-          <h2>
+        <div class="oc-card-header oc-link-resolve-error-title">
+          <h2 key="public-link-error">
             <translate>An error occurred while loading the public link</translate>
           </h2>
         </div>
-        <div class="oc-card-body oc-link-resolve-error">
+        <div class="oc-card-body oc-link-resolve-error-message">
           <p class="oc-text-lead">{{ errorMessage }}</p>
         </div>
       </template>
@@ -88,7 +88,7 @@ export default {
       return this.$gettext('Enter password for public link')
     }
   },
-  mounted() {
+  created() {
     this.resolvePublicLink()
   },
   methods: {

--- a/packages/web-app-files/tests/unit/views/PrivateLink.spec.js
+++ b/packages/web-app-files/tests/unit/views/PrivateLink.spec.js
@@ -22,7 +22,7 @@ const $route = {
 const selectors = {
   pageTitle: 'h1.oc-invisible-sr',
   loader: '.oc-card-body',
-  errorMessage: '.oc-link-resolve-error'
+  errorTitle: '.oc-link-resolve-error-title'
 }
 
 describe('PrivateLink view', () => {
@@ -62,7 +62,7 @@ describe('PrivateLink view', () => {
 
       await new Promise((resolve) => {
         setTimeout(() => {
-          expect(wrapper.find(selectors.errorMessage)).toMatchSnapshot()
+          expect(wrapper.find(selectors.errorTitle)).toMatchSnapshot()
           resolve()
         }, 1)
       })

--- a/packages/web-app-files/tests/unit/views/PrivateLink.spec.js
+++ b/packages/web-app-files/tests/unit/views/PrivateLink.spec.js
@@ -6,8 +6,9 @@ localVue.prototype.$client.files = {
   getPathForFileId: jest.fn(() => Promise.resolve('/lorem.txt'))
 }
 
-const backgroundImgPath = 'assets/loginBackground.jpg'
-const loginLogoPath = 'assets/logo.svg'
+const theme = {
+  general: { slogan: 'some-slogan' }
+}
 
 const $route = {
   params: {
@@ -19,11 +20,9 @@ const $route = {
 }
 
 const selectors = {
-  backgroundImg: '.oc-login',
   pageTitle: 'h1.oc-invisible-sr',
-  loginLogo: '.oc-login-logo',
-  loader: '.oc-login-card-body',
-  errorMessage: '.oc-login-card-body'
+  loader: '.oc-card-body',
+  errorMessage: '.oc-link-resolve-error'
 }
 
 describe('PrivateLink view', () => {
@@ -37,22 +36,8 @@ describe('PrivateLink view', () => {
       wrapper = getShallowWrapper()
     })
 
-    it('should have the background image set', () => {
-      const backgroundImg = wrapper.find(selectors.backgroundImg)
-
-      expect(backgroundImg.exists()).toBeTruthy()
-      expect(backgroundImg.attributes().style).toEqual(
-        `background-image: url(${backgroundImgPath});`
-      )
-    })
     it('should display the page title', () => {
       expect(wrapper.find(selectors.pageTitle)).toMatchSnapshot()
-    })
-    it('should display the logo', () => {
-      const loginLogo = wrapper.find(selectors.loginLogo)
-
-      expect(loginLogo.exists()).toBeTruthy()
-      expect(loginLogo.attributes().src).toEqual(loginLogoPath)
     })
     it('should resolve the provided file id to a path', () => {
       expect(localVue.prototype.$client.files.getPathForFileId).toHaveBeenCalledTimes(1)
@@ -111,7 +96,6 @@ function getShallowWrapper(loading = false) {
 
 function createStore() {
   return getStore({
-    loginBackgroundImg: backgroundImgPath,
-    loginLogo: loginLogoPath
+    slogan: theme.general.slogan
   })
 }

--- a/packages/web-app-files/tests/unit/views/PublicLink.spec.js
+++ b/packages/web-app-files/tests/unit/views/PublicLink.spec.js
@@ -19,7 +19,7 @@ const selectors = {
   cardFooter: '.oc-card-footer',
   cardBody: '.oc-card-body',
   submitButton: '.oc-login-authorize-button',
-  errorMessage: '.oc-link-resolve-error',
+  errorTitle: '.oc-link-resolve-error-title',
   publicLinkPasswordRequired: 'form > .oc-card-title'
 }
 
@@ -49,7 +49,7 @@ describe('PublicLink', () => {
       expect(loading).toMatchSnapshot()
     })
     it('should not display the error message', () => {
-      expect(wrapper.find(selectors.errorMessage).exists()).toBeFalsy()
+      expect(wrapper.find(selectors.errorTitle).exists()).toBeFalsy()
     })
     it('should not display the password required form', () => {
       expect(wrapper.find(selectors.publicLinkPasswordRequired).exists()).toBeFalsy()
@@ -67,8 +67,8 @@ describe('PublicLink', () => {
       const wrapper = getWrapper({ loading: false })
       await wrapper.setData({ errorMessage: 'some-error-message' })
 
-      expect(wrapper.find(selectors.errorMessage).exists()).toBeTruthy()
-      expect(wrapper.find(selectors.errorMessage)).toMatchSnapshot()
+      expect(wrapper.find(selectors.errorTitle).exists()).toBeTruthy()
+      expect(wrapper.find(selectors.errorTitle)).toMatchSnapshot()
     })
 
     describe('and when "passwordRequired" is set as true', () => {

--- a/packages/web-app-files/tests/unit/views/PublicLink.spec.js
+++ b/packages/web-app-files/tests/unit/views/PublicLink.spec.js
@@ -3,9 +3,7 @@ import { getStore, localVue } from './views.setup.js'
 import { shallowMount, mount } from '@vue/test-utils'
 
 const theme = {
-  general: { slogan: 'some-slogan' },
-  logo: 'some-logo',
-  loginPage: { backgroundImg: 'some-image' }
+  general: { slogan: 'some-slogan' }
 }
 
 const stubs = {
@@ -18,12 +16,11 @@ const route = { meta: { title: 'some page title' }, params: { token: 'some-token
 const component = { ...PublicLink, mounted: jest.fn(), created: jest.fn() }
 
 const selectors = {
-  loginLogo: '.oc-login-logo',
-  loginCardFooter: '.oc-login-card-footer',
-  loginCardBody: '.oc-login-card-body',
+  cardFooter: '.oc-card-footer',
+  cardBody: '.oc-card-body',
   submitButton: '.oc-login-authorize-button',
-  errorMessage: '.oc-login-card-error',
-  publicLinkPasswordRequired: 'form > .oc-login-card-title'
+  errorMessage: '.oc-link-resolve-error',
+  publicLinkPasswordRequired: 'form > .oc-card-title'
 }
 
 const spinnerStub = 'oc-spinner-stub'
@@ -33,16 +30,11 @@ describe('PublicLink', () => {
   describe('theming options', () => {
     const wrapper = getWrapper()
 
-    it('should have the background image and page-title set', () => {
+    it('should have the page-title set', () => {
       expect(wrapper).toMatchSnapshot()
     })
-    it('should display the logo image inside login card', () => {
-      const logo = wrapper.find(selectors.loginLogo)
-
-      expect(logo).toMatchSnapshot()
-    })
     it('should display the configuration theme general slogan as the login card footer', () => {
-      const slogan = wrapper.find(selectors.loginCardFooter)
+      const slogan = wrapper.find(selectors.cardFooter)
 
       expect(slogan).toMatchSnapshot()
     })
@@ -51,7 +43,7 @@ describe('PublicLink', () => {
   describe('when the view is still loading', () => {
     const wrapper = getWrapper({ loading: true })
     it('should display the loading text with the spinner', () => {
-      const loading = wrapper.find(selectors.loginCardBody)
+      const loading = wrapper.find(selectors.cardBody)
 
       expect(wrapper.find(spinnerStub).exists()).toBeTruthy()
       expect(loading).toMatchSnapshot()
@@ -67,9 +59,9 @@ describe('PublicLink', () => {
   describe('when the view is not loading anymore', () => {
     it('should not display the loading text and the spinner', () => {
       const wrapper = getWrapper({ loading: false })
-      const loading = wrapper.find(selectors.loginCardBody)
+      const loading = wrapper.find(selectors.cardBody)
 
-      expect(loading).toMatchSnapshot()
+      expect(loading.exists()).toBeFalsy()
     })
     it('should display the error message if "errorMessage" is not empty', async () => {
       const wrapper = getWrapper({ loading: false })
@@ -148,9 +140,7 @@ describe('PublicLink', () => {
 function getMountOptions({
   $route = route,
   store = getStore({
-    slogan: theme.general.slogan,
-    loginLogo: theme.logo,
-    loginBackgroundImg: theme.loginPage.backgroundImg
+    slogan: theme.general.slogan
   }),
   loading = false
 } = {}) {

--- a/packages/web-app-files/tests/unit/views/__snapshots__/PrivateLink.spec.js.snap
+++ b/packages/web-app-files/tests/unit/views/__snapshots__/PrivateLink.spec.js.snap
@@ -23,7 +23,9 @@ exports[`PrivateLink view when the view is still loading should display the load
 `;
 
 exports[`PrivateLink view when there was an error should display the error message 1`] = `
-<div class="oc-card-body oc-link-resolve-error">
-  <p class="oc-text-lead">Error: some error</p>
+<div class="oc-card-header oc-link-resolve-error-title">
+  <h2>
+    <translate-stub tag="span">An error occurred while resolving the private link</translate-stub>
+  </h2>
 </div>
 `;

--- a/packages/web-app-files/tests/unit/views/__snapshots__/PrivateLink.spec.js.snap
+++ b/packages/web-app-files/tests/unit/views/__snapshots__/PrivateLink.spec.js.snap
@@ -3,28 +3,27 @@
 exports[`PrivateLink view when the page has loaded successfully should display the page title 1`] = `<h1 class="oc-invisible-sr">Resolving private link</h1>`;
 
 exports[`PrivateLink view when the view has finished loading and there was no error should not display the loading text and the error message 1`] = `
-<div class="oc-login oc-height-viewport" style="background-image: url(assets/loginBackground.jpg);">
+<div class="oc-height-1-1">
   <h1 class="oc-invisible-sr">Resolving private link</h1>
-  <div class="oc-login-card oc-position-center"><img src="assets/logo.svg" alt="" aria-hidden="true" class="oc-login-logo">
+  <div class="oc-card oc-border oc-rounded oc-position-center oc-text-center oc-width-large">
     <!---->
-    <!---->
+    <div class="oc-card-footer">
+      <p>
+        some-slogan
+      </p>
+    </div>
   </div>
 </div>
 `;
 
 exports[`PrivateLink view when the view is still loading should display the loading text with the spinner 1`] = `
-<div class="oc-login-card-body">
-  <h2 class="oc-login-card-title">
-    <translate-stub tag="span">Resolving private link…</translate-stub>
-  </h2>
+<div class="oc-card-body">
   <oc-spinner-stub arialabel="" size="medium" aria-hidden="true"></oc-spinner-stub>
 </div>
 `;
 
 exports[`PrivateLink view when there was an error should display the error message 1`] = `
-<div class="oc-login-card-body">
-  <h2 class="oc-login-card-title">
-    <translate-stub tag="span">An error occurred while resolving the private link</translate-stub>
-  </h2> <span>Error: some error</span>
+<div class="oc-card-body oc-link-resolve-error">
+  <p class="oc-text-lead">Error: some error</p>
 </div>
 `;

--- a/packages/web-app-files/tests/unit/views/__snapshots__/PublicLink.spec.js.snap
+++ b/packages/web-app-files/tests/unit/views/__snapshots__/PublicLink.spec.js.snap
@@ -1,23 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PublicLink theming options should display the configuration theme general slogan as the login card footer 1`] = `
-<div class="oc-login-card-footer">
+<div class="oc-card-footer">
   <p>
     some-slogan
   </p>
 </div>
 `;
 
-exports[`PublicLink theming options should display the logo image inside login card 1`] = `<img src="some-logo" alt="" aria-hidden="true" class="oc-login-logo">`;
-
-exports[`PublicLink theming options should have the background image and page-title set 1`] = `
-<div class="oc-login oc-height-viewport" style="background-image: url(some-image);">
+exports[`PublicLink theming options should have the page-title set 1`] = `
+<div class="oc-height-1-1">
   <h1 class="oc-invisible-sr">some page title</h1>
-  <div class="oc-login-card oc-position-center"><img src="some-logo" alt="" aria-hidden="true" class="oc-login-logo">
-    <div class="oc-login-card-body">
-      <!---->
-    </div>
-    <div class="oc-login-card-footer">
+  <div class="oc-card oc-border oc-rounded oc-position-center oc-text-center oc-width-large">
+    <!---->
+    <div class="oc-card-footer">
       <p>
         some-slogan
       </p>
@@ -38,33 +34,28 @@ exports[`PublicLink when the view is not loading anymore and when "passwordRequi
 
 exports[`PublicLink when the view is not loading anymore and when "passwordRequired" is set as true should display the password required form 1`] = `
 <form>
-  <h2 class="oc-login-card-title">
-    <translate-stub tag="span">This resource is password-protected.</translate-stub>
-  </h2>
-  <oc-text-input-stub id="oc-textinput-3" type="password" clearbuttonaccessiblelabel="" label="Enter password for public link" class="oc-mb-s"></oc-text-input-stub>
-  <oc-button-stub type="button" disabled="true" size="medium" variation="primary" appearance="filled" justifycontent="center" gapsize="medium" class="oc-login-authorize-button">
-    <translate-stub tag="span">Continue</translate-stub>
-  </oc-button-stub>
+  <div class="oc-card-header">
+    <h2>
+      <translate-stub tag="span">This resource is password-protected</translate-stub>
+    </h2>
+  </div>
+  <div class="oc-card-body">
+    <oc-text-input-stub id="oc-textinput-3" type="password" clearbuttonaccessiblelabel="" label="Enter password for public link" class="oc-mb-s"></oc-text-input-stub>
+    <oc-button-stub type="button" disabled="true" size="medium" variation="primary" appearance="filled" justifycontent="center" gapsize="medium" class="oc-login-authorize-button">
+      <translate-stub tag="span">Continue</translate-stub>
+    </oc-button-stub>
+  </div>
 </form>
 `;
 
 exports[`PublicLink when the view is not loading anymore should display the error message if "errorMessage" is not empty 1`] = `
-<h2 class="oc-login-card-title oc-login-card-error">
-  <translate-stub tag="span">An error occurred while loading the public link</translate-stub>
-</h2>
-`;
-
-exports[`PublicLink when the view is not loading anymore should not display the loading text and the spinner 1`] = `
-<div class="oc-login-card-body">
-  <!---->
+<div class="oc-card-body oc-link-resolve-error">
+  <p class="oc-text-lead">some-error-message</p>
 </div>
 `;
 
 exports[`PublicLink when the view is still loading should display the loading text with the spinner 1`] = `
-<div class="oc-login-card-body">
-  <h2 class="oc-login-card-title">
-    <translate-stub tag="span">Loading public link…</translate-stub>
-  </h2>
+<div class="oc-card-body">
   <oc-spinner-stub arialabel="" size="medium" aria-hidden="true"></oc-spinner-stub>
 </div>
 `;

--- a/packages/web-app-files/tests/unit/views/__snapshots__/PublicLink.spec.js.snap
+++ b/packages/web-app-files/tests/unit/views/__snapshots__/PublicLink.spec.js.snap
@@ -49,8 +49,10 @@ exports[`PublicLink when the view is not loading anymore and when "passwordRequi
 `;
 
 exports[`PublicLink when the view is not loading anymore should display the error message if "errorMessage" is not empty 1`] = `
-<div class="oc-card-body oc-link-resolve-error">
-  <p class="oc-text-lead">some-error-message</p>
+<div class="oc-card-header oc-link-resolve-error-title">
+  <h2>
+    <translate-stub tag="span">An error occurred while loading the public link</translate-stub>
+  </h2>
 </div>
 `;
 

--- a/packages/web-app-markdown-editor/src/index.js
+++ b/packages/web-app-markdown-editor/src/index.js
@@ -4,9 +4,7 @@ import translations from '../l10n/translations'
 const routes = [
   {
     path: '/:contextRouteName/:filePath*',
-    components: {
-      app: App
-    },
+    component: App,
     name: 'markdown-editor',
     meta: {
       patchCleanPath: true

--- a/packages/web-app-media-viewer/src/index.js
+++ b/packages/web-app-media-viewer/src/index.js
@@ -9,9 +9,7 @@ function $gettext(msg) {
 const routes = [
   {
     path: '/:contextRouteName/:filePath*',
-    components: {
-      app: App
-    },
+    component: App,
     name: 'media',
     meta: {
       auth: false,

--- a/packages/web-app-search/src/index.ts
+++ b/packages/web-app-search/src/index.ts
@@ -30,9 +30,7 @@ export default {
     {
       name: 'search',
       path: '/',
-      components: {
-        app: App
-      },
+      component: App,
       children: [
         {
           name: 'provider-list',

--- a/packages/web-app-skeleton/src/app.js
+++ b/packages/web-app-skeleton/src/app.js
@@ -38,9 +38,7 @@ export default {
     {
       name: 'skeleton',
       path: '/',
-      components: {
-        app: App
-      }
+      component: App
     }
   ],
   async mounted(api) {

--- a/packages/web-runtime/src/components/SidebarNav/SidebarNav.vue
+++ b/packages/web-runtime/src/components/SidebarNav/SidebarNav.vue
@@ -101,7 +101,7 @@ export default {
   max-width: 250px !important;
 }
 .oc-app-navigation-collapsed {
-  min-width: 67px !important;
-  max-width: 67px !important;
+  min-width: 64px !important;
+  max-width: 64px !important;
 }
 </style>

--- a/packages/web-runtime/src/layouts/Application.vue
+++ b/packages/web-runtime/src/layouts/Application.vue
@@ -1,0 +1,151 @@
+<template>
+  <div id="web-content">
+    <div id="web-content-header">
+      <top-bar :applications-list="applicationsList" :active-notifications="activeNotifications" />
+    </div>
+    <div id="web-content-main" class="oc-px-s oc-pb-s">
+      <message-bar :active-messages="activeMessages" @deleteMessage="deleteMessage" />
+      <div class="app-container oc-flex">
+        <sidebar-nav v-if="isSidebarVisible" class="app-navigation" :nav-items="sidebarNavItems" />
+        <router-view class="app-content oc-width-1-1" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapActions, mapGetters } from 'vuex'
+import TopBar from '../components/Topbar/TopBar.vue'
+import MessageBar from '../components/MessageBar.vue'
+import SidebarNav from '../components/SidebarNav/SidebarNav.vue'
+
+export default {
+  components: {
+    MessageBar,
+    TopBar,
+    SidebarNav
+  },
+  data() {
+    return {
+      windowWidth: 0
+    }
+  },
+  mounted() {
+    this.$nextTick(() => {
+      window.addEventListener('resize', this.onResize)
+      this.onResize()
+    })
+  },
+  beforeDestroy() {
+    window.removeEventListener('resize', this.onResize)
+  },
+  computed: {
+    ...mapGetters([
+      'capabilities',
+      'configuration',
+      'getExtensionsWithNavItems',
+      'apps',
+      'activeNotifications',
+      'activeMessages',
+      'getNavItemsByExtension'
+    ]),
+    isSidebarVisible() {
+      return this.sidebarNavItems.length && this.windowWidth >= 640
+    },
+    sidebarNavItems() {
+      if (this.publicPage()) {
+        return []
+      }
+
+      const items = this.getNavItemsByExtension(this.currentExtension)
+      if (!items) {
+        return []
+      }
+
+      items.filter((item) => {
+        if (this.capabilities === undefined) {
+          return false
+        }
+
+        if (item.enabled === undefined) {
+          return true
+        }
+
+        return item.enabled(this.capabilities)
+      })
+
+      const { href: currentHref } = this.$router.resolve(this.$route)
+      return items.map((item) => {
+        const { href: comparativeHref } = this.$router.resolve(item.route)
+
+        return {
+          ...item,
+          name: this.$gettext(item.name),
+          active: currentHref.startsWith(comparativeHref)
+        }
+      })
+    },
+    applicationsList() {
+      const list = []
+
+      // Get extensions which have at least one nav item
+      this.getExtensionsWithNavItems.forEach((extensionId) => {
+        list.push({
+          ...this.apps[extensionId],
+          type: 'extension'
+        })
+      })
+
+      // Get extensions manually added into config
+      this.configuration.applications.forEach((application) => {
+        list.push({
+          ...application,
+          type: 'link'
+        })
+      })
+
+      return list
+    }
+  },
+  methods: {
+    ...mapActions(['deleteMessage']),
+    onResize() {
+      this.windowWidth = window.innerWidth
+    }
+  }
+}
+</script>
+<style lang="scss">
+#web-content {
+  display: flex;
+  flex-flow: column;
+  flex-wrap: nowrap;
+  height: 100vh;
+
+  #web-content-header,
+  #web-content-main {
+    flex-shrink: 1;
+    flex-basis: auto;
+  }
+
+  #web-content-header {
+    flex-grow: 0;
+  }
+
+  #web-content-main {
+    flex-grow: 1;
+    overflow-y: hidden;
+
+    .app-container {
+      height: 100%;
+      background-color: var(--oc-color-background-default);
+      border-radius: 15px;
+      overflow: hidden;
+
+      .app-content {
+        transition: all 0.35s cubic-bezier(0.34, 0.11, 0, 1.12);
+      }
+    }
+  }
+}
+</style>

--- a/packages/web-runtime/src/layouts/Application.vue
+++ b/packages/web-runtime/src/layouts/Application.vue
@@ -30,15 +30,6 @@ export default {
       windowWidth: 0
     }
   },
-  mounted() {
-    this.$nextTick(() => {
-      window.addEventListener('resize', this.onResize)
-      this.onResize()
-    })
-  },
-  beforeDestroy() {
-    window.removeEventListener('resize', this.onResize)
-  },
   computed: {
     ...mapGetters([
       'capabilities',
@@ -106,6 +97,15 @@ export default {
 
       return list
     }
+  },
+  mounted() {
+    this.$nextTick(() => {
+      window.addEventListener('resize', this.onResize)
+      this.onResize()
+    })
+  },
+  beforeDestroy() {
+    window.removeEventListener('resize', this.onResize)
   },
   methods: {
     ...mapActions(['deleteMessage']),

--- a/packages/web-runtime/src/layouts/Loading.vue
+++ b/packages/web-runtime/src/layouts/Loading.vue
@@ -1,0 +1,38 @@
+<template>
+  <div
+    class="loading-overlay oc-flex oc-flex-middle oc-flex-center"
+    :style="{
+      backgroundImage: 'url(' + configuration.currentTheme.loginPage.backgroundImg + ')'
+    }"
+  >
+    <oc-spinner size="xlarge" :aria-label="$gettext('Loading')" />
+  </div>
+</template>
+<script>
+import { mapGetters } from 'vuex'
+
+export default {
+  computed: {
+    ...mapGetters(['configuration'])
+  }
+}
+</script>
+<style lang="scss">
+.loading-overlay {
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
+  height: 100%;
+  width: 100%;
+
+  .oc-spinner {
+    color: #0a264e;
+    display: inline-block;
+
+    &::after {
+      border: 10px solid;
+      border-bottom: 10px solid transparent;
+    }
+  }
+}
+</style>

--- a/packages/web-runtime/src/layouts/Plain.vue
+++ b/packages/web-runtime/src/layouts/Plain.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>
+    <router-view />
+  </div>
+</template>
+<style lang="scss"></style>

--- a/packages/web-runtime/src/layouts/Plain.vue
+++ b/packages/web-runtime/src/layouts/Plain.vue
@@ -3,4 +3,3 @@
     <router-view />
   </div>
 </template>
-<style lang="scss"></style>

--- a/packages/web-runtime/src/router/index.js
+++ b/packages/web-runtime/src/router/index.js
@@ -20,51 +20,43 @@ const router = new Router({
     {
       path: '/login',
       name: 'login',
-      components: {
-        fullscreen: LoginPage
-      },
-      meta: { auth: false, hideHeadbar: true, title: $gettext('Login') }
+      component: LoginPage,
+      meta: { auth: false, title: $gettext('Login') }
     },
     {
       path: '/oidc-callback',
-      components: {
-        fullscreen: OidcCallbackPage
-      },
-      meta: { auth: false, hideHeadbar: true, title: $gettext('Oidc callback') }
+      name: 'oidcCallback',
+      component: OidcCallbackPage,
+      meta: { auth: false, title: $gettext('Oidc callback') }
     },
     {
       path: '/oidc-silent-redirect',
-      components: {
-        fullscreen: OidcCallbackPage
-      },
-      meta: { auth: false, hideHeadbar: true, title: $gettext('Oidc redirect') }
+      name: 'oidcSilentRedirect',
+      component: OidcCallbackPage,
+      meta: { auth: false, title: $gettext('Oidc redirect') }
     },
     {
       path: '/f/:fileId',
       name: 'privateLink',
       redirect: '/files/ops/resolver/private-link/:fileId',
-      meta: { hideHeadbar: true, title: $gettext('Private link') }
+      meta: { title: $gettext('Private link') }
     },
     {
       path: '/s/:token',
       name: 'publicLink',
       redirect: '/files/ops/resolver/public-link/:token',
-      meta: { auth: false, hideHeadbar: true, title: $gettext('Public link') }
+      meta: { auth: false, title: $gettext('Public link') }
     },
     {
       path: '/access-denied',
       name: 'accessDenied',
-      components: {
-        fullscreen: AccessDeniedPage
-      },
-      meta: { auth: false, hideHeadbar: true, title: $gettext('Access denied') }
+      component: AccessDeniedPage,
+      meta: { auth: false, title: $gettext('Access denied') }
     },
     {
       path: '/account',
       name: 'account',
-      components: {
-        app: Account
-      },
+      component: Account,
       meta: { title: $gettext('Account') }
     }
   ]

--- a/tests/acceptance/features/webUIPrivateLinks/accessingPrivateLinks.feature
+++ b/tests/acceptance/features/webUIPrivateLinks/accessingPrivateLinks.feature
@@ -36,11 +36,11 @@ Feature: Access private link
     Given user "Brian" has been created with default attributes and without skeleton files in the server
     And user "Brian" has logged in using the webUI
     When the user navigates to the private link created by user "Alice" for file "lorem.txt"
-    Then the user should see the following error message on the login card dialog
+    Then the user should see the following error message on the link resolve page
       """
       An error occurred while resolving the private link
-      Error: Unknown error
       """
+
 
   Scenario: Access the private link anonymously
     When an anonymous user tries to navigate to the private link created by user "Alice" for file "lorem.txt"

--- a/tests/acceptance/features/webUISharingPublicManagement/sharingPublicSession.feature
+++ b/tests/acceptance/features/webUISharingPublicManagement/sharingPublicSession.feature
@@ -37,8 +37,8 @@ Feature: Session storage for public link
     And user "Alice" has created file "simple-folder/lorem.txt" in the server
     And user "Alice" has shared folder "simple-folder" with link with "read" permissions and password "pass123" in the server
     When the public uses the webUI to access the last public link created by user "Alice" with password "pass123"
-    And user "Alice" changes the password of last public link  to "newpass" using the Sharing API in the server
     Then file "lorem.txt" should be listed on the webUI
+    And user "Alice" changes the password of last public link  to "newpass" using the Sharing API in the server
     When the user reloads the current page of the webUI
     Then the password input for the public link should appear on the webUI
     When the user accesses the public link with password "newpass" using the webUI
@@ -49,8 +49,8 @@ Feature: Session storage for public link
     Given user "Alice" has created file "lorem.txt" in the server
     And user "Alice" has shared folder "lorem.txt" with link with "read" permissions and password "pass123" in the server
     When the public uses the webUI to access the last public link created by user "Alice" with password "pass123"
-    And user "Alice" changes the password of last public link  to "newpass" using the Sharing API in the server
     Then file "lorem.txt" should be listed on the webUI
+    And user "Alice" changes the password of last public link  to "newpass" using the Sharing API in the server
     When the user reloads the current page of the webUI
     Then the password input for the public link should appear on the webUI
     When the user accesses the public link with password "newpass" using the webUI

--- a/tests/acceptance/pageObjects/publicLinkPasswordPage.js
+++ b/tests/acceptance/pageObjects/publicLinkPasswordPage.js
@@ -54,19 +54,14 @@ module.exports = {
       selector: '.oc-login-authorize-button'
     },
     resourceProtectedText: {
-      selector: '//h2[@class="oc-login-card-title"]/span',
+      selector: '//*[@class="oc-card-header"]',
       locateStrategy: 'xpath'
     },
-    loadingPublicLink: {
-      selector: "//div[@class='oc-login-card oc-position-center']//span[.='Loading public link…']",
-      locateStrategy: 'xpath'
-    },
-    loginCardDialogBox: {
-      selector: '.oc-login-card-body'
+    linkResolveErrorTitle: {
+      selector: '.oc-link-resolve-error-title'
     },
     publicLinkPasswordSection: {
-      selector:
-        '//div[@class="oc-login-card-body"]//h2[@class="oc-login-card-title"]/span[text()="This resource is password-protected."]',
+      selector: '//*[@class="oc-card-header"]//*[text()="This resource is password-protected"]',
       locateStrategy: 'xpath'
     }
   }

--- a/tests/acceptance/stepDefinitions/generalContext.js
+++ b/tests/acceptance/stepDefinitions/generalContext.js
@@ -101,12 +101,12 @@ Then(
 )
 
 Then(
-  'the user should see the following error message on the login card dialog',
+  'the user should see the following error message on the link resolve page',
   function (message) {
     return client.page
       .publicLinkPasswordPage()
-      .waitForElementVisible('@loginCardDialogBox')
-      .expect.element('@loginCardDialogBox')
+      .waitForElementVisible('@linkResolveErrorTitle')
+      .expect.element('@linkResolveErrorTitle')
       .text.to.equal(message)
   }
 )

--- a/tests/acceptance/stepDefinitions/publicLinkContext.js
+++ b/tests/acceptance/stepDefinitions/publicLinkContext.js
@@ -107,7 +107,7 @@ Then('the public should not get access to the publicly shared file', async funct
     .submitLinkPasswordForm() // form is submitted as password input is filled in the step before this particular step in 'when' part
     .getResourceAccessDeniedMsg()
   return assert.strictEqual(
-    'This resource is password-protected.',
+    'This resource is password-protected',
     message,
     'Resource protected message invalid, Found: ',
     message


### PR DESCRIPTION
## Description
Prior this, extensions where able to decide if the ui should render the header or not,
this now is disabled to transport even more the feeling of having a portal.

## Related Issue
- Needed for https://github.com/owncloud/web/issues/6248

## Motivation and Context
have more integrated applications

## How Has This Been Tested?
- existing unit and integration tests

## Screenshots (if appropriate):
![Bildschirmfoto 2022-02-09 um 15 11 39](https://user-images.githubusercontent.com/49308105/153218285-c94967fe-a92d-4a01-9d32-3295336f23b5.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] Code changes
