### PR TITLE
[tests-only] remove language related log outputs in unit-tests

### DIFF
--- a/packages/web-app-files/tests/unit/views/LocationPicker.spec.js
+++ b/packages/web-app-files/tests/unit/views/LocationPicker.spec.js
@@ -481,6 +481,7 @@ describe('LocationPicker', () => {
       mountOptions(store, $route, loading, setup, {
         'oc-button': false,
         'list-info': true,
+        translate: true,
         pagination: true,
         RouterLink: RouterLinkStub
       })

--- a/packages/web-app-files/tests/unit/views/__snapshots__/SharedViaLink.spec.js.snap
+++ b/packages/web-app-files/tests/unit/views/__snapshots__/SharedViaLink.spec.js.snap
@@ -6,7 +6,7 @@ exports[`SharedViaLink view when the view is not loading anymore when there are 
     <div class="oc-icon oc-icon-xxl oc-icon-passive">
       <!---->
     </div>
-    <div class="oc-text-muted oc-text-large"><span data-msgid="There are no resources with a public link at the moment" data-current-language="en_US">There are no resources with a public link at the moment</span></div>
+    <div class="oc-text-muted oc-text-large"><span>There are no resources with a public link at the moment</span></div>
     <div class="oc-text-muted"></div>
   </div>
 </div>

--- a/packages/web-app-files/tests/unit/views/spaces/Project.spec.js
+++ b/packages/web-app-files/tests/unit/views/spaces/Project.spec.js
@@ -1,5 +1,5 @@
 import GetTextPlugin from 'vue-gettext'
-import { mount, RouterLinkStub } from '@vue/test-utils'
+import { RouterLinkStub, shallowMount } from '@vue/test-utils'
 import { localVue } from '../views.setup'
 import { createStore } from 'vuex-extensions'
 import Files from '@/__fixtures__/files'
@@ -199,7 +199,7 @@ function getMountedWrapper(spaceResources = [], spaceItem = null) {
     }
   }
 
-  return mount(SpaceProject, {
+  return shallowMount(SpaceProject, {
     localVue,
     stubs: {
       RouterLink: RouterLinkStub
@@ -212,8 +212,7 @@ function getMountedWrapper(spaceResources = [], spaceItem = null) {
           getFileContents: jest.fn(() => 'fileContent'),
           list: jest.fn(() => spaceResources)
         }
-      },
-      $ngettext: () => 'text'
+      }
     },
 
     store: createStore(Vuex.Store, {

--- a/packages/web-app-files/tests/unit/views/spaces/Projects.spec.js
+++ b/packages/web-app-files/tests/unit/views/spaces/Projects.spec.js
@@ -115,6 +115,9 @@ function getMountedWrapper() {
           }
         }
       }
-    })
+    }),
+    stubs: {
+      translate: true
+    }
   })
 }

--- a/packages/web-app-files/tests/unit/views/spaces/__snapshots__/Project.spec.js.snap
+++ b/packages/web-app-files/tests/unit/views/spaces/__snapshots__/Project.spec.js.snap
@@ -15,15 +15,7 @@ exports[`Spaces project view space image should show if given 1`] = `
       </div>
     </div>
   </div>
-  <div class="oc-height-1-1 oc-flex oc-flex-column oc-flex-center oc-flex-middle oc-text-center files-empty" id="files-space-empty">
-    <div class="oc-icon oc-icon-xxl oc-icon-passive">
-      <!---->
-    </div>
-    <div class="oc-text-muted oc-text-large">
-      <p class="oc-text-muted" data-msgid="No resources found" data-current-language="en_US">No resources found</p>
-    </div>
-    <div class="oc-text-muted"></div>
-  </div>
+  <no-content-message-stub icon="folder" id="files-space-empty" class="files-empty"></no-content-message-stub>
 </div>
 `;
 
@@ -42,14 +34,6 @@ exports[`Spaces project view space readme should show if given 1`] = `
       </div>
     </div>
   </div>
-  <div class="oc-height-1-1 oc-flex oc-flex-column oc-flex-center oc-flex-middle oc-text-center files-empty" id="files-space-empty">
-    <div class="oc-icon oc-icon-xxl oc-icon-passive">
-      <!---->
-    </div>
-    <div class="oc-text-muted oc-text-large">
-      <p class="oc-text-muted" data-msgid="No resources found" data-current-language="en_US">No resources found</p>
-    </div>
-    <div class="oc-text-muted"></div>
-  </div>
+  <no-content-message-stub icon="folder" id="files-space-empty" class="files-empty"></no-content-message-stub>
 </div>
 `;

--- a/packages/web-app-files/tests/unit/views/spaces/__snapshots__/Projects.spec.js.snap
+++ b/packages/web-app-files/tests/unit/views/spaces/__snapshots__/Projects.spec.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Spaces component should only list drives of type "project" 1`] = `
-<div class="oc-py-s oc-px-m"><button aria-label="Create a new space" class="oc-mb-l oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-primary" id="new-space-menu-btn" data-testid="spaces-list-create-space-btn"><span class="oc-icon oc-icon-m oc-icon-passive"><!----></span> <span>Create Space</span></button>
+<div class="oc-py-s oc-px-m"><button aria-label="Create a new space" class="oc-mb-l oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-primary" id="new-space-menu-btn" data-testid="spaces-list-create-space-btn"><span class="oc-icon oc-icon-m oc-icon-passive"><!----></span>
+    <translate-stub tag="span">Create Space</translate-stub>
+  </button>
   <div class="oc-pb-xl oc-border-b"><span>Store your project related files in Spaces for seamless collaboration.</span></div>
   <div class="spaces-list oc-mt-l">
     <ul class="

--- a/packages/web-app-files/tests/unit/views/views.setup.js
+++ b/packages/web-app-files/tests/unit/views/views.setup.js
@@ -35,6 +35,11 @@ localVue.use(GetTextPlugin, {
   silent: true
 })
 
+// mock `v-translate` directive
+localVue.directive('translate', {
+  inserted: (el) => {}
+})
+
 export const getRouter = ({ query = {} }) => ({
   afterEach: jest.fn(),
   replace: jest.fn(),

--- a/tests/unit/config/jest.init.js
+++ b/tests/unit/config/jest.init.js
@@ -14,6 +14,13 @@ try {
 
 config.mocks = {
   $gettext: (str) => str,
+  $ngettext: (msgid, plural, n) => {
+    if (n > 1 || n === 0 || n < 0 || !Number.isInteger(n)) {
+      return plural
+    } else {
+      return msgid
+    }
+  },
   isIE11: () => false,
   $language: {
     current: 'en'

--- a/tests/unit/config/jest.init.js
+++ b/tests/unit/config/jest.init.js
@@ -14,6 +14,7 @@ try {
 
 config.mocks = {
   $gettext: (str) => str,
+  $pgettext: (context, msgid) => msgid,
   $ngettext: (msgid, plural, n) => {
     if (n > 1 || n === 0 || n < 0 || !Number.isInteger(n)) {
       return plural


### PR DESCRIPTION
## Description
- mock $ngettext & $pgettext
- shallowMount in Project.spec.js
- mock `<translate>` in Projects.spec.js & LocationPicker.spec.js
- mock v-translate directive

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
part of #6337

## Motivation and Context
reduce log output in unit tests

## How Has This Been Tested?
`yarn run test:unit 2>&1 | wc -l`

before this PR: 2641
after this PR: 583

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
