### PR TITLE
[tests-only] reduce log output when running unit tests of SideBar

### DIFF
--- a/packages/web-app-files/tests/unit/components/SideBar/SideBar.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/SideBar.spec.js
@@ -1,4 +1,4 @@
-import { mount, createLocalVue } from '@vue/test-utils'
+import { shallowMount, createLocalVue } from '@vue/test-utils'
 import VueCompositionAPI from '@vue/composition-api'
 import Vuex from 'vuex'
 import GetTextPlugin from 'vue-gettext'
@@ -27,7 +27,7 @@ function createWrapper({ item, selectedItems, mocks }) {
     translations: 'does-not-matter.json',
     silent: true
   })
-  return mount(SideBar, {
+  return shallowMount(SideBar, {
     store: new Vuex.Store({
       getters: {
         user: function () {

--- a/packages/web-app-files/tests/unit/components/SideBar/SideBar.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/SideBar.spec.js
@@ -11,6 +11,8 @@ import { buildResource, renameResource } from '@files/src/helpers/resources'
 import SideBar from '@files/src/components/SideBar/SideBar.vue'
 import { createLocationSpaces } from '../../../../src/router'
 
+jest.mock('web-pkg/src/observer')
+
 const simpleOwnFolder = {
   type: 'folder',
   ownerId: 'marie',


### PR DESCRIPTION

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
- use only shallowMount in SideBar unit tests (I cannot see why a full mount would be needed here, but I might be wrong)
- mock observer in SideBar unit tests

## Related Issue
- part of #6337

## Motivation and Context
get rid of log outputs like
```
[Vue warn]: Error in render: "TypeError: Cannot read properties of undefined (reading 'replace')"`
[vuex] unknown getter: Files/sharesTree
[vuex] unknown getter: Files/versions
[Vue warn]: Error in render: "TypeError: Cannot read properties of undefined (reading 'length')"
[Vue warn]: Error in nextTick: "TypeError: this.intersectionObserver.observe is not a function"
```
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- running unit tests locally
- :robot:

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
