### PR TITLE
[tests-only] use jest.mocked instead of mocked from ts-jest/utils

### DIFF
--- a/packages/web-runtime/tests/unit/container/bootstrap.spec.ts
+++ b/packages/web-runtime/tests/unit/container/bootstrap.spec.ts
@@ -1,6 +1,5 @@
 import { announceApplications } from '../../../src/container'
 import { buildApplication } from '../../../src/container/application'
-import { mocked } from 'ts-jest/utils'
 
 jest.mock('../../../src/container/application')
 
@@ -20,7 +19,7 @@ describe('announce applications', () => {
         return Promise.reject(fishyError)
       })
 
-    mocked(buildApplication).mockImplementation(buildApplicationMock)
+    jest.mocked(buildApplication).mockImplementation(buildApplicationMock)
 
     await announceApplications({
       runtimeConfiguration: {


### PR DESCRIPTION
## Description
the `mocked` util function is now deprecated and has been moved to Jest repository, see https://github.com/facebook/jest/pull

the log output is probably there since bumping jest to 27.x 7fa3b712

alternative is to disable the warning with `process.env.DISABLE_MOCKED_WARNING=true` but I don't see why that should be good
@pascalwengerter (you have bumped jest) @fschade (you have written the tests) opinions?

## Related Issue
- part of https://github.com/owncloud/web/issues/6337

## Motivation and Context
get rid of this log output
```
 `mocked` util function is now deprecated and has been moved to Jest repository, see https://github.com/facebook/jest/pull/12089. In `ts-jest` v28.0.0, `mocked` function will be completely removed. Users are encouraged to use to Jest v27.4.0 or above to have `mocked` function available from `jest-mock`. One can disable this warning by setting environment variable process.env.DISABLE_MOCKED_WARNING=true
```


## How Has This Been Tested?
- running unit tests locally
- :robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
