### PR TITLE
[tests-only] mock date/time functions in FileInfo unit test

### DIFF
--- a/packages/web-app-files/tests/unit/components/SideBar/FileInfo.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/FileInfo.spec.js
@@ -40,10 +40,14 @@ const formRelativeDateFromRFC = jest.fn()
 const resetDateMocks = () => {
   formDateFromRFC.mockReset()
   formRelativeDateFromRFC.mockReset()
+  formDateFromRFC.mockImplementation(() => 'ABSOLUTE_TIME')
+  formRelativeDateFromRFC.mockImplementation(() => 'RELATIVE_TIME')
 }
 
 describe('FileInfo', () => {
   it('shows file info', () => {
+    resetDateMocks()
+
     const tooltipStub = jest.fn()
     const wrapper = createWrapper(simpleOwnFile, tooltipStub)
     expect(wrapper.find(selectors.name).exists()).toBeTruthy()
@@ -52,8 +56,6 @@ describe('FileInfo', () => {
 
   it('shows modification date info', () => {
     resetDateMocks()
-    formDateFromRFC.mockImplementation(() => 'ABSOLUTE_MODIFICATION_TIME')
-    formRelativeDateFromRFC.mockImplementation(() => 'RELATIVE_MODIFICATION_TIME')
 
     const tooltipStub = jest.fn()
     const wrapper = createWrapper(simpleOwnFile, tooltipStub)
@@ -68,8 +70,6 @@ describe('FileInfo', () => {
 
   it('shows deletion date info', () => {
     resetDateMocks()
-    formDateFromRFC.mockImplementation(() => 'ABSOLUTE_DELETION_TIME')
-    formRelativeDateFromRFC.mockImplementation(() => 'RELATIVE_DELETION_TIME')
 
     const tooltipStub = jest.fn()
     const wrapper = createWrapper(simpleDeletedFile, tooltipStub, 'files-common-trash')

--- a/packages/web-app-files/tests/unit/components/SideBar/__snapshots__/FileInfo.spec.js.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/__snapshots__/FileInfo.spec.js.snap
@@ -8,7 +8,7 @@ exports[`FileInfo shows deletion date info 1`] = `
       <oc-resource-name-stub type="file"></oc-resource-name-stub>
     </h3>
     <p class="oc-my-rm">
-      <!----> <span data-testid="files-info-mdate" tabindex="0" aria-label="deleted RELATIVE_DELETION_TIME (ABSOLUTE_DELETION_TIME)">deleted RELATIVE_DELETION_TIME</span>
+      <!----> <span data-testid="files-info-mdate" tabindex="0" aria-label="deleted RELATIVE_TIME (ABSOLUTE_TIME)">deleted RELATIVE_TIME</span>
     </p>
   </div>
   <!---->
@@ -22,7 +22,7 @@ exports[`FileInfo shows modification date info 1`] = `
     <h3 data-testid="files-info-name">
       <oc-resource-name-stub type="file"></oc-resource-name-stub>
     </h3>
-    <p class="oc-my-rm">740 B, <span data-testid="files-info-mdate" tabindex="0" aria-label="modified RELATIVE_MODIFICATION_TIME (ABSOLUTE_MODIFICATION_TIME)">modified RELATIVE_MODIFICATION_TIME</span></p>
+    <p class="oc-my-rm">740 B, <span data-testid="files-info-mdate" tabindex="0" aria-label="modified RELATIVE_TIME (ABSOLUTE_TIME)">modified RELATIVE_TIME</span></p>
   </div>
   <!---->
 </div>


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
mock the date/time functions in all tests, not only in some

@JammingBen @dschmidt you have been working on these tests, please review. How much do we care about the string? If we don't we can reduce the complexity a bit more.
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- part of #6337


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
```
Cannot evaluate expression: timeRelative
  console.warn
    Cannot evaluate expression: timeRelative

      57 |         obj.timeRelative = this.formRelativeDateFromRFC(obj.sourceTime)
      58 |
    > 59 |         obj.infoString = this.$gettextInterpolate(obj.infoString, obj)
         | ^
      60 |         obj.ariaLabel = this.$gettextInterpolate(obj.ariaLabel, obj)
      61 |         return obj
      62 |       }

      at Object.evalInContext (node_modules/vue-gettext/dist/vue-gettext.js:280:21)
      at node_modules/vue-gettext/dist/vue-gettext.js:293:28
          at String.replace (<anonymous>)
      at Function.interpolate (node_modules/vue-gettext/dist/vue-gettext.js:247:24)
      at interpolate (packages/web-app-files/src/components/SideBar/FileInfo.vue:59:1)
      at VueComponent.timeData (packages/web-app-files/src/components/SideBar/FileInfo.vue:75:1)
      at Watcher.get (node_modules/vue/dist/vue.runtime.common.dev.js:4481:25)
```

## How Has This Been Tested?
- running unit tests locally
- :robot:

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
