### PR TITLE
[tests-only] reduce log output in Projects unit tests

### DIFF
--- a/packages/web-app-files/tests/unit/views/spaces/Projects.spec.js
+++ b/packages/web-app-files/tests/unit/views/spaces/Projects.spec.js
@@ -89,9 +89,15 @@ describe('Spaces component', () => {
 })
 
 function getMountedWrapper() {
+  const routes = [
+    {
+      name: 'files-spaces-project',
+      path: '/'
+    }
+  ]
   return mount(SpaceProjects, {
     localVue,
-    router: new VueRouter(),
+    router: new VueRouter({ routes }),
     store: createStore(Vuex.Store, {
       getters: {
         configuration: () => ({

--- a/packages/web-app-files/tests/unit/views/spaces/Projects.spec.js
+++ b/packages/web-app-files/tests/unit/views/spaces/Projects.spec.js
@@ -106,6 +106,14 @@ function getMountedWrapper() {
       },
       actions: {
         createModal: jest.fn()
+      },
+      modules: {
+        Files: {
+          namespaced: true,
+          mutations: {
+            SET_CURRENT_FOLDER: jest.fn()
+          }
+        }
       }
     })
   })


### PR DESCRIPTION

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
- mock files-spaces-project route
- mock SET_CURRENT_FOLDER in Files module

@JammingBen you have created those tests, any reason not to mock these things?

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- part of #6337

## Motivation and Context
get rid of log outputs like:

```
  console.error
    [vuex] module namespace not found in mapMutations(): Files/

      188 |
      189 |     const loadResourcesTask = useTask(function* (signal, ref) {
    > 190 |       ref.SET_CURRENT_FOLDER(null)
          | ^
      191 |
      192 |       yield ref.loadSpacesTask.perform(ref)
      193 |       yield ref.loadImagesTask.perform(ref)

      at getModuleByNamespace (node_modules/vuex/dist/vuex.common.js:1136:13)
      at VueComponent.mappedMutation (node_modules/vuex/dist/vuex.common.js:989:22)
      at _callee4$ (packages/web-app-files/src/views/spaces/Projects.vue:190:1)
      at tryCatch (node_modules/regenerator-runtime/runtime.js:63:40)
      at Generator.invoke [as _invoke] (node_modules/regenerator-runtime/runtime.js:293:22)
      at Generator.next (node_modules/regenerator-runtime/runtime.js:118:21)
      at getNextResult (node_modules/caf/src/caf.src.js:215:26)
```

```
  console.warn
    [vue-router] Route with name 'files-spaces-project' does not exist

      at warn (node_modules/vue-router/dist/vue-router.common.js:18:47)
      at Object.match (node_modules/vue-router/dist/vue-router.common.js:1594:9)
      at VueRouter.match (node_modules/vue-router/dist/vue-router.common.js:2940:23)
      at VueRouter.resolve (node_modules/vue-router/dist/vue-router.common.js:3094:20)
      at Proxy.render (node_modules/vue-router/dist/vue-router.common.js:1099:22)
      at node_modules/@vue/composition-api/dist/vue-composition-api.common.js:1892:35
      at activateCurrentInstance (node_modules/@vue/composition-api/dist/vue-composition-api.common.js:1842:16)
```

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- run unit-tests locally
- :robot:

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
