### PR TITLE
fix variable name in error object

### DIFF
--- a/changelog/unreleased/bugfix-error-message-move
+++ b/changelog/unreleased/bugfix-error-message-move
@@ -1,0 +1,5 @@
+Bugfix: Failed move by drag'n'drop doesn't show the resource name in the error
+
+We fixed the error message when moving an item via drag-and-drop failed, now it shows the correct name of the item.
+
+https://github.com/owncloud/web/issues/6412

--- a/packages/web-app-files/src/views/Personal.vue
+++ b/packages/web-app-files/src/views/Personal.vue
@@ -312,7 +312,7 @@ export default {
             if (exists) {
               const message = this.$gettext('Resource with name %{name} already exists')
               errors.push({
-                resource: resource.name,
+                resourceName: resource.name,
                 message: this.$gettextInterpolate(message, { name: resource.name }, true)
               })
               return

--- a/packages/web-app-files/tests/unit/views/Personal.spec.js
+++ b/packages/web-app-files/tests/unit/views/Personal.spec.js
@@ -107,8 +107,13 @@ describe('Personal view', () => {
       const spyOnMoveFiles = jest.spyOn(localVue.prototype.$client.files, 'move')
 
       const wrapper = createWrapper([resourceDocumentsFolder])
+      const spyOnshowMessage = jest.spyOn(wrapper.vm, 'showMessage')
       await wrapper.vm.fileDropped(resourcePdfsFolder.id)
       expect(spyOnMoveFiles).not.toBeCalled()
+      expect(spyOnshowMessage).toBeCalledWith({
+        status: 'danger',
+        title: 'Failed to move "Documents"'
+      })
 
       spyOnMoveFiles.mockReset()
       spyOnGetFolderItems.mockReset()


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
the variable name should be `error.resourceName`, `error.resource` is not used anywhere
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #6412 
- part of #6337

## Motivation and Context
found when cleaning up unit test log messages:
```
  console.warn
    Cannot evaluate expression: resourceName

      356 |         title = this.$gettext('Failed to move "%{resourceName}"')
      357 |         this.showMessage({
    > 358 |           title: this.$gettextInterpolate(title, { resourceName: errors[0]?.resourceName }, true),
          | ^
      359 |           status: 'danger'
      360 |         })
      361 |         return

      at Object.evalInContext (node_modules/vue-gettext/dist/vue-gettext.js:280:21)
      at node_modules/vue-gettext/dist/vue-gettext.js:293:28
          at String.replace (<anonymous>)
      at Function.interpolate (node_modules/vue-gettext/dist/vue-gettext.js:247:24)
      at _callee5$ (packages/web-app-files/src/views/Personal.vue:358:1)
      at tryCatch (node_modules/regenerator-runtime/runtime.js:63:40)
      at Generator.invoke [as _invoke] (node_modules/regenerator-runtime/runtime.js:293:22)
```
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- reproducing example in #6412
- added assertion in unit test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
