### PR TITLE
[tests-only] set user object in LocationPicker unit tests

### DIFF
--- a/packages/web-app-files/tests/unit/views/LocationPicker.spec.js
+++ b/packages/web-app-files/tests/unit/views/LocationPicker.spec.js
@@ -438,7 +438,8 @@ describe('LocationPicker', () => {
       currentFolder: currentFolder,
       totalFilesSize: totalFilesSize,
       totalFilesCount: totalFilesCount,
-      generalThemeName: generalThemeName
+      generalThemeName: generalThemeName,
+      user: { id: 'test' }
     })
   }
 

--- a/packages/web-app-files/tests/unit/views/views.setup.js
+++ b/packages/web-app-files/tests/unit/views/views.setup.js
@@ -167,7 +167,8 @@ export const getStore = function ({
             namespaced: true
           }
         }
-      }
+      },
+      user: { state: user }
     }
   })
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
give the test a user id, so that it does not try to get it from `undefined`
that line was added in #6287
@JanAckermann is it OK to mock the user that way and reuse the existing object in `getStore`?

<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
part of #6337

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
get rid of error logs during unit test runs
```
    console.error
      [Vue warn]: Error in v-on handler (Promise/async): "TypeError: Cannot read property 'id' of undefined"

      found in

      ---> <OcButton>
             <OcGrid>
               <Anonymous>
                 <Root>

      at warn (node_modules/vue/dist/vue.runtime.common.dev.js:621:15)
      at logError (node_modules/vue/dist/vue.runtime.common.dev.js:1889:5)
      at globalHandleError (node_modules/vue/dist/vue.runtime.common.dev.js:1884:3)
      at handleError (node_modules/vue/dist/vue.runtime.common.dev.js:1844:5)
      at node_modules/vue/dist/vue.runtime.common.dev.js:1861:39

    console.error
      TypeError: Cannot read property 'id' of undefined
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- run unit tests locally
- :robot:

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
