### PR TITLE
[tests-only] mock router-link in Trashbin unit tests

### DIFF
--- a/packages/web-app-files/tests/unit/views/Trashbin.spec.js
+++ b/packages/web-app-files/tests/unit/views/Trashbin.spec.js
@@ -8,7 +8,8 @@ const stubs = {
   'resource-table': true,
   'context-actions': true,
   pagination: true,
-  'list-info': true
+  'list-info': true,
+  'router-link': true
 }
 
 const listLoaderStub = 'list-loader-stub'

--- a/packages/web-app-files/tests/unit/views/__snapshots__/Trashbin.spec.js.snap
+++ b/packages/web-app-files/tests/unit/views/__snapshots__/Trashbin.spec.js.snap
@@ -25,7 +25,7 @@ exports[`Trashbin View when the view is not loading anymore when length of the p
             <!---->
             </span>
             <div class="oc-resource-indicators">
-              <router-link to="[object Object]" class="parent-folder" style="cursor: pointer;"><span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="text">file-path</span></router-link>
+              <router-link-stub to="[object Object]" class="parent-folder" style="cursor: pointer;"><span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="text">file-path</span></router-link-stub>
               <!---->
             </div>
           </div>
@@ -46,7 +46,7 @@ exports[`Trashbin View when the view is not loading anymore when length of the p
             <!---->
             </span>
             <div class="oc-resource-indicators">
-              <router-link to="[object Object]" class="parent-folder" style="cursor: pointer;"><span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="text">file-path</span></router-link>
+              <router-link-stub to="[object Object]" class="parent-folder" style="cursor: pointer;"><span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="text">file-path</span></router-link-stub>
               <!---->
             </div>
           </div>
@@ -67,7 +67,7 @@ exports[`Trashbin View when the view is not loading anymore when length of the p
             <!---->
             </span>
             <div class="oc-resource-indicators">
-              <router-link to="[object Object]" class="parent-folder" style="cursor: pointer;"><span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="text">file-path</span></router-link>
+              <router-link-stub to="[object Object]" class="parent-folder" style="cursor: pointer;"><span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="text">file-path</span></router-link-stub>
               <!---->
             </div>
           </div>


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
mock the `router-link` element un Trashbin unit tests

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #6337 

YES ITS THE LAST ONE! I get a nice clean run locally now:
```
artur@deepthought3:~/www/owncloud-web$ yarn run test:unit
 PASS  packages/web-app-files/tests/unit/views/spaces/Projects.spec.js (13.722 s)
 PASS  packages/web-app-files/tests/unit/views/Favorites.spec.js (14.042 s)
 PASS  packages/web-app-files/tests/unit/components/SideBar/Links/PublicLinks/LinkEdit.spec.js (14.78 s)
 PASS  packages/web-app-files/tests/unit/components/AppBar/AppBar.spec.js (14.597 s)
 PASS  packages/web-app-files/tests/unit/views/PublicFiles.spec.ts (14.77 s)
 PASS  packages/web-app-files/tests/unit/views/SharedViaLink.spec.js (15.276 s)
 PASS  packages/web-app-files/tests/unit/views/SharedWithMe.spec.js
 PASS  packages/web-app-files/tests/unit/search/sdk.spec.ts
 PASS  packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.js
 PASS  packages/web-app-files/tests/unit/views/Trashbin.spec.js
 PASS  packages/web-app-files/tests/unit/views/SharedWithOthers.spec.js
 PASS  packages/web-app-files/tests/unit/components/FilesList/ContextActions.spec.js
 PASS  packages/web-app-files/tests/unit/views/LocationPicker.spec.js
 PASS  packages/web-app-files/tests/unit/components/FilesList/ResourceTable.spec.js (17.755 s)
 PASS  packages/web-app-search/tests/unit/portals/SearchBar.spec.ts
 PASS  packages/web-app-files/tests/unit/components/SideBar/Shares/InviteCollaborator/ExpirationDatepicker.spec.ts
 PASS  packages/web-runtime/tests/unit/components/Topbar/FeedbackLink.spec.js
 PASS  packages/web-app-files/tests/unit/views/Personal.spec.js
 PASS  packages/web-app-files/tests/unit/views/spaces/Project.spec.js
 PASS  packages/web-app-files/tests/unit/components/SideBar/Shares/RoleDropdown.spec.js
 PASS  packages/web-app-files/tests/unit/components/SideBar/Links/FileLinks.spec.js
 PASS  packages/web-app-files/tests/unit/components/Search/List.spec.js
 PASS  packages/web-app-files/tests/unit/views/PublicLink.spec.js
 PASS  packages/web-runtime/tests/unit/container/bootstrap.spec.ts
 PASS  packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.js
 PASS  packages/web-app-files/tests/unit/views/FilesDrop.spec.js
 PASS  packages/web-app-files/tests/unit/components/SideBar/SideBar.spec.js
 PASS  packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/ListItem.spec.js
 PASS  packages/web-app-files/tests/unit/components/Upload/ProgressBar.spec.js
 PASS  packages/web-app-files/tests/unit/components/SideBar/Links/PublicLinks/LinkInfo.spec.js
 PASS  packages/web-runtime/tests/unit/components/Topbar/ThemeSwitcher.spec.js
 PASS  packages/web-app-files/tests/unit/components/SideBar/Versions/FileVersions.spec.js
 PASS  packages/web-app-files/tests/unit/components/AppBar/ViewOptions.spec.js
 PASS  packages/web-app-files/tests/unit/components/SideBar/Actions/FileActions.spec.js
 PASS  packages/web-app-files/tests/unit/components/Search/Preview.spec.js
 PASS  packages/web-app-files/tests/unit/components/SideBar/Shares/InviteCollaborator/AutocompleteItem.spec.js
 PASS  packages/web-app-files/tests/unit/components/SideBar/Shares/InviteCollaborator/RecipientContainer.spec.js
 PASS  packages/web-app-files/tests/unit/search/filter.spec.ts
 PASS  packages/web-runtime/tests/unit/store/config.spec.js
 PASS  packages/web-app-files/tests/unit/components/SideBar/Details/FileDetailsMultiple.spec.js
 PASS  packages/web-pkg/tests/unit/composables/router/useRouteQuery.spec.ts
 PASS  packages/web-runtime/tests/unit/components/Topbar/UserMenu.spec.js
 PASS  packages/web-app-files/tests/unit/helpers/share/triggerShareAction.spec.js
 PASS  packages/web-app-files/tests/unit/components/AppBar/Upload/FileUpload.spec.js
 PASS  packages/web-app-files/tests/unit/views/PrivateLink.spec.js
 PASS  packages/web-app-files/tests/unit/components/AppBar/Upload/FolderUpload.spec.js
 PASS  packages/web-app-files/tests/unit/components/SideBar/FileInfo.spec.js
 PASS  packages/web-app-files/tests/unit/composables/fileListHeaderPosition/useFileListHeaderPosition.spec.ts
 PASS  packages/web-pkg/tests/unit/composables/store/useStore.spec.ts
 PASS  packages/web-app-files/tests/unit/components/FilesList/NotFoundMessage.spec.js
 PASS  packages/web-app-files/tests/unit/mixins/actions/rename.spec.js
 PASS  packages/web-runtime/tests/unit/components/Topbar/TopBar.spec.js
 PASS  packages/web-app-files/tests/unit/store/mutations.spec.js
 PASS  packages/web-app-files/tests/unit/components/Upload/DetailsWidget.spec.js
 PASS  packages/web-app-files/tests/unit/composables/pagination/usePagination.spec.ts
 PASS  packages/web-runtime/tests/unit/components/Topbar/Notification.spec.js
 PASS  packages/web-app-files/tests/unit/helpers/share/role.spec.ts
 PASS  packages/web-pkg/tests/unit/composables/router/useRouter.spec.ts
 PASS  packages/web-pkg/tests/unit/composables/store/useMutationSubscription.spec.ts
 PASS  packages/web-app-files/tests/unit/components/AppBar/Upload/FileDrop.spec.js
 PASS  packages/web-app-files/tests/unit/mixins/actions/acceptShare.spec.js
 PASS  packages/web-runtime/tests/unit/components/SidebarNav/SidebarNav.spec.js
 PASS  packages/web-app-files/tests/unit/components/SideBar/Links/PublicLinks/ListItem.spec.js
 PASS  packages/web-runtime/tests/unit/helpers/theme.spec.js
 PASS  packages/web-app-files/tests/unit/helpers/share/type.spec.ts
 PASS  packages/web-app-files/tests/unit/mixins.spec.js
 PASS  packages/web-app-files/tests/unit/composables/sort/useSort.spec.ts
 PASS  packages/web-app-files/tests/unit/helpers/share/permission.spec.ts
 PASS  packages/web-app-files/tests/unit/components/FilesList/ListInfo.spec.js
 PASS  packages/web-pkg/tests/unit/event/bus.spec.ts
 PASS  packages/web-runtime/tests/unit/components/Avatar.spec.js
 PASS  packages/web-app-files/tests/unit/store/getters.spec.js
 PASS  packages/web-app-files/tests/unit/components/FilesList/QuickActions.spec.js
 PASS  packages/web-app-files/tests/unit/components/ActionMenuItem.spec.js
 PASS  packages/web-app-files/tests/unit/components/SideBar/Links/PublicLinks/LinkActions.spec.js
 PASS  packages/web-runtime/tests/unit/components/SidebarNav/SidebarNavItem.spec.js
 PASS  packages/web-app-files/tests/unit/components/SideBar/Links/PrivateLinkItem.spec.js
 PASS  packages/web-app-files/tests/unit/components/SideBar/Links/CopyToClipboardButton.spec.js
 PASS  packages/web-app-external/tests/unit/app.spec.js
 PASS  packages/web-app-files/tests/unit/helpers/resource/sameResource.spec.ts
 PASS  packages/web-app-files/tests/unit/components/AppBar/SelectedResources/SizeInfo.spec.js
 PASS  packages/web-app-files/tests/unit/mixins/spaces/rename.spec.js
 PASS  packages/web-app-files/tests/unit/components/FilesList/Pagination.spec.js
 PASS  packages/web-app-files/tests/unit/mixins/actions/delete.spec.js
 PASS  packages/web-app-files/tests/unit/mixins/deleteResources.spec.js
 PASS  packages/web-app-files/tests/unit/components/AppBar/SelectedResources/BatchActions.spec.js
 PASS  packages/web-app-files/tests/unit/helpers/user/avatarUrl.spec.ts
 PASS  packages/web-pkg/tests/unit/http/client.spec.ts
 PASS  packages/web-app-files/tests/unit/router/utils.spec.ts
 PASS  packages/web-app-files/tests/unit/helpers/download/downloadAsArchive.spec.ts
 PASS  packages/web-app-files/tests/unit/components/FilesList/NoContentMessage.spec.js
 PASS  packages/web-runtime/tests/unit/components/SkipTo.spec.js
 PASS  packages/web-app-files/tests/unit/helpers/resource/filter.spec.ts
 PASS  packages/web-app-files/tests/unit/helpers/resource/publicPreviewUrl.spec.ts
 PASS  packages/web-app-files/tests/unit/helpers/resource/privatePreviewBlob.spec.ts
 PASS  packages/web-runtime/tests/unit/components/Topbar/ApplicationsMenu.spec.js
 PASS  packages/web-runtime/tests/unit/mixins/lifecycleMixin.spec.js
 PASS  packages/web-app-files/tests/unit/services/cache.spec.ts
 PASS  packages/web-runtime/tests/unit/components/MessageBar.spec.js
 PASS  packages/web-app-files/tests/unit/services/archiver.spec.ts
 PASS  packages/web-pkg/tests/unit/observer/visibility.spec.ts
 PASS  packages/web-runtime/tests/unit/mixins/focusMixin.spec.js
 PASS  packages/web-app-files/tests/unit/mixins/spaces/delete.spec.js
 PASS  packages/web-pkg/tests/unit/services/client.spec.ts
 PASS  packages/web-app-external/tests/unit/components/ErrorScreen.spec.ts
 PASS  packages/web-pkg/tests/unit/cache/cache.spec.ts
 PASS  packages/web-pkg/tests/unit/instance/index.spec.ts
 PASS  packages/web-app-search/tests/unit/views/List.spec.ts
 PASS  packages/web-runtime/tests/unit/container/versions.spec.ts
 PASS  packages/web-pkg/tests/unit/utils/objectKeys.spec.ts
 PASS  packages/web-app-files/tests/unit/helpers/statusIndicator.spec.js
 PASS  packages/web-app-search/tests/unit/store/options.spec.ts
 PASS  packages/web-app-files/tests/unit/helpers/store.spec.ts
 PASS  packages/web-app-files/tests/unit/helpers/path.spec.js
 PASS  packages/web-app-files/tests/unit/helpers/ui/filesList.spec.ts
 PASS  packages/web-pkg/tests/unit/decorator/debounce.spec.ts
 PASS  packages/web-pkg/tests/unit/utils/encodePath.spec.ts
 PASS  packages/web-app-search/tests/unit/service/providerStore.spec.ts
 PASS  packages/web-app-files/tests/unit/helpers/resource/asset.spec.ts
 PASS  packages/web-app-files/tests/unit/helpers/permissions.spec.js
 PASS  packages/web-app-files/tests/unit/store/modules/sidebar.spec.js
 PASS  packages/web-app-files/tests/unit/mixins/resources.spec.js
 PASS  packages/web-app-files/tests/unit/helpers/textUtils.spec.js
 PASS  packages/web-runtime/tests/unit/helpers/config.spec.js
 PASS  packages/web-app-files/tests/unit/components/SideBar/Shares/InviteCollaborator/InviteCollaboratorForm.spec.js
 PASS  packages/web-app-files/tests/unit/helpers/resource/common.spec.ts
 PASS  packages/web-app-external/tests/unit/components/LoadingScreen.spec.ts
 PASS  packages/web-runtime/tests/unit/helpers/resource.spec.js

Test Suites: 128 passed, 128 total
Tests:       34 todo, 832 passed, 866 total
Snapshots:   105 passed, 105 total
Time:        39.398 s
Ran all test suites.
```

## Motivation and Context
get rid of error log outputs during test runs
```
  ● Console

    console.error
      [Vue warn]: Unknown custom element: <router-link> - did you register the component correctly? For recursive components, make sure to provide the "name" option.
      
      found in
      
      ---> <OcResource>
             <OcTableCell>
               <OcTd>
                 <OcTr>
                   <OcTbody>
                     <OcTable>
                       <ResourceTable>
                         <Anonymous>
                           <Root>

      at warn (node_modules/vue/dist/vue.runtime.common.dev.js:621:15)
      at createElm (node_modules/vue/dist/vue.runtime.common.dev.js:5962:11)
      at createChildren (node_modules/vue/dist/vue.runtime.common.dev.js:6077:9)
      at createElm (node_modules/vue/dist/vue.runtime.common.dev.js:5978:9)
      at createChildren (node_modules/vue/dist/vue.runtime.common.dev.js:6077:9)
      at createElm (node_modules/vue/dist/vue.runtime.common.dev.js:5978:9)
      at createChildren (node_modules/vue/dist/vue.runtime.common.dev.js:6077:9)
      at createElm (node_modules/vue/dist/vue.runtime.common.dev.js:5978:9)
```

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- run unit tests locally
- :robot:

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
