### PR TITLE
Use the Vue store for spaces

### DIFF
--- a/changelog/unreleased/enhancement-spaces-use-store
+++ b/changelog/unreleased/enhancement-spaces-use-store
@@ -1,0 +1,5 @@
+Enhancement: Use the Vue store for spaces
+
+Using the store for spaces integrates them seamlessly in our ecosystem and makes it easier to develop spaces even further. E.g. the properties of a space can now be altered without fetching all spaces again. This was achieved by introducing a "buildSpace" method, that transforms a space into a more generic resource object (just like regular files or shares).
+
+https://github.com/owncloud/web/pull/6427

--- a/packages/web-app-files/src/helpers/resources.js
+++ b/packages/web-app-files/src/helpers/resources.js
@@ -102,6 +102,80 @@ export function buildResource(resource) {
   }
 }
 
+export function buildSpace(space) {
+  let spaceImageData, spaceReadmeData, spacePermissions
+  let disabled = false
+
+  if (space.special) {
+    spaceImageData = space.special.find((el) => el.specialFolder.name === 'image')
+    spaceReadmeData = space.special.find((el) => el.specialFolder.name === 'readme')
+  }
+
+  if (space.root) {
+    spacePermissions = space.root.permissions
+
+    if (space.root.deleted) {
+      disabled = space.root?.deleted?.state === 'trashed'
+    }
+  }
+
+  return {
+    id: space.id,
+    fileId: '',
+    mimeType: '',
+    name: space.name,
+    description: space.description,
+    extension: '',
+    path: '',
+    webDavPath: '',
+    type: 'space',
+    isFolder: true,
+    mdate: space.lastModifiedDateTime,
+    size: '',
+    indicators: [],
+    permissions: '',
+    starred: false,
+    etag: '',
+    sharePermissions: '',
+    shareTypes: (function () {
+      return []
+    })(),
+    privateLink: '',
+    downloadURL: '',
+    ownerDisplayName: '',
+    ownerId: '',
+    disabled,
+    spaceQuota: space.quota,
+    spacePermissions,
+    spaceImageData,
+    spaceReadmeData,
+    canUpload: function () {
+      return true
+    },
+    canDownload: function () {
+      return true
+    },
+    canBeDeleted: function () {
+      return true
+    },
+    canRename: function () {
+      return true
+    },
+    canShare: function () {
+      return true
+    },
+    canCreate: function () {
+      return true
+    },
+    isMounted: function () {
+      return true
+    },
+    isReceivedShare: function () {
+      return false
+    }
+  }
+}
+
 export function buildWebDavFilesPath(userId, path) {
   return `/files/${userId}/${path}`
 }

--- a/packages/web-app-files/src/helpers/resources.js
+++ b/packages/web-app-files/src/helpers/resources.js
@@ -115,7 +115,7 @@ export function buildSpace(space) {
     spacePermissions = space.root.permissions
 
     if (space.root.deleted) {
-      disabled = space.root?.deleted?.state === 'trashed'
+      disabled = space.root.deleted?.state === 'trashed'
     }
   }
 

--- a/packages/web-app-files/src/mixins/spaces/actions/delete.js
+++ b/packages/web-app-files/src/mixins/spaces/actions/delete.js
@@ -1,4 +1,4 @@
-import { mapActions, mapGetters } from 'vuex'
+import { mapActions, mapGetters, mapMutations } from 'vuex'
 import { clientService } from 'web-pkg/src/services'
 
 export default {
@@ -19,7 +19,7 @@ export default {
               return false
             }
 
-            return spaces[0].root?.deleted?.state === 'trashed'
+            return spaces[0].disabled
           },
           componentType: 'oc-button',
           class: 'oc-files-actions-delete-trigger'
@@ -35,6 +35,7 @@ export default {
       'showMessage',
       'toggleModalConfirmButton'
     ]),
+    ...mapMutations('Files', ['REMOVE_FILE']),
 
     $_delete_trigger({ spaces }) {
       if (spaces.length !== 1) {
@@ -66,7 +67,7 @@ export default {
         })
         .then(() => {
           this.hideModal()
-          this.loadSpacesTask.perform(this)
+          this.REMOVE_FILE({ id })
         })
         .catch((error) => {
           this.showMessage({

--- a/packages/web-app-files/src/mixins/spaces/actions/disable.js
+++ b/packages/web-app-files/src/mixins/spaces/actions/disable.js
@@ -64,7 +64,7 @@ export default {
         .then(() => {
           this.hideModal()
           this.UPDATE_RESOURCE_FIELD({
-            id: id,
+            id,
             field: 'disabled',
             value: true
           })

--- a/packages/web-app-files/src/mixins/spaces/actions/disable.js
+++ b/packages/web-app-files/src/mixins/spaces/actions/disable.js
@@ -1,4 +1,4 @@
-import { mapActions, mapGetters } from 'vuex'
+import { mapActions, mapGetters, mapMutations } from 'vuex'
 import { clientService } from 'web-pkg/src/services'
 
 export default {
@@ -19,7 +19,7 @@ export default {
               return false
             }
 
-            return spaces[0].root?.deleted?.state !== 'trashed'
+            return !spaces[0].disabled
           },
           componentType: 'oc-button',
           class: 'oc-files-actions-disable-trigger'
@@ -35,6 +35,7 @@ export default {
       'showMessage',
       'toggleModalConfirmButton'
     ]),
+    ...mapMutations('Files', ['UPDATE_RESOURCE_FIELD']),
 
     $_disable_trigger({ spaces }) {
       if (spaces.length !== 1) {
@@ -62,7 +63,11 @@ export default {
         .deleteDrive(id)
         .then(() => {
           this.hideModal()
-          this.loadSpacesTask.perform(this)
+          this.UPDATE_RESOURCE_FIELD({
+            id: id,
+            field: 'disabled',
+            value: true
+          })
         })
         .catch((error) => {
           this.showMessage({

--- a/packages/web-app-files/src/mixins/spaces/actions/editDescription.js
+++ b/packages/web-app-files/src/mixins/spaces/actions/editDescription.js
@@ -1,4 +1,4 @@
-import { mapActions, mapGetters } from 'vuex'
+import { mapActions, mapGetters, mapMutations } from 'vuex'
 import { clientService } from 'web-pkg/src/services'
 
 export default {
@@ -29,6 +29,7 @@ export default {
       'showMessage',
       'toggleModalConfirmButton'
     ]),
+    ...mapMutations('Files', ['UPDATE_RESOURCE_FIELD']),
 
     $_editDescription_trigger({ spaces }) {
       if (spaces.length !== 1) {
@@ -57,7 +58,11 @@ export default {
         .updateDrive(id, { description }, {})
         .then(() => {
           this.hideModal()
-          this.loadSpacesTask.perform(this)
+          this.UPDATE_RESOURCE_FIELD({
+            id: id,
+            field: 'description',
+            value: description
+          })
         })
         .catch((error) => {
           this.showMessage({

--- a/packages/web-app-files/src/mixins/spaces/actions/editDescription.js
+++ b/packages/web-app-files/src/mixins/spaces/actions/editDescription.js
@@ -59,7 +59,7 @@ export default {
         .then(() => {
           this.hideModal()
           this.UPDATE_RESOURCE_FIELD({
-            id: id,
+            id,
             field: 'description',
             value: description
           })

--- a/packages/web-app-files/src/mixins/spaces/actions/rename.js
+++ b/packages/web-app-files/src/mixins/spaces/actions/rename.js
@@ -1,4 +1,4 @@
-import { mapActions, mapGetters } from 'vuex'
+import { mapActions, mapGetters, mapMutations } from 'vuex'
 import { clientService } from 'web-pkg/src/services'
 
 export default {
@@ -29,6 +29,7 @@ export default {
       'showMessage',
       'toggleModalConfirmButton'
     ]),
+    ...mapMutations('Files', ['UPDATE_RESOURCE_FIELD']),
 
     $_rename_trigger({ spaces }) {
       if (spaces.length !== 1) {
@@ -64,7 +65,11 @@ export default {
         .updateDrive(id, { name }, {})
         .then(() => {
           this.hideModal()
-          this.loadSpacesTask.perform(this)
+          this.UPDATE_RESOURCE_FIELD({
+            id: id,
+            field: 'name',
+            value: name
+          })
         })
         .catch((error) => {
           this.showMessage({

--- a/packages/web-app-files/src/mixins/spaces/actions/rename.js
+++ b/packages/web-app-files/src/mixins/spaces/actions/rename.js
@@ -66,7 +66,7 @@ export default {
         .then(() => {
           this.hideModal()
           this.UPDATE_RESOURCE_FIELD({
-            id: id,
+            id,
             field: 'name',
             value: name
           })

--- a/packages/web-app-files/src/mixins/spaces/actions/restore.js
+++ b/packages/web-app-files/src/mixins/spaces/actions/restore.js
@@ -1,4 +1,4 @@
-import { mapActions, mapGetters } from 'vuex'
+import { mapActions, mapGetters, mapMutations } from 'vuex'
 import { clientService } from 'web-pkg/src/services'
 
 export default {
@@ -19,7 +19,7 @@ export default {
               return false
             }
 
-            return spaces[0].root?.deleted?.state === 'trashed'
+            return spaces[0].disabled
           },
           componentType: 'oc-button',
           class: 'oc-files-actions-restore-trigger'
@@ -35,6 +35,7 @@ export default {
       'showMessage',
       'toggleModalConfirmButton'
     ]),
+    ...mapMutations('Files', ['UPDATE_RESOURCE_FIELD']),
 
     $_restore_trigger({ spaces }) {
       if (spaces.length !== 1) {
@@ -70,7 +71,11 @@ export default {
         )
         .then(() => {
           this.hideModal()
-          this.loadSpacesTask.perform(this)
+          this.UPDATE_RESOURCE_FIELD({
+            id: id,
+            field: 'disabled',
+            value: false
+          })
         })
         .catch((error) => {
           this.showMessage({

--- a/packages/web-app-files/src/mixins/spaces/actions/restore.js
+++ b/packages/web-app-files/src/mixins/spaces/actions/restore.js
@@ -72,7 +72,7 @@ export default {
         .then(() => {
           this.hideModal()
           this.UPDATE_RESOURCE_FIELD({
-            id: id,
+            id,
             field: 'disabled',
             value: false
           })

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -53,7 +53,7 @@
               <div class="oc-card-media-top oc-border-b">
                 <router-link v-if="!loadImagesTask.isRunning" :to="getSpaceProjectRoute(space)">
                   <oc-tag
-                    v-if="isSpaceDisabled(space)"
+                    v-if="space.disabled"
                     class="oc-position-absolute space-disabled-indicator"
                     type="span"
                   >
@@ -133,7 +133,7 @@
 <script>
 import NoContentMessage from '../../components/FilesList/NoContentMessage.vue'
 import ListLoader from '../../components/FilesList/ListLoader.vue'
-import { ref } from '@vue/composition-api'
+import { computed, ref } from '@vue/composition-api'
 import { useStore } from 'web-pkg/src/composables'
 import { useTask } from 'vue-concurrency'
 import { createLocationSpaces } from '../../router'
@@ -145,7 +145,7 @@ import Disable from '../../mixins/spaces/actions/disable'
 import Restore from '../../mixins/spaces/actions/restore'
 import EditDescription from '../../mixins/spaces/actions/editDescription'
 import ShowDetails from '../../mixins/spaces/actions/showDetails'
-import { buildWebDavSpacesPath } from '../../helpers/resources'
+import { buildSpace, buildWebDavSpacesPath } from '../../helpers/resources'
 import { clientService } from 'web-pkg/src/services'
 
 export default {
@@ -156,18 +156,23 @@ export default {
   mixins: [Rename, Delete, EditDescription, Disable, ShowDetails, Restore],
   setup() {
     const store = useStore()
-    const spaces = ref([])
+    const spaces = computed(() => store.getters['Files/activeFiles'] || [])
     const imageContentObject = ref({})
     const graphClient = clientService.graphAuthenticated(
       store.getters.configuration.server,
       store.getters.getToken
     )
 
-    const loadSpacesTask = useTask(function* () {
+    const loadSpacesTask = useTask(function* (signal, ref) {
+      ref.CLEAR_CURRENT_FILES_LIST()
+
       const response = yield graphClient.drives.listMyDrives()
-      spaces.value = (response.data?.value || [])
+      let loadedSpaces = (response.data?.value || [])
         .filter((drive) => drive.driveType === 'project')
         .sort((a, b) => a.name.localeCompare(b.name))
+
+      loadedSpaces = loadedSpaces.map(buildSpace)
+      ref.LOAD_FILES({ currentFolder: null, files: loadedSpaces })
     })
 
     const loadImageTask = useTask(function* (signal, { client, spaceId, fileName }) {
@@ -183,23 +188,19 @@ export default {
 
     const loadImagesTask = useTask(function* (signal, ref) {
       for (const space of spaces.value) {
-        const imageEntry = space?.special?.find((el) => el?.specialFolder?.name === 'image')
-
-        if (!imageEntry) {
+        if (!space?.spaceImageData) {
           continue
         }
 
         yield loadImageTask.perform({
           client: ref.$client,
           spaceId: space?.id,
-          fileName: imageEntry?.name
+          fileName: space.spaceImageData.name
         })
       }
     })
 
     const loadResourcesTask = useTask(function* (signal, ref) {
-      ref.SET_CURRENT_FOLDER(null)
-
       yield ref.loadSpacesTask.perform(ref)
       yield ref.loadImagesTask.perform(ref)
     })
@@ -219,7 +220,7 @@ export default {
       return true
     }
   },
-  mounted() {
+  created() {
     this.loadResourcesTask.perform(this)
 
     const loadSpacesEventToken = bus.subscribe('app.files.list.load', (path) => {
@@ -230,7 +231,7 @@ export default {
   },
   methods: {
     ...mapActions(['createModal', 'hideModal', 'setModalInputErrorMessage']),
-    ...mapMutations('Files', ['SET_CURRENT_FOLDER']),
+    ...mapMutations('Files', ['SET_CURRENT_FOLDER', 'LOAD_FILES', 'CLEAR_CURRENT_FILES_LIST']),
 
     getContextMenuActions(space) {
       return [
@@ -295,14 +296,10 @@ export default {
     },
 
     getSpaceCardAdditionalClass(space) {
-      if (this.isSpaceDisabled(space)) {
+      if (space.disabled) {
         return 'state-trashed'
       }
       return ''
-    },
-
-    isSpaceDisabled(space) {
-      return space.root?.deleted?.state === 'trashed'
     }
   }
 }

--- a/packages/web-app-files/tests/unit/mixins/spaces/delete.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/spaces/delete.spec.js
@@ -37,6 +37,14 @@ describe('delete', () => {
             server: 'https://example.com'
           }),
           getToken: () => 'token'
+        },
+        modules: {
+          Files: {
+            namespaced: true,
+            mutations: {
+              REMOVE_FILE: jest.fn()
+            }
+          }
         }
       })
     })
@@ -44,9 +52,6 @@ describe('delete', () => {
 
   describe('method "$_delete_trigger"', () => {
     it('should trigger the delete modal window', async () => {
-      mockAxios.request.mockImplementationOnce(() => {
-        return Promise.resolve()
-      })
       const wrapper = getWrapper()
       const spyCreateModalStub = jest.spyOn(wrapper.vm, 'createModal')
       await wrapper.vm.$_delete_trigger({ spaces: [{ id: 1 }] })

--- a/packages/web-app-files/tests/unit/mixins/spaces/rename.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/spaces/rename.spec.js
@@ -38,6 +38,14 @@ describe('rename', () => {
             server: 'https://example.com'
           }),
           getToken: () => 'token'
+        },
+        modules: {
+          Files: {
+            namespaced: true,
+            mutations: {
+              UPDATE_RESOURCE_FIELD: jest.fn()
+            }
+          }
         }
       })
     })
@@ -45,9 +53,6 @@ describe('rename', () => {
 
   describe('method "$_rename_trigger"', () => {
     it('should trigger the rename modal window', async () => {
-      mockAxios.request.mockImplementationOnce(() => {
-        return Promise.resolve()
-      })
       const wrapper = getWrapper()
       const spyCreateModalStub = jest.spyOn(wrapper.vm, 'createModal')
       await wrapper.vm.$_rename_trigger({ spaces: [{ id: 1, name: 'renamed space' }] })
@@ -58,9 +63,6 @@ describe('rename', () => {
 
   describe('method "$_rename_checkName"', () => {
     it('should throw an error with an empty space name', async () => {
-      mockAxios.request.mockImplementationOnce(() => {
-        return Promise.resolve()
-      })
       const wrapper = getWrapper()
       const spyInputErrorMessageStub = jest.spyOn(wrapper.vm, 'setModalInputErrorMessage')
       await wrapper.vm.$_rename_checkName('')

--- a/packages/web-app-files/tests/unit/views/spaces/Project.spec.js
+++ b/packages/web-app-files/tests/unit/views/spaces/Project.spec.js
@@ -161,10 +161,7 @@ describe('Spaces project view', () => {
         })
       })
 
-      const spaceResource = buildResource(Files['/'][0])
-      spaceResource.path = '/'
-
-      const wrapper = getMountedWrapper([spaceResource])
+      const wrapper = getMountedWrapper([Files['/'][0]])
       await wrapper.vm.loadResourcesTask.last
 
       expect(wrapper.find(selectors.emptySpace).exists()).toBeFalsy()

--- a/packages/web-app-files/tests/unit/views/spaces/Project.spec.js
+++ b/packages/web-app-files/tests/unit/views/spaces/Project.spec.js
@@ -5,7 +5,6 @@ import { createStore } from 'vuex-extensions'
 import Files from '@/__fixtures__/files'
 import mockAxios from 'jest-mock-axios'
 import SpaceProject from '../../../../src/views/spaces/Project.vue'
-import { buildResource } from '@files/src/helpers/resources'
 import Vuex from 'vuex'
 
 localVue.use(GetTextPlugin, {

--- a/packages/web-app-files/tests/unit/views/spaces/Projects.spec.js
+++ b/packages/web-app-files/tests/unit/views/spaces/Projects.spec.js
@@ -31,19 +31,18 @@ describe('Spaces component', () => {
     expect(wrapper.find(selectors.sharesNoContentMessage).exists()).toBeTruthy()
   })
 
-  it('should only list drives of type "project"', async () => {
+  it('should list spaces', async () => {
+    const drives = [{ driveType: 'project', id: '1' }]
+
     mockAxios.request.mockImplementationOnce(() => {
       return Promise.resolve({
         data: {
-          value: [
-            { driveType: 'project', id: '1' },
-            { driveType: 'personal', id: '2' }
-          ]
+          value: drives
         }
       })
     })
 
-    const wrapper = getMountedWrapper()
+    const wrapper = getMountedWrapper(drives)
     await wrapper.vm.loadSpacesTask.last
 
     expect(wrapper.vm.spaces.length).toEqual(1)
@@ -88,7 +87,7 @@ describe('Spaces component', () => {
   })
 })
 
-function getMountedWrapper() {
+function getMountedWrapper(activeFiles = []) {
   const routes = [
     {
       name: 'files-spaces-project',
@@ -110,8 +109,14 @@ function getMountedWrapper() {
       modules: {
         Files: {
           namespaced: true,
+          getters: {
+            activeFiles: () => activeFiles
+          },
           mutations: {
-            SET_CURRENT_FOLDER: jest.fn()
+            SET_CURRENT_FOLDER: jest.fn(),
+            CLEAR_CURRENT_FILES_LIST: jest.fn(),
+            CLEAR_FILES_SEARCHED: jest.fn(),
+            LOAD_FILES: jest.fn()
           }
         }
       }

--- a/packages/web-app-files/tests/unit/views/spaces/__snapshots__/Projects.spec.js.snap
+++ b/packages/web-app-files/tests/unit/views/spaces/__snapshots__/Projects.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Spaces component should only list drives of type "project" 1`] = `
+exports[`Spaces component should list spaces 1`] = `
 <div class="oc-py-s oc-px-m"><button aria-label="Create a new space" class="oc-mb-l oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-primary" id="new-space-menu-btn" data-testid="spaces-list-create-space-btn"><span class="oc-icon oc-icon-m oc-icon-passive"><!----></span>
     <translate-stub tag="span">Create Space</translate-stub>
   </button>


### PR DESCRIPTION
## Description
Using the store for spaces integrates them seamlessly in our ecosystem and makes it easier to develop spaces even further. E.g. the properties of a space can now be altered without fetching all spaces again. This was achieved by introducing a "buildSpace" method, that transforms a space into a more generic resource object (just like regular files or shares).

## Motivation and Context
Groundwork for https://github.com/owncloud/web/issues/6284 (and basically all space-related issues)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
