### PR TITLE
App compatibility for old named routes

### DIFF
--- a/changelog/unreleased/bugfix-catch-router-view-names
+++ b/changelog/unreleased/bugfix-catch-router-view-names
@@ -1,0 +1,5 @@
+Bugfix: App compatibility
+
+We've made sure that apps that were not made compatible with ownCloud Web 5.0.0 don't run into a non-rendered state.
+
+https://github.com/owncloud/web/pull/6439

--- a/packages/web-runtime/src/layouts/Application.vue
+++ b/packages/web-runtime/src/layouts/Application.vue
@@ -7,7 +7,12 @@
       <message-bar :active-messages="activeMessages" @deleteMessage="deleteMessage" />
       <div class="app-container oc-flex">
         <sidebar-nav v-if="isSidebarVisible" class="app-navigation" :nav-items="sidebarNavItems" />
-        <router-view class="app-content oc-width-1-1" />
+        <router-view
+          v-for="name in ['default', 'app', 'fullscreen']"
+          :key="`router-view-${name}`"
+          class="app-content oc-width-1-1"
+          :name="name"
+        />
       </div>
     </div>
   </div>
@@ -18,7 +23,8 @@ import { mapActions, mapGetters } from 'vuex'
 import TopBar from '../components/Topbar/TopBar.vue'
 import MessageBar from '../components/MessageBar.vue'
 import SidebarNav from '../components/SidebarNav/SidebarNav.vue'
-import { useActiveApp } from 'web-pkg/src/composables'
+import { useActiveApp, useRoute } from 'web-pkg/src/composables'
+import { watch } from '@vue/composition-api'
 
 export default {
   components: {
@@ -27,6 +33,25 @@ export default {
     SidebarNav
   },
   setup() {
+    // FIXME: we can convert to a single router-view without name (thus without the loop) and without this watcher when we release v6.0.0
+    watch(
+      useRoute(),
+      (route) => {
+        if (route.matched.length) {
+          route.matched.forEach((match) => {
+            const keys = Object.keys(match.components).filter((key) => key !== 'default')
+            if (keys.length) {
+              console.warn(
+                `named components are deprecated, use "default" instead of "${keys.join(
+                  ', '
+                )}" on route ${route.name}`
+              )
+            }
+          })
+        }
+      },
+      { immediate: true }
+    )
     return {
       activeApp: useActiveApp()
     }


### PR DESCRIPTION
## Description
Apps had to define their route components for named views in the past, either
```js
components: {
  app: ComponentName
}
```
or
```js
components: {
  fullscreen: ComponentName
}
```

We've removed the named routes in https://github.com/owncloud/web/pull/6401 so that routes now need to be defined as
```js
component: ComponentName
```

This broke "old" apps with an unrendered state, because the router-view with the respective name could not be found anymore.
This PR defines identical router-views for the `default` name and for the old `app` and `fullscreen` names, but all rendered in the same way (inside the app container, because we don't allow apps without topbar anymore).
Also added a deprecation warning. We can basically revert this commit once we release the next major version.

## Motivation and Context
App compatibility

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually define an app with the old schema and make sure that it renders correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
