### PR TITLE
Do not load files from cache

### DIFF
--- a/changelog/unreleased/bugfix-do-not-load-from-cache
+++ b/changelog/unreleased/bugfix-do-not-load-from-cache
@@ -1,0 +1,6 @@
+Bugfix: Do not load files from cache
+
+When apps (i.e Drawio) try to load a file, the browser caches the request.
+If the file was modified somewhere else, this causes inconsistent results which prevent saving any changes until the cache is properly cleared.
+
+https://github.com/owncloud/web/pull/6447

--- a/packages/web-app-draw-io/src/App.vue
+++ b/packages/web-app-draw-io/src/App.vue
@@ -137,7 +137,7 @@ export default {
         })
     },
     load() {
-      this.getFileContents(this.filePath, { resolveWithResponseObject: true })
+      this.getFileContents(this.filePath)
         .then((resp) => {
           this.currentETag = resp.headers.ETag
           this.$refs.drawIoEditor.contentWindow.postMessage(

--- a/packages/web-pkg/src/composables/appDefaults/useAppFileHandling.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppFileHandling.ts
@@ -69,7 +69,8 @@ export function useAppFileHandling(options: AppFileHandlingOptions): AppFileHand
       }
     } else {
       return client.files.getFileContents(filePath, {
-        resolveWithResponseObject: true
+        resolveWithResponseObject: true,
+        noCache: true
       })
     }
   }


### PR DESCRIPTION
When apps (i.e Drawio) try to load a file, the browser caches the request.
If the file was modified somewhere else, this causes inconsistent results which prevent saving any changes until the cache is properly cleared.

We had observed this is the past in our text editor, hence the `noCache` addition to the SDK. Now we also saw it in Drawio.