### PR TITLE
Fix file creation

### DIFF
--- a/packages/web-app-files/src/components/AppBar/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar/AppBar.vue
@@ -601,15 +601,20 @@ export default {
           throw new Error(`An error has occurred: ${response.status}`)
         }
 
-        const path = pathUtil.join(this.currentPath, fileName)
         let resource
+        let path = pathUtil.join(this.currentPath, fileName)
+
         if (this.isPersonalLocation) {
+          path = buildWebDavFilesPath(this.user.id, path)
+          resource = await this.$client.files.fileInfo(path, DavProperties.Default)
+        } else if (this.isSpacesProjectLocation) {
+          path = buildWebDavSpacesPath(this.$route.params.spaceId, path)
           resource = await this.$client.files.fileInfo(path, DavProperties.Default)
         } else {
           resource = await this.$client.publicFiles.getFileInfo(
             path,
             this.publicLinkPassword,
-            DavProperties.PublicLink
+            DavProperties.Default
           )
         }
         resource = buildResource(resource)

--- a/packages/web-app-files/src/components/AppBar/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar/AppBar.vue
@@ -521,6 +521,13 @@ export default {
           path = buildWebDavSpacesPath(this.$route.params.spaceId, path)
           await this.$client.files.putFileContents(path, '')
           resource = await this.$client.files.fileInfo(path, DavProperties.Default)
+        } else {
+          await this.$client.publicFiles.putFileContents('', path, this.publicLinkPassword, '')
+          resource = await this.$client.publicFiles.getFileInfo(
+            path,
+            this.publicLinkPassword,
+            DavProperties.Default
+          )
         }
 
         if (this.newFileAction) {

--- a/packages/web-app-files/src/components/AppBar/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar/AppBar.vue
@@ -437,7 +437,7 @@ export default {
           resource = await this.$client.publicFiles.getFileInfo(
             path,
             this.publicLinkPassword,
-            DavProperties.Default
+            DavProperties.PublicLink
           )
         }
         resource = buildResource(resource)
@@ -526,7 +526,7 @@ export default {
           resource = await this.$client.publicFiles.getFileInfo(
             path,
             this.publicLinkPassword,
-            DavProperties.Default
+            DavProperties.PublicLink
           )
         }
 
@@ -621,7 +621,7 @@ export default {
           resource = await this.$client.publicFiles.getFileInfo(
             path,
             this.publicLinkPassword,
-            DavProperties.Default
+            DavProperties.PublicLink
           )
         }
         resource = buildResource(resource)
@@ -699,7 +699,7 @@ export default {
           resource = await this.$client.publicFiles.getFileInfo(
             path,
             this.publicLinkPassword,
-            DavProperties.Default
+            DavProperties.PublicLink
           )
         }
 


### PR DESCRIPTION
When #6287 got merged, you forgot to update `addAppProviderFile`, so creating files via app provider would fail when stating.
edit: the normal creation of files was also broken in public links