### PR TITLE
[full-ci] Fix several file handling issues for apps

### DIFF
--- a/__mocks__/sdk.js
+++ b/__mocks__/sdk.js
@@ -9,27 +9,21 @@ import fixturePublicFiles from '../__fixtures__/publicFiles'
 import fixtureRecipients from '../__fixtures__/recipients'
 import { DateTime } from 'luxon'
 
+const mockPath = (path) => {
+  if (path.startsWith('/files/')) {
+    path = '/' + path.split('/').splice(3).join('/')
+  }
+  return path
+}
+
 export default {
   files: {
     list: (path = '/') => {
-      if (path.startsWith('/files/')) {
-        path = path.split('/').splice(3).join('/')
-        if (path === '') {
-          path = '/'
-        }
-      }
-
-      return fixtureFiles[path]
+      return fixtureFiles[mockPath(path)]
     },
     getFavoriteFiles: () => fixtureFavoriteFiles,
     fileInfo: (path) => {
-      if (path.startsWith('/files/')) {
-        path = path.split('/').splice(3).join('/')
-        if (path === '') {
-          path = '/'
-        }
-      }
-      return fixtureFiles[path][0]
+      return fixtureFiles[mockPath(path)][0]
     }
   },
   users: {

--- a/changelog/unreleased/bugfix-app-file-handling
+++ b/changelog/unreleased/bugfix-app-file-handling
@@ -1,0 +1,6 @@
+Bugfix: File handling in apps
+
+We fixed loading and saving files in apps in all contexts. It's now possible to open files in apps in personal files, favorites, share views and spaces.
+
+https://github.com/owncloud/web/pull/6456
+

--- a/packages/web-app-files/src/helpers/resource/resource.ts
+++ b/packages/web-app-files/src/helpers/resource/resource.ts
@@ -3,5 +3,6 @@
 export interface Resource {
   id: number | string
   path: string
+  webDavPath: string
   downloadURL?: string
 }

--- a/packages/web-app-files/src/helpers/resources.js
+++ b/packages/web-app-files/src/helpers/resources.js
@@ -177,11 +177,11 @@ export function buildSpace(space) {
 }
 
 export function buildWebDavFilesPath(userId, path) {
-  return `/files/${userId}/${path}`
+  return '/' + `files/${userId}/${path}`.split('/').filter(Boolean).join('/')
 }
 
 export function buildWebDavSpacesPath(spaceId, path) {
-  return `/spaces/${spaceId}/${path}`
+  return '/' + `spaces/${spaceId}/${path}`.split('/').filter(Boolean).join('/')
 }
 
 export function attachIndicators(resource, sharesTree) {

--- a/packages/web-app-files/tests/unit/helpers/resource/sameResource.spec.ts
+++ b/packages/web-app-files/tests/unit/helpers/resource/sameResource.spec.ts
@@ -4,20 +4,30 @@ describe('isSameResource', () => {
   test('evaluates to false if one of the resources is nullish', () => {
     expect(isSameResource(null, null)).toBe(false)
     expect(isSameResource(undefined, undefined)).toBe(false)
-    expect(isSameResource(null, { id: 1, path: '' })).toBe(false)
-    expect(isSameResource(undefined, { id: 1, path: '' })).toBe(false)
-    expect(isSameResource({ id: 1, path: '' }, null)).toBe(false)
-    expect(isSameResource({ id: 1, path: '' }, undefined)).toBe(false)
+    expect(isSameResource(null, { id: 1, path: '', webDavPath: '' })).toBe(false)
+    expect(isSameResource(undefined, { id: 1, path: '', webDavPath: '' })).toBe(false)
+    expect(isSameResource({ id: 1, path: '', webDavPath: '' }, null)).toBe(false)
+    expect(isSameResource({ id: 1, path: '', webDavPath: '' }, undefined)).toBe(false)
   })
   test('evaluates to false if ids are of different types', () => {
-    expect(isSameResource({ id: 1, path: '' }, { id: '1', path: '' })).toBe(false)
+    expect(
+      isSameResource({ id: 1, path: '', webDavPath: '' }, { id: '1', path: '', webDavPath: '' })
+    ).toBe(false)
   })
   test('evaluates to false if ids are different values', () => {
-    expect(isSameResource({ id: 1, path: '' }, { id: 2, path: '' })).toBe(false)
-    expect(isSameResource({ id: '1', path: '' }, { id: '2', path: '' })).toBe(false)
+    expect(
+      isSameResource({ id: 1, path: '', webDavPath: '' }, { id: 2, path: '', webDavPath: '' })
+    ).toBe(false)
+    expect(
+      isSameResource({ id: '1', path: '', webDavPath: '' }, { id: '2', path: '', webDavPath: '' })
+    ).toBe(false)
   })
   test('evaluates to true if ids are the same', () => {
-    expect(isSameResource({ id: 1, path: '' }, { id: 1, path: '' })).toBe(true)
-    expect(isSameResource({ id: '1', path: '' }, { id: '1', path: '' })).toBe(true)
+    expect(
+      isSameResource({ id: 1, path: '', webDavPath: '' }, { id: 1, path: '', webDavPath: '' })
+    ).toBe(true)
+    expect(
+      isSameResource({ id: '1', path: '', webDavPath: '' }, { id: '1', path: '', webDavPath: '' })
+    ).toBe(true)
   })
 })

--- a/packages/web-app-media-viewer/src/App.vue
+++ b/packages/web-app-media-viewer/src/App.vue
@@ -185,7 +185,8 @@ export default {
         x: this.thumbDimensions,
         y: this.thumbDimensions,
         // strip double quotes from etag
-        c: this.activeMediaFile.etag.substr(1, this.activeMediaFile.etag.length - 2),
+        // we have no etag, e.g. on shared with others page
+        c: this.activeMediaFile.etag?.substr(1, this.activeMediaFile.etag.length - 2),
         scalingup: 0,
         preview: 1,
         a: 1

--- a/packages/web-app-media-viewer/src/App.vue
+++ b/packages/web-app-media-viewer/src/App.vue
@@ -256,7 +256,7 @@ export default {
 
     // update route and url
     updateLocalHistory() {
-      this.$route.params.filePath = this.activeMediaFile.path
+      this.$route.params.filePath = this.activeMediaFile.webDavPath
       history.pushState({}, document.title, this.$router.resolve(this.$route).href)
     },
 

--- a/packages/web-pkg/src/composables/appDefaults/useAppFileHandling.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppFileHandling.ts
@@ -29,13 +29,17 @@ export function useAppFileHandling(options: AppFileHandlingOptions): AppFileHand
   const isPublicLinkContext = options.isPublicLinkContext
   const publicLinkPassword = options.publicLinkPassword
 
-  const getUrlForResource = ({ path, downloadURL }: Resource, query: QueryParameters = null) => {
+  const getUrlForResource = (
+    { webDavPath, downloadURL }: Resource,
+    query: QueryParameters = null
+  ) => {
     const queryStr = qs.stringify(query)
     if (unref(isPublicLinkContext)) {
       // If the resource does not contain the downloadURL we fallback to the normal
       // public files path.
       if (!downloadURL) {
-        const urlPath = ['..', 'dav', 'public-files', path].join('/')
+        // TODO: check whether we can fix the resource to always contain public-files in the webDavPath
+        const urlPath = ['public-files', webDavPath].join('/')
         return [client.files.getFileUrl(urlPath), queryStr].filter(Boolean).join('?')
       }
 
@@ -49,8 +53,7 @@ export function useAppFileHandling(options: AppFileHandlingOptions): AppFileHand
       return [url, combinedQuery].filter(Boolean).join('?')
     }
 
-    const urlPath = ['..', 'dav', 'files', store.getters.user.id, path.replace(/^\//, '')].join('/')
-    return [client.files.getFileUrl(urlPath), queryStr].filter(Boolean).join('?')
+    return [client.files.getFileUrl(webDavPath), queryStr].filter(Boolean).join('?')
   }
 
   const getFileContents = async (filePath: string) => {

--- a/packages/web-runtime/src/router/index.js
+++ b/packages/web-runtime/src/router/index.js
@@ -50,7 +50,9 @@ const base = document.querySelector('base')
 export const router = patchRouter(
   new Router({
     parseQuery(query) {
-      return qs.parse(query)
+      return qs.parse(query, {
+        allowDots: true
+      })
     },
     stringifyQuery(obj) {
       return qs.stringify(obj, {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR fixes a bunch of scenarios where mediaviewer (and possibly other apps) were broken:
- `getUrlForResource` was using an ugly hack to retrieve a webdav url before `webDavPath` was introduced in https://github.com/owncloud/web/pull/6287, we could now get rid of that hack and make this function work for spaces and a bunch of other contexts work as well (Kudos for that PR!!)
- mediaviewer: clicking next/previous updated the url with the resource `path` instead of the `webDavPath`: that broke reloading
- router.parseQuery: our `qs.parse` invocation was missing the `allowDots` option, so nested objects in query were not correctly parsed and closing the apps, at least on public links was broken 


## Related Issues
There are two oCIS bugs left, which cause the mediaviewer to fail
- for images in spaces https://github.com/owncloud/ocis/issues/3088 
- for shares https://github.com/owncloud/ocis/issues/2462

With oC 10 *everything* seems to work just fine.

Biggest remaining issue is, that reloading the mediaviewer will only load the correct context folder for personal files or public links - i.e. if you open the mediaviewer in the shares overview you can cycle through your shared pictures, if you reload the page you will cycle through the folder from which the file was shared.
Fixing that is way beyond the scope of this PR and needs to be handled in a follow up PR.

## Motivation and Context
It's annoying when the mediaviewer or other apps don't work in all contexts :-P 

## How Has This Been Tested?
Apart from the before mentioned issues, I'm not aware of any remaining ones.
With these changes the mediaviewer works in `Personal`,  `Favorites`, `Shared With Others`, `Shared Via Link` and `Spaces` views.

~~Just `Shared With Me` I haven't tested yet.~~ `Shared With Me` was tested, works.

~~Query Parsing seems to behave a little weird, needs to be double checked again.~~
~~I needed the change to fix closing apps on public links, but now reloading seems broken in `Personal`. Marking the PR as WIP for now.~~
Seems to have been a hiccup, cannot reproduce anymore.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
