### PR TITLE
[tests-only] Add e2e test for unauthorized user opening public link

### DIFF
--- a/tests/e2e/cucumber/publicLinkToFolderJourney.feature
+++ b/tests/e2e/cucumber/publicLinkToFolderJourney.feature
@@ -21,3 +21,13 @@ Feature: Create public link to folder
       | resource     | name         | role     | dateOfExpiration | password |
       | folderPublic | myPublicLink | uploader | +5 days          | 12345    |
     Then "Alice" should see 1 public link
+    When the public accesses the last created public link with password "12345"
+    Then the public should not see the following resource
+      | lorem.txt |
+    When the public uploads the following files on the files-drop page
+      | textfile.txt |
+    Then the public should see the following files on the files-drop page
+      | textfile.txt |
+    When the public reloads the public link pages
+    Then the public should not see the following files on the files-drop page
+      | textfile.txt |

--- a/tests/e2e/support/cta/files/index.ts
+++ b/tests/e2e/support/cta/files/index.ts
@@ -1,3 +1,4 @@
 /* eslint-disable */
 export * as sidebar from './sidebar'
 export * from './misc'
+export * from './publicLink'

--- a/tests/e2e/support/cta/files/misc.ts
+++ b/tests/e2e/support/cta/files/misc.ts
@@ -53,3 +53,15 @@ export const waitForResources = async ({
     names.map((name) => page.waitForSelector(`[data-test-resource-name="${name}"]`))
   )
 }
+
+export const resourceExistenceErrorMessage = (
+  actionType: string,
+  resourceExist: boolean,
+  resource: string
+): void => {
+  if (actionType === '' && !resourceExist) {
+    throw new Error(`resource wasn't found: "${resource}"`)
+  } else if (actionType === 'not' && resourceExist) {
+    throw new Error(`resource was found: "${resource}"`)
+  }
+}

--- a/tests/e2e/support/cta/files/publicLink.ts
+++ b/tests/e2e/support/cta/files/publicLink.ts
@@ -1,0 +1,25 @@
+import { DataTable } from '@cucumber/cucumber'
+import { PublicLinkPage } from '../../page/publicLinkPage'
+import { filesCta } from '../../cta'
+
+export const checkResourcesExistence = async ({
+  actionType,
+  stepTable,
+  pageType = 'public'
+}: {
+  actionType: string
+  stepTable: DataTable
+  pageType?: string
+}): Promise<void> => {
+  const publicLinkPage = new PublicLinkPage()
+  actionType = actionType.trim()
+
+  const files = stepTable.raw().map((f) => f[0])
+  for (const file of files) {
+    const resourceExist = await publicLinkPage.resourceExists({
+      pageType,
+      name: file
+    })
+    filesCta.resourceExistenceErrorMessage(actionType, resourceExist, file)
+  }
+}

--- a/tests/e2e/support/page/files/publicLink.ts
+++ b/tests/e2e/support/page/files/publicLink.ts
@@ -22,6 +22,8 @@ export class PublicLink {
   private readonly publicLinkListSelector: string
   private readonly roleSelector: string
   private readonly folderSelector: string
+  private publicLinkSelector: string
+  private static lastCreatedPublicLink: string
 
   constructor({ actor }: { actor: Actor }) {
     this.actor = actor
@@ -48,6 +50,7 @@ export class PublicLink {
     this.publicLinkListSelector = `//ul[@class = 'oc-list oc-list-divider oc-overflow-hidden oc-m-rm']/li`
     this.roleSelector = `//span[@id="files-role-%s"]`
     this.folderSelector = `//*[@data-test-resource-name="%s"]/ancestor::tr//button[contains(@class, "files-quick-action-collaborators")]`
+    this.publicLinkSelector = `//ul/li//h5[contains(text(),'%s')]/following-sibling::div/a`
   }
 
   async getLinksCount(): Promise<number> {
@@ -117,5 +120,18 @@ export class PublicLink {
     }
 
     await this.createLinkButtonLocator.click()
+
+    const publicLinkUrl = await page
+      .locator(util.format(this.publicLinkSelector, name))
+      .textContent()
+    PublicLink.setLastCreatedPublicLink(publicLinkUrl)
+  }
+
+  public static setLastCreatedPublicLink(publicLinkUrl: string): void {
+    this.lastCreatedPublicLink = publicLinkUrl
+  }
+
+  public static getLastCreatedPublicLink(): string {
+    return this.lastCreatedPublicLink
   }
 }

--- a/tests/e2e/support/page/publicLinkPage.ts
+++ b/tests/e2e/support/page/publicLinkPage.ts
@@ -1,0 +1,68 @@
+import { errors, Page } from 'playwright'
+import util from 'util'
+import { state } from '../../cucumber/environment/shared'
+import { PublicLink } from './files/publicLink'
+
+export class PublicLinkPage {
+  private static page: Page
+  private readonly passwordInput: string
+  private readonly passwordSubmitButton: string
+  private readonly fileUploadInput: string
+  private publicResourceSelector: string
+  private uploadedResourceSelector: string
+
+  constructor() {
+    this.passwordInput = 'input[type="password"]'
+    this.passwordSubmitButton =
+      '//*[@id="password-submit"]|//*[@id="oc-textinput-3"]/ancestor::div[contains(@class, "oc-mb-s")]/following-sibling::button'
+    this.publicResourceSelector = `[data-test-resource-name="%s"]`
+    this.uploadedResourceSelector = `//tbody/tr/td[contains(@class, "oc-pl-rm") and contains(text(), "%s")]`
+    this.fileUploadInput = '//input[@id="file_upload_start" or @class="dz-hidden-input"]'
+  }
+
+  public static async setup(): Promise<PublicLinkPage> {
+    PublicLinkPage.page = await state.browser
+      .newContext({ ignoreHTTPSErrors: true })
+      .then((context) => context.newPage())
+    return new PublicLinkPage()
+  }
+
+  async navigateToPublicLink(): Promise<void> {
+    await PublicLinkPage.page.goto(PublicLink.getLastCreatedPublicLink())
+  }
+
+  async authenticatePassword(password: string): Promise<void> {
+    await PublicLinkPage.page.locator(this.passwordInput).fill(password)
+    await PublicLinkPage.page.locator(this.passwordSubmitButton).click()
+  }
+
+  async resourceExists({ pageType, name, timeout = 500 }): Promise<boolean> {
+    let exist = true
+    let resourceSelector
+    if (pageType === 'upload') {
+      resourceSelector = this.uploadedResourceSelector
+    } else {
+      resourceSelector = this.publicResourceSelector
+    }
+
+    await PublicLinkPage.page
+      .waitForSelector(util.format(resourceSelector, name), { timeout })
+      .catch((e) => {
+        if (!(e instanceof errors.TimeoutError)) {
+          throw e
+        }
+
+        exist = false
+      })
+
+    return exist
+  }
+
+  async uploadFiles(filePath: string): Promise<void> {
+    await PublicLinkPage.page.locator(this.fileUploadInput).setInputFiles(filePath)
+  }
+
+  async reload(): Promise<void> {
+    await PublicLinkPage.page.reload()
+  }
+}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds step implementation for testing 
- unauthorized users opening the public link of a folder.
- unauthorized user uploads new file
- unauthorized user refreshes page. (page is empty)

Folder public link was created with name, password, expiration date, and **`role: uploader`**

- Before merging this PR,  https://github.com/owncloud/web/pull/6422 PR must be merged.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/web/issues/6389

## Motivation and Context
This PR adds tests step for unauthorized user accessing the last created public link of a folder

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] e2e tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
