### PR TITLE
revert all files breadcrumb link to /

### DIFF
--- a/changelog/unreleased/bugfix-breadcrumb-root-path
+++ b/changelog/unreleased/bugfix-breadcrumb-root-path
@@ -1,0 +1,6 @@
+Bugfix: Breadcrumb 'All Files' path
+
+We've reverted the `All Files` breadcrumb link back to `/` to be storage agnostic and don't rely on configured homeFolder.
+
+https://github.com/owncloud/web/pull/6467
+https://github.com/owncloud/web/issues/6327

--- a/changelog/unreleased/bugfix-breadcrumb-root-path
+++ b/changelog/unreleased/bugfix-breadcrumb-root-path
@@ -1,6 +1,6 @@
-Bugfix: Breadcrumb 'All Files' path
+Bugfix: Breadcrumb 'All Files' link
 
-We've reverted the `All Files` breadcrumb link back to `/` to be storage agnostic and don't rely on configured homeFolder.
+The `All Files` link in the breadcrumb now always point to the root of the personal storage home instead of the optional homeFolder.
 
 https://github.com/owncloud/web/pull/6467
 https://github.com/owncloud/web/issues/6327

--- a/packages/web-app-files/src/components/AppBar/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar/AppBar.vue
@@ -290,6 +290,7 @@ export default {
             if (acc.length) {
               if (this.isPersonalLocation) {
                 acc[0].text = this.$gettext('All files')
+                acc[0].to = acc[0].to + '/'
               } else if (this.isSpacesProjectLocation || this.isSpacesProjectsLocation) {
                 acc[0] = {
                   text: this.$gettext('Spaces'),

--- a/packages/web-app-files/src/views/Personal.vue
+++ b/packages/web-app-files/src/views/Personal.vue
@@ -232,14 +232,9 @@ export default {
   watch: {
     $route: {
       handler: function (to, from) {
-        const sameRoute = to.name === from?.name
-        const sameItem = to.params?.item === from?.params?.item
-
         const needsRedirectToHome =
-          this.homeFolder !== '/' &&
-          isNil(to.params.item) &&
-          !to.path.endsWith('/') &&
-          (!sameRoute || !sameItem)
+          this.homeFolder !== '/' && isNil(to.params.item) && !to.path.endsWith('/')
+
         if (needsRedirectToHome) {
           this.$router.replace(
             {
@@ -259,6 +254,8 @@ export default {
           return
         }
 
+        const sameRoute = to.name === from?.name
+        const sameItem = to.params?.item === from?.params?.item
         if (!sameRoute || !sameItem) {
           this.loadResourcesTask.perform(this, sameRoute)
         }


### PR DESCRIPTION
## Description
Point `All Files` breadcrumb link to `/` instead of the configured homeFolder.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/6327

## Motivation and Context
https://github.com/owncloud/web/issues/6327

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- unit tests

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)