### PR TITLE
[full-ci] enable capability loading for password protected public links

### DIFF
--- a/changelog/unreleased/bugfix-password-protected-public-link-capabilities
+++ b/changelog/unreleased/bugfix-password-protected-public-link-capabilities
@@ -1,0 +1,6 @@
+Bugfix: Load capabilities for password protected public links
+
+We've enabled capability loading for password protected public links.
+
+https://github.com/owncloud/web/pull/6471
+https://github.com/owncloud/web/issues/5863

--- a/packages/web-app-files/src/views/PublicFiles.vue
+++ b/packages/web-app-files/src/views/PublicFiles.vue
@@ -103,6 +103,7 @@ const unauthenticatedUserReady = async (router, store) => {
 
   // ocis at the moment is not able to create archives for public links that are password protected
   // till this is supported by the backend remove it hard as a workaround
+  // https://github.com/owncloud/web/issues/6515
   if (publicLinkPassword) {
     store.commit('SET_CAPABILITIES', {
       capabilities: omit(store.getters.capabilities, ['files.archivers']),


### PR DESCRIPTION
## Description
as title says, enable capability loading for password protected public links.

## Related Issue
- Fixes #5863
- Needs: https://github.com/owncloud/ocis/pull/3229

## Motivation and Context
https://github.com/owncloud/web/issues/5863

## How Has This Been Tested?
- unit & integration tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] Code changes