### PR TITLE
[tests-only] Fix account information elements selector

### DIFF
--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -498,3 +498,8 @@ Other free text and markdown formatting can be used elsewhere in the document if
 
 ### [empty subfolder inside a folder to be uploaded is not created on the server](https://github.com/owncloud/web/issues/6348)
 -   [webUIUpload/upload.feature:42](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/upload.feature#L42)
+
+### [Account page group membership information is set differently for `ocis` and `oc10`](https://github.com/owncloud/web/issues/6475)
+-   [webUIAccount/accountInformation.feature:34](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIAccount/accountInformation.feature#L34)
+-   [webUIAccount/accountInformation.feature:20](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIAccount/accountInformation.feature#L20)
+-   [webUIAccount/accountInformation.feature:10](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIAccount/accountInformation.feature#L10)

--- a/tests/acceptance/features/webUIAccount/accountInformation.feature
+++ b/tests/acceptance/features/webUIAccount/accountInformation.feature
@@ -26,7 +26,7 @@ Feature: View account information
     When the user browses to the account page
     Then the user should have following details displayed on the account information
       | Username          | Alice             |
-      | Display name      | Alice Hansen          |
+      | Display name      | Alice Hansen      |
       | Email             | alice@example.org |
       | Group memberships | Group1            |
 
@@ -50,6 +50,6 @@ Feature: View account information
     When the user browses to the account page
     Then the user should have following details displayed on the account information
       | Username          | Alice                                            |
-      | Display name      | Alice Hansen                                         |
+      | Display name      | Alice Hansen                                     |
       | Email             | alice@example.org                                |
       | Group memberships | Group1, Group2, Group3, Group4, Group31, A111111 |

--- a/tests/acceptance/features/webUIAccount/accountInformation.feature
+++ b/tests/acceptance/features/webUIAccount/accountInformation.feature
@@ -12,7 +12,7 @@ Feature: View account information
     When the user browses to the account page
     Then the user should have following details displayed on the account information
       | Username          | Alice                         |
-      | Display name      | Alice Hansen                      |
+      | Display name      | Alice Hansen                  |
       | Email             | alice@example.org             |
       | Group memberships | You are not part of any group |
 

--- a/tests/acceptance/pageObjects/accountPage.js
+++ b/tests/acceptance/pageObjects/accountPage.js
@@ -60,7 +60,7 @@ module.exports = {
       selector: '#account-page-title'
     },
     accountInformationElements: {
-      selector: '//dt[contains(@class, "account-page-info-")]',
+      selector: '//dt[contains(@class, "account-page-info-")]/parent::div',
       locateStrategy: 'xpath'
     }
   }

--- a/tests/acceptance/stepDefinitions/accountContext.js
+++ b/tests/acceptance/stepDefinitions/accountContext.js
@@ -13,6 +13,37 @@ Then(
     const expectedAccInfo = dataTable.rowsHash()
     const actualAccInfo = await client.page.accountPage().getAccountInformation()
     const actualEntries = Object.entries(actualAccInfo)
+
+    const expectedKeys = Object.keys(expectedAccInfo)
+    const actualKeys = Object.keys(actualAccInfo)
+
+    if (actualKeys.length === 0) {
+      throw new Error('Sorry, no any account information was found.')
+    }
+
+    const notFoundArray = []
+
+    // every expected key should be inside the actual keys array
+    expectedKeys.forEach((key) => {
+      if (!actualKeys.includes(key)) {
+        notFoundArray.push(key)
+      }
+    })
+
+    if (notFoundArray.length > 0) {
+      throw new Error(
+        'Error: Missing account information' +
+          '\n' +
+          'Expected: ' +
+          expectedKeys.join(', ') +
+          '\n' +
+          'Found: ' +
+          actualKeys.join(', ') +
+          '\n' +
+          'Missing: ' +
+          notFoundArray.join(', ')
+      )
+    }
     for (const [key, value] of actualEntries) {
       if (key === 'Group memberships') {
         const actualGroupMembership = value.split(',').map((grp) => grp.trim())
@@ -21,10 +52,11 @@ Then(
         assert.strictEqual(
           differenceInGroups.length,
           0,
-          'Actual group membership for the user was ' +
+          'Actual group membership for the user was "' +
             actualGroupMembership +
-            ' but was expected to be ' +
-            expectedGroupMembership
+            '" but was expected to be "' +
+            expectedGroupMembership +
+            '"'
         )
       } else {
         assert.strictEqual(value, expectedAccInfo[key])

--- a/tests/acceptance/stepDefinitions/accountContext.js
+++ b/tests/acceptance/stepDefinitions/accountContext.js
@@ -18,7 +18,7 @@ Then(
     const actualKeys = Object.keys(actualAccInfo)
 
     if (actualKeys.length === 0) {
-      throw new Error('Sorry, no any account information was found.')
+      throw new Error('Sorry, no account information was found.')
     }
 
     const notFoundArray = []


### PR DESCRIPTION
### Description
with this pr:
- fixed account information elements selector
- added extra checks for account information keys before checking for values
- added failing tests(with ocis) to the expected failures list

### Related
- #6468

- https://github.com/owncloud/web/issues/6475
   if the issue is just the expected behavior for ocis backend, then this PR can be closed on behalf of https://github.com/owncloud/web/pull/6476 where features are modified accordingly