### PR TITLE
[tests-only] Fix account information feature in acceptance tests

### DIFF
--- a/tests/acceptance/features/webUIAccount/accountInformation.feature
+++ b/tests/acceptance/features/webUIAccount/accountInformation.feature
@@ -7,17 +7,25 @@ Feature: View account information
     Given user "Alice" has been created with default attributes and without skeleton files in the server
 
   @ocis-reva-issue-107
-  Scenario: view account information when the user has been created without group memberships
+  Scenario Outline: view account information when the user has been created without group memberships
     Given user "Alice" has logged in using the webUI
     When the user browses to the account page
     Then the user should have following details displayed on the account information
-      | Username          | Alice                         |
-      | Display name      | Alice Hansen                      |
-      | Email             | alice@example.org             |
-      | Group memberships | You are not part of any group |
+      | Username          | Alice              |
+      | Display name      | Alice Hansen       |
+      | Email             | alice@example.org  |
+      | Group memberships | <group-membership> |
+    @skipOnOCIS
+    Examples:
+      | group-membership              |
+      | You are not part of any group |
+    @skipOnOC10
+    Examples:
+      | group-membership |
+      | users            |
 
   @ocis-konnectd-issue-42
-  Scenario: view account information when the user has been added to a group
+  Scenario Outline: view account information when the user has been added to a group
     Given these groups have been created in the server:
       | groupname |
       | Group1    |
@@ -26,12 +34,20 @@ Feature: View account information
     When the user browses to the account page
     Then the user should have following details displayed on the account information
       | Username          | Alice             |
-      | Display name      | Alice Hansen          |
+      | Display name      | Alice Hansen      |
       | Email             | alice@example.org |
-      | Group memberships | Group1            |
+      | Group memberships | <group-membership> |
+    @skipOnOCIS
+    Examples:
+      | group-membership |
+      | Group1                |
+    @skipOnOC10
+    Examples:
+      | group-membership |
+      | users, Group1    |
 
   @ocis-reva-issue-107 @ocis-konnectd-issue-42
-  Scenario: view account information when the user has been added to multiple groups
+  Scenario Outline: view account information when the user has been added to multiple groups
     Given these groups have been created in the server:
       | groupname |
       | Group1    |
@@ -49,7 +65,15 @@ Feature: View account information
     And user "Alice" has logged in using the webUI
     When the user browses to the account page
     Then the user should have following details displayed on the account information
-      | Username          | Alice                                            |
-      | Display name      | Alice Hansen                                         |
-      | Email             | alice@example.org                                |
-      | Group memberships | Group1, Group2, Group3, Group4, Group31, A111111 |
+      | Username          | Alice              |
+      | Display name      | Alice Hansen       |
+      | Email             | alice@example.org  |
+      | Group memberships | <group-membership> |
+    @skipOnOCIS
+    Examples:
+      | group-membership                                 |
+      | Group1, Group2, Group3, Group4, Group31, A111111 |
+    @skipOnOC10
+    Examples:
+      | group-membership                                        |
+      | users, Group1, Group2, Group3, Group4, Group31, A111111 |

--- a/tests/acceptance/pageObjects/accountPage.js
+++ b/tests/acceptance/pageObjects/accountPage.js
@@ -60,7 +60,7 @@ module.exports = {
       selector: '#account-page-title'
     },
     accountInformationElements: {
-      selector: '//dt[contains(@class, "account-page-info-")]',
+      selector: '//dt[contains(@class, "account-page-info-")]/parent::div',
       locateStrategy: 'xpath'
     }
   }

--- a/tests/acceptance/stepDefinitions/accountContext.js
+++ b/tests/acceptance/stepDefinitions/accountContext.js
@@ -13,6 +13,37 @@ Then(
     const expectedAccInfo = dataTable.rowsHash()
     const actualAccInfo = await client.page.accountPage().getAccountInformation()
     const actualEntries = Object.entries(actualAccInfo)
+
+    const expectedKeys = Object.keys(expectedAccInfo)
+    const actualKeys = Object.keys(actualAccInfo)
+
+    if (actualKeys.length === 0) {
+      throw new Error('Sorry, no account information was found.')
+    }
+
+    const notFoundArray = []
+
+    // every expected key should be inside the actual keys array
+    expectedKeys.forEach((key) => {
+      if (!actualKeys.includes(key)) {
+        notFoundArray.push(key)
+      }
+    })
+
+    if (notFoundArray.length > 0) {
+      throw new Error(
+        'Error: Missing account information' +
+          '\n' +
+          'Expected: ' +
+          expectedKeys.join(', ') +
+          '\n' +
+          'Found: ' +
+          actualKeys.join(', ') +
+          '\n' +
+          'Missing: ' +
+          notFoundArray.join(', ')
+      )
+    }
     for (const [key, value] of actualEntries) {
       if (key === 'Group memberships') {
         const actualGroupMembership = value.split(',').map((grp) => grp.trim())
@@ -21,10 +52,11 @@ Then(
         assert.strictEqual(
           differenceInGroups.length,
           0,
-          'Actual group membership for the user was ' +
+          'Actual group membership for the user was "' +
             actualGroupMembership +
-            ' but was expected to be ' +
-            expectedGroupMembership
+            '" but was expected to be "' +
+            expectedGroupMembership +
+            '"'
         )
       } else {
         assert.strictEqual(value, expectedAccInfo[key])


### PR DESCRIPTION
## Description
With this PR:
- added different examples for group membership while running with ocis and oc10 backends
- fixed account information elements selector
- fixed account information assertions with expected items

## Related Issue
- part of https://github.com/owncloud/web/issues/6475
this pr should only be required if the stated behavior in the issue is actually expected.
if that is not the case, then this PR can be closed on behalf of https://github.com/owncloud/web/pull/6473

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
