### PR TITLE
[test-only] check in shared with me page first after unsharing

### DIFF
--- a/tests/acceptance/features/webUISharingAcceptSharesToRoot/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingAcceptSharesToRoot/acceptShares.feature
@@ -118,12 +118,12 @@ Feature: accept/decline shares coming from internal users
     And the user has browsed to the shared-with-me page
     When the user unshares folder "simple-folder" using the webUI
     And the user unshares file "testimage.jpg" using the webUI
-    And the user browses to the files page
-    Then folder "simple-folder" should not be listed on the webUI
-    And file "testimage.jpg" should not be listed on the webUI
-    When the user browses to the shared-with-me page in declined shares view
+    And the user browses to the shared-with-me page in declined shares view
     Then folder "simple-folder" shared by "Alice Hansen" should be in "Declined" state on the webUI
     And file "testimage.jpg" shared by "Alice Hansen" should be in "Declined" state on the webUI
+    When the user browses to the files page
+    Then folder "simple-folder" should not be listed on the webUI
+    And file "testimage.jpg" should not be listed on the webUI
 
   Scenario: unshare renamed shares
     Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes" in the server


### PR DESCRIPTION
## Description
after unsharing resources, with this pr:
- check for the resources state in the shared with me declined view
- then only browse to the files page and check for the presence of the unshared resource
with this order, the tests are passing solid. see demonstration at https://github.com/owncloud/web/pull/6112

## Related Issue
- Fixes https://github.com/owncloud/web/issues/6097
