### PR TITLE
Fix old appSwitcher icon in OC10 deployment docs

### DIFF
--- a/docs/deployments/oc10-app.md
+++ b/docs/deployments/oc10-app.md
@@ -87,7 +87,7 @@ There are a few config values which need to be set in order for ownCloud Web to 
         "fr": "Design classique",
         "zh_CN": "文件"
       },
-      "icon": "switch_ui",
+      "icon": "swap-box",
       "url": "https://<your-owncloud-server>/index.php/apps/files"
     },
     {


### PR DESCRIPTION
Fixes https://talk.owncloud.com/channel/general?msg=2Dff3wJCg74kNqviG