### PR TITLE
Fix wording of create/upload CTA after "+ new" button split

### DIFF
--- a/changelog/unreleased/enhancement-redesign-create-upload-buttons
+++ b/changelog/unreleased/enhancement-redesign-create-upload-buttons
@@ -5,3 +5,4 @@ also using the new resource type icons for more consistency.
 
 https://github.com/owncloud/web/issues/6279
 https://github.com/owncloud/web/pull/6358
+https://github.com/owncloud/web/pull/6500

--- a/packages/web-app-files/src/views/Personal.vue
+++ b/packages/web-app-files/src/views/Personal.vue
@@ -13,7 +13,9 @@
           <span v-translate>There are no resources in this folder</span>
         </template>
         <template #callToAction>
-          <span v-translate>Drag files and folders here or use the "+ New" button to upload</span>
+          <span v-translate>
+            Drag files and folders here or use the "New" or "Upload" buttons to add files
+          </span>
         </template>
       </no-content-message>
       <resource-table

--- a/packages/web-app-files/src/views/PublicFiles.vue
+++ b/packages/web-app-files/src/views/PublicFiles.vue
@@ -14,7 +14,7 @@
         </template>
         <template v-if="currentFolder.canCreate()" #callToAction>
           <span v-translate data-testid="public-files-call-to-action">
-            Drag files and folders here or use the "+ New" button to upload
+            Drag files and folders here or use the "New" or "Upload" buttons to add files
           </span>
         </template>
       </no-content-message>


### PR DESCRIPTION
## Description
"+ New" button is now "New" and "Upload", this PR adjusts CTA wording accordingly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
