### PR TITLE
[tests-only] add unit tests for the account page and minimize coverage from acceptance tests

### DIFF
--- a/packages/web-runtime/src/pages/account.vue
+++ b/packages/web-runtime/src/pages/account.vue
@@ -7,11 +7,23 @@
     <template v-else>
       <div class="oc-flex oc-flex-between oc-flex-middle">
         <h1 id="account-page-title" v-translate class="oc-page-title">Account</h1>
-        <oc-button v-if="editUrl" variation="primary" type="a" :href="editUrl">
+        <oc-button
+          v-if="editUrl"
+          variation="primary"
+          type="a"
+          :href="editUrl"
+          data-testid="account-page-edit-url-btn"
+        >
           <oc-icon name="edit" />
           <translate>Edit</translate>
         </oc-button>
-        <oc-button v-else-if="editRoute" variation="primary" type="router-link" :to="editRoute">
+        <oc-button
+          v-else-if="editRoute"
+          variation="primary"
+          type="router-link"
+          :to="editRoute"
+          data-testid="account-page-edit-route-btn"
+        >
           <oc-icon name="edit" />
           <translate>Edit</translate>
         </oc-button>
@@ -20,39 +32,35 @@
       <h2 v-translate class="oc-text-bold oc-text-initial oc-mb">Account Information</h2>
 
       <dl class="account-page-info oc-flex oc-flex-wrap">
-        <div class="oc-mb oc-width-1-2@s">
-          <dt v-translate class="account-page-info-username oc-text-normal oc-text-muted">
-            Username
-          </dt>
+        <div class="account-page-info-username oc-mb oc-width-1-2@s">
+          <dt v-translate class="oc-text-normal oc-text-muted">Username</dt>
           <dd>
             {{ user.username || user.id }}
           </dd>
         </div>
-        <div v-if="user.username && user.id">
-          <dt v-translate class="account-page-info-userid oc-text-normal oc-text-muted">User ID</dt>
+        <div v-if="user.username && user.id" class="account-page-info-userid">
+          <dt v-translate class="oc-text-normal oc-text-muted">User ID</dt>
           <dd>
             {{ user.id }}
           </dd>
         </div>
-        <div class="oc-mb oc-width-1-2@s">
-          <dt v-translate class="account-page-info-displayname oc-text-normal oc-text-muted">
-            Display name
-          </dt>
+        <div class="account-page-info-displayname oc-mb oc-width-1-2@s">
+          <dt v-translate class="oc-text-normal oc-text-muted">Display name</dt>
           <dd>
             {{ user.displayname }}
           </dd>
         </div>
-        <div class="oc-mb oc-width-1-2@s">
-          <dt v-translate class="account-page-info-email oc-text-normal oc-text-muted">Email</dt>
+        <div class="account-page-info-email oc-mb oc-width-1-2@s">
+          <dt v-translate class="oc-text-normal oc-text-muted">Email</dt>
           <dd>
             <template v-if="user.email">{{ user.email }}</template>
             <span v-else v-translate>No email has been set up</span>
           </dd>
         </div>
-        <div class="oc-mb oc-width-1-2@s">
+        <div class="account-page-info-groups oc-mb oc-width-1-2@s">
           <dt
             v-translate
-            class="account-page-info-groups oc-text-normal oc-text-muted"
+            class="oc-text-normal oc-text-muted"
             @click="$_oc_settingsAccount_getGroup"
           >
             Group memberships

--- a/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.js.snap
+++ b/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`account when the wrapper is not loading anymore account information with group information 1`] = `
+exports[`account when the page is not in loading state anymore account information with group information 1`] = `
 <div class="account-page-info-groups oc-mb oc-width-1-2@s">
   <dt class="oc-text-normal oc-text-muted">
     Group memberships
@@ -9,7 +9,7 @@ exports[`account when the wrapper is not loading anymore account information wit
 </div>
 `;
 
-exports[`account when the wrapper is not loading anymore account information without group information 1`] = `
+exports[`account when the page is not in loading state anymore account information without group information 1`] = `
 <dl class="account-page-info oc-flex oc-flex-wrap">
   <div class="account-page-info-username oc-mb oc-width-1-2@s">
     <dt class="oc-text-normal oc-text-muted">Username</dt>
@@ -37,34 +37,16 @@ exports[`account when the wrapper is not loading anymore account information wit
 </dl>
 `;
 
-exports[`account when the wrapper is not loading anymore edit buttons edit route button should be displayed if running with ocis and has navItems 1`] = `
+exports[`account when the page is not in loading state anymore edit buttons edit route button should be displayed if running with ocis and has navItems 1`] = `
 <oc-button-stub variation="primary" type="router-link" to="some-route" data-testid="account-page-edit-route-btn">
   <oc-icon-stub name="edit"></oc-icon-stub>
   <translate-stub tag="span">Edit</translate-stub>
 </oc-button-stub>
 `;
 
-exports[`account when the wrapper is not loading anymore edit buttons edit route button should be displayed if running with ocis and has navItems 2`] = `
-Object {
-  "data-testid": "account-page-edit-route-btn",
-  "to": "some-route",
-  "type": "router-link",
-  "variation": "primary",
-}
-`;
-
-exports[`account when the wrapper is not loading anymore edit buttons edit url button should be displayed if not running with ocis 1`] = `
+exports[`account when the page is not in loading state anymore edit buttons edit url button should be displayed if not running with ocis 1`] = `
 <oc-button-stub variation="primary" type="a" href="http://server/address/index.php/settings/personal" data-testid="account-page-edit-url-btn">
   <oc-icon-stub name="edit"></oc-icon-stub>
   <translate-stub tag="span">Edit</translate-stub>
 </oc-button-stub>
-`;
-
-exports[`account when the wrapper is not loading anymore edit buttons edit url button should be displayed if not running with ocis 2`] = `
-Object {
-  "data-testid": "account-page-edit-url-btn",
-  "href": "http://server/address/index.php/settings/personal",
-  "type": "a",
-  "variation": "primary",
-}
 `;

--- a/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.js.snap
+++ b/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.js.snap
@@ -1,0 +1,70 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`account when the wrapper is not loading anymore account information with group information 1`] = `
+<div class="account-page-info-groups oc-mb oc-width-1-2@s">
+  <dt class="oc-text-normal oc-text-muted">
+    Group memberships
+  </dt>
+  <dd><span>one, two, three</span></dd>
+</div>
+`;
+
+exports[`account when the wrapper is not loading anymore account information without group information 1`] = `
+<dl class="account-page-info oc-flex oc-flex-wrap">
+  <div class="account-page-info-username oc-mb oc-width-1-2@s">
+    <dt class="oc-text-normal oc-text-muted">Username</dt>
+    <dd>
+      some-username
+    </dd>
+  </div>
+  <!---->
+  <div class="account-page-info-displayname oc-mb oc-width-1-2@s">
+    <dt class="oc-text-normal oc-text-muted">Display name</dt>
+    <dd>
+      some-displayname
+    </dd>
+  </div>
+  <div class="account-page-info-email oc-mb oc-width-1-2@s">
+    <dt class="oc-text-normal oc-text-muted">Email</dt>
+    <dd>some-email</dd>
+  </div>
+  <div class="account-page-info-groups oc-mb oc-width-1-2@s">
+    <dt class="oc-text-normal oc-text-muted">
+      Group memberships
+    </dt>
+    <dd><span>You are not part of any group</span></dd>
+  </div>
+</dl>
+`;
+
+exports[`account when the wrapper is not loading anymore edit buttons edit route button should be displayed if running with ocis and has navItems 1`] = `
+<oc-button-stub variation="primary" type="router-link" to="some-route" data-testid="account-page-edit-route-btn">
+  <oc-icon-stub name="edit"></oc-icon-stub>
+  <translate-stub tag="span">Edit</translate-stub>
+</oc-button-stub>
+`;
+
+exports[`account when the wrapper is not loading anymore edit buttons edit route button should be displayed if running with ocis and has navItems 2`] = `
+Object {
+  "data-testid": "account-page-edit-route-btn",
+  "to": "some-route",
+  "type": "router-link",
+  "variation": "primary",
+}
+`;
+
+exports[`account when the wrapper is not loading anymore edit buttons edit url button should be displayed if not running with ocis 1`] = `
+<oc-button-stub variation="primary" type="a" href="http://server/address/index.php/settings/personal" data-testid="account-page-edit-url-btn">
+  <oc-icon-stub name="edit"></oc-icon-stub>
+  <translate-stub tag="span">Edit</translate-stub>
+</oc-button-stub>
+`;
+
+exports[`account when the wrapper is not loading anymore edit buttons edit url button should be displayed if not running with ocis 2`] = `
+Object {
+  "data-testid": "account-page-edit-url-btn",
+  "href": "http://server/address/index.php/settings/personal",
+  "type": "a",
+  "variation": "primary",
+}
+`;

--- a/packages/web-runtime/tests/unit/pages/account.spec.js
+++ b/packages/web-runtime/tests/unit/pages/account.spec.js
@@ -1,0 +1,171 @@
+import account from '../../../src/pages/account.vue'
+import { shallowMount, createLocalVue } from '@vue/test-utils'
+import Vuex from 'vuex'
+import { createStore } from 'vuex-extensions'
+import GetTextPlugin from 'vue-gettext'
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
+
+localVue.use(GetTextPlugin, {
+  translations: 'does-not-matter.json',
+  silent: true
+})
+
+localVue.directive('translate', {
+  inserted: (el) => {}
+})
+
+const $route = {
+  meta: {
+    title: 'Some Title'
+  }
+}
+
+const selectors = {
+  pageTitle: '.oc-page-title',
+  loaderStub: 'oc-loader-stub',
+  accountPageTitle: '#account-page-title',
+  editUrlButton: '[data-testid="account-page-edit-url-btn"]',
+  editRouteButton: '[data-testid="account-page-edit-route-btn"]',
+  accountPageInfo: '.account-page-info',
+  groupInformation: '.account-page-info-groups'
+}
+
+describe('account', () => {
+  describe('when the wrapper is still loading', () => {
+    let wrapper
+    beforeEach(() => {
+      wrapper = getWrapper()
+      wrapper.setData({ loading: true })
+    })
+    it('should render the loading state', () => {
+      const pageTitle = wrapper.find(selectors.pageTitle)
+      const ocLoader = wrapper.find(selectors.loaderStub)
+      expect(pageTitle.text()).toBe($route.meta.title)
+      expect(ocLoader.exists()).toBeTruthy()
+    })
+    it('should not render the account page content', () => {
+      const accountPageTitle = wrapper.find(selectors.accountPageTitle)
+      const accountPageInfo = wrapper.find('.account-page-info')
+      expect(accountPageTitle.exists()).toBeFalsy()
+      expect(accountPageInfo.exists()).toBeFalsy()
+    })
+  })
+  describe('when the wrapper is not loading anymore', () => {
+    it('should not render the loading state', async () => {
+      const store = getStore()
+      const wrapper = getWrapper(store)
+      await wrapper.setData({ loading: false })
+      const pageTitle = wrapper.find(selectors.pageTitle)
+      const ocLoader = wrapper.find(selectors.loaderStub)
+      expect(pageTitle.text()).toBe('Account')
+      expect(ocLoader.exists()).toBeFalsy()
+    })
+
+    describe('edit buttons', () => {
+      describe('edit url button', () => {
+        it('should be displayed if not running with ocis', async () => {
+          const store = getStore({
+            server: 'http://server/address/',
+            isOcis: false
+          })
+          const wrapper = getWrapper(store)
+          await wrapper.setData({ loading: false })
+          const editUrlButton = wrapper.find(selectors.editUrlButton)
+          const editRouteButton = wrapper.find(selectors.editRouteButton)
+          expect(editUrlButton).toMatchSnapshot()
+          expect(editUrlButton.attributes()).toMatchSnapshot()
+          expect(editRouteButton.exists()).toBeFalsy()
+        })
+        it('should not be displayed if running with ocis', async () => {
+          const store = getStore({
+            server: 'http://server/address/',
+            isOcis: true
+          })
+          const wrapper = getWrapper(store)
+          await wrapper.setData({ loading: false })
+          const editButton = wrapper.find(selectors.editUrlButton)
+          expect(editButton.exists()).toBeFalsy()
+        })
+      })
+      describe('edit route button', () => {
+        it('should be displayed if running with ocis and has navItems', async () => {
+          const store = getStore({
+            isOcis: true,
+            getNavItemsByExtension: jest.fn(() => [{ route: 'some-route' }])
+          })
+          const wrapper = getWrapper(store)
+          await wrapper.setData({ loading: false })
+          const editRouteButton = wrapper.find(selectors.editRouteButton)
+          expect(editRouteButton).toMatchSnapshot()
+          expect(editRouteButton.attributes()).toMatchSnapshot()
+        })
+      })
+    })
+
+    describe('account information', () => {
+      it('without group information', async () => {
+        const store = getStore({
+          user: {
+            username: 'some-username',
+            displayname: 'some-displayname',
+            email: 'some-email'
+          }
+        })
+        const wrapper = getWrapper(store)
+        await wrapper.setData({ loading: false })
+
+        const accountPageInfo = wrapper.find(selectors.accountPageInfo)
+        expect(accountPageInfo).toMatchSnapshot()
+      })
+      it('with group information', async () => {
+        const store = getStore()
+        const wrapper = getWrapper(store)
+        await wrapper.setData({ loading: false })
+        await wrapper.setData({ groups: ['one', 'two', 'three'] })
+
+        const groupInformation = wrapper.find(selectors.groupInformation)
+        expect(groupInformation).toMatchSnapshot()
+      })
+    })
+  })
+})
+
+function getWrapper(store = null) {
+  const component = {
+    ...account,
+    mounted: jest.fn()
+  }
+  const opts = {
+    localVue,
+    mocks: {
+      $route
+    },
+    stubs: {
+      'oc-loader': true,
+      'oc-button': true,
+      'oc-icon': true
+    }
+  }
+  if (store) opts.store = store
+  return shallowMount(component, opts)
+}
+
+function getStore({
+  user = {},
+  server = '',
+  getNavItemsByExtension = jest.fn(() => []),
+  isOcis = false
+} = {}) {
+  return createStore(Vuex.Store, {
+    getters: {
+      user: () => user,
+      configuration: () => ({
+        server: server
+      }),
+      getNavItemsByExtension: () => getNavItemsByExtension,
+      isOcis: () => isOcis
+    }
+  })
+}

--- a/packages/web-runtime/tests/unit/pages/account.spec.js
+++ b/packages/web-runtime/tests/unit/pages/account.spec.js
@@ -33,7 +33,7 @@ const selectors = {
 }
 
 describe('account', () => {
-  describe('when the wrapper is still loading', () => {
+  describe('when the page is still loading', () => {
     let wrapper
     beforeEach(() => {
       wrapper = getWrapper()
@@ -47,12 +47,12 @@ describe('account', () => {
     })
     it('should not render the account page content', () => {
       const accountPageTitle = wrapper.find(selectors.accountPageTitle)
-      const accountPageInfo = wrapper.find('.account-page-info')
+      const accountPageInfo = wrapper.find(selectors.accountPageInfo)
       expect(accountPageTitle.exists()).toBeFalsy()
       expect(accountPageInfo.exists()).toBeFalsy()
     })
   })
-  describe('when the wrapper is not loading anymore', () => {
+  describe('when the page is not in loading state anymore', () => {
     it('should not render the loading state', async () => {
       const store = getStore()
       const wrapper = getWrapper(store)
@@ -75,7 +75,6 @@ describe('account', () => {
           const editUrlButton = wrapper.find(selectors.editUrlButton)
           const editRouteButton = wrapper.find(selectors.editRouteButton)
           expect(editUrlButton).toMatchSnapshot()
-          expect(editUrlButton.attributes()).toMatchSnapshot()
           expect(editRouteButton.exists()).toBeFalsy()
         })
         it('should not be displayed if running with ocis', async () => {
@@ -99,7 +98,6 @@ describe('account', () => {
           await wrapper.setData({ loading: false })
           const editRouteButton = wrapper.find(selectors.editRouteButton)
           expect(editRouteButton).toMatchSnapshot()
-          expect(editRouteButton.attributes()).toMatchSnapshot()
         })
       })
     })

--- a/tests/acceptance/features/webUIAccount/accountInformation.feature
+++ b/tests/acceptance/features/webUIAccount/accountInformation.feature
@@ -10,46 +10,4 @@ Feature: View account information
   Scenario: view account information when the user has been created without group memberships
     Given user "Alice" has logged in using the webUI
     When the user browses to the account page
-    Then the user should have following details displayed on the account information
-      | Username          | Alice                         |
-      | Display name      | Alice Hansen                      |
-      | Email             | alice@example.org             |
-      | Group memberships | You are not part of any group |
-
-  @ocis-konnectd-issue-42
-  Scenario: view account information when the user has been added to a group
-    Given these groups have been created in the server:
-      | groupname |
-      | Group1    |
-    And user "Alice" has been added to group "Group1" in the server
-    And user "Alice" has logged in using the webUI
-    When the user browses to the account page
-    Then the user should have following details displayed on the account information
-      | Username          | Alice             |
-      | Display name      | Alice Hansen          |
-      | Email             | alice@example.org |
-      | Group memberships | Group1            |
-
-  @ocis-reva-issue-107 @ocis-konnectd-issue-42
-  Scenario: view account information when the user has been added to multiple groups
-    Given these groups have been created in the server:
-      | groupname |
-      | Group1    |
-      | Group2    |
-      | Group3    |
-      | Group4    |
-      | Group31   |
-      | A111111   |
-    And user "Alice" has been added to group "Group1" in the server
-    And user "Alice" has been added to group "Group2" in the server
-    And user "Alice" has been added to group "Group3" in the server
-    And user "Alice" has been added to group "Group4" in the server
-    And user "Alice" has been added to group "Group31" in the server
-    And user "Alice" has been added to group "A111111" in the server
-    And user "Alice" has logged in using the webUI
-    When the user browses to the account page
-    Then the user should have following details displayed on the account information
-      | Username          | Alice                                            |
-      | Display name      | Alice Hansen                                         |
-      | Email             | alice@example.org                                |
-      | Group memberships | Group1, Group2, Group3, Group4, Group31, A111111 |
+    Then the accounts page should be visible on the webUI

--- a/tests/acceptance/pageObjects/accountPage.js
+++ b/tests/acceptance/pageObjects/accountPage.js
@@ -12,39 +12,10 @@ module.exports = {
     navigateAndWaitTillLoaded: function () {
       return this.navigate(this.url()).waitForElementVisible('@accountDisplay')
     },
-
     /**
-     * Gets the account information details from the account information element on the account page
-     *
-     * @returns {object}
+     * return the visibility of the account display element
+     * @returns {Promise<boolean>}
      */
-    getAccountInformation: async function () {
-      const accountInformation = []
-      let accountInfoElementIds = []
-      await this.waitForElementVisible('@accountInformationElements').api.elements(
-        '@accountInformationElements',
-        function (result) {
-          accountInfoElementIds = result.value
-        }
-      )
-      for (const elementIdIndex in accountInfoElementIds) {
-        await this.api.elementIdText(
-          accountInfoElementIds[elementIdIndex].ELEMENT,
-          function (elementText) {
-            accountInformation.push(elementText.value)
-          }
-        )
-      }
-      const actualAccInfo = {}
-      for (const elem of accountInformation) {
-        if (elem.indexOf('\n') < 0) {
-          continue
-        }
-        const s = elem.split('\n')
-        actualAccInfo[s[0].trim()] = s[1].trim()
-      }
-      return actualAccInfo
-    },
     isPageVisible: async function () {
       let isVisible = true
 
@@ -58,10 +29,6 @@ module.exports = {
   elements: {
     accountDisplay: {
       selector: '#account-page-title'
-    },
-    accountInformationElements: {
-      selector: '//dt[contains(@class, "account-page-info-")]',
-      locateStrategy: 'xpath'
     }
   }
 }

--- a/tests/acceptance/stepDefinitions/accountContext.js
+++ b/tests/acceptance/stepDefinitions/accountContext.js
@@ -1,34 +1,6 @@
 const { client } = require('nightwatch-api')
-const { When, Then } = require('@cucumber/cucumber')
-const assert = require('assert')
-const _ = require('lodash')
+const { When } = require('@cucumber/cucumber')
 
 When('the user browses to the account page', function () {
   return client.page.accountPage().navigateAndWaitTillLoaded()
 })
-
-Then(
-  'the user should have following details displayed on the account information',
-  async function (dataTable) {
-    const expectedAccInfo = dataTable.rowsHash()
-    const actualAccInfo = await client.page.accountPage().getAccountInformation()
-    const actualEntries = Object.entries(actualAccInfo)
-    for (const [key, value] of actualEntries) {
-      if (key === 'Group memberships') {
-        const actualGroupMembership = value.split(',').map((grp) => grp.trim())
-        const expectedGroupMembership = expectedAccInfo[key].split(',').map((grp) => grp.trim())
-        const differenceInGroups = _.difference(actualGroupMembership, expectedGroupMembership)
-        assert.strictEqual(
-          differenceInGroups.length,
-          0,
-          'Actual group membership for the user was ' +
-            actualGroupMembership +
-            ' but was expected to be ' +
-            expectedGroupMembership
-        )
-      } else {
-        assert.strictEqual(value, expectedAccInfo[key])
-      }
-    }
-  }
-)


### PR DESCRIPTION
## Description
- added unit tests for the account page
- removed accounts page related acceptance tests other than verifying the successful page load

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/web/issues/6475

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
