### PR TITLE
Don't write error message on passing ReadmeContentModal.spec.js test

### DIFF
--- a/changelog/unreleased/bugfix-readme-content-modal-test-write-error-output
+++ b/changelog/unreleased/bugfix-readme-content-modal-test-write-error-output
@@ -3,3 +3,4 @@ Bugfix: Don't write error message on passing ReadmeContentModal.spec.js test
 ReadmeContentModal.spec.js test doesn't write error output anymore while passing
 
 https://github.com/owncloud/web/pull/6525
+https://github.com/owncloud/web/issues/6337

--- a/changelog/unreleased/bugfix-readme-content-modal-test-write-error-output
+++ b/changelog/unreleased/bugfix-readme-content-modal-test-write-error-output
@@ -1,0 +1,5 @@
+Bugfix: Don't write error message on passing ReadmeContentModal.spec.js test
+
+ReadmeContentModal.spec.js test doesn't write error output anymore while passing
+
+https://github.com/owncloud/web/pull/6525

--- a/packages/web-app-files/tests/unit/components/Spaces/ReadmeContentModal.spec.js
+++ b/packages/web-app-files/tests/unit/components/Spaces/ReadmeContentModal.spec.js
@@ -22,6 +22,7 @@ describe('editReadmeContent', () => {
     })
 
     it('should show message on error', async () => {
+      jest.spyOn(console, 'error').mockImplementation(() => {})
       const wrapper = getWrapper(false)
       const showMessageStub = jest.spyOn(wrapper.vm, 'showMessage')
       await wrapper.vm.editReadme()


### PR DESCRIPTION
## Description
Bugfix: Don't write error message on passing ReadmeContentModal.spec.js test

ReadmeContentModal.spec.js test doesn't write error output anymore while passing

## Related Issue
- Fixes #6337

