### PR TITLE
Add a watcher for the share panel of a space

### DIFF
--- a/changelog/unreleased/enhancement-add-space-share-panel-watcher
+++ b/changelog/unreleased/enhancement-add-space-share-panel-watcher
@@ -1,0 +1,5 @@
+Enhancement: Add a watcher for the share panel of a space
+
+We've added a watcher for the share panel of a space to ensure seamless navigation via the share indicator.
+
+https://github.com/owncloud/web/pull/6543

--- a/packages/web-app-files/src/components/SideBar/Shares/SpaceShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SpaceShares.vue
@@ -97,9 +97,6 @@ export default {
       immediate: true
     }
   },
-  mounted() {
-    this.loadSharesTask.perform(this)
-  },
   methods: {
     ...mapActions('Files', ['loadCurrentFileOutgoingShares', 'deleteShare']),
 

--- a/packages/web-app-files/src/components/SideBar/Shares/SpaceShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SpaceShares.vue
@@ -87,6 +87,16 @@ export default {
       return currentUserCollaborator?.role?.name === spaceRoleManager.name
     }
   },
+  watch: {
+    highlightedFile: {
+      handler: function (newItem, oldItem) {
+        if (oldItem !== newItem) {
+          this.loadSharesTask.perform(this)
+        }
+      },
+      immediate: true
+    }
+  },
   mounted() {
     this.loadSharesTask.perform(this)
   },

--- a/packages/web-app-files/src/views/spaces/Project.vue
+++ b/packages/web-app-files/src/views/spaces/Project.vue
@@ -447,8 +447,7 @@ export default {
   methods: {
     ...mapActions('Files', ['loadIndicators', 'loadPreview', 'loadCurrentFileOutgoingShares']),
     ...mapActions('Files/sidebar', {
-      openSidebarWithPanel: 'openWithPanel',
-      closeSidebar: 'close'
+      openSidebarWithPanel: 'openWithPanel'
     }),
     ...mapMutations('Files', [
       'SET_CURRENT_FOLDER',
@@ -521,8 +520,7 @@ export default {
     closeQuotaModal() {
       this.$_editQuota_closeModal()
     },
-    async openSidebarSharePanel() {
-      await this.closeSidebar()
+    openSidebarSharePanel() {
       this.SET_FILE_SELECTION([this.space])
       this.openSidebarWithPanel('space-share-item')
     },

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -260,8 +260,7 @@ export default {
   methods: {
     ...mapActions(['createModal', 'hideModal', 'setModalInputErrorMessage']),
     ...mapActions('Files/sidebar', {
-      openSidebarWithPanel: 'openWithPanel',
-      closeSidebar: 'close'
+      openSidebarWithPanel: 'openWithPanel'
     }),
     ...mapMutations('Files', [
       'SET_CURRENT_FOLDER',
@@ -379,8 +378,7 @@ export default {
       }
       return ''
     },
-    async openSidebarSharePanel(space) {
-      await this.closeSidebar()
+    openSidebarSharePanel(space) {
       this.SET_FILE_SELECTION([space])
       this.openSidebarWithPanel('space-share-item')
     }


### PR DESCRIPTION
## Description
We've added a watcher for the share panel of a space to ensure seamless navigation via the share indicator.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- See comment: https://github.com/owncloud/web/pull/6455#discussion_r820598017

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
