### PR TITLE
Update the stored space object after members have been changed

### DIFF
--- a/changelog/unreleased/enhancement-space-update-store
+++ b/changelog/unreleased/enhancement-space-update-store
@@ -1,0 +1,5 @@
+Enhancement: Update the stored space after its members have been changed
+
+We now update the stored space after its members have been changed. Also, the permission-object of a built space has been simplified in the course of this.
+
+https://github.com/owncloud/web/pull/6545

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
@@ -93,6 +93,7 @@ import { DateTime } from 'luxon'
 import EditDropdown from './EditDropdown.vue'
 import RoleDropdown from '../RoleDropdown.vue'
 import { SharePermissions, ShareTypes } from '../../../../helpers/share'
+import { clientService } from 'web-pkg/src/services'
 
 export default {
   name: 'ListItem',
@@ -113,7 +114,7 @@ export default {
   },
   computed: {
     ...mapGetters('Files', ['highlightedFile']),
-    ...mapGetters(['isOcis']),
+    ...mapGetters(['isOcis', 'getToken', 'configuration']),
     ...mapState(['user']),
 
     shareType() {
@@ -218,6 +219,10 @@ export default {
         .endOf('day')
         .setLocale(this.$language.current)
         .toRelative()
+    },
+
+    graphClient() {
+      return clientService.graphAuthenticated(this.configuration.server, this.getToken)
     }
   },
   methods: {
@@ -263,6 +268,7 @@ export default {
           )
       this.changeShare({
         client: this.$client,
+        graphClient: this.graphClient,
         share: this.share,
         permissions: bitmask,
         expirationDate: expirationDate || ''

--- a/packages/web-app-files/src/components/SideBar/Shares/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/InviteCollaborator/InviteCollaboratorForm.vue
@@ -85,6 +85,7 @@ import {
   ShareTypes,
   SpacePeopleShareRoles
 } from '../../../../helpers/share'
+import { clientService } from 'web-pkg/src/services'
 
 export default {
   name: 'InviteCollaboratorForm',
@@ -109,8 +110,7 @@ export default {
   },
   computed: {
     ...mapGetters('Files', ['currentFileOutgoingCollaborators', 'highlightedFile']),
-    ...mapGetters(['user']),
-    ...mapGetters(['configuration', 'isOcis']),
+    ...mapGetters(['configuration', 'isOcis', 'getToken', 'user']),
 
     inviteDescriptionMessage() {
       return this.$gettext('Add new person by name, email or federation IDs')
@@ -133,6 +133,9 @@ export default {
 
     resourceIsSpace() {
       return this.highlightedFile.type === 'space'
+    },
+    graphClient() {
+      return clientService.graphAuthenticated(this.configuration.server, this.getToken)
     }
   },
   mounted() {
@@ -252,6 +255,7 @@ export default {
                 )
             this.addShare({
               client: this.$client,
+              graphClient: this.graphClient,
               path: this.highlightedFile.path,
               $gettext: this.$gettext,
               shareWith: collaborator.value.shareWith,

--- a/packages/web-app-files/src/components/SideBar/Shares/SpaceShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SpaceShares.vue
@@ -118,6 +118,7 @@ export default {
     $_ocCollaborators_deleteShare(share) {
       this.deleteShare({
         client: this.$client,
+        graphClient: this.graphClient,
         share: share,
         resource: this.highlightedFile
       }).then(() => {

--- a/packages/web-app-files/src/helpers/resources.js
+++ b/packages/web-app-files/src/helpers/resources.js
@@ -111,7 +111,10 @@ export function buildResource(resource) {
 }
 
 export function buildSpace(space) {
-  let spaceImageData, spaceReadmeData, spacePermissions
+  let spaceImageData, spaceReadmeData
+  let spaceViewers = []
+  let spaceEditors = []
+  let spaceManagers = []
   let disabled = false
 
   if (space.special) {
@@ -120,7 +123,19 @@ export function buildSpace(space) {
   }
 
   if (space.root) {
-    spacePermissions = space.root.permissions
+    for (const permission of space.root.permissions) {
+      if (permission.roles.includes(spaceRoleViewer.name)) {
+        spaceViewers = spaceViewers.concat(permission.grantedTo.map((el) => el.user.id))
+      }
+
+      if (permission.roles.includes(spaceRoleEditor.name)) {
+        spaceEditors = spaceEditors.concat(permission.grantedTo.map((el) => el.user.id))
+      }
+
+      if (permission.roles.includes(spaceRoleManager.name)) {
+        spaceManagers = spaceManagers.concat(permission.grantedTo.map((el) => el.user.id))
+      }
+    }
 
     if (space.root.deleted) {
       disabled = space.root.deleted?.state === 'trashed'
@@ -154,7 +169,11 @@ export function buildSpace(space) {
     ownerId: '',
     disabled,
     spaceQuota: space.quota,
-    spacePermissions,
+    spaceRoles: {
+      viewers: spaceViewers,
+      editors: spaceEditors,
+      managers: spaceManagers
+    },
     spaceImageData,
     spaceReadmeData,
     canUpload: function () {

--- a/packages/web-app-files/src/helpers/resources.js
+++ b/packages/web-app-files/src/helpers/resources.js
@@ -9,6 +9,7 @@ import {
   SharePermissions,
   ShareStatus,
   ShareTypes,
+  SpacePeopleShareRoles,
   spaceRoleEditor,
   spaceRoleManager,
   spaceRoleViewer
@@ -112,10 +113,11 @@ export function buildResource(resource) {
 
 export function buildSpace(space) {
   let spaceImageData, spaceReadmeData
-  let spaceViewers = []
-  let spaceEditors = []
-  let spaceManagers = []
   let disabled = false
+  const spaceRoles = SpacePeopleShareRoles.list().reduce((obj, role) => {
+    obj[role.name] = []
+    return obj
+  }, {})
 
   if (space.special) {
     spaceImageData = space.special.find((el) => el.specialFolder.name === 'image')
@@ -124,16 +126,12 @@ export function buildSpace(space) {
 
   if (space.root) {
     for (const permission of space.root.permissions) {
-      if (permission.roles.includes(spaceRoleViewer.name)) {
-        spaceViewers = spaceViewers.concat(permission.grantedTo.map((el) => el.user.id))
-      }
-
-      if (permission.roles.includes(spaceRoleEditor.name)) {
-        spaceEditors = spaceEditors.concat(permission.grantedTo.map((el) => el.user.id))
-      }
-
-      if (permission.roles.includes(spaceRoleManager.name)) {
-        spaceManagers = spaceManagers.concat(permission.grantedTo.map((el) => el.user.id))
+      for (const role of SpacePeopleShareRoles.list()) {
+        if (permission.roles.includes(role.name)) {
+          spaceRoles[role.name] = spaceRoles[role.name].concat(
+            permission.grantedTo.map((el) => el.user.id)
+          )
+        }
       }
     }
 
@@ -169,11 +167,7 @@ export function buildSpace(space) {
     ownerId: '',
     disabled,
     spaceQuota: space.quota,
-    spaceRoles: {
-      viewers: spaceViewers,
-      editors: spaceEditors,
-      managers: spaceManagers
-    },
+    spaceRoles,
     spaceImageData,
     spaceReadmeData,
     canUpload: function () {

--- a/packages/web-app-files/src/helpers/resources.js
+++ b/packages/web-app-files/src/helpers/resources.js
@@ -128,9 +128,7 @@ export function buildSpace(space) {
     for (const permission of space.root.permissions) {
       for (const role of SpacePeopleShareRoles.list()) {
         if (permission.roles.includes(role.name)) {
-          spaceRoles[role.name] = spaceRoles[role.name].concat(
-            permission.grantedTo.map((el) => el.user.id)
-          )
+          spaceRoles[role.name].push(...permission.grantedTo.map((el) => el.user.id))
         }
       }
     }

--- a/packages/web-app-files/src/store/actions.js
+++ b/packages/web-app-files/src/store/actions.js
@@ -13,13 +13,7 @@ import { $gettext, $gettextInterpolate } from '../gettext'
 import { loadPreview } from '../helpers/resource'
 import { avatarUrl } from '../helpers/user'
 import { has } from 'lodash-es'
-import {
-  ShareTypes,
-  SpacePeopleShareRoles,
-  spaceRoleEditor,
-  spaceRoleManager,
-  spaceRoleViewer
-} from '../helpers/share'
+import { ShareTypes, SpacePeopleShareRoles } from '../helpers/share'
 
 export default {
   updateFileProgress({ commit }, progress) {
@@ -164,23 +158,9 @@ export default {
     if (space) {
       const promises = []
       const spaceShares = []
-      const userRoles = [
-        {
-          role: spaceRoleViewer.name,
-          userIds: space.spaceRoles.viewers
-        },
-        {
-          role: spaceRoleEditor.name,
-          userIds: space.spaceRoles.editors
-        },
-        {
-          role: spaceRoleManager.name,
-          userIds: space.spaceRoles.managers
-        }
-      ]
 
-      for (const { role, userIds } of userRoles) {
-        for (const userId of userIds) {
+      for (const role of Object.keys(space.spaceRoles)) {
+        for (const userId of space.spaceRoles[role]) {
           promises.push(
             client.users.getUser(userId).then((resolved) => {
               spaceShares.push(

--- a/packages/web-app-files/tests/integration/specs/peopleExpirationDate.spec.js
+++ b/packages/web-app-files/tests/integration/specs/peopleExpirationDate.spec.js
@@ -344,6 +344,14 @@ function createStore(store) {
     Store,
     {
       modules: {
+        config: {
+          getters: {
+            configuration: () => ({
+              server: 'https://example.com',
+              options: {}
+            })
+          }
+        },
         user: {
           state: {
             id: 'alice',

--- a/packages/web-app-files/tests/unit/store/actions.spec.js
+++ b/packages/web-app-files/tests/unit/store/actions.spec.js
@@ -141,6 +141,7 @@ describe('vuex store actions', () => {
 
       await actions.deleteShare(stateMock, {
         client: clientMock,
+        graphClient: graphClientMock,
         share: dataSet.share,
         resource: {}
       })

--- a/packages/web-app-files/tests/unit/store/actions.spec.js
+++ b/packages/web-app-files/tests/unit/store/actions.spec.js
@@ -1,5 +1,6 @@
 import actions from '../../../src/store/actions'
 import { ShareTypes, spaceRoleManager } from '../../../src/helpers/share'
+import { buildSpace } from '../../../src/helpers/resources'
 
 const stateMock = {
   commit: jest.fn(),
@@ -37,22 +38,24 @@ const clientMock = {
   }
 }
 
+const graphClientMock = {
+  drives: {
+    getDrive: () => {
+      return Promise.resolve({ data: spaceMock })
+    }
+  }
+}
 const shareMock = {
   id: '1',
   shareType: ShareTypes.user.value
 }
 
-const spaceMock = {
+const spaceMock = buildSpace({
   type: 'space',
   name: ' space',
   id: '1',
-  mdate: 'Wed, 21 Oct 2015 07:28:00 GMT',
-  spacePermissions: [{ grantedTo: [{ user: { id: 1 } }], roles: ['manager'] }],
-  spaceQuota: {
-    used: 100,
-    total: 1000
-  }
-}
+  root: { permissions: [{ roles: ['manager'], grantedTo: [{ user: { id: 1 } }] }] }
+})
 
 const spaceShareMock = {
   id: '1',
@@ -91,21 +94,22 @@ describe('vuex store actions', () => {
   })
 
   describe('changeShare', () => {
-    it.each([{ share: spaceShareMock }, { share: shareMock }])(
-      'succeeds using action %s',
-      async (dataSet) => {
-        const commitSpy = jest.spyOn(stateMock, 'commit')
+    it.each([
+      { share: spaceShareMock, expectedCommitCalls: 2 },
+      { share: shareMock, expectedCommitCalls: 1 }
+    ])('succeeds using action %s', async (dataSet) => {
+      const commitSpy = jest.spyOn(stateMock, 'commit')
 
-        await actions.changeShare(stateMock, {
-          client: clientMock,
-          share: dataSet.share,
-          permissions: 1,
-          expirationDate: null
-        })
+      await actions.changeShare(stateMock, {
+        client: clientMock,
+        graphClient: graphClientMock,
+        share: dataSet.share,
+        permissions: 1,
+        expirationDate: null
+      })
 
-        expect(commitSpy).toBeCalledTimes(1)
-      }
-    )
+      expect(commitSpy).toBeCalledTimes(dataSet.expectedCommitCalls)
+    })
   })
 
   describe('addShare', () => {
@@ -117,6 +121,7 @@ describe('vuex store actions', () => {
 
       await actions.addShare(stateMock, {
         client: clientMock,
+        graphClient: graphClientMock,
         shareType: dataSet.shareType,
         spaceId: dataSet.spaceId,
         permissions: 1,


### PR DESCRIPTION
## Description
We now update the stored space after its members have been changed. Also, the permission-object of a built space has been simplified in the course of this.

Currently the only way to update the space object is by fetching the space again because the response from the OCS-API gives us no usable information. As soon as UUIDs have been introduced to the OCS-API, we could use those instead.

Note that there is still a caching bug in OCIS. E.g. when navigating between space's share panels via the share indicator, and adding/removing members, and then switching back and forth between the share panels again, the change seems to be lost. A reload reveals that this is actually not the case.

## Related Issue
- Groundwork for https://github.com/owncloud/web/pull/6531

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
