### PR TITLE
Cleaned up account info page

### DIFF
--- a/changelog/unreleased/enhancement-account-page-loading
+++ b/changelog/unreleased/enhancement-account-page-loading
@@ -1,0 +1,5 @@
+Enhancement: Don't block account page while groups are loading
+
+We don't show a loading state for the full account information page anymore while the group membership information is loading. Instead we only show a loading spinner for the group membership information, while the rest of the user information is available immediately.
+
+https://github.com/owncloud/web/pull/6547

--- a/packages/web-runtime/src/pages/account.vue
+++ b/packages/web-runtime/src/pages/account.vue
@@ -1,12 +1,8 @@
 <template>
-  <div class="oc-width-1-1 oc-container oc-p">
-    <div v-if="loading" class="oc-flex oc-flex-between oc-flex-middle">
-      <h1 class="oc-page-title">{{ pageTitle }}</h1>
-      <oc-loader />
-    </div>
-    <template v-else>
-      <div class="oc-flex oc-flex-between oc-flex-middle">
-        <h1 id="account-page-title" v-translate class="oc-page-title">Account</h1>
+  <main id="account" class="oc-height-1-1 oc-m">
+    <div class="oc-flex oc-flex-between oc-flex-bottom oc-width-1-1 oc-border-b oc-py">
+      <h1 id="account-page-title" class="oc-page-title oc-m-rm">{{ pageTitle }}</h1>
+      <div>
         <oc-button
           v-if="editUrl"
           variation="primary"
@@ -28,51 +24,51 @@
           <translate>Edit</translate>
         </oc-button>
       </div>
-      <hr />
-      <h2 v-translate class="oc-text-bold oc-text-initial oc-mb">Account Information</h2>
-
-      <dl class="account-page-info oc-flex oc-flex-wrap">
-        <div class="account-page-info-username oc-mb oc-width-1-2@s">
-          <dt v-translate class="oc-text-normal oc-text-muted">Username</dt>
-          <dd>
-            {{ user.username || user.id }}
-          </dd>
-        </div>
-        <div v-if="user.username && user.id" class="account-page-info-userid">
-          <dt v-translate class="oc-text-normal oc-text-muted">User ID</dt>
-          <dd>
-            {{ user.id }}
-          </dd>
-        </div>
-        <div class="account-page-info-displayname oc-mb oc-width-1-2@s">
-          <dt v-translate class="oc-text-normal oc-text-muted">Display name</dt>
-          <dd>
-            {{ user.displayname }}
-          </dd>
-        </div>
-        <div class="account-page-info-email oc-mb oc-width-1-2@s">
-          <dt v-translate class="oc-text-normal oc-text-muted">Email</dt>
-          <dd>
-            <template v-if="user.email">{{ user.email }}</template>
-            <span v-else v-translate>No email has been set up</span>
-          </dd>
-        </div>
-        <div class="account-page-info-groups oc-mb oc-width-1-2@s">
-          <dt
-            v-translate
-            class="oc-text-normal oc-text-muted"
-            @click="$_oc_settingsAccount_getGroup"
+    </div>
+    <h2 v-translate class="oc-text-bold oc-text-initial oc-mb">Account Information</h2>
+    <dl class="account-page-info oc-flex oc-flex-wrap">
+      <div class="account-page-info-username oc-mb oc-width-1-2@s">
+        <dt v-translate class="oc-text-normal oc-text-muted">Username</dt>
+        <dd>
+          {{ user.username || user.id }}
+        </dd>
+      </div>
+      <div v-if="user.username && user.id" class="account-page-info-userid">
+        <dt v-translate class="oc-text-normal oc-text-muted">User ID</dt>
+        <dd>
+          {{ user.id }}
+        </dd>
+      </div>
+      <div class="account-page-info-displayname oc-mb oc-width-1-2@s">
+        <dt v-translate class="oc-text-normal oc-text-muted">Display name</dt>
+        <dd>
+          {{ user.displayname }}
+        </dd>
+      </div>
+      <div class="account-page-info-email oc-mb oc-width-1-2@s">
+        <dt v-translate class="oc-text-normal oc-text-muted">Email</dt>
+        <dd>
+          <template v-if="user.email">{{ user.email }}</template>
+          <span v-else v-translate>No email has been set up</span>
+        </dd>
+      </div>
+      <div class="account-page-info-groups oc-mb oc-width-1-2@s">
+        <dt v-translate class="oc-text-normal oc-text-muted" @click="loadGroups">
+          Group memberships
+        </dt>
+        <dd data-testid="group-names">
+          <oc-spinner
+            v-if="loadingGroups"
+            :aria-label="$gettext('Loading group membership information')"
+          />
+          <span v-else-if="groupNames">{{ groupNames }}</span>
+          <span v-else v-translate data-testid="group-names-empty"
+            >You are not part of any group</span
           >
-            Group memberships
-          </dt>
-          <dd>
-            <span v-if="groupNames">{{ groupNames }}</span>
-            <span v-else v-translate>You are not part of any group</span>
-          </dd>
-        </div>
-      </dl>
-    </template>
-  </div>
+        </dd>
+      </div>
+    </dl>
+  </main>
 </template>
 
 <script>
@@ -81,7 +77,7 @@ export default {
   name: 'Personal',
   data() {
     return {
-      loading: true,
+      loadingGroups: true,
       groups: []
     }
   },
@@ -108,14 +104,12 @@ export default {
     }
   },
   mounted() {
-    this.$_oc_settingsAccount_getGroup()
+    this.loadGroups()
   },
   methods: {
-    $_oc_settingsAccount_getGroup() {
-      this.$client.users.getUserGroups(this.user.id).then((groups) => {
-        this.groups = groups
-        this.loading = false
-      })
+    async loadGroups() {
+      this.groups = await this.$client.users.getUserGroups(this.user.id)
+      this.loadingGroups = false
     }
   }
 }

--- a/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.js.snap
+++ b/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.js.snap
@@ -1,15 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`account when the page is not in loading state anymore account information with group information 1`] = `
-<div class="account-page-info-groups oc-mb oc-width-1-2@s">
-  <dt class="oc-text-normal oc-text-muted">
-    Group memberships
-  </dt>
-  <dd><span>one, two, three</span></dd>
-</div>
-`;
-
-exports[`account when the page is not in loading state anymore account information without group information 1`] = `
+exports[`account page account information displays basic user information 1`] = `
 <dl class="account-page-info oc-flex oc-flex-wrap">
   <div class="account-page-info-username oc-mb oc-width-1-2@s">
     <dt class="oc-text-normal oc-text-muted">Username</dt>
@@ -32,19 +23,23 @@ exports[`account when the page is not in loading state anymore account informati
     <dt class="oc-text-normal oc-text-muted">
       Group memberships
     </dt>
-    <dd><span>You are not part of any group</span></dd>
+    <dd data-testid="group-names">
+      <oc-spinner-stub aria-label="Loading group membership information"></oc-spinner-stub>
+    </dd>
   </div>
 </dl>
 `;
 
-exports[`account when the page is not in loading state anymore edit buttons edit route button should be displayed if running with ocis and has navItems 1`] = `
+exports[`account page account information group membership displays group names 1`] = `<dd data-testid="group-names"><span>one, two, three</span></dd>`;
+
+exports[`account page header section edit buttons edit route button should be displayed if running with ocis and has navItems 1`] = `
 <oc-button-stub variation="primary" type="router-link" to="some-route" data-testid="account-page-edit-route-btn">
   <oc-icon-stub name="edit"></oc-icon-stub>
   <translate-stub tag="span">Edit</translate-stub>
 </oc-button-stub>
 `;
 
-exports[`account when the page is not in loading state anymore edit buttons edit url button should be displayed if not running with ocis 1`] = `
+exports[`account page header section edit buttons edit url button should be displayed if not running with ocis 1`] = `
 <oc-button-stub variation="primary" type="a" href="http://server/address/index.php/settings/personal" data-testid="account-page-edit-url-btn">
   <oc-icon-stub name="edit"></oc-icon-stub>
   <translate-stub tag="span">Edit</translate-stub>


### PR DESCRIPTION
## Description
As a followup of https://github.com/owncloud/web/pull/6522 I've removed code duplication in the template and limited the loading spinner to the part of the template where actual loading happens (only the group membership info). The rest of the account info page now loads immediately.

## How Has This Been Tested?
- unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
