### PR TITLE
Prevent the member count inside a space from disappearing

### DIFF
--- a/changelog/unreleased/bugfix-space-member-count
+++ b/changelog/unreleased/bugfix-space-member-count
@@ -1,0 +1,5 @@
+Bugfix: Prevent the member count inside a space from disappearing
+
+We've fixed a bug where opening the sidebar for a file inside a space caused the member count of the space to disappear.
+
+https://github.com/owncloud/web/pull/6550

--- a/packages/web-app-files/src/helpers/resources.js
+++ b/packages/web-app-files/src/helpers/resources.js
@@ -166,6 +166,7 @@ export function buildSpace(space) {
     disabled,
     spaceQuota: space.quota,
     spaceRoles,
+    spaceMemberIds: Object.values(spaceRoles).reduce((arr, ids) => arr.concat(ids), []),
     spaceImageData,
     spaceReadmeData,
     canUpload: function () {

--- a/packages/web-app-files/src/views/spaces/Project.vue
+++ b/packages/web-app-files/src/views/spaces/Project.vue
@@ -330,8 +330,7 @@ export default {
       return !this.configuration.options.disablePreviews
     },
     memberCount() {
-      const roles = Object.values(this.space.spaceRoles)
-      return roles.reduce((arr, obj) => arr.concat(obj), []).length
+      return this.space.spaceMemberIds.length
     },
     memberCountString() {
       const translated = this.$ngettext('%{count} member', '%{count} members', this.memberCount)

--- a/packages/web-app-files/tests/unit/views/spaces/Project.spec.js
+++ b/packages/web-app-files/tests/unit/views/spaces/Project.spec.js
@@ -39,6 +39,7 @@ const spaceMocks = {
   spaceWithReadmeAndImage: {
     id: 1,
     name: 'space',
+    root: { permissions: [{ roles: ['manager'], grantedTo: [{ user: { id: 1 } }] }] },
     special: [
       {
         specialFolder: { name: 'readme' },
@@ -55,6 +56,7 @@ const spaceMocks = {
   spaceWithoutReadmeAndImage: {
     id: 1,
     name: 'space',
+    root: { permissions: [{ roles: ['manager'], grantedTo: [{ user: { id: 1 } }] }] },
     special: []
   }
 }


### PR DESCRIPTION
## Description
We've fixed a bug where opening the sidebar for a file inside a space caused the member count of the space to disappear.

Also reduced the complexity a bit by removing the `loadSharesTask` within a space. Counting the members can now be done via the space object itself thanks to https://github.com/owncloud/web/pull/6545.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
