### PR TITLE
[full-ci] Move OcStatusIndicators in separate column

### DIFF
--- a/changelog/unreleased/enhancement-move-share-indicators
+++ b/changelog/unreleased/enhancement-move-share-indicators
@@ -1,0 +1,8 @@
+Enhancement: Move share indicators
+
+We've moved the share/status indicators into a separate column
+and adjusted the design in ODS.
+
+https://github.com/owncloud/web/issues/5976
+https://github.com/owncloud/web/pull/6552
+https://github.com/owncloud/owncloud-design-system/pull/2014

--- a/changelog/unreleased/enhancement-update-ods
+++ b/changelog/unreleased/enhancement-update-ods
@@ -1,11 +1,13 @@
-Enhancement: Update ODS to v13.0.0-rc.1
+Enhancement: Update ODS to v13.0.0-rc.2
 
-We updated the ownCloud Design System to version 13.0.0-rc.1. Please refer to the full changelog in the ODS release (linked) for more details. Summary:
+We updated the ownCloud Design System to version 13.0.0-rc.2. Please refer to the full changelog in the ODS release (linked) for more details. Summary:
 
 - Change - Default type of OcButton: https//github.com/owncloud/owncloud-design-system/pull/2009
-- Enhancement - Apply size property to oc-card: https//github.com/owncloud/owncloud-design-system/pull/2011
+- Change - Remove OcStatusIndicators from OcResource: https://github.com/owncloud/owncloud-design-system/pull/5976
+- Enhancement - Redesign OcStatusIndicators: https://github.com/owncloud/owncloud-design-system/pull/5976
+- Enhancement - Apply size property to oc-tag: https//github.com/owncloud/owncloud-design-system/pull/2011
 - Bugfix - Disabled OcSelect background: https//github.com/owncloud/owncloud-design-system/pull/2008
 - Bugfix - Icons/Thumbnails were only visible for clickable resources: https//github.com/owncloud/owncloud-design-system/pull/2007
 
 https://github.com/owncloud/web/pull/6540
-https://github.com/owncloud/owncloud-design-system/releases/tag/v13.0.0-rc.1
+https://github.com/owncloud/owncloud-design-system/releases/tag/v13.0.0-rc.2

--- a/packages/web-app-files/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceTable.vue
@@ -80,6 +80,13 @@
         v-text="formatDateRelative(item.mdate)"
       />
     </template>
+    <template #shareTypes="{ item }">
+      <oc-status-indicators
+        v-if="item.indicators.length"
+        :resource="item"
+        :indicators="item.indicators"
+      ></oc-status-indicators>
+    </template>
     <template #sdate="{ item }">
       <span
         v-oc-tooltip="formatDate(item.sdate)"
@@ -394,6 +401,8 @@ export default {
         })
       }
       const sortFields = determineSortFields(firstResource)
+      console.log('FIRST RESOURCE')
+      console.log(firstResource)
       fields.push(
         ...[
           {
@@ -402,6 +411,13 @@ export default {
             type: 'slot',
             width: 'expand',
             wrap: 'truncate'
+          },
+          {
+            name: 'shareTypes',
+            title: this.$gettext('Shares'), // How do we get the translations here?
+            type: 'slot',
+            alignH: 'right',
+            wrap: 'nowrap'
           },
           {
             name: 'size',

--- a/packages/web-app-files/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceTable.vue
@@ -85,7 +85,7 @@
         v-if="item.indicators.length"
         :resource="item"
         :indicators="item.indicators"
-      ></oc-status-indicators>
+      />
     </template>
     <template #sdate="{ item }">
       <span
@@ -401,20 +401,18 @@ export default {
         })
       }
       const sortFields = determineSortFields(firstResource)
-      console.log('FIRST RESOURCE')
-      console.log(firstResource)
       fields.push(
         ...[
           {
             name: 'name',
-            title: this.$gettext('Name'), // How do we get the translations here?
+            title: this.$gettext('Name'),
             type: 'slot',
             width: 'expand',
             wrap: 'truncate'
           },
           {
             name: 'shareTypes',
-            title: this.$gettext('Shares'), // How do we get the translations here?
+            title: this.$gettext('Shares'),
             type: 'slot',
             alignH: 'right',
             wrap: 'nowrap'

--- a/packages/web-app-files/tests/unit/views/__snapshots__/Trashbin.spec.js.snap
+++ b/packages/web-app-files/tests/unit/views/__snapshots__/Trashbin.spec.js.snap
@@ -25,7 +25,6 @@ exports[`Trashbin View when the view is not loading anymore when length of the p
             <!----></span></span>
             <div class="oc-resource-indicators">
               <router-link-stub to="[object Object]" class="parent-folder" style="cursor: pointer;"><span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="text">file-path</span></router-link-stub>
-              <!---->
             </div>
           </div>
         </div>
@@ -45,7 +44,6 @@ exports[`Trashbin View when the view is not loading anymore when length of the p
             <!----></span></span>
             <div class="oc-resource-indicators">
               <router-link-stub to="[object Object]" class="parent-folder" style="cursor: pointer;"><span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="text">file-path</span></router-link-stub>
-              <!---->
             </div>
           </div>
         </div>
@@ -65,7 +63,6 @@ exports[`Trashbin View when the view is not loading anymore when length of the p
             <!----></span></span>
             <div class="oc-resource-indicators">
               <router-link-stub to="[object Object]" class="parent-folder" style="cursor: pointer;"><span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="text">file-path</span></router-link-stub>
-              <!---->
             </div>
           </div>
         </div>

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -18,7 +18,7 @@
     "luxon": "^2.3.0",
     "marked": "^4.0.12",
     "oidc-client": "1.11.5",
-    "owncloud-design-system": "^13.0.0-rc.1",
+    "owncloud-design-system": "^13.0.0-rc.2",
     "owncloud-sdk": "~2.1.0-alpha.3",
     "p-queue": "^6.1.1",
     "popper-max-size-modifier": "^0.2.0",

--- a/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
@@ -8,7 +8,7 @@ Feature: deleting files and folders
     And user "Alice" has logged in using the webUI
     And the user reloads the current page of the webUI
 
-  @smokeTest @ocisSmokeTest @disablePreviews
+  @smokeTest @ocisSmokeTest @disablePreviews @skipOnXGAPortraitResolution
   Scenario: Delete files & folders one by one and check its existence after page reload
     Given user "Alice" has created folder "simple-empty-folder" in the server
     And user "Alice" has created folder "simple-folder" in the server

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -12,7 +12,7 @@ Feature: Sharing files and folders with internal users
       | Brian    |
     And user "Brian" has created folder "simple-folder" in the server
 
-  @smokeTest @issue-ocis-2260 @ocisSmokeTest @disablePreviews
+  @smokeTest @issue-ocis-2260 @ocisSmokeTest @disablePreviews @skipOnXGAPortraitResolution
   Scenario Outline: share a file & folder with another internal user
     Given user "Brian" has created file "testimage.jpg" in the server
     And user "Brian" has created file "simple-folder/lorem.txt" in the server
@@ -48,10 +48,10 @@ Feature: Sharing files and folders with internal users
     # When the user opens the share dialog for file "testimage.jpg" using the webUI
     # Then user "Brian Murphy" should be listed as "Owner" in the collaborators list on the webUI
     Examples:
-      | set-role             | expected-role        | permissions-folder              | permissions-file  |
-      | Viewer               | Viewer               | read,share                      | read, share       |
-      | Editor               | Editor               | read,update,create,delete,share | read,update,share |
-      | Custom permissions   | Custom permissions   | read                            | read              |
+      | set-role           | expected-role      | permissions-folder              | permissions-file  |
+      | Viewer             | Viewer             | read,share                      | read, share       |
+      | Editor             | Editor             | read,update,create,delete,share | read,update,share |
+      | Custom permissions | Custom permissions | read                            | read              |
 
   @issue-4102 @issue-ocis-2267 @disablePreviews
   Scenario: share a file with another internal user who overwrites and unshares the file
@@ -271,9 +271,9 @@ Feature: Sharing files and folders with internal users
       | Sample,Folder,With,Comma |
       | sample,1.txt             |
     Examples:
-      | set-role             | expected-role        | permissions-folder              | permissions-file  |
-      | Viewer               | Viewer               | read,share                      | read,share        |
-      | Editor               | Editor               | read,update,create,delete,share | read,update,share |
+      | set-role           | expected-role      | permissions-folder              | permissions-file  |
+      | Viewer             | Viewer             | read,share                      | read,share        |
+      | Editor             | Editor             | read,update,create,delete,share | read,update,share |
       | Custom permissions | Custom permissions | read                            | read              |
 
   @skipOnOC10 @ocisSmokeTest @disablePreviews
@@ -309,9 +309,9 @@ Feature: Sharing files and folders with internal users
       | Sample,Folder,With,Comma |
       | sample,1.txt             |
     Examples:
-      | set-role             | expected-role | permissions-folder        | permissions-file |
-      | Viewer               | Viewer        | read                      | read             |
-      | Editor               | Editor        | read,update,create,delete | read,update      |
+      | set-role           | expected-role | permissions-folder        | permissions-file |
+      | Viewer             | Viewer        | read                      | read             |
+      | Editor             | Editor        | read,update,create,delete | read,update      |
       | Custom permissions | Viewer        | read                      | read             |
 
 

--- a/tests/acceptance/features/webUISharingInternalUsersToRoot/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersToRoot/shareWithUsers.feature
@@ -10,7 +10,7 @@ Feature: Sharing files and folders with internal users
       | Alice    |
       | Brian    |
 
-  @smokeTest @disablePreviews
+  @smokeTest @disablePreviews @skipOnXGAPortraitResolution
   Scenario Outline: share a file & folder with another internal user
     Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes" in the server
     And user "Brian" has created folder "simple-folder" in the server
@@ -44,10 +44,10 @@ Feature: Sharing files and folders with internal users
     # When the user opens the share dialog for file "testimage.jpg" using the webUI
     # Then user "Brian Murphy" should be listed as "Owner" in the collaborators list on the webUI
     Examples:
-      | set-role             | expected-role        | permissions-folder              | permissions-file  |
-      | Viewer               | Viewer               | read,share                      | read,share        |
-      | Editor               | Editor               | read,update,create,delete,share | read,update,share |
-      | Custom permissions   | Custom permissions   | read                            | read              |
+      | set-role           | expected-role      | permissions-folder              | permissions-file  |
+      | Viewer             | Viewer             | read,share                      | read,share        |
+      | Editor             | Editor             | read,update,create,delete,share | read,update,share |
+      | Custom permissions | Custom permissions | read                            | read              |
 
   @disablePreviews
   Scenario: share a file with another internal user who overwrites and unshares the file
@@ -248,9 +248,9 @@ Feature: Sharing files and folders with internal users
       | Sample,Folder,With,Comma |
       | sample,1.txt             |
     Examples:
-      | set-role             | expected-role        | permissions-folder              | permissions-file  |
-      | Viewer               | Viewer               | read,share                      | read,share        |
-      | Editor               | Editor               | read,update,create,delete,share | read,update,share |
+      | set-role           | expected-role      | permissions-folder              | permissions-file  |
+      | Viewer             | Viewer             | read,share                      | read,share        |
+      | Editor             | Editor             | read,update,create,delete,share | read,update,share |
       | Custom permissions | Custom permissions | read                            | read              |
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9595,9 +9595,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"owncloud-design-system@npm:^13.0.0-rc.1":
-  version: 13.0.0-rc.1
-  resolution: "owncloud-design-system@npm:13.0.0-rc.1"
+"owncloud-design-system@npm:^13.0.0-rc.2":
+  version: 13.0.0-rc.2
+  resolution: "owncloud-design-system@npm:13.0.0-rc.2"
   peerDependencies:
     "@popperjs/core": ^2.4.0
     "@vue/composition-api": ^1.4.3
@@ -9614,7 +9614,7 @@ __metadata:
     vue-inline-svg: ^2.0.0
     vue-select: ^3.12.0
     webfontloader: ^1.6.28
-  checksum: 366d0d4484533b4b84cbc1f51ac08e4f596f104ee09ef44a4d2b00c445c1343f9deeea3da2bff369097adfcfe6b3b9dfecc40db14c088948149b2da94ce6fcad
+  checksum: 0e6dd8fdb9f5fef2fed6de9286d52b7dda964e183546d90bd21f94fbd3f551623cb7ed284aad169bce04b47430c43ccafc791d9fabbcec37d64291766e699f9a
   languageName: node
   linkType: hard
 
@@ -13604,7 +13604,7 @@ __metadata:
     luxon: ^2.3.0
     marked: ^4.0.12
     oidc-client: 1.11.5
-    owncloud-design-system: ^13.0.0-rc.1
+    owncloud-design-system: ^13.0.0-rc.2
     owncloud-sdk: ~2.1.0-alpha.3
     p-queue: ^6.1.1
     popper-max-size-modifier: ^0.2.0


### PR DESCRIPTION
## Related Issue
- Fixes #5976

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
