### PR TITLE
Change hover effect for context menu to background-color change

### DIFF
--- a/packages/web-app-files/src/components/FilesList/ContextActions.vue
+++ b/packages/web-app-files/src/components/FilesList/ContextActions.vue
@@ -210,6 +210,10 @@ export default {
 
   li {
     padding: 6px;
+    &:hover {
+      background-color: var(--oc-color-background-hover);
+      border-radius: 4px;
+    }
   }
 
   > li {
@@ -224,12 +228,6 @@ export default {
       vertical-align: top;
       width: 100%;
       text-align: left;
-
-      span:hover,
-      &:hover {
-        color: var(--oc-color-swatch-passive-hover) !important;
-        text-decoration: underline !important;
-      }
     }
   }
 


### PR DESCRIPTION
## Description
Changes the hover effect from underline to background-color 

## Related Issue
- Fixes https://github.com/owncloud/owncloud-design-system/issues/2004

## Motivation and Context
We find, color hover fits better for actions than the underline effect which is commonly used for links.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Apply to context menu in the breadcrumb
