### PR TITLE
Fix context menu in public links

### DIFF
--- a/changelog/unreleased/enhancement-load-space-images-as-preview
+++ b/changelog/unreleased/enhancement-load-space-images-as-preview
@@ -3,3 +3,4 @@ Enhancement: Load space images as preview
 We've added a new logic which renders space images as preview to minimize data traffic
 
 https://github.com/owncloud/web/pull/6529
+https://github.com/owncloud/web/pull/6558

--- a/packages/web-app-files/src/services/thumbnail.ts
+++ b/packages/web-app-files/src/services/thumbnail.ts
@@ -16,17 +16,20 @@ export class ThumbnailService {
     return !!this.capability?.version
   }
 
+  private get supportedMimeTypes() {
+    return this.capability?.supportedMimeTypes || []
+  }
+
   public isMimetypeSupported(mimeType: string, onlyImages = false) {
-    return onlyImages
-      ? mimeType.startsWith('image/') && this.capability.supportedMimeTypes.includes(mimeType)
-      : this.capability.supportedMimeTypes.includes(mimeType)
+    const mimeTypes = this.getSupportedMimeTypes(onlyImages ? 'image/' : null)
+    return mimeTypes.includes(mimeType)
   }
 
   public getSupportedMimeTypes(filter?: string) {
     if (!filter) {
-      return this.capability.supportedMimeTypes
+      return this.supportedMimeTypes
     }
-    return this.capability.supportedMimeTypes.filter((mimeType) => mimeType.startsWith(filter))
+    return this.supportedMimeTypes.filter((mimeType) => mimeType.startsWith(filter))
   }
 }
 


### PR DESCRIPTION
## Description
The context menu in public links file lists was broken due to an initialization issue of the new `thumbnailService`. This PR only fixes the symptom, not the initialization which is still not being called. Context menu is functional again.

## Motivation and Context
Hardening

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
