### PR TITLE
Fix TypeErrors when trying to destruct undefined properties

### DIFF
--- a/changelog/unreleased/bugfix-space-permission-destructing
+++ b/changelog/unreleased/bugfix-space-permission-destructing
@@ -1,0 +1,5 @@
+Bugfix: TypeErrors when trying to destruct undefined properties
+
+We fixed TypeErrors when trying to destruct undefined properties in the space permissions checks by providing a default value.
+
+https://github.com/owncloud/web/pull/6568

--- a/packages/web-app-files/src/helpers/resources.js
+++ b/packages/web-app-files/src/helpers/resources.js
@@ -169,7 +169,7 @@ export function buildSpace(space) {
     spaceMemberIds: Object.values(spaceRoles).reduce((arr, ids) => arr.concat(ids), []),
     spaceImageData,
     spaceReadmeData,
-    canUpload: function ({ user }) {
+    canUpload: function ({ user } = {}) {
       const allowedRoles = [
         ...this.spaceRoles[spaceRoleManager.name],
         ...this.spaceRoles[spaceRoleEditor.name]
@@ -179,45 +179,45 @@ export function buildSpace(space) {
     canDownload: function () {
       return true
     },
-    canBeDeleted: function ({ user }) {
+    canBeDeleted: function ({ user } = {}) {
       const allowedRoles = [...this.spaceRoles[spaceRoleManager.name]]
       return this.disabled && user && allowedRoles.includes(user.uuid)
     },
-    canRename: function ({ user }) {
+    canRename: function ({ user } = {}) {
       const allowedRoles = [...this.spaceRoles[spaceRoleManager.name]]
       return user && allowedRoles.includes(user.uuid)
     },
-    canEditDescription: function ({ user }) {
+    canEditDescription: function ({ user } = {}) {
       const allowedRoles = [...this.spaceRoles[spaceRoleManager.name]]
       return user && allowedRoles.includes(user.uuid)
     },
-    canRestore: function ({ user }) {
+    canRestore: function ({ user } = {}) {
       const allowedRoles = [...this.spaceRoles[spaceRoleManager.name]]
       return this.disabled && user && allowedRoles.includes(user.uuid)
     },
-    canDisable: function ({ user }) {
+    canDisable: function ({ user } = {}) {
       const allowedRoles = [...this.spaceRoles[spaceRoleManager.name]]
       return !this.disabled && user && allowedRoles.includes(user.uuid)
     },
-    canShare: function ({ user }) {
+    canShare: function ({ user } = {}) {
       const allowedRoles = [...this.spaceRoles[spaceRoleManager.name]]
       return user && allowedRoles.includes(user.uuid)
     },
-    canEditImage: function ({ user }) {
+    canEditImage: function ({ user } = {}) {
       const allowedRoles = [
         ...this.spaceRoles[spaceRoleManager.name],
         ...this.spaceRoles[spaceRoleEditor.name]
       ]
       return user && allowedRoles.includes(user.uuid)
     },
-    canEditReadme: function ({ user }) {
+    canEditReadme: function ({ user } = {}) {
       const allowedRoles = [
         ...this.spaceRoles[spaceRoleManager.name],
         ...this.spaceRoles[spaceRoleEditor.name]
       ]
       return user && allowedRoles.includes(user.uuid)
     },
-    canEditQuota: function ({ user }) {
+    canEditQuota: function ({ user } = {}) {
       const allowedRoles = [...this.spaceRoles[spaceRoleManager.name]]
       return user && allowedRoles.includes(user.uuid)
     },


### PR DESCRIPTION
## Description
We fixed TypeErrors when trying to destruct undefined properties in the space permissions checks by providing a default value.

They appeared e.g. when navigating into a subfolder within a space.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
