### PR TITLE
Fix resize observer errors within subfolders of a space

### DIFF
--- a/changelog/unreleased/bugfix-resize-observer-errors
+++ b/changelog/unreleased/bugfix-resize-observer-errors
@@ -1,0 +1,5 @@
+Bugfix: Resize observer errors within subfolders of a space
+
+We've fixed a bug where the resize observer crashes within subfolders of a space because there is no element to observe.
+
+https://github.com/owncloud/web/pull/6569

--- a/packages/web-app-files/src/views/spaces/Project.vue
+++ b/packages/web-app-files/src/views/spaces/Project.vue
@@ -324,6 +324,13 @@ export default {
         if ((!sameRoute || !sameItem) && from) {
           this.loadResourcesTask.perform(this, sameRoute, to.params.item)
         }
+
+        if (this.$refs.markdownContainer) {
+          if (this.markdownResizeObserver) {
+            this.markdownResizeObserver.unobserve(this.$refs.markdownContainer)
+          }
+          this.markdownResizeObserver.observe(this.$refs.markdownContainer)
+        }
       },
       immediate: true
     },
@@ -381,11 +388,6 @@ export default {
   },
   async mounted() {
     await this.loadResourcesTask.perform(this, false, this.$route.params.item || '')
-
-    if (this.markdownResizeObserver) {
-      this.markdownResizeObserver.unobserve(this.$refs.markdownContainer)
-    }
-    this.markdownResizeObserver.observe(this.$refs.markdownContainer)
 
     document.title = `${this.space.name} - ${this.$route.meta.title}`
     this.$route.params.name = this.space.name


### PR DESCRIPTION
## Description
We've fixed a bug where the resize observer crashes within subfolders of a space because there is no element to observe.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
