### PR TITLE
Federated and lightweight accounts

### DIFF
--- a/packages/web-app-files/src/index.js
+++ b/packages/web-app-files/src/index.js
@@ -14,6 +14,7 @@ import SpaceProject from './views/spaces/Project.vue'
 import SpaceTrashbin from './views/spaces/Trashbin.vue'
 import SpaceProjects from './views/spaces/Projects.vue'
 import Trashbin from './views/Trashbin.vue'
+import Home from './views/Home.vue'
 import translations from '../l10n/translations.json'
 import quickActions from './quickActions'
 import store from './store'
@@ -41,16 +42,20 @@ const appInfo = {
   extensions: [],
   fileSideBars
 }
-const navItems = [
+
+const navItemFirst = [
   {
     name(capabilities) {
       return capabilities.spaces?.enabled ? $gettext('Personal') : $gettext('All files')
     },
     icon: appInfo.icon,
+    hideByLightweight: true,
     route: {
       path: `/${appInfo.id}/spaces/personal/home`
     }
-  },
+  }
+]
+const navItems = [
   {
     name: $gettext('Favorites'),
     icon: 'star',
@@ -94,6 +99,16 @@ const navItems = [
   }
 ]
 
+const navItemsLightweight = [
+  {
+    name: $gettext('Shared with me'),
+    icon: 'share-forward',
+    route: {
+      path: `/${appInfo.id}/shares/with-me`
+    }
+  }
+]
+
 export default {
   appInfo,
   store,
@@ -116,9 +131,10 @@ export default {
       Projects: SpaceProjects,
       Trashbin: SpaceTrashbin
     },
-    Trashbin
+    Trashbin,
+    Home
   }),
-  navItems,
+  navItems: navItemFirst,
   quickActions,
   translations,
   ready({ router, store }) {
@@ -136,6 +152,16 @@ export default {
       store.dispatch('Files/loadSpaces', { clientService })
     }
 
+    // add nav items depending on user type
+    ;(store.getters.user.usertype && store.getters.user.usertype === 'lightweight'
+      ? navItemsLightweight
+      : navItems
+    ).forEach((navItem) => {
+      store.commit('ADD_NAV_ITEM', {
+        extension: 'files',
+        navItem
+      })
+    })
     archiverService.initialize(
       store.getters.configuration.server || window.location.origin,
       get(store, 'getters.capabilities.files.archivers', [

--- a/packages/web-app-files/src/router/common.ts
+++ b/packages/web-app-files/src/router/common.ts
@@ -2,17 +2,19 @@ import { RouteComponents } from './router'
 import { Location, RouteConfig } from 'vue-router'
 import { createLocation, $gettext, isLocationActiveDirector } from './utils'
 
-type commonTypes = 'files-common-favorites' | 'files-common-search'
+type commonTypes = 'files-common-favorites' | 'files-common-search' | 'files-common-home'
 
 export const createLocationCommon = (name: commonTypes, location = {}): Location =>
   createLocation(name, location)
 
 export const locationFavorites = createLocationCommon('files-common-favorites')
 export const locationSearch = createLocationCommon('files-common-search')
+export const locationHome = createLocationCommon('files-common-home')
 
 export const isLocationCommonActive = isLocationActiveDirector<commonTypes>(
   locationFavorites,
-  locationSearch
+  locationSearch,
+  locationHome
 )
 
 export const buildRoutes = (components: RouteComponents): RouteConfig[] => [
@@ -41,6 +43,22 @@ export const buildRoutes = (components: RouteComponents): RouteConfig[] => [
         component: components.Favorites,
         meta: {
           title: $gettext('Favorite files')
+        }
+      }
+    ]
+  },
+  {
+    path: '/home',
+    components: {
+      app: components.App
+    },
+    children: [
+      {
+        name: locationHome.name,
+        path: '',
+        component: components.Home,
+        meta: {
+          title: $gettext('Home')
         }
       }
     ]

--- a/packages/web-app-files/src/router/router.ts
+++ b/packages/web-app-files/src/router/router.ts
@@ -26,4 +26,5 @@ export interface RouteComponents {
     Trashbin: ComponentOptions<Vue>
   }
   Trashbin: ComponentOptions<Vue>
+  Home: ComponentOptions<Vue>
 }

--- a/packages/web-app-files/src/views/Home.vue
+++ b/packages/web-app-files/src/views/Home.vue
@@ -1,0 +1,24 @@
+<template>
+  <div class="full-height oc-text-center">
+    <div class="oc-text-center centered">
+      <h1 v-translate class="oc-text-lead">Welcome to CERNBox</h1>
+      <p v-translate>With this account you can access shared content and collaborate on projects</p>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  methods: {}
+}
+</script>
+
+<style scoped>
+.full-height {
+  height: 100%;
+}
+.centered {
+  width: 50%;
+  margin: 0 auto;
+}
+</style>

--- a/packages/web-app-files/src/views/Personal.vue
+++ b/packages/web-app-files/src/views/Personal.vue
@@ -1,74 +1,77 @@
 <template>
   <div>
-    <app-bar
-      :has-bulk-actions="true"
-      :breadcrumbs="breadcrumbs"
-      :breadcrumbs-context-actions-items="[currentFolder]"
-      :show-actions-on-selection="true"
-    >
-      <template #actions>
-        <create-and-upload />
+    <div v-if="isLightweight && isHomeRoute"><home /></div>
+    <div v-else>
+      <app-bar
+        :has-bulk-actions="true"
+        :breadcrumbs="breadcrumbs"
+        :breadcrumbs-context-actions-items="[currentFolder]"
+        :show-actions-on-selection="true"
+      >
+        <template #actions>
+          <create-and-upload />
+        </template>
+      </app-bar>
+      <app-loading-spinner v-if="loadResourcesTask.isRunning" />
+      <template v-else>
+        <not-found-message v-if="folderNotFound" class="files-not-found oc-height-1-1" />
+        <no-content-message
+          v-else-if="isEmpty"
+          id="files-personal-empty"
+          class="files-empty"
+          icon="folder"
+        >
+          <template #message>
+            <span v-translate>There are no resources in this folder</span>
+          </template>
+          <template #callToAction>
+            <span v-translate>
+              Drag files and folders here or use the "New" or "Upload" buttons to add files
+            </span>
+          </template>
+        </no-content-message>
+        <resource-table
+          v-else
+          id="files-personal-table"
+          v-model="selectedResources"
+          class="files-table"
+          :class="{ 'files-table-squashed': !sidebarClosed }"
+          :are-thumbnails-displayed="displayThumbnails"
+          :resources="paginatedResources"
+          :target-route="resourceTargetLocation"
+          :header-position="fileListHeaderY"
+          :drag-drop="true"
+          :sort-by="sortBy"
+          :sort-dir="sortDir"
+          @fileDropped="fileDropped"
+          @fileClick="$_fileActions_triggerDefaultAction"
+          @rowMounted="rowMounted"
+          @sort="handleSort"
+        >
+          <template #quickActions="{ resource }">
+            <quick-actions
+              :class="resource.preview"
+              class="oc-visible@s"
+              :item="resource"
+              :actions="app.quickActions"
+            />
+          </template>
+          <template #contextMenu="{ resource }">
+            <context-actions v-if="isResourceInSelection(resource)" :items="selectedResources" />
+          </template>
+          <template #footer>
+            <pagination :pages="paginationPages" :current-page="paginationPage" />
+            <list-info
+              v-if="paginatedResources.length > 0"
+              class="oc-width-1-1 oc-my-s"
+              :files="totalFilesCount.files"
+              :folders="totalFilesCount.folders"
+              :size="totalFilesSize"
+            />
+          </template>
+        </resource-table>
       </template>
-    </app-bar>
-    <app-loading-spinner v-if="loadResourcesTask.isRunning" />
-    <template v-else>
-      <not-found-message v-if="folderNotFound" class="files-not-found oc-height-1-1" />
-      <no-content-message
-        v-else-if="isEmpty"
-        id="files-personal-empty"
-        class="files-empty"
-        icon="folder"
-      >
-        <template #message>
-          <span v-translate>There are no resources in this folder</span>
-        </template>
-        <template #callToAction>
-          <span v-translate>
-            Drag files and folders here or use the "New" or "Upload" buttons to add files
-          </span>
-        </template>
-      </no-content-message>
-      <resource-table
-        v-else
-        id="files-personal-table"
-        v-model="selectedResources"
-        class="files-table"
-        :class="{ 'files-table-squashed': !sidebarClosed }"
-        :are-thumbnails-displayed="displayThumbnails"
-        :resources="paginatedResources"
-        :target-route="resourceTargetLocation"
-        :header-position="fileListHeaderY"
-        :drag-drop="true"
-        :sort-by="sortBy"
-        :sort-dir="sortDir"
-        @fileDropped="fileDropped"
-        @fileClick="$_fileActions_triggerDefaultAction"
-        @rowMounted="rowMounted"
-        @sort="handleSort"
-      >
-        <template #quickActions="{ resource }">
-          <quick-actions
-            :class="resource.preview"
-            class="oc-visible@s"
-            :item="resource"
-            :actions="app.quickActions"
-          />
-        </template>
-        <template #contextMenu="{ resource }">
-          <context-actions v-if="isResourceInSelection(resource)" :items="selectedResources" />
-        </template>
-        <template #footer>
-          <pagination :pages="paginationPages" :current-page="paginationPage" />
-          <list-info
-            v-if="paginatedResources.length > 0"
-            class="oc-width-1-1 oc-my-s"
-            :files="totalFilesCount.files"
-            :folders="totalFilesCount.folders"
-            :size="totalFilesSize"
-          />
-        </template>
-      </resource-table>
-    </template>
+    </div>
   </div>
 </template>
 
@@ -99,6 +102,7 @@ import Pagination from '../components/FilesList/Pagination.vue'
 import ContextActions from '../components/FilesList/ContextActions.vue'
 import { createLocationSpaces } from '../router'
 import { useResourcesViewDefaults } from '../composables'
+import Home from './Home.vue'
 import { defineComponent } from '@vue/composition-api'
 import { Resource, move } from '../helpers/resource'
 import { useCapabilityShareJailEnabled } from 'web-pkg/src/composables'
@@ -116,7 +120,8 @@ export default defineComponent({
     NotFoundMessage,
     ListInfo,
     Pagination,
-    ContextActions
+    ContextActions,
+    Home
   },
 
   mixins: [
@@ -146,6 +151,12 @@ export default defineComponent({
     ]),
     ...mapGetters(['user', 'homeFolder', 'configuration']),
 
+    isLightweight() {
+      return this.user.usertype === 'lightweight'
+    },
+    isHomeRoute() {
+      return this.$route.fullPath.includes(`/${this.user.id.charAt(0)}/${this.user.id}`)
+    },
     isEmpty() {
       return this.paginatedResources.length < 1
     },

--- a/packages/web-app-files/src/views/shares/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithMe.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="oc-flex oc-flex-column">
-    <app-bar :has-shares-navigation="true" :has-bulk-actions="true" />
+    <app-bar :has-shares-navigation="!isLightweight" :has-bulk-actions="true" />
     <app-loading-spinner v-if="loadResourcesTask.isRunning" />
     <template v-else>
       <!-- Pending shares -->
@@ -296,7 +296,12 @@ export default defineComponent({
   computed: {
     ...mapGetters('Files', ['selectedFiles']),
     ...mapGetters(['configuration', 'getToken']),
+    ...mapGetters(['user']),
     ...mapState('Files/sidebar', { sidebarClosed: 'closed' }),
+
+    isLightweight() {
+      return this.user.usertype === 'lightweight'
+    },
 
     // pending shares
     pendingSelected: {

--- a/packages/web-runtime/src/store/user.js
+++ b/packages/web-runtime/src/store/user.js
@@ -136,7 +136,11 @@ const actions = {
           token,
           isAuthenticated: true,
           groups: userGroups,
-          language
+          language,
+          usertype:
+            user['user-type'] === 'federated' || user['user-type'] === 'lightweight'
+              ? 'lightweight'
+              : ''
         })
 
         if (user.quota.definition !== 'default' && user.quota.definition !== 'none') {
@@ -265,6 +269,7 @@ const mutations = {
     state.groups = user.groups
     state.language = user.language
     sentrySetUser({ username: user.id })
+    state.usertype = user.usertype
   },
   SET_CAPABILITIES(state, data) {
     state.capabilities = data.capabilities


### PR DESCRIPTION
## Description
Implementation of the interface for federated and lightweight accounts at CERNBox

## Related Issue

## Motivation and Context
At CERNBox users with federated and lightweight accounts don't have their own quota. It's possible to share with them as well as include them in projects. Based on these capabilities we implemented following elements:

- Home view that appears instead of the resources table if the account is federated or lightweight and the user is in his home directrory (functions isLightweight & isHomeRoute-> CERNBox only). 
- Navitems are changing if the account is federated or lightweight: the user doesn't see "Shared with others", "Shared by link", "Trashbin"



## Screenshots:
![Screenshot from 2022-03-11 10-45-27](https://user-images.githubusercontent.com/7430156/157842832-cfb1081a-713c-45bd-a88d-3da1018e61aa.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] the isHomeRoute function needs reimplementation. Currently it's based on the url part like "/eos/user/r/ragozina/" and checks if the userid matches the loggedin user. 
- [ ] We also want to use "home" route instead of "files-personal" as there can't be any files in home directory of f.&l. users. But we didn't find a way to dynamically change home route, so we are currently showing home inside personal view instead
