### PR TITLE
Fix SET_QUOTA call in the loader for the personal files list

### DIFF
--- a/packages/web-app-files/src/services/folder/loaderPersonal.ts
+++ b/packages/web-app-files/src/services/folder/loaderPersonal.ts
@@ -53,7 +53,7 @@ export class FolderLoaderPersonal implements FolderLoader {
         // The semicolon is important to separate from the previous statement
         ;(async () => {
           const user = await promiseUser
-          store.commit('Files/SET_QUOTA', user.quota)
+          store.commit('SET_QUOTA', user.quota)
         })()
       } catch (error) {
         store.commit('Files/SET_CURRENT_FOLDER', null)


### PR DESCRIPTION
## Description
Fixes issue that was introduced by https://github.com/owncloud/web/pull/6563/files. `SET_QUOTA` does not live under the `Files` namespace.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
