### PR TITLE
[full-ci][tests-only] Fix waitForFileVisible function

### DIFF
--- a/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
@@ -8,7 +8,7 @@ Feature: deleting files and folders
     And user "Alice" has logged in using the webUI
     And the user reloads the current page of the webUI
 
-  @smokeTest @ocisSmokeTest @disablePreviews @skipOnXGAPortraitResolution
+  @smokeTest @ocisSmokeTest @disablePreviews
   Scenario: Delete files & folders one by one and check its existence after page reload
     Given user "Alice" has created folder "simple-empty-folder" in the server
     And user "Alice" has created folder "simple-folder" in the server

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -12,7 +12,7 @@ Feature: Sharing files and folders with internal users
       | Brian    |
     And user "Brian" has created folder "simple-folder" in the server
 
-  @smokeTest @issue-ocis-2260 @ocisSmokeTest @disablePreviews @skipOnXGAPortraitResolution
+  @smokeTest @issue-ocis-2260 @ocisSmokeTest @disablePreviews
   Scenario Outline: share a file & folder with another internal user
     Given user "Brian" has created file "testimage.jpg" in the server
     And user "Brian" has created file "simple-folder/lorem.txt" in the server

--- a/tests/acceptance/features/webUISharingInternalUsersToRoot/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersToRoot/shareWithUsers.feature
@@ -10,7 +10,7 @@ Feature: Sharing files and folders with internal users
       | Alice    |
       | Brian    |
 
-  @smokeTest @disablePreviews @skipOnXGAPortraitResolution
+  @smokeTest @disablePreviews
   Scenario Outline: share a file & folder with another internal user
     Given the setting "shareapi_auto_accept_share" of app "core" has been set to "yes" in the server
     And user "Brian" has created folder "simple-folder" in the server

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -353,26 +353,7 @@ module.exports = {
       await this.checkFileName(fileName, elementType)
       const rowSelector = this.getFileRowSelectorByFileName(fileName, elementType)
       await appSideBar.closeSidebarIfOpen()
-
-      let rowElementId = null
-      await this.waitForElementPresent(
-        { selector: rowSelector, locateStrategy: 'xpath' },
-        (result) => {
-          rowElementId = result.WebdriverElementId
-        }
-      )
-      let offset = 0
-      await this.api.elementIdLocation(rowElementId, (result) => {
-        offset = result.value.y
-      })
-      let firstRowElementId = null
-      await this.waitForElementPresent('@fileRow', (result) => {
-        firstRowElementId = result.WebdriverElementId
-      })
-      await this.api.elementIdLocation(firstRowElementId, (result) => {
-        offset -= result.value.y
-      })
-      this.api.execute('scrollTo(0,' + offset + ')')
+      await this.waitForElementPresent({ selector: rowSelector, locateStrategy: 'xpath' })
     },
     checkFileName: async function (fileName, elementType = 'any') {
       const fileSelector = this.getFileSelectorByFileName(fileName, elementType)

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -353,7 +353,7 @@ module.exports = {
       await this.checkFileName(fileName, elementType)
       const rowSelector = this.getFileRowSelectorByFileName(fileName, elementType)
       await appSideBar.closeSidebarIfOpen()
-      await this.waitForElementPresent({ selector: rowSelector, locateStrategy: 'xpath' })
+      await this.waitForElementVisible({ selector: rowSelector, locateStrategy: 'xpath' })
     },
     checkFileName: async function (fileName, elementType = 'any') {
       const fileSelector = this.getFileSelectorByFileName(fileName, elementType)


### PR DESCRIPTION
## Description
The issue with #6594 was that different files/folders were selected for actions.
This was due to scrolling from `waitForFileVisible`. Custom scrolling is not required as the Nightwatch APIs will scroll elements into view before performing actions.

## Related Issue
Fixes https://github.com/owncloud/web/issues/6594

## Motivation and Context

## How Has This Been Tested?
- test environment: local

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
