### PR TITLE
[tests-only][full-ci]Fix e2e intermittent failure

### DIFF
--- a/tests/e2e/support/page/files/allFiles.ts
+++ b/tests/e2e/support/page/files/allFiles.ts
@@ -152,10 +152,18 @@ export class AllFilesPage {
         page.waitForResponse((resp) => resp.url().includes('sharees') && resp.status() === 200),
         shareInputLocator.fill(user.id)
       ])
-      await shareInputLocator.focus()
-      await page.waitForSelector('.vs--open')
-      await page.locator('#files-share-invite-input').press('Enter')
 
+      // sometimes the 'locator.fill()' doesn't work for shareInputLocator
+      // check if fill worked
+      // if not try again
+      if ((await shareInputLocator.getAttribute('value')) !== user.displayName) {
+        await shareInputLocator.fill(user.id)
+      }
+      await page
+        .locator(
+          `//div[contains(@data-testid, "recipient-autocomplete-item")]//span[text()="${user.displayName}"]`
+        )
+        .click()
       await page.locator('//*[@id="files-collaborators-role-button-new"]').click()
       await page.locator(`//*[@id="files-role-${role}"]`).click()
     }


### PR DESCRIPTION
## Description
Fixes intermittent failure on e2e tests

Issue in 
- shareFileJourney.feature ( **`typed text gets cleared on collaborator input box sometime.Problem with Locator.fill("some input")`**)

Related to
https://github.com/owncloud/web/issues/6596