### PR TITLE
Improve resource loading within spaces

### DIFF
--- a/changelog/unreleased/enhancement-improve-space-resource-loading
+++ b/changelog/unreleased/enhancement-improve-space-resource-loading
@@ -2,7 +2,7 @@ Enhancement: Improve resource loading within spaces
 
 We've improved the loading of resources within a space. This enhances performance and overall stability within spaces.
 
-* A new parameter was introduced to determine if a space needs to be fetched or not. Route changes within a space do not require the space the be fetched again. This also ensures that the space image and readme won't be fetched in subfolders.
+* The loading task will determine if a space needs to be fetched or not. Route changes within a space do not require the space the be fetched again. This also ensures that the space image and readme won't be fetched when navigating into subfolders.
 * The space now gets set at the end of the loading task. This ensures that the space task has finished as soon as the image and readme get loaded.
 
 https://github.com/owncloud/web/pull/6601

--- a/changelog/unreleased/enhancement-improve-space-resource-loading
+++ b/changelog/unreleased/enhancement-improve-space-resource-loading
@@ -1,0 +1,8 @@
+Enhancement: Improve resource loading within spaces
+
+We've improved the loading of resources within a space. This enhances performance and overall stability within spaces.
+
+* A new parameter was introduced to determine if a space needs to be fetched or not. Route changes within a space do not require the space the be fetched again. This also ensures that the space image and readme won't be fetched in subfolders.
+* The space now gets set at the end of the loading task. This ensures that the space task has finished as soon as the image and readme get loaded.
+
+https://github.com/owncloud/web/pull/6601

--- a/packages/web-app-files/src/services/folder/loaderProject.ts
+++ b/packages/web-app-files/src/services/folder/loaderProject.ts
@@ -14,11 +14,11 @@ export class FolderLoaderProject implements FolderLoader {
     const router = context.router
     const store = context.store
 
-    return useTask(function* (signal1, signal2, ref, sameRoute, path = null, fetchSpace = true) {
+    return useTask(function* (signal1, signal2, ref, sameRoute, path = null) {
       ref.CLEAR_CURRENT_FILES_LIST()
 
       let space
-      if (fetchSpace) {
+      if (!sameRoute) {
         const graphClient = clientService.graphAuthenticated(
           store.getters.configuration.server,
           store.getters.getToken
@@ -63,7 +63,7 @@ export class FolderLoaderProject implements FolderLoader {
         currentFolder: currentFolder?.path
       })
 
-      if (fetchSpace) {
+      if (!sameRoute) {
         ref.space = space
       }
     })

--- a/packages/web-app-files/src/views/spaces/Project.vue
+++ b/packages/web-app-files/src/views/spaces/Project.vue
@@ -288,12 +288,12 @@ export default {
   },
   watch: {
     $route: {
-      handler: function (to, from) {
+      handler: async function (to, from) {
         const sameRoute = to.name === from?.name
         const sameItem = to.params?.item === from?.params?.item
 
         if ((!sameRoute || !sameItem) && from) {
-          this.loadResourcesTask.perform(this, sameRoute, to.params.item)
+          await this.loadResourcesTask.perform(this, sameRoute, to.params.item, false)
         }
 
         if (this.$refs.markdownContainer) {

--- a/packages/web-app-files/src/views/spaces/Project.vue
+++ b/packages/web-app-files/src/views/spaces/Project.vue
@@ -289,11 +289,11 @@ export default {
   watch: {
     $route: {
       handler: async function (to, from) {
-        const sameRoute = to.name === from?.name
+        const sameRoute = to.name === from?.name && to.params?.storageId === from?.params?.storageId
         const sameItem = to.params?.item === from?.params?.item
 
         if ((!sameRoute || !sameItem) && from) {
-          await this.loadResourcesTask.perform(this, sameRoute, to.params.item, false)
+          await this.loadResourcesTask.perform(this, sameRoute, to.params.item)
         }
 
         if (this.$refs.markdownContainer) {


### PR DESCRIPTION
## Description
I recently noticed some issues when navigating within spaces when is comes to loading the image & readme also also (once again) the resize observer. So I improved the loading of resources within a space. This enhances performance and overall stability within spaces.

* A new parameter was introduced to determine if a space needs to be fetched or not. Route changes within a space do not require the space to be fetched again. This also ensures that the space image and readme won't be fetched in subfolders.
* The space now gets set at the end of the loading task. This ensures that the space task has finished as soon as the image and readme get loaded.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
