### PR TITLE
Implement the share inheritance indicators

### DIFF
--- a/changelog/unreleased/enhancement-share-inheritance-indicators
+++ b/changelog/unreleased/enhancement-share-inheritance-indicators
@@ -1,0 +1,6 @@
+Enhancement: Share inheritance indicators
+
+We've implemented the share inheritance indicators in the share sidebar panel. They indicate whether a resource is shared indirectly via one of its parent folders.
+
+https://github.com/owncloud/web/pull/6613
+https://github.com/owncloud/web/issues/6528

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
@@ -45,7 +45,7 @@
           <span v-if="sharedParentRoute" class="oc-resource-indicators oc-text-truncate">
             <span class="oc-mx-s">·</span>
             <router-link
-              v-oc-tooltip="$gettext('Navigate to inheriting folder')"
+              v-oc-tooltip="$gettext('Navigate to parent folder')"
               class="parent-folder oc-text-truncate"
               :to="sharedParentRoute"
             >

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
@@ -36,12 +36,24 @@
           />
           <span class="oc-invisible-sr" v-text="screenreaderShareDisplayName" />
         </p>
-        <p class="oc-m-rm">
+        <p class="oc-m-rm oc-flex">
           <span
             aria-hidden="true"
             class="files-collaborators-collaborator-share-type"
             v-text="shareTypeText"
           />
+          <span v-if="sharedParentRoute" class="oc-resource-indicators oc-text-truncate">
+            <span class="oc-mx-s">·</span>
+            <router-link
+              v-oc-tooltip="$gettext('Navigate to inheriting folder')"
+              class="parent-folder oc-text-truncate"
+              :to="sharedParentRoute"
+            >
+              <span class="text" v-text="$gettext('via')" />
+              <oc-icon name="folder-2" size="small" fill-type="line" class="oc-px-xs" />
+              <span class="text oc-text-truncate" v-text="sharedParentDir" />
+            </router-link>
+          </span>
           <span class="oc-invisible-sr" v-text="screenreaderShareDetails" />
         </p>
         <p v-if="hasExpirationDate" class="oc-m-rm">
@@ -111,6 +123,10 @@ export default {
     modifiable: {
       type: Boolean,
       default: false
+    },
+    sharedParentRoute: {
+      type: Object,
+      default: null
     }
   },
   setup() {
@@ -229,6 +245,10 @@ export default {
 
     graphClient() {
       return clientService.graphAuthenticated(this.configuration.server, this.getToken)
+    },
+
+    sharedParentDir() {
+      return this.sharedParentRoute?.params?.item.split('/').pop()
     }
   },
   methods: {

--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -67,7 +67,7 @@ import { watch, computed } from '@vue/composition-api'
 import { useStore, useDebouncedRef } from 'web-pkg/src/composables'
 import { textUtils } from '../../../helpers/textUtils'
 import { getParentPaths } from '../../../helpers/path'
-import path, { dirname } from 'path'
+import { dirname } from 'path'
 import InviteCollaboratorForm from './InviteCollaborator/InviteCollaboratorForm.vue'
 import CollaboratorListItem from './Collaborators/ListItem.vue'
 import { ShareTypes } from '../../../helpers/share'
@@ -368,30 +368,22 @@ export default {
       })
     },
     getSharedParentRoute(parentShare) {
-      let currentPath = this.highlightedFile.path
-      if (!currentPath || parentShare.path === currentPath) {
+      if (!parentShare.indirect) {
         return null
       }
 
-      while (currentPath !== '/') {
-        const share = this.sharesTree[currentPath]
-        if (
-          share !== undefined &&
-          share[0] !== undefined &&
-          parentShare.collaborator.name === share[0].collaborator.name
-        ) {
-          if (isLocationSpacesActive(this.$router, 'files-spaces-project')) {
-            return createLocationSpaces('files-spaces-project', {
-              params: { storageId: this.$route.params.storageId, item: currentPath }
-            })
-          }
-
-          return createLocationSpaces('files-spaces-personal-home', {
-            params: { item: currentPath }
+      if (this.sharesTree[parentShare.path]) {
+        if (isLocationSpacesActive(this.$router, 'files-spaces-project')) {
+          return createLocationSpaces('files-spaces-project', {
+            params: { storageId: this.$route.params.storageId, item: parentShare.path }
           })
         }
-        currentPath = path.dirname(currentPath)
+
+        return createLocationSpaces('files-spaces-personal-home', {
+          params: { item: parentShare.path }
+        })
       }
+
       return null
     }
   }

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/ListItem.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/ListItem.spec.js
@@ -20,7 +20,8 @@ const selectors = {
   collaboratorName: '.files-collaborators-collaborator-name',
   shareType: '.files-collaborators-collaborator-share-type',
   collaboratorRole: '.files-collaborators-collaborator-role',
-  collaboratorEdit: '.files-collaborators-collaborator-edit'
+  collaboratorEdit: '.files-collaborators-collaborator-edit',
+  shareInheritanceIndicators: '.oc-resource-indicators'
 }
 
 describe('Collaborator ListItem component', () => {
@@ -90,6 +91,17 @@ describe('Collaborator ListItem component', () => {
       expect(wrapper.find(selectors.collaboratorEdit).exists()).toBeFalsy()
     })
   })
+  describe('share inheritance indicators', () => {
+    it('show when sharedParentRoute is given', () => {
+      const wrapper = createWrapper({ sharedParentRoute: { params: { item: '/folder' } } })
+      expect(wrapper.find(selectors.shareInheritanceIndicators).exists()).toBeTruthy()
+      expect(wrapper).toMatchSnapshot()
+    })
+    it('do not show when sharedParentRoute is not given', () => {
+      const wrapper = createWrapper()
+      expect(wrapper.find(selectors.shareInheritanceIndicators).exists()).toBeFalsy()
+    })
+  })
 })
 
 function createWrapper({
@@ -100,7 +112,8 @@ function createWrapper({
     additionalInfo: 'brian@owncloud.com'
   },
   role = peopleRoleViewerFolder,
-  modifiable = true
+  modifiable = true,
+  sharedParentRoute = null
 } = {}) {
   return mount(ListItem, {
     store: new Vuex.Store({
@@ -124,7 +137,8 @@ function createWrapper({
         shareType,
         role
       },
-      modifiable
+      modifiable,
+      sharedParentRoute
     },
     localVue,
     stubs: {

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/ListItem.spec.js.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/ListItem.spec.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Collaborator ListItem component share inheritance indicators show when sharedParentRoute is given 1`] = `
+<div data-testid="collaborator-user-item-brian" class="files-collaborators-collaborator oc-flex oc-flex-middle oc-py-xs oc-flex-between">
+  <div class="oc-width-2-3 oc-flex oc-flex-middle" style="gap: 10px;">
+    <avatar-image-stub userid="brian" user-name="Brian Murphy" width="48" class="files-collaborators-collaborator-indicator"></avatar-image-stub>
+    <div class="oc-text-truncate">
+      <p class="oc-text-bold oc-text-truncate oc-m-rm"><span aria-hidden="true" class="files-collaborators-collaborator-name">Brian Murphy</span> <span aria-hidden="true" class="files-collaborators-collaborator-additional-info"> (brian@owncloud.com)</span> <span class="oc-invisible-sr">Share receiver name: Brian Murphy (brian@owncloud.com)</span></p>
+      <p class="oc-m-rm oc-flex"><span aria-hidden="true" class="files-collaborators-collaborator-share-type">User</span> <span class="oc-resource-indicators oc-text-truncate"><span class="oc-mx-s">·</span>
+        <router-link-stub to="[object Object]" class="parent-folder oc-text-truncate"><span class="text">via</span>
+          <oc-icon-stub name="folder-2" size="small" fill-type="line" class="oc-px-xs"></oc-icon-stub> <span class="text oc-text-truncate">folder</span>
+        </router-link-stub>
+        </span> <span class="oc-invisible-sr">Share type: User</span>
+      </p>
+      <!---->
+    </div>
+  </div>
+  <div class="oc-width-1-3 oc-flex oc-flex-nowrap oc-flex-right oc-flex-middle">
+    <role-dropdown-stub resource="[object Object]" existingrole="[object Object]" existingpermissions="" allowsharepermission="true" class="files-collaborators-collaborator-role"></role-dropdown-stub>
+    <edit-dropdown-stub sharecategory="user" data-testid="collaborator-edit" class="files-collaborators-collaborator-edit"></edit-dropdown-stub>
+  </div>
+</div>
+`;

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/ListItem.spec.js.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/ListItem.spec.js.snap
@@ -16,7 +16,7 @@ exports[`Collaborator ListItem component share inheritance indicators show when 
     </div>
   </div>
   <div class="oc-width-1-3 oc-flex oc-flex-nowrap oc-flex-right oc-flex-middle">
-    <role-dropdown-stub resource="[object Object]" existingrole="[object Object]" existingpermissions="" allowsharepermission="true" class="files-collaborators-collaborator-role"></role-dropdown-stub>
+    <role-dropdown-stub resource="[object Object]" existingrole="[object Object]" existingpermissions="" class="files-collaborators-collaborator-role"></role-dropdown-stub>
     <edit-dropdown-stub sharecategory="user" data-testid="collaborator-edit" class="files-collaborators-collaborator-edit"></edit-dropdown-stub>
   </div>
 </div>

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.js
@@ -114,7 +114,7 @@ describe('FileShares', () => {
     it('correctly passes the shared parent route to the collaborator list item', () => {
       const wrapper = getShallowMountedWrapper({
         user,
-        outgoingCollaborators: collaborators
+        outgoingCollaborators: [{ ...Collaborators[0], indirect: true }]
       })
       expect(wrapper).toMatchSnapshot()
     })
@@ -203,8 +203,6 @@ const storeOptions = (data) => {
     owner = user
   }
 
-  const highlightedFile = 'testfile.jpg'
-
   return {
     state: {
       user
@@ -213,17 +211,12 @@ const storeOptions = (data) => {
       Files: {
         state: {
           incomingShares: incomingCollaborators,
-          sharesTree: { [`/${highlightedFile}`]: [Collaborators[0]] }
+          sharesTree: { [Collaborators[0].path]: [Collaborators[0]] }
         },
         namespaced: true,
         getters: {
           highlightedFile: () => {
-            return getResource({
-              filename: highlightedFile.split('.')[0],
-              extension: highlightedFile.split('.')[1],
-              type: 'file',
-              canShare
-            })
+            return getResource({ filename: 'testfile', extension: 'jpg', type: 'file', canShare })
           },
           currentFileOutgoingCollaborators: () => outgoingCollaborators,
           currentFileOutgoingSharesLoading: () => false,

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.js
@@ -111,6 +111,13 @@ describe('FileShares', () => {
       await wrapper.vm.$nextTick()
       expect(spyOnReloadShares).toHaveBeenCalledTimes(1)
     })
+    it('correctly passes the shared parent route to the collaborator list item', () => {
+      const wrapper = getShallowMountedWrapper({
+        user,
+        outgoingCollaborators: collaborators
+      })
+      expect(wrapper).toMatchSnapshot()
+    })
   })
 
   describe('current space', () => {
@@ -196,6 +203,8 @@ const storeOptions = (data) => {
     owner = user
   }
 
+  const highlightedFile = 'testfile.jpg'
+
   return {
     state: {
       user
@@ -204,12 +213,17 @@ const storeOptions = (data) => {
       Files: {
         state: {
           incomingShares: incomingCollaborators,
-          sharesTree: []
+          sharesTree: { [`/${highlightedFile}`]: [Collaborators[0]] }
         },
         namespaced: true,
         getters: {
           highlightedFile: () => {
-            return getResource({ filename: 'testfile', extension: 'jpg', type: 'file', canShare })
+            return getResource({
+              filename: highlightedFile.split('.')[0],
+              extension: highlightedFile.split('.')[1],
+              type: 'file',
+              canShare
+            })
           },
           currentFileOutgoingCollaborators: () => outgoingCollaborators,
           currentFileOutgoingSharesLoading: () => false,
@@ -264,7 +278,15 @@ function getMountedWrapper(data, loading = false) {
     mocks: {
       sharesLoading: loading,
       $route: {
-        params: {}
+        params: { storageId: 1 }
+      },
+      $router: {
+        currentRoute: { name: 'some-route' },
+        resolve: (r) => {
+          return {
+            href: r.name
+          }
+        }
       }
     },
     stubs: {
@@ -290,6 +312,14 @@ function getShallowMountedWrapper(data, loading = false) {
       $route: {
         params: {
           storageId: 1
+        }
+      },
+      $router: {
+        currentRoute: { name: 'some-route' },
+        resolve: (r) => {
+          return {
+            href: r.name
+          }
         }
       }
     }

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/FileShares.spec.js.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/FileShares.spec.js.snap
@@ -18,6 +18,27 @@ exports[`FileShares if currentUser can share initially renders add people dialog
 </div>
 `;
 
+exports[`FileShares if there are collaborators present correctly passes the shared parent route to the collaborator list item 1`] = `
+<div id="oc-files-sharing-sidebar" class="oc-position-relative">
+  <invite-collaborator-form-stub class="oc-my-s"></invite-collaborator-form-stub>
+  <div class="avatars-wrapper oc-flex oc-flex-middle oc-flex-between">
+    <h4 class="oc-text-initial oc-text-bold oc-my-rm">Shared with</h4>
+    <oc-button-stub type="button" size="medium" arialabel="Collapse list of invited people" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" data-testid="collaborators-show-people">
+      <oc-icon-stub name="arrow-up-s" filltype="fill" accessiblelabel="" type="span" size="medium" variation="passive" color=""></oc-icon-stub>
+    </oc-button-stub>
+  </div>
+  <ul id="files-collaborators-list" aria-label="Share receivers" class="oc-list oc-list-divider oc-overflow-hidden oc-m-rm">
+    <li>
+      <collaborator-list-item-stub share="[object Object]" modifiable="true" sharedparentroute="[object Object]"></collaborator-list-item-stub>
+    </li>
+    <li>
+      <collaborator-list-item-stub share="[object Object]" modifiable="true"></collaborator-list-item-stub>
+    </li>
+  </ul>
+  <!---->
+</div>
+`;
+
 exports[`FileShares if there are collaborators present renders sharedWithLabel and sharee list 1`] = `
 <div id="oc-files-sharing-sidebar" class="oc-position-relative">
   <invite-collaborator-form-stub class="oc-my-s"></invite-collaborator-form-stub>
@@ -29,7 +50,7 @@ exports[`FileShares if there are collaborators present renders sharedWithLabel a
   </div>
   <ul id="files-collaborators-list" aria-label="Share receivers" class="oc-list oc-list-divider oc-overflow-hidden oc-m-rm">
     <li>
-      <collaborator-list-item-stub share="[object Object]" modifiable="true"></collaborator-list-item-stub>
+      <collaborator-list-item-stub share="[object Object]" modifiable="true" sharedparentroute="[object Object]"></collaborator-list-item-stub>
     </li>
     <li>
       <collaborator-list-item-stub share="[object Object]" modifiable="true"></collaborator-list-item-stub>

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/FileShares.spec.js.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/FileShares.spec.js.snap
@@ -29,10 +29,7 @@ exports[`FileShares if there are collaborators present correctly passes the shar
   </div>
   <ul id="files-collaborators-list" aria-label="Share receivers" class="oc-list oc-list-divider oc-overflow-hidden oc-m-rm">
     <li>
-      <collaborator-list-item-stub share="[object Object]" modifiable="true" sharedparentroute="[object Object]"></collaborator-list-item-stub>
-    </li>
-    <li>
-      <collaborator-list-item-stub share="[object Object]" modifiable="true"></collaborator-list-item-stub>
+      <collaborator-list-item-stub share="[object Object]" sharedparentroute="[object Object]"></collaborator-list-item-stub>
     </li>
   </ul>
   <!---->
@@ -50,7 +47,7 @@ exports[`FileShares if there are collaborators present renders sharedWithLabel a
   </div>
   <ul id="files-collaborators-list" aria-label="Share receivers" class="oc-list oc-list-divider oc-overflow-hidden oc-m-rm">
     <li>
-      <collaborator-list-item-stub share="[object Object]" modifiable="true" sharedparentroute="[object Object]"></collaborator-list-item-stub>
+      <collaborator-list-item-stub share="[object Object]" modifiable="true"></collaborator-list-item-stub>
     </li>
     <li>
       <collaborator-list-item-stub share="[object Object]" modifiable="true"></collaborator-list-item-stub>


### PR DESCRIPTION
## Description
We've implemented the share inheritance indicators in the share sidebar panel. They indicate whether a resource is shared indirectly via one of its parent folders.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/6528

## Screenshots:
![image](https://user-images.githubusercontent.com/50302941/158812798-c4129109-6fd6-42b8-8a1d-86c1fc039689.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
