### PR TITLE
fix flaky share accept e2e test action

### DIFF
--- a/tests/e2e/support/objects/app-files/share/actions.ts
+++ b/tests/e2e/support/objects/app-files/share/actions.ts
@@ -69,12 +69,17 @@ export type acceptShareArgs = {
 
 export const acceptShare = async (args: acceptShareArgs): Promise<void> => {
   const { name, page } = args
-  await page
-    .locator(
-      `//*[@data-test-resource-name="${name}"]/ancestor::tr//button[contains(@class, "file-row-share-status-accept")]`
-    )
-    .click()
-  await page.waitForResponse((resp) => resp.url().includes('shares') && resp.status() === 200)
+  await Promise.all([
+    page
+      .locator(
+        `//*[@data-test-resource-name="${name}"]/ancestor::tr//button[contains(@class, "file-row-share-status-accept")]`
+      )
+      .click(),
+    page.waitForResponse((resp) => resp.url().includes('shares') && resp.status() === 200),
+    page
+      .locator(`#files-shared-with-me-shares-table [data-test-resource-name="${args.name}"]`)
+      .waitFor()
+  ])
 }
 
 /**/

--- a/tests/e2e/support/objects/app-files/share/index.ts
+++ b/tests/e2e/support/objects/app-files/share/index.ts
@@ -11,8 +11,6 @@ import {
   declineShareArgs,
   declineShare
 } from './actions'
-import path from 'path'
-import { clickResource } from '../resource/actions'
 
 export class Share {
   #page: Page
@@ -30,23 +28,7 @@ export class Share {
   }
 
   async accept(args: Omit<acceptShareArgs, 'page'>): Promise<void> {
-    const startUrl = this.#page.url()
     await acceptShare({ page: this.#page, ...args })
-
-    /**
-     * the next part exists to trick the backend, in some cases accepting a share can take longer in the backend.
-     * therefore we're waiting for the resource to exist, navigate into it (if resource is a folder) to be really sure its there and then come back.
-     * If the logic is needed more often it can be refactored into a shared helper.
-     */
-    await this.#page
-      .locator(`#files-shared-with-me-shares-table [data-test-resource-name="${args.name}"]`)
-      .waitFor()
-
-    if (!path.extname(args.name)) {
-      await clickResource({ page: this.#page, path: args.name })
-    }
-
-    await this.#page.goto(startUrl)
   }
 
   async declineShare(args: Omit<declineShareArgs, 'page'>): Promise<void> {


### PR DESCRIPTION
## Description
Visiting the personal space failed often in the e2e tests after a share was accepted. This PR fixes that behavior by removing an earlier workaround which is no longer needed.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/6610