### PR TITLE
[full-ci] Multiple fixes

### DIFF
--- a/changelog/unreleased/enhancement-editor-role
+++ b/changelog/unreleased/enhancement-editor-role
@@ -1,0 +1,5 @@
+Enhancement: Editor role for single file public links
+
+Allow creating a public link with editor role for a single file. Only available in oCIS.
+
+https://github.com/owncloud/web/pull/6618

--- a/changelog/unreleased/enhancement-optional-ui-elements
+++ b/changelog/unreleased/enhancement-optional-ui-elements
@@ -1,0 +1,12 @@
+Enhancement: Make some UI elements/actions optional
+
+Make renaming a share, permanently deleting files and showing the custom permissions role optional via capabilities.
+By default, all of these options are enabled/showed.
+
+Capabilities:
+* capabilities.files_sharing.can_rename
+* capabilities.files.permanent_deletion
+* capabilities.files_sharing.allow_custom
+
+https://github.com/owncloud/web/pull/6618
+https://github.com/owncloud/web/issues/6324

--- a/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkEdit.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkEdit.vue
@@ -190,7 +190,7 @@ export default {
   },
   computed: {
     ...mapGetters('Files', ['highlightedFile']),
-    ...mapGetters(['getToken', 'capabilities']),
+    ...mapGetters(['getToken', 'capabilities', 'isOcis']),
     ...mapState('Files', ['publicLinkInEdit']),
 
     selectedRole() {
@@ -219,7 +219,7 @@ export default {
     },
 
     availableRoleOptions() {
-      return LinkShareRoles.list(this.highlightedFile.isFolder).map((r) =>
+      return LinkShareRoles.list(this.highlightedFile.isFolder, this.isOcis).map((r) =>
         this.convertRoleToSelectOption(r)
       )
     },

--- a/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkEdit.vue
+++ b/packages/web-app-files/src/components/SideBar/Links/PublicLinks/LinkEdit.vue
@@ -190,7 +190,7 @@ export default {
   },
   computed: {
     ...mapGetters('Files', ['highlightedFile']),
-    ...mapGetters(['getToken', 'capabilities', 'isOcis']),
+    ...mapGetters(['getToken', 'capabilities']),
     ...mapState('Files', ['publicLinkInEdit']),
 
     selectedRole() {
@@ -219,9 +219,10 @@ export default {
     },
 
     availableRoleOptions() {
-      return LinkShareRoles.list(this.highlightedFile.isFolder, this.isOcis).map((r) =>
-        this.convertRoleToSelectOption(r)
-      )
+      return LinkShareRoles.list(
+        this.highlightedFile.isFolder,
+        this.capabilities.files_sharing?.public?.can_edit
+      ).map((r) => this.convertRoleToSelectOption(r))
     },
 
     $_expirationDate() {

--- a/packages/web-app-files/src/components/SideBar/Shares/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/InviteCollaborator/InviteCollaboratorForm.vue
@@ -227,6 +227,9 @@ export default {
         return []
       }
 
+      // Allow advanced queries
+      query = query.split(':')[1] || query
+
       return recipients.filter(
         (recipient) =>
           recipient.value.shareType === ShareTypes.remote.value ||

--- a/packages/web-app-files/src/components/SideBar/Shares/RoleDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/RoleDropdown.vue
@@ -75,6 +75,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import get from 'lodash-es/get'
 import RoleItem from '../Shared/RoleItem.vue'
 import {
@@ -120,6 +121,8 @@ export default {
     }
   },
   computed: {
+    ...mapGetters(['capabilities']),
+
     roleButtonId() {
       if (this.shareId) {
         return `files-collaborators-role-button-${this.shareId}-${uuid.v4()}`
@@ -145,7 +148,10 @@ export default {
       if (this.resourceIsSpace) {
         return SpacePeopleShareRoles.list()
       }
-      return PeopleShareRoles.list(this.resource.isFolder)
+      return PeopleShareRoles.list(
+        this.resource.isFolder,
+        this.capabilities.files_sharing.allow_custom !== false
+      )
     },
     availablePermissions() {
       return this.customPermissionsRole.permissions(this.allowSharePermission)

--- a/packages/web-app-files/src/components/SideBar/Shares/RoleDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/RoleDropdown.vue
@@ -150,7 +150,7 @@ export default {
       }
       return PeopleShareRoles.list(
         this.resource.isFolder,
-        this.capabilities.files_sharing.allow_custom !== false
+        this.capabilities?.files_sharing?.allow_custom !== false
       )
     },
     availablePermissions() {

--- a/packages/web-app-files/src/helpers/resources.js
+++ b/packages/web-app-files/src/helpers/resources.js
@@ -439,6 +439,9 @@ function _buildLink(link) {
     case 1: // read (1)
       description = $gettext('Viewer')
       break
+    case 3: // read (1) + update (2)
+      description = $gettext('Editor')
+      break
     case 5: // read (1) + create (4)
       description = $gettext('Contributor')
       break

--- a/packages/web-app-files/src/helpers/share/role.ts
+++ b/packages/web-app-files/src/helpers/share/role.ts
@@ -259,21 +259,21 @@ export abstract class PeopleShareRoles {
     peopleRoleViewerFile,
     peopleRoleViewerFolder,
     peopleRoleEditorFile,
-    peopleRoleEditorFolder,
-    peopleRoleCustomFile,
-    peopleRoleCustomFolder
+    peopleRoleEditorFolder
   ]
 
-  static list(isFolder: boolean): ShareRole[] {
-    return this.all.filter((r) => r.folder === isFolder)
+  static readonly allWithCustom = [...this.all, peopleRoleCustomFile, peopleRoleCustomFolder]
+
+  static list(isFolder: boolean, hasCustom: boolean): ShareRole[] {
+    return (hasCustom ? this.allWithCustom : this.all).filter((r) => r.folder === isFolder)
   }
 
   static custom(isFolder: boolean): ShareRole {
-    return this.all.find((r) => r.folder === isFolder && r.hasCustomPermissions)
+    return this.allWithCustom.find((r) => r.folder === isFolder && r.hasCustomPermissions)
   }
 
   static getByBitmask(bitmask: number, isFolder: boolean, allowSharing: boolean): ShareRole {
-    const role = this.all
+    const role = this.allWithCustom
       .filter((r) => !r.hasCustomPermissions)
       .find((r) => r.folder === isFolder && r.bitmask(allowSharing) === bitmask)
     return role || this.custom(isFolder)

--- a/packages/web-app-files/src/helpers/share/role.ts
+++ b/packages/web-app-files/src/helpers/share/role.ts
@@ -193,6 +193,13 @@ export const linkRoleContributorFolder = new LinkShareRole(
   $gettext('contributor'),
   [SharePermissions.read, SharePermissions.create]
 )
+export const linkRoleEditorFile = new LinkShareRole(
+  'editor',
+  false,
+  $gettext('Editor'),
+  $gettext('editor'),
+  [SharePermissions.read, SharePermissions.update]
+)
 export const linkRoleEditorFolder = new LinkShareRole(
   'editor',
   true,
@@ -282,12 +289,13 @@ export abstract class LinkShareRoles {
     linkRoleUploaderFolder
   ]
 
-  static list(isFolder: boolean): ShareRole[] {
-    return this.all.filter((r) => r.folder === isFolder)
+  static list(isFolder: boolean, isOcis: boolean): ShareRole[] {
+    return [...this.all, ...(isOcis ? [linkRoleEditorFile] : [])].filter((r) => r.folder === isFolder)
   }
 
   static getByBitmask(bitmask: number, isFolder: boolean): ShareRole {
-    return this.all.find((r) => r.folder === isFolder && r.bitmask(false) === bitmask)
+    return [...this.all, linkRoleEditorFile] // Always return all roles
+      .find((r) => r.folder === isFolder && r.bitmask(false) === bitmask)
   }
 }
 
@@ -316,6 +324,7 @@ const linkRoleDescriptions = {
   [linkRoleContributorFolder.bitmask(false)]: $gettext(
     'Recipients can view, download and upload contents.'
   ),
+  [linkRoleEditorFile.bitmask(false)]: $gettext('Recipients can view, download and edit contents.'),
   [linkRoleEditorFolder.bitmask(false)]: $gettext(
     'Recipients can view, download, edit, delete and upload contents.'
   ),

--- a/packages/web-app-files/src/helpers/share/role.ts
+++ b/packages/web-app-files/src/helpers/share/role.ts
@@ -264,7 +264,7 @@ export abstract class PeopleShareRoles {
 
   static readonly allWithCustom = [...this.all, peopleRoleCustomFile, peopleRoleCustomFolder]
 
-  static list(isFolder: boolean, hasCustom: boolean): ShareRole[] {
+  static list(isFolder: boolean, hasCustom = true): ShareRole[] {
     return (hasCustom ? this.allWithCustom : this.all).filter((r) => r.folder === isFolder)
   }
 
@@ -289,8 +289,10 @@ export abstract class LinkShareRoles {
     linkRoleUploaderFolder
   ]
 
-  static list(isFolder: boolean, isOcis: boolean): ShareRole[] {
-    return [...this.all, ...(isOcis ? [linkRoleEditorFile] : [])].filter((r) => r.folder === isFolder)
+  static list(isFolder: boolean, isOcis = false): ShareRole[] {
+    return [...this.all, ...(isOcis ? [linkRoleEditorFile] : [])].filter(
+      (r) => r.folder === isFolder
+    )
   }
 
   static getByBitmask(bitmask: number, isFolder: boolean): ShareRole {

--- a/packages/web-app-files/src/helpers/share/role.ts
+++ b/packages/web-app-files/src/helpers/share/role.ts
@@ -289,8 +289,8 @@ export abstract class LinkShareRoles {
     linkRoleUploaderFolder
   ]
 
-  static list(isFolder: boolean, isOcis = false): ShareRole[] {
-    return [...this.all, ...(isOcis ? [linkRoleEditorFile] : [])].filter(
+  static list(isFolder: boolean, canEditFile = false): ShareRole[] {
+    return [...this.all, ...(canEditFile ? [linkRoleEditorFile] : [])].filter(
       (r) => r.folder === isFolder
     )
   }

--- a/packages/web-app-files/src/mixins/actions/delete.js
+++ b/packages/web-app-files/src/mixins/actions/delete.js
@@ -6,7 +6,7 @@ export default {
   mixins: [MixinDeleteResources],
   computed: {
     ...mapState('Files', ['currentFolder']),
-    ...mapGetters('capabilities'),
+    ...mapGetters(['capabilities']),
     $_delete_items() {
       return [
         {
@@ -47,7 +47,7 @@ export default {
             ) {
               return false
             }
-            if (this.capabilities.files.permanent_deletion === false) {
+            if (this.capabilities?.files?.permanent_deletion === false) {
               return false
             }
             return resources.length > 0

--- a/packages/web-app-files/src/mixins/actions/delete.js
+++ b/packages/web-app-files/src/mixins/actions/delete.js
@@ -1,11 +1,12 @@
 import MixinDeleteResources from '../../mixins/deleteResources'
-import { mapState } from 'vuex'
+import { mapState, mapGetters } from 'vuex'
 import { isLocationPublicActive, isLocationSpacesActive, isLocationTrashActive } from '../../router'
 
 export default {
   mixins: [MixinDeleteResources],
   computed: {
     ...mapState('Files', ['currentFolder']),
+    ...mapGetters('capabilities'),
     $_delete_items() {
       return [
         {
@@ -44,6 +45,9 @@ export default {
               !isLocationTrashActive(this.$router, 'files-trash-personal') &&
               !isLocationTrashActive(this.$router, 'files-trash-spaces-project')
             ) {
+              return false
+            }
+            if (this.capabilities.files.permanent_deletion === false) {
               return false
             }
             return resources.length > 0

--- a/packages/web-app-files/src/mixins/actions/emptyTrashBin.js
+++ b/packages/web-app-files/src/mixins/actions/emptyTrashBin.js
@@ -5,7 +5,7 @@ import { buildWebDavFilesTrashPath, buildWebDavSpacesTrashPath } from '../../hel
 export default {
   computed: {
     ...mapGetters('Files', ['activeFiles']),
-    ...mapGetters('capabilities'),
+    ...mapGetters(['capabilities']),
     ...mapState(['user']),
     $_emptyTrashBin_items() {
       return [
@@ -21,7 +21,7 @@ export default {
             ) {
               return false
             }
-            if (this.capabilities.files.permanent_deletion === false) {
+            if (this.capabilities?.files?.permanent_deletion === false) {
               return false
             }
             // empty trash bin is not available for individual resources, but only for the trash bin as a whole

--- a/packages/web-app-files/src/mixins/actions/emptyTrashBin.js
+++ b/packages/web-app-files/src/mixins/actions/emptyTrashBin.js
@@ -5,6 +5,7 @@ import { buildWebDavFilesTrashPath, buildWebDavSpacesTrashPath } from '../../hel
 export default {
   computed: {
     ...mapGetters('Files', ['activeFiles']),
+    ...mapGetters('capabilities'),
     ...mapState(['user']),
     $_emptyTrashBin_items() {
       return [
@@ -18,6 +19,9 @@ export default {
               !isLocationTrashActive(this.$router, 'files-trash-personal') &&
               !isLocationTrashActive(this.$router, 'files-trash-spaces-project')
             ) {
+              return false
+            }
+            if (this.capabilities.files.permanent_deletion === false) {
               return false
             }
             // empty trash bin is not available for individual resources, but only for the trash bin as a whole

--- a/packages/web-app-files/src/mixins/actions/rename.js
+++ b/packages/web-app-files/src/mixins/actions/rename.js
@@ -8,7 +8,7 @@ import { isLocationTrashActive, isLocationSharesActive } from '../../router'
 export default {
   computed: {
     ...mapGetters('Files', ['files', 'currentFolder']),
-    ...mapGetters('capabilities'),
+    ...mapGetters(['capabilities']),
 
     $_rename_items() {
       return [
@@ -28,7 +28,7 @@ export default {
             }
             if (
               isLocationSharesActive(this.$router, 'files-shares-with-me') &&
-              this.capabilities.files_sharing.can_rename === false
+              this.capabilities?.files_sharing?.can_rename === false
             ) {
               return false
             }

--- a/packages/web-app-files/src/mixins/actions/rename.js
+++ b/packages/web-app-files/src/mixins/actions/rename.js
@@ -3,11 +3,12 @@ import { mapActions, mapGetters } from 'vuex'
 import { isSameResource } from '../../helpers/resource'
 import { getParentPaths } from '../../helpers/path'
 import { buildResource } from '../../helpers/resources'
-import { isLocationTrashActive } from '../../router'
+import { isLocationTrashActive, isLocationSharesActive } from '../../router'
 
 export default {
   computed: {
     ...mapGetters('Files', ['files', 'currentFolder']),
+    ...mapGetters('capabilities'),
 
     $_rename_items() {
       return [
@@ -22,6 +23,12 @@ export default {
             if (
               isLocationTrashActive(this.$router, 'files-trash-personal') ||
               isLocationTrashActive(this.$router, 'files-trash-spaces-project')
+            ) {
+              return false
+            }
+            if (
+              isLocationSharesActive(this.$router, 'files-shares-with-me') &&
+              this.capabilities.files_sharing.can_rename === false
             ) {
               return false
             }

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/RoleDropdown.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/RoleDropdown.spec.js
@@ -25,6 +25,14 @@ const stubs = {
   'oc-icon': true
 }
 
+const store = new Vuex.Store({
+  getters: {
+    capabilities: () => {
+      return {}
+    }
+  }
+})
+
 // needs differentiation between file and folder type?
 
 describe('RoleDropdown', () => {
@@ -208,6 +216,7 @@ function getMountOptions({ existingRole, shareId, resourceType = 'folder' }) {
       shareId,
       allowSharePermission: true
     },
+    store,
     localVue,
     stubs
   }

--- a/packages/web-app-files/tests/unit/helpers/share/role.spec.ts
+++ b/packages/web-app-files/tests/unit/helpers/share/role.spec.ts
@@ -58,14 +58,14 @@ describe('PeopleShareRoles', () => {
         'all folder related share roles',
         {
           folder: true,
-          result: PeopleShareRoles.all.filter((r) => r.folder === true)
+          result: PeopleShareRoles.allWithCustom.filter((r) => r.folder === true)
         }
       ],
       [
         'all file related share roles',
         {
           folder: false,
-          result: PeopleShareRoles.all.filter((r) => r.folder === false)
+          result: PeopleShareRoles.allWithCustom.filter((r) => r.folder === false)
         }
       ]
     ])('%s', (name: string, { folder, result }) => {

--- a/packages/web-app-files/tests/unit/mixins/actions/delete.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/actions/delete.spec.js
@@ -15,6 +15,14 @@ const Component = {
   mixins: [Delete]
 }
 
+const store = new Vuex.Store({
+  getters: {
+    capabilities: () => {
+      return {}
+    }
+  }
+})
+
 describe('delete', () => {
   describe('computed property "$_delete_items"', () => {
     describe('delete isEnabled property of returned element', () => {
@@ -57,6 +65,7 @@ describe('delete', () => {
 function getWrapper({ deletePermanent = false, invalidLocation = false } = {}) {
   return mount(Component, {
     localVue,
+    store,
     mocks: {
       $router: {
         currentRoute: invalidLocation


### PR DESCRIPTION
As we discussed, I'm trying to push some of our changes, in particular I refactored the code to make some parts optional. 

Renaming a share, permanently deleting files and showing the custom permissions role are now optional. By default, it keeps the same behavior as the current master.

Added the possibility to add "tags" while searching for users (as we discussed).

Also as discussed, I've added the "editor" role for single files public links. This seems not to be possible with oc10, so I've added a check to enable it only for oCIS.
(this needs another fix... I saw the "rename" button on the file and I shouldn't, but at least if fails when I tried to do it)

@elizavetaRa is still working on the css for the drop down menus.

Fixes #6324
Fixes #5913