### PR TITLE
Default to empty object for capabilities in navItem.enabled check

### DIFF
--- a/packages/web-runtime/src/store/navigation.js
+++ b/packages/web-runtime/src/store/navigation.js
@@ -65,7 +65,7 @@ const getters = {
         return true
       }
       try {
-        return navItem.enabled(getters.capabilities)
+        return navItem.enabled(getters.capabilities || {})
       } catch (e) {
         console.error('`enabled` callback on navItem ' + navItem.name + ' threw an error', e)
         return false


### PR DESCRIPTION
## Description
After first page load after login we had console errors during capability checks. Added an empty object as fallback for capabilities to mitigate it. Better solution would of course be to have the capabilities available directly after login... but that's another story.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/6571

## Motivation and Context
Keep browser console clean(er).

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
