### PR TITLE
Fix parent folder rename

### DIFF
--- a/changelog/unreleased/bugfix-rename-parent
+++ b/changelog/unreleased/bugfix-rename-parent
@@ -1,0 +1,6 @@
+Bugfix: Rename parent folder
+
+We fixed the rename option in the parent folder / breadcrumb context menu. It was broken due to malformed webdav paths.
+
+https://github.com/owncloud/web/issues/6516
+https://github.com/owncloud/web/pull/6631

--- a/packages/web-app-files/src/mixins/actions/rename.js
+++ b/packages/web-app-files/src/mixins/actions/rename.js
@@ -53,7 +53,10 @@ export default {
     async $_rename_trigger({ resources }) {
       let parentResources
       if (isSameResource(resources[0], this.currentFolder)) {
-        const parentPaths = getParentPaths(resources[0].path, false)
+        const prefix = resources[0].webDavPath.slice(0, -resources[0].path.length)
+        const parentPaths = getParentPaths(resources[0].path, false).map((path) => {
+          return prefix + path
+        })
         parentResources = await this.$client.files.list(parentPaths[0], 1)
         parentResources = parentResources.map(buildResource)
       }

--- a/packages/web-app-files/tests/unit/mixins/actions/rename.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/actions/rename.spec.js
@@ -9,7 +9,8 @@ localVue.use(Vuex)
 
 const currentFolder = {
   id: 1,
-  path: '/folder'
+  path: '/folder',
+  webDavPath: '/files/admin/folder'
 }
 
 const Component = {
@@ -36,7 +37,7 @@ describe('rename', () => {
     it('should trigger the rename modal window', async () => {
       const wrapper = getWrapper()
       const spyCreateModalStub = jest.spyOn(wrapper.vm, 'createModal')
-      const resources = [{ id: 1 }]
+      const resources = [currentFolder]
       await wrapper.vm.$_rename_trigger({ resources })
       expect(spyCreateModalStub).toHaveBeenCalledTimes(1)
     })
@@ -91,7 +92,7 @@ describe('rename', () => {
 
       const wrapper = getWrapper(promise)
       const spyHideModalStub = jest.spyOn(wrapper.vm, 'hideModal')
-      const resource = { id: 2, path: 'folder' }
+      const resource = { id: 2, path: '/folder', webDavPath: '/files/admin/folder' }
       wrapper.vm.$_rename_renameResource(resource, 'new name')
       await wrapper.vm.$nextTick()
 


### PR DESCRIPTION
## Description
Fetching fileinfo during parent folder rename had malformed webdav paths. Fixed it...

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/6516

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
