### PR TITLE
Fix natural sort order

### DIFF
--- a/changelog/unreleased/bugfix-sort-order
+++ b/changelog/unreleased/bugfix-sort-order
@@ -1,0 +1,6 @@
+Bugfix: Natural sort order
+
+We've fixed the sort order to respect natural sorting again. Also used the chance to make use of `Intl.Collator` instead of `localeCompare` which is considered to be a performance improvement.
+
+https://github.com/owncloud/web/issues/6532
+https://github.com/owncloud/web/pull/6632

--- a/packages/web-app-files/src/composables/sort/useSort.ts
+++ b/packages/web-app-files/src/composables/sort/useSort.ts
@@ -125,23 +125,31 @@ const sortHelper = <T extends SortableItem>(
     return items
   }
   const { sortable } = field
+  const collator = new Intl.Collator(navigator.language, { sensitivity: 'base', numeric: true })
 
   if (sortBy === 'name') {
     const folders = [...items.filter((i) => i.type === 'folder')].sort((a, b) =>
-      compare(a, b, sortBy, sortDir, sortable)
+      compare(a, b, collator, sortBy, sortDir, sortable)
     )
     const files = [...items.filter((i) => i.type !== 'folder')].sort((a, b) =>
-      compare(a, b, sortBy, sortDir, sortable)
+      compare(a, b, collator, sortBy, sortDir, sortable)
     )
     if (sortDir === SortDir.Asc) {
       return folders.concat(files)
     }
     return files.concat(folders)
   }
-  return [...items].sort((a, b) => compare(a, b, sortBy, sortDir, sortable))
+  return [...items].sort((a, b) => compare(a, b, collator, sortBy, sortDir, sortable))
 }
 
-const compare = (a: SortableItem, b: SortableItem, sortBy: string, sortDir: SortDir, sortable) => {
+const compare = (
+  a: SortableItem,
+  b: SortableItem,
+  collator: Intl.Collator,
+  sortBy: string,
+  sortDir: SortDir,
+  sortable
+) => {
   let aValue = a[sortBy]
   let bValue = b[sortBy]
   const modifier = sortDir === SortDir.Asc ? 1 : -1
@@ -163,10 +171,7 @@ const compare = (a: SortableItem, b: SortableItem, sortBy: string, sortDir: Sort
   if (!isNaN(aValue) && !isNaN(bValue)) {
     return (aValue - bValue) * modifier
   }
-  const userLang = navigator.language // FIXME: ts error: || navigator.userLanguage
-  const c = (aValue || '')
-    .toString()
-    .localeCompare((bValue || '').toString(), userLang, { sensitivity: 'base' })
+  const c = collator.compare((aValue || '').toString(), (bValue || '').toString())
   return c * modifier
 }
 

--- a/packages/web-app-files/tests/unit/composables/sort/useSort.spec.ts
+++ b/packages/web-app-files/tests/unit/composables/sort/useSort.spec.ts
@@ -47,7 +47,8 @@ describe('useSort', () => {
       { id: '5', name: 'dir2', path: '', webDavPath: '', time: 7, type: 'folder' },
       { id: '6', name: 'b.png', path: '', webDavPath: '', time: 1 },
       { id: '7', name: 'Dir1', path: '', webDavPath: '', time: 5, type: 'folder' },
-      { id: '8', name: 'dir3', path: '', webDavPath: '', time: 8, type: 'folder' }
+      { id: '8', name: 'dir11', path: '', webDavPath: '', time: 8, type: 'folder' },
+      { id: '9', name: 'dir3', path: '', webDavPath: '', time: 9, type: 'folder' }
     ]
 
     it('sorts resources by name', () => {
@@ -76,6 +77,7 @@ describe('useSort', () => {
           'dir2',
           'dir3',
           'Dir4',
+          'dir11',
           'a.png',
           'A.png',
           'b.png',
@@ -88,6 +90,7 @@ describe('useSort', () => {
           'b.png',
           'a.png',
           'A.png',
+          'dir11',
           'Dir4',
           'dir3',
           'dir2',


### PR DESCRIPTION
## Description
Fix sorting to respect natural sort order again. Also used the chance to switch over to `Intl.Collator` which is considered to be a performance improvement, compared to `localeCompare`. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/6532

## How Has This Been Tested?
Added an example for non-natural order being sorted to natural sort order to the existing unit test for the sorting composable.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
