### PR TITLE
Implement group sharing for resources within spaces

### DIFF
--- a/changelog/unreleased/enhancement-spaces-group-sharing
+++ b/changelog/unreleased/enhancement-spaces-group-sharing
@@ -1,0 +1,6 @@
+Enhancement: Spaces group sharing
+
+Resources within a space can now be shared with user groups. Spaces themselves can't be shared with groups, therefore those have been removed from the autocomplete results when adding members to a space.
+
+https://github.com/owncloud/web/pull/6639
+https://github.com/owncloud/web/issues/6283

--- a/packages/web-app-files/src/components/SideBar/Shares/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/InviteCollaborator/InviteCollaboratorForm.vue
@@ -20,7 +20,8 @@
         <autocomplete-item :item="option" />
       </template>
       <template #no-options>
-        <translate> No users or groups found. </translate>
+        <translate v-if="resourceIsSpace"> No users found. </translate>
+        <translate v-else> No users or groups found. </translate>
       </template>
       <template #selected-option-container="{ option, deselect }">
         <recipient-container
@@ -173,7 +174,12 @@ export default {
             // Inject the correct share type here as the response has always type "user"
             return { ...result, value: { ...result.value, shareType } }
           })
-        const groups = recipients.exact.groups.concat(recipients.groups)
+
+        let groups = []
+        if (!this.resourceIsSpace) {
+          groups = recipients.exact.groups.concat(recipients.groups)
+        }
+
         const remotes = recipients.exact.remotes.concat(recipients.remotes)
 
         this.autocompleteResults = users.concat(groups, remotes).filter((collaborator) => {

--- a/packages/web-app-files/src/store/actions.js
+++ b/packages/web-app-files/src/store/actions.js
@@ -329,11 +329,17 @@ export default {
       displayName
     }
   ) {
+    let spaceRef
+    if (storageId) {
+      spaceRef = `${storageId}${path}`
+    }
+
     if (shareType === ShareTypes.group.value) {
       client.shares
         .shareFileWithGroup(path, shareWith, {
           permissions: permissions,
-          expirationDate: expirationDate
+          expirationDate: expirationDate,
+          spaceRef
         })
         .then((share) => {
           context.commit(
@@ -399,11 +405,6 @@ export default {
           )
         })
       return
-    }
-
-    let spaceRef
-    if (storageId) {
-      spaceRef = `${storageId}${path}`
     }
 
     const remoteShare = shareType === ShareTypes.remote.value


### PR DESCRIPTION
## Description
Resources within a space can now be shared with user groups. Spaces themselves can't be shared with groups, therefore those have been removed from the autocomplete results when adding members to a space.

Needs `owncloud-sdk` version `3.0.0-alpha.4` to work. However, it's not included in this PR as we already bump it via https://github.com/owncloud/web/pull/6633.

## Related Issue
- https://github.com/owncloud/web/issues/6283

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
