### PR TITLE
Adjust the topbar layout on the spaces overview

### DIFF
--- a/changelog/unreleased/enhancement-spaces-overview-topbar
+++ b/changelog/unreleased/enhancement-spaces-overview-topbar
@@ -1,0 +1,6 @@
+Enhancement: Spaces overview topbar layout
+
+We've adjusted the topbar layout of the spaces overview to match the other pages.
+
+https://github.com/owncloud/web/pull/6642
+https://github.com/owncloud/web/issues/6641

--- a/packages/web-app-files/src/components/AppBar/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar/AppBar.vue
@@ -26,7 +26,7 @@
           </template>
         </oc-breadcrumb>
         <shares-navigation v-if="isSharesLocation" />
-        <view-options v-if="!hideViewOptions" />
+        <view-options />
       </div>
       <div class="files-app-bar-actions">
         <div
@@ -169,9 +169,6 @@ export default {
     },
     hasBulkActions() {
       return this.$route.meta.hasBulkActions === true
-    },
-    hideViewOptions() {
-      return this.$route.meta.hideViewOptions === true
     },
     pageTitle() {
       const title = this.$route.meta.title

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="oc-flex-inline oc-width-1-1" style="gap: 15px">
-    <template v-if="createFileActionsAvailable">
+    <create-space v-if="createSpaceActionAvailable" />
+    <template v-else-if="createFileActionsAvailable">
       <oc-button
         id="new-file-menu-btn"
         key="new-file-menu-btn-enabled"
@@ -70,46 +71,48 @@
         <translate>New folder</translate>
       </oc-button>
     </template>
-    <oc-button
-      id="upload-menu-btn"
-      key="upload-menu-btn-enabled"
-      v-oc-tooltip="uploadButtonTooltip"
-      :aria-label="uploadButtonAriaLabel"
-      :disabled="uploadOrFileCreationBlocked"
-    >
-      <oc-icon name="upload" fill-type="line" />
-      <translate>Upload</translate>
-    </oc-button>
-    <oc-drop
-      drop-id="upload-menu-drop"
-      toggle="#upload-menu-btn"
-      mode="click"
-      class="oc-width-auto"
-      close-on-click
-      padding-size="small"
-    >
-      <oc-list id="upload-list">
-        <li>
-          <folder-upload
-            :root-path="currentPath"
-            :path="currentPath"
-            :headers="headers"
-            @success="uploadSuccess"
-            @error="uploadError"
-            @progress="uploadProgress"
-          />
-        </li>
-        <li>
-          <file-upload
-            :path="currentPath"
-            :headers="headers"
-            @success="uploadSuccess"
-            @error="uploadError"
-            @progress="uploadProgress"
-          />
-        </li>
-      </oc-list>
-    </oc-drop>
+    <template v-if="uploadFileActionsAvailable">
+      <oc-button
+        id="upload-menu-btn"
+        key="upload-menu-btn-enabled"
+        v-oc-tooltip="uploadButtonTooltip"
+        :aria-label="uploadButtonAriaLabel"
+        :disabled="uploadOrFileCreationBlocked"
+      >
+        <oc-icon name="upload" fill-type="line" />
+        <translate>Upload</translate>
+      </oc-button>
+      <oc-drop
+        drop-id="upload-menu-drop"
+        toggle="#upload-menu-btn"
+        mode="click"
+        class="oc-width-auto"
+        close-on-click
+        padding-size="small"
+      >
+        <oc-list id="upload-list">
+          <li>
+            <folder-upload
+              :root-path="currentPath"
+              :path="currentPath"
+              :headers="headers"
+              @success="uploadSuccess"
+              @error="uploadError"
+              @progress="uploadProgress"
+            />
+          </li>
+          <li>
+            <file-upload
+              :path="currentPath"
+              :headers="headers"
+              @success="uploadSuccess"
+              @error="uploadError"
+              @progress="uploadProgress"
+            />
+          </li>
+        </oc-list>
+      </oc-drop>
+    </template>
   </div>
 </template>
 
@@ -127,11 +130,13 @@ import { DavProperties, DavProperty } from 'web-pkg/src/constants'
 
 import FileUpload from './Upload/FileUpload.vue'
 import FolderUpload from './Upload/FolderUpload.vue'
+import CreateSpace from './CreateSpace.vue'
 
 export default {
   components: {
     FileUpload,
-    FolderUpload
+    FolderUpload,
+    CreateSpace
   },
   mixins: [Mixins, MixinFileActions],
   props: {
@@ -163,6 +168,12 @@ export default {
     },
     createFileActionsAvailable() {
       return this.newFileHandlers.length > 0 || this.mimetypesAllowedForCreation.length > 0
+    },
+    createSpaceActionAvailable() {
+      return this.isSpacesProjectsLocation && !this.$route.params.storageId
+    },
+    uploadFileActionsAvailable() {
+      return !this.isSpacesProjectsLocation || this.$route.params.storageId
     },
     newButtonTooltip() {
       if (!this.canUpload) {

--- a/packages/web-app-files/src/components/AppBar/CreateSpace.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateSpace.vue
@@ -1,0 +1,127 @@
+<template>
+  <oc-button
+    id="new-space-menu-btn"
+    key="new-space-menu-btn-enabled"
+    v-oc-tooltip="$gettext('Create a new space')"
+    :aria-label="$gettext('Create a new space')"
+    appearance="raw"
+    variation="inverse"
+    class="oc-background-primary-gradient oc-px-s oc-text-nowrap oc-py-s"
+    @click="showCreateSpaceModal"
+  >
+    <oc-icon name="add" />
+    <translate>Create Space</translate>
+  </oc-button>
+</template>
+
+<script>
+import { mapActions, mapGetters, mapMutations } from 'vuex'
+
+import { buildSpace } from '../../helpers/resources'
+import { useStore } from 'web-pkg/src/composables'
+import { clientService } from 'web-pkg/src/services'
+
+export default {
+  setup() {
+    const store = useStore()
+    const graphClient = clientService.graphAuthenticated(
+      store.getters.configuration.server,
+      store.getters.getToken
+    )
+
+    return { graphClient }
+  },
+  computed: {
+    ...mapGetters(['getToken', 'configuration'])
+  },
+  methods: {
+    ...mapActions(['showMessage', 'createModal', 'hideModal', 'setModalInputErrorMessage']),
+    ...mapMutations('Files', [
+      'SET_CURRENT_FOLDER',
+      'LOAD_FILES',
+      'CLEAR_CURRENT_FILES_LIST',
+      'SET_FILE_SELECTION',
+      'UPSERT_RESOURCE',
+      'UPDATE_RESOURCE_FIELD'
+    ]),
+
+    showCreateSpaceModal() {
+      const modal = {
+        variation: 'passive',
+        title: this.$gettext('Create a new space'),
+        cancelText: this.$gettext('Cancel'),
+        confirmText: this.$gettext('Create'),
+        hasInput: true,
+        inputLabel: this.$gettext('Space name'),
+        inputValue: this.$gettext('New space'),
+        onCancel: this.hideModal,
+        onConfirm: this.addNewSpace,
+        onInput: this.checkSpaceName
+      }
+
+      this.createModal(modal)
+    },
+
+    checkSpaceName(name) {
+      if (name.trim() === '') {
+        this.setModalInputErrorMessage(this.$gettext('Space name cannot be empty'))
+        return
+      }
+      return this.setModalInputErrorMessage(null)
+    },
+
+    addNewSpace(name) {
+      return this.graphClient.drives
+        .createDrive({ name }, {})
+        .then(({ data: space }) => {
+          this.hideModal()
+          const resource = buildSpace(space)
+          this.UPSERT_RESOURCE(resource)
+
+          this.$client.files.createFolder(`spaces/${space.id}/.space`).then(() => {
+            this.$client.files
+              .putFileContents(
+                `spaces/${space.id}/.space/readme.md`,
+                `### 👋 ${this.$gettext('Hello!')}\r\n${this.$gettext(
+                  'Add a description to welcome the members of the Space.'
+                )}\r\n${this.$gettext(
+                  'Use markdown to format your text. [More info]'
+                )}(https://www.markdownguide.org/basic-syntax/)`
+              )
+              .then((markdown) => {
+                this.graphClient.drives
+                  .updateDrive(
+                    space.id,
+                    {
+                      special: [
+                        {
+                          specialFolder: {
+                            name: 'readme'
+                          },
+                          id: markdown['OC-FileId']
+                        }
+                      ]
+                    },
+                    {}
+                  )
+                  .then(({ data }) => {
+                    this.UPDATE_RESOURCE_FIELD({
+                      id: space.id,
+                      field: 'spaceReadmeData',
+                      value: data.special.find((special) => special.specialFolder.name === 'readme')
+                    })
+                  })
+              })
+          })
+        })
+        .catch((error) => {
+          this.showMessage({
+            title: this.$gettext('Creating space failed…'),
+            desc: error,
+            status: 'danger'
+          })
+        })
+    }
+  }
+}
+</script>

--- a/packages/web-app-files/src/components/AppBar/ViewOptions.vue
+++ b/packages/web-app-files/src/components/AppBar/ViewOptions.vue
@@ -1,17 +1,46 @@
 <template>
   <div class="oc-flex">
+    <template v-if="!hideViewOptions">
+      <oc-button
+        id="files-view-options-btn"
+        key="files-view-options-btn"
+        v-oc-tooltip="viewOptionsButtonLabel"
+        data-testid="files-view-options-btn"
+        :aria-label="viewOptionsButtonLabel"
+        appearance="raw"
+        class="oc-my-s oc-p-xs"
+      >
+        <oc-icon name="settings-3" fill-type="line" />
+      </oc-button>
+      <oc-drop
+        drop-id="files-view-options-drop"
+        toggle="#files-view-options-btn"
+        mode="click"
+        class="oc-width-auto"
+        padding-size="small"
+      >
+        <oc-list>
+          <li class="files-view-options-list-item">
+            <oc-switch
+              v-model="hiddenFilesShownModel"
+              data-testid="files-switch-hidden-files"
+              :label="$gettext('Show hidden files')"
+            />
+          </li>
+          <li class="files-view-options-list-item">
+            <oc-page-size
+              v-model="itemsPerPage"
+              data-testid="files-pagination-size"
+              :label="$gettext('Items per page')"
+              :options="[100, 500, 1000, $gettext('All')]"
+              class="files-pagination-size"
+            />
+          </li>
+        </oc-list>
+      </oc-drop>
+    </template>
     <oc-button
-      id="files-view-options-btn"
-      key="files-view-options-btn"
-      v-oc-tooltip="viewOptionsButtonLabel"
-      data-testid="files-view-options-btn"
-      :aria-label="viewOptionsButtonLabel"
-      appearance="raw"
-      class="oc-my-s oc-p-xs"
-    >
-      <oc-icon name="settings-3" fill-type="line" />
-    </oc-button>
-    <oc-button
+      v-if="!hideSidebarToggle"
       id="files-toggle-sidebar"
       v-oc-tooltip="toggleSidebarButtonLabel"
       :aria-label="toggleSidebarButtonLabel"
@@ -21,32 +50,6 @@
     >
       <oc-icon name="side-bar-right" :fill-type="toggleSidebarButtonIconFillType" />
     </oc-button>
-    <oc-drop
-      drop-id="files-view-options-drop"
-      toggle="#files-view-options-btn"
-      mode="click"
-      class="oc-width-auto"
-      padding-size="small"
-    >
-      <oc-list>
-        <li class="files-view-options-list-item">
-          <oc-switch
-            v-model="hiddenFilesShownModel"
-            data-testid="files-switch-hidden-files"
-            :label="$gettext('Show hidden files')"
-          />
-        </li>
-        <li class="files-view-options-list-item">
-          <oc-page-size
-            v-model="itemsPerPage"
-            data-testid="files-pagination-size"
-            :label="$gettext('Items per page')"
-            :options="[100, 500, 1000, $gettext('All')]"
-            class="files-pagination-size"
-          />
-        </li>
-      </oc-list>
-    </oc-drop>
   </div>
 </template>
 
@@ -91,6 +94,14 @@ export default {
       set(value) {
         this.SET_HIDDEN_FILES_VISIBILITY(value)
       }
+    },
+
+    hideViewOptions() {
+      return this.$route.meta.hideViewOptions === true
+    },
+
+    hideSidebarToggle() {
+      return this.$route.meta.hideSidebarToggle === true
     }
   },
   methods: {

--- a/packages/web-app-files/src/router/spaces.ts
+++ b/packages/web-app-files/src/router/spaces.ts
@@ -35,7 +35,6 @@ export const buildRoutes = (components: RouteComponents): RouteConfig[] => [
         name: locationSpacesProjects.name,
         component: components.Spaces.Projects,
         meta: {
-          hideFilelistActions: true,
           hasBulkActions: false,
           hideViewOptions: true,
           title: $gettext('Spaces')

--- a/packages/web-app-files/tests/unit/components/AppBar/CreateSpace.spec.js
+++ b/packages/web-app-files/tests/unit/components/AppBar/CreateSpace.spec.js
@@ -1,0 +1,58 @@
+import { createLocalVue, mount } from '@vue/test-utils'
+import { createStore } from 'vuex-extensions'
+import CreateSpace from '../../../../src/components/AppBar/CreateSpace.vue'
+import VueRouter from 'vue-router'
+import Vuex from 'vuex'
+import VueCompositionAPI from '@vue/composition-api'
+import DesignSystem from 'owncloud-design-system'
+
+const localVue = createLocalVue()
+localVue.use(VueRouter)
+localVue.use(DesignSystem)
+localVue.use(VueCompositionAPI)
+localVue.use(Vuex)
+
+describe('CreateSpace component', () => {
+  it('should show the "create new space" modal', async () => {
+    const wrapper = getMountedWrapper()
+    const createModalStub = jest.spyOn(wrapper.vm, 'createModal')
+    const button = wrapper.find('#new-space-menu-btn')
+    expect(button.exists()).toBeTruthy()
+    await button.trigger('click')
+
+    expect(createModalStub).toHaveBeenCalledTimes(1)
+  })
+
+  it('should show an error message when trying to create a space with an empty name', () => {
+    const wrapper = getMountedWrapper()
+    wrapper.vm.setModalInputErrorMessage = jest.fn()
+
+    const spyInputErrorMessageStub = jest.spyOn(wrapper.vm, 'setModalInputErrorMessage')
+    wrapper.vm.checkSpaceName('')
+
+    expect(spyInputErrorMessageStub).toHaveBeenCalledWith('Space name cannot be empty')
+  })
+})
+
+function getMountedWrapper() {
+  return mount(CreateSpace, {
+    localVue,
+    store: createStore(Vuex.Store, {
+      getters: {
+        configuration: () => ({
+          server: 'https://example.com/'
+        })
+      },
+      actions: {
+        createModal: jest.fn()
+      }
+    }),
+    stubs: {
+      translate: true,
+      'oc-icon': true
+    },
+    directives: {
+      'oc-tooltip': jest.fn()
+    }
+  })
+}

--- a/packages/web-app-files/tests/unit/views/spaces/Projects.spec.js
+++ b/packages/web-app-files/tests/unit/views/spaces/Projects.spec.js
@@ -49,43 +49,6 @@ describe('Spaces projects view', () => {
     expect(wrapper.vm.spaces.length).toEqual(1)
     expect(wrapper).toMatchSnapshot()
   })
-
-  it('should show the "create new space" modal with sufficient permissions', async () => {
-    mockAxios.request.mockImplementationOnce(() => {
-      return Promise.resolve({
-        data: {
-          value: []
-        }
-      })
-    })
-    const wrapper = getMountedWrapper()
-    await wrapper.vm.loadResourcesTask.last
-
-    const createModalStub = jest.spyOn(wrapper.vm, 'createModal')
-    const button = wrapper.find('[data-testid="spaces-list-create-space-btn"]')
-    expect(button.exists()).toBeTruthy()
-    await button.trigger('click')
-
-    expect(createModalStub).toHaveBeenCalledTimes(1)
-  })
-
-  it('should show an error message when trying to create a space with an empty name', async () => {
-    mockAxios.request.mockImplementationOnce(() => {
-      return Promise.resolve({
-        data: {
-          value: []
-        }
-      })
-    })
-    const wrapper = getMountedWrapper()
-    await wrapper.vm.loadResourcesTask.last
-    wrapper.vm.setModalInputErrorMessage = jest.fn()
-
-    const spyInputErrorMessageStub = jest.spyOn(wrapper.vm, 'setModalInputErrorMessage')
-    wrapper.vm.checkSpaceName('')
-
-    expect(spyInputErrorMessageStub).toHaveBeenCalledWith('Space name cannot be empty')
-  })
 })
 
 function getMountedWrapper(activeFiles = []) {
@@ -106,9 +69,6 @@ function getMountedWrapper(activeFiles = []) {
         user: () => ({
           id: 'marie'
         })
-      },
-      actions: {
-        createModal: jest.fn()
       },
       modules: {
         Files: {

--- a/packages/web-app-files/tests/unit/views/spaces/__snapshots__/Projects.spec.js.snap
+++ b/packages/web-app-files/tests/unit/views/spaces/__snapshots__/Projects.spec.js.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Spaces projects view should list spaces 1`] = `
-<div class="oc-py-s oc-px-m"><button aria-label="Create a new space" type="button" class="oc-mb-l oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-primary oc-button-primary-filled" id="new-space-menu-btn" data-testid="spaces-list-create-space-btn"><span class="oc-icon oc-icon-m oc-icon-passive"><!----></span>
-    <translate-stub tag="span">Create Space</translate-stub>
-  </button>
+<div class="oc-py-s oc-px-m">
   <div class="oc-pb-xl oc-border-b"><span>Store your project related files in Spaces for seamless collaboration.</span></div>
   <div class="spaces-list oc-mt-l"><input id="space-image-upload-input" type="file" name="file" multiple="multiple" tabindex="-1" accept="image/*">
     <!---->


### PR DESCRIPTION
## Description
Align the topbar layout of the spaces overview with the other pages. In the course of this: 

* Moved the "Create Space"-button to its own component which is then used by the topbar
* Included the sidebar quick action

## Related Issue
- Fixes https://github.com/owncloud/web/issues/6641

## Screenshots (if appropriate):

old:

![image](https://user-images.githubusercontent.com/50302941/159498328-19afddad-0779-4baa-963e-0e6de45d0d83.png)

new:

![image](https://user-images.githubusercontent.com/50302941/159498366-19f96ddc-a99f-432e-975e-c9d413d4e941.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
