### PR TITLE
Show filename and app name in external app tab title

### DIFF
--- a/packages/web-app-draw-io/src/App.vue
+++ b/packages/web-app-draw-io/src/App.vue
@@ -155,10 +155,7 @@ export default {
     },
     importVisio() {
       const url = this.getFileUrl(this.filePath)
-      const headers = new Headers({
-        Authorization: 'Bearer ' + this.getToken,
-        'X-Requested-With': 'XMLHttpRequest'
-      })
+
       const getDescription = () =>
         this.$gettextInterpolate(
           this.$gettext('The diagram will open as a new .drawio file: %{file}'),
@@ -171,7 +168,7 @@ export default {
         title: this.$gettext('Diagram imported'),
         desc: getDescription()
       })
-      fetch(url, { headers })
+      this.makeRequest('GET', url)
         .then((resp) => {
           // Not setting `currentETag` on imports allows to create new files
           // otherwise the ETag comparison fails with a 412 during the autosave/save event

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -82,8 +82,7 @@ export default {
     formParameters: {}
   }),
   computed: {
-    ...mapGetters(['getToken', 'capabilities', 'configuration']),
-    ...mapGetters('Files', ['publicLinkPassword']),
+    ...mapGetters(['capabilities', 'configuration']),
 
     pageTitle() {
       const translated = this.$gettext('"%{appName}" app page')
@@ -116,22 +115,6 @@ export default {
       const filePath = this.currentFileContext.path
       const fileId = this.fileId || (await this.getFileInfoResource(filePath)).fileId
 
-      // build headers with respect to the actual auth situation
-      const publicToken = (filePath || '').split('/')[1]
-      const publicLinkPassword = this.publicLinkPassword
-      const accessToken = this.getToken
-      const headers = {
-        'X-Requested-With': 'XMLHttpRequest',
-        ...(!accessToken && publicToken && { 'public-token': publicToken }),
-        ...(publicLinkPassword && {
-          Authorization:
-            'Basic ' + Buffer.from(['public', publicLinkPassword].join(':')).toString('base64')
-        }),
-        ...(accessToken && {
-          Authorization: 'Bearer ' + accessToken
-        })
-      }
-
       // fetch iframe params for app and file
       const configUrl = this.configuration.server
       const appOpenUrl = this.capabilities.files.app_providers[0].open_url.replace(/^\/+/, '')
@@ -141,10 +124,7 @@ export default {
         `?file_id=${fileId}` +
         (this.appName ? `&app_name=${this.appName}` : '')
 
-      const response = await fetch(url, {
-        method: 'POST',
-        headers
-      })
+      const response = await this.makeRequest('POST', url)
 
       if (response.status !== 200) {
         this.errorMessage = response.message

--- a/packages/web-app-external/src/index.js
+++ b/packages/web-app-external/src/index.js
@@ -2,11 +2,6 @@ import translations from '../l10n/translations'
 import App from './App.vue'
 import store from './store'
 
-// just a dummy function to trick gettext tools
-function $gettext(msg) {
-  return msg
-}
-
 const appInfo = {
   name: 'External',
   id: 'external'
@@ -15,11 +10,11 @@ const appInfo = {
 const routes = [
   {
     name: 'apps',
-    path: '/:fileId/:appName?',
+    path: '/:filePath*',
     component: App,
     meta: {
       auth: false,
-      title: $gettext('External app')
+      patchCleanPath: true
     }
   }
 ]

--- a/packages/web-app-external/tests/unit/app.spec.js
+++ b/packages/web-app-external/tests/unit/app.spec.js
@@ -18,19 +18,32 @@ const componentStubs = {
 
 const $route = {
   query: {
-    'public-token': 'a-token'
+    'public-token': 'a-token',
+    app: 'exampleApp',
+    fileId: '2147491323'
   },
   params: {
-    appName: 'exampleApp',
-    fileId: '2147491323'
+    filePath: 'someFile.md'
   }
 }
+
+const mockFileInfo = jest.fn(() => ({
+  name: $route.params.filePath,
+  fileInfo: {
+    '{http://owncloud.org/ns}fileid': '2147491323'
+  }
+}))
 
 const storeOptions = {
   getters: {
     getToken: jest.fn(() => 'GFwHKXdsMgoFwt'),
     configuration: jest.fn(() => ({
-      server: 'http://example.com/'
+      server: 'http://example.com/',
+      currentTheme: {
+        general: {
+          name: 'some-company'
+        }
+      }
     })),
     userReady: () => true,
     capabilities: jest.fn(() => ({
@@ -137,6 +150,7 @@ describe('The app provider extension', () => {
     const wrapper = createShallowMountWrapper()
     await wrapper.vm.$nextTick()
     await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
     expect(wrapper).toMatchSnapshot()
   })
   it('should be able to load an iFrame via post', async () => {
@@ -150,6 +164,7 @@ describe('The app provider extension', () => {
     const wrapper = createShallowMountWrapper()
     await wrapper.vm.$nextTick()
     await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
     expect(wrapper).toMatchSnapshot()
   })
 })
@@ -161,6 +176,12 @@ function createShallowMountWrapper(options = {}) {
     stubs: componentStubs,
     mocks: {
       $route
+    },
+    computed: {
+      currentFileContext: () => $route.params
+    },
+    methods: {
+      getFileInfo: mockFileInfo
     },
     ...options
   })

--- a/packages/web-app-external/tests/unit/app.spec.js
+++ b/packages/web-app-external/tests/unit/app.spec.js
@@ -100,7 +100,7 @@ describe('The app provider extension', () => {
   })
 
   it('should show a loading spinner while loading', async () => {
-    global.fetch = jest.fn(() =>
+    const makeRequest = jest.fn(() =>
       setTimeout(() => {
         Promise.resolve({
           ok: true,
@@ -108,38 +108,38 @@ describe('The app provider extension', () => {
         })
       }, 500)
     )
-    const wrapper = createShallowMountWrapper()
+    const wrapper = createShallowMountWrapper(makeRequest)
     await wrapper.vm.$nextTick()
     expect(wrapper).toMatchSnapshot()
   })
   it('should show a meaningful message if an error occurs during loading', async () => {
-    global.fetch = jest.fn(() =>
+    const makeRequest = jest.fn(() =>
       Promise.resolve({
         ok: false,
         status: 500,
         message: 'We encountered an internal error'
       })
     )
-    const wrapper = createShallowMountWrapper()
+    const wrapper = createShallowMountWrapper(makeRequest)
     await wrapper.vm.$nextTick()
     await wrapper.vm.$nextTick()
     expect(wrapper).toMatchSnapshot()
   })
   it('should fail for unauthenticated users', async () => {
-    global.fetch = jest.fn(() =>
+    const makeRequest = jest.fn(() =>
       Promise.resolve({
         ok: true,
         status: 401,
         message: 'Login Required'
       })
     )
-    const wrapper = createShallowMountWrapper()
+    const wrapper = createShallowMountWrapper(makeRequest)
     await wrapper.vm.$nextTick()
     await wrapper.vm.$nextTick()
     expect(wrapper).toMatchSnapshot()
   })
   it('should be able to load an iFrame via get', async () => {
-    global.fetch = jest.fn(() =>
+    const makeRequest = jest.fn(() =>
       Promise.resolve({
         ok: true,
         status: 200,
@@ -147,21 +147,21 @@ describe('The app provider extension', () => {
       })
     )
 
-    const wrapper = createShallowMountWrapper()
+    const wrapper = createShallowMountWrapper(makeRequest)
     await wrapper.vm.$nextTick()
     await wrapper.vm.$nextTick()
     await wrapper.vm.$nextTick()
     expect(wrapper).toMatchSnapshot()
   })
   it('should be able to load an iFrame via post', async () => {
-    global.fetch = jest.fn(() =>
+    const makeRequest = jest.fn(() =>
       Promise.resolve({
         ok: true,
         status: 200,
         json: () => providerSuccessResponsePost
       })
     )
-    const wrapper = createShallowMountWrapper()
+    const wrapper = createShallowMountWrapper(makeRequest)
     await wrapper.vm.$nextTick()
     await wrapper.vm.$nextTick()
     await wrapper.vm.$nextTick()
@@ -169,7 +169,7 @@ describe('The app provider extension', () => {
   })
 })
 
-function createShallowMountWrapper(options = {}) {
+function createShallowMountWrapper(makeRequest, options = {}) {
   return shallowMount(App, {
     localVue,
     store: createStore(),
@@ -181,7 +181,8 @@ function createShallowMountWrapper(options = {}) {
       currentFileContext: () => $route.params
     },
     methods: {
-      getFileInfo: mockFileInfo
+      getFileInfo: mockFileInfo,
+      makeRequest
     },
     ...options
   })

--- a/packages/web-app-files/src/mixins/fileActions.js
+++ b/packages/web-app-files/src/mixins/fileActions.js
@@ -1,7 +1,7 @@
 import get from 'lodash-es/get'
 import { mapGetters, mapActions, mapState } from 'vuex'
 
-import { isAuthenticatedRoute, isLocationTrashActive } from '../router'
+import { isLocationTrashActive } from '../router'
 import { routeToContextQuery } from 'web-pkg/src/composables/appDefaults'
 import AcceptShare from './actions/acceptShare'
 import Copy from './actions/copy'
@@ -232,8 +232,7 @@ export default {
       if (resources.length !== 1) {
         return []
       }
-
-      const { mimeType, fileId } = resources[0]
+      const { mimeType, webDavPath, fileId } = resources[0]
       const mimeTypes = this.$store.getters['External/mimeTypes'] || []
       if (
         mimeType === undefined ||
@@ -260,30 +259,26 @@ export default {
           class: `oc-files-actions-${app.name}-trigger`,
           isEnabled: () => true,
           canBeDefault: defaultApplication === app.name,
-          handler: () => this.$_fileActions_openLink(app.name, fileId),
+          handler: () => this.$_fileActions_openLink(app.name, webDavPath, fileId),
           label: () => this.$gettextInterpolate(label, { appName: app.name })
         }
       })
     },
 
-    $_fileActions_openLink(appName, resourceId) {
+    $_fileActions_openLink(app, filePath, fileId) {
       const routeOpts = this.$_fileActions__routeOpts(
         {
           routeName: 'external-apps'
         },
+        filePath,
         undefined,
-        resourceId,
         undefined
       )
 
-      routeOpts.params.appName = appName
-
       routeOpts.query = {
-        ...routeOpts.query,
-        // public-token retrieval is weak, same as packages/web-app-files/src/index.js:106
-        ...(!isAuthenticatedRoute(this.$route) && {
-          'public-token': (this.$route.params.item || '').split('/')[0]
-        })
+        app,
+        fileId,
+        ...routeOpts.query
       }
 
       // TODO: Let users configure whether to open in same/new tab (`_blank` vs `_self`)

--- a/packages/web-pkg/src/composables/appDefaults/types.ts
+++ b/packages/web-pkg/src/composables/appDefaults/types.ts
@@ -2,6 +2,7 @@ import { MaybeRef } from '../../utils'
 import { LocationParams, LocationQuery } from '../router'
 export interface FileContext {
   path: MaybeRef<string>
+  fileName: MaybeRef<string>
   routeName: MaybeRef<string>
   routeParams: MaybeRef<LocationParams>
   routeQuery: MaybeRef<LocationQuery>

--- a/packages/web-pkg/src/composables/appDefaults/useAppDefaults.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppDefaults.ts
@@ -46,6 +46,16 @@ export function useAppDefaults(options: AppDefaultsOptions): AppDefaultsResult {
     return store.getters['Files/publicLinkPassword']
   })
 
+  const accessToken = computed(() => {
+    return store.getters.getToken
+  })
+
+  const publicToken = computed(() => {
+    return (unref(currentRoute).params.item || unref(currentRoute).params.filePath || '').split(
+      '/'
+    )[0]
+  })
+
   const currentFileContext = computed((): FileContext => {
     const queryItemAsString = (queryItem: string | string[]) => {
       if (Array.isArray(queryItem)) {
@@ -71,7 +81,14 @@ export function useAppDefaults(options: AppDefaultsOptions): AppDefaultsResult {
 
     ...useAppConfig({ store, ...options }),
     ...useAppNavigation({ router, currentFileContext }),
-    ...useAppFileHandling({ clientService, store, isPublicLinkContext, publicLinkPassword }),
+    ...useAppFileHandling({
+      clientService,
+      store,
+      isPublicLinkContext,
+      publicLinkPassword,
+      accessToken,
+      publicToken
+    }),
     ...useAppFolderHandling({ clientService, store, isPublicLinkContext, publicLinkPassword })
   }
 }

--- a/packages/web-pkg/src/composables/appDefaults/useAppDefaults.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppDefaults.ts
@@ -2,6 +2,7 @@ import { computed, unref, Ref } from '@vue/composition-api'
 import { useRouter, useRoute } from '../router'
 import { useStore } from '../store'
 import { ClientService, clientService as defaultClientService } from '../../services'
+import { basename } from 'path'
 
 import { FileContext } from './types'
 import {
@@ -54,8 +55,11 @@ export function useAppDefaults(options: AppDefaultsOptions): AppDefaultsResult {
       return queryItem
     }
 
+    const path = `/${unref(currentRoute).params.filePath.split('/').filter(Boolean).join('/')}`
+
     return {
-      path: `/${unref(currentRoute).params.filePath.split('/').filter(Boolean).join('/')}`,
+      path,
+      fileName: basename(path),
       routeName: queryItemAsString(unref(currentRoute).query[contextRouteNameKey]),
       ...contextQueryToFileContextProps(unref(currentRoute).query)
     }

--- a/packages/web-pkg/src/composables/appDefaults/useAppNavigation.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppNavigation.ts
@@ -1,5 +1,4 @@
 import { unref } from '@vue/composition-api'
-import { basename } from 'path'
 import VueRouter, { Location } from 'vue-router'
 
 import { MaybeRef } from '../../utils'
@@ -64,14 +63,14 @@ export function useAppNavigation(options: AppNavigationOptions): AppNavigationRe
   const navigateToContext = (context: MaybeRef<FileContext>) => {
     const router = options.router
 
-    const { path, routeName, routeParams, routeQuery } = unref(context)
+    const { fileName, routeName, routeParams, routeQuery } = unref(context)
 
     return router.push({
       name: unref(routeName),
       params: unref(routeParams),
       query: {
         ...unref(routeQuery),
-        scrollTo: basename(unref(path))
+        scrollTo: unref(fileName)
       }
     })
   }


### PR DESCRIPTION
## Description
The pr changes external apps route to take filePath instead of fileId. It extracts fileName from filePath and sets document.title to <fileName> - <appName>

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/5958

## Motivation and Context
Current document title for external apps is not helpful in understanding, which file is open and with which app. By several open files, it's hard to find the right one.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
