### PR TITLE
Use oC10 navigation entry names

### DIFF
--- a/changelog/unreleased/bugfix-oc10-navigation-entry-names
+++ b/changelog/unreleased/bugfix-oc10-navigation-entry-names
@@ -1,0 +1,7 @@
+Bugfix: Use oC10 navigation entry names
+
+When fetching navigation entries from oC10, we previously used the app's names. This caused issues when the navigation entry ID and the app ID differ. Also, the navigation entries did not match with the ones in the classic UI.
+This has been fixed as we now use the navigation entry name, which falls back to the app name if not given.
+
+https://github.com/owncloud/web/pull/6656
+https://github.com/owncloud/web/issues/6585

--- a/packages/web-integration-oc10/lib/Controller/ConfigController.php
+++ b/packages/web-integration-oc10/lib/Controller/ConfigController.php
@@ -111,7 +111,7 @@ class ConfigController extends Controller {
             $titles = [];
             foreach ($supportedLanguages as $lang) {
                 $l10n = \OC::$server->getL10N($appInfo['id'], $lang);
-                $titles[$lang] = $l10n->t($appInfo['name']);
+                $titles[$lang] = $l10n->t($navigationEntry['name']);
             }
 
             $apps[] = [


### PR DESCRIPTION
## Description
When fetching navigation entries from oC10, we previously used the app's names. This caused issues when the navigation entry ID and the app ID differ. Also, the navigation entries did not match with the ones in the classic UI.

This has been fixed as we now use the navigation entry name, which falls back to the app name if not given.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/6585

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
