### PR TITLE
Determine link share role from bitmask

### DIFF
--- a/packages/web-app-files/src/helpers/resources.js
+++ b/packages/web-app-files/src/helpers/resources.js
@@ -5,6 +5,7 @@ import { getIndicators } from './statusIndicators'
 import { $gettext } from '../gettext'
 import { DavPermission, DavProperty } from 'web-pkg/src/constants'
 import {
+  LinkShareRoles,
   PeopleShareRoles,
   SharePermissions,
   ShareStatus,
@@ -434,23 +435,9 @@ export function buildSpaceShare(s, storageId) {
 function _buildLink(link) {
   let description = ''
 
-  // FIXME: use bitmask matching with constants
-  switch (parseInt(link.permissions)) {
-    case 1: // read (1)
-      description = $gettext('Viewer')
-      break
-    case 3: // read (1) + update (2)
-      description = $gettext('Editor')
-      break
-    case 5: // read (1) + create (4)
-      description = $gettext('Contributor')
-      break
-    case 4: // create (4)
-      description = $gettext('Uploader')
-      break
-    case 15: // read (1) + update (2) + create (4) + delete (8)
-      description = $gettext('Editor')
-      break
+  const role = LinkShareRoles.getByBitmask(parseInt(link.permissions), link.item_type === 'folder')
+  if (role) {
+    description = $gettext(role.label)
   }
 
   return {


### PR DESCRIPTION
## Description
When building link share objects in `resources.js` we now use `LinkShareRoles.getByBitmask` to find the name of a role instead of hardcoding mappings of bitmasks to role names.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes a `FIXME` in the codebase

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
