### PR TITLE
Enable typescript in single file components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,8 +10,12 @@ module.exports = {
     'plugin:prettier/recommended',
     'plugin:jest/recommended'
   ],
-  parser: '@babel/eslint-parser',
+  parser: 'vue-eslint-parser',
   parserOptions: {
+    parser: {
+      "js": "@babel/eslint-parser",
+      "ts": "@typescript-eslint/parser",
+    },
     requireConfigFile: false,
     sourceType: 'module'
   },

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@types/node-fetch": "^2.6.0",
     "@typescript-eslint/eslint-plugin": "^5.14.0",
     "@typescript-eslint/parser": "^5.14.0",
+    "@vue/runtime-dom": "^3.2.31",
     "@vue/test-utils": "^1.3.0",
     "autoprefixer": "^10.4.2",
     "babel-core": "^7.0.0-bridge.0",

--- a/packages/web-app-files/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceTable.vue
@@ -158,7 +158,7 @@
   </oc-table>
 </template>
 
-<script>
+<script lang="ts">
 import { DateTime } from 'luxon'
 import maxSize from 'popper-max-size-modifier'
 import { mapGetters } from 'vuex'
@@ -168,8 +168,10 @@ import * as path from 'path'
 import { determineSortFields } from '../../helpers/ui/resourceTable'
 import { useCapabilitySpacesEnabled } from 'web-pkg/src/composables'
 import Rename from '../../mixins/actions/rename'
+import { defineComponent, PropType } from '@vue/composition-api'
+import { Resource } from '../../helpers/resource'
 
-export default {
+export default defineComponent({
   mixins: [Rename],
   model: {
     prop: 'selection',
@@ -192,7 +194,7 @@ export default {
      * - opensInNewWindow: Open the link in a new window
      */
     resources: {
-      type: Array,
+      type: Array as PropType<Resource[]>,
       required: true
     },
     /**
@@ -282,7 +284,7 @@ export default {
       type: String,
       required: false,
       default: 'small',
-      validator: (size) => /(xsmall|small|medium|large|xlarge)/.test(size)
+      validator: (size: string) => /(xsmall|small|medium|large|xlarge)/.test(size)
     },
     /**
      * Enable Drag & Drop events
@@ -315,8 +317,10 @@ export default {
       type: String,
       required: false,
       default: undefined,
-      validator: (value) => {
-        return value === undefined || [SortDir.Asc, SortDir.Desc].includes(value)
+      validator: (value: string) => {
+        return (
+          value === undefined || [SortDir.Asc.toString(), SortDir.Desc.toString()].includes(value)
+        )
       }
     }
   },
@@ -663,7 +667,7 @@ export default {
       })
     }
   }
-}
+})
 </script>
 <style lang="scss">
 .resource-table {

--- a/packages/web-app-files/src/views/Personal.vue
+++ b/packages/web-app-files/src/views/Personal.vue
@@ -62,7 +62,7 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import { mapGetters, mapState, mapActions, mapMutations } from 'vuex'
 import isNil from 'lodash-es/isNil'
 import debounce from 'lodash-es/debounce'
@@ -89,10 +89,12 @@ import PQueue from 'p-queue'
 import { createLocationSpaces } from '../router'
 import { useResourcesViewDefaults } from '../composables'
 import { fetchResources } from '../services/folder/loaderPersonal'
+import { defineComponent } from '@vue/composition-api'
+import { Resource } from '../helpers/resource'
 
 const visibilityObserver = new VisibilityObserver()
 
-export default {
+export default defineComponent({
   components: {
     ResourceTable,
     QuickActions,
@@ -113,7 +115,7 @@ export default {
   ],
   setup() {
     return {
-      ...useResourcesViewDefaults(),
+      ...useResourcesViewDefaults<Resource, any, any[]>(),
       resourceTargetLocation: createLocationSpaces('files-spaces-personal-home')
     }
   },
@@ -324,5 +326,5 @@ export default {
       return this.selected?.includes(resource)
     }
   }
-}
+})
 </script>

--- a/packages/web-runtime/src/App.vue
+++ b/packages/web-runtime/src/App.vue
@@ -29,15 +29,16 @@
     />
   </div>
 </template>
-<script>
+<script lang="ts">
 import { mapGetters, mapState, mapActions } from 'vuex'
 import SkipTo from './components/SkipTo.vue'
 import LayoutApplication from './layouts/Application.vue'
 import LayoutLoading from './layouts/Loading.vue'
 import LayoutPlain from './layouts/Plain.vue'
 import { getBackendVersion, getWebVersion } from './container/versions'
+import { defineComponent } from '@vue/composition-api'
 
-export default {
+export default defineComponent({
   components: {
     SkipTo
   },
@@ -130,7 +131,7 @@ export default {
   },
 
   metaInfo() {
-    const metaInfo = {}
+    const metaInfo: any = {}
     if (this.favicon) {
       metaInfo.link = [{ rel: 'icon', href: this.favicon }]
     }
@@ -189,7 +190,7 @@ export default {
       return titleSegments.join(' - ')
     }
   }
-}
+})
 </script>
 <style lang="scss">
 body {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -86,5 +86,11 @@
   },
   "exclude": [
     "node_modules"
-  ]
+  ],
+  "vueCompilerOptions": {
+    "experimentalCompatMode": 2,
+    "experimentalTemplateCompilerOptions": {
+      "compatConfig": { "MODE": 2 } // optional
+    }
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2856,10 +2856,47 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/reactivity@npm:3.2.31":
+  version: 3.2.31
+  resolution: "@vue/reactivity@npm:3.2.31"
+  dependencies:
+    "@vue/shared": 3.2.31
+  checksum: acef40b4fff4ca7c1409a2c25a9449f122621d19e0efa5a25dfac2625e420ea899a31dd714c4923868e739318cf2ec8212ed6a80a36c127d84803caa3f72010c
+  languageName: node
+  linkType: hard
+
+"@vue/runtime-core@npm:3.2.31":
+  version: 3.2.31
+  resolution: "@vue/runtime-core@npm:3.2.31"
+  dependencies:
+    "@vue/reactivity": 3.2.31
+    "@vue/shared": 3.2.31
+  checksum: c3e2a34d7e96fb05921d6af7ad4ad5f5e183eb78ed159f62cecc406b2d2b05a0c35cea680db6ff4f390a589d7e6d295908456a92137546b870e0f35b9219dc3c
+  languageName: node
+  linkType: hard
+
+"@vue/runtime-dom@npm:^3.2.31":
+  version: 3.2.31
+  resolution: "@vue/runtime-dom@npm:3.2.31"
+  dependencies:
+    "@vue/runtime-core": 3.2.31
+    "@vue/shared": 3.2.31
+    csstype: ^2.6.8
+  checksum: c4b3b64434221002536b6f1e54a717eeac4bdacfa220909080a9298467810b4280ee1235b6ea0258383d4206fb6352fdb3a60d2848b51d008dc4d6c9bea682ad
+  languageName: node
+  linkType: hard
+
 "@vue/shared@npm:3.1.1":
   version: 3.1.1
   resolution: "@vue/shared@npm:3.1.1"
   checksum: 20c62892cce5952a5684d7bfd6021f897792b25d6b6db1434dfc3920e2982dbf713dff54e460ed76efc511c18fd8500c3ee27995023079241e71662f1381185b
+  languageName: node
+  linkType: hard
+
+"@vue/shared@npm:3.2.31":
+  version: 3.2.31
+  resolution: "@vue/shared@npm:3.2.31"
+  checksum: bf614d9d06f7c01fbe3f5f50d8f7621fffd83d2eebd6c2ccf540c59754283d3b659aa93f7d610ed4c16284a4d5208ef5aec12337f2d4d0ab05e9a271cd4a2051
   languageName: node
   linkType: hard
 
@@ -4872,6 +4909,13 @@ __metadata:
   dependencies:
     cssom: ~0.3.6
   checksum: 5f05e6fd2e3df0b44695c2f08b9ef38b011862b274e320665176467c0725e44a53e341bc4959a41176e83b66064ab786262e7380fd1cabeae6efee0d255bb4e3
+  languageName: node
+  linkType: hard
+
+"csstype@npm:^2.6.8":
+  version: 2.6.20
+  resolution: "csstype@npm:2.6.20"
+  checksum: cb5d5ded49c3390909e93b20b285d4a63d0ba5b10294bdfbc4cf911f80e91d6cf367ea671f99f09570762535c14ea7074a2c7fa73f02008203f01328dea8968b
   languageName: node
   linkType: hard
 
@@ -11642,6 +11686,7 @@ __metadata:
     "@types/node-fetch": ^2.6.0
     "@typescript-eslint/eslint-plugin": ^5.14.0
     "@typescript-eslint/parser": ^5.14.0
+    "@vue/runtime-dom": ^3.2.31
     "@vue/test-utils": ^1.3.0
     autoprefixer: ^10.4.2
     babel-core: ^7.0.0-bridge.0


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This enables typescript in `.vue` files and adjusts the linter to deal with it properly.

As you can see we need to wrap components in `defineComponent` from `composition-api` to make the type checking work at all. Before you ask: yes, it's completely valid to wrap components that use only options api.

## Motivation and Context
After I have replaced the old Vetur extension with the new [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar) extension in VS Code (this PR is mostly based on its README), I have some basic autocompletion and type checking working in `.vue` files. 
It works very well in the templates, not so much in the `script` part of the SFC. For some reason autocompletion and typechecking seems to only really work in the `data()` function, not in setup(), not in methods, not in computeds, just in data.

We probably can now have better types with vuetype or vue-tsc, but that might require more involved changes, so I'd leave that for later. I think this is already a great improvement :) 

## Screenshots (if appropriate):
![Screenshot_20220325_204252](https://user-images.githubusercontent.com/448487/160190499-e42fe763-b2c6-4883-b742-88967232809a.png)

Notice:
- `fetchResources` (a method) can be autocompleted, just like any other vue instance members: Vue api, props, data members, methods ....
- `highlightedFile` is accordingly recognized as a valid reference
- `foobardoobardoo` is marked invalid

Interestingly my IDE marks `foobardoobardoo` as not being defined, but the compilation does not fail 🤷🏻
We might be able to tune tsconfig.json to have stricter warnings/errors. But again I'd leave that for later.