### PR TITLE
[tests-only] [full-ci] Bump OCIS_COMMITID

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=49d275cb33d40f7f06dc503408fc9578702dbd60
+OCIS_COMMITID=4a0592d24847a31ae7e148e4a78e6e39963011fa
 OCIS_BRANCH=master


### PR DESCRIPTION
## Description
Bump OCIS_COMMITID after reva update PR https://github.com/owncloud/ocis/pull/3405

## Related Issue
https://github.com/owncloud/QA/issues/735

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
