### PR TITLE
Reset store on logout

### DIFF
--- a/changelog/unreleased/bugfix-resetting-store-on-logout
+++ b/changelog/unreleased/bugfix-resetting-store-on-logout
@@ -1,0 +1,6 @@
+Bugfix: Resetting store on logout
+
+When logging out, only some parts of vuex store were reset to default. This caused bugs by switching to another account that has some other/missing settings. For example, if the account has no quota, the quota of the previously logged in account was shown. We have fixed this by resetting the user store module on logout with reset function (vuex extensions library) and creating an action to reset dynamic nav items.
+
+https://github.com/owncloud/web/pull/6694
+https://github.com/owncloud/web/issues/6549

--- a/packages/web-runtime/src/store/navigation.js
+++ b/packages/web-runtime/src/store/navigation.js
@@ -43,6 +43,10 @@ const mutations = {
     }
     state.dynamicNavItems = dynamicNavItems
   },
+  /* Sets dynamic nav items */
+  SET_DYNAMIC_NAV_ITEMS(state, navItems) {
+    state.dynamicNavItems = navItems
+  },
   SET_CLOSED(state, closed) {
     state.closed = closed
   }
@@ -89,6 +93,9 @@ const actions = {
   },
   closeNavigation({ commit }) {
     commit('SET_CLOSED', true)
+  },
+  clearDynamicNavItems({ commit }) {
+    commit('SET_DYNAMIC_NAV_ITEMS', {})
   }
 }
 export default {

--- a/packages/web-runtime/src/store/user.js
+++ b/packages/web-runtime/src/store/user.js
@@ -25,12 +25,11 @@ const actions = {
     if (context.state.id === '') {
       return
     }
-    // reset user to default state
-    context.commit('SET_USER', state)
-    // reset capabilities to default state
-    context.commit('SET_CAPABILITIES', { capabilities: null, version: null })
-    // set userReady to false
-    context.commit('SET_USER_READY', false)
+    // reset user
+    this.reset({ self: false, nested: false, modules: { user: { self: true } } })
+
+    // clear dynamic navItems
+    context.dispatch('clearDynamicNavItems')
 
     // clear oidc client state
     vueAuthInstance.clearLoginState()
@@ -41,9 +40,6 @@ const actions = {
       dispatch('cleanUpLoginState')
       dispatch('hideModal')
       dispatch('loadSettingsValues')
-
-      // Reset store
-      this.reset()
 
       // Force redirect to login
       if (forceRedirect) {

--- a/packages/web-runtime/src/store/user.js
+++ b/packages/web-runtime/src/store/user.js
@@ -42,6 +42,9 @@ const actions = {
       dispatch('hideModal')
       dispatch('loadSettingsValues')
 
+      // Reset store
+      this.reset()
+
       // Force redirect to login
       if (forceRedirect) {
         router.push({ name: 'login' })


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
When logging out, only some parts of vuex store were reset to default. This caused bugs by switching to another account that has some other/missing settings. For example, if the account has no quota, the quota of the previously logged in account was shown. We have fixed this by resetting the store on logout with reset function (vuex extensions library).

## Related Issue
- Fixes [6549](https://github.com/owncloud/web/issues/6549)


## How Has This Been Tested?
 logging in, logging out, logging in
- test case 1: logging in with account with quota, logging out, logging in with account without quota --> quota not shown
- test case 2:  logging in with account with navItems, logging out, logging in with account with another set of navItems --> they are displayed correctly
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->