### PR TITLE
Fix #6527 - TopBar on redirect

### DIFF
--- a/changelog/unreleased/bugfix-topbar-on-redirect
+++ b/changelog/unreleased/bugfix-topbar-on-redirect
@@ -1,0 +1,6 @@
+Bugfix: TopBar on redirect
+
+We fixed a visual glitch that showed the topbar on redirect pages.
+
+https://github.com/owncloud/web/pull/6704
+https://github.com/owncloud/web/issues/6527

--- a/packages/web-runtime/src/App.vue
+++ b/packages/web-runtime/src/App.vue
@@ -59,6 +59,7 @@ export default defineComponent({
       }
 
       if (
+        !this.$route.name ||
         [
           'login',
           'oidcCallback',


### PR DESCRIPTION
## Description
From my understanding (and the browser logs), `this.$route.name` evaluates to `undefined` for enough time to render the full `LayoutApplication`. To reproduce, log the route in the `layout()` computed prop in the runtime app. To check the fix, add `setTimeout(console.log('waiting'), 10000)` to the mounted-nexttick on oidcCallback.vue

## Related Issue
- Fixes https://github.com/owncloud/web/issues/6527