### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/changelog/unreleased/enhancement-replace-deprecated-substr
+++ b/changelog/unreleased/enhancement-replace-deprecated-substr
@@ -1,0 +1,7 @@
+Enhancement: Replace deprecated String.prototype.substr()
+
+We've replaced all occurrences of the deprecated String.prototype.substr()
+function with String.prototype.slice() which works similarly but isn't
+deprecated.
+
+https://github.com/owncloud/web/pull/6718

--- a/packages/web-app-files/src/mixins/actions/rename.js
+++ b/packages/web-app-files/src/mixins/actions/rename.js
@@ -165,7 +165,7 @@ export default {
           this.hideModal()
 
           if (sameResource) {
-            const newPath = resource.path.substr(1, resource.path.lastIndexOf('/'))
+            const newPath = resource.path.slice(1, resource.path.lastIndexOf('/') + 1)
             this.$router.push({
               params: {
                 item: '/' + newPath + newName || '/'

--- a/packages/web-app-files/src/mixins/deleteResources.js
+++ b/packages/web-app-files/src/mixins/deleteResources.js
@@ -170,7 +170,8 @@ export default {
           isSameResource(this.resourcesToDelete[0], this.currentFolder)
         ) {
           const resourcePath = this.resourcesToDelete[0].path
-          parentFolderPath = resourcePath.substr(0, resourcePath.lastIndexOf('/'))
+          const lastSlash = resourcePath.lastIndexOf('/')
+          parentFolderPath = resourcePath.slice(0, lastSlash !== -1 ? lastSlash : 0)
         }
 
         if (parentFolderPath !== undefined) {

--- a/packages/web-app-files/src/store/actions.js
+++ b/packages/web-app-files/src/store/actions.js
@@ -128,7 +128,7 @@ export default {
   },
   renameFile(context, { file, newValue, client, publicPage, isSameResource }) {
     if (file !== undefined && newValue !== undefined && newValue !== file.name) {
-      const newPath = file.webDavPath.substr(1, file.webDavPath.lastIndexOf('/'))
+      const newPath = file.webDavPath.slice(1, file.webDavPath.lastIndexOf('/') + 1)
       if (publicPage) {
         return client.publicFiles
           .move(file.webDavPath, newPath + newValue, context.getters.publicLinkPassword)

--- a/packages/web-app-preview/src/App.vue
+++ b/packages/web-app-preview/src/App.vue
@@ -202,7 +202,7 @@ export default {
         y: this.thumbDimensions,
         // strip double quotes from etag
         // we have no etag, e.g. on shared with others page
-        c: this.activeFilteredFile.etag?.substr(1, this.activeFilteredFile.etag.length - 2),
+        c: this.activeFilteredFile.etag?.slice(1, -1),
         scalingup: 0,
         preview: 1,
         a: 1

--- a/packages/web-runtime/src/components/Topbar/Notifications.vue
+++ b/packages/web-runtime/src/components/Topbar/Notifications.vue
@@ -76,7 +76,7 @@ export default {
       this.$client.requests
         .ocs({
           service: 'apps/' + app,
-          action: link.substr(link.lastIndexOf('api')),
+          action: link.slice(link.lastIndexOf('api')),
           method: type
         })
         .then((res) => {
@@ -86,7 +86,7 @@ export default {
           })
           res.json().then((json) => {
             json.ocs.data.forEach((item) => {
-              const path = item.path.substr(0, item.path.lastIndexOf('/') + 1)
+              const path = item.path.slice(0, item.path.lastIndexOf('/') + 1)
               const absolutePath = this.$route.params.item ? this.$route.params.item : '/'
               if (path === absolutePath) this.reloadFilesList(path)
             })

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -148,8 +148,9 @@ const plugins = [
                 }
                 files[c].forEach((f) => {
                   const fp = path.parse(f.fileName)
+                  const lastDash = fp.name.lastIndexOf('-')
                   acc[c][
-                    production ? fp.name.substr(0, fp.name.lastIndexOf('-')) || fp.name : fp.name
+                    production ? fp.name.slice(0, lastDash !== -1 ? lastDash : 0) || fp.name : fp.name
                   ] = c === 'js' ? fp.name : f.fileName
                 })
 


### PR DESCRIPTION
## Description

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## Related Issue


## Motivation and Context

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated .


## How Has This Been Tested?
I tested the return of each statement to make sure it's still the same as before

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:

