### PR TITLE
[tests-only] fix log output of unit test in FileShares.spec

### DIFF
--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.js
@@ -8,6 +8,7 @@ import Collaborators from '@/__fixtures__/collaborators'
 import mockAxios from 'jest-mock-axios'
 import { spaceRoleManager } from '../../../../../src/helpers/share'
 import VueCompositionAPI from '@vue/composition-api/dist/vue-composition-api'
+import * as reactivities from 'web-pkg/src/composables/reactivity'
 
 const localVue = createLocalVue()
 localVue.use(DesignSystem)
@@ -17,6 +18,8 @@ localVue.use(GetTextPlugin, {
   translations: 'does-not-matter.json',
   silent: true
 })
+
+jest.mock('web-pkg/src/composables/reactivity')
 
 const user = Users.alice
 const collaborators = [Collaborators[0], Collaborators[1]]
@@ -269,7 +272,6 @@ function getMountedWrapper(data, loading = false) {
     localVue,
     store: createStore(data),
     mocks: {
-      sharesLoading: loading,
       $route: {
         params: { storageId: 1 }
       },
@@ -292,6 +294,8 @@ function getMountedWrapper(data, loading = false) {
 }
 
 function getShallowMountedWrapper(data, loading = false) {
+  reactivities.useDebouncedRef.mockImplementationOnce(() => loading)
+
   return shallowMount(FileShares, {
     localVue,
     store: createStore(data),
@@ -301,7 +305,6 @@ function getShallowMountedWrapper(data, loading = false) {
       'oc-spinner': true
     },
     mocks: {
-      sharesLoading: loading,
       $route: {
         params: {
           storageId: 1


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
fix unit test log output of FileShares.spec.js

## Related Issue
- part of #6337

## Motivation and Context
get rid of these log outputs, make the tests work correctly
```
  console.error
    [Vue warn]: The setup binding property "sharesLoading" is already declared.

    found in

    ---> <FileShares>
           <Root>

      at Object.warn (node_modules/vue/dist/vue.runtime.common.dev.js:621:15)
      at warn (node_modules/@vue/composition-api/dist/vue-composition-api.common.js:427:18)
      at asVmProperty (node_modules/@vue/composition-api/dist/vue-composition-api.common.js:1764:13)
      at node_modules/@vue/composition-api/dist/vue-composition-api.common.js:2006:17
          at Array.forEach (<anonymous>)
      at initSetup (node_modules/@vue/composition-api/dist/vue-composition-api.common.js:1982:39)
      at VueComponent.wrappedData (node_modules/@vue/composition-api/dist/vue-composition-api.common.js:1943:13)
```

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
running tests locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
