### PR TITLE
Vertically centered loading spinner or error message on startup

### DIFF
--- a/packages/web-container/index.html.ejs
+++ b/packages/web-container/index.html.ejs
@@ -16,6 +16,10 @@
   <script src="js/require.js?<%= data.compilationTimestamp %>"></script>
   <% } %>
   <style>
+    html,
+    body {
+      height: 100%
+    }
     .splash-banner {
       display: flex;
       flex-direction: row;


### PR DESCRIPTION
We discussed this some weeks ago. Noop change, since when the app loads it will change it.
But with this, while the app is not loaded, we see the spinner centered.

---
Can we also commit a hover effect to the quick actions on the files table? The idea is to hide them and only show on hover, like so:
![image](https://user-images.githubusercontent.com/2589871/161551515-96dccccf-1c4f-4e86-ba63-e0722b0c49a2.png)
