### PR TITLE
[tests-only] mock v-translate directive in views tests

### DIFF
--- a/packages/web-app-files/tests/unit/views/views.shared.ts
+++ b/packages/web-app-files/tests/unit/views/views.shared.ts
@@ -16,6 +16,11 @@ localVue.use(GetTextPlugin, {
   translations: 'does-not-matter.json',
   silent: true
 })
+// mock `v-translate` directive
+localVue.directive('translate', {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  inserted: () => {}
+})
 
 const stubs = {
   'create-and-upload': true,


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
mock v-translate here also, simmilar to https://github.com/owncloud/web/pull/6404/files#diff-0dd79c75d790d047f8dde209581a57ea4dc2708fcda916ad00f5aee313d7e02dR38

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- part of #6337 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
get rid of warnings like
```
    console.warn
      No translations found for en_US

      at Object.getTranslation (node_modules/vue-gettext/dist/vue-gettext.js:357:19)
      at updateTranslation (node_modules/vue-gettext/dist/vue-gettext.js:700:33)
      at bind (node_modules/vue-gettext/dist/vue-gettext.js:756:7)
      at callHook$1 (node_modules/vue/dist/vue.runtime.common.dev.js:6702:7)
      at _update (node_modules/vue/dist/vue.runtime.common.dev.js:6623:7)
      at Array.updateDirectives (node_modules/vue/dist/vue.runtime.common.dev.js:6604:5)
      at invokeCreateHooks (node_modules/vue/dist/vue.runtime.common.dev.js:6093:22)
      at createElm (node_modules/vue/dist/vue.runtime.common.dev.js:5980:11)
```


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
running unit tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
