### PR TITLE
Add markdown-editor to simple-editor alias for config compatibility

### DIFF
--- a/changelog/unreleased/enhancement-simple-editor
+++ b/changelog/unreleased/enhancement-simple-editor
@@ -11,3 +11,4 @@ Replace MarkdownEditor with SimpleEditor and add the following improvements:
 * UI polish
 
 https://github.com/owncloud/web/pull/6667
+https://github.com/owncloud/web/pull/6754

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -155,7 +155,10 @@ export const announceApplications = async ({
 const rewriteDeprecatedAppNames = (
   runtimeConfiguration: RuntimeConfiguration
 ): RuntimeConfiguration => {
-  const appAliases = [{ name: 'preview', oldName: 'media-viewer' }]
+  const appAliases = [
+    { name: 'preview', oldName: 'media-viewer' },
+    { name: 'simple-editor', oldName: 'markdown-editor' }
+  ]
   return {
     ...runtimeConfiguration,
     apps: runtimeConfiguration.apps.map((appName) => {


### PR DESCRIPTION
## Description
The `markdown-editor` has recently been renamed to [`simple-editor`](https://github.com/owncloud/web/pull/6667). In order to not break old configs this PR adds an alias for the app bootstraping (i.e. when `markdown-editor` gets found in a config.json it gets replaced with `simple-editor` during runtime, before the apps are being loaded).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
