### PR TITLE
Sentry as option

### DIFF
--- a/changelog/unreleased/enhancement-add-sentry-support
+++ b/changelog/unreleased/enhancement-add-sentry-support
@@ -1,0 +1,5 @@
+Enhancement: Add Sentry support
+
+We've added Sentry support to enable monitoring and error tracking (see docs "getting started").
+
+https://github.com/owncloud/web/pull/6759

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,9 +53,25 @@ substring of a value of the authenticated user. Examples are `/Shares`, `/{{.Id}
 - `options.feedbackLink` This accepts an object with the following optional fields to customize the feedback link in the topbar:
   - `options.feedbackLink.href` Set a different target URL for the feedback link. Make sure to prepend it with `http(s)://`. Defaults to `https://owncloud.com/web-design-feedback`.
   - `options.feedbackLink.ariaLabel` Since the link only has an icon, you can set an e.g. screen reader accessible label. Defaults to `ownCloud feedback survey`.
-  - `options.feedbackLink.description` Provide any description you want to see as tooltip and as accessible description. Defaults to `Provide your feedback: We'd like to improve the web design and would be happy to hear your feedback. Thank you! Your ownCloud team.` 
+  - `options.feedbackLink.description` Provide any description you want to see as tooltip and as accessible description. Defaults to `Provide your feedback: We'd like to improve the web design and would be happy to hear your feedback. Thank you! Your ownCloud team.`
 - `options.sharingRecipientsPerPage` Sets the amount of users shown as recipients in the dropdown when sharing resources. Default amount is 200.
 - `options.sidebar.shares.showAllOnLoad` Sets the list of (link) shares list in the sidebar to be initially expanded (default is a collapsed state, only showing the first three shares).
+
+### Sentry
+
+Web supports [Sentry](https://sentry.io/welcome/) to provide monitoring and error tracking.
+To enable sending data to a Sentry instance, you can use the following configuration keys:
+
+- `sentry.dsn` Should contain the DSN for your sentry project.
+- `sentry.environment`: Lets you specify the enviroment to use in Sentry. Defaults to `production`.
+
+Any other key under `sentry` will be forwarded to the Sentry initialization. You can find out more
+settings in the [Sentry docs](https://docs.sentry.io/platforms/javascript/configuration/).
+
+{{< hint info >}}
+If you are using an old version of Sentry (9 and before), you might want to add the setting `sentry.autoSessionTracking: false` to avoid errors related to breaking changes introduced in the
+integration libraries.
+{{< /hint >}}
 
 ## Setting up backend and running
 

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -6,13 +6,9 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",
     "@popperjs/core": "^2.4.0",
-<<<<<<< HEAD
     "@uppy/core": "^2.1.10",
-=======
     "@sentry/browser": "^6.19.7",
     "@sentry/integrations": "^6.19.7",
-    "@uppy/core": "^2.1.7",
->>>>>>> Sentry support
     "@uppy/drop-target": "^1.1.1",
     "@uppy/status-bar": "^2.1.3",
     "@uppy/tus": "^2.2.2",

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -6,7 +6,13 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",
     "@popperjs/core": "^2.4.0",
+<<<<<<< HEAD
     "@uppy/core": "^2.1.10",
+=======
+    "@sentry/browser": "^6.19.7",
+    "@sentry/integrations": "^6.19.7",
+    "@uppy/core": "^2.1.7",
+>>>>>>> Sentry support
     "@uppy/drop-target": "^1.1.1",
     "@uppy/status-bar": "^2.1.3",
     "@uppy/tus": "^2.2.2",

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -319,11 +319,17 @@ export const announceVersions = ({ store }: { store: Store<unknown> }): void => 
  */
 export const startSentry = (runtimeConfiguration: RuntimeConfiguration): void => {
   if (runtimeConfiguration.sentry?.dsn) {
+    const {
+      dsn,
+      environment = 'production',
+      ...moreSentryOptions
+    } = runtimeConfiguration.sentry;
+
     SentryInit({
-      dsn: runtimeConfiguration.sentry.dsn,
+      dsn,
+      environment,
       integrations: [new SentryVueIntegration({ Vue, attachProps: true, logErrors: true })],
-      environment: runtimeConfiguration.sentry.environment || 'production',
-      autoSessionTracking: false
+      ...moreSentryOptions,
     })
   }
 }

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -3,7 +3,7 @@ import { RuntimeConfiguration } from './types'
 import { buildApplication, NextApplication } from './application'
 import { Store } from 'vuex'
 import VueRouter from 'vue-router'
-import Vue from 'vue'
+import { VueConstructor } from 'vue'
 import { loadTheme } from '../helpers/theme'
 import OwnCloud from 'owncloud-sdk'
 import { sync as routerSync } from 'vuex-router-sync'
@@ -51,7 +51,7 @@ export const announceStore = async ({
   runtimeConfiguration,
   store
 }: {
-  vue: Vue.VueConstructor
+  vue: VueConstructor
   runtimeConfiguration: RuntimeConfiguration
   store: Store<any>
 }): Promise<void> => {
@@ -192,7 +192,7 @@ export const announceTheme = async ({
   runtimeConfiguration
 }: {
   store: Store<unknown>
-  vue: Vue.VueConstructor
+  vue: VueConstructor
   designSystem: any
   runtimeConfiguration?: RuntimeConfiguration
 }): Promise<void> => {
@@ -221,7 +221,7 @@ export const announceTranslations = ({
   supportedLanguages,
   translations
 }: {
-  vue: Vue.VueConstructor
+  vue: VueConstructor
   supportedLanguages: unknown
   translations: unknown
 }): void => {
@@ -243,7 +243,7 @@ export const announceClientService = ({
   vue,
   runtimeConfiguration
 }: {
-  vue: Vue.VueConstructor
+  vue: VueConstructor
   runtimeConfiguration: RuntimeConfiguration
 }): void => {
   const sdk = new OwnCloud()
@@ -258,7 +258,7 @@ export const announceClientService = ({
  *
  * @param vue
  */
-export const announceUppyService = ({ vue }: { vue: Vue.VueConstructor }): void => {
+export const announceUppyService = ({ vue }: { vue: VueConstructor }): void => {
   vue.prototype.$uppyService = new UppyService()
 }
 
@@ -317,19 +317,18 @@ export const announceVersions = ({ store }: { store: Store<unknown> }): void => 
  *
  * @param runtimeConfiguration
  */
-export const startSentry = (runtimeConfiguration: RuntimeConfiguration): void => {
+export const startSentry = (
+  runtimeConfiguration: RuntimeConfiguration,
+  Vue: VueConstructor
+): void => {
   if (runtimeConfiguration.sentry?.dsn) {
-    const {
-      dsn,
-      environment = 'production',
-      ...moreSentryOptions
-    } = runtimeConfiguration.sentry;
+    const { dsn, environment = 'production', ...moreSentryOptions } = runtimeConfiguration.sentry
 
     SentryInit({
       dsn,
       environment,
       integrations: [new SentryVueIntegration({ Vue, attachProps: true, logErrors: true })],
-      ...moreSentryOptions,
+      ...moreSentryOptions
     })
   }
 }

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -20,11 +20,13 @@ import {
   announceTranslations,
   announceVersions,
   applicationStore,
-  announceUppyService
+  announceUppyService,
+  startSentry
 } from './container'
 
 export const bootstrap = async (configurationPath: string): Promise<void> => {
   const runtimeConfiguration = await requestConfiguration(configurationPath)
+  startSentry(runtimeConfiguration)
   announceClientService({ vue: Vue, runtimeConfiguration })
   announceUppyService({ vue: Vue })
   await announceClient(runtimeConfiguration)

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -26,7 +26,7 @@ import {
 
 export const bootstrap = async (configurationPath: string): Promise<void> => {
   const runtimeConfiguration = await requestConfiguration(configurationPath)
-  startSentry(runtimeConfiguration)
+  startSentry(runtimeConfiguration, Vue)
   announceClientService({ vue: Vue, runtimeConfiguration })
   announceUppyService({ vue: Vue })
   await announceClient(runtimeConfiguration)

--- a/packages/web-runtime/src/store/user.js
+++ b/packages/web-runtime/src/store/user.js
@@ -4,6 +4,8 @@ import initVueAuthenticate from '../services/auth'
 import { router } from '../router'
 import { clientService } from 'web-pkg/src/services'
 
+import { setUser as sentrySetUser } from '@sentry/browser'
+
 let vueAuthInstance
 
 const state = {
@@ -249,6 +251,7 @@ const mutations = {
     state.isAuthenticated = user.isAuthenticated
     state.token = user.token
     state.groups = user.groups
+    sentrySetUser({ username: user.id })
   },
   SET_CAPABILITIES(state, data) {
     state.capabilities = data.capabilities

--- a/yarn.lock
+++ b/yarn.lock
@@ -2157,6 +2157,82 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/browser@npm:^6.19.7":
+  version: 6.19.7
+  resolution: "@sentry/browser@npm:6.19.7"
+  dependencies:
+    "@sentry/core": 6.19.7
+    "@sentry/types": 6.19.7
+    "@sentry/utils": 6.19.7
+    tslib: ^1.9.3
+  checksum: 071d00c76c2d0384580474c634c58c6196bbd1a3cf510da1309bd1565c57df7422fca8ceb717db189fa557f2c711a21664ee1ab935dfd9869faf416d388e6f78
+  languageName: node
+  linkType: hard
+
+"@sentry/core@npm:6.19.7":
+  version: 6.19.7
+  resolution: "@sentry/core@npm:6.19.7"
+  dependencies:
+    "@sentry/hub": 6.19.7
+    "@sentry/minimal": 6.19.7
+    "@sentry/types": 6.19.7
+    "@sentry/utils": 6.19.7
+    tslib: ^1.9.3
+  checksum: d212e8ef07114549de4a93b81f8bfa217ca1550ca7a5eeaa611e5629faef78ff72663ce561ffa2cff48f3dc556745ef65177044f9965cdd3cbccf617cf3bf675
+  languageName: node
+  linkType: hard
+
+"@sentry/hub@npm:6.19.7":
+  version: 6.19.7
+  resolution: "@sentry/hub@npm:6.19.7"
+  dependencies:
+    "@sentry/types": 6.19.7
+    "@sentry/utils": 6.19.7
+    tslib: ^1.9.3
+  checksum: 10bb1c5cba1b0f1e27a3dd0a186c22f94aeaf11c4662890ab07b2774f46f46af78d61e3ba71d76edc750a7b45af86edd032f35efecdb4efa2eaf551080ccdcb1
+  languageName: node
+  linkType: hard
+
+"@sentry/integrations@npm:^6.19.7":
+  version: 6.19.7
+  resolution: "@sentry/integrations@npm:6.19.7"
+  dependencies:
+    "@sentry/types": 6.19.7
+    "@sentry/utils": 6.19.7
+    localforage: ^1.8.1
+    tslib: ^1.9.3
+  checksum: 6ea22ef8d518e6ade96ad00c07f5346c8316264ae6ec353c299e03d1d3cf4b226f639bde07dd5d1da28feaa031338e75df25fc60a083a24d847f4cfde4dbc8e9
+  languageName: node
+  linkType: hard
+
+"@sentry/minimal@npm:6.19.7":
+  version: 6.19.7
+  resolution: "@sentry/minimal@npm:6.19.7"
+  dependencies:
+    "@sentry/hub": 6.19.7
+    "@sentry/types": 6.19.7
+    tslib: ^1.9.3
+  checksum: 9153ac426ee056fc34c5be898f83d74ec08f559d69f544c5944ec05e584b62ed356b92d1a9b08993a7022ad42b5661c3d72881221adc19bee5fc1af3ad3864a8
+  languageName: node
+  linkType: hard
+
+"@sentry/types@npm:6.19.7":
+  version: 6.19.7
+  resolution: "@sentry/types@npm:6.19.7"
+  checksum: f46ef74a33376ad6ea9b128115515c58eb9369d89293c60aa67abca26b5d5d519aa4d0a736db56ae0d75ffd816643d62187018298523cbc2e6c2fb3a6b2a9035
+  languageName: node
+  linkType: hard
+
+"@sentry/utils@npm:6.19.7":
+  version: 6.19.7
+  resolution: "@sentry/utils@npm:6.19.7"
+  dependencies:
+    "@sentry/types": 6.19.7
+    tslib: ^1.9.3
+  checksum: a000223b9c646c64e3565e79cace1eeb75114342b768367c4dddd646476c215eb1bddfb70c63f05e2352d3bce2d7d415344e4757a001605d0e01ac74da5dd306
+  languageName: node
+  linkType: hard
+
 "@sinonjs/commons@npm:^1.7.0":
   version: 1.8.3
   resolution: "@sinonjs/commons@npm:1.8.3"
@@ -6982,6 +7058,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"immediate@npm:~3.0.5":
+  version: 3.0.6
+  resolution: "immediate@npm:3.0.6"
+  checksum: f9b3486477555997657f70318cc8d3416159f208bec4cca3ff3442fd266bc23f50f0c9bd8547e1371a6b5e82b821ec9a7044a4f7b944798b25aa3cc6d5e63e62
+  languageName: node
+  linkType: hard
+
 "import-cwd@npm:^3.0.0":
   version: 3.0.0
   resolution: "import-cwd@npm:3.0.0"
@@ -8516,6 +8599,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lie@npm:3.1.1":
+  version: 3.1.1
+  resolution: "lie@npm:3.1.1"
+  dependencies:
+    immediate: ~3.0.5
+  checksum: 6da9f2121d2dbd15f1eca44c0c7e211e66a99c7b326ec8312645f3648935bc3a658cf0e9fa7b5f10144d9e2641500b4f55bd32754607c3de945b5f443e50ddd1
+  languageName: node
+  linkType: hard
+
 "lilconfig@npm:^2.0.3":
   version: 2.0.3
   resolution: "lilconfig@npm:2.0.3"
@@ -8571,6 +8663,15 @@ __metadata:
     emojis-list: ^3.0.0
     json5: ^1.0.1
   checksum: d150b15e7a42ac47d935c8b484b79e44ff6ab4c75df7cc4cb9093350cf014ec0b17bdb60c5d6f91a37b8b218bd63b973e263c65944f58ca2573e402b9a27e717
+  languageName: node
+  linkType: hard
+
+"localforage@npm:^1.8.1":
+  version: 1.10.0
+  resolution: "localforage@npm:1.10.0"
+  dependencies:
+    lie: 3.1.1
+  checksum: f2978b434dafff9bcb0d9498de57d97eba165402419939c944412e179cab1854782830b5ec196212560b22712d1dd03918939f59cf1d4fc1d756fca7950086cf
   languageName: node
   linkType: hard
 
@@ -12995,7 +13096,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.10.0, tslib@npm:^1.8.1":
+"tslib@npm:^1.10.0, tslib@npm:^1.8.1, tslib@npm:^1.9.3":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
@@ -13674,6 +13775,8 @@ __metadata:
   dependencies:
     "@fortawesome/fontawesome-free": ^6.1.1
     "@popperjs/core": ^2.4.0
+    "@sentry/browser": ^6.19.7
+    "@sentry/integrations": ^6.19.7
     "@types/luxon": ^2.3.1
     "@types/semver": ^7.3.8
     "@uppy/core": ^2.1.10


### PR DESCRIPTION
Would you take this? This is quite useful for us to get user's issues without having to wait for a ticket.
I've made it optional and configurable.
But.. Our centrally managed Sentry instance doesn't run the latest version, so the config/package version in here is also not the latest.