### PR TITLE
Feedback link customization

### DIFF
--- a/changelog/unreleased/enhancement-customizable-feedback-link
+++ b/changelog/unreleased/enhancement-customizable-feedback-link
@@ -1,0 +1,7 @@
+Enhancement: Customizable feedback link
+
+We've added options and documentation for customization of the `href`, `ariaLabel` and `description` of the feedback link in the topbar. See https://owncloud.dev/clients/web/getting-started/ for documentation.
+
+https://github.com/owncloud/web/issues/6702
+https://github.com/owncloud/web/pull/6761
+https://owncloud.dev/clients/web/getting-started/

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,6 +51,10 @@ substring of a value of the authenticated user. Examples are `/Shares`, `/{{.Id}
 - `options.previewFileExtensions` Specifies which filetypes will be previewed in the ui. For example to only preview jpg and txt files set this option to `["jpg", "txt"]`.
 - `options.disableFeedbackLink` Set this option to `true` to disable the feedback link in the topbar. Keeping it enabled (value `false` or absence of the option)
   allows ownCloud to get feedback from your user base through a dedicated survey website.
+- `options.feedbackLink` This accepts an object with the following optional fields to customize the feedback link in the topbar:
+  - `options.feedbackLink.href` Set a different target URL for the feedback link. Make sure to prepend it with `http(s)://`. Defaults to `https://owncloud.com/web-design-feedback`.
+  - `options.feedbackLink.ariaLabel` Since the link only has an icon, you can set an e.g. screen reader accessible label. Defaults to `ownCloud feedback survey`.
+  - `options.feedbackLink.description` Provide any description you want to see as tooltip and as accessible description. Defaults to `Provide your feedback: We'd like to improve the web design and would be happy to hear your feedback. Thank you! Your ownCloud team.` 
 - `options.sharingRecipientsPerPage` Sets the amount of users shown as recipients in the dropdown when sharing resources. Default amount is 200.
 
 ## Setting up backend and running

--- a/packages/web-runtime/src/components/Topbar/FeedbackLink.vue
+++ b/packages/web-runtime/src/components/Topbar/FeedbackLink.vue
@@ -1,34 +1,54 @@
 <template>
   <div class="oc-flex">
     <oc-button
-      v-oc-tooltip="description"
+      v-oc-tooltip="descriptionOrFallback"
       type="a"
-      :href="href"
+      :href="hrefOrFallback"
       target="_blank"
       appearance="raw"
       variation="inverse"
-      :aria-label="ariaLabel"
+      :aria-label="ariaLabelOrFallback"
       aria-describedby="oc-feedback-link-description"
     >
       <oc-icon name="feedback" />
     </oc-button>
-    <p id="oc-feedback-link-description" class="oc-invisible-sr" v-text="description" />
+    <p id="oc-feedback-link-description" class="oc-invisible-sr" v-text="descriptionOrFallback" />
   </div>
 </template>
 
 <script>
 export default {
   name: 'FeedbackLink',
+  props: {
+    href: {
+      type: String,
+      required: false,
+      default: null
+    },
+    ariaLabel: {
+      type: String,
+      required: false,
+      default: null
+    },
+    description: {
+      type: String,
+      required: false,
+      default: null
+    }
+  },
   computed: {
-    href() {
-      return 'https://owncloud.com/web-design-feedback'
+    hrefOrFallback() {
+      return this.href || 'https://owncloud.com/web-design-feedback'
     },
-    ariaLabel() {
-      return this.$gettext('ownCloud feedback survey')
+    ariaLabelOrFallback() {
+      return this.ariaLabel || this.$gettext('ownCloud feedback survey')
     },
-    description() {
-      return this.$gettext(
-        "Provide your feedback: We'd like to improve the web design and would be happy to hear your feedback. Thank you! Your ownCloud team."
+    descriptionOrFallback() {
+      return (
+        this.description ||
+        this.$gettext(
+          "Provide your feedback: We'd like to improve the web design and would be happy to hear your feedback. Thank you! Your ownCloud team."
+        )
       )
     }
   }

--- a/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -15,7 +15,7 @@
     </div>
     <div class="oc-topbar-right oc-flex oc-flex-middle oc-flex-between">
       <theme-switcher v-if="darkThemeAvailable" />
-      <feedback-link v-if="isFeedbackLinkEnabled" />
+      <feedback-link v-if="isFeedbackLinkEnabled" v-bind="feedbackLinkOptions" />
       <notifications v-if="isNotificationBellEnabled" />
       <user-menu v-if="isUserMenuEnabled" :applications-list="userMenuItems" />
     </div>
@@ -81,6 +81,19 @@ export default {
 
     isFeedbackLinkEnabled() {
       return !this.configuration.options.disableFeedbackLink
+    },
+
+    feedbackLinkOptions() {
+      const feedback = this.configuration.options.feedbackLink
+      if (!this.isFeedbackLinkEnabled || !feedback) {
+        return {}
+      }
+
+      return {
+        ...(feedback.href && { href: feedback.href }),
+        ...(feedback.ariaLabel && { ariaLabel: feedback.ariaLabel }),
+        ...(feedback.description && { description: feedback.description })
+      }
     },
 
     isNotificationBellEnabled() {

--- a/packages/web-runtime/tests/unit/components/Topbar/FeedbackLink.spec.js
+++ b/packages/web-runtime/tests/unit/components/Topbar/FeedbackLink.spec.js
@@ -1,5 +1,5 @@
 import FeedbackLink from '../../../../src/components/Topbar/FeedbackLink'
-import { createLocalVue, mount } from '@vue/test-utils'
+import { createLocalVue, mount, shallowMount } from '@vue/test-utils'
 import { axe, toHaveNoViolations } from 'jest-axe'
 import DesignSystem from 'owncloud-design-system'
 const localVue = createLocalVue()
@@ -24,5 +24,35 @@ describe('FeedbackLink component', () => {
       })
     ).toHaveNoViolations()
     expect(wrapper).toMatchSnapshot()
+  })
+
+  describe('properties', () => {
+    let wrapper
+    beforeEach(() => {
+      wrapper = shallowMount(FeedbackLink, {
+        stubs: {
+          'oc-button': true,
+          'oc-icon': true
+        },
+        directives: {
+          'oc-tooltip': jest.fn()
+        }
+      })
+    })
+    it('allows to overwrite the link href', async () => {
+      const url = 'https://some-link.tld/'
+      await wrapper.setProps({ href: url })
+      expect(wrapper.find('oc-button-stub').attributes().href).toEqual(url)
+    })
+    it('allows to overwrite the link ariaLabel', async () => {
+      const ariaLabel = 'some aria label'
+      await wrapper.setProps({ ariaLabel })
+      expect(wrapper.find('oc-button-stub').attributes()['aria-label']).toEqual(ariaLabel)
+    })
+    it('allows to overwrite the link description', async () => {
+      const description = 'some lengthy description'
+      await wrapper.setProps({ description })
+      expect(wrapper.find('#oc-feedback-link-description').text()).toEqual(description)
+    })
   })
 })


### PR DESCRIPTION
## Description
Adds configuration options for overwriting feedback link props

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Works towards https://github.com/owncloud/web/issues/6702

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- unit tests to test the overrides

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
