### PR TITLE
[unit-tests] fix failing `packages/web-app-files/tests/unit/views/shares/SharedWithOthers.spec.js`

### DIFF
--- a/packages/web-app-files/tests/unit/views/shares/SharedWithOthers.spec.js
+++ b/packages/web-app-files/tests/unit/views/shares/SharedWithOthers.spec.js
@@ -8,7 +8,7 @@ import { buildSharedResource } from '../../../../src/helpers/resources'
 import { Settings, DateTime } from 'luxon'
 const resourcesList = SharedData.json().ocs.data.map((resource) => buildSharedResource(resource))
 
-const expectedNow = DateTime.local(2022, 1, 1, 23, 0, 0);
+const expectedNow = DateTime.local(2022, 1, 1, 23, 0, 0)
 
 const router = {
   push: jest.fn(),

--- a/packages/web-app-files/tests/unit/views/shares/SharedWithOthers.spec.js
+++ b/packages/web-app-files/tests/unit/views/shares/SharedWithOthers.spec.js
@@ -5,8 +5,10 @@ import SharedWithOthers from '@files/src/views/shares/SharedWithOthers.vue'
 import SharedData from '@/__fixtures__/sharedFiles.js'
 import { createLocationShares } from '../../../../src/router'
 import { buildSharedResource } from '../../../../src/helpers/resources'
-import { Settings } from 'luxon'
+import { Settings, DateTime } from 'luxon'
 const resourcesList = SharedData.json().ocs.data.map((resource) => buildSharedResource(resource))
+
+const expectedNow = DateTime.local(2022, 1, 1, 23, 0, 0);
 
 const router = {
   push: jest.fn(),
@@ -47,6 +49,7 @@ const paginationStub = 'pagination-stub'
 describe('SharedWithOthers view', () => {
   beforeAll(() => {
     Settings.defaultZone = 'utc'
+    Settings.now = () => expectedNow
   })
 
   it('should show the app-loading-spinner component when the wrapper is still loading', () => {

--- a/packages/web-app-files/tests/unit/views/shares/__snapshots__/SharedWithOthers.spec.js.snap
+++ b/packages/web-app-files/tests/unit/views/shares/__snapshots__/SharedWithOthers.spec.js.snap
@@ -37,7 +37,7 @@ exports[`SharedWithOthers view when the wrapper is not loading anymore when leng
           <oc-avatars-stub items="[object Object]" stacked="true" istooltipdisplayed="true" maxdisplayed="3" accessibledescription=" This folder is shared via 1 link" class="resource-table-people"></oc-avatars-stub>
         </oc-button-stub>
       </td>
-      <td class="oc-td oc-table-cell oc-table-cell-align-right oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-table-data-cell oc-table-data-cell-sdate" aria-label="9 months ago (June 9, 2021, 12:44 PM UTC)"><span tabindex="0">9 months ago</span></td>
+      <td class="oc-td oc-table-cell oc-table-cell-align-right oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-table-data-cell oc-table-data-cell-sdate" aria-label="6 months ago (June 9, 2021, 12:44 PM UTC)"><span tabindex="0">6 months ago</span></td>
       <td class="oc-td oc-table-cell oc-table-cell-align-right oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-table-data-cell oc-table-data-cell-actions oc-pr-m">
         <div class="resource-table-actions">
           <oc-button-stub type="button" size="medium" arialabel="Show context menu" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" id="context-menu-trigger-38" class="resource-table-btn-action-dropdown"><span class="oc-icon oc-icon-m oc-icon-passive"><!----></span></oc-button-stub>
@@ -60,7 +60,7 @@ exports[`SharedWithOthers view when the wrapper is not loading anymore when leng
           <oc-avatars-stub items="[object Object]" stacked="true" istooltipdisplayed="true" maxdisplayed="3" accessibledescription=" This folder is shared via 1 link" class="resource-table-people"></oc-avatars-stub>
         </oc-button-stub>
       </td>
-      <td class="oc-td oc-table-cell oc-table-cell-align-right oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-table-data-cell oc-table-data-cell-sdate" aria-label="9 months ago (June 9, 2021, 12:44 PM UTC)"><span tabindex="0">9 months ago</span></td>
+      <td class="oc-td oc-table-cell oc-table-cell-align-right oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-table-data-cell oc-table-data-cell-sdate" aria-label="6 months ago (June 9, 2021, 12:44 PM UTC)"><span tabindex="0">6 months ago</span></td>
       <td class="oc-td oc-table-cell oc-table-cell-align-right oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-table-data-cell oc-table-data-cell-actions oc-pr-m">
         <div class="resource-table-actions">
           <oc-button-stub type="button" size="medium" arialabel="Show context menu" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" id="context-menu-trigger-64" class="resource-table-btn-action-dropdown"><span class="oc-icon oc-icon-m oc-icon-passive"><!----></span></oc-button-stub>
@@ -83,7 +83,7 @@ exports[`SharedWithOthers view when the wrapper is not loading anymore when leng
           <oc-avatars-stub items="[object Object]" stacked="true" istooltipdisplayed="true" maxdisplayed="3" accessibledescription=" This folder is shared via 1 link" class="resource-table-people"></oc-avatars-stub>
         </oc-button-stub>
       </td>
-      <td class="oc-td oc-table-cell oc-table-cell-align-right oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-table-data-cell oc-table-data-cell-sdate" aria-label="9 months ago (June 9, 2021, 12:44 PM UTC)"><span tabindex="0">9 months ago</span></td>
+      <td class="oc-td oc-table-cell oc-table-cell-align-right oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-table-data-cell oc-table-data-cell-sdate" aria-label="6 months ago (June 9, 2021, 12:44 PM UTC)"><span tabindex="0">6 months ago</span></td>
       <td class="oc-td oc-table-cell oc-table-cell-align-right oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-table-data-cell oc-table-data-cell-actions oc-pr-m">
         <div class="resource-table-actions">
           <oc-button-stub type="button" size="medium" arialabel="Show context menu" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" id="context-menu-trigger-39" class="resource-table-btn-action-dropdown"><span class="oc-icon oc-icon-m oc-icon-passive"><!----></span></oc-button-stub>
@@ -106,7 +106,7 @@ exports[`SharedWithOthers view when the wrapper is not loading anymore when leng
           <oc-avatars-stub items="[object Object],[object Object]" stacked="true" istooltipdisplayed="true" maxdisplayed="3" accessibledescription="This file is shared via 1 invite This file is shared via 1 link" class="resource-table-people"></oc-avatars-stub>
         </oc-button-stub>
       </td>
-      <td class="oc-td oc-table-cell oc-table-cell-align-right oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-table-data-cell oc-table-data-cell-sdate" aria-label="9 months ago (June 9, 2021, 12:37 PM UTC)"><span tabindex="0">9 months ago</span></td>
+      <td class="oc-td oc-table-cell oc-table-cell-align-right oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-table-data-cell oc-table-data-cell-sdate" aria-label="6 months ago (June 9, 2021, 12:37 PM UTC)"><span tabindex="0">6 months ago</span></td>
       <td class="oc-td oc-table-cell oc-table-cell-align-right oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-table-data-cell oc-table-data-cell-actions oc-pr-m">
         <div class="resource-table-actions">
           <oc-button-stub type="button" size="medium" arialabel="Show context menu" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" id="context-menu-trigger-30" class="resource-table-btn-action-dropdown"><span class="oc-icon oc-icon-m oc-icon-passive"><!----></span></oc-button-stub>


### PR DESCRIPTION
## Description
unit test at `packages/web-app-files/tests/unit/views/shares/SharedWithOthers.spec.js`
>SharedWithOthers view › when the wrapper is not loading anymore › when length of paginated resources is greater than zero › should load the resource table with correct props

started failing in recent ci builds. check the related issue for more details

Imo the problem is with the relative sdate used in the `ResourceTable` component used by `SharedWithOthers` view. We use resources from the fixtures with constant stime set.

The calculated relative sdate was 9 months previously and is 10 months now. It will keep on rising every month. So maybe it's better to only assert for props rather matching the whole html snapshot.

With this PR:
- match only props for the `ResourceTable`
- update related screenshots

### Related
Fixes https://github.com/owncloud/web/issues/6764