### PR TITLE
add demo users flag to docker dev env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       WEB_ASSET_PATH: ${WEB_ASSET_PATH:-/web/dist}
       IDP_IDENTIFIER_REGISTRATION_CONF: ${IDP_IDENTIFIER_REGISTRATION_CONF:-/web/identifier-registration.yml}
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-true}"
+      ACCOUNTS_DEMO_USERS_AND_GROUPS: "${DEMO_USERS:-true}"  # deprecated, remove after switching to LibreIDM
+      IDM_CREATE_DEMO_USERS: "${DEMO_USERS:-true}"
       OCIS_LOG_LEVEL: ${OCIS_LOG_LEVEL:-error}
     volumes:
       - ./dist:/web/dist:ro


### PR DESCRIPTION
## Description
Literally the same as, #6773 but for the local dev env we use. 
`demo users are now opt in and therefore re-enabled in this PR`

## Related Issue
- extends #6773
