### PR TITLE
fix readonly flag in texteditor

### DIFF
--- a/packages/web-app-text-editor/src/App.vue
+++ b/packages/web-app-text-editor/src/App.vue
@@ -91,8 +91,9 @@ export default {
       unref(defaults)
         .getFileInfo(filePath, [DavProperty.Permissions])
         .then((response) => {
-          isReadOnly.value =
-            response.fileInfo[DavProperty.Permissions].indexOf(DavPermission.Updateable) === -1
+          isReadOnly.value = ![DavPermission.Updateable, DavPermission.FileUpdateable].includes(
+            response.fileInfo[DavProperty.Permissions]
+          )
         })
 
       return yield unref(defaults)

--- a/packages/web-app-text-editor/src/App.vue
+++ b/packages/web-app-text-editor/src/App.vue
@@ -91,8 +91,8 @@ export default {
       unref(defaults)
         .getFileInfo(filePath, [DavProperty.Permissions])
         .then((response) => {
-          isReadOnly.value = ![DavPermission.Updateable, DavPermission.FileUpdateable].includes(
-            response.fileInfo[DavProperty.Permissions]
+          isReadOnly.value = ![DavPermission.Updateable, DavPermission.FileUpdateable].some(
+            (p) => response.fileInfo[DavProperty.Permissions].indexOf(p) > -1
           )
         })
 


### PR DESCRIPTION
## Description

This fixes the readonly flag for the texteditor when the backend returns WebDAVPermissions `W` (FileUpdateable)


## Related Issue

- Occured during ocis Release


## Motivation and Context

Make Single File Sharing in public links work

## How Has This Been Tested?
- Manually

## Example Response (if appropriate):


```xml
<?xml version="1.0"?>
<d:multistatus xmlns:s="http://sabredav.org/ns" xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
  <d:response>
    <d:href>/remote.php/dav/public-files/OWDoMgbKaUcKRAz/</d:href>
    <d:propstat>
      <d:prop>
        <oc:permissions/>
        <d:resourcetype>
          <d:collection/>
        </d:resourcetype>
        <oc:public-link-item-type>folder</oc:public-link-item-type>
        <oc:public-link-share-datetime>Thu, 14 Apr 2022 10:51:11 GMT</oc:public-link-share-datetime>
        <oc:public-link-share-owner>admin</oc:public-link-share-owner>
      </d:prop>
      <d:status>HTTP/1.1 200 OK</d:status>
    </d:propstat>
    <d:propstat>
      <d:prop>
        <oc:favorite/>
        <oc:fileid/>
        <oc:owner-id/>
        <oc:owner-display-name/>
        <oc:share-types/>
        <oc:privatelink/>
        <d:getcontentlength/>
        <oc:size/>
        <d:getlastmodified/>
        <d:getetag/>
        <d:getcontenttype/>
        <oc:downloadURL/>
        <oc:public-link-permission/>
        <oc:public-link-expiration/>
        <oc:public-link-expiration/>
      </d:prop>
      <d:status>HTTP/1.1 404 Not Found</d:status>
    </d:propstat>
  </d:response>
  <d:response>
    <d:href>/remote.php/dav/public-files/OWDoMgbKaUcKRAz/README.md</d:href>
    <d:propstat>
      <d:prop>
        <oc:permissions>W</oc:permissions>
        <oc:fileid>ddc2004c-0977-11eb-9d3f-a793888cd0f8!70b8854e-fd5a-4332-ab35-f25150016408</oc:fileid>
        <oc:owner-id>admin</oc:owner-id>
        <oc:owner-display-name>Admin</oc:owner-display-name>
        <d:getcontentlength>306</d:getcontentlength>
        <oc:size>306</oc:size>
        <d:getlastmodified>Thu, 14 Apr 2022 10:37:44 GMT</d:getlastmodified>
        <d:getetag>"7717c93aa2851ad412874a04cc3c0773"</d:getetag>
        <d:getcontenttype>text/markdown</d:getcontenttype>
        <d:resourcetype/>
        <oc:downloadURL>https://localhost:9200/remote.php/dav/public-files/OWDoMgbKaUcKRAz/README.md</oc:downloadURL>
        <oc:public-link-item-type>file</oc:public-link-item-type>
        <oc:public-link-permission>3</oc:public-link-permission>
        <oc:public-link-share-datetime>Thu, 14 Apr 2022 10:51:11 GMT</oc:public-link-share-datetime>
        <oc:public-link-share-owner>admin</oc:public-link-share-owner>
      </d:prop>
      <d:status>HTTP/1.1 200 OK</d:status>
    </d:propstat>
    <d:propstat>
      <d:prop>
        <oc:favorite/>
        <oc:share-types/>
        <oc:privatelink/>
        <oc:public-link-expiration/>
        <oc:public-link-expiration/>
      </d:prop>
      <d:status>HTTP/1.1 404 Not Found</d:status>
    </d:propstat>
  </d:response>
</d:multistatus>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
