### PR TITLE
Style fixes for menus: ContextDrop

### DIFF
--- a/packages/web-app-files/src/components/ActionMenuItem.vue
+++ b/packages/web-app-files/src/components/ActionMenuItem.vue
@@ -109,12 +109,5 @@ export default {
 <style lang="scss">
 .action-menu-item {
   vertical-align: middle;
-  &:hover {
-    color: var(--oc-color-swatch-brand-hover);
-    text-decoration: underline;
-    .oc-icon > svg {
-      fill: var(--oc-color-swatch-brand-hover) !important;
-    }
-  }
 }
 </style>

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -13,6 +13,7 @@
         <oc-icon name="add" />
         <translate>New</translate>
       </oc-button>
+
       <oc-drop
         drop-id="new-file-menu-drop"
         toggle="#new-file-menu-btn"
@@ -21,39 +22,47 @@
         class="oc-width-auto"
         padding-size="small"
       >
-        <oc-list id="create-list">
-          <li class="create-list-folder">
-            <oc-button id="new-folder-btn" appearance="raw" @click="showCreateResourceModal">
-              <oc-resource-icon :resource="{ isFolder: true, extension: '' }" />
-              <translate>Folder</translate>
-            </oc-button>
-          </li>
-          <li v-for="(newFileHandler, key) in newFileHandlers" :key="key" class="create-list-file">
-            <oc-button
-              appearance="raw"
-              :class="['new-file-btn-' + newFileHandler.ext]"
-              @click="showCreateResourceModal(false, newFileHandler.ext, newFileHandler.action)"
-            >
-              <oc-resource-icon :resource="{ type: 'file', extension: newFileHandler.ext }" />
-              <span>{{ newFileHandler.menuTitle($gettext) }}</span>
-            </oc-button>
-          </li>
-          <template v-if="mimetypesAllowedForCreation">
-            <li
-              v-for="(mimetype, key) in mimetypesAllowedForCreation"
-              :key="key"
-              class="create-list-file"
-            >
-              <oc-button
-                appearance="raw"
-                @click="showCreateResourceModal(false, mimetype.ext, false, true)"
+        <context-drop>
+          <template #drop-content>
+            <oc-list id="create-list">
+              <li class="create-list-folder">
+                <oc-button id="new-folder-btn" appearance="raw" @click="showCreateResourceModal">
+                  <oc-resource-icon :resource="{ isFolder: true, extension: '' }" />
+                  <translate>Folder</translate>
+                </oc-button>
+              </li>
+              <li
+                v-for="(newFileHandler, key) in newFileHandlers"
+                :key="key"
+                class="create-list-file"
               >
-                <oc-resource-icon :resource="{ type: 'file', extension: mimetype.ext }" />
-                <translate :translate-params="{ name: mimetype.name }">%{name}</translate>
-              </oc-button>
-            </li>
+                <oc-button
+                  appearance="raw"
+                  :class="['new-file-btn-' + newFileHandler.ext]"
+                  @click="showCreateResourceModal(false, newFileHandler.ext, newFileHandler.action)"
+                >
+                  <oc-resource-icon :resource="{ type: 'file', extension: newFileHandler.ext }" />
+                  <span>{{ newFileHandler.menuTitle($gettext) }}</span>
+                </oc-button>
+              </li>
+              <template v-if="mimetypesAllowedForCreation">
+                <li
+                  v-for="(mimetype, key) in mimetypesAllowedForCreation"
+                  :key="key"
+                  class="create-list-file"
+                >
+                  <oc-button
+                    appearance="raw"
+                    @click="showCreateResourceModal(false, mimetype.ext, false, true)"
+                  >
+                    <oc-resource-icon :resource="{ type: 'file', extension: mimetype.ext }" />
+                    <translate :translate-params="{ name: mimetype.name }">%{name}</translate>
+                  </oc-button>
+                </li>
+              </template>
+            </oc-list>
           </template>
-        </oc-list>
+        </context-drop>
       </oc-drop>
     </template>
     <template v-else>
@@ -89,6 +98,7 @@
       <oc-icon name="upload" fill-type="line" />
       <translate>Upload</translate>
     </oc-button>
+
     <oc-drop
       drop-id="upload-menu-drop"
       toggle="#upload-menu-btn"
@@ -97,27 +107,31 @@
       close-on-click
       padding-size="small"
     >
-      <oc-list id="upload-list">
-        <li>
-          <folder-upload
-            :root-path="currentPath"
-            :path="currentPath"
-            :headers="headers"
-            @success="onFileSuccess"
-            @error="onFileError"
-            @progress="onFileProgress"
-          />
-        </li>
-        <li>
-          <file-upload
-            :path="currentPath"
-            :headers="headers"
-            @success="onFileSuccess"
-            @error="onFileError"
-            @progress="onFileProgress"
-          />
-        </li>
-      </oc-list>
+      <context-drop>
+        <template #drop-content>
+          <oc-list id="upload-list">
+            <li>
+              <folder-upload
+                :root-path="currentPath"
+                :path="currentPath"
+                :headers="headers"
+                @success="onFileSuccess"
+                @error="onFileError"
+                @progress="onFileProgress"
+              />
+            </li>
+            <li>
+              <file-upload
+                :path="currentPath"
+                :headers="headers"
+                @success="onFileSuccess"
+                @error="onFileError"
+                @progress="onFileProgress"
+              />
+            </li>
+          </oc-list>
+        </template>
+      </context-drop>
     </oc-drop>
   </div>
 </template>
@@ -137,12 +151,14 @@ import { DavProperties, DavProperty } from 'web-pkg/src/constants'
 import FileDrop from './Upload/FileDrop.vue'
 import FileUpload from './Upload/FileUpload.vue'
 import FolderUpload from './Upload/FolderUpload.vue'
+import ContextDrop from '../ContextDrop.vue'
 
 export default {
   components: {
     FileDrop,
     FileUpload,
-    FolderUpload
+    FolderUpload,
+    ContextDrop
   },
   mixins: [Mixins, MixinFileActions],
   setup() {

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -644,12 +644,15 @@ export default {
   .create-list-folder {
     border-bottom: 1px solid var(--oc-color-border);
   }
-  .create-list-file button {
-    margin: 2px 0;
+  .create-list-folder button {
+    margin-bottom: 8px;
+  }
+  .create-list-file:nth-child(2) button {
+    margin-top: 6px;
   }
 }
 #upload-list,
 #new-file-menu-drop {
-  min-width: 200px;
+  min-width: 250px;
 }
 </style>

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -27,7 +27,7 @@
             <oc-list id="create-list">
               <li class="create-list-folder">
                 <oc-button id="new-folder-btn" appearance="raw" @click="showCreateResourceModal">
-                  <oc-resource-icon :resource="{ isFolder: true, extension: '' }" />
+                  <oc-resource-icon :resource="{ isFolder: true, extension: '' }" size="medium" />
                   <translate>Folder</translate>
                 </oc-button>
               </li>
@@ -41,7 +41,10 @@
                   :class="['new-file-btn-' + newFileHandler.ext]"
                   @click="showCreateResourceModal(false, newFileHandler.ext, newFileHandler.action)"
                 >
-                  <oc-resource-icon :resource="{ type: 'file', extension: newFileHandler.ext }" />
+                  <oc-resource-icon
+                    :resource="{ type: 'file', extension: newFileHandler.ext }"
+                    size="medium"
+                  />
                   <span>{{ newFileHandler.menuTitle($gettext) }}</span>
                 </oc-button>
               </li>
@@ -55,7 +58,10 @@
                     appearance="raw"
                     @click="showCreateResourceModal(false, mimetype.ext, false, true)"
                   >
-                    <oc-resource-icon :resource="{ type: 'file', extension: mimetype.ext }" />
+                    <oc-resource-icon
+                      :resource="{ type: 'file', extension: mimetype.ext }"
+                      size="medium"
+                    />
                     <translate :translate-params="{ name: mimetype.name }">%{name}</translate>
                   </oc-button>
                 </li>

--- a/packages/web-app-files/src/components/AppBar/Upload/FileUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/Upload/FileUpload.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <oc-button class="oc-width-1-1" justify-content="left" appearance="raw" @click="triggerUpload">
-      <oc-resource-icon :resource="{ extension: '' }" />
+      <oc-resource-icon :resource="{ extension: '' }" size="medium" />
       <span id="files-file-upload-button" v-translate>Files</span>
     </oc-button>
     <input

--- a/packages/web-app-files/src/components/AppBar/Upload/FolderUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/Upload/FolderUpload.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <oc-button class="oc-width-1-1" justify-content="left" appearance="raw" @click="triggerUpload">
-      <oc-resource-icon :resource="{ isFolder: true, extension: '' }" />
+      <oc-resource-icon :resource="{ isFolder: true, extension: '' }" size="medium" />
       <span id="files-folder-upload-button" v-translate>Folder</span>
     </oc-button>
     <input

--- a/packages/web-app-files/src/components/ContextActionMenu.vue
+++ b/packages/web-app-files/src/components/ContextActionMenu.vue
@@ -62,11 +62,6 @@ export default {
   white-space: normal;
 
   > li {
-    padding: 6px;
-    &:hover {
-      background-color: var(--oc-color-background-hover);
-    }
-
     a,
     button,
     span {
@@ -78,11 +73,6 @@ export default {
       vertical-align: top;
       width: 100%;
       text-align: left;
-
-      &:hover {
-        color: var(--oc-color-swatch-passive-default);
-        text-decoration: none !important;
-      }
     }
   }
 

--- a/packages/web-app-files/src/components/ContextActionMenu.vue
+++ b/packages/web-app-files/src/components/ContextActionMenu.vue
@@ -1,29 +1,34 @@
 <template>
   <div id="oc-files-context-menu">
-    <oc-list
-      v-for="(section, sectionIndex) in menuSections"
-      :id="`oc-files-context-actions-${section.name}`"
-      :key="`section-${section.name}-list`"
-      class="oc-files-context-actions"
-      :class="getSectionClasses(sectionIndex)"
-    >
-      <action-menu-item
-        v-for="(action, actionIndex) in section.items"
-        :key="`section-${section.name}-action-${actionIndex}`"
-        :action="action"
-        :items="items"
-        class="oc-files-context-action oc-px-s oc-rounded"
-      />
-    </oc-list>
+    <context-drop>
+      <template #drop-content>
+        <oc-list
+          v-for="(section, sectionIndex) in menuSections"
+          :id="`oc-files-context-actions-${section.name}`"
+          :key="`section-${section.name}-list`"
+          class="oc-files-context-actions"
+          :class="getSectionClasses(sectionIndex)"
+        >
+          <action-menu-item
+            v-for="(action, actionIndex) in section.items"
+            :key="`section-${section.name}-action-${actionIndex}`"
+            :action="action"
+            :items="items"
+            class="oc-files-context-action oc-px-s oc-rounded"
+          />
+        </oc-list>
+      </template>
+    </context-drop>
   </div>
 </template>
 
 <script>
 import ActionMenuItem from './ActionMenuItem.vue'
+import ContextDrop from './ContextDrop.vue'
 
 export default {
   name: 'ContextActionMenu',
-  components: { ActionMenuItem },
+  components: { ActionMenuItem, ContextDrop },
   props: {
     menuSections: {
       type: Array,

--- a/packages/web-app-files/src/components/ContextDrop.vue
+++ b/packages/web-app-files/src/components/ContextDrop.vue
@@ -33,6 +33,9 @@ export default {
       span {
         text-decoration: none !important;
       }
+      .oc-icon-m > svg {
+        height: 24px;
+      }
     }
   }
 }

--- a/packages/web-app-files/src/components/ContextDrop.vue
+++ b/packages/web-app-files/src/components/ContextDrop.vue
@@ -1,0 +1,39 @@
+<template>
+  <div class="context-drop">
+    <slot name="drop-content" />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ContextDrop'
+}
+</script>
+
+<style lang="scss">
+// note: needed so that the box shadow from `oc-box-shadow-medium` doesn't get suppressed
+.context-drop {
+  li {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    a,
+    button:not([role='switch']) {
+      box-sizing: border-box !important;
+      padding: 6px !important;
+      &:focus,
+      &:hover {
+        background-color: var(--oc-color-background-hover) !important;
+
+        text-decoration: none !important;
+        border-radius: 5px !important;
+      }
+      &:hover span {
+        color: var(--oc-color-swatch-brand-hover) !important;
+      }
+      span {
+        text-decoration: none !important;
+      }
+    }
+  }
+}
+</style>


### PR DESCRIPTION
## Description
- moving hover effect to ContextDrop component
- unifying spacings



## Related Issue
Fixes hover menus issues from https://github.com/owncloud/web/issues/6555

## Motivation and Context
More consistency in style of different menus:

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):
![menus](https://user-images.githubusercontent.com/7430156/162973959-b086af9d-6782-4492-96af-33f8ee8cc9f0.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated


