### PR TITLE
Take path into account while renaming a file

### DIFF
--- a/changelog/unreleased/bugfix-renaming-favorites-issue
+++ b/changelog/unreleased/bugfix-renaming-favorites-issue
@@ -1,7 +1,7 @@
-Bugfix: Rename a file in the favorites list to a file with the same name but in a different folder not possible
+Bugfix: Rename a file in favorites list to a file with the same name located in different folder
 
-We've fixed a bug, where renaming a file in the favorites file list to a file with the same name but in a different
-folder was not possible, as the message `The name "..." is already taken` appeared.
+We've fixed a bug, where renaming a file in the favorites file list to a file with the same name but located
+in a different folder was not possible, as the message `The name "..." is already taken` appeared.
 
 https://github.com/owncloud/web/pull/6804
 https://github.com/owncloud/web/issues/1750

--- a/changelog/unreleased/bugfix-renaming-favorites-issue
+++ b/changelog/unreleased/bugfix-renaming-favorites-issue
@@ -1,4 +1,4 @@
-Bugfix: Rename a file in favorites list to a file with the same name located in different folder
+Bugfix: Rename a file in favorites list with same name but in different folder
 
 We've fixed a bug, where renaming a file in the favorites file list to a file with the same name but located
 in a different folder was not possible, as the message `The name "..." is already taken` appeared.

--- a/changelog/unreleased/bugfix-renaming-favorites-issue
+++ b/changelog/unreleased/bugfix-renaming-favorites-issue
@@ -1,0 +1,7 @@
+Bugfix: Rename a file in the favorites list to a file with the same name but in a different folder not possible
+
+We've fixed a bug, where renaming a file in the favorites file list to a file with the same name but in a different
+folder was not possible, as the message `The name "..." is already taken` appeared.
+
+https://github.com/owncloud/web/pull/6804
+https://github.com/owncloud/web/issues/1750

--- a/packages/web-app-files/src/helpers/resources.ts
+++ b/packages/web-app-files/src/helpers/resources.ts
@@ -25,7 +25,7 @@ export function renameResource(resource, newName, newPath) {
   }
 
   resource.name = newName
-  resource.path = resourcePath
+  resource.path = '/' + resourcePath
   resource.webDavPath = '/' + newPath + newName
   resource.extension = extractExtensionFromFile(resource)
 

--- a/packages/web-app-files/src/mixins/actions/rename.js
+++ b/packages/web-app-files/src/mixins/actions/rename.js
@@ -79,7 +79,7 @@ export default {
         if (!this.areFileExtensionsShown) {
           newName = `${newName}.${resources[0].extension}`
         }
-        this.$_rename_checkNewName(resources[0].name, newName, parentResources)
+        this.$_rename_checkNewName(resources[0], newName, parentResources)
       }
       const nameWithoutExtension = extractNameWithoutExtension(resources[0])
       const modalTitle =
@@ -123,7 +123,10 @@ export default {
       this.createModal(modal)
     },
 
-    $_rename_checkNewName(currentName, newName, parentResources) {
+    $_rename_checkNewName(resource, newName, parentResources) {
+      const newPath =
+        resource.path.substring(0, resource.path.length - resource.name.length) + newName
+
       if (!newName) {
         return this.setModalInputErrorMessage(this.$gettext('The name cannot be empty'))
       }
@@ -145,7 +148,7 @@ export default {
       }
 
       if (!this.flatFileList) {
-        const exists = this.files.find((file) => file.name === newName && currentName !== newName)
+        const exists = this.files.find((file) => file.path === newPath && resource.name !== newName)
 
         if (exists) {
           const translated = this.$gettext('The name "%{name}" is already taken')
@@ -158,7 +161,7 @@ export default {
 
       if (parentResources) {
         const exists = parentResources.find(
-          (file) => file.name === newName && currentName !== newName
+          (file) => file.path === newPath && resource.name !== newName
         )
 
         if (exists) {

--- a/packages/web-app-files/tests/unit/mixins/actions/rename.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/actions/rename.spec.js
@@ -51,6 +51,16 @@ describe('rename', () => {
       expect(spyErrorMessageStub).toHaveBeenCalledWith(null)
     })
 
+    it('should not show an error if resource name already exists but in different folder', () => {
+      const wrapper = getWrapper()
+      const spyErrorMessageStub = jest.spyOn(wrapper.vm, 'setModalInputErrorMessage')
+      wrapper.vm.$_rename_checkNewName(
+        { name: 'currentName', path: '/favorites/currentName' },
+        'file1'
+      )
+      expect(spyErrorMessageStub).toHaveBeenCalledWith(null)
+    })
+
     it.each([
       { currentName: 'currentName', newName: '', message: 'The name cannot be empty' },
       { currentName: 'currentName', newName: 'new/name', message: 'The name cannot contain "/"' },

--- a/packages/web-app-files/tests/unit/mixins/actions/rename.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/actions/rename.spec.js
@@ -47,7 +47,7 @@ describe('rename', () => {
     it('should not show an error with a valid name', () => {
       const wrapper = getWrapper()
       const spyErrorMessageStub = jest.spyOn(wrapper.vm, 'setModalInputErrorMessage')
-      wrapper.vm.$_rename_checkNewName('currentName', 'newName')
+      wrapper.vm.$_rename_checkNewName({ name: 'currentName', path: '/currentName' }, 'newName')
       expect(spyErrorMessageStub).toHaveBeenCalledWith(null)
     })
 
@@ -69,14 +69,14 @@ describe('rename', () => {
       {
         currentName: 'currentName',
         newName: 'newname',
-        parentResources: [{ name: 'newname' }],
+        parentResources: [{ name: 'newname', path: '/newname' }],
         message: 'The name "%{name}" is already taken'
       }
     ])('should detect name errors and display error messages accordingly', (inputData) => {
       const wrapper = getWrapper()
       const spyGetTextStub = jest.spyOn(wrapper.vm, '$gettext')
       wrapper.vm.$_rename_checkNewName(
-        inputData.currentName,
+        { name: inputData.currentName, path: `/${inputData.currentName}` },
         inputData.newName,
         inputData.parentResources
       )
@@ -142,7 +142,9 @@ function getWrapper(renameFilePromise) {
           return { href: r.name }
         }
       },
-      $client: { files: { find: jest.fn(() => [{ name: 'file1' }]), list: jest.fn(() => []) } },
+      $client: {
+        files: { find: jest.fn(() => [{ name: 'file1', path: '/file1' }]), list: jest.fn(() => []) }
+      },
       $gettextInterpolate: jest.fn(),
       $gettext: jest.fn(),
       publicPage: () => false,
@@ -154,7 +156,7 @@ function getWrapper(renameFilePromise) {
           namespaced: true,
           getters: {
             currentFolder: () => currentFolder,
-            files: () => [{ name: 'file1' }]
+            files: () => [{ name: 'file1', path: '/file1' }]
           },
           actions: {
             renameFile: jest.fn(() => {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Bugfix: Rename a file in the favorites list to a file with the same name but in a different folder not possible

We've fixed a bug, where renaming a file in the favorites file list to a file with the same name but in a different
folder was not possible, as the message `The name "..." is already taken` appeared.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/1750

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/26169327/164649675-79b4635c-9fad-4b20-8869-e390c6c99a25.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
