### PR TITLE
l10n for typescript files 

### DIFF
--- a/packages/web-runtime/l10n/Makefile
+++ b/packages/web-runtime/l10n/Makefile
@@ -48,7 +48,8 @@ $(TEMPLATE_FILE):
 			export OUT_DIR=$$app/l10n; \
 		fi; \
 		mkdir -p $$OUT_DIR; \
-		export GETTEXT_APP_SOURCES=`find $$app/src -name '*.vue' -o -name '*.js'`; \
+		#FIXME: we need to find out why share.ts fails to get parsed and fix it
+		export GETTEXT_APP_SOURCES=`find $$app/src -name '*.vue' -o -name '*.js' -o -name '*.ts' ! -path '*/web-app-files/src/helpers/share/share.ts'`; \
 		node $(NODE_MODULES)/easygettext/src/extract-cli.js --attribute v-translate --output $$OUT_DIR/template.pot $$GETTEXT_APP_SOURCES; \
 	done;
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Note: 
1. The library easygettext, which we are using to extract translations, **is not capable to extract the LOC Number and therefore it is missing in the respective POT file**, see: https://github.com/Polyconseil/easygettext#known-issues
2. Babel and acorn parsers are complaining about the file: packages/web-app-files/src/helpers/share/share.ts, therefore I ignored it, maybe @dschmidt might help later to find the issue:
```[easygettext] could not read: '../../web-app-files/src/helpers/share/share.ts' using babel as parser
Trace: SyntaxError: Line 1, column 13: Unexpected
    at report (/home/jan/working/web/node_modules/buntis/dist/buntis.umd.js:4472:21)
    at parseModuleSpecifier (/home/jan/working/web/node_modules/buntis/dist/buntis.umd.js:6490:11)
    at parseImportDeclaration (/home/jan/working/web/node_modules/buntis/dist/buntis.umd.js:6465:20)
    at parseDeclarationList (/home/jan/working/web/node_modules/buntis/dist/buntis.umd.js:6176:22)
    at parseDeclarations (/home/jan/working/web/node_modules/buntis/dist/buntis.umd.js:6109:27)
    at parseSource (/home/jan/working/web/node_modules/buntis/dist/buntis.umd.js:6087:17)
    at parseTSScript (/home/jan/working/web/node_modules/buntis/dist/buntis.umd.js:11782:14)
    at getGettextEntriesFromTypeScript (/home/jan/working/web/node_modules/easygettext/src/typescript-extract.js:45:8)
    at Object.extractStringsFromTypeScript (/home/jan/working/web/node_modules/easygettext/src/typescript-extract.js:63:48)
    at Extractor.parseTypeScript (/home/jan/working/web/node_modules/easygettext/src/extract.js:331:52) {
  index: 13,
  line: 1,
  column: 13,
  description: 'Unexpected'
}
    at /home/jan/working/web/node_modules/easygettext/src/extract-cli.js:75:13
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/home/jan/working/web/node_modules/easygettext/src/extract-cli.js:61:7)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:17:47
```


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/6460

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
