### PR TITLE
[full-ci] Bump ocis commit and test-middleware 

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=4202a99600ef15bc7a6bd91b011074775c19a24a
+OCIS_COMMITID=0758854b638d4aeb9f229165f6ef34da42eacc40
 OCIS_BRANCH=master

--- a/.drone.star
+++ b/.drone.star
@@ -20,7 +20,7 @@ OC_CI_HUGO = "owncloudci/hugo:0.89.4"
 OC_CI_NODEJS = "owncloudci/nodejs:14"
 OC_CI_PHP = "owncloudci/php:7.4"
 OC_CI_WAIT_FOR = "owncloudci/wait-for:latest"
-OC_TESTING_MIDDLEWARE = "owncloud/owncloud-test-middleware:1.4.2"
+OC_TESTING_MIDDLEWARE = "owncloud/owncloud-test-middleware:1.5.0"
 OC_UBUNTU = "owncloud/ubuntu:20.04"
 PLUGINS_DOCKER = "plugins/docker:18.09"
 PLUGINS_DOWNSTREAM = "plugins/downstream"
@@ -2986,6 +2986,7 @@ def middlewareService(ocis = False, federatedServer = False):
         "REMOTE_UPLOAD_DIR": "/uploads",
         "NODE_TLS_REJECT_UNAUTHORIZED": "0",
         "MIDDLEWARE_HOST": "middleware",
+        "TEST_WITH_GRAPH_API": "true",
     }
 
     if (federatedServer):


### PR DESCRIPTION
oCIS switched to libregraph/idm for users and groups. We need the newer
middleware for user provisioning.
