### PR TITLE
Switch to dschmidt/easygettext to use typescript-estree

### DIFF
--- a/packages/web-runtime/l10n/Makefile
+++ b/packages/web-runtime/l10n/Makefile
@@ -48,8 +48,7 @@ $(TEMPLATE_FILE):
 			export OUT_DIR=$$app/l10n; \
 		fi; \
 		mkdir -p $$OUT_DIR; \
-		#FIXME: we need to find out why share.ts fails to get parsed and fix it
-		export GETTEXT_APP_SOURCES=`find $$app/src -name '*.vue' -o -name '*.js' -o -name '*.ts' ! -path '*/web-app-files/src/helpers/share/share.ts'`; \
+		export GETTEXT_APP_SOURCES=`find $$app/src -name '*.vue' -o -name '*.js' -o -name '*.ts'`; \
 		node $(NODE_MODULES)/easygettext/src/extract-cli.js --attribute v-translate --output $$OUT_DIR/template.pot $$GETTEXT_APP_SOURCES; \
 	done;
 

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -14,7 +14,7 @@
     "@vue/composition-api": "^1.4.9",
     "axios": "^0.26.1",
     "cross-fetch": "^3.0.6",
-    "easygettext": "^2.16.1",
+    "easygettext": "github:dschmidt/easygettext#da6f3d7ac03345ecec44a2694957533bc56c0f15",
     "filesize": "^8.0.7",
     "focus-trap": "^6.4.0",
     "focus-trap-vue": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4037,13 +4037,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buntis@npm:0.2.1":
-  version: 0.2.1
-  resolution: "buntis@npm:0.2.1"
-  checksum: 9942c9797ec5776cc4c4bc5fe2f90c08feca2e9eb84aa1e909e07362c3857c694f8db2c9483fbbe665f7e020ca27476bd888e628d2b563830886b5f328058fad
-  languageName: node
-  linkType: hard
-
 "cacache@npm:^15.0.5":
   version: 15.3.0
   resolution: "cacache@npm:15.3.0"
@@ -5497,16 +5490,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"easygettext@npm:^2.16.1":
-  version: 2.17.0
-  resolution: "easygettext@npm:2.17.0"
+"easygettext@github:dschmidt/easygettext#da6f3d7ac03345ecec44a2694957533bc56c0f15":
+  version: 2.16.0
+  resolution: "easygettext@https://github.com/dschmidt/easygettext.git#commit=da6f3d7ac03345ecec44a2694957533bc56c0f15"
   dependencies:
     "@babel/core": ^7.11.6
     "@vue/compiler-sfc": ^3.0.0
     acorn: ^7.4.0
     acorn-stage3: ^4.0.0
     acorn-walk: ^8.0.0
-    buntis: 0.2.1
     cheerio: ^1.0.0-rc.3
     estree-walker: ^2.0.1
     flow-remove-types: ^2.135.0
@@ -5519,9 +5511,9 @@ __metadata:
     pug:
       optional: true
   bin:
-    gettext-compile: src/compile-cli.js
-    gettext-extract: src/extract-cli.js
-  checksum: 0ec5d0716f4b68103467ee527d369ae4d5c7741841b88697e6acc755fdb6c73a0b5e3dcbe596d0460adf3e0e3b1c3fbdba6bc3218bcb0a94fa68aab28cc06be3
+    gettext-compile: ./src/compile-cli.js
+    gettext-extract: ./src/extract-cli.js
+  checksum: 328c7be2f4709b19d8afbfa07928e5f6d7a74ec165e8dd765341bdb281ff89eec1c26e8c09f3153e81b1fa81cc4ebb6086034679ecc9626a339901fa80df52fe
   languageName: node
   linkType: hard
 
@@ -13931,7 +13923,7 @@ __metadata:
     "@vue/composition-api": ^1.4.9
     axios: ^0.26.1
     cross-fetch: ^3.0.6
-    easygettext: ^2.16.1
+    easygettext: "github:dschmidt/easygettext#da6f3d7ac03345ecec44a2694957533bc56c0f15"
     filesize: ^8.0.7
     focus-trap: ^6.4.0
     focus-trap-vue: ^1.1.1


### PR DESCRIPTION
…from typescript-eslint project instead of outdated buntis parser

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
buntis is outdated and fails to parse newer javascript/typescript syntax like optional chaining.
There is a [PR ](https://github.com/Polyconseil/easygettext/pull/107) open for porting to the properly maintained typescript-eslint/typescript-estree library, but it hasn't seen any feedback. It does not fix linenumbers anyhow.
I've sent a new PR which also fixes line numbers, I'm not optimistic it will be merged instead ... we should consider creating a fork in owncloud organization. Let's discuss tomorrow...


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Supersedes https://github.com/owncloud/web/pull/6830

## Motivation and Context
It fixes missing line numbers and parse errors in ts files/vue files using typescript.

## How Has This Been Tested?
removed .pot files from .gitignore
used old version to create those files, commited them. used new version and looked at the diff: only a few line numbers diverged slightly, most probably nothing to worry about.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Open tasks:
- [ ] I don't like to make projects depend on my personal fork, should we create a fork repo in owncloud organization?
