### PR TITLE
[full-ci] Set document title consistently for all apps in useAppDefaults composable

### DIFF
--- a/packages/web-app-draw-io/src/App.vue
+++ b/packages/web-app-draw-io/src/App.vue
@@ -34,7 +34,7 @@ export default {
   setup() {
     return {
       ...useAppDefaults({
-        applicationName: 'draw-io'
+        applicationId: 'draw-io'
       })
     }
   },

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -68,7 +68,7 @@ export default {
   setup() {
     return {
       ...useAppDefaults({
-        applicationName: 'external'
+        applicationId: 'external'
       })
     }
   },
@@ -102,10 +102,6 @@ export default {
     fileId() {
       return this.$route.query.fileId
     }
-  },
-  mounted() {
-    const appNameTitle = this.appName ? `${this.appName} - ` : ''
-    document.title = `${this.currentFileContext.fileName} - ${appNameTitle}${this.configuration.currentTheme.general.name}`
   },
   async created() {
     await unauthenticatedUserReady(this.$router, this.$store)

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -119,7 +119,7 @@ import MixinFileActions, { EDITOR_MODE_CREATE } from '../../mixins/fileActions'
 import { buildResource, buildWebDavFilesPath, buildWebDavSpacesPath } from '../../helpers/resources'
 import { isLocationPublicActive, isLocationSpacesActive } from '../../router'
 import { useActiveLocation } from '../../composables'
-import { useAppDefaults, useCapabilityShareJailEnabled } from 'web-pkg/src/composables'
+import { useRequest, useCapabilityShareJailEnabled } from 'web-pkg/src/composables'
 
 import { DavProperties, DavProperty } from 'web-pkg/src/constants'
 
@@ -167,10 +167,8 @@ export default defineComponent({
       isSpacesProjectsLocation: useActiveLocation(isLocationSpacesActive, 'files-spaces-projects'),
       isSpacesProjectLocation: useActiveLocation(isLocationSpacesActive, 'files-spaces-project'),
       isSpacesShareLocation: useActiveLocation(isLocationSpacesActive, 'files-spaces-share'),
-      ...useAppDefaults({
-        applicationName: 'files'
-      }),
-      hasShareJail: useCapabilityShareJailEnabled()
+      hasShareJail: useCapabilityShareJailEnabled(),
+      ...useRequest()
     }
   },
   data: () => ({

--- a/packages/web-app-pdf-viewer/src/App.vue
+++ b/packages/web-app-pdf-viewer/src/App.vue
@@ -25,7 +25,7 @@ export default {
   setup() {
     return {
       ...useAppDefaults({
-        applicationName: 'pdf-viewer'
+        applicationId: 'pdf-viewer'
       })
     }
   },

--- a/packages/web-app-preview/src/App.vue
+++ b/packages/web-app-preview/src/App.vue
@@ -117,17 +117,18 @@
     </div>
   </main>
 </template>
-<script>
+<script lang="ts">
+import { defineComponent } from '@vue/runtime-core'
 import { mapGetters } from 'vuex'
 import { useAppDefaults } from 'web-pkg/src/composables'
 import Preview from './index'
 
-export default {
+export default defineComponent({
   name: 'Preview',
   setup() {
     return {
       ...useAppDefaults({
-        applicationName: 'media'
+        applicationId: 'preview'
       })
     }
   },
@@ -359,7 +360,7 @@ export default {
       this.updateLocalHistory()
     }
   }
-}
+})
 </script>
 
 <style lang="scss" scoped>

--- a/packages/web-app-text-editor/src/App.vue
+++ b/packages/web-app-text-editor/src/App.vue
@@ -77,7 +77,7 @@ export default {
   },
   setup() {
     const defaults = useAppDefaults({
-      applicationName: 'text-editor'
+      applicationId: 'text-editor'
     })
     const { applicationConfig, currentFileContext } = defaults
     const serverContent = ref()

--- a/packages/web-container/index.html.ejs
+++ b/packages/web-container/index.html.ejs
@@ -63,7 +63,7 @@
   </noscript>
   <script>
     var loader = document.getElementById('splash-loading')
-    var loaderTimer = setTimeout(function () {  
+    var loaderTimer = setTimeout(function () {
       loader.classList.remove('splash-loading-hide')
     }, 1000);
 
@@ -90,7 +90,7 @@
         throw e
       })
     }
-    
+
   </script>
 </body>
 </html>

--- a/packages/web-pkg/src/composables/appDefaults/types.ts
+++ b/packages/web-pkg/src/composables/appDefaults/types.ts
@@ -7,3 +7,5 @@ export interface FileContext {
   routeParams: MaybeRef<LocationParams>
   routeQuery: MaybeRef<LocationQuery>
 }
+
+export type AppConfigObject = Record<string, any>

--- a/packages/web-pkg/src/composables/appDefaults/useAppConfig.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppConfig.ts
@@ -1,27 +1,21 @@
 import { Store } from 'vuex'
-import { computed, Ref } from '@vue/composition-api'
-
+import { computed, Ref, unref } from '@vue/composition-api'
+import { useAppMeta } from './useAppMeta'
+import type { AppConfigObject } from './types'
 interface AppConfigOptions {
   store: Store<any>
-  applicationName: string
+  applicationId: string
 }
-
-type AppConfigObject = Record<string, any>
 
 export interface AppConfigResult {
   applicationConfig: Ref<AppConfigObject>
 }
 
 export function useAppConfig(options: AppConfigOptions): AppConfigResult {
-  const store = options.store
-  const applicationName = options.applicationName
-  const applicationConfig = computed(() => {
-    const editor = store.state.apps.fileEditors.find((e) => e.app === applicationName)
-    if (!editor) {
-      throw new Error(`useAppConfig: could not find config for applicationName: ${applicationName}`)
-    }
-    return editor.config || {}
-  })
+  const applicationMetaResult = useAppMeta(options)
+  const applicationConfig = computed(
+    () => unref(applicationMetaResult.applicationMeta).config || {}
+  )
 
   return {
     applicationConfig

--- a/packages/web-pkg/src/composables/appDefaults/useAppDocumentTitle.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppDocumentTitle.ts
@@ -1,0 +1,36 @@
+import { Ref, computed, unref } from '@vue/composition-api'
+import { basename } from 'path'
+import { FileContext } from './types'
+import { useAppMeta } from './useAppMeta'
+import { useDocumentTitle } from './useDocumentTitle'
+import { Store } from 'vuex'
+
+interface AppDocumentTitleOptions {
+  store: Store<any>
+  document: Document
+  applicationId: string
+  currentFileContext: Ref<FileContext>
+}
+
+export function useAppDocumentTitle({
+  store,
+  document,
+  applicationId,
+  currentFileContext
+}: AppDocumentTitleOptions): void {
+  const appMeta = useAppMeta({ applicationId, store })
+
+  const title = computed(() => {
+    const fileName = basename(unref(unref(currentFileContext).fileName))
+    const meta = unref(unref(appMeta).applicationMeta)
+
+    return [fileName, meta.name || meta.id, store.getters.configuration.currentTheme.general.name]
+      .filter(Boolean)
+      .join(' - ')
+  })
+
+  useDocumentTitle({
+    document,
+    title
+  })
+}

--- a/packages/web-pkg/src/composables/appDefaults/useAppFolderHandling.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppFolderHandling.ts
@@ -2,7 +2,7 @@ import { Store } from 'vuex'
 import { computed, Ref, ref, unref } from '@vue/composition-api'
 import { dirname } from 'path'
 
-import { ClientService, clientService as defaultClientService } from '../../services'
+import { ClientService } from '../../services'
 import { MaybeRef } from '../../utils'
 
 import { DavProperties } from '../../constants'
@@ -25,13 +25,12 @@ export interface AppFolderHandlingResult {
   loadFolderForFileContext(context: MaybeRef<FileContext>): Promise<any>
 }
 
-export function useAppFolderHandling(options: AppFolderHandlingOptions): AppFolderHandlingResult {
-  const client = (options.clientService || defaultClientService).owncloudSdk
-  const store = options.store
-
-  const isPublicLinkContext = options.isPublicLinkContext
-  const publicLinkPassword = options.publicLinkPassword
-
+export function useAppFolderHandling({
+  store,
+  clientService: { owncloudSdk: client },
+  isPublicLinkContext,
+  publicLinkPassword
+}: AppFolderHandlingOptions): AppFolderHandlingResult {
   const isFolderLoading = ref(false)
   const activeFiles = computed(() => {
     return store.getters['Files/activeFiles']

--- a/packages/web-pkg/src/composables/appDefaults/useAppMeta.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppMeta.ts
@@ -1,0 +1,37 @@
+import { Store } from 'vuex'
+import { computed, Ref } from '@vue/composition-api'
+import type { AppConfigObject } from './types'
+
+interface AppMetaOptions {
+  store: Store<any>
+  applicationId: string
+}
+
+export interface AppMetaObject {
+  config: AppConfigObject
+  autosave: boolean
+  theme: string
+  url: string
+  icon: string
+  id: string
+  img: string
+  name: string
+}
+
+export interface AppMetaResult {
+  applicationMeta: Ref<AppMetaObject>
+}
+
+export function useAppMeta({ store, applicationId }: AppMetaOptions): AppMetaResult {
+  const applicationMeta = computed(() => {
+    const editor = store.getters.apps[applicationId]
+    if (!editor) {
+      throw new Error(`useAppConfig: could not find config for applicationId: ${applicationId}`)
+    }
+    return editor || {}
+  })
+
+  return {
+    applicationMeta
+  }
+}

--- a/packages/web-pkg/src/composables/appDefaults/useAppNavigation.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppNavigation.ts
@@ -59,10 +59,11 @@ const queryItemAsString = (queryItem: string | string[]) => {
   return queryItem
 }
 
-export function useAppNavigation(options: AppNavigationOptions): AppNavigationResult {
+export function useAppNavigation({
+  router,
+  currentFileContext
+}: AppNavigationOptions): AppNavigationResult {
   const navigateToContext = (context: MaybeRef<FileContext>) => {
-    const router = options.router
-
     const { fileName, routeName, routeParams, routeQuery } = unref(context)
 
     return router.push({
@@ -76,7 +77,7 @@ export function useAppNavigation(options: AppNavigationOptions): AppNavigationRe
   }
 
   const closeApp = () => {
-    return navigateToContext(options.currentFileContext)
+    return navigateToContext(currentFileContext)
   }
 
   return {

--- a/packages/web-pkg/src/composables/appDefaults/useDocumentTitle.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useDocumentTitle.ts
@@ -1,0 +1,16 @@
+import { watch, Ref } from '@vue/composition-api'
+
+interface DocumentTitleOptions {
+  document: Document
+  title: Ref<string>
+}
+
+export function useDocumentTitle({ document, title }: DocumentTitleOptions): void {
+  watch(
+    title,
+    (newTitle) => {
+      document.title = newTitle
+    },
+    { immediate: true }
+  )
+}

--- a/packages/web-pkg/src/composables/authContext/index.ts
+++ b/packages/web-pkg/src/composables/authContext/index.ts
@@ -1,0 +1,5 @@
+export * from './useAccessToken'
+export * from './usePublicLinkContext'
+export * from './usePublicLinkPassword'
+export * from './usePublicToken'
+export * from './useRequest'

--- a/packages/web-pkg/src/composables/authContext/useAccessToken.ts
+++ b/packages/web-pkg/src/composables/authContext/useAccessToken.ts
@@ -1,0 +1,12 @@
+import { Store } from 'vuex'
+import { computed } from '@vue/composition-api'
+
+interface AccessTokenOptions {
+  store: Store<any>
+}
+
+export const useAccessToken = ({ store }: AccessTokenOptions) => {
+  return computed(() => {
+    return store.getters.getToken
+  })
+}

--- a/packages/web-pkg/src/composables/authContext/usePublicLinkContext.ts
+++ b/packages/web-pkg/src/composables/authContext/usePublicLinkContext.ts
@@ -1,0 +1,16 @@
+import { Route } from 'vue-router'
+import { computed, unref } from '@vue/composition-api'
+import { contextRouteNameKey } from '../appDefaults/useAppNavigation'
+import { MaybeRef } from '../../utils'
+import { useRoute } from '../router'
+
+interface PublicLinkTokenOptions {
+  currentRoute?: MaybeRef<Route>
+}
+
+export const usePublicLinkContext = (options: PublicLinkTokenOptions) => {
+  const currentRoute = options.currentRoute || useRoute()
+  return computed(() => {
+    return unref(currentRoute).query[contextRouteNameKey] === 'files-public-files'
+  })
+}

--- a/packages/web-pkg/src/composables/authContext/usePublicLinkPassword.ts
+++ b/packages/web-pkg/src/composables/authContext/usePublicLinkPassword.ts
@@ -1,0 +1,12 @@
+import { Store } from 'vuex'
+import { computed } from '@vue/composition-api'
+
+interface PublicLinkPasswordOptions {
+  store: Store<any>
+}
+
+export const usePublicLinkPassword = ({ store }: PublicLinkPasswordOptions) => {
+  return computed(() => {
+    return store.getters['Files/publicLinkPassword']
+  })
+}

--- a/packages/web-pkg/src/composables/authContext/usePublicToken.ts
+++ b/packages/web-pkg/src/composables/authContext/usePublicToken.ts
@@ -1,0 +1,15 @@
+import { Route } from 'vue-router'
+import { computed, unref } from '@vue/composition-api'
+import { MaybeRef } from '../../utils'
+
+interface PublicLinkTokenOptions {
+  currentRoute: MaybeRef<Route>
+}
+
+export const usePublicLinkToken = ({ currentRoute }: PublicLinkTokenOptions) => {
+  return computed(() => {
+    return (unref(currentRoute).params.item || unref(currentRoute).params.filePath || '').split(
+      '/'
+    )[0]
+  })
+}

--- a/packages/web-pkg/src/composables/authContext/useRequest.ts
+++ b/packages/web-pkg/src/composables/authContext/useRequest.ts
@@ -1,0 +1,65 @@
+import { unref } from '@vue/composition-api'
+import { useClientService } from '../clientService'
+import type { Store } from 'vuex'
+import type { Route } from 'vue-router'
+import type { Method, AxiosRequestConfig, AxiosResponse } from 'axios'
+import { ClientService } from '../../services'
+import { useAccessToken, usePublicLinkPassword, usePublicLinkToken, usePublicLinkContext } from './'
+import { useStore } from '../store'
+import { useRoute } from '../router'
+
+interface RequestOptions {
+  store?: Store<any>
+  clientService?: ClientService
+  currentRoute?: Route
+}
+
+export interface RequestResult {
+  makeRequest(method: Method, url: string, config: AxiosRequestConfig): Promise<AxiosResponse>
+}
+
+export function useRequest(options: RequestOptions = {}): RequestResult {
+  const clientService = options.clientService ?? useClientService()
+  const store = options.store ?? useStore()
+  const currentRoute = options.currentRoute ?? useRoute()
+
+  const isPublicLinkContext = usePublicLinkContext({ currentRoute })
+  const publicLinkPassword = usePublicLinkPassword({ store })
+  const accessToken = useAccessToken({ store })
+  const publicToken = usePublicLinkToken({ currentRoute })
+
+  const makeRequest = (
+    method: Method,
+    url: string,
+    config: AxiosRequestConfig
+  ): Promise<AxiosResponse> => {
+    let httpClient
+    if (unref(accessToken)) {
+      httpClient = clientService.httpAuthenticated(unref(accessToken))
+    } else {
+      httpClient = clientService.httpUnAuthenticated
+    }
+
+    config = config || {}
+    config.headers = config.headers || {}
+
+    if (unref(isPublicLinkContext)) {
+      if (unref(publicLinkPassword)) {
+        config.headers.Authorization =
+          'Basic ' + Buffer.from(['public', unref(publicLinkPassword)].join(':')).toString('base64')
+      }
+      if (unref(publicToken)) {
+        config.headers['public-token'] = unref(publicToken)
+      }
+    }
+
+    config.method = method
+    config.url = url
+
+    return httpClient.request(config)
+  }
+
+  return {
+    makeRequest
+  }
+}

--- a/packages/web-pkg/src/composables/index.ts
+++ b/packages/web-pkg/src/composables/index.ts
@@ -1,4 +1,5 @@
 export * from './appDefaults'
+export * from './authContext'
 export * from './capability'
 export * from './clientService'
 export * from './localStorage'


### PR DESCRIPTION
... and move `makeRequest` to its own composable.



<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This refactors document title setting and moves `makeRequest` into its own composable.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- follow up for https://github.com/owncloud/web/pull/6655
- 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- I've opened files in preview and text-editor app and the title is set correctly
- the only usage of makeRequest in `addAppProviderFile` seems to produce the same request as before the refactor, but my ocis doesn't like either.. so I cannot be 100%. Could anyone with a working wopi setup give this a spin?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
