### PR TITLE
Install make library

### DIFF
--- a/dev/docker/oc10.Dockerfile
+++ b/dev/docker/oc10.Dockerfile
@@ -4,5 +4,6 @@ FROM ${OC10_IMAGE}
 RUN apt -qqy update \
   && apt -qqy --no-install-recommends install \
     bash \
+    make \
   && rm -rf /var/lib/apt/lists/* \
   && apt -qyy clean


### PR DESCRIPTION
Fixes https://github.com/owncloud/web/issues/6878
While running `docker-compose up oc10`, the command fails with `make: command not found`
Added `make` so that the command will be executed