### PR TITLE
Fix several issues when setting image and readme for spaces

### DIFF
--- a/changelog/unreleased/bugfix-set-space-image-and-readme
+++ b/changelog/unreleased/bugfix-set-space-image-and-readme
@@ -1,0 +1,8 @@
+Bugfix: Setting image and readme for spaces
+
+* An issue where setting a space-image or -readme would corrupt the file list has been fixed.
+* Setting images from within the `.space` folder has been fixed.
+* Setting images and readme files with specials characters in their names has been fixed.
+
+https://github.com/owncloud/web/pull/6898
+https://github.com/owncloud/web/issues/6875

--- a/packages/web-app-files/src/mixins/spaces/actions/setReadme.js
+++ b/packages/web-app-files/src/mixins/spaces/actions/setReadme.js
@@ -51,18 +51,15 @@ export default {
     ...mapActions(['showMessage']),
     async $_setSpaceReadme_trigger({ resources }) {
       try {
-        const storageId = this.$route.params.storageId
-        const space = this.spaces.find((s) => s.id === storageId)
-
         const fileContent = await this.$client.files.getFileContents(resources[0].webDavPath)
         const fileMetaData = await this.$client.files.putFileContents(
-          `/spaces/${space.id}/.space/readme.md`,
+          `/spaces/${this.space.id}/.space/readme.md`,
           fileContent
         )
         this.UPDATE_SPACE_FIELD({
-          id: space.id,
+          id: this.space.id,
           field: 'spaceReadmeData',
-          value: { ...space.spaceReadmeData, ...{ etag: fileMetaData?.ETag } }
+          value: { ...this.space.spaceReadmeData, ...{ etag: fileMetaData?.ETag } }
         })
         this.showMessage({
           title: this.$gettext('Space description was set successfully')

--- a/packages/web-app-files/src/mixins/spaces/actions/setReadme.js
+++ b/packages/web-app-files/src/mixins/spaces/actions/setReadme.js
@@ -1,6 +1,5 @@
 import { isLocationSpacesActive } from '../../../router'
 import { mapMutations, mapState, mapActions } from 'vuex'
-import { bus } from 'web-pkg/src/instance'
 
 export default {
   inject: {
@@ -9,7 +8,7 @@ export default {
     }
   },
   computed: {
-    ...mapState('Files', ['currentFolder']),
+    ...mapState('Files', ['currentFolder', 'spaces']),
     ...mapState(['user']),
     $_setSpaceReadme_items() {
       return [
@@ -48,18 +47,19 @@ export default {
     }
   },
   methods: {
-    ...mapMutations('Files', ['UPDATE_RESOURCE_FIELD']),
+    ...mapMutations('Files', ['UPDATE_SPACE_FIELD']),
     ...mapActions(['showMessage']),
     async $_setSpaceReadme_trigger({ resources }) {
-      const space = this.currentFolder
-
       try {
+        const storageId = this.$route.params.storageId
+        const space = this.spaces.find((s) => s.id === storageId)
+
         const fileContent = await this.$client.files.getFileContents(resources[0].webDavPath)
         const fileMetaData = await this.$client.files.putFileContents(
           `/spaces/${space.id}/.space/readme.md`,
           fileContent
         )
-        this.UPDATE_RESOURCE_FIELD({
+        this.UPDATE_SPACE_FIELD({
           id: space.id,
           field: 'spaceReadmeData',
           value: { ...space.spaceReadmeData, ...{ etag: fileMetaData?.ETag } }
@@ -67,7 +67,6 @@ export default {
         this.showMessage({
           title: this.$gettext('Space description was set successfully')
         })
-        bus.publish('app.files.list.load')
       } catch (error) {
         console.error(error)
         this.showMessage({

--- a/packages/web-app-files/src/services/folder/spaces/loaderProject.ts
+++ b/packages/web-app-files/src/services/folder/spaces/loaderProject.ts
@@ -72,9 +72,9 @@ export class FolderLoaderSpacesProject implements FolderLoader {
         currentFolder: currentFolder?.path,
         storageId: space.id
       })
+      ref.UPSERT_SPACE(space)
 
       if (!sameRoute) {
-        ref.UPSERT_SPACE(space)
         ref.space = space
       }
     })

--- a/packages/web-app-files/src/services/folder/spaces/loaderProject.ts
+++ b/packages/web-app-files/src/services/folder/spaces/loaderProject.ts
@@ -74,6 +74,7 @@ export class FolderLoaderSpacesProject implements FolderLoader {
       })
 
       if (!sameRoute) {
+        ref.UPSERT_SPACE(space)
         ref.space = space
       }
     })

--- a/packages/web-app-files/src/store/getters.js
+++ b/packages/web-app-files/src/store/getters.js
@@ -7,6 +7,9 @@ export default {
   files: (state) => {
     return state.files
   },
+  spaces: (state) => {
+    return state.spaces
+  },
   filesAll: (state) => state.filesSearched || state.files,
   currentFolder: (state) => {
     return state.currentFolder

--- a/packages/web-app-files/src/store/mutations.js
+++ b/packages/web-app-files/src/store/mutations.js
@@ -36,7 +36,16 @@ export default {
     Vue.set(spaceSource, index, newResource)
   },
   UPSERT_SPACE(state, space) {
-    state.spaces.push(space)
+    const spaces = [...state.spaces]
+    const index = spaces.findIndex((r) => r.id === space.id)
+    const found = index > -1
+
+    if (found) {
+      spaces.splice(index, 1, space)
+    } else {
+      spaces.push(space)
+    }
+    state.spaces = spaces
   },
   REMOVE_SPACE(state, space) {
     state.spaces = state.spaces.filter((s) => s.id !== space.id)
@@ -50,6 +59,9 @@ export default {
   },
   SET_CURRENT_FOLDER(state, currentFolder) {
     state.currentFolder = currentFolder
+  },
+  SET_CURRENT_SPACE(state, currentSpace) {
+    state.currentSpace = currentSpace
   },
   CLEAR_FILES(state) {
     state.files = []

--- a/packages/web-app-files/src/views/spaces/Project.vue
+++ b/packages/web-app-files/src/views/spaces/Project.vue
@@ -265,19 +265,21 @@ export default defineComponent({
           .slice(webDavPathComponents.indexOf(this.space.id) + 1)
           .join('/')
 
-        this.$client.files.fileInfo(buildWebDavSpacesPath(this.space.id, path)).then((data) => {
-          const resource = buildResource(data)
-          loadPreview({
-            resource,
-            isPublic: false,
-            dimensions: ImageDimension.Preview,
-            server: this.configuration.server,
-            userId: this.user.id,
-            token: this.getToken
-          }).then((imageBlob) => {
-            this.imageContent = imageBlob
+        this.$client.files
+          .fileInfo(buildWebDavSpacesPath(this.space.id, decodeURIComponent(path)))
+          .then((data) => {
+            const resource = buildResource(data)
+            loadPreview({
+              resource,
+              isPublic: false,
+              dimensions: ImageDimension.Preview,
+              server: this.configuration.server,
+              userId: this.user.id,
+              token: this.getToken
+            }).then((imageBlob) => {
+              this.imageContent = imageBlob
+            })
           })
-        })
       },
       deep: true
     },
@@ -292,7 +294,7 @@ export default defineComponent({
           .join('/')
 
         this.$client.files
-          .getFileContents(buildWebDavSpacesPath(this.space.id, path))
+          .getFileContents(buildWebDavSpacesPath(this.space.id, decodeURIComponent(path)))
           .then((fileContents) => {
             if (this.markdownResizeObserver && this.$refs.markdownContainer) {
               this.markdownResizeObserver.unobserve(this.$refs.markdownContainer)
@@ -338,6 +340,7 @@ export default defineComponent({
     ...mapMutations('Files', [
       'SET_CURRENT_FOLDER',
       'LOAD_FILES',
+      'UPSERT_SPACE',
       'CLEAR_CURRENT_FILES_LIST',
       'REMOVE_FILE',
       'REMOVE_FILE_FROM_SEARCHED',

--- a/packages/web-app-files/tests/unit/mixins/spaces/setImage.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/spaces/setImage.spec.js
@@ -7,7 +7,6 @@ import mockAxios from 'jest-mock-axios'
 // eslint-disable-next-line jest/no-mocks-import
 import sdkMock from '@/__mocks__/sdk'
 import fileFixtures from '__fixtures__/files'
-import { bus } from 'web-pkg/src/instance'
 import { thumbnailService } from '../../../../src/services'
 import { buildSpace } from '../../../../src/helpers/resources'
 
@@ -73,7 +72,7 @@ describe('setImage', () => {
           Files: {
             namespaced: true,
             mutations: {
-              UPDATE_RESOURCE_FIELD: jest.fn()
+              UPDATE_SPACE_FIELD: jest.fn()
             }
           }
         }
@@ -162,7 +161,6 @@ describe('setImage', () => {
 
       const wrapper = getWrapper()
       const showMessageStub = jest.spyOn(wrapper.vm, 'showMessage')
-      bus.publish = jest.fn((path) => path)
       await wrapper.vm.$_setSpaceImage_trigger({
         resources: [
           {
@@ -173,7 +171,6 @@ describe('setImage', () => {
       })
 
       expect(showMessageStub).toHaveBeenCalledTimes(1)
-      expect(bus.publish).toHaveBeenCalledTimes(1)
     })
 
     it('should show message on error', async () => {
@@ -196,7 +193,10 @@ describe('setImage', () => {
       expect(showMessageStub).toHaveBeenCalledTimes(1)
     })
 
-    it('should not set the image if source and destination path are the same', async () => {
+    it('should not copy the image if source and destination path are the same', async () => {
+      mockAxios.request.mockImplementationOnce(() => {
+        return Promise.resolve({ data: { special: [{ specialFolder: { name: 'image' } }] } })
+      })
       const wrapper = getWrapper()
       await wrapper.vm.$_setSpaceImage_trigger({
         resources: [

--- a/packages/web-app-files/tests/unit/mixins/spaces/setReadme.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/spaces/setReadme.spec.js
@@ -6,7 +6,6 @@ import { createLocationSpaces } from '../../../../src/router'
 // eslint-disable-next-line jest/no-mocks-import
 import sdkMock from '@/__mocks__/sdk'
 import { buildSpace } from '../../../../src/helpers/resources'
-
 const localVue = createLocalVue()
 localVue.use(Vuex)
 
@@ -79,8 +78,7 @@ describe('setReadme', () => {
             state: {
               currentFolder: {
                 id: '1fe58d8b-aa69-4c22-baf7-97dd57479f22'
-              },
-              spaces: [{ id: 1 }]
+              }
             }
           }
         }
@@ -137,7 +135,7 @@ describe('setReadme', () => {
   })
   describe('method "$_setSpaceReadme_trigger"', () => {
     it('should show message on success', async () => {
-      const wrapper = getWrapper()
+      const wrapper = getWrapper(true, { id: 1 })
       const showMessageStub = jest.spyOn(wrapper.vm, 'showMessage')
       await wrapper.vm.$_setSpaceReadme_trigger({
         resources: [
@@ -153,7 +151,7 @@ describe('setReadme', () => {
 
     it('should show message on error', async () => {
       jest.spyOn(console, 'error').mockImplementation(() => {})
-      const wrapper = getWrapper(false)
+      const wrapper = getWrapper(false, { id: 1 })
       const showMessageStub = jest.spyOn(wrapper.vm, 'showMessage')
       await wrapper.vm.$_setSpaceReadme_trigger({
         resources: [

--- a/packages/web-app-files/tests/unit/mixins/spaces/setReadme.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/spaces/setReadme.spec.js
@@ -5,7 +5,6 @@ import setReadme from '@files/src/mixins/spaces/actions/setReadme.js'
 import { createLocationSpaces } from '../../../../src/router'
 // eslint-disable-next-line jest/no-mocks-import
 import sdkMock from '@/__mocks__/sdk'
-import { bus } from 'web-pkg/src/instance'
 import { buildSpace } from '../../../../src/helpers/resources'
 
 const localVue = createLocalVue()
@@ -35,6 +34,9 @@ describe('setReadme', () => {
               .fn()
               .mockImplementation(() => Promise.resolve({ ETag: '60c7243c2e7f1' }))
           }
+        },
+        $route: {
+          params: { storageId: 1 }
         },
         $router: {
           currentRoute: createLocationSpaces('files-spaces-projects'),
@@ -72,12 +74,13 @@ describe('setReadme', () => {
           Files: {
             namespaced: true,
             mutations: {
-              UPDATE_RESOURCE_FIELD: jest.fn()
+              UPDATE_SPACE_FIELD: jest.fn()
             },
             state: {
               currentFolder: {
                 id: '1fe58d8b-aa69-4c22-baf7-97dd57479f22'
-              }
+              },
+              spaces: [{ id: 1 }]
             }
           }
         }
@@ -136,7 +139,6 @@ describe('setReadme', () => {
     it('should show message on success', async () => {
       const wrapper = getWrapper()
       const showMessageStub = jest.spyOn(wrapper.vm, 'showMessage')
-      bus.publish = jest.fn((path) => path)
       await wrapper.vm.$_setSpaceReadme_trigger({
         resources: [
           {
@@ -147,7 +149,6 @@ describe('setReadme', () => {
       })
 
       expect(showMessageStub).toHaveBeenCalledTimes(1)
-      expect(bus.publish).toHaveBeenCalledTimes(1)
     })
 
     it('should show message on error', async () => {

--- a/packages/web-app-files/tests/unit/views/spaces/Project.spec.js
+++ b/packages/web-app-files/tests/unit/views/spaces/Project.spec.js
@@ -280,6 +280,7 @@ function getMountedWrapper(spaceResources = [], spaceItem = null, imageContent =
           mutations: {
             CLEAR_CURRENT_FILES_LIST: jest.fn(),
             CLEAR_FILES_SEARCHED: jest.fn(),
+            UPSERT_SPACE: jest.fn(),
             LOAD_FILES: jest.fn()
           },
           actions: {


### PR DESCRIPTION
## Description
* An issue where setting a space-image or -readme would corrupt the file list has been fixed.
* Setting images from within the `.space` folder has been fixed.
* Setting images and readme files with specials characters in their names has been fixed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/6875

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
