### PR TITLE
Prevent 'Create Space'-button from disappearing when sidebar is open

### DIFF
--- a/changelog/unreleased/bugfix-create-space-button-sidebar
+++ b/changelog/unreleased/bugfix-create-space-button-sidebar
@@ -1,0 +1,6 @@
+Bugfix: "Create Space"-button with open sidebar
+
+We've fixed a bug where the "Create Space"-button would disappear when opening the sidebar for a space.
+
+https://github.com/owncloud/web/pull/6919
+https://github.com/owncloud/web/issues/6918

--- a/packages/web-app-files/src/components/AppBar/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar/AppBar.vue
@@ -33,7 +33,7 @@
       </div>
       <div class="files-app-bar-actions">
         <div class="oc-flex-1 oc-flex oc-flex-start" style="gap: 15px">
-          <slot v-if="selectedFiles.length === 0" name="actions" />
+          <slot v-if="showActionsOnSelection || selectedFiles.length === 0" name="actions" />
           <size-info v-if="showSelectionInfo" class="oc-visible@l" />
           <batch-actions v-if="showBatchActions" />
         </div>
@@ -73,7 +73,8 @@ export default {
     hasBulkActions: { type: Boolean, default: false },
     hasSharesNavigation: { type: Boolean, default: false },
     hasSidebarToggle: { type: Boolean, default: true },
-    hasViewOptions: { type: Boolean, default: true }
+    hasViewOptions: { type: Boolean, default: true },
+    showActionsOnSelection: { type: Boolean, default: false }
   },
   computed: {
     ...mapGetters('Files', ['files', 'selectedFiles']),

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -5,6 +5,7 @@
       :breadcrumbs="breadcrumbs"
       :has-view-options="false"
       :has-sidebar-toggle="false"
+      :show-actions-on-selection="true"
     >
       <template #actions>
         <create-space />

--- a/packages/web-app-files/tests/unit/views/spaces/__snapshots__/Projects.spec.js.snap
+++ b/packages/web-app-files/tests/unit/views/spaces/__snapshots__/Projects.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Spaces projects view should list spaces 1`] = `
 <div>
-  <app-bar-stub breadcrumbs="[object Object]" breadcrumbscontextactionsitems="" class="oc-border-b"></app-bar-stub>
+  <app-bar-stub breadcrumbs="[object Object]" breadcrumbscontextactionsitems="" showactionsonselection="true" class="oc-border-b"></app-bar-stub>
   <div class="spaces-list oc-px-m oc-mt-l">
     <ul class="
           oc-grid


### PR DESCRIPTION
## Description
We've fixed a bug where the "Create Space"-button would disappear when opening the sidebar for a space.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/6918

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests