### PR TITLE
Update web&ocis dev docs

### DIFF
--- a/docs/backend-ocis.md
+++ b/docs/backend-ocis.md
@@ -9,23 +9,28 @@ geekdocFilePath: backend-ocis.md
 
 {{< toc >}}
 
-## Setting up oCIS services
-
-- Setup oCIS by following the [setup instructions](https://owncloud.dev/ocis/getting-started/).
-- Kill the oCIS Web service `./ocis kill web`
-
 ## Setting up Web
 
+- Clone the [repository](https://github.com/owncloud/web/)
+- Initally install all dependencies by running `yarn install`
 - Copy `./config/config.json.sample-ocis` to `./config/config.json` and adjust values if required
 
 ## Running Web
 
-- in the Web checkout folder, run `yarn serve`
-- open [https://localhost:9200](https://localhost:9200) and accept the certificate.
+- Start bundling web with a watcher by running `yarn build:w`
+
+## Setting up oCIS
+
+- Setup oCIS by following the [setup instructions](https://owncloud.dev/ocis/getting-started/)
+- Start oCIS with local links to your bundled web frontend and config by running `WEB_ASSET_PATH=../../web/dist WEB_UI_CONFIG=../../web/dist/config.json OCIS_INSECURE=true IDM_CREATE_DEMO_USERS=true ./bin/ocis server` (and make sure to adjust paths as necessary)
+
+## Start oCIS
+
+- open [https://localhost:9200](https://localhost:9200) and accept the certificate
 - when signing in, use one of the [available demo users](https://owncloud.dev/ocis/getting-started/demo-users/)
 - whenever code changes are made, you need to manually reload the browser page (no hot reload)
 
-## Running acceptance tests
+## Running tests
 
 For testing, please refer to the [testing docs]({{< ref "testing/_index.md" >}})
 


### PR DESCRIPTION
Necessary since the `kill` command has been dropped by infinite scale