### PR TITLE
Prevent space image from showing even though no image has been set

### DIFF
--- a/changelog/unreleased/bugfix-spaces-image-without-setting
+++ b/changelog/unreleased/bugfix-spaces-image-without-setting
@@ -1,0 +1,6 @@
+Bugfix: Space image showing without setting it
+
+We've fixed a bug where an image would show for a space even though no image has been set.
+
+https://github.com/owncloud/web/issues/6920
+https://github.com/owncloud/web/pull/6928

--- a/packages/web-app-files/src/components/SideBar/Details/SpaceDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/SpaceDetails.vue
@@ -108,6 +108,7 @@ export default defineComponent({
 
     const loadImageTask = useTask(function* (signal, ref) {
       if (!ref.space?.spaceImageData) {
+        spaceImage.value = undefined
         return
       }
 
@@ -116,7 +117,9 @@ export default defineComponent({
         .slice(webDavPathComponents.indexOf(ref.space.id) + 1)
         .join('/')
 
-      const fileInfo = yield ref.$client.files.fileInfo(buildWebDavSpacesPath(ref.space.id, path))
+      const fileInfo = yield ref.$client.files.fileInfo(
+        buildWebDavSpacesPath(ref.space.id, decodeURIComponent(path))
+      )
       const resource = buildResource(fileInfo)
 
       spaceImage.value = yield loadPreview({
@@ -201,10 +204,7 @@ export default defineComponent({
   },
   watch: {
     'space.spaceImageData': {
-      handler(val) {
-        if (!val) {
-          return
-        }
+      handler() {
         this.loadImageTask.perform(this)
       },
       deep: true

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -209,22 +209,24 @@ export default defineComponent({
             .slice(webDavPathComponents.indexOf(space.id) + 1)
             .join('/')
 
-          this.$client.files.fileInfo(buildWebDavSpacesPath(space.id, path)).then((fileInfo) => {
-            const resource = buildResource(fileInfo)
-            loadPreview({
-              resource,
-              isPublic: false,
-              dimensions: ImageDimension.Preview,
-              server: this.configuration.server,
-              userId: this.user.id,
-              token: this.getToken
-            }).then((imageBlob) => {
-              this.$set(this.imageContentObject, space.id, {
-                fileId: space.spaceImageData.id,
-                data: imageBlob
+          this.$client.files
+            .fileInfo(buildWebDavSpacesPath(space.id, decodeURIComponent(path)))
+            .then((fileInfo) => {
+              const resource = buildResource(fileInfo)
+              loadPreview({
+                resource,
+                isPublic: false,
+                dimensions: ImageDimension.Preview,
+                server: this.configuration.server,
+                userId: this.user.id,
+                token: this.getToken
+              }).then((imageBlob) => {
+                this.$set(this.imageContentObject, space.id, {
+                  fileId: space.spaceImageData.id,
+                  data: imageBlob
+                })
               })
             })
-          })
         }
       },
       deep: true


### PR DESCRIPTION
## Description
We've fixed a bug where an image would show for a space even though no image has been set.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/6920

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
