### PR TITLE
Don't wait for new button in breadcrumb check

### DIFF
--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -687,13 +687,7 @@ const assertBreadcrumbIsDisplayedFor = async function (resource, clickable, nonC
     breadcrumbElement.selector,
     xpathHelper.buildXpathLiteral(resource)
   )
-  let isBreadcrumbVisible = false
-
-  // lets hope that the breadcrumbs would not take longer than the "NEW" button
-  await client.waitForElementVisible({
-    selector: client.page.personalPage().elements.newFileMenuButtonAnyState.selector,
-    abortOnFailure: false
-  })
+  let isBreadcrumbVisible
 
   try {
     await client.waitForElementVisible({


### PR DESCRIPTION
## Description
When coming back from an editor app the edited file gets selected, thus the `new` and `upload` buttons are not visible. It doesn't make sense to wait for the new button. Also, waiting until the breadcrumbs become visible seems to be a good fit.

The new button check was emitting a stale element reference and let the test fail (although the check was configured to not abort on failures).

## Related Issue
- Fixes https://github.com/owncloud/web/issues/6931

## Motivation and Context
Make tests reliable

## How Has This Been Tested?
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
