### PR TITLE
Create folders that have been uploaded to public drop pages

### DIFF
--- a/changelog/unreleased/bugfix-folder-upload-on-drop-zones
+++ b/changelog/unreleased/bugfix-folder-upload-on-drop-zones
@@ -1,0 +1,6 @@
+Bugfix: Create folders that have been uploaded to public drop pages
+
+Folders that have been uploaded to public drop pages will now get created.
+
+https://github.com/owncloud/web/issues/2443
+https://github.com/owncloud/web/pull/6935

--- a/packages/web-app-files/src/composables/upload/useUploadHelpers.ts
+++ b/packages/web-app-files/src/composables/upload/useUploadHelpers.ts
@@ -30,6 +30,7 @@ export function useUploadHelpers(): UploadHelpersResult {
   const route = useRoute()
   const publicLinkPassword = computed((): string => store.getters['Files/publicLinkPassword'])
   const isPublicLocation = useActiveLocation(isLocationPublicActive, 'files-public-files')
+  const isPublicDropLocation = useActiveLocation(isLocationPublicActive, 'files-public-drop')
   const isSpacesProjectLocation = useActiveLocation(isLocationSpacesActive, 'files-spaces-project')
   const isSpacesShareLocation = useActiveLocation(isLocationSpacesActive, 'files-spaces-share')
   const clientService = useClientService()
@@ -37,6 +38,10 @@ export function useUploadHelpers(): UploadHelpersResult {
 
   const currentPath = computed((): string => {
     const { params } = unref(route)
+    if (unref(isPublicDropLocation)) {
+      return params.token + '/'
+    }
+
     const path = params.item || ''
     if (path.endsWith('/')) {
       return path
@@ -48,7 +53,7 @@ export function useUploadHelpers(): UploadHelpersResult {
     const { params, query } = unref(route)
     const { owncloudSdk: client } = clientService
 
-    if (unref(isPublicLocation)) {
+    if (unref(isPublicLocation) || unref(isPublicDropLocation)) {
       return client.publicFiles.getFileUrl(unref(currentPath))
     }
 

--- a/packages/web-runtime/src/components/UploadInfo.vue
+++ b/packages/web-runtime/src/components/UploadInfo.vue
@@ -135,7 +135,7 @@ export default {
       this.uploadCancelled = false
     },
     displayFileAsResource(file) {
-      return !!file.targetRoute
+      return file.targetRoute?.name !== 'files-public-drop'
     },
     folderLink(file) {
       return this.createFolderLink(file.path, file.storageId, file.targetRoute)

--- a/packages/web-runtime/src/composables/upload/useUpload.ts
+++ b/packages/web-runtime/src/composables/upload/useUpload.ts
@@ -93,6 +93,7 @@ export function useUpload(options: UploadOptions): UploadResult {
     createDirectoryTree: createDirectoryTree({
       clientService,
       isPublicLocation,
+      isPublicDropLocation,
       publicLinkPassword
     })
   }
@@ -101,10 +102,12 @@ export function useUpload(options: UploadOptions): UploadResult {
 const createDirectoryTree = ({
   clientService,
   isPublicLocation,
+  isPublicDropLocation,
   publicLinkPassword
 }: {
   clientService: ClientService
   isPublicLocation: Ref<boolean>
+  isPublicDropLocation: Ref<boolean>
   publicLinkPassword?: Ref<string>
 }) => {
   return async (files: UppyResource[]) => {
@@ -132,7 +135,7 @@ const createDirectoryTree = ({
           continue
         }
 
-        if (unref(isPublicLocation)) {
+        if (unref(isPublicLocation) || unref(isPublicDropLocation)) {
           await client.publicFiles.createFolder(
             currentFolder,
             folderToCreate,

--- a/packages/web-runtime/tests/unit/components/UploadInfo.spec.js
+++ b/packages/web-runtime/tests/unit/components/UploadInfo.spec.js
@@ -16,8 +16,10 @@ describe('UploadInfo component', () => {
     const wrapper = getShallowWrapper(true)
     expect(wrapper).toMatchSnapshot()
   })
-  it('should show uploaded files without parent folder link', () => {
-    const wrapper = getShallowWrapper(true, [{ name: 'file', type: 'file' }])
+  it('should show uploaded files without parent folder link on public drop pages', () => {
+    const wrapper = getShallowWrapper(true, [
+      { name: 'file', type: 'file', targetRoute: { name: 'files-public-drop' } }
+    ])
     expect(wrapper).toMatchSnapshot()
   })
   it('should show uploaded files with parent folder link', () => {

--- a/packages/web-runtime/tests/unit/components/__snapshots__/UploadInfo.spec.js.snap
+++ b/packages/web-runtime/tests/unit/components/__snapshots__/UploadInfo.spec.js.snap
@@ -47,7 +47,7 @@ exports[`UploadInfo component should show uploaded files with parent folder link
 </div>
 `;
 
-exports[`UploadInfo component should show uploaded files without parent folder link 1`] = `
+exports[`UploadInfo component should show uploaded files without parent folder link on public drop pages 1`] = `
 <div id="upload-info" class="oc-rounded oc-box-shadow-medium">
   <div class="upload-info-title oc-flex oc-flex-between oc-flex-middle oc-px-m oc-pt-m"><span class="oc-flex oc-flex-middle"></span>
     <oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" id="close-upload-info-btn">


### PR DESCRIPTION
## Description
Recursively create folders that have been uploaded to public drop pages instead of flattening the hierarchy.

Note that we currently don't care if a folder already exists. Is this the case, the request for creating folders will fail, hence no upload happens.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/2443

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
