### PR TITLE
Fix downloads on shared with me page

### DIFF
--- a/changelog/unreleased/bugfix-share-downloads
+++ b/changelog/unreleased/bugfix-share-downloads
@@ -1,0 +1,6 @@
+Bugfix: Share downloads
+
+Both single file and folder shares didn't have the download action available on the `Shared with me` page. We've fixed this by allowing the shared with me route for download actions and by fixing a download permission check on shares.
+
+https://github.com/owncloud/ocis/issues/3760
+https://github.com/owncloud/web/pull/6936

--- a/packages/web-app-files/src/helpers/resources.ts
+++ b/packages/web-app-files/src/helpers/resources.ts
@@ -388,7 +388,7 @@ export function buildSharedResource(
       resource.path = share.file_target
       resource.webDavPath = buildWebDavFilesPath(share.share_with, share.file_target)
     }
-    resource.canDownload = () => share.state === ShareStatus.accepted
+    resource.canDownload = () => parseInt(share.state) === ShareStatus.accepted
     resource.canShare = () => SharePermissions.share.enabled(share.permissions)
     resource.canRename = () => SharePermissions.update.enabled(share.permissions)
     resource.canBeDeleted = () => SharePermissions.delete.enabled(share.permissions)

--- a/packages/web-app-files/src/mixins/actions/downloadArchive.js
+++ b/packages/web-app-files/src/mixins/actions/downloadArchive.js
@@ -1,6 +1,7 @@
 import {
   isLocationCommonActive,
   isLocationPublicActive,
+  isLocationSharesActive,
   isLocationSpacesActive
 } from '../../router'
 import isFilesAppActive from './helpers/isFilesAppActive'
@@ -27,7 +28,8 @@ export default {
               !isLocationSpacesActive(this.$router, 'files-spaces-project') &&
               !isLocationSpacesActive(this.$router, 'files-spaces-share') &&
               !isLocationPublicActive(this.$router, 'files-public-files') &&
-              !isLocationCommonActive(this.$router, 'files-common-favorites')
+              !isLocationCommonActive(this.$router, 'files-common-favorites') &&
+              !isLocationSharesActive(this.$router, 'files-shares-with-me')
             ) {
               return false
             }

--- a/packages/web-app-files/src/mixins/actions/downloadFile.js
+++ b/packages/web-app-files/src/mixins/actions/downloadFile.js
@@ -1,6 +1,7 @@
 import {
   isLocationCommonActive,
   isLocationPublicActive,
+  isLocationSharesActive,
   isLocationSpacesActive
 } from '../../router'
 import isFilesAppActive from './helpers/isFilesAppActive'
@@ -24,7 +25,8 @@ export default {
               !isLocationSpacesActive(this.$router, 'files-spaces-project') &&
               !isLocationSpacesActive(this.$router, 'files-spaces-share') &&
               !isLocationPublicActive(this.$router, 'files-public-files') &&
-              !isLocationCommonActive(this.$router, 'files-common-favorites')
+              !isLocationCommonActive(this.$router, 'files-common-favorites') &&
+              !isLocationSharesActive(this.$router, 'files-shares-with-me')
             ) {
               return false
             }


### PR DESCRIPTION
## Description
Single file shares and folder shares didn't have their respective download action available. (note: this is not related to the sharing jail. we just never had downloads on the shared with me page)

## Related Issue
- Works towards https://github.com/owncloud/ocis/issues/3760

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
