### PR TITLE
[tests-only] Refactored e2e test to move selector name to constant [Part 2]

### DIFF
--- a/tests/e2e/support/objects/app-files/spaces/actions.ts
+++ b/tests/e2e/support/objects/app-files/spaces/actions.ts
@@ -1,6 +1,19 @@
 import { Page } from 'playwright'
 import { sidebar } from '../utils'
+import util from 'util'
 
+const newSpaceMenuButton = '#new-space-menu-btn'
+const spaceNameInputField = '.oc-modal input'
+const actionConfirmButton = '.oc-modal-body-actions-confirm'
+const spaceIdSelector = `[data-space-id="%s"]`
+const spacesRenameOptionSelector = '.oc-files-actions-rename-trigger'
+const editSpacesSubtitleOptionSelector = '.oc-files-actions-edit-description-trigger'
+const editQuotaOptionSelector = '.oc-files-actions-edit-quota-trigger'
+const spacesQuotaSearchField = '.oc-modal .vs__search'
+const selectedQuotaValueField = '.vs--open'
+const quotaValueDropDown = `.vs__dropdown-option :text-is("%s")`
+const editSpacesDescription = '.oc-files-actions-edit-readme-content-trigger'
+const spacesDescriptionInputArea = '#description-input-area'
 /**/
 
 export interface createSpaceArgs {
@@ -11,19 +24,19 @@ export interface createSpaceArgs {
 export const createSpace = async (args: createSpaceArgs): Promise<string> => {
   const { page, name } = args
 
-  await page.locator('#new-space-menu-btn').click()
-  await page.locator('.oc-modal input').fill(name)
+  await page.locator(newSpaceMenuButton).click()
+  await page.locator(spaceNameInputField).fill(name)
   const [response] = await Promise.all([
     page.waitForResponse(
       (resp) =>
         resp.status() === 201 && resp.request().method() === 'POST' && resp.url().endsWith('drives')
     ),
-    page.locator('.oc-modal-body-actions-confirm').click()
+    page.locator(actionConfirmButton).click()
   ])
 
   const { id } = await response.json()
 
-  await page.waitForSelector(`[data-space-id="${id}"]`)
+  await page.waitForSelector(util.format(spaceIdSelector, id))
 
   return id
 }
@@ -37,7 +50,7 @@ export interface openSpaceArgs {
 
 export const openSpace = async (args: openSpaceArgs): Promise<void> => {
   const { page, id } = args
-  await page.locator(`[data-space-id="${id}"]`).click()
+  await page.locator(util.format(spaceIdSelector, id)).click()
 }
 
 /**/
@@ -51,8 +64,8 @@ export const changeSpaceName = async (args: {
   await sidebar.open({ page: page })
   await sidebar.openPanel({ page: page, name: 'space-actions' })
 
-  await page.locator('.oc-files-actions-rename-trigger').click()
-  await page.locator('.oc-text-input').fill(value)
+  await page.locator(spacesRenameOptionSelector).click()
+  await page.locator(spaceNameInputField).fill(value)
   await Promise.all([
     page.waitForResponse(
       (resp) =>
@@ -60,7 +73,7 @@ export const changeSpaceName = async (args: {
         resp.status() === 200 &&
         resp.request().method() === 'PATCH'
     ),
-    page.locator('.oc-modal-body-actions-confirm').click()
+    page.locator(actionConfirmButton).click()
   ])
 
   await sidebar.close({ page: page })
@@ -77,8 +90,8 @@ export const changeSpaceSubtitle = async (args: {
   await sidebar.open({ page: page })
   await sidebar.openPanel({ page: page, name: 'space-actions' })
 
-  await page.locator('.oc-files-actions-edit-description-trigger').click()
-  await page.locator('.oc-text-input').fill(value)
+  await page.locator(editSpacesSubtitleOptionSelector).click()
+  await page.locator(spaceNameInputField).fill(value)
   await Promise.all([
     page.waitForResponse(
       (resp) =>
@@ -86,7 +99,7 @@ export const changeSpaceSubtitle = async (args: {
         resp.status() === 200 &&
         resp.request().method() === 'PATCH'
     ),
-    page.locator('.oc-modal-body-actions-confirm').click()
+    page.locator(actionConfirmButton).click()
   ])
 
   await sidebar.close({ page: page })
@@ -109,10 +122,10 @@ export const changeSpaceDescription = async (args: {
         resp.request().method() === 'GET'
     )
 
-  await page.locator('.oc-files-actions-edit-readme-content-trigger').click()
+  await page.locator(editSpacesDescription).click()
   await waitForUpdate()
-  await page.locator('#description-input-area').fill(value)
-  await Promise.all([waitForUpdate(), page.locator('.oc-modal-body-actions-confirm').click()])
+  await page.locator(spacesDescriptionInputArea).fill(value)
+  await Promise.all([waitForUpdate(), page.locator(actionConfirmButton).click()])
   await sidebar.close({ page: page })
 }
 
@@ -127,11 +140,11 @@ export const changeQuota = async (args: {
   await sidebar.open({ page: page })
   await sidebar.openPanel({ page: page, name: 'space-actions' })
 
-  await page.locator('.oc-files-actions-edit-quota-trigger').click()
-  const searchLocator = await page.locator('.oc-modal .vs__search')
+  await page.locator(editQuotaOptionSelector).click()
+  const searchLocator = await page.locator(spacesQuotaSearchField)
   await searchLocator.fill(value)
-  await page.waitForSelector('.vs--open')
-  await page.locator(`.vs__dropdown-option :text-is("${value}")`).click()
+  await page.waitForSelector(selectedQuotaValueField)
+  await page.locator(util.format(quotaValueDropDown, value)).click()
 
   await Promise.all([
     page.waitForResponse(
@@ -140,7 +153,7 @@ export const changeQuota = async (args: {
         resp.status() === 200 &&
         resp.request().method() === 'PATCH'
     ),
-    page.locator('.oc-modal-body-actions-confirm').click()
+    page.locator(actionConfirmButton).click()
   ])
 
   await sidebar.close({ page: page })


### PR DESCRIPTION
## Description
This PR 
-  moves the selector name to constants [in `tests/e2e/support/objects/app-files/spaces/` folder]

## Related Issue
- https://github.com/owncloud/web/issues/6908

## How Has This Been Tested?
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] ...
