### PR TITLE
[full-ci] Reload file list after accepting a remote share

### DIFF
--- a/changelog/unreleased/bugfix-accept-remote-share-reload
+++ b/changelog/unreleased/bugfix-accept-remote-share-reload
@@ -4,3 +4,5 @@ We've fixed a bug where the file list would not reload after accepting a remote 
 
 https://github.com/owncloud/web/pull/6942
 https://github.com/owncloud/web/issues/1774
+https://github.com/owncloud/web/issues/4247
+https://github.com/owncloud/web/issues/4839

--- a/changelog/unreleased/bugfix-accept-remote-share-reload
+++ b/changelog/unreleased/bugfix-accept-remote-share-reload
@@ -1,0 +1,6 @@
+Bugfix: Reload file list after accepting a remote share
+
+We've fixed a bug where the file list would not reload after accepting a remote share.
+
+https://github.com/owncloud/web/pull/6942
+https://github.com/owncloud/web/issues/1774

--- a/packages/web-pkg/src/composables/appDefaults/useAppFolderHandling.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppFolderHandling.ts
@@ -23,6 +23,7 @@ export interface AppFolderHandlingResult {
   activeFiles: Ref<Array<Resource>>
 
   loadFolderForFileContext(context: MaybeRef<FileContext>): Promise<any>
+  loadFolder(absoluteDirPath: string): void
 }
 
 export function useAppFolderHandling(options: AppFolderHandlingOptions): AppFolderHandlingResult {
@@ -75,6 +76,7 @@ export function useAppFolderHandling(options: AppFolderHandlingOptions): AppFold
   return {
     isFolderLoading,
     loadFolderForFileContext,
+    loadFolder,
     activeFiles
   }
 }

--- a/packages/web-pkg/src/composables/appDefaults/useAppFolderHandling.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppFolderHandling.ts
@@ -23,7 +23,6 @@ export interface AppFolderHandlingResult {
   activeFiles: Ref<Array<Resource>>
 
   loadFolderForFileContext(context: MaybeRef<FileContext>): Promise<any>
-  loadFolder(absoluteDirPath: string): void
 }
 
 export function useAppFolderHandling(options: AppFolderHandlingOptions): AppFolderHandlingResult {
@@ -76,7 +75,6 @@ export function useAppFolderHandling(options: AppFolderHandlingOptions): AppFold
   return {
     isFolderLoading,
     loadFolderForFileContext,
-    loadFolder,
     activeFiles
   }
 }

--- a/packages/web-runtime/src/components/Topbar/Notifications.vue
+++ b/packages/web-runtime/src/components/Topbar/Notifications.vue
@@ -59,18 +59,11 @@
 </template>
 <script>
 import { mapGetters, mapActions } from 'vuex'
-import { useAppDefaults } from 'web-pkg/src/composables'
+import { bus } from 'web-pkg/src/instance'
 
 export default {
-  setup() {
-    return {
-      ...useAppDefaults({
-        applicationName: 'runtime'
-      })
-    }
-  },
   computed: {
-    ...mapGetters(['activeNotifications', 'configuration', 'user']),
+    ...mapGetters(['activeNotifications', 'configuration']),
 
     notificationsLabel() {
       return this.$gettext('Notifications')
@@ -95,23 +88,15 @@ export default {
             json.ocs.data.forEach((item) => {
               const currentPath = this.$route.params.item ? `/${this.$route.params.item}` : '/'
               const { state, path, file_target: fileTarget } = item
+
               // accepted federated share
               if (state === 0 && fileTarget) {
-                let shareRoot = fileTarget.substring(0, fileTarget.lastIndexOf('/') + 1)
-                if (shareRoot !== '/') {
-                  // remove trailing slash
-                  shareRoot = shareRoot.replace(/\/+$/, '')
-                }
-
-                if (shareRoot === currentPath) {
-                  this.loadFolder(`files/${this.user.id}/${currentPath}`)
-                  return
-                }
+                bus.publish('app.files.list.load')
               }
 
               if (path) {
                 const itemPath = path.slice(0, path.lastIndexOf('/') + 1)
-                if (itemPath === currentPath) this.loadFolder(`files/${this.user.id}/${itemPath}`)
+                if (itemPath === currentPath) bus.publish('app.files.list.load')
               }
             })
           })

--- a/packages/web-runtime/src/components/Topbar/Notifications.vue
+++ b/packages/web-runtime/src/components/Topbar/Notifications.vue
@@ -92,6 +92,7 @@ export default {
               // accepted federated share
               if (state === 0 && fileTarget) {
                 bus.publish('app.files.list.load')
+                return
               }
 
               if (path) {

--- a/packages/web-runtime/src/components/Topbar/Notifications.vue
+++ b/packages/web-runtime/src/components/Topbar/Notifications.vue
@@ -60,6 +60,7 @@
 <script>
 import { mapGetters, mapActions } from 'vuex'
 import { bus } from 'web-pkg/src/instance'
+import { ShareStatus } from 'files/src/helpers/share'
 
 export default {
   computed: {
@@ -90,7 +91,7 @@ export default {
               const { state, path, file_target: fileTarget } = item
 
               // accepted federated share
-              if (state === 0 && fileTarget) {
+              if (state === ShareStatus.accepted && fileTarget) {
                 bus.publish('app.files.list.load')
                 return
               }

--- a/tests/acceptance/expected-failures-Iphone-oc10-server-oauth2-login.md
+++ b/tests/acceptance/expected-failures-Iphone-oc10-server-oauth2-login.md
@@ -1,7 +1,6 @@
 ## Scenarios from web tests run on Iphone that are expected to fail on oC10
 
 ### [renaming a resource does not work](https://github.com/owncloud/ocis-reva/issues/14)
--   [webUISharingNotificationsToRoot/shareWithUsers.feature:40](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingNotificationsToRoot/shareWithUsers.feature#L40)
 -   [webUISharingAcceptSharesToRoot/acceptShares.feature:50](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAcceptSharesToRoot/acceptShares.feature#L50)
 
 ### [File link in notifications seems to not work](https://github.com/owncloud/web/issues/5227)

--- a/tests/acceptance/expected-failures-XGA-with-oc10-server-oauth2-login.md
+++ b/tests/acceptance/expected-failures-XGA-with-oc10-server-oauth2-login.md
@@ -1,8 +1,5 @@
 ## Scenarios from web tests run on XGA Portrait that are expected to fail on oC10
 
-### [renaming a resource does not work](https://github.com/owncloud/ocis-reva/issues/14)
--   [webUISharingNotificationsToRoot/shareWithUsers.feature:40](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingNotificationsToRoot/shareWithUsers.feature#L40)
-
 ### [File link in notifications seems to not work](https://github.com/owncloud/web/issues/5227)
 -   [webUISharingNotifications/notificationLink.feature:18](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingNotifications/notificationLink.feature#L18)
 -   [webUISharingNotificationsToRoot/notificationLink.feature:17](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingNotificationsToRoot/notificationLink.feature#L17)

--- a/tests/acceptance/expected-failures-with-oc10-server-oauth2-login-and-web-integration-app.md
+++ b/tests/acceptance/expected-failures-with-oc10-server-oauth2-login-and-web-integration-app.md
@@ -8,9 +8,6 @@ Level-3 headings should be used for the references to the relevant issues. Inclu
 
 Other free text and markdown formatting can be used elsewhere in the document if needed. But if you want to explain something about the issue, then please post that in the issue itself.
 
-### [regression in accepting shares from notifications](https://github.com/owncloud/web/issues/4839)
--   [webUISharingNotificationsToRoot/shareWithUsers.feature:40](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingNotificationsToRoot/shareWithUsers.feature#L40)
-
 ### [File link in notifications seems to not work](https://github.com/owncloud/web/issues/5227)
 -   [webUISharingNotifications/notificationLink.feature:18](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingNotifications/notificationLink.feature#L18)
 -   [webUISharingNotificationsToRoot/notificationLink.feature:17](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingNotificationsToRoot/notificationLink.feature#L17)

--- a/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
+++ b/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
@@ -15,9 +15,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 ### [webUILogin/adminBlocksUser.feature:20 behaves differently on CI](https://github.com/owncloud/web/issues/4743)
 -   [webUILogin/adminBlocksUser.feature:20](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/adminBlocksUser.feature#L20)
 
-### [regression in accepting shares from notifications](https://github.com/owncloud/web/issues/4839)
--   [webUISharingNotificationsToRoot/shareWithUsers.feature:40](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingNotificationsToRoot/shareWithUsers.feature#L40)
-
 ### [Comments in sidebar](https://github.com/owncloud/web/issues/1158)
 -   [webUIComments/comments.feature:25](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIComments/comments.feature#L25)
 -   [webUIComments/comments.feature:26](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIComments/comments.feature#L26)

--- a/tests/acceptance/expected-failures-with-oc10-server-openid-login.md
+++ b/tests/acceptance/expected-failures-with-oc10-server-openid-login.md
@@ -17,6 +17,3 @@ Other free text and markdown formatting can be used elsewhere in the document if
 ### [sorting for files lists needs to be reimplemented](https://github.com/owncloud/ocis/issues/1179)
 -   [webUIFilesList/sort.feature:51](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesList/sort.feature#L51)
 -   [webUIFilesList/sort.feature:72](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesList/sort.feature#L72)
-
-### [regression in accepting shares from notifications](https://github.com/owncloud/web/issues/4839)
--   [webUISharingNotificationsToRoot/shareWithUsers.feature:40](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingNotificationsToRoot/shareWithUsers.feature#L40)


### PR DESCRIPTION
## Description
We've fixed a bug where the file list would not reload after accepting a remote share.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/1774
- Fixes https://github.com/owncloud/web/issues/4247
- Fixes https://github.com/owncloud/web/issues/4839

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
