### PR TITLE
[full-ci] Bump oCIS commit ID after flock fix & glauth/accounts service removal

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=761d72d901cce2c03b524d11cf0b169293e2c8cd
+OCIS_COMMITID=5526d6179cdb6322c02840fc3e4ee219f200fe7c
 OCIS_BRANCH=master

--- a/.drone.star
+++ b/.drone.star
@@ -2086,6 +2086,8 @@ def buildGlauth():
         "image": OC_CI_GOLANG,
         "commands": [
             "cd /srv/app/src/github.com/owncloud/ocis/glauth || exit",
+            # Fixme: Relies on an old ocis commit to provide oc10 tests with oidc
+            "git checkout 761d72d901cce2c03b524d11cf0b169293e2c8cd",
             "make build",
             "cp bin/glauth %s" % dir["base"],
         ],


### PR DESCRIPTION
## Description
Should make CI way more reliable since the personal space flock issue has been resolved in Reva.

Also, accounts&glauth service have been removed from oCIS. Now, the oc10 acceptance tests relying on OIDC use an old/outdated oCIS instance for their glauth service, which we should eventually replace with a proper solution