### PR TITLE
Use oc-etag instead of etag

### DIFF
--- a/changelog/unreleased/bugfix-use-oc-etag-instead-of-etag-in-text-editor
+++ b/changelog/unreleased/bugfix-use-oc-etag-instead-of-etag-in-text-editor
@@ -1,0 +1,9 @@
+Bugfix: Use OC-ETag instead of ETag in text editor app
+
+We've fixed a bug, where the ETag instead of OC-ETag in the text editor app was used,
+due to server encoding, the ETag might be manipulated and contain the gzip suffix on a large text file.
+Saving the respective file, might cause an error, as the sent ETag doesn't match the server's ETag.
+
+https://github.com/owncloud/web/pull/6952
+https://github.com/owncloud/web/issues/6947
+https://github.com/owncloud/web/issues/4605

--- a/packages/web-app-text-editor/src/App.vue
+++ b/packages/web-app-text-editor/src/App.vue
@@ -100,7 +100,7 @@ export default {
         .getFileContents(filePath)
         .then((response) => {
           serverContent.value = currentContent.value = response.body
-          currentETag.value = response.headers.ETag
+          currentETag.value = response.headers['OC-ETag']
           return response
         })
     }).restartable()
@@ -116,8 +116,7 @@ export default {
         .then(
           (response) => {
             serverContent.value = newContent
-            // FIXME: above we need response.headers.ETag, here we need response ETag - feels inconsistent
-            currentETag.value = response.ETag
+            currentETag.value = response['OC-ETag']
           },
           (error) => {
             switch (error.statusCode) {

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -24,7 +24,7 @@
     "marked": "^4.0.12",
     "oidc-client": "1.11.5",
     "owncloud-design-system": "^13.1.0-rc.5",
-    "owncloud-sdk": "~3.0.0-alpha.8",
+    "owncloud-sdk": "~3.0.0-alpha.9",
     "p-queue": "^6.1.1",
     "popper-max-size-modifier": "^0.2.0",
     "portal-vue": "^2.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9635,9 +9635,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"owncloud-sdk@npm:~3.0.0-alpha.8":
-  version: 3.0.0-alpha.8
-  resolution: "owncloud-sdk@npm:3.0.0-alpha.8"
+"owncloud-sdk@npm:~3.0.0-alpha.9":
+  version: 3.0.0-alpha.9
+  resolution: "owncloud-sdk@npm:3.0.0-alpha.9"
   peerDependencies:
     axios: ^0.26.0
     cross-fetch: ^3.0.6
@@ -9647,7 +9647,10 @@ __metadata:
     uuid: ^8.2.0
     webdav: 4.9.0
     xml-js: ^1.6.11
-  checksum: 96e09c641010a9356bba63e5fe8aa259cf54279a8bb2c3ae81653f5d9e5598acd4050be707477229c6e53cd7c9d798d451c455182e0160d452738249ecf03c63
+  dependenciesMeta:
+    "@pact-foundation/pact":
+      built: true
+  checksum: 4ef6bcfc68c59739d40f09c18d34a9116e3e24930e3f659c0738900c6e00cf68c09083012da1deb619b31dbd7561d83006ca9c0fa120068bcd26409029b982f9
   languageName: node
   linkType: hard
 
@@ -13692,7 +13695,7 @@ __metadata:
     marked: ^4.0.12
     oidc-client: 1.11.5
     owncloud-design-system: ^13.1.0-rc.5
-    owncloud-sdk: ~3.0.0-alpha.8
+    owncloud-sdk: ~3.0.0-alpha.9
     p-queue: ^6.1.1
     popper-max-size-modifier: ^0.2.0
     portal-vue: ^2.1.7


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Bugfix: Use OC-ETag instead of ETag in text editor app

We've fixed a bug, where the ETag instead of OC-ETag in the text editor app was used,
due to server encoding, the ETag might be manipulated and contain the gzip suffix on large text files.
Saving the respective file, might cause an error, as the sent ETag doesn't match the server's ETag.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/6947
- Fixes https://github.com/owncloud/web/issues/4605

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
