### PR TITLE
Multiple fixes

### DIFF
--- a/changelog/unreleased/bugfix-text-color-application-menu-item
+++ b/changelog/unreleased/bugfix-text-color-application-menu-item
@@ -1,0 +1,6 @@
+Bugfix: The selected app item has a bad text color contrast in light mode
+
+We've fixed the contrast of the text color for hovered and active application menus items.
+
+https://github.com/owncloud/web/pull/6954
+https://github.com/owncloud/web/issues/6958

--- a/changelog/unreleased/enhancement-sort-default-action-first-context-menu
+++ b/changelog/unreleased/enhancement-sort-default-action-first-context-menu
@@ -1,0 +1,6 @@
+Enhancement: Show default action at the first place in context menu
+
+We've added the sorting of actions in the way that default file handler shows first in the context menu
+
+https://github.com/owncloud/web/issues/6971
+https://github.com/owncloud/web/pull/6954

--- a/packages/web-app-files/src/components/FilesList/ContextActions.vue
+++ b/packages/web-app-files/src/components/FilesList/ContextActions.vue
@@ -130,7 +130,9 @@ export default {
         ...this.$_fileActions_loadExternalAppActions(this.filterParams.resources)
       ]
 
-      return [...fileHandlers].filter((item) => item.isEnabled(this.filterParams))
+      return [...fileHandlers]
+        .filter((item) => item.isEnabled(this.filterParams))
+        .sort((x, y) => Number(y.canBeDefault) - Number(x.canBeDefault))
     },
 
     menuItemsShare() {

--- a/packages/web-app-text-editor/src/App.vue
+++ b/packages/web-app-text-editor/src/App.vue
@@ -17,7 +17,7 @@
       />
     </oc-notifications>
     <div class="oc-flex editor-wrapper-height">
-      <div :class="showPreview ? 'oc-width-1-2 oc-height-1-1' : 'oc-width-1-1 oc-height-1-1'">
+      <div :class="showPreview ? 'oc-width-1-2' : 'oc-width-1-1'" class="oc-height-1-1">
         <oc-textarea
           id="text-editor-input"
           v-model="currentContent"
@@ -238,12 +238,9 @@ export default {
 }
 #text-editor-input {
   resize: vertical;
+  height: 100%;
 }
 .editor-wrapper-height {
   height: calc(100% - 42px);
-}
-
-#text-editor-input {
-  height: 100%;
 }
 </style>

--- a/packages/web-app-text-editor/src/App.vue
+++ b/packages/web-app-text-editor/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <main id="text-editor" class="oc-mx-l oc-my-m">
+  <main id="text-editor" class="oc-px-l oc-py-m oc-height-1-1">
     <app-bar
       :current-file-context="currentFileContext"
       :is-loading="isLoading"
@@ -16,8 +16,8 @@
         @close="clearLastError"
       />
     </oc-notifications>
-    <div class="oc-flex">
-      <div :class="showPreview ? 'oc-width-1-2' : 'oc-width-1-1'">
+    <div class="oc-flex editor-wrapper-height">
+      <div :class="showPreview ? 'oc-width-1-2 oc-height-1-1' : 'oc-width-1-1 oc-height-1-1'">
         <oc-textarea
           id="text-editor-input"
           v-model="currentContent"
@@ -231,12 +231,19 @@ export default {
   }
 }
 </script>
-<style lang="scss" scoped>
+<style lang="scss">
 #text-editor-preview {
   max-height: 80vh;
   overflow-y: scroll;
 }
 #text-editor-input {
   resize: vertical;
+}
+.editor-wrapper-height {
+  height: calc(100% - 42px);
+}
+
+#text-editor-input {
+  height: 100%;
 }
 </style>

--- a/packages/web-pkg/src/components/sidebar/SideBar.vue
+++ b/packages/web-pkg/src/components/sidebar/SideBar.vue
@@ -338,6 +338,7 @@ export default defineComponent({
 
   &__body {
     overflow-y: auto;
+    overflow-x: hidden;
     padding: 10px;
   }
 

--- a/packages/web-runtime/src/components/Topbar/ApplicationsMenu.vue
+++ b/packages/web-runtime/src/components/Topbar/ApplicationsMenu.vue
@@ -103,5 +103,13 @@ export default {
       right: 1rem;
     }
   }
+
+  a.router-link-active,
+  button.router-link-active {
+    &:focus,
+    &:hover {
+      color: var(--oc-color-swatch-inverse-default);
+    }
+  }
 }
 </style>


### PR DESCRIPTION
## Description
- text editor textarea gets full height of app
- default action is shown as first action in the context menu, fixes https://github.com/owncloud/web/issues/6971
- application menu items hover: text color fix, fixes https://github.com/owncloud/web/issues/6958
- prevent horizontal scrollbar in sidebar by long emails of sharees, fixes https://github.com/owncloud/web/issues/6973



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] fix unit tests
