### PR TITLE
Changes to links in sidebar, fix tooltips

### DIFF
--- a/changelog/unreleased/enhancement-changes-to-links-in-sidebar
+++ b/changelog/unreleased/enhancement-changes-to-links-in-sidebar
@@ -1,8 +1,8 @@
-Changes to links in sidebar, fix tooltips
+Enhancement: Changes in sidebar, fix tooltips
 
-We've added an `isEos` setting which, if on, displays two entries in the sidebar: the EOS path and a
-direct link to the file. These paths along with the sidebar tooltips can now handle very long text
-without overflowing.
+We've added a `runningOnEos` setting which, if on, displays two entries in the sidebar: the EOS
+path and a direct link to the file. These paths along with the sidebar tooltips can now handle very
+long text without overflowing.
 
 https://github.com/owncloud/web/issues/6849
 https://github.com/owncloud/web/pull/6959

--- a/changelog/unreleased/enhancement-changes-to-links-in-sidebar
+++ b/changelog/unreleased/enhancement-changes-to-links-in-sidebar
@@ -1,0 +1,8 @@
+Changes to links in sidebar, fix tooltips
+
+We've added an `isEos` setting which, if on, displays two entries in the sidebar: the EOS path and a
+direct link to the file. These paths along with the sidebar tooltips can now handle very long text
+without overflowing.
+
+https://github.com/owncloud/web/issues/6849
+https://github.com/owncloud/web/pull/6959

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -56,6 +56,7 @@ substring of a value of the authenticated user. Examples are `/Shares`, `/{{.Id}
   - `options.feedbackLink.description` Provide any description you want to see as tooltip and as accessible description. Defaults to `Provide your feedback: We'd like to improve the web design and would be happy to hear your feedback. Thank you! Your ownCloud team.`
 - `options.sharingRecipientsPerPage` Sets the amount of users shown as recipients in the dropdown when sharing resources. Default amount is 200.
 - `options.sidebar.shares.showAllOnLoad` Sets the list of (link) shares list in the sidebar to be initially expanded (default is a collapsed state, only showing the first three shares).
+- `options.runningOnEos` Set this option to `true` if running on an [EOS storage backend](https://eos-web.web.cern.ch/eos-web/) to enable its specific features. Defaults to `false`.
 
 ### Sentry
 

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -78,7 +78,7 @@
             />
           </td>
         </tr>
-        <tr v-if="isEos">
+        <tr v-if="runningOnEos">
           <th scope="col" class="oc-pr-s" v-text="eosPathLabel" />
           <td>
             <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
@@ -219,8 +219,8 @@ export default defineComponent({
       return this.displayedItem.value
     },
 
-    isEos() {
-      return !!this.configuration.options?.eos
+    runningOnEos() {
+      return !!this.configuration?.options?.runningOnEos
     },
 
     hasSharees() {

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.js
@@ -146,6 +146,13 @@ function createWrapper(testResource, testVersions = [], testPreview, publicRoute
       getters: {
         user: function () {
           return { id: 'marie' }
+        },
+        configuration: function () {
+          return {
+            options: {
+              isEos: true
+            }
+          }
         }
       },
       modules: {

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.js
@@ -150,7 +150,7 @@ function createWrapper(testResource, testVersions = [], testPreview, publicRoute
         configuration: function () {
           return {
             options: {
-              isEos: true
+              runningOnEos: true
             }
           }
         }

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.js.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.js.snap
@@ -12,18 +12,18 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
     </div>
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Last modified:</th>
+        <th scope="col" class="oc-pr-s">Last modified</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <tr data-testid="shared-via">
-        <th scope="col" class="oc-pr-s">Shared via:</th>
+        <th scope="col" class="oc-pr-s">Shared via</th>
         <td>
           <router-link-stub><span></span></router-link-stub>
         </td>
       </tr>
       <!---->
       <tr data-testid="ownerDisplayName">
-        <th scope="col" class="oc-pr-s">Owner:</th>
+        <th scope="col" class="oc-pr-s">Owner</th>
         <td>
           <p class="oc-m-rm">
             Einstein
@@ -33,10 +33,24 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
         </td>
       </tr>
       <tr data-testid="sizeInfo">
-        <th scope="col" class="oc-pr-s">Size:</th>
+        <th scope="col" class="oc-pr-s">Size</th>
         <td>740 B</td>
       </tr>
       <!---->
+      <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">Direct link</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <div class="oc-flex oc-flex-middle">
+              <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home/Shares/123.png</p>
+            </div>
+            <oc-button-stub oc-tooltip="Copy direct link" appearance="raw" aria-label="Copy direct link" variation="passive" class="oc-files-private-link-copy-url"><span text="EOS Path"></span>
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
     </table>
   </div>
 </div>
@@ -54,21 +68,21 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
     </div>
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Last modified:</th>
+        <th scope="col" class="oc-pr-s">Last modified</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <tr data-testid="shared-via">
-        <th scope="col" class="oc-pr-s">Shared via:</th>
+        <th scope="col" class="oc-pr-s">Shared via</th>
         <td>
           <router-link-stub><span>/Shares/123.png</span></router-link-stub>
         </td>
       </tr>
       <tr data-testid="shared-by">
-        <th scope="col" class="oc-pr-s">Shared by:</th>
+        <th scope="col" class="oc-pr-s">Shared by</th>
         <td><span>Marie Curie</span></td>
       </tr>
       <tr data-testid="ownerDisplayName">
-        <th scope="col" class="oc-pr-s">Owner:</th>
+        <th scope="col" class="oc-pr-s">Owner</th>
         <td>
           <p class="oc-m-rm">
             Einstein
@@ -78,10 +92,24 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
         </td>
       </tr>
       <tr data-testid="sizeInfo">
-        <th scope="col" class="oc-pr-s">Size:</th>
+        <th scope="col" class="oc-pr-s">Size</th>
         <td>740 B</td>
       </tr>
       <!---->
+      <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">Direct link</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <div class="oc-flex oc-flex-middle">
+              <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home/Shares/123.png</p>
+            </div>
+            <oc-button-stub oc-tooltip="Copy direct link" appearance="raw" aria-label="Copy direct link" variation="passive" class="oc-files-private-link-copy-url"><span text="EOS Path"></span>
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
     </table>
   </div>
 </div>
@@ -94,13 +122,13 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
     <!---->
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Last modified:</th>
+        <th scope="col" class="oc-pr-s">Last modified</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <!---->
       <!---->
       <tr data-testid="ownerDisplayName">
-        <th scope="col" class="oc-pr-s">Owner:</th>
+        <th scope="col" class="oc-pr-s">Owner</th>
         <td>
           <p class="oc-m-rm">
             Marie
@@ -110,10 +138,24 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
         </td>
       </tr>
       <tr data-testid="sizeInfo">
-        <th scope="col" class="oc-pr-s">Size:</th>
+        <th scope="col" class="oc-pr-s">Size</th>
         <td>740 B</td>
       </tr>
       <!---->
+      <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">Direct link</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <div class="oc-flex oc-flex-middle">
+              <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home</p>
+            </div>
+            <oc-button-stub oc-tooltip="Copy direct link" appearance="raw" aria-label="Copy direct link" variation="passive" class="oc-files-private-link-copy-url"><span text="EOS Path"></span>
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
     </table>
   </div>
 </div>
@@ -128,18 +170,18 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
     <!---->
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Last modified:</th>
+        <th scope="col" class="oc-pr-s">Last modified</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <tr data-testid="shared-via">
-        <th scope="col" class="oc-pr-s">Shared via:</th>
+        <th scope="col" class="oc-pr-s">Shared via</th>
         <td>
           <router-link-stub><span></span></router-link-stub>
         </td>
       </tr>
       <!---->
       <tr data-testid="ownerDisplayName">
-        <th scope="col" class="oc-pr-s">Owner:</th>
+        <th scope="col" class="oc-pr-s">Owner</th>
         <td>
           <p class="oc-m-rm">
             Einstein
@@ -149,10 +191,24 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
         </td>
       </tr>
       <tr data-testid="sizeInfo">
-        <th scope="col" class="oc-pr-s">Size:</th>
+        <th scope="col" class="oc-pr-s">Size</th>
         <td>740 B</td>
       </tr>
       <!---->
+      <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">Direct link</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <div class="oc-flex oc-flex-middle">
+              <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home/Shares/123.png</p>
+            </div>
+            <oc-button-stub oc-tooltip="Copy direct link" appearance="raw" aria-label="Copy direct link" variation="passive" class="oc-files-private-link-copy-url"><span text="EOS Path"></span>
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
     </table>
   </div>
 </div>
@@ -167,13 +223,13 @@ exports[`Details SideBar Panel displays a resource of type file on a public page
     <!---->
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Last modified:</th>
+        <th scope="col" class="oc-pr-s">Last modified</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <!---->
       <!---->
       <tr data-testid="ownerDisplayName">
-        <th scope="col" class="oc-pr-s">Owner:</th>
+        <th scope="col" class="oc-pr-s">Owner</th>
         <td>
           <p class="oc-m-rm">
             Einstein
@@ -183,10 +239,24 @@ exports[`Details SideBar Panel displays a resource of type file on a public page
         </td>
       </tr>
       <tr data-testid="sizeInfo">
-        <th scope="col" class="oc-pr-s">Size:</th>
+        <th scope="col" class="oc-pr-s">Size</th>
         <td>740 B</td>
       </tr>
       <!---->
+      <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">Direct link</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <div class="oc-flex oc-flex-middle">
+              <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home/Shares/123.png</p>
+            </div>
+            <oc-button-stub oc-tooltip="Copy direct link" appearance="raw" aria-label="Copy direct link" variation="passive" class="oc-files-private-link-copy-url"><span text="EOS Path"></span>
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
     </table>
   </div>
 </div>
@@ -201,13 +271,13 @@ exports[`Details SideBar Panel displays a resource of type file on a public page
     <!---->
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Last modified:</th>
+        <th scope="col" class="oc-pr-s">Last modified</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <!---->
       <!---->
       <tr data-testid="ownerDisplayName">
-        <th scope="col" class="oc-pr-s">Owner:</th>
+        <th scope="col" class="oc-pr-s">Owner</th>
         <td>
           <p class="oc-m-rm">
             Einstein
@@ -217,10 +287,24 @@ exports[`Details SideBar Panel displays a resource of type file on a public page
         </td>
       </tr>
       <tr data-testid="sizeInfo">
-        <th scope="col" class="oc-pr-s">Size:</th>
+        <th scope="col" class="oc-pr-s">Size</th>
         <td>740 B</td>
       </tr>
       <!---->
+      <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">Direct link</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <div class="oc-flex oc-flex-middle">
+              <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home/Shares/123.png</p>
+            </div>
+            <oc-button-stub oc-tooltip="Copy direct link" appearance="raw" aria-label="Copy direct link" variation="passive" class="oc-files-private-link-copy-url"><span text="EOS Path"></span>
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
     </table>
   </div>
 </div>
@@ -233,13 +317,13 @@ exports[`Details SideBar Panel displays a resource of type folder on a private p
     <!---->
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Last modified:</th>
+        <th scope="col" class="oc-pr-s">Last modified</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <!---->
       <!---->
       <tr data-testid="ownerDisplayName">
-        <th scope="col" class="oc-pr-s">Owner:</th>
+        <th scope="col" class="oc-pr-s">Owner</th>
         <td>
           <p class="oc-m-rm">
             Marie
@@ -249,10 +333,24 @@ exports[`Details SideBar Panel displays a resource of type folder on a private p
         </td>
       </tr>
       <tr data-testid="sizeInfo">
-        <th scope="col" class="oc-pr-s">Size:</th>
+        <th scope="col" class="oc-pr-s">Size</th>
         <td>740 B</td>
       </tr>
       <!---->
+      <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">Direct link</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <div class="oc-flex oc-flex-middle">
+              <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home</p>
+            </div>
+            <oc-button-stub oc-tooltip="Copy direct link" appearance="raw" aria-label="Copy direct link" variation="passive" class="oc-files-private-link-copy-url"><span text="EOS Path"></span>
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
     </table>
   </div>
 </div>
@@ -265,13 +363,13 @@ exports[`Details SideBar Panel displays a resource of type folder on a private p
     <!---->
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Last modified:</th>
+        <th scope="col" class="oc-pr-s">Last modified</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <!---->
       <!---->
       <tr data-testid="ownerDisplayName">
-        <th scope="col" class="oc-pr-s">Owner:</th>
+        <th scope="col" class="oc-pr-s">Owner</th>
         <td>
           <p class="oc-m-rm">
             Einstein
@@ -281,10 +379,24 @@ exports[`Details SideBar Panel displays a resource of type folder on a private p
         </td>
       </tr>
       <tr data-testid="sizeInfo">
-        <th scope="col" class="oc-pr-s">Size:</th>
+        <th scope="col" class="oc-pr-s">Size</th>
         <td>740 B</td>
       </tr>
       <!---->
+      <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">Direct link</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <div class="oc-flex oc-flex-middle">
+              <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home</p>
+            </div>
+            <oc-button-stub oc-tooltip="Copy direct link" appearance="raw" aria-label="Copy direct link" variation="passive" class="oc-files-private-link-copy-url"><span text="EOS Path"></span>
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
     </table>
   </div>
 </div>
@@ -297,13 +409,13 @@ exports[`Details SideBar Panel displays a resource of type folder on a public pa
     <!---->
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Last modified:</th>
+        <th scope="col" class="oc-pr-s">Last modified</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <!---->
       <!---->
       <tr data-testid="ownerDisplayName">
-        <th scope="col" class="oc-pr-s">Owner:</th>
+        <th scope="col" class="oc-pr-s">Owner</th>
         <td>
           <p class="oc-m-rm">
             Einstein
@@ -313,10 +425,24 @@ exports[`Details SideBar Panel displays a resource of type folder on a public pa
         </td>
       </tr>
       <tr data-testid="sizeInfo">
-        <th scope="col" class="oc-pr-s">Size:</th>
+        <th scope="col" class="oc-pr-s">Size</th>
         <td>740 B</td>
       </tr>
       <!---->
+      <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">Direct link</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <div class="oc-flex oc-flex-middle">
+              <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home</p>
+            </div>
+            <oc-button-stub oc-tooltip="Copy direct link" appearance="raw" aria-label="Copy direct link" variation="passive" class="oc-files-private-link-copy-url"><span text="EOS Path"></span>
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
     </table>
   </div>
 </div>

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.js.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.js.snap
@@ -37,15 +37,23 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
         <td>740 B</td>
       </tr>
       <!---->
-      <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">EOS Path</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate">/Shares/123.png</p>
+            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
       <tr>
         <th scope="col" class="oc-pr-s">Direct link</th>
         <td>
           <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
-            <div class="oc-flex oc-flex-middle">
-              <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home/Shares/123.png</p>
-            </div>
-            <oc-button-stub oc-tooltip="Copy direct link" appearance="raw" aria-label="Copy direct link" variation="passive" class="oc-files-private-link-copy-url"><span text="EOS Path"></span>
+            <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home/Shares/123.png</p>
+            <oc-button-stub aria-label="Copy direct link" appearance="raw" variation="passive">
               <oc-icon-stub name="clipboard"></oc-icon-stub>
             </oc-button-stub>
           </div>
@@ -96,15 +104,23 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
         <td>740 B</td>
       </tr>
       <!---->
-      <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">EOS Path</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate">/Shares/123.png</p>
+            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
       <tr>
         <th scope="col" class="oc-pr-s">Direct link</th>
         <td>
           <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
-            <div class="oc-flex oc-flex-middle">
-              <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home/Shares/123.png</p>
-            </div>
-            <oc-button-stub oc-tooltip="Copy direct link" appearance="raw" aria-label="Copy direct link" variation="passive" class="oc-files-private-link-copy-url"><span text="EOS Path"></span>
+            <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home/Shares/123.png</p>
+            <oc-button-stub aria-label="Copy direct link" appearance="raw" variation="passive">
               <oc-icon-stub name="clipboard"></oc-icon-stub>
             </oc-button-stub>
           </div>
@@ -142,15 +158,23 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
         <td>740 B</td>
       </tr>
       <!---->
-      <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">EOS Path</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate"></p>
+            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
       <tr>
         <th scope="col" class="oc-pr-s">Direct link</th>
         <td>
           <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
-            <div class="oc-flex oc-flex-middle">
-              <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home</p>
-            </div>
-            <oc-button-stub oc-tooltip="Copy direct link" appearance="raw" aria-label="Copy direct link" variation="passive" class="oc-files-private-link-copy-url"><span text="EOS Path"></span>
+            <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home</p>
+            <oc-button-stub aria-label="Copy direct link" appearance="raw" variation="passive">
               <oc-icon-stub name="clipboard"></oc-icon-stub>
             </oc-button-stub>
           </div>
@@ -195,15 +219,23 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
         <td>740 B</td>
       </tr>
       <!---->
-      <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">EOS Path</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate">/Shares/123.png</p>
+            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
       <tr>
         <th scope="col" class="oc-pr-s">Direct link</th>
         <td>
           <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
-            <div class="oc-flex oc-flex-middle">
-              <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home/Shares/123.png</p>
-            </div>
-            <oc-button-stub oc-tooltip="Copy direct link" appearance="raw" aria-label="Copy direct link" variation="passive" class="oc-files-private-link-copy-url"><span text="EOS Path"></span>
+            <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home/Shares/123.png</p>
+            <oc-button-stub aria-label="Copy direct link" appearance="raw" variation="passive">
               <oc-icon-stub name="clipboard"></oc-icon-stub>
             </oc-button-stub>
           </div>
@@ -243,15 +275,23 @@ exports[`Details SideBar Panel displays a resource of type file on a public page
         <td>740 B</td>
       </tr>
       <!---->
-      <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">EOS Path</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate">/Shares/123.png</p>
+            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
       <tr>
         <th scope="col" class="oc-pr-s">Direct link</th>
         <td>
           <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
-            <div class="oc-flex oc-flex-middle">
-              <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home/Shares/123.png</p>
-            </div>
-            <oc-button-stub oc-tooltip="Copy direct link" appearance="raw" aria-label="Copy direct link" variation="passive" class="oc-files-private-link-copy-url"><span text="EOS Path"></span>
+            <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home/Shares/123.png</p>
+            <oc-button-stub aria-label="Copy direct link" appearance="raw" variation="passive">
               <oc-icon-stub name="clipboard"></oc-icon-stub>
             </oc-button-stub>
           </div>
@@ -291,15 +331,23 @@ exports[`Details SideBar Panel displays a resource of type file on a public page
         <td>740 B</td>
       </tr>
       <!---->
-      <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">EOS Path</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate">/Shares/123.png</p>
+            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
       <tr>
         <th scope="col" class="oc-pr-s">Direct link</th>
         <td>
           <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
-            <div class="oc-flex oc-flex-middle">
-              <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home/Shares/123.png</p>
-            </div>
-            <oc-button-stub oc-tooltip="Copy direct link" appearance="raw" aria-label="Copy direct link" variation="passive" class="oc-files-private-link-copy-url"><span text="EOS Path"></span>
+            <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home/Shares/123.png</p>
+            <oc-button-stub aria-label="Copy direct link" appearance="raw" variation="passive">
               <oc-icon-stub name="clipboard"></oc-icon-stub>
             </oc-button-stub>
           </div>
@@ -337,15 +385,23 @@ exports[`Details SideBar Panel displays a resource of type folder on a private p
         <td>740 B</td>
       </tr>
       <!---->
-      <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">EOS Path</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate"></p>
+            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
       <tr>
         <th scope="col" class="oc-pr-s">Direct link</th>
         <td>
           <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
-            <div class="oc-flex oc-flex-middle">
-              <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home</p>
-            </div>
-            <oc-button-stub oc-tooltip="Copy direct link" appearance="raw" aria-label="Copy direct link" variation="passive" class="oc-files-private-link-copy-url"><span text="EOS Path"></span>
+            <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home</p>
+            <oc-button-stub aria-label="Copy direct link" appearance="raw" variation="passive">
               <oc-icon-stub name="clipboard"></oc-icon-stub>
             </oc-button-stub>
           </div>
@@ -383,15 +439,23 @@ exports[`Details SideBar Panel displays a resource of type folder on a private p
         <td>740 B</td>
       </tr>
       <!---->
-      <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">EOS Path</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate"></p>
+            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
       <tr>
         <th scope="col" class="oc-pr-s">Direct link</th>
         <td>
           <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
-            <div class="oc-flex oc-flex-middle">
-              <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home</p>
-            </div>
-            <oc-button-stub oc-tooltip="Copy direct link" appearance="raw" aria-label="Copy direct link" variation="passive" class="oc-files-private-link-copy-url"><span text="EOS Path"></span>
+            <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home</p>
+            <oc-button-stub aria-label="Copy direct link" appearance="raw" variation="passive">
               <oc-icon-stub name="clipboard"></oc-icon-stub>
             </oc-button-stub>
           </div>
@@ -429,15 +493,23 @@ exports[`Details SideBar Panel displays a resource of type folder on a public pa
         <td>740 B</td>
       </tr>
       <!---->
-      <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">EOS Path</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate"></p>
+            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
       <tr>
         <th scope="col" class="oc-pr-s">Direct link</th>
         <td>
           <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
-            <div class="oc-flex oc-flex-middle">
-              <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home</p>
-            </div>
-            <oc-button-stub oc-tooltip="Copy direct link" appearance="raw" aria-label="Copy direct link" variation="passive" class="oc-files-private-link-copy-url"><span text="EOS Path"></span>
+            <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home</p>
+            <oc-button-stub aria-label="Copy direct link" appearance="raw" variation="passive">
               <oc-icon-stub name="clipboard"></oc-icon-stub>
             </oc-button-stub>
           </div>

--- a/packages/web-runtime/src/store/config.js
+++ b/packages/web-runtime/src/store/config.js
@@ -48,7 +48,8 @@ const state = {
       }
     },
     previewFileExtensions: [],
-    sharingRecipientsPerPage: 200
+    sharingRecipientsPerPage: 200,
+    runningOnEos: false
   }
 }
 


### PR DESCRIPTION
This PR addresses some additions and fixes to the sidebar links:

* Adds an `isEos` setting into `config.json` as discussed in https://github.com/owncloud/web/issues/6702#issuecomment-1117256159
* Adds direct link to the side bar (maybe related to https://github.com/owncloud/web/issues/6840)
* Adds an eos path to the side bar, shown if `isEos`
* Ellipsizes long links so the sidebar does not get a scrollbar. Along with https://github.com/owncloud/owncloud-design-system/pull/2137, these two should close https://github.com/owncloud/web/issues/6849.
* Normalized some sidebar table method names (some of them were `titleSomething`, all are now `labelSomething`)
* Removed the colons and made the headers of the table `nowrap`. This makes the table looks better, as there is no need to have colons in headers; and they are not extremely long

Current looks:

![image](https://user-images.githubusercontent.com/6058151/168080252-40cb6244-aa9a-47ab-ab5f-95e4c12f6e74.png)
