### PR TITLE
[tests-only] Refactored e2e test to move selector name to constant [Part 3]

### DIFF
--- a/tests/e2e/support/objects/runtime/application.ts
+++ b/tests/e2e/support/objects/runtime/application.ts
@@ -1,5 +1,8 @@
 import { Page } from 'playwright'
+import util from 'util'
 
+const appSwitcherButton = '#_appSwitcherButton'
+const appSelector = `//ul[contains(@class, "applications-list")]//a[@href="#/%s" or @href="/%s"]`
 export class Application {
   #page: Page
 
@@ -8,11 +11,7 @@ export class Application {
   }
 
   async open({ name }: { name: string }): Promise<void> {
-    await this.#page.locator('#_appSwitcherButton').click()
-    await this.#page
-      .locator(
-        `//ul[contains(@class, "applications-list")]//a[@href="#/${name}" or @href="/${name}"]`
-      )
-      .click()
+    await this.#page.locator(appSwitcherButton).click()
+    await this.#page.locator(util.format(appSelector, name, name)).click()
   }
 }


### PR DESCRIPTION
## Description
This PR 
-  moves the selector name to constants [in `tests/e2e/support/objects/app-files/runtime/` folder]

## Related Issue
- https://github.com/owncloud/web/issues/6908

## How Has This Been Tested?
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] ...
