### PR TITLE
[tests-only][full-ci] Use webUI steps after the server setup steps

### DIFF
--- a/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
+++ b/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
@@ -32,7 +32,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIFilesDetails/fileDetails.feature:153](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesDetails/fileDetails.feature#L153)
 
 ### [Tags page not implemented yet](https://github.com/owncloud/web/issues/5017)
--   [webUIDeleteFilesFolders/deleteFilesFolders.feature:136](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L136)
+-   [webUIDeleteFilesFolders/deleteFilesFolders.feature:135](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L135)
 -   [webUIFilesSearch/search.feature:63](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L63)
 -   [webUIFilesSearch/search.feature:71](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L71)
 -   [webUIFilesSearch/search.feature:84](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L84)

--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -331,7 +331,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUITrashbinDelete/trashbinDelete.feature:48](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITrashbinDelete/trashbinDelete.feature#L48)
 
 ### [Tags page not implemented yet](https://github.com/owncloud/web/issues/5017)
--   [webUIDeleteFilesFolders/deleteFilesFolders.feature:136](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L136)
+-   [webUIDeleteFilesFolders/deleteFilesFolders.feature:135](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature#L135)
 -   [webUIFilesSearch/search.feature:63](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L63)
 -   [webUIFilesSearch/search.feature:71](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L71)
 -   [webUIFilesSearch/search.feature:84](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L84)

--- a/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
@@ -241,11 +241,13 @@ Feature: deleting files and folders
   Scenario: Try to delete file and folder that used to exist but does not anymore
     Given user "Alice" has created folder "simple-folder" in the server
     And user "Alice" has created file "lorem.txt" in the server
+    # user logs in first and deletes the files/folders using the API requests (demanded by the scenario)
+    # so that the steps are organized as follows
+    And user "Alice" has logged in using the webUI
     And the following files have been deleted by user "Alice" in the server
       | name          |
       | lorem.txt     |
       | simple-folder |
-    And user "Alice" has logged in using the webUI
     When the user deletes file "lorem.txt" using the webUI
     Then the error message with header 'Failed to delete "lorem.txt"' should be displayed on the webUI
     When the user clears all error message from the webUI

--- a/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
@@ -5,8 +5,6 @@ Feature: deleting files and folders
 
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files in the server
-    And user "Alice" has logged in using the webUI
-    And the user reloads the current page of the webUI
 
   @smokeTest @ocisSmokeTest @disablePreviews
   Scenario: Delete files & folders one by one and check its existence after page reload
@@ -18,7 +16,7 @@ Feature: deleting files and folders
     And user "Alice" has created file "strängé filename (duplicate #2 &).txt" in the server
     And user "Alice" has created file "sample,1.txt" in the server
     And user "Alice" has created folder "Sample,Folder,With,Comma" in the server
-    And the user has reloaded the current page of the webUI
+    And user "Alice" has logged in using the webUI
     When the user deletes the following elements using the webUI
       | name                                  |
       | simple-folder                         |
@@ -43,8 +41,8 @@ Feature: deleting files and folders
 
   Scenario Outline: Delete a file with problematic characters
     Given user "Alice" has created file <file_name> in the server
-    When the user reloads the current page of the webUI
-    And the user deletes file <file_name> using the webUI
+    And user "Alice" has logged in using the webUI
+    When the user deletes file <file_name> using the webUI
     Then file <file_name> should not be listed on the webUI
     When the user reloads the current page of the webUI
     Then file <file_name> should not be listed on the webUI
@@ -60,7 +58,7 @@ Feature: deleting files and folders
     Given user "Alice" has uploaded file "data.zip" to "data.zip" in the server
     And user "Alice" has created file "lorem.txt" in the server
     And user "Alice" has created folder "simple-folder" in the server
-    And the user has reloaded the current page of the webUI
+    And user "Alice" has logged in using the webUI
     When the user batch deletes these files using the webUI
       | name          |
       | data.zip      |
@@ -78,7 +76,7 @@ Feature: deleting files and folders
     Given user "Alice" has uploaded file "data.zip" to "data.zip" in the server
     And user "Alice" has created file "lorem.txt" in the server
     And user "Alice" has created folder "simple-folder" in the server
-    And the user has browsed to the personal page
+    And user "Alice" has logged in using the webUI
     When the user marks all files for batch action using the webUI
     And the user batch deletes the marked files using the webUI
     Then as "Alice" file "data.zip" should not exist in the server
@@ -94,7 +92,7 @@ Feature: deleting files and folders
     And user "Alice" has created file "fileToDelete.txt" in the server
     And user "Alice" has created folder "folderToDelete" in the server
     And user "Alice" has created folder "simple-folder" in the server
-    And the user has reloaded the current page of the webUI
+    And user "Alice" has logged in using the webUI
     When the user marks all files for batch action using the webUI
     And the user unmarks these files for batch action using the webUI
       | name          |
@@ -114,6 +112,7 @@ Feature: deleting files and folders
 
   @ocis-reva-issue-106
   Scenario: Delete an empty folder
+    Given user "Alice" has logged in using the webUI
     When the user creates a folder with the name "my-empty-folder" using the webUI
     And the user creates a folder with the name "my-other-empty-folder" using the webUI
     And the user deletes folder "my-empty-folder" using the webUI
@@ -126,7 +125,7 @@ Feature: deleting files and folders
 
   Scenario: Delete the last file in a folder
     Given user "Alice" has created file "zzzz-must-be-last-file-in-folder.txt" in the server
-    And the user has reloaded the current page of the webUI
+    And user "Alice" has logged in using the webUI
     When the user deletes file "zzzz-must-be-last-file-in-folder.txt" using the webUI
     Then as "Alice" file "zzzz-must-be-last-file-in-folder.txt" should not exist in the server
     And file "zzzz-must-be-last-file-in-folder.txt" should not be listed on the webUI
@@ -135,9 +134,9 @@ Feature: deleting files and folders
   @issue-5017 @systemtags-app-required
   Scenario: delete files from tags page
     Given user "Alice" has created file "lorem.txt" in the server
-    And the user has reloaded the current page of the webUI
     And user "Alice" has created a "normal" tag with name "lorem" in the server
     And user "Alice" has added tag "lorem" to file "/lorem.txt" in the server
+    And user "Alice" has logged in using the webUI
     When the user browses to the tags page
     And the user searches for tag "lorem" using the webUI
     Then file "lorem.txt" should be listed on the webUI
@@ -153,7 +152,6 @@ Feature: deleting files and folders
     And user "Alice" has created file "simple-folder/lorem.txt" in the server
     And user "Alice" has created folder "simple-folder/simple-empty-folder" in the server
     And user "Alice" has created folder "simple-folder/strängé filename (duplicate #2 &).txt" in the server
-    And the user has reloaded the current page of the webUI
     And user "Alice" has shared folder "simple-folder" with link with "read, update, create, delete" permissions in the server
     When the public uses the webUI to access the last public link created by user "Alice" in a new session
     And the user deletes the following elements using the webUI
@@ -172,7 +170,6 @@ Feature: deleting files and folders
   Scenario: delete a file on a public share with problematic characters
     Given user "Alice" has created file "lorem.txt" in the server
     And user "Alice" has created folder "simple-folder" in the server
-    And the user has reloaded the current page of the webUI
     And user "Alice" has renamed the following file in the server
       | from-name-parts | to-name-parts   |
       | lorem.txt       | simple-folder/  |
@@ -209,7 +206,6 @@ Feature: deleting files and folders
     And user "Alice" has created file "simple-folder/data.zip" in the server
     And user "Alice" has created file "simple-folder/lorem.txt" in the server
     And user "Alice" has created file "simple-folder/simple-empty-folder" in the server
-    And the user has reloaded the current page of the webUI
     And user "Alice" has shared folder "simple-folder" with link with "read, update, create, delete" permissions in the server
     When the public uses the webUI to access the last public link created by user "Alice" in a new session
     And the user batch deletes these files using the webUI
@@ -231,6 +227,7 @@ Feature: deleting files and folders
     And user "Brian" has created file "lorem.txt" in the server
     And user "Brian" has shared folder "simple-folder" with user "Alice" in the server
     And user "Brian" has shared file "lorem.txt" with user "Alice" in the server
+    And user "Alice" has logged in using the webUI
     And the user has browsed to the shared-with-me page
     When the user accepts share "simple-folder" offered by user "Brian Murphy" using the webUI
     When the user accepts share "lorem.txt" offered by user "Brian Murphy" using the webUI
@@ -244,11 +241,11 @@ Feature: deleting files and folders
   Scenario: Try to delete file and folder that used to exist but does not anymore
     Given user "Alice" has created folder "simple-folder" in the server
     And user "Alice" has created file "lorem.txt" in the server
-    And the user has browsed to the personal page
     And the following files have been deleted by user "Alice" in the server
       | name          |
       | lorem.txt     |
       | simple-folder |
+    And user "Alice" has logged in using the webUI
     When the user deletes file "lorem.txt" using the webUI
     Then the error message with header 'Failed to delete "lorem.txt"' should be displayed on the webUI
     When the user clears all error message from the webUI
@@ -268,7 +265,7 @@ Feature: deleting files and folders
       | fo.1     |
       | fo...1.. |
       | fo.xyz   |
-    And the user has reloaded the current page of the webUI
+    And user "Alice" has logged in using the webUI
     When the user batch deletes these files using the webUI
       | folders  |
       | fo.      |


### PR DESCRIPTION
## Description
This PR has rearranged the given steps so that the WebUI steps come after the server setup steps. Doing so also eliminates the unnecessary use of reloading page steps in the scenarios.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/6979

## How Has This Been Tested?
- test environment: local

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
