### PR TITLE
[tests-only][full-ci]Added function to close the filesFolderUploadProgress on each upload

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -432,13 +432,24 @@ module.exports = {
      * @param {string} elementType
      * @returns {boolean}
      */
-    isElementListed: async function (name, elementType = 'any') {
+    isElementListed: async function (name, elementType = 'any', expectToBeListed = true) {
       const selector = this.getFileRowSelectorByFileName(name, elementType)
       let isVisible = false
+      const timeout = expectToBeListed
+        ? this.api.globals.waitForConditionTimeout
+        : this.api.globals.waitForNegativeConditionTimeout
 
-      await this.api.element('xpath', selector, function (result) {
-        isVisible = !!(result.value && result.value.ELEMENT)
-      })
+      await this.isVisible(
+        {
+          selector,
+          locateStrategy: 'xpath',
+          timeout,
+          suppressNotFoundErrors: expectToBeListed !== true
+        },
+        (result) => {
+          isVisible = result.value === true
+        }
+      )
 
       return isVisible
     },

--- a/tests/acceptance/pageObjects/personalPage.js
+++ b/tests/acceptance/pageObjects/personalPage.js
@@ -171,7 +171,9 @@ module.exports = {
     },
 
     closeFileFolderUploadProgress: function () {
-      return this.click('@filesFoldersUploadProgressClose')
+      return this.waitForElementVisible('@filesFoldersUploadProgressClose').click(
+        '@filesFoldersUploadProgressClose'
+      )
     },
     /**
      * This uploads a folder that is inside the selenium host,

--- a/tests/acceptance/pageObjects/personalPage.js
+++ b/tests/acceptance/pageObjects/personalPage.js
@@ -167,7 +167,11 @@ module.exports = {
           this.api.globals.waitForConditionPollInterval,
           false
         )
-        .click('@uploadFilesButton')
+        .closeFileFolderUploadProgress()
+    },
+
+    closeFileFolderUploadProgress: function () {
+      return this.click('@filesFoldersUploadProgressClose')
     },
     /**
      * This uploads a folder that is inside the selenium host,
@@ -216,7 +220,7 @@ module.exports = {
           this.api.globals.waitForConditionPollInterval,
           false
         )
-        .click('@uploadFilesButton')
+        .closeFileFolderUploadProgress()
     },
     /**
      * Returns whether files or folders can be created in the current page.
@@ -411,6 +415,9 @@ module.exports = {
     },
     fileUploadProgress: {
       selector: '#upload-info'
+    },
+    filesFoldersUploadProgressClose: {
+      selector: '#upload-info #close-upload-info-btn'
     },
     dialog: {
       selector: '.oc-modal'

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -369,7 +369,7 @@ Then('the last uploaded folder should be listed on the webUI', async function ()
 
 Then('file {string} should not be listed on the webUI', function (file) {
   return client.page.FilesPageElement.filesList()
-    .isElementListed(file, 'file', client.globals.waitForNegativeConditionTimeout)
+    .isElementListed(file, 'file', false)
     .then((state) => {
       const message = state
         ? `Error: File '${file}' is listed on the filesList`
@@ -380,7 +380,7 @@ Then('file {string} should not be listed on the webUI', function (file) {
 
 Then('folder {string} should not be listed on the webUI', (folder) => {
   return client.page.FilesPageElement.filesList()
-    .isElementListed(folder, 'folder', client.globals.waitForNegativeConditionTimeout)
+    .isElementListed(folder, 'folder', false)
     .then((state) => {
       const message = state
         ? `Error: Folder '${folder}' is listed on the filesList`
@@ -565,7 +565,7 @@ const theseResourcesShouldNotBeListed = async function (table) {
     const state = await client.page.FilesPageElement.filesList().isElementListed(
       entry[0],
       'file',
-      client.globals.waitForNegativeConditionTimeout
+      false
     )
     assert.ok(!state, `Expected resource '${entry[0]}' to be 'not present' but found 'present'`)
   }
@@ -609,7 +609,7 @@ Then(
   async function (file, target) {
     await client.page.personalPage().navigateAndWaitTillLoaded(target)
     return client.page.FilesPageElement.filesList()
-      .isElementListed(file, 'file', client.globals.waitForNegativeConditionTimeout)
+      .isElementListed(file, 'file', false)
       .then((state) => {
         return client.assert.ok(!state, `Error: Folder '${file}' is listed on the '${target}'`)
       })
@@ -924,7 +924,7 @@ const assertElementsAreNotListed = async function (elements) {
     const state = await client.page.FilesPageElement.filesList().isElementListed(
       element,
       'any',
-      client.globals.waitForNegativeConditionTimeout
+      false
     )
     assert.ok(!state, `Expected resource '${element}' to be 'not present' but found 'present'`)
   }
@@ -971,7 +971,11 @@ Then(
   'file/folder {string} should not be listed in shared-with-others page on the webUI',
   async function (filename) {
     await client.page.sharedWithOthersPage().navigateAndWaitTillLoaded()
-    const state = await client.page.FilesPageElement.filesList().isElementListed(filename)
+    const state = await client.page.FilesPageElement.filesList().isElementListed(
+      filename,
+      'any',
+      false
+    )
     assert.ok(
       !state,
       `Error: Resource ${filename} is present on the shared-with-others page on the webUI`
@@ -1100,7 +1104,7 @@ Then('the following file should not be listed on the webUI', async function (tab
     .hashes()
     .map((data) => data['name-parts'])
     .join('')
-  const state = await client.page.FilesPageElement.filesList().isElementListed(name)
+  const state = await client.page.FilesPageElement.filesList().isElementListed(name, 'any', false)
   return assert.ok(!state, `Element ${name} is present on the filesList!`)
 })
 


### PR DESCRIPTION
## Description
This PR adds a functions which closes upload progress bar for files/folders after each upload. 

## Related Issue
- https://github.com/owncloud/web/issues/6978

## How Has This Been Tested?
- Locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] ...
