### PR TITLE
[full-ci] Show password prompt if role change on public link enforces password

### DIFF
--- a/changelog/unreleased/bugfix-link-permission-enforced-password
+++ b/changelog/unreleased/bugfix-link-permission-enforced-password
@@ -1,0 +1,7 @@
+Bugfix: Changing link permissions to role requiring password
+
+We have added a dialogue option for updates of a link's permissions to a new role that would require a password.
+It now prompts the user to add a password instead of failing directly.
+
+https://github.com/owncloud/web/pull/6989
+https://github.com/owncloud/web/issues/6974

--- a/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
@@ -144,6 +144,7 @@ import { DateTime } from 'luxon'
 import { mapActions } from 'vuex'
 import Mixins from '../../../../mixins'
 import { createLocationSpaces, isLocationSpacesActive } from '../../../../router'
+import { showQuickLinkPasswordModal } from '../../../../quickActions'
 import { LinkShareRoles, SharePermissions } from '../../../../helpers/share'
 
 export default {
@@ -392,9 +393,16 @@ export default {
       onSuccess = () => {}
     }) {
       if (this.checkPasswordEnforcedFor(link) && link.password === false) {
-        this.showMessage({
-          title: this.$gettext('Role requires password to be set for link'),
-          status: 'warning'
+        showQuickLinkPasswordModal({ store: this.$store }, (password) => {
+          if (!password || password.trim() === '') {
+            return this.showMessage({
+              title: this.$gettext('Password cannot be empty'),
+              status: 'danger'
+            })
+          }
+          link.password = password
+          this.$emit('updateLink', { link, onSuccess })
+          this.hideModal()
         })
       } else {
         this.$emit('updateLink', { link, onSuccess })

--- a/tests/acceptance/features/webUISharingPublicBasic/publicLinkEdit.feature
+++ b/tests/acceptance/features/webUISharingPublicBasic/publicLinkEdit.feature
@@ -7,7 +7,6 @@ Feature: Edit public link shares
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files in the server
 
-
   @issue-ocis-1328
   Scenario Outline: user tries to change the role of an existing public link role without entering share password while enforce password for that role is enforced
     Given the setting "<setting-name>" of app "core" has been set to "yes" in the server
@@ -18,7 +17,8 @@ Feature: Edit public link shares
       | permissions | <initial-permissions> |
     And user "Alice" has logged in using the webUI
     When the user tries to edit the public link named "Public-link" of folder "simple-folder" changing the role to "<role>"
-    Then the user should see an error message on the public link share dialog saying "Role requires password to be set for link"
+    Then the user should see a password modal dialog with message "Passwords for links are required." on the webUI
+    # Doesn't check settings the password
     And user "Alice" should have a share with these details in the server:
       | field       | value                 |
       | share_type  | public_link           |

--- a/tests/acceptance/stepDefinitions/publicLinkContext.js
+++ b/tests/acceptance/stepDefinitions/publicLinkContext.js
@@ -128,6 +128,15 @@ When(
   }
 )
 
+Then(
+  'the user should see a password modal dialog with message {string} on the webUI',
+  async function (expectedMessage) {
+    const actualMessage =
+      await client.page.FilesPageElement.publicLinksDialog().getErrorMessageFromModal()
+    return client.assert.strictEqual(actualMessage, expectedMessage)
+  }
+)
+
 When(
   'the user tries to edit the public link named {string} of file/folder/resource {string} changing the role to {string}',
   async function (linkName, resource, role) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/6974

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
