### PR TITLE
Port EOS details to details tab in files sidebar

### DIFF
--- a/changelog/unreleased/enhancement-changes-to-links-in-sidebar
+++ b/changelog/unreleased/enhancement-changes-to-links-in-sidebar
@@ -1,8 +1,0 @@
-Enhancement: Changes in sidebar, fix tooltips
-
-We've added a `runningOnEos` setting which, if on, displays two entries in the sidebar: the EOS
-path and a direct link to the file. These paths along with the sidebar tooltips can now handle very
-long text without overflowing.
-
-https://github.com/owncloud/web/issues/6849
-https://github.com/owncloud/web/pull/6959

--- a/changelog/unreleased/enhancement-changes-to-links-in-sidebar
+++ b/changelog/unreleased/enhancement-changes-to-links-in-sidebar
@@ -1,0 +1,8 @@
+Enhancement: Changes in sidebar, fix tooltips
+
+We've added a `runningOnEos` setting which, if on, displays two entries in the sidebar: the EOS
+path and a direct link to the file. These paths along with the sidebar tooltips can now handle very
+long text without overflowing.
+
+https://github.com/owncloud/web/issues/6849
+https://github.com/owncloud/web/pull/6959

--- a/changelog/unreleased/enhancement-eos-links-in-sidebar
+++ b/changelog/unreleased/enhancement-eos-links-in-sidebar
@@ -1,0 +1,9 @@
+Enhancement: EOS links insidebar, fix tooltips
+
+We've added a `runningOnEos` setting which, if set to true, displays two entries in the sidebar: 
+The EOS path and a direct link to the file. Along with adding the two links, we have also resolved 
+an issue with overflowing text/tooltips in the sidebar for very long text.
+
+https://github.com/owncloud/web/issues/6849
+https://github.com/owncloud/web/pull/6959
+https://github.com/owncloud/web/pull/6997

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -56,6 +56,7 @@ substring of a value of the authenticated user. Examples are `/Shares`, `/{{.Id}
   - `options.feedbackLink.description` Provide any description you want to see as tooltip and as accessible description. Defaults to `Provide your feedback: We'd like to improve the web design and would be happy to hear your feedback. Thank you! Your ownCloud team.`
 - `options.sharingRecipientsPerPage` Sets the amount of users shown as recipients in the dropdown when sharing resources. Default amount is 200.
 - `options.sidebar.shares.showAllOnLoad` Sets the list of (link) shares list in the sidebar to be initially expanded (default is a collapsed state, only showing the first three shares).
+- `options.runningOnEos` Set this option to `true` if running on an [EOS storage backend](https://eos-web.web.cern.ch/eos-web/) to enable its specific features. Defaults to `false`.
 
 ### Sentry
 

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -106,7 +106,7 @@
             </div>
           </td>
         </tr>
-        <tr>
+        <tr v-if="runningOnEos">
           <th scope="col" class="oc-pr-s" v-text="directLinkLabel" />
           <td>
             <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.js
@@ -78,10 +78,18 @@ describe('Details SideBar Panel', () => {
         const wrapper = createWrapper(sharedFolder)
         expect(wrapper).toMatchSnapshot()
       })
+      it('with timestamp, size info, share info and share date running on eos', () => {
+        const wrapper = createWrapper(sharedFolder, [], null, false, true)
+        expect(wrapper).toMatchSnapshot()
+      })
     })
     describe('on a public page', () => {
       it('with owner, timestamp, size info and no share info', () => {
         const wrapper = createWrapper(sharedFolder, [], null, true)
+        expect(wrapper).toMatchSnapshot()
+      })
+      it('with owner, timestamp, size info and no share info running on eos', () => {
+        const wrapper = createWrapper(sharedFolder, [], null, true, true)
         expect(wrapper).toMatchSnapshot()
       })
     })
@@ -94,6 +102,10 @@ describe('Details SideBar Panel', () => {
       })
       it('with timestamp, size info, share info, share date and preview', () => {
         const wrapper = createWrapper(sharedFile)
+        expect(wrapper).toMatchSnapshot()
+      })
+      it('with timestamp, size info, share info, share date and preview running on eos', () => {
+        const wrapper = createWrapper(sharedFile, [], null, false, true)
         expect(wrapper).toMatchSnapshot()
       })
 
@@ -128,19 +140,25 @@ describe('Details SideBar Panel', () => {
       })
     })
     describe('on a public page', () => {
-      it('with owner, timestap, size info, no share info and preview', () => {
+      it('with owner, timestamp, size info, no share info and preview', () => {
         const wrapper = createWrapper(sharedFile, [], null, true)
         expect(wrapper).toMatchSnapshot()
       })
-      it('with owner, timestamp, size info, no share info and preview', () => {
-        const wrapper = createWrapper(sharedFile, [], null, true)
+      it('with owner, timestamp, size info, no share info and preview running on eos', () => {
+        const wrapper = createWrapper(sharedFile, [], null, true, true)
         expect(wrapper).toMatchSnapshot()
       })
     })
   })
 })
 
-function createWrapper(testResource, testVersions = [], testPreview, publicRoute = false) {
+function createWrapper(
+  testResource,
+  testVersions = [],
+  testPreview,
+  publicRoute = false,
+  runningOnEos = false
+) {
   return shallowMount(FileDetails, {
     store: new Vuex.Store({
       getters: {
@@ -150,7 +168,7 @@ function createWrapper(testResource, testVersions = [], testPreview, publicRoute
         configuration: function () {
           return {
             options: {
-              runningOnEos: true
+              runningOnEos
             }
           }
         }

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.js
@@ -146,6 +146,13 @@ function createWrapper(testResource, testVersions = [], testPreview, publicRoute
       getters: {
         user: function () {
           return { id: 'marie' }
+        },
+        configuration: function () {
+          return {
+            options: {
+              runningOnEos: true
+            }
+          }
         }
       },
       modules: {

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.js.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.js.snap
@@ -12,18 +12,18 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
     </div>
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Last modified:</th>
+        <th scope="col" class="oc-pr-s">Last modified</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <tr data-testid="shared-via">
-        <th scope="col" class="oc-pr-s">Shared via:</th>
+        <th scope="col" class="oc-pr-s">Shared via</th>
         <td>
           <router-link-stub><span></span></router-link-stub>
         </td>
       </tr>
       <!---->
       <tr data-testid="ownerDisplayName">
-        <th scope="col" class="oc-pr-s">Owner:</th>
+        <th scope="col" class="oc-pr-s">Owner</th>
         <td>
           <p class="oc-m-rm">
             Einstein
@@ -33,10 +33,32 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
         </td>
       </tr>
       <tr data-testid="sizeInfo">
-        <th scope="col" class="oc-pr-s">Size:</th>
+        <th scope="col" class="oc-pr-s">Size</th>
         <td>740 B</td>
       </tr>
       <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">EOS Path</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate">/Shares/123.png</p>
+            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <th scope="col" class="oc-pr-s">Direct link</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home/Shares/123.png</p>
+            <oc-button-stub aria-label="Copy direct link" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
     </table>
   </div>
 </div>
@@ -54,21 +76,21 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
     </div>
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Last modified:</th>
+        <th scope="col" class="oc-pr-s">Last modified</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <tr data-testid="shared-via">
-        <th scope="col" class="oc-pr-s">Shared via:</th>
+        <th scope="col" class="oc-pr-s">Shared via</th>
         <td>
           <router-link-stub><span>/Shares/123.png</span></router-link-stub>
         </td>
       </tr>
       <tr data-testid="shared-by">
-        <th scope="col" class="oc-pr-s">Shared by:</th>
+        <th scope="col" class="oc-pr-s">Shared by</th>
         <td><span>Marie Curie</span></td>
       </tr>
       <tr data-testid="ownerDisplayName">
-        <th scope="col" class="oc-pr-s">Owner:</th>
+        <th scope="col" class="oc-pr-s">Owner</th>
         <td>
           <p class="oc-m-rm">
             Einstein
@@ -78,10 +100,32 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
         </td>
       </tr>
       <tr data-testid="sizeInfo">
-        <th scope="col" class="oc-pr-s">Size:</th>
+        <th scope="col" class="oc-pr-s">Size</th>
         <td>740 B</td>
       </tr>
       <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">EOS Path</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate">/Shares/123.png</p>
+            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <th scope="col" class="oc-pr-s">Direct link</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home/Shares/123.png</p>
+            <oc-button-stub aria-label="Copy direct link" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
     </table>
   </div>
 </div>
@@ -94,13 +138,13 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
     <!---->
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Last modified:</th>
+        <th scope="col" class="oc-pr-s">Last modified</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <!---->
       <!---->
       <tr data-testid="ownerDisplayName">
-        <th scope="col" class="oc-pr-s">Owner:</th>
+        <th scope="col" class="oc-pr-s">Owner</th>
         <td>
           <p class="oc-m-rm">
             Marie
@@ -110,10 +154,32 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
         </td>
       </tr>
       <tr data-testid="sizeInfo">
-        <th scope="col" class="oc-pr-s">Size:</th>
+        <th scope="col" class="oc-pr-s">Size</th>
         <td>740 B</td>
       </tr>
       <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">EOS Path</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate"></p>
+            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <th scope="col" class="oc-pr-s">Direct link</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home</p>
+            <oc-button-stub aria-label="Copy direct link" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
     </table>
   </div>
 </div>
@@ -128,18 +194,18 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
     <!---->
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Last modified:</th>
+        <th scope="col" class="oc-pr-s">Last modified</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <tr data-testid="shared-via">
-        <th scope="col" class="oc-pr-s">Shared via:</th>
+        <th scope="col" class="oc-pr-s">Shared via</th>
         <td>
           <router-link-stub><span></span></router-link-stub>
         </td>
       </tr>
       <!---->
       <tr data-testid="ownerDisplayName">
-        <th scope="col" class="oc-pr-s">Owner:</th>
+        <th scope="col" class="oc-pr-s">Owner</th>
         <td>
           <p class="oc-m-rm">
             Einstein
@@ -149,10 +215,32 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
         </td>
       </tr>
       <tr data-testid="sizeInfo">
-        <th scope="col" class="oc-pr-s">Size:</th>
+        <th scope="col" class="oc-pr-s">Size</th>
         <td>740 B</td>
       </tr>
       <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">EOS Path</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate">/Shares/123.png</p>
+            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <th scope="col" class="oc-pr-s">Direct link</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home/Shares/123.png</p>
+            <oc-button-stub aria-label="Copy direct link" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
     </table>
   </div>
 </div>
@@ -167,13 +255,13 @@ exports[`Details SideBar Panel displays a resource of type file on a public page
     <!---->
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Last modified:</th>
+        <th scope="col" class="oc-pr-s">Last modified</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <!---->
       <!---->
       <tr data-testid="ownerDisplayName">
-        <th scope="col" class="oc-pr-s">Owner:</th>
+        <th scope="col" class="oc-pr-s">Owner</th>
         <td>
           <p class="oc-m-rm">
             Einstein
@@ -183,10 +271,32 @@ exports[`Details SideBar Panel displays a resource of type file on a public page
         </td>
       </tr>
       <tr data-testid="sizeInfo">
-        <th scope="col" class="oc-pr-s">Size:</th>
+        <th scope="col" class="oc-pr-s">Size</th>
         <td>740 B</td>
       </tr>
       <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">EOS Path</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate">/Shares/123.png</p>
+            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <th scope="col" class="oc-pr-s">Direct link</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home/Shares/123.png</p>
+            <oc-button-stub aria-label="Copy direct link" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
     </table>
   </div>
 </div>
@@ -201,13 +311,13 @@ exports[`Details SideBar Panel displays a resource of type file on a public page
     <!---->
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Last modified:</th>
+        <th scope="col" class="oc-pr-s">Last modified</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <!---->
       <!---->
       <tr data-testid="ownerDisplayName">
-        <th scope="col" class="oc-pr-s">Owner:</th>
+        <th scope="col" class="oc-pr-s">Owner</th>
         <td>
           <p class="oc-m-rm">
             Einstein
@@ -217,10 +327,32 @@ exports[`Details SideBar Panel displays a resource of type file on a public page
         </td>
       </tr>
       <tr data-testid="sizeInfo">
-        <th scope="col" class="oc-pr-s">Size:</th>
+        <th scope="col" class="oc-pr-s">Size</th>
         <td>740 B</td>
       </tr>
       <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">EOS Path</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate">/Shares/123.png</p>
+            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <th scope="col" class="oc-pr-s">Direct link</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home/Shares/123.png</p>
+            <oc-button-stub aria-label="Copy direct link" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
     </table>
   </div>
 </div>
@@ -233,13 +365,13 @@ exports[`Details SideBar Panel displays a resource of type folder on a private p
     <!---->
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Last modified:</th>
+        <th scope="col" class="oc-pr-s">Last modified</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <!---->
       <!---->
       <tr data-testid="ownerDisplayName">
-        <th scope="col" class="oc-pr-s">Owner:</th>
+        <th scope="col" class="oc-pr-s">Owner</th>
         <td>
           <p class="oc-m-rm">
             Marie
@@ -249,10 +381,32 @@ exports[`Details SideBar Panel displays a resource of type folder on a private p
         </td>
       </tr>
       <tr data-testid="sizeInfo">
-        <th scope="col" class="oc-pr-s">Size:</th>
+        <th scope="col" class="oc-pr-s">Size</th>
         <td>740 B</td>
       </tr>
       <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">EOS Path</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate"></p>
+            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <th scope="col" class="oc-pr-s">Direct link</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home</p>
+            <oc-button-stub aria-label="Copy direct link" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
     </table>
   </div>
 </div>
@@ -265,13 +419,13 @@ exports[`Details SideBar Panel displays a resource of type folder on a private p
     <!---->
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Last modified:</th>
+        <th scope="col" class="oc-pr-s">Last modified</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <!---->
       <!---->
       <tr data-testid="ownerDisplayName">
-        <th scope="col" class="oc-pr-s">Owner:</th>
+        <th scope="col" class="oc-pr-s">Owner</th>
         <td>
           <p class="oc-m-rm">
             Einstein
@@ -281,10 +435,32 @@ exports[`Details SideBar Panel displays a resource of type folder on a private p
         </td>
       </tr>
       <tr data-testid="sizeInfo">
-        <th scope="col" class="oc-pr-s">Size:</th>
+        <th scope="col" class="oc-pr-s">Size</th>
         <td>740 B</td>
       </tr>
       <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">EOS Path</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate"></p>
+            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <th scope="col" class="oc-pr-s">Direct link</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home</p>
+            <oc-button-stub aria-label="Copy direct link" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
     </table>
   </div>
 </div>
@@ -297,13 +473,13 @@ exports[`Details SideBar Panel displays a resource of type folder on a public pa
     <!---->
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
-        <th scope="col" class="oc-pr-s">Last modified:</th>
+        <th scope="col" class="oc-pr-s">Last modified</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
       <!---->
       <!---->
       <tr data-testid="ownerDisplayName">
-        <th scope="col" class="oc-pr-s">Owner:</th>
+        <th scope="col" class="oc-pr-s">Owner</th>
         <td>
           <p class="oc-m-rm">
             Einstein
@@ -313,10 +489,32 @@ exports[`Details SideBar Panel displays a resource of type folder on a public pa
         </td>
       </tr>
       <tr data-testid="sizeInfo">
-        <th scope="col" class="oc-pr-s">Size:</th>
+        <th scope="col" class="oc-pr-s">Size</th>
         <td>740 B</td>
       </tr>
       <!---->
+      <tr>
+        <th scope="col" class="oc-pr-s">EOS Path</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate"></p>
+            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <th scope="col" class="oc-pr-s">Direct link</th>
+        <td>
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
+            <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home</p>
+            <oc-button-stub aria-label="Copy direct link" appearance="raw" variation="passive">
+              <oc-icon-stub name="clipboard"></oc-icon-stub>
+            </oc-button-stub>
+          </div>
+        </td>
+      </tr>
     </table>
   </div>
 </div>

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.js.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.js.snap
@@ -37,28 +37,8 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
         <td>740 B</td>
       </tr>
       <!---->
-      <tr>
-        <th scope="col" class="oc-pr-s">EOS Path</th>
-        <td>
-          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
-            <p class="oc-my-rm oc-text-truncate">/Shares/123.png</p>
-            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
-              <oc-icon-stub name="clipboard"></oc-icon-stub>
-            </oc-button-stub>
-          </div>
-        </td>
-      </tr>
-      <tr>
-        <th scope="col" class="oc-pr-s">Direct link</th>
-        <td>
-          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
-            <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home/Shares/123.png</p>
-            <oc-button-stub aria-label="Copy direct link" appearance="raw" variation="passive">
-              <oc-icon-stub name="clipboard"></oc-icon-stub>
-            </oc-button-stub>
-          </div>
-        </td>
-      </tr>
+      <!---->
+      <!---->
     </table>
   </div>
 </div>
@@ -104,28 +84,8 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
         <td>740 B</td>
       </tr>
       <!---->
-      <tr>
-        <th scope="col" class="oc-pr-s">EOS Path</th>
-        <td>
-          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
-            <p class="oc-my-rm oc-text-truncate">/Shares/123.png</p>
-            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
-              <oc-icon-stub name="clipboard"></oc-icon-stub>
-            </oc-button-stub>
-          </div>
-        </td>
-      </tr>
-      <tr>
-        <th scope="col" class="oc-pr-s">Direct link</th>
-        <td>
-          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
-            <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home/Shares/123.png</p>
-            <oc-button-stub aria-label="Copy direct link" appearance="raw" variation="passive">
-              <oc-icon-stub name="clipboard"></oc-icon-stub>
-            </oc-button-stub>
-          </div>
-        </td>
-      </tr>
+      <!---->
+      <!---->
     </table>
   </div>
 </div>
@@ -158,34 +118,55 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
         <td>740 B</td>
       </tr>
       <!---->
-      <tr>
-        <th scope="col" class="oc-pr-s">EOS Path</th>
-        <td>
-          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
-            <p class="oc-my-rm oc-text-truncate"></p>
-            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
-              <oc-icon-stub name="clipboard"></oc-icon-stub>
-            </oc-button-stub>
-          </div>
-        </td>
-      </tr>
-      <tr>
-        <th scope="col" class="oc-pr-s">Direct link</th>
-        <td>
-          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
-            <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home</p>
-            <oc-button-stub aria-label="Copy direct link" appearance="raw" variation="passive">
-              <oc-icon-stub name="clipboard"></oc-icon-stub>
-            </oc-button-stub>
-          </div>
-        </td>
-      </tr>
+      <!---->
+      <!---->
     </table>
   </div>
 </div>
 `;
 
 exports[`Details SideBar Panel displays a resource of type file on a private page with timestamp, size info, share info, share date and preview 1`] = `
+<div id="oc-file-details-sidebar">
+  <div>
+    <div data-testid="preview" class="details-preview oc-flex oc-flex-middle oc-flex-center oc-mb" style="background-image: none;">
+      <oc-spinner-stub></oc-spinner-stub>
+    </div>
+    <!---->
+    <table aria-label="Overview of the information about the selected file" class="details-table">
+      <tr data-testid="timestamp">
+        <th scope="col" class="oc-pr-s">Last modified</th>
+        <td><span>ABSOLUTE_TIME</span></td>
+      </tr>
+      <tr data-testid="shared-via">
+        <th scope="col" class="oc-pr-s">Shared via</th>
+        <td>
+          <router-link-stub><span></span></router-link-stub>
+        </td>
+      </tr>
+      <!---->
+      <tr data-testid="ownerDisplayName">
+        <th scope="col" class="oc-pr-s">Owner</th>
+        <td>
+          <p class="oc-m-rm">
+            Einstein
+            <!---->
+            <!---->
+          </p>
+        </td>
+      </tr>
+      <tr data-testid="sizeInfo">
+        <th scope="col" class="oc-pr-s">Size</th>
+        <td>740 B</td>
+      </tr>
+      <!---->
+      <!---->
+      <!---->
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Details SideBar Panel displays a resource of type file on a private page with timestamp, size info, share info, share date and preview running on eos 1`] = `
 <div id="oc-file-details-sidebar">
   <div>
     <div data-testid="preview" class="details-preview oc-flex oc-flex-middle oc-flex-center oc-mb" style="background-image: none;">
@@ -275,34 +256,14 @@ exports[`Details SideBar Panel displays a resource of type file on a public page
         <td>740 B</td>
       </tr>
       <!---->
-      <tr>
-        <th scope="col" class="oc-pr-s">EOS Path</th>
-        <td>
-          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
-            <p class="oc-my-rm oc-text-truncate">/Shares/123.png</p>
-            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
-              <oc-icon-stub name="clipboard"></oc-icon-stub>
-            </oc-button-stub>
-          </div>
-        </td>
-      </tr>
-      <tr>
-        <th scope="col" class="oc-pr-s">Direct link</th>
-        <td>
-          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
-            <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home/Shares/123.png</p>
-            <oc-button-stub aria-label="Copy direct link" appearance="raw" variation="passive">
-              <oc-icon-stub name="clipboard"></oc-icon-stub>
-            </oc-button-stub>
-          </div>
-        </td>
-      </tr>
+      <!---->
+      <!---->
     </table>
   </div>
 </div>
 `;
 
-exports[`Details SideBar Panel displays a resource of type file on a public page with owner, timestap, size info, no share info and preview 1`] = `
+exports[`Details SideBar Panel displays a resource of type file on a public page with owner, timestamp, size info, no share info and preview running on eos 1`] = `
 <div id="oc-file-details-sidebar">
   <div>
     <div data-testid="preview" class="details-preview oc-flex oc-flex-middle oc-flex-center oc-mb" style="background-image: none;">
@@ -385,34 +346,48 @@ exports[`Details SideBar Panel displays a resource of type folder on a private p
         <td>740 B</td>
       </tr>
       <!---->
-      <tr>
-        <th scope="col" class="oc-pr-s">EOS Path</th>
-        <td>
-          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
-            <p class="oc-my-rm oc-text-truncate"></p>
-            <oc-button-stub aria-label="Copy EOS path" appearance="raw" variation="passive">
-              <oc-icon-stub name="clipboard"></oc-icon-stub>
-            </oc-button-stub>
-          </div>
-        </td>
-      </tr>
-      <tr>
-        <th scope="col" class="oc-pr-s">Direct link</th>
-        <td>
-          <div class="oc-flex oc-flex-middle oc-flex-between oc-width-1-1">
-            <p class="oc-my-rm oc-text-truncate">undefinedfiles/spaces/personal/home</p>
-            <oc-button-stub aria-label="Copy direct link" appearance="raw" variation="passive">
-              <oc-icon-stub name="clipboard"></oc-icon-stub>
-            </oc-button-stub>
-          </div>
-        </td>
-      </tr>
+      <!---->
+      <!---->
     </table>
   </div>
 </div>
 `;
 
 exports[`Details SideBar Panel displays a resource of type folder on a private page with timestamp, size info, share info and share date 1`] = `
+<div id="oc-file-details-sidebar">
+  <div>
+    <!---->
+    <!---->
+    <table aria-label="Overview of the information about the selected file" class="details-table">
+      <tr data-testid="timestamp">
+        <th scope="col" class="oc-pr-s">Last modified</th>
+        <td><span>ABSOLUTE_TIME</span></td>
+      </tr>
+      <!---->
+      <!---->
+      <tr data-testid="ownerDisplayName">
+        <th scope="col" class="oc-pr-s">Owner</th>
+        <td>
+          <p class="oc-m-rm">
+            Einstein
+            <!---->
+            <!---->
+          </p>
+        </td>
+      </tr>
+      <tr data-testid="sizeInfo">
+        <th scope="col" class="oc-pr-s">Size</th>
+        <td>740 B</td>
+      </tr>
+      <!---->
+      <!---->
+      <!---->
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Details SideBar Panel displays a resource of type folder on a private page with timestamp, size info, share info and share date running on eos 1`] = `
 <div id="oc-file-details-sidebar">
   <div>
     <!---->
@@ -467,6 +442,40 @@ exports[`Details SideBar Panel displays a resource of type folder on a private p
 `;
 
 exports[`Details SideBar Panel displays a resource of type folder on a public page with owner, timestamp, size info and no share info 1`] = `
+<div id="oc-file-details-sidebar">
+  <div>
+    <!---->
+    <!---->
+    <table aria-label="Overview of the information about the selected file" class="details-table">
+      <tr data-testid="timestamp">
+        <th scope="col" class="oc-pr-s">Last modified</th>
+        <td><span>ABSOLUTE_TIME</span></td>
+      </tr>
+      <!---->
+      <!---->
+      <tr data-testid="ownerDisplayName">
+        <th scope="col" class="oc-pr-s">Owner</th>
+        <td>
+          <p class="oc-m-rm">
+            Einstein
+            <!---->
+            <!---->
+          </p>
+        </td>
+      </tr>
+      <tr data-testid="sizeInfo">
+        <th scope="col" class="oc-pr-s">Size</th>
+        <td>740 B</td>
+      </tr>
+      <!---->
+      <!---->
+      <!---->
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Details SideBar Panel displays a resource of type folder on a public page with owner, timestamp, size info and no share info running on eos 1`] = `
 <div id="oc-file-details-sidebar">
   <div>
     <!---->

--- a/packages/web-runtime/src/store/config.js
+++ b/packages/web-runtime/src/store/config.js
@@ -48,7 +48,8 @@ const state = {
       }
     },
     previewFileExtensions: [],
-    sharingRecipientsPerPage: 200
+    sharingRecipientsPerPage: 200,
+    runningOnEos: false
   }
 }
 

--- a/packages/web-runtime/src/store/config.js
+++ b/packages/web-runtime/src/store/config.js
@@ -48,8 +48,8 @@ const state = {
       }
     },
     previewFileExtensions: [],
-    sharingRecipientsPerPage: 200,
-    runningOnEos: false
+    runningOnEos: false,
+    sharingRecipientsPerPage: 200
   }
 }
 


### PR DESCRIPTION
## Description
This ports #6959 over, with slight adoptions:
- unit tests now run with default disabled EOS, and have cases with eos to make sure the component does what we expect
- "direct links" now also are only visible if EOS ins enabled in the config (pretty sure `web` should have dedicated private links for OC10 and a strong incentive for users to use quicklinks/public links)