### PR TITLE
[full-ci] Fix breadcrumb auto focus

### DIFF
--- a/changelog/unreleased/bugfix-breadcrumb-focus
+++ b/changelog/unreleased/bugfix-breadcrumb-focus
@@ -1,0 +1,5 @@
+Bugfix: Breadcrumb auto focus
+
+We've fixed a bug where the auto focus couldn't be set on the current breadcrumb item when navigating.
+
+https://github.com/owncloud/web/pull/6846

--- a/packages/web-app-files/src/mixins/accessibleBreadcrumb.js
+++ b/packages/web-app-files/src/mixins/accessibleBreadcrumb.js
@@ -10,7 +10,7 @@ export default {
       const activeBreadcrumb = last(
         document.getElementById('files-breadcrumb').children[0].children
       )
-      const activeBreadcrumbItem = activeBreadcrumb.lastChild
+      const activeBreadcrumbItem = activeBreadcrumb.getElementsByTagName('button')[0]
 
       if (!activeBreadcrumbItem) {
         return


### PR DESCRIPTION
## Description
We've fixed a bug where the auto focus couldn't be set on the current breadcrumb item when navigating. It also gets rid of all the console errors when navigating: `TypeError: activeBreadcrumbItem.focus is not a function`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
