### PR TITLE
[full-ci] Fix inheritance of share permissions on reshares

### DIFF
--- a/changelog/unreleased/bugfix-share-permissions-inheritance
+++ b/changelog/unreleased/bugfix-share-permissions-inheritance
@@ -1,0 +1,6 @@
+Bugfix: Inheritance of share permissions
+
+We've fixed a bug where the permissions of a share were not inherited when trying to reshare a resource. We've also disabled the role-select-dropdown if only one role is available for sharing.
+
+https://github.com/owncloud/web/pull/7015
+https://github.com/owncloud/web/issues/2963

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
@@ -174,7 +174,7 @@ export default {
         return SpacePeopleShareRoles.list()
       }
 
-      if (this.resourceIsSharable && this.share) {
+      if (this.resource.isReceivedShare() && this.resourceIsSharable && this.share) {
         return PeopleShareRoles.listByBitmask(
           parseInt(this.share.permissions),
           this.resource.isFolder,
@@ -186,7 +186,7 @@ export default {
       return PeopleShareRoles.list(this.resource.isFolder, this.allowCustomSharing !== false)
     },
     availablePermissions() {
-      if (this.resourceIsSharable && this.share) {
+      if (this.resource.isReceivedShare() && this.resourceIsSharable && this.share) {
         return this.customPermissionsRole.permissionsByBitmask(
           parseInt(this.share.permissions),
           this.allowSharePermission

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
@@ -172,7 +172,7 @@ export default {
       }
 
       if (this.resource.isReceivedShare() && this.resourceIsSharable && this.share) {
-        return PeopleShareRoles.listByBitmask(
+        return PeopleShareRoles.filterByBitmask(
           parseInt(this.share.permissions),
           this.resource.isFolder,
           this.allowSharePermission,

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
@@ -93,7 +93,6 @@ import {
   SpacePeopleShareRoles
 } from '../../../../helpers/share'
 import * as uuid from 'uuid'
-import { DavPermission } from 'web-pkg/src/constants'
 
 export default {
   name: 'RoleDropdown',
@@ -155,9 +154,7 @@ export default {
       return PeopleShareRoles.custom(this.resource.isFolder)
     },
     resourceIsSharable() {
-      return (
-        this.allowSharePermission && this.resource.permissions.includes(DavPermission.Shareable)
-      )
+      return this.allowSharePermission && this.resource.canShare()
     },
     share() {
       const userShares = this.sharesTree[this.resource.path]?.filter((s) =>

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
@@ -1,6 +1,11 @@
 <template>
   <span v-if="selectedRole" class="oc-flex oc-flex-middle">
+    <span v-if="availableRoles.length === 1">
+      <span v-if="!existingRole" v-text="inviteLabel" />
+      <span v-else>{{ $gettext(selectedRole.label) }}</span>
+    </span>
     <oc-button
+      v-else
       :id="roleButtonId"
       class="files-recipient-role-select-btn"
       appearance="raw"
@@ -11,6 +16,7 @@
       <oc-icon name="arrow-down-s" />
     </oc-button>
     <oc-drop
+      v-if="availableRoles.length > 1"
       ref="rolesDrop"
       :toggle="'#' + roleButtonId"
       mode="click"
@@ -35,6 +41,7 @@
       </oc-list>
     </oc-drop>
     <oc-drop
+      v-if="availableRoles.length > 1"
       ref="customPermissionsDrop"
       class="files-recipient-custom-permissions-drop"
       mode="manual"
@@ -75,16 +82,18 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex'
+import { mapGetters, mapState } from 'vuex'
 import get from 'lodash-es/get'
 import RoleItem from '../Shared/RoleItem.vue'
 import {
   PeopleShareRoles,
   SharePermissions,
   ShareRole,
+  ShareTypes,
   SpacePeopleShareRoles
 } from '../../../../helpers/share'
 import * as uuid from 'uuid'
+import { DavPermission } from 'web-pkg/src/constants'
 
 export default {
   name: 'RoleDropdown',
@@ -121,6 +130,7 @@ export default {
     }
   },
   computed: {
+    ...mapState('Files', ['sharesTree']),
     ...mapGetters(['capabilities']),
 
     roleButtonId() {
@@ -144,16 +154,44 @@ export default {
     customPermissionsRole() {
       return PeopleShareRoles.custom(this.resource.isFolder)
     },
+    resourceIsSharable() {
+      return (
+        this.allowSharePermission && this.resource.permissions.includes(DavPermission.Shareable)
+      )
+    },
+    share() {
+      const userShares = this.sharesTree[this.resource.path]?.filter((s) =>
+        ShareTypes.containsAnyValue(ShareTypes.individuals, [s.shareType])
+      )
+
+      return userShares?.length ? userShares[0] : undefined
+    },
+    allowCustomSharing() {
+      return this.capabilities?.files_sharing?.allow_custom
+    },
     availableRoles() {
       if (this.resourceIsSpace) {
         return SpacePeopleShareRoles.list()
       }
-      return PeopleShareRoles.list(
-        this.resource.isFolder,
-        this.capabilities?.files_sharing?.allow_custom !== false
-      )
+
+      if (this.resourceIsSharable && this.share) {
+        return PeopleShareRoles.listByBitmask(
+          parseInt(this.share.permissions),
+          this.resource.isFolder,
+          this.allowSharePermission,
+          this.allowCustomSharing !== false
+        )
+      }
+
+      return PeopleShareRoles.list(this.resource.isFolder, this.allowCustomSharing !== false)
     },
     availablePermissions() {
+      if (this.resourceIsSharable && this.share) {
+        return this.customPermissionsRole.permissionsByBitmask(
+          parseInt(this.share.permissions),
+          this.allowSharePermission
+        )
+      }
       return this.customPermissionsRole.permissions(this.allowSharePermission)
     },
     resourceIsSpace() {

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
@@ -184,10 +184,7 @@ export default {
     },
     availablePermissions() {
       if (this.resource.isReceivedShare() && this.resourceIsSharable && this.share) {
-        return this.customPermissionsRole.permissionsByBitmask(
-          parseInt(this.share.permissions),
-          this.allowSharePermission
-        )
+        return SharePermissions.bitmaskToPermissions(parseInt(this.share.permissions))
       }
       return this.customPermissionsRole.permissions(this.allowSharePermission)
     },

--- a/packages/web-app-files/src/helpers/share/role.ts
+++ b/packages/web-app-files/src/helpers/share/role.ts
@@ -59,10 +59,6 @@ export abstract class ShareRole {
     })
   }
 
-  public permissionsByBitmask(bitmask: number, allowSharing: boolean): SharePermission[] {
-    return this.permissions(allowSharing).filter((p: SharePermission) => bitmask & p.bit)
-  }
-
   public abstract description(allowSharing: boolean): string
 
   /**

--- a/packages/web-app-files/src/helpers/share/role.ts
+++ b/packages/web-app-files/src/helpers/share/role.ts
@@ -279,7 +279,14 @@ export abstract class PeopleShareRoles {
     return role || this.custom(isFolder)
   }
 
-  static listByBitmask(
+  /**
+   * Filter all roles that have either exactly the permissions from the bitmask or a subset of them.
+   * @param bitmask
+   * @param isFolder
+   * @param allowSharing
+   * @param allowCustom
+   */
+  static filterByBitmask(
     bitmask: number,
     isFolder: boolean,
     allowSharing: boolean,

--- a/packages/web-app-files/src/helpers/share/role.ts
+++ b/packages/web-app-files/src/helpers/share/role.ts
@@ -59,6 +59,10 @@ export abstract class ShareRole {
     })
   }
 
+  public permissionsByBitmask(bitmask: number, allowSharing: boolean): SharePermission[] {
+    return this.permissions(allowSharing).filter((p: SharePermission) => bitmask & p.bit)
+  }
+
   public abstract description(allowSharing: boolean): string
 
   /**
@@ -277,6 +281,24 @@ export abstract class PeopleShareRoles {
       .filter((r) => !r.hasCustomPermissions)
       .find((r) => r.folder === isFolder && r.bitmask(allowSharing) === bitmask)
     return role || this.custom(isFolder)
+  }
+
+  static listByBitmask(
+    bitmask: number,
+    isFolder: boolean,
+    allowSharing: boolean,
+    allowCustom: boolean
+  ): ShareRole[] {
+    const roles = this.all.filter((r) => {
+      return r.folder === isFolder && bitmask === (bitmask | r.bitmask(allowSharing))
+    })
+
+    if (allowCustom) {
+      const customRoles = [peopleRoleCustomFile, peopleRoleCustomFolder]
+      return [...roles, ...customRoles.filter((c) => c.folder === isFolder)]
+    }
+
+    return roles
   }
 }
 

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/RoleDropdown.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/RoleDropdown.spec.js
@@ -302,6 +302,7 @@ function getResource({
     etag: '"89128c0e8122002db57bd19c9ec33004"',
     shareTypes: [],
     downloadURL: '',
-    isReceivedShare: () => isReceivedShare
+    isReceivedShare: () => isReceivedShare,
+    canShare: () => true
   }
 }

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/RoleDropdown.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/RoleDropdown.spec.js
@@ -147,6 +147,7 @@ describe('RoleDropdown', () => {
       ])("inherits the parents share's permissions: %s", (sharePermissions) => {
         const wrapper = getShallowMountedWrapper({
           existingRole: PeopleShareRoles.list(true)[0],
+          isReceivedShare: true,
           sharesTree: {
             '/testfolder': [
               {
@@ -172,6 +173,7 @@ describe('RoleDropdown', () => {
       it('does not render a button if only one role is available', () => {
         const wrapper = getShallowMountedWrapper({
           existingRole: PeopleShareRoles.list(true)[0],
+          isReceivedShare: true,
           sharesTree: {
             '/testfolder': [
               {
@@ -252,13 +254,20 @@ function getShallowMountedWrapper(data) {
   return shallowMount(RoleDropdown, getMountOptions(data))
 }
 
-function getMountOptions({ existingRole, shareId, resourceType = 'folder', sharesTree = {} }) {
+function getMountOptions({
+  existingRole,
+  shareId,
+  resourceType = 'folder',
+  sharesTree = {},
+  isReceivedShare = false
+}) {
   return {
     propsData: {
       resource: getResource({
         filename: resourceType === 'folder' ? 'testfolder' : 'testfile',
         extension: resourceType === 'folder' ? '' : 'jpg',
-        type: resourceType
+        type: resourceType,
+        isReceivedShare
       }),
       existingRole,
       shareId,
@@ -270,7 +279,12 @@ function getMountOptions({ existingRole, shareId, resourceType = 'folder', share
   }
 }
 
-function getResource({ filename = 'testFile', extension = 'txt', type = 'file' }) {
+function getResource({
+  filename = 'testFile',
+  extension = 'txt',
+  type = 'file',
+  isReceivedShare = false
+}) {
   return {
     id: '4',
     fileId: '4',
@@ -287,6 +301,7 @@ function getResource({ filename = 'testFile', extension = 'txt', type = 'file' }
     starred: false,
     etag: '"89128c0e8122002db57bd19c9ec33004"',
     shareTypes: [],
-    downloadURL: ''
+    downloadURL: '',
+    isReceivedShare: () => isReceivedShare
   }
 }

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/RoleDropdown.spec.js.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/RoleDropdown.spec.js.snap
@@ -1,10 +1,139 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RoleDropdown for file shares when an existing role is present renders a button with existing role if given for resource type file 1`] = `
+exports[`RoleDropdown for file shares custom permissions inherits the parents share's permissions: 17 1`] = `
+<span class="oc-flex oc-flex-middle"><oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="none" id="files-collaborators-role-button-new" class="files-recipient-role-select-btn"><span>Viewer</span>
+<oc-icon-stub name="arrow-down-s" filltype="fill" accessiblelabel="" type="span" size="medium" variation="passive" color=""></oc-icon-stub>
+</oc-button-stub>
+<oc-drop-stub dropid="oc-drop-15" toggle="#files-collaborators-role-button-new" position="bottom-start" mode="click" closeonclick="true" paddingsize="remove">
+  <oc-list-stub aria-label="Select role for the invitation" class="files-recipient-role-drop-list">
+    <li>
+      <oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="space-between" gapsize="medium" id="files-recipient-role-drop-btn-viewer" class="files-recipient-role-drop-btn oc-py-xs oc-px-s selected">
+        <role-item-stub role="[object Object]" allowsharepermission="true"></role-item-stub>
+        <oc-icon-stub name="check" filltype="fill" accessiblelabel="" type="span" size="medium" variation="passive" color=""></oc-icon-stub>
+      </oc-button-stub>
+    </li>
+    <li>
+      <oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="space-between" gapsize="medium" id="files-recipient-role-drop-btn-custom" class="files-recipient-role-drop-btn oc-py-xs oc-px-s">
+        <role-item-stub role="[object Object]" allowsharepermission="true"></role-item-stub>
+        <!---->
+      </oc-button-stub>
+    </li>
+  </oc-list-stub>
+</oc-drop-stub>
+<oc-drop-stub dropid="oc-drop-16" toggle="" position="bottom-start" mode="manual" target="#files-collaborators-role-button-new" paddingsize="small" class="files-recipient-custom-permissions-drop">
+  <h4 class="oc-text-bold oc-text-initial">Custom permissions</h4>
+  <oc-list-stub class="oc-mb">
+    <li class="oc-my-xs">
+      <oc-checkbox-stub id="files-collaborators-permission-read" disabled="true" value="[object Object],[object Object]" option="[object Object]" label="Read" size="medium" data-testid="files-collaborators-permission-read" class="oc-mr-xs files-collaborators-permission-checkbox"></oc-checkbox-stub>
+    </li>
+    <li class="oc-my-xs">
+      <oc-checkbox-stub id="files-collaborators-permission-share" value="[object Object],[object Object]" option="[object Object]" label="Share" size="medium" data-testid="files-collaborators-permission-share" class="oc-mr-xs files-collaborators-permission-checkbox"></oc-checkbox-stub>
+    </li>
+  </oc-list-stub>
+  <div class="files-recipient-custom-permissions-drop-cancel-confirm-btns">
+    <oc-button-stub type="button" size="small" submit="button" variation="passive" appearance="outline" justifycontent="center" gapsize="medium">Cancel</oc-button-stub>
+    <oc-button-stub type="button" size="small" submit="button" variation="primary" appearance="filled" justifycontent="center" gapsize="medium">Apply</oc-button-stub>
+  </div>
+</oc-drop-stub>
+</span>
+`;
+
+exports[`RoleDropdown for file shares custom permissions inherits the parents share's permissions: 23 1`] = `
 <span class="oc-flex oc-flex-middle"><oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="none" id="files-collaborators-role-button-new" class="files-recipient-role-select-btn"><span>Viewer</span>
 <oc-icon-stub name="arrow-down-s" filltype="fill" accessiblelabel="" type="span" size="medium" variation="passive" color=""></oc-icon-stub>
 </oc-button-stub>
 <oc-drop-stub dropid="oc-drop-17" toggle="#files-collaborators-role-button-new" position="bottom-start" mode="click" closeonclick="true" paddingsize="remove">
+  <oc-list-stub aria-label="Select role for the invitation" class="files-recipient-role-drop-list">
+    <li>
+      <oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="space-between" gapsize="medium" id="files-recipient-role-drop-btn-viewer" class="files-recipient-role-drop-btn oc-py-xs oc-px-s selected">
+        <role-item-stub role="[object Object]" allowsharepermission="true"></role-item-stub>
+        <oc-icon-stub name="check" filltype="fill" accessiblelabel="" type="span" size="medium" variation="passive" color=""></oc-icon-stub>
+      </oc-button-stub>
+    </li>
+    <li>
+      <oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="space-between" gapsize="medium" id="files-recipient-role-drop-btn-custom" class="files-recipient-role-drop-btn oc-py-xs oc-px-s">
+        <role-item-stub role="[object Object]" allowsharepermission="true"></role-item-stub>
+        <!---->
+      </oc-button-stub>
+    </li>
+  </oc-list-stub>
+</oc-drop-stub>
+<oc-drop-stub dropid="oc-drop-18" toggle="" position="bottom-start" mode="manual" target="#files-collaborators-role-button-new" paddingsize="small" class="files-recipient-custom-permissions-drop">
+  <h4 class="oc-text-bold oc-text-initial">Custom permissions</h4>
+  <oc-list-stub class="oc-mb">
+    <li class="oc-my-xs">
+      <oc-checkbox-stub id="files-collaborators-permission-read" disabled="true" value="[object Object],[object Object]" option="[object Object]" label="Read" size="medium" data-testid="files-collaborators-permission-read" class="oc-mr-xs files-collaborators-permission-checkbox"></oc-checkbox-stub>
+    </li>
+    <li class="oc-my-xs">
+      <oc-checkbox-stub id="files-collaborators-permission-update" value="[object Object],[object Object]" option="[object Object]" label="Update" size="medium" data-testid="files-collaborators-permission-update" class="oc-mr-xs files-collaborators-permission-checkbox"></oc-checkbox-stub>
+    </li>
+    <li class="oc-my-xs">
+      <oc-checkbox-stub id="files-collaborators-permission-create" value="[object Object],[object Object]" option="[object Object]" label="Create" size="medium" data-testid="files-collaborators-permission-create" class="oc-mr-xs files-collaborators-permission-checkbox"></oc-checkbox-stub>
+    </li>
+    <li class="oc-my-xs">
+      <oc-checkbox-stub id="files-collaborators-permission-share" value="[object Object],[object Object]" option="[object Object]" label="Share" size="medium" data-testid="files-collaborators-permission-share" class="oc-mr-xs files-collaborators-permission-checkbox"></oc-checkbox-stub>
+    </li>
+  </oc-list-stub>
+  <div class="files-recipient-custom-permissions-drop-cancel-confirm-btns">
+    <oc-button-stub type="button" size="small" submit="button" variation="passive" appearance="outline" justifycontent="center" gapsize="medium">Cancel</oc-button-stub>
+    <oc-button-stub type="button" size="small" submit="button" variation="primary" appearance="filled" justifycontent="center" gapsize="medium">Apply</oc-button-stub>
+  </div>
+</oc-drop-stub>
+</span>
+`;
+
+exports[`RoleDropdown for file shares custom permissions inherits the parents share's permissions: 25 1`] = `
+<span class="oc-flex oc-flex-middle"><oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="none" id="files-collaborators-role-button-new" class="files-recipient-role-select-btn"><span>Viewer</span>
+<oc-icon-stub name="arrow-down-s" filltype="fill" accessiblelabel="" type="span" size="medium" variation="passive" color=""></oc-icon-stub>
+</oc-button-stub>
+<oc-drop-stub dropid="oc-drop-19" toggle="#files-collaborators-role-button-new" position="bottom-start" mode="click" closeonclick="true" paddingsize="remove">
+  <oc-list-stub aria-label="Select role for the invitation" class="files-recipient-role-drop-list">
+    <li>
+      <oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="space-between" gapsize="medium" id="files-recipient-role-drop-btn-viewer" class="files-recipient-role-drop-btn oc-py-xs oc-px-s selected">
+        <role-item-stub role="[object Object]" allowsharepermission="true"></role-item-stub>
+        <oc-icon-stub name="check" filltype="fill" accessiblelabel="" type="span" size="medium" variation="passive" color=""></oc-icon-stub>
+      </oc-button-stub>
+    </li>
+    <li>
+      <oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="space-between" gapsize="medium" id="files-recipient-role-drop-btn-custom" class="files-recipient-role-drop-btn oc-py-xs oc-px-s">
+        <role-item-stub role="[object Object]" allowsharepermission="true"></role-item-stub>
+        <!---->
+      </oc-button-stub>
+    </li>
+  </oc-list-stub>
+</oc-drop-stub>
+<oc-drop-stub dropid="oc-drop-20" toggle="" position="bottom-start" mode="manual" target="#files-collaborators-role-button-new" paddingsize="small" class="files-recipient-custom-permissions-drop">
+  <h4 class="oc-text-bold oc-text-initial">Custom permissions</h4>
+  <oc-list-stub class="oc-mb">
+    <li class="oc-my-xs">
+      <oc-checkbox-stub id="files-collaborators-permission-read" disabled="true" value="[object Object],[object Object]" option="[object Object]" label="Read" size="medium" data-testid="files-collaborators-permission-read" class="oc-mr-xs files-collaborators-permission-checkbox"></oc-checkbox-stub>
+    </li>
+    <li class="oc-my-xs">
+      <oc-checkbox-stub id="files-collaborators-permission-delete" value="[object Object],[object Object]" option="[object Object]" label="Delete" size="medium" data-testid="files-collaborators-permission-delete" class="oc-mr-xs files-collaborators-permission-checkbox"></oc-checkbox-stub>
+    </li>
+    <li class="oc-my-xs">
+      <oc-checkbox-stub id="files-collaborators-permission-share" value="[object Object],[object Object]" option="[object Object]" label="Share" size="medium" data-testid="files-collaborators-permission-share" class="oc-mr-xs files-collaborators-permission-checkbox"></oc-checkbox-stub>
+    </li>
+  </oc-list-stub>
+  <div class="files-recipient-custom-permissions-drop-cancel-confirm-btns">
+    <oc-button-stub type="button" size="small" submit="button" variation="passive" appearance="outline" justifycontent="center" gapsize="medium">Cancel</oc-button-stub>
+    <oc-button-stub type="button" size="small" submit="button" variation="primary" appearance="filled" justifycontent="center" gapsize="medium">Apply</oc-button-stub>
+  </div>
+</oc-drop-stub>
+</span>
+`;
+
+exports[`RoleDropdown for file shares when an existing role is present does not render a button if only one role is available 1`] = `
+<span class="oc-flex oc-flex-middle"><span><span>Viewer</span></span>
+<!---->
+<!----></span>
+`;
+
+exports[`RoleDropdown for file shares when an existing role is present renders a button with existing role if given for resource type file 1`] = `
+<span class="oc-flex oc-flex-middle"><oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="none" id="files-collaborators-role-button-new" class="files-recipient-role-select-btn"><span>Viewer</span>
+<oc-icon-stub name="arrow-down-s" filltype="fill" accessiblelabel="" type="span" size="medium" variation="passive" color=""></oc-icon-stub>
+</oc-button-stub>
+<oc-drop-stub dropid="oc-drop-23" toggle="#files-collaborators-role-button-new" position="bottom-start" mode="click" closeonclick="true" paddingsize="remove">
   <oc-list-stub aria-label="Select role for the invitation" class="files-recipient-role-drop-list">
     <li>
       <oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="space-between" gapsize="medium" id="files-recipient-role-drop-btn-viewer" class="files-recipient-role-drop-btn oc-py-xs oc-px-s selected">
@@ -26,7 +155,7 @@ exports[`RoleDropdown for file shares when an existing role is present renders a
     </li>
   </oc-list-stub>
 </oc-drop-stub>
-<oc-drop-stub dropid="oc-drop-18" toggle="" position="bottom-start" mode="manual" target="#files-collaborators-role-button-new" paddingsize="small" class="files-recipient-custom-permissions-drop">
+<oc-drop-stub dropid="oc-drop-24" toggle="" position="bottom-start" mode="manual" target="#files-collaborators-role-button-new" paddingsize="small" class="files-recipient-custom-permissions-drop">
   <h4 class="oc-text-bold oc-text-initial">Custom permissions</h4>
   <oc-list-stub class="oc-mb">
     <li class="oc-my-xs">
@@ -57,7 +186,7 @@ exports[`RoleDropdown for file shares when an existing role is present renders a
 <span class="oc-flex oc-flex-middle"><oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="none" id="files-collaborators-role-button-new" class="files-recipient-role-select-btn"><span>Viewer</span>
 <oc-icon-stub name="arrow-down-s" filltype="fill" accessiblelabel="" type="span" size="medium" variation="passive" color=""></oc-icon-stub>
 </oc-button-stub>
-<oc-drop-stub dropid="oc-drop-15" toggle="#files-collaborators-role-button-new" position="bottom-start" mode="click" closeonclick="true" paddingsize="remove">
+<oc-drop-stub dropid="oc-drop-21" toggle="#files-collaborators-role-button-new" position="bottom-start" mode="click" closeonclick="true" paddingsize="remove">
   <oc-list-stub aria-label="Select role for the invitation" class="files-recipient-role-drop-list">
     <li>
       <oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="space-between" gapsize="medium" id="files-recipient-role-drop-btn-viewer" class="files-recipient-role-drop-btn oc-py-xs oc-px-s selected">
@@ -79,7 +208,7 @@ exports[`RoleDropdown for file shares when an existing role is present renders a
     </li>
   </oc-list-stub>
 </oc-drop-stub>
-<oc-drop-stub dropid="oc-drop-16" toggle="" position="bottom-start" mode="manual" target="#files-collaborators-role-button-new" paddingsize="small" class="files-recipient-custom-permissions-drop">
+<oc-drop-stub dropid="oc-drop-22" toggle="" position="bottom-start" mode="manual" target="#files-collaborators-role-button-new" paddingsize="small" class="files-recipient-custom-permissions-drop">
   <h4 class="oc-text-bold oc-text-initial">Custom permissions</h4>
   <oc-list-stub class="oc-mb">
     <li class="oc-my-xs">

--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -33,7 +33,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIFavorites/unfavoriteFile.feature:102](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature#L102)
 -   [webUIFilesSearch/search.feature:103](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L103)
 -   [webUIFilesSearch/search.feature:175](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L175)
--   [webUIResharing1/reshareUsers.feature:230](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L230)
 
 ### [file_path property is not unique for a share created with same resource name i.e already present in sharee](https://github.com/owncloud/ocis/issues/2249)
 -   [webUIRenameFiles/renameFiles.feature:209](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFiles/renameFiles.feature#L209)
@@ -302,10 +301,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 ### [no checkbox for share while using advanced permissions as role](https://github.com/owncloud/web/issues/5461)
 -   [webUIResharing1/reshareUsers.feature:145](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L145)
 -   [webUIResharing1/reshareUsers.feature:166](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L166)
--   [webUIResharing1/reshareUsers.feature:187](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L187)
-
-### [share permissions not enforced](https://github.com/owncloud/product/issues/270)
--   [webUIResharing1/reshareUsers.feature:248](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L248)
 
 ### [Comments in sidebar](https://github.com/owncloud/web/issues/1158)
 -   [webUIComments/comments.feature:25](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIComments/comments.feature#L25)

--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -302,7 +302,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 ### [no checkbox for share while using advanced permissions as role](https://github.com/owncloud/web/issues/5461)
 -   [webUIResharing1/reshareUsers.feature:145](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L145)
 -   [webUIResharing1/reshareUsers.feature:166](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L166)
--   [webUIResharing1/reshareUsers.feature:187](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L187)
 
 ### [share permissions not enforced](https://github.com/owncloud/product/issues/270)
 -   [webUIResharing1/reshareUsers.feature:248](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L248)

--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -302,6 +302,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 ### [no checkbox for share while using advanced permissions as role](https://github.com/owncloud/web/issues/5461)
 -   [webUIResharing1/reshareUsers.feature:145](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L145)
 -   [webUIResharing1/reshareUsers.feature:166](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L166)
+-   [webUIResharing1/reshareUsers.feature:187](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L187)
 
 ### [share permissions not enforced](https://github.com/owncloud/product/issues/270)
 -   [webUIResharing1/reshareUsers.feature:248](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L248)

--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -33,7 +33,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIFavorites/unfavoriteFile.feature:102](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature#L102)
 -   [webUIFilesSearch/search.feature:103](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L103)
 -   [webUIFilesSearch/search.feature:175](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L175)
--   [webUIResharing1/reshareUsers.feature:219](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L230)
+-   [webUIResharing1/reshareUsers.feature:219](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L219)
 
 ### [file_path property is not unique for a share created with same resource name i.e already present in sharee](https://github.com/owncloud/ocis/issues/2249)
 -   [webUIRenameFiles/renameFiles.feature:209](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFiles/renameFiles.feature#L209)
@@ -304,7 +304,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIResharing1/reshareUsers.feature:166](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L166)
 
 ### [share permissions not enforced](https://github.com/owncloud/product/issues/270)
--   [webUIResharing1/reshareUsers.feature:237](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L248)
+-   [webUIResharing1/reshareUsers.feature:237](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L237)
 
 ### [Comments in sidebar](https://github.com/owncloud/web/issues/1158)
 -   [webUIComments/comments.feature:25](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIComments/comments.feature#L25)

--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -33,6 +33,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIFavorites/unfavoriteFile.feature:102](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature#L102)
 -   [webUIFilesSearch/search.feature:103](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L103)
 -   [webUIFilesSearch/search.feature:175](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L175)
+-   [webUIResharing1/reshareUsers.feature:219](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L230)
 
 ### [file_path property is not unique for a share created with same resource name i.e already present in sharee](https://github.com/owncloud/ocis/issues/2249)
 -   [webUIRenameFiles/renameFiles.feature:209](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFiles/renameFiles.feature#L209)
@@ -301,6 +302,9 @@ Other free text and markdown formatting can be used elsewhere in the document if
 ### [no checkbox for share while using advanced permissions as role](https://github.com/owncloud/web/issues/5461)
 -   [webUIResharing1/reshareUsers.feature:145](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L145)
 -   [webUIResharing1/reshareUsers.feature:166](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L166)
+
+### [share permissions not enforced](https://github.com/owncloud/product/issues/270)
+-   [webUIResharing1/reshareUsers.feature:237](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L248)
 
 ### [Comments in sidebar](https://github.com/owncloud/web/issues/1158)
 -   [webUIComments/comments.feature:25](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIComments/comments.feature#L25)

--- a/tests/acceptance/features/webUIResharing1/reshareUsers.feature
+++ b/tests/acceptance/features/webUIResharing1/reshareUsers.feature
@@ -192,8 +192,8 @@ Feature: Resharing shared files with different permissions
     And user "Alice" has accepted the share "Shares/lorem.txt" offered by user "Brian" in the server
     And user "Alice" has logged in using the webUI
     And the user has browsed to the shared-with-me page
-    When the user shares folder "simple-folder" with user "Carol King" as "Viewer" using the webUI
-    And the user shares file "lorem.txt" with user "Carol King" as "Viewer" using the webUI
+    When the user shares folder "simple-folder" with user "Carol King" as "Editor" using the webUI
+    And the user shares file "lorem.txt" with user "Carol King" as "Editor" using the webUI
     And user "Carol" accepts the share "Shares/simple-folder" offered by user "Alice" using the sharing API in the server
     And user "Carol" accepts the share "Shares/lorem.txt" offered by user "Alice" using the sharing API in the server
     Then as "Carol" folder "/Shares/simple-folder" should exist in the server

--- a/tests/acceptance/features/webUIResharing1/reshareUsers.feature
+++ b/tests/acceptance/features/webUIResharing1/reshareUsers.feature
@@ -183,17 +183,6 @@ Feature: Resharing shared files with different permissions
       | item_type   | folder                |
       | permissions | delete, read          |
 
-  @issue-5461
-  Scenario: User is not allowed to reshare a file/folder with the higher permissions
-    Given user "Brian" has shared folder "simple-folder" with user "Alice" with "read, share, delete" permissions in the server
-    And user "Alice" has accepted the share "Shares/simple-folder" offered by user "Brian" in the server
-    And user "Alice" has logged in using the webUI
-    When the user opens folder "Shares" using the webUI
-    And the user shares folder "simple-folder" with user "Carol King" as "Custom permissions" with permissions "share, delete, update" using the webUI
-    Then the error message with header "Error while sharing." should be displayed on the webUI
-    And as "Carol" folder "Shares/simple-folder" should not exist in the server
-    And user "Carol" should not have received any shares in the server
-
   @skipOnOCIS
   Scenario: Reshare a file and folder from shared with me page
     Given user "Brian" has created file "lorem.txt" in the server
@@ -203,8 +192,8 @@ Feature: Resharing shared files with different permissions
     And user "Alice" has accepted the share "Shares/lorem.txt" offered by user "Brian" in the server
     And user "Alice" has logged in using the webUI
     And the user has browsed to the shared-with-me page
-    When the user shares folder "simple-folder" with user "Carol King" as "Editor" using the webUI
-    And the user shares file "lorem.txt" with user "Carol King" as "Editor" using the webUI
+    When the user shares folder "simple-folder" with user "Carol King" as "Viewer" using the webUI
+    And the user shares file "lorem.txt" with user "Carol King" as "Viewer" using the webUI
     And user "Carol" accepts the share "Shares/simple-folder" offered by user "Alice" using the sharing API in the server
     And user "Carol" accepts the share "Shares/lorem.txt" offered by user "Alice" using the sharing API in the server
     Then as "Carol" folder "/Shares/simple-folder" should exist in the server

--- a/tests/acceptance/features/webUIResharingToRoot/reshareUsers.feature
+++ b/tests/acceptance/features/webUIResharingToRoot/reshareUsers.feature
@@ -198,7 +198,7 @@ Feature: Resharing shared files with different permissions
     And user "Brian" has shared file "lorem.txt" with user "Alice" in the server
     And user "Alice" has logged in using the webUI
     And the user has browsed to the shared-with-me page
-    When the user shares folder "simple-folder" with user "Carol King" as "Viewer" using the webUI
+    When the user shares folder "simple-folder" with user "Carol King" as "Editor" using the webUI
     And the user shares file "lorem.txt" with user "Carol King" as "Editor" using the webUI
     Then as "Carol" folder "simple-folder" should exist in the server
     And as "Carol" file "lorem.txt" should exist in the server

--- a/tests/acceptance/features/webUIResharingToRoot/reshareUsers.feature
+++ b/tests/acceptance/features/webUIResharingToRoot/reshareUsers.feature
@@ -192,22 +192,13 @@ Feature: Resharing shared files with different permissions
       | item_type   | folder             |
       | permissions | delete, read       |
 
-
-  Scenario: User is not allowed to reshare a file/folder with the higher permissions
-    Given user "Brian" has shared folder "simple-folder" with user "Alice" with "read, share, delete" permissions in the server
-    And user "Alice" has logged in using the webUI
-    When the user shares folder "simple-folder" with user "Carol King" as "Custom permissions" with permissions "share, delete, update" using the webUI
-    Then the error message with header "Error while sharing." should be displayed on the webUI
-    And as "Carol" folder "simple-folder" should not exist in the server
-
-
   Scenario: Reshare a file and folder from shared with me page
     Given user "Brian" has created file "lorem.txt" in the server
     And user "Brian" has shared folder "simple-folder" with user "Alice" in the server
     And user "Brian" has shared file "lorem.txt" with user "Alice" in the server
     And user "Alice" has logged in using the webUI
     And the user has browsed to the shared-with-me page
-    When the user shares folder "simple-folder" with user "Carol King" as "Editor" using the webUI
+    When the user shares folder "simple-folder" with user "Carol King" as "Viewer" using the webUI
     And the user shares file "lorem.txt" with user "Carol King" as "Editor" using the webUI
     Then as "Carol" folder "simple-folder" should exist in the server
     And as "Carol" file "lorem.txt" should exist in the server


### PR DESCRIPTION
## Description
We've fixed a bug where the permissions of a share were not inherited when trying to reshare a resource. We've also disabled the role-select-dropdown if only one role is available for sharing.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/2963

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
