### PR TITLE
[tests-only] Pin oc10 to 10.09.1 until middleware for latest is ready

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -35,7 +35,7 @@ SONARSOURCE_SONAR_SCANNER_CLI = "sonarsource/sonar-scanner-cli:latest"
 THEGEEKLAB_DRONE_GITHUB_COMMENT = "thegeeklab/drone-github-comment:1"
 TOOLHIPPIE_CALENS = "toolhippie/calens:latest"
 
-OC10_VERSION = "latest"
+OC10_VERSION = "10.09.1"
 
 dir = {
     "base": "/var/www/owncloud",

--- a/.drone.star
+++ b/.drone.star
@@ -35,7 +35,7 @@ SONARSOURCE_SONAR_SCANNER_CLI = "sonarsource/sonar-scanner-cli:latest"
 THEGEEKLAB_DRONE_GITHUB_COMMENT = "thegeeklab/drone-github-comment:1"
 TOOLHIPPIE_CALENS = "toolhippie/calens:latest"
 
-OC10_VERSION = "10.09.1"
+OC10_VERSION = "10.9.1"
 
 dir = {
     "base": "/var/www/owncloud",


### PR DESCRIPTION
## Description
Changes in the recently released oc10 v10.10 break the CI (trashbin changes in combination with the middelware AFAIK)