### PR TITLE
Fix webDavPath construction for space image and readme

### DIFF
--- a/changelog/unreleased/bugfix-space-special-files
+++ b/changelog/unreleased/bugfix-space-special-files
@@ -1,0 +1,5 @@
+Bugfix: Cover image and readme in spaces
+
+The URL construction for cover image and readme of a space was wrong and led to both not being shown. This has been fixed by making the URL construction more reliable regarding different ID formats.
+
+https://github.com/owncloud/web/pull/7017

--- a/packages/web-app-files/src/views/spaces/Project.vue
+++ b/packages/web-app-files/src/views/spaces/Project.vue
@@ -259,14 +259,20 @@ export default defineComponent({
     },
     'space.spaceImageData': {
       handler: function (val) {
-        if (!val) return
+        if (!val) {
+          return
+        }
         const webDavPathComponents = this.space.spaceImageData.webDavUrl.split('/')
+        const idComponent = webDavPathComponents.find((c) => c.startsWith(this.space.id))
+        if (!idComponent) {
+          return
+        }
         const path = webDavPathComponents
-          .slice(webDavPathComponents.indexOf(this.space.id) + 1)
+          .slice(webDavPathComponents.indexOf(idComponent) + 1)
           .join('/')
 
         this.$client.files
-          .fileInfo(buildWebDavSpacesPath(this.space.id, decodeURIComponent(path)))
+          .fileInfo(buildWebDavSpacesPath(idComponent, decodeURIComponent(path)))
           .then((data) => {
             const resource = buildResource(data)
             loadPreview({
@@ -289,12 +295,16 @@ export default defineComponent({
           return
         }
         const webDavPathComponents = this.space.spaceReadmeData.webDavUrl.split('/')
+        const idComponent = webDavPathComponents.find((c) => c.startsWith(this.space.id))
+        if (!idComponent) {
+          return
+        }
         const path = webDavPathComponents
-          .slice(webDavPathComponents.indexOf(this.space.id) + 1)
+          .slice(webDavPathComponents.indexOf(idComponent) + 1)
           .join('/')
 
         this.$client.files
-          .getFileContents(buildWebDavSpacesPath(this.space.id, decodeURIComponent(path)))
+          .getFileContents(buildWebDavSpacesPath(idComponent, decodeURIComponent(path)))
           .then((fileContents) => {
             if (this.markdownResizeObserver && this.$refs.markdownContainer) {
               this.markdownResizeObserver.unobserve(this.$refs.markdownContainer)

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -207,12 +207,16 @@ export default defineComponent({
           }
 
           const webDavPathComponents = space.spaceImageData.webDavUrl.split('/')
+          const idComponent = webDavPathComponents.find((c) => c.startsWith(space.id))
+          if (!idComponent) {
+            return
+          }
           const path = webDavPathComponents
-            .slice(webDavPathComponents.indexOf(space.id) + 1)
+            .slice(webDavPathComponents.indexOf(idComponent) + 1)
             .join('/')
 
           this.$client.files
-            .fileInfo(buildWebDavSpacesPath(space.id, decodeURIComponent(path)))
+            .fileInfo(buildWebDavSpacesPath(idComponent, decodeURIComponent(path)))
             .then((fileInfo) => {
               const resource = buildResource(fileInfo)
               loadPreview({

--- a/packages/web-app-files/tests/unit/views/spaces/Project.spec.js
+++ b/packages/web-app-files/tests/unit/views/spaces/Project.spec.js
@@ -64,12 +64,12 @@ const spaceMocks = {
     special: [
       {
         specialFolder: { name: 'readme' },
-        webDavUrl: '/',
+        webDavUrl: 'https://owncloud.test/dav/spaces/1/readme.md',
         file: { mimeType: 'text/plain' }
       },
       {
         specialFolder: { name: 'image' },
-        webDavUrl: '/',
+        webDavUrl: 'https://owncloud.test/dav/spaces/1/image.png',
         file: { mimeType: 'image/png' }
       }
     ]


### PR DESCRIPTION
## Description

Fix webDavPath construction for space image and readme.
Finding the relative webDavPath needs to be a prefix match since the URL has the spaceId as nodeId in
the URL (uniform 3-part id syntax) but the space id we maintain
internally is 2-part.

I will not de-duplicate this code, because we want to use the absolute webDavUrl from the graph response ASAP anyway. And then all this splitting and finding goes away.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
