### PR TITLE
Config option for hoverable quick actions

### DIFF
--- a/changelog/unreleased/enhancement-add-config-option-hoverable-quick-actions
+++ b/changelog/unreleased/enhancement-add-config-option-hoverable-quick-actions
@@ -1,0 +1,6 @@
+Enhancement: Add config option for hoverable quick actions
+
+We've added the possibility to add hover effect for quick actions with the option "hoverableQuickActions" in config.json. The hover effect applies to "edit name", "add people" and "copy quicklink" actions in the corresponding hovered row.
+
+https://github.com/owncloud/web/pull/7022
+https://github.com/owncloud/web/issues/7021

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,6 +58,8 @@ substring of a value of the authenticated user. Examples are `/Shares`, `/{{.Id}
 - `options.sidebar.shares.showAllOnLoad` Sets the list of (link) shares list in the sidebar to be initially expanded (default is a collapsed state, only showing the first three shares).
 - `options.runningOnEos` Set this option to `true` if running on an [EOS storage backend](https://eos-web.web.cern.ch/eos-web/) to enable its specific features. Defaults to `false`.
 - `options.cernFeatures` Enabling this will activate CERN-specific features. Defaults to `false`.
+- `options.hoverableQuickActions` Set this option to `true` to hide the quick actions (buttons appearing on file rows), and only show them when the user
+hovers the row with his mouse. Defaults to `false`.
 
 ### Sentry
 

--- a/packages/web-app-files/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceTable.vue
@@ -1,5 +1,6 @@
 <template>
   <oc-table
+    :class="hoverableQuickActions && 'hoverable-quick-actions'"
     :data="resources"
     :fields="fields"
     :highlighted="selectedIds"
@@ -551,6 +552,9 @@ export default defineComponent({
     },
     currentLanguage() {
       return (this.$language?.current || '').split('_')[0]
+    },
+    hoverableQuickActions() {
+      return this.configuration?.options?.hoverableQuickActions
     }
   },
   methods: {
@@ -802,6 +806,21 @@ export default defineComponent({
     align-items: center;
     display: flex;
     justify-content: center;
+  }
+}
+
+.hoverable-quick-actions.files-table {
+  tr {
+    .resource-table-edit-name,
+    .resource-table-actions div:first-child {
+      visibility: hidden;
+    }
+  }
+  tr:hover {
+    .resource-table-edit-name,
+    .resource-table-actions div:first-child {
+      visibility: visible;
+    }
   }
 }
 

--- a/packages/web-app-files/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceTable.vue
@@ -810,16 +810,18 @@ export default defineComponent({
 }
 
 .hoverable-quick-actions.files-table {
-  tr {
-    .resource-table-edit-name,
-    .resource-table-actions div:first-child {
-      visibility: hidden;
+  @media (pointer: fine) {
+    tr {
+      .resource-table-edit-name,
+      .resource-table-actions div:first-child {
+        visibility: hidden;
+      }
     }
-  }
-  tr:hover {
-    .resource-table-edit-name,
-    .resource-table-actions div:first-child {
-      visibility: visible;
+    tr:hover {
+      .resource-table-edit-name,
+      .resource-table-actions div:first-child {
+        visibility: visible;
+      }
     }
   }
 }

--- a/packages/web-runtime/src/store/config.js
+++ b/packages/web-runtime/src/store/config.js
@@ -42,6 +42,7 @@ const state = {
     disablePreviews: false,
     displayResourcesLazy: true,
     homeFolder: '',
+    hoverableQuickActions: false,
     sidebar: {
       shares: {
         showAllOnLoad: false


### PR DESCRIPTION
## Description
Adds the possibility to add hover effect for quick actions with the option "hoverableQuickActions" in config.json
The hover effect applies to "edit name", "add people" and "copy quicklink" actions in the corresponding hovered row.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7021

## Motivation and Context
For CERNBox we don't want to show quick actions for each row, just for hovered ones
