### PR TITLE
Fix rendering unlimited quota

### DIFF
--- a/changelog/unreleased/bugfix-respect-unlimited-quota
+++ b/changelog/unreleased/bugfix-respect-unlimited-quota
@@ -4,3 +4,4 @@ We have fixed an UI glitch where the UI stopped working if the backend reports a
 
 https://github.com/owncloud/web/pull/6923
 https://github.com/owncloud/web/issues/6913
+https://github.com/owncloud/web/pull/7044

--- a/packages/web-runtime/src/components/Topbar/UserMenu.vue
+++ b/packages/web-runtime/src/components/Topbar/UserMenu.vue
@@ -58,10 +58,8 @@
           <oc-icon name="cloud" fill-type="line" class="oc-p-xs" />
           <div class="storage-wrapper-text">
             <p class="oc-my-rm">
-              <template v-if="limitedPersonalStorage">
-                <span v-text="personalStorageLabel" />
-                <br />
-              </template>
+              <span v-text="personalStorageLabel" />
+              <br />
               <span class="oc-text-small" v-text="personalStorageDetailsLabel" />
             </p>
             <oc-progress
@@ -81,6 +79,7 @@
 <script>
 import { mapGetters } from 'vuex'
 import filesize from 'filesize'
+import isNil from 'lodash-es/isNil'
 
 export default {
   props: {
@@ -97,13 +96,16 @@ export default {
       return this.user.username || this.user.id
     },
     personalStorageLabel() {
+      if (!this.limitedPersonalStorage) {
+        return this.$gettext('Personal storage')
+      }
       return this.$gettextInterpolate(this.$gettext('Personal storage (%{percentage}% used)'), {
         percentage: this.quota.relative || 0
       })
     },
     personalStorageDetailsLabel() {
       const total = this.quota.definition === 'none' ? 0 : this.quota.total || 0
-      const used = this.quota.used
+      const used = this.quota.used || 0
       return this.$gettextInterpolate(
         total ? this.$gettext('%{used} of %{total} used') : this.$gettext('%{used} used'),
         {
@@ -113,7 +115,7 @@ export default {
       )
     },
     limitedPersonalStorage() {
-      return !isNaN(this.quota.relative) && this.quota.definition !== 'none'
+      return !isNil(this.quota.relative) && this.quota.definition !== 'none'
     },
     quotaEnabled() {
       return !!this.quota

--- a/packages/web-runtime/tests/unit/components/Topbar/__snapshots__/UserMenu.spec.js.snap
+++ b/packages/web-runtime/tests/unit/components/Topbar/__snapshots__/UserMenu.spec.js.snap
@@ -245,9 +245,7 @@ exports[`User Menu component when quota is not defined renders no percentag of t
       <li class="storage-wrapper oc-pl-s">
         <oc-icon-stub name="cloud" filltype="line" accessiblelabel="" type="span" size="medium" variation="passive" color="" class="oc-p-xs"></oc-icon-stub>
         <div class="storage-wrapper-text">
-          <p class="oc-my-rm">
-            <!----> <span class="oc-text-small">910 B used</span>
-          </p>
+          <p class="oc-my-rm"><span>Personal storage</span> <br> <span class="oc-text-small">910 B used</span></p>
           <!---->
         </div>
       </li>
@@ -285,9 +283,7 @@ exports[`User Menu component when quota is unlimited renders no percentag of tot
       <li class="storage-wrapper oc-pl-s">
         <oc-icon-stub name="cloud" filltype="line" accessiblelabel="" type="span" size="medium" variation="passive" color="" class="oc-p-xs"></oc-icon-stub>
         <div class="storage-wrapper-text">
-          <p class="oc-my-rm">
-            <!----> <span class="oc-text-small">300 B used</span>
-          </p>
+          <p class="oc-my-rm"><span>Personal storage</span> <br> <span class="oc-text-small">300 B used</span></p>
           <!---->
         </div>
       </li>


### PR DESCRIPTION
## Description
Reintroducing a "Personal storage" label in the user menu after https://github.com/owncloud/web/pull/6923 was merged. Also, the `used` value for the quota details was broken for 0, as that is somehow `NaN` instead of `0`. Fixed by using `0` as a fallback.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/6913

## Screenshots
![Screenshot 2022-05-23 at 16 29 53](https://user-images.githubusercontent.com/3532843/169843452-0e5d8074-d450-41f9-b335-25e4650dd314.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
