### PR TITLE
Make use of new productversion field if available

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=ea435449d2843a96c6b5d030e139eb6658a17078
+OCIS_COMMITID=4aeac5c93f1bf6a74e1962a51efebbdf30164cf2
 OCIS_BRANCH=master

--- a/changelog/unreleased/enhancement-productversion-log
+++ b/changelog/unreleased/enhancement-productversion-log
@@ -1,0 +1,6 @@
+Enhancement: Log correct oCIS version if available
+
+oCIS has introduced a new `productversion` field to announce it's correct version while maintaining a fake 10.x.x version in the `versionstring` field to keep clients compatible. We're using the new productversion field when it exists and use versionstring as a fallback. Thus the backend product information prints the correct oCIS version now.
+
+https://github.com/owncloud/ocis/pull/3805
+https://github.com/owncloud/web/pull/7045

--- a/packages/web-runtime/src/container/versions.ts
+++ b/packages/web-runtime/src/container/versions.ts
@@ -6,12 +6,12 @@ export const getWebVersion = (): string => {
 }
 
 export const getBackendVersion = ({ store }: { store: Store<unknown> }): string => {
-  const backendVersion = store.getters.user.version
-  if (!backendVersion || !backendVersion.string) {
+  const backendStatus = store.getters.capabilities?.core?.status
+  if (!backendStatus || !backendStatus.versionstring) {
     return undefined
   }
-  const product = backendVersion.product || 'ownCloud'
-  const version = backendVersion.string
-  const edition = backendVersion.edition
+  const product = backendStatus.product || 'ownCloud'
+  const version = backendStatus.productversion || backendStatus.versionstring
+  const edition = backendStatus.edition
   return `${product} ${version} ${edition}`
 }

--- a/packages/web-runtime/tests/unit/container/versions.spec.ts
+++ b/packages/web-runtime/tests/unit/container/versions.spec.ts
@@ -21,13 +21,13 @@ describe('collect version information', () => {
     it('returns undefined when the backend version object has no "string" field', () => {
       const store = versionStore({
         product: 'ownCloud',
-        string: undefined
+        versionstring: undefined
       })
       expect(getBackendVersion({ store })).toBeUndefined()
     })
     it('falls back to "ownCloud" as a product when none is defined', () => {
       const store = versionStore({
-        string: '10.8.0',
+        versionstring: '10.8.0',
         edition: 'Community'
       })
       expect(getBackendVersion({ store })).toBe('ownCloud 10.8.0 Community')
@@ -35,10 +35,19 @@ describe('collect version information', () => {
     it('provides the backend version as concatenation of product, version and edition', () => {
       const store = versionStore({
         product: 'oCIS',
-        string: '1.16.0',
+        versionstring: '1.16.0',
         edition: 'Reva'
       })
       expect(getBackendVersion({ store })).toBe('oCIS 1.16.0 Reva')
+    })
+    it('prefers the productversion over versionstring field if both are provided', () => {
+      const store = versionStore({
+        product: 'oCIS',
+        versionstring: '10.8.0',
+        productversion: '2.0.0',
+        edition: 'Community'
+      })
+      expect(getBackendVersion({ store })).toBe('oCIS 2.0.0 Community')
     })
   })
 })
@@ -46,7 +55,13 @@ describe('collect version information', () => {
 const versionStore = (version: any): Store<any> => {
   return new Vuex.Store({
     getters: {
-      user: jest.fn(() => ({ version }))
+      capabilities: jest.fn(() => ({
+        core: {
+          status: {
+            ...version
+          }
+        }
+      }))
     }
   })
 }


### PR DESCRIPTION
## Description
oCIS has introduced a new `productversion` field to announce it's correct version while maintaining a fake 10.x.x version in the `versionstring` field to keep clients compatible. We're using the new productversion field when it exists and use versionstring as a fallback. Thus the backend product information prints the correct oCIS version now.

Since it seems to be encouraged to use `capabilities.core.status` this PR switches over to using that instead of the `version` object. 🤷 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related to https://github.com/owncloud/ocis/issues/3788
- Related to https://github.com/owncloud/ocis/pull/3805 (needed for manual testing if not yet merged)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
