### PR TITLE
Prevent the resource name in the sidebar from being truncated

### DIFF
--- a/changelog/unreleased/enhancement-sidebar-resource-name-truncate
+++ b/changelog/unreleased/enhancement-sidebar-resource-name-truncate
@@ -1,0 +1,6 @@
+Enhancement: Prevent the resource name in the sidebar from being truncated
+
+We now prevent the resource name in the right sidebar from being truncated to ensure that the full name can be read at any time.
+
+https://github.com/owncloud/web/issues/6776
+https://github.com/owncloud/web/pull/7052

--- a/packages/web-app-files/src/components/SideBar/FileInfo.vue
+++ b/packages/web-app-files/src/components/SideBar/FileInfo.vue
@@ -10,6 +10,7 @@
           :full-path="file.webDavPath"
           :is-extension-displayed="areFileExtensionsShown"
           :is-path-displayed="false"
+          :truncate-name="false"
         />
       </h3>
       <p class="oc-my-rm">


### PR DESCRIPTION
## Description
We now prevent the resource name in the right sidebar from being truncated to ensure that the full name can be read at any time.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/6776

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
