### PR TITLE
[full-ci] personal spaceId in URL

### DIFF
--- a/changelog/unreleased/enhancement-personal-storage-id
+++ b/changelog/unreleased/enhancement-personal-storage-id
@@ -1,0 +1,5 @@
+Enhancement: Personal space id in URL
+
+We now include the personal space id in the URL instead of using a magic "home" alias. When using the old "home" alias the user gets redirected to the URL with their personal space id.
+
+https://github.com/owncloud/web/pull/7053

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -82,13 +82,13 @@ and make sure there are no conflicting ports and everything runs smoothly. You c
 Depending on the backend you want to run the tests on, you can either run
 
 ```shell
-$ yarn test:e2e:cucumber tests/e2e/cucumber
+$ yarn test:e2e:cucumber tests/e2e/cucumber/**/*[!.ocis].feature
 ```
 
 for an ownCloud 10 backend or
 
 ```shell
-$ OCIS=true yarn test:e2e:cucumber tests/e2e/cucumber
+$ OCIS=true yarn test:e2e:cucumber tests/e2e/cucumber/**/*[!.oc10].feature
 ```
 
 for an oCIS backend.

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -162,7 +162,7 @@ export default defineComponent({
         uppyService
       }),
       ...useUploadHelpers(),
-      isPersonalLocation: useActiveLocation(isLocationSpacesActive, 'files-spaces-personal-home'),
+      isPersonalLocation: useActiveLocation(isLocationSpacesActive, 'files-spaces-personal'),
       isPublicLocation: useActiveLocation(isLocationPublicActive, 'files-public-files'),
       isSpacesProjectsLocation: useActiveLocation(isLocationSpacesActive, 'files-spaces-projects'),
       isSpacesProjectLocation: useActiveLocation(isLocationSpacesActive, 'files-spaces-project'),

--- a/packages/web-app-files/src/components/FilesList/NotFoundMessage.vue
+++ b/packages/web-app-files/src/components/FilesList/NotFoundMessage.vue
@@ -61,9 +61,9 @@ export default {
 
     return {
       showPublicLinkButton: isLocationPublicActive(router, 'files-public-files'),
-      showHomeButton: isLocationSpacesActive(router, 'files-spaces-personal-home'),
+      showHomeButton: isLocationSpacesActive(router, 'files-spaces-personal'),
       showSpacesButton: isLocationSpacesActive(router, 'files-spaces-project'),
-      homeRoute: createLocationSpaces('files-spaces-personal-home', {
+      homeRoute: createLocationSpaces('files-spaces-personal', {
         params: { item: store.getters.homeFolder }
       }),
       publicLinkRoute: createLocationPublic('files-public-files', {

--- a/packages/web-app-files/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceTable.vue
@@ -577,24 +577,24 @@ export default defineComponent({
       this.openWithPanel('sharing-item')
     },
     folderLink(file) {
-      return this.createFolderLink(file.path, file, false)
+      return this.createFolderLink(file.path, file)
     },
     parentFolderLink(file) {
-      return this.createFolderLink(path.dirname(file.path), file, true)
+      return this.createFolderLink(path.dirname(file.path), file)
     },
-    createFolderLink(path, resource, parentFolder) {
+    createFolderLink(path, resource) {
       if (this.targetRoute === null) {
         return {}
       }
 
       const params = {
         item: path.replace(/^\//, '') || '/',
-        ...this.targetRoute.params,
-        ...mapResourceFields(resource, this.targetRouteParamMapping)
+        ...mapResourceFields(resource, this.targetRouteParamMapping),
+        ...this.targetRoute.params
       }
       const query = {
-        ...this.targetRoute.query,
-        ...mapResourceFields(resource, this.targetRouteQueryMapping)
+        ...mapResourceFields(resource, this.targetRouteQueryMapping),
+        ...this.targetRoute.query
       }
 
       if (this.hasProjectSpaces) {

--- a/packages/web-app-files/src/components/Search/List.vue
+++ b/packages/web-app-files/src/components/Search/List.vue
@@ -76,7 +76,7 @@ export default defineComponent({
     return {
       ...useResourcesViewDefaults<Resource, any, any[]>(),
 
-      resourceTargetLocation: createLocationSpaces('files-spaces-personal-home')
+      resourceTargetLocation: createLocationSpaces('files-spaces-personal')
     }
   },
   computed: {

--- a/packages/web-app-files/src/components/Search/Preview.vue
+++ b/packages/web-app-files/src/components/Search/Preview.vue
@@ -45,7 +45,7 @@ export default {
   setup() {
     return {
       hasShareJail: useCapabilityShareJailEnabled(),
-      resourceTargetLocation: createLocationSpaces('files-spaces-personal-home'),
+      resourceTargetLocation: createLocationSpaces('files-spaces-personal'),
       resourceTargetLocationSpace: createLocationSpaces('files-spaces-project')
     }
   },

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -172,7 +172,7 @@ export default defineComponent({
         })
       }
 
-      return createLocationSpaces('files-spaces-personal-home', {
+      return createLocationSpaces('files-spaces-personal', {
         params: { item: sharedParentDir.value }
       })
     })

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -140,7 +140,7 @@
   </div>
 </template>
 <script lang="ts">
-import { computed, defineComponent, ref } from '@vue/composition-api'
+import { computed, defineComponent, ref, unref } from '@vue/composition-api'
 import Mixins from '../../../mixins'
 import MixinResources from '../../../mixins/resources'
 import { mapActions, mapGetters } from 'vuex'
@@ -150,7 +150,7 @@ import upperFirst from 'lodash-es/upperFirst'
 import path from 'path'
 import { createLocationSpaces, isAuthenticatedRoute, isLocationSpacesActive } from '../../../router'
 import { ShareTypes } from '../../../helpers/share'
-import { useRoute, useRouter } from 'web-pkg/src/composables'
+import { useRouteParam, useRouter } from 'web-pkg/src/composables'
 import { getIndicators } from '../../../helpers/statusIndicators'
 import copyToClipboard from 'copy-to-clipboard'
 import { encodePath } from 'web-pkg/src/utils'
@@ -163,23 +163,24 @@ export default defineComponent({
   setup() {
     const sharedParentDir = ref('')
     const router = useRouter()
-    const route = useRoute()
+    const currentStorageId = useRouteParam('storageId')
 
     const sharedParentRoute = computed(() => {
       if (isLocationSpacesActive(router, 'files-spaces-project')) {
         return createLocationSpaces('files-spaces-project', {
-          params: { storageId: route.value.params.storageId, item: sharedParentDir.value }
+          params: { storageId: unref(currentStorageId), item: unref(sharedParentDir) }
         })
       }
 
       return createLocationSpaces('files-spaces-personal', {
-        params: { item: sharedParentDir.value }
+        params: { item: unref(sharedParentDir) }
       })
     })
 
     return {
       sharedParentDir,
-      sharedParentRoute
+      sharedParentRoute,
+      currentStorageId
     }
   },
 
@@ -392,7 +393,7 @@ export default defineComponent({
         client: this.$client,
         path: this.file.path,
         $gettext: this.$gettext,
-        storageId: this.$route.params.storageId
+        ...(this.currentStorageId && { storageId: this.currentStorageId })
       })
       this.shareIndicators = getIndicators(this.file, this.sharesTree)
     },

--- a/packages/web-app-files/src/components/SideBar/FileInfo.vue
+++ b/packages/web-app-files/src/components/SideBar/FileInfo.vue
@@ -51,7 +51,7 @@ export default {
   },
   setup() {
     return {
-      isPersonalLocation: useActiveLocation(isLocationSpacesActive, 'files-spaces-personal-home')
+      isPersonalLocation: useActiveLocation(isLocationSpacesActive, 'files-spaces-personal')
     }
   },
   computed: {

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -186,6 +186,9 @@ export default {
       return this.$gettext('Invite')
     },
 
+    currentStorageId() {
+      return this.$route.params.storageId
+    },
     resourceIsSpace() {
       return this.highlightedFile.type === 'space'
     },
@@ -326,8 +329,8 @@ export default {
             let storageId
             if (this.resourceIsSpace) {
               storageId = this.highlightedFile.id
-            } else if (this.$route.params.storageId) {
-              storageId = this.$route.params.storageId
+            } else if (this.currentStorageId) {
+              storageId = this.currentStorageId
             }
 
             this.addShare({

--- a/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
@@ -132,7 +132,11 @@ export default defineComponent({
 
     const linkListCollapsed = !store.getters.configuration.options.sidebar.shares.showAllOnLoad
 
-    return { graphClient, hasSpaces: useCapabilitySpacesEnabled(), linkListCollapsed }
+    return {
+      graphClient,
+      hasSpaces: useCapabilitySpacesEnabled(),
+      linkListCollapsed
+    }
   },
   data() {
     return {
@@ -346,14 +350,14 @@ export default defineComponent({
         graphClient: this.graphClient,
         path: this.highlightedFile.path,
         $gettext: this.$gettext,
-        storageId: this.currentStorageId,
+        ...(this.currentStorageId && { storageId: this.currentStorageId }),
         resource: this.highlightedFile
       })
       this.loadSharesTree({
         client: this.$client,
         path: this.highlightedFile.path === '' ? '/' : dirname(this.highlightedFile.path),
         $gettext: this.$gettext,
-        storageId: this.currentStorageId
+        ...(this.currentStorageId && { storageId: this.currentStorageId })
       })
     },
 
@@ -425,6 +429,7 @@ export default defineComponent({
         quicklink: link.quicklink,
         name: link.name,
         ...(this.currentStorageId && {
+          storageId: this.currentStorageId,
           spaceRef: `${this.currentStorageId}${this.highlightedFile.path}`
         })
       }
@@ -437,8 +442,7 @@ export default defineComponent({
         path: this.highlightedFile.path,
         client: this.$client,
         $gettext: this.$gettext,
-        params,
-        storageId: this.currentStorageId
+        params
       }).catch(showError)
 
       this.currentView = VIEW_SHOW
@@ -495,7 +499,12 @@ export default defineComponent({
       this.hideModal()
       // removeLink currently fetches all shares from the backend in order to reload the shares indicators
       // TODO: Check if to-removed link is last link share and only reload if it's the last link
-      await this.removeLink({ client, share, resource, storageId: this.currentStorageId })
+      await this.removeLink({
+        client,
+        share,
+        resource,
+        ...(this.currentStorageId && { storageId: this.currentStorageId })
+      })
         .then(
           this.showMessage({
             title: this.$gettext('Link was deleted successfully')

--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -417,7 +417,7 @@ export default {
           })
         }
 
-        return createLocationSpaces('files-spaces-personal-home', {
+        return createLocationSpaces('files-spaces-personal', {
           params: { item: parentShare.path }
         })
       }

--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -64,13 +64,18 @@
 import { dirname } from 'path'
 import { useTask } from 'vue-concurrency'
 import { mapGetters, mapActions, mapState } from 'vuex'
-import { watch, computed } from '@vue/composition-api'
-import { useStore, useDebouncedRef } from 'web-pkg/src/composables'
+import { watch, computed, ref, unref } from '@vue/composition-api'
+import {
+  useStore,
+  useDebouncedRef,
+  useRouteParam,
+  useCapabilityProjectSpacesEnabled
+} from 'web-pkg/src/composables'
 import { clientService } from 'web-pkg/src/services'
 import { createLocationSpaces, isLocationSpacesActive } from '../../../router'
 import { textUtils } from '../../../helpers/textUtils'
 import { getParentPaths } from '../../../helpers/path'
-import { buildSpace, buildSpaceShare } from '../../../helpers/resources'
+import { buildSpaceShare } from '../../../helpers/resources'
 import { ShareTypes } from '../../../helpers/share'
 import { sortSpaceMembers } from '../../../helpers/space'
 import InviteCollaboratorForm from './Collaborators/InviteCollaborator/InviteCollaboratorForm.vue'
@@ -97,53 +102,53 @@ export default {
         sharesTreeLoading.value
     })
 
+    const currentSpace = ref(null)
+    const spaceMembers = ref([])
+    const currentStorageId = useRouteParam('storageId')
+    watch(
+      currentStorageId,
+      (storageId) => {
+        currentSpace.value = store.state.Files.spaces?.find((space) => space.id === storageId)
+      },
+      { immediate: true }
+    )
+    const isCurrentSpaceTypeProject = computed(() => unref(currentSpace)?.driveType === 'project')
+
     const graphClient = clientService.graphAuthenticated(
       store.getters.configuration.server,
       store.getters.getToken
     )
 
-    const loadSpaceTask = useTask(function* (signal, ref, storageId) {
-      const graphResponse = yield graphClient.drives.getDrive(storageId)
-
-      if (!graphResponse.data) {
-        return
-      }
-
-      ref.currentSpace = buildSpace(graphResponse.data)
-    })
-
     const loadSpaceMembersTask = useTask(function* (signal, ref) {
       const promises = []
       const spaceShares = []
 
-      for (const role of Object.keys(ref.currentSpace.spaceRoles)) {
-        for (const userId of ref.currentSpace.spaceRoles[role]) {
+      for (const role of Object.keys(unref(currentSpace).spaceRoles)) {
+        for (const userId of unref(currentSpace).spaceRoles[role]) {
           promises.push(
             graphClient.users.getUser(userId).then((resolved) => {
-              spaceShares.push(buildSpaceShare({ ...resolved.data, role }, ref.currentSpace.id))
+              spaceShares.push(buildSpaceShare({ ...resolved.data, role }, unref(currentSpace).id))
             })
           )
         }
       }
 
       yield Promise.all(promises).then(() => {
-        ref.spaceMembers = sortSpaceMembers(spaceShares)
+        spaceMembers.value = sortSpaceMembers(spaceShares)
       })
     })
 
     const sharesListCollapsed = !store.getters.configuration.options.sidebar.shares.showAllOnLoad
 
     return {
-      loadSpaceTask,
+      currentStorageId,
+      currentSpace,
+      spaceMembers,
+      isCurrentSpaceTypeProject,
       loadSpaceMembersTask,
       sharesListCollapsed,
-      sharesLoading
-    }
-  },
-  data() {
-    return {
-      currentSpace: null,
-      spaceMembers: []
+      sharesLoading,
+      hasProjectSpaces: useCapabilityProjectSpacesEnabled()
     }
   },
   computed: {
@@ -279,11 +284,12 @@ export default {
       return null
     },
     currentUserIsMemberOfSpace() {
-      return this.currentSpace?.spaceMemberIds.includes(this.user.uuid)
+      return this.currentSpace?.spaceMemberIds?.includes(this.user.uuid)
     },
     showSpaceMembers() {
       return (
         this.currentSpace &&
+        this.isCurrentSpaceTypeProject &&
         this.highlightedFile.type !== 'space' &&
         this.currentUserIsMemberOfSpace
       )
@@ -299,13 +305,9 @@ export default {
       immediate: true
     }
   },
-  async mounted() {
-    if (this.$route.params.storageId) {
-      await this.loadSpaceTask.perform(this, this.$route.params.storageId)
-
-      if (this.showSpaceMembers) {
-        this.loadSpaceMembersTask.perform(this)
-      }
+  mounted() {
+    if (this.showSpaceMembers) {
+      this.loadSpaceMembersTask.perform()
     }
   },
   methods: {
@@ -369,7 +371,7 @@ export default {
         client: this.$client,
         share: share,
         resource: this.highlightedFile,
-        storageId: this.$route.params.storageId
+        ...(this.currentStorageId && { storageId: this.currentStorageId })
       })
         .then(() => {
           this.hideModal()
@@ -386,23 +388,22 @@ export default {
         })
     },
     $_reloadShares() {
-      this.loadCurrentFileOutgoingShares({
+      const requestParams = {
         client: this.$client,
-        path: this.highlightedFile.path,
         $gettext: this.$gettext,
-        storageId: this.$route.params.storageId
+        ...(this.currentStorageId && { storageId: this.currentStorageId })
+      }
+      this.loadCurrentFileOutgoingShares({
+        ...requestParams,
+        path: this.highlightedFile.path
       })
       this.loadIncomingShares({
-        client: this.$client,
-        path: this.highlightedFile.path,
-        $gettext: this.$gettext,
-        storageId: this.$route.params.storageId
+        ...requestParams,
+        path: this.highlightedFile.path
       })
       this.loadSharesTree({
-        client: this.$client,
-        path: dirname(this.highlightedFile.path),
-        $gettext: this.$gettext,
-        storageId: this.$route.params.storageId
+        ...requestParams,
+        path: dirname(this.highlightedFile.path)
       })
     },
     getSharedParentRoute(parentShare) {
@@ -413,7 +414,7 @@ export default {
       if (this.sharesTree[parentShare.path]) {
         if (isLocationSpacesActive(this.$router, 'files-spaces-project')) {
           return createLocationSpaces('files-spaces-project', {
-            params: { storageId: this.$route.params.storageId, item: parentShare.path }
+            params: { storageId: this.currentStorageId, item: parentShare.path }
           })
         }
 

--- a/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
@@ -295,7 +295,7 @@ export default {
       const viaPath = this.link.path
       const locationName = isLocationSpacesActive(this.$router, 'files-spaces-project')
         ? 'files-spaces-project'
-        : 'files-spaces-personal-home'
+        : 'files-spaces-personal'
 
       return createLocationSpaces(locationName, {
         params: {

--- a/packages/web-app-files/src/helpers/resources.ts
+++ b/packages/web-app-files/src/helpers/resources.ts
@@ -58,9 +58,7 @@ export function buildResource(resource): Resource {
   return {
     id,
     fileId: resource.fileInfo[DavProperty.FileId],
-    storageId:
-      extractStorageId(resource.fileInfo[DavProperty.FileId]) ||
-      resource.fileInfo[DavProperty.OwnerId],
+    storageId: extractStorageId(resource.fileInfo[DavProperty.FileId]),
     mimeType: resource.fileInfo[DavProperty.MimeType],
     name: path.basename(resource.name),
     extension: isFolder ? '' : extension,

--- a/packages/web-app-files/src/helpers/resources.ts
+++ b/packages/web-app-files/src/helpers/resources.ts
@@ -58,7 +58,9 @@ export function buildResource(resource): Resource {
   return {
     id,
     fileId: resource.fileInfo[DavProperty.FileId],
-    storageId: extractStorageId(resource.fileInfo[DavProperty.FileId]),
+    storageId:
+      extractStorageId(resource.fileInfo[DavProperty.FileId]) ||
+      resource.fileInfo[DavProperty.OwnerId],
     mimeType: resource.fileInfo[DavProperty.MimeType],
     name: path.basename(resource.name),
     extension: isFolder ? '' : extension,

--- a/packages/web-app-files/src/index.js
+++ b/packages/web-app-files/src/index.js
@@ -132,7 +132,7 @@ export default {
   },
   userReady({ store }) {
     // Load spaces to make them available across the application
-    if (store.getters.capabilities.spaces?.enabled) {
+    if (store.getters.capabilities?.spaces?.enabled) {
       store.dispatch('Files/loadSpaces', { clientService })
     }
 

--- a/packages/web-app-files/src/index.js
+++ b/packages/web-app-files/src/index.js
@@ -48,7 +48,7 @@ const navItems = [
     },
     icon: appInfo.icon,
     route: {
-      path: `/${appInfo.id}/spaces/personal/home`
+      path: `/${appInfo.id}/spaces/personal`
     }
   },
   {

--- a/packages/web-app-files/src/mixins/accessibleBreadcrumb.js
+++ b/packages/web-app-files/src/mixins/accessibleBreadcrumb.js
@@ -11,7 +11,6 @@ export default {
         document.getElementById('files-breadcrumb').children[0].children
       )
       const activeBreadcrumbItem = activeBreadcrumb.getElementsByTagName('button')[0]
-
       if (!activeBreadcrumbItem) {
         return
       }

--- a/packages/web-app-files/src/mixins/actions/copy.js
+++ b/packages/web-app-files/src/mixins/actions/copy.js
@@ -61,6 +61,11 @@ export default {
         query.storageId = this.$route.params.storageId
       }
 
+      if (isLocationSpacesActive(this.$router, 'files-spaces-personal')) {
+        context = 'personal'
+        query.storageId = this.$route.params.storageId
+      }
+
       const item = this.currentFolder.path || this.homeFolder
 
       return this.$router.push(

--- a/packages/web-app-files/src/mixins/actions/copy.js
+++ b/packages/web-app-files/src/mixins/actions/copy.js
@@ -17,7 +17,7 @@ export default {
             this.$pgettext('Action in the files list row to initiate copying resources', 'Copy'),
           isEnabled: ({ resources }) => {
             if (
-              !isLocationSpacesActive(this.$router, 'files-spaces-personal-home') &&
+              !isLocationSpacesActive(this.$router, 'files-spaces-personal') &&
               !isLocationSpacesActive(this.$router, 'files-spaces-project') &&
               !isLocationPublicActive(this.$router, 'files-public-files') &&
               !isLocationCommonActive(this.$router, 'files-common-favorites')

--- a/packages/web-app-files/src/mixins/actions/delete.js
+++ b/packages/web-app-files/src/mixins/actions/delete.js
@@ -16,7 +16,7 @@ export default {
           handler: this.$_delete_trigger,
           isEnabled: ({ resources }) => {
             if (
-              !isLocationSpacesActive(this.$router, 'files-spaces-personal-home') &&
+              !isLocationSpacesActive(this.$router, 'files-spaces-personal') &&
               !isLocationSpacesActive(this.$router, 'files-spaces-project') &&
               !isLocationSpacesActive(this.$router, 'files-spaces-share') &&
               !isLocationPublicActive(this.$router, 'files-public-files')

--- a/packages/web-app-files/src/mixins/actions/downloadArchive.js
+++ b/packages/web-app-files/src/mixins/actions/downloadArchive.js
@@ -24,7 +24,7 @@ export default {
           isEnabled: ({ resources }) => {
             if (
               this.$_isFilesAppActive &&
-              !isLocationSpacesActive(this.$router, 'files-spaces-personal-home') &&
+              !isLocationSpacesActive(this.$router, 'files-spaces-personal') &&
               !isLocationSpacesActive(this.$router, 'files-spaces-project') &&
               !isLocationSpacesActive(this.$router, 'files-spaces-share') &&
               !isLocationPublicActive(this.$router, 'files-public-files') &&

--- a/packages/web-app-files/src/mixins/actions/downloadFile.js
+++ b/packages/web-app-files/src/mixins/actions/downloadFile.js
@@ -21,7 +21,7 @@ export default {
           isEnabled: ({ resources }) => {
             if (
               this.$_isFilesAppActive &&
-              !isLocationSpacesActive(this.$router, 'files-spaces-personal-home') &&
+              !isLocationSpacesActive(this.$router, 'files-spaces-personal') &&
               !isLocationSpacesActive(this.$router, 'files-spaces-project') &&
               !isLocationSpacesActive(this.$router, 'files-spaces-share') &&
               !isLocationPublicActive(this.$router, 'files-public-files') &&

--- a/packages/web-app-files/src/mixins/actions/favorite.js
+++ b/packages/web-app-files/src/mixins/actions/favorite.js
@@ -21,7 +21,7 @@ export default {
           isEnabled: ({ resources }) => {
             if (
               this.$_isFilesAppActive &&
-              !isLocationSpacesActive(this.$router, 'files-spaces-personal-home') &&
+              !isLocationSpacesActive(this.$router, 'files-spaces-personal') &&
               !isLocationCommonActive(this.$router, 'files-common-favorites')
             ) {
               return false

--- a/packages/web-app-files/src/mixins/actions/move.js
+++ b/packages/web-app-files/src/mixins/actions/move.js
@@ -18,7 +18,7 @@ export default {
             this.$pgettext('Action in the files list row to initiate moving resources', 'Move'),
           isEnabled: ({ resources }) => {
             if (
-              !isLocationSpacesActive(this.$router, 'files-spaces-personal-home') &&
+              !isLocationSpacesActive(this.$router, 'files-spaces-personal') &&
               !isLocationSpacesActive(this.$router, 'files-spaces-project') &&
               !isLocationPublicActive(this.$router, 'files-public-files') &&
               !isLocationCommonActive(this.$router, 'files-common-favorites')

--- a/packages/web-app-files/src/mixins/actions/move.js
+++ b/packages/web-app-files/src/mixins/actions/move.js
@@ -63,6 +63,11 @@ export default {
         query.storageId = this.$route.params.storageId
       }
 
+      if (isLocationSpacesActive(this.$router, 'files-spaces-personal')) {
+        context = 'personal'
+        query.storageId = this.$route.params.storageId
+      }
+
       const item = this.currentFolder.path || this.homeFolder
 
       return this.$router.push(

--- a/packages/web-app-files/src/mixins/actions/navigate.js
+++ b/packages/web-app-files/src/mixins/actions/navigate.js
@@ -85,7 +85,7 @@ export default {
         return createLocationSpaces('files-spaces-share')
       }
 
-      return createLocationSpaces('files-spaces-personal-home')
+      return createLocationSpaces('files-spaces-personal')
     }
   },
   methods: {

--- a/packages/web-app-files/src/router/deprecated.ts
+++ b/packages/web-app-files/src/router/deprecated.ts
@@ -43,11 +43,19 @@ export const buildRoutes = (): RouteConfig[] =>
   [
     {
       path: '/list',
-      redirect: (to) => createLocationSpaces('files-spaces-personal', to)
+      redirect: (to) =>
+        createLocationSpaces('files-spaces-personal', {
+          ...to,
+          params: { ...to.params, storageId: 'home' }
+        })
     },
     {
       path: '/list/all/:item*',
-      redirect: (to) => createLocationSpaces('files-spaces-personal', to)
+      redirect: (to) =>
+        createLocationSpaces('files-spaces-personal', {
+          ...to,
+          params: { ...to.params, storageId: 'home' }
+        })
     },
     {
       path: '/list/favorites',

--- a/packages/web-app-files/src/router/deprecated.ts
+++ b/packages/web-app-files/src/router/deprecated.ts
@@ -43,11 +43,11 @@ export const buildRoutes = (): RouteConfig[] =>
   [
     {
       path: '/list',
-      redirect: (to) => createLocationSpaces('files-spaces-personal-home', to)
+      redirect: (to) => createLocationSpaces('files-spaces-personal', to)
     },
     {
       path: '/list/all/:item*',
-      redirect: (to) => createLocationSpaces('files-spaces-personal-home', to)
+      redirect: (to) => createLocationSpaces('files-spaces-personal', to)
     },
     {
       path: '/list/favorites',
@@ -103,7 +103,7 @@ export const isLocationActive = (
 ): boolean => {
   const [first, ...rest] = comparatives.map((c) => {
     const newName = {
-      'files-personal': createLocationSpaces('files-spaces-personal-home').name,
+      'files-personal': createLocationSpaces('files-spaces-personal').name,
       'files-favorites': createLocationCommon('files-common-favorites').name,
       'files-shared-with-others': createLocationShares('files-shares-with-others').name,
       'files-shared-with-me': createLocationShares('files-shares-with-me').name,

--- a/packages/web-app-files/src/router/index.ts
+++ b/packages/web-app-files/src/router/index.ts
@@ -36,7 +36,7 @@ import { isAuthenticatedRoute, ActiveRouteDirectorFunc } from './utils'
 
 const ROOT_ROUTE = {
   path: '/',
-  redirect: (to) => createLocationSpaces('files-spaces-personal-home', to)
+  redirect: (to) => createLocationSpaces('files-spaces-personal', to)
 }
 
 const buildRoutes = (components: RouteComponents): RouteConfig[] => [

--- a/packages/web-app-files/src/router/public.ts
+++ b/packages/web-app-files/src/router/public.ts
@@ -37,7 +37,7 @@ export const buildRoutes = (components: RouteComponents): RouteConfig[] => [
   },
   {
     name: locationPublicDrop.name,
-    path: '/public/drop/:token',
+    path: '/public/drop/:token?',
     component: components.FilesDrop,
     meta: { auth: false, title: $gettext('Public file upload') }
   }

--- a/packages/web-app-files/src/router/spaces.ts
+++ b/packages/web-app-files/src/router/spaces.ts
@@ -9,15 +9,7 @@ type spaceTypes =
   | 'files-spaces-share'
 
 export const createLocationSpaces = (name: spaceTypes, location = {}): Location =>
-  createLocation(
-    name,
-    {
-      params: {
-        ...(name === 'files-spaces-personal-home' && { storage: 'home' })
-      }
-    },
-    location
-  )
+  createLocation(name, location)
 
 export const locationSpacesProject = createLocationSpaces('files-spaces-project')
 export const locationSpacesProjects = createLocationSpaces('files-spaces-projects')
@@ -54,8 +46,7 @@ export const buildRoutes = (components: RouteComponents): RouteConfig[] => [
         }
       },
       {
-        // intentionally not `storageId`, yet, because we use an alphanumeric alias here instead of an id
-        path: 'personal/:storage/:item*',
+        path: 'personal/:storageId?/:item*',
         name: locationSpacesPersonalHome.name,
         component: components.Personal,
         meta: {

--- a/packages/web-app-files/src/router/spaces.ts
+++ b/packages/web-app-files/src/router/spaces.ts
@@ -3,7 +3,7 @@ import { RouteComponents } from './router'
 import { createLocation, isLocationActiveDirector, $gettext } from './utils'
 
 type spaceTypes =
-  | 'files-spaces-personal-home'
+  | 'files-spaces-personal'
   | 'files-spaces-project'
   | 'files-spaces-projects'
   | 'files-spaces-share'
@@ -13,13 +13,13 @@ export const createLocationSpaces = (name: spaceTypes, location = {}): Location 
 
 export const locationSpacesProject = createLocationSpaces('files-spaces-project')
 export const locationSpacesProjects = createLocationSpaces('files-spaces-projects')
-export const locationSpacesPersonalHome = createLocationSpaces('files-spaces-personal-home')
+export const locationSpacesPersonal = createLocationSpaces('files-spaces-personal')
 export const locationSpacesShare = createLocationSpaces('files-spaces-share')
 
 export const isLocationSpacesActive = isLocationActiveDirector<spaceTypes>(
   locationSpacesProject,
   locationSpacesProjects,
-  locationSpacesPersonalHome,
+  locationSpacesPersonal,
   locationSpacesShare
 )
 
@@ -47,7 +47,7 @@ export const buildRoutes = (components: RouteComponents): RouteConfig[] => [
       },
       {
         path: 'personal/:storageId?/:item*',
-        name: locationSpacesPersonalHome.name,
+        name: locationSpacesPersonal.name,
         component: components.Personal,
         meta: {
           patchCleanPath: true,

--- a/packages/web-app-files/src/search/filter/index.ts
+++ b/packages/web-app-files/src/search/filter/index.ts
@@ -44,6 +44,6 @@ export default class Provider extends EventBus implements SearchProvider {
   }
 
   public get available(): boolean {
-    return isLocationSpacesActive(this.router, 'files-spaces-personal-home')
+    return isLocationSpacesActive(this.router, 'files-spaces-personal')
   }
 }

--- a/packages/web-app-files/src/search/sdk/index.ts
+++ b/packages/web-app-files/src/search/sdk/index.ts
@@ -53,6 +53,6 @@ export default class Provider extends EventBus implements SearchProvider {
   }
 
   public get available(): boolean {
-    return this.store.getters.capabilities.dav.reports.includes('search-files')
+    return this.store.getters.capabilities?.dav?.reports?.includes('search-files')
   }
 }

--- a/packages/web-app-files/src/services/folder/legacy/loaderPersonal.ts
+++ b/packages/web-app-files/src/services/folder/legacy/loaderPersonal.ts
@@ -30,7 +30,10 @@ export class FolderLoaderLegacyPersonal implements FolderLoader {
 
         let resources = yield fetchResources(
           client,
-          buildWebDavFilesPath(ref.user.id, path || router.currentRoute.params.item || ''),
+          buildWebDavFilesPath(
+            router.currentRoute.params.storageId,
+            path || router.currentRoute.params.item || ''
+          ),
           DavProperties.Default
         )
         resources = resources.map(buildResource)
@@ -52,7 +55,7 @@ export class FolderLoaderLegacyPersonal implements FolderLoader {
 
         // fetch user quota
         ;(async () => {
-          const user = await client.users.getUser(ref.user.id)
+          const user = await client.users.getUser(router.currentRoute.params.storageId)
           store.commit('SET_QUOTA', user.quota)
         })()
       } catch (error) {

--- a/packages/web-app-files/src/services/folder/legacy/loaderPersonal.ts
+++ b/packages/web-app-files/src/services/folder/legacy/loaderPersonal.ts
@@ -14,7 +14,7 @@ export class FolderLoaderLegacyPersonal implements FolderLoader {
   }
 
   public isActive(router: Router): boolean {
-    return isLocationSpacesActive(router, 'files-spaces-personal-home')
+    return isLocationSpacesActive(router, 'files-spaces-personal')
   }
 
   public getTask(context: TaskContext): FolderLoaderTask {

--- a/packages/web-app-files/src/services/folder/spaces/loaderPersonal.ts
+++ b/packages/web-app-files/src/services/folder/spaces/loaderPersonal.ts
@@ -20,24 +20,14 @@ export class FolderLoaderSpacesPersonal implements FolderLoader {
   public getTask(context: TaskContext): FolderLoaderTask {
     const { store, router, clientService } = context
 
-    const graphClient = clientService.graphAuthenticated(
-      store.getters.configuration.server,
-      store.getters.getToken
-    )
-
     return useTask(function* (signal1, signal2, ref, sameRoute, path = null) {
       try {
         store.commit('Files/CLEAR_CURRENT_FILES_LIST')
 
-        const drivesResponse = yield graphClient.drives.listMyDrives('', 'driveType eq personal')
-        if (!drivesResponse.data) {
-          throw new Error('No personal space found')
-        }
-
         let resources = yield fetchResources(
           clientService.owncloudSdk,
           buildWebDavSpacesPath(
-            drivesResponse.data.value[0].id,
+            router.currentRoute.params.storageId,
             path || router.currentRoute.params.item || ''
           ),
           DavProperties.Default

--- a/packages/web-app-files/src/services/folder/spaces/loaderPersonal.ts
+++ b/packages/web-app-files/src/services/folder/spaces/loaderPersonal.ts
@@ -14,7 +14,7 @@ export class FolderLoaderSpacesPersonal implements FolderLoader {
   }
 
   public isActive(router: Router): boolean {
-    return isLocationSpacesActive(router, 'files-spaces-personal-home')
+    return isLocationSpacesActive(router, 'files-spaces-personal')
   }
 
   public getTask(context: TaskContext): FolderLoaderTask {

--- a/packages/web-app-files/src/views/Favorites.vue
+++ b/packages/web-app-files/src/views/Favorites.vue
@@ -88,7 +88,7 @@ export default defineComponent({
   setup() {
     return {
       ...useResourcesViewDefaults<Resource, any, any[]>(),
-      resourceTargetLocation: createLocationSpaces('files-spaces-personal-home')
+      resourceTargetLocation: createLocationSpaces('files-spaces-personal')
     }
   },
 

--- a/packages/web-app-files/src/views/FilesDrop.vue
+++ b/packages/web-app-files/src/views/FilesDrop.vue
@@ -139,6 +139,7 @@ export default {
             )
             return
           }
+          console.error(error)
           this.errorMessage = error
         })
         .finally(() => {

--- a/packages/web-app-files/src/views/LocationPicker.vue
+++ b/packages/web-app-files/src/views/LocationPicker.vue
@@ -377,7 +377,7 @@ export default {
           break
         default:
           this.$router.push(
-            createLocationSpaces('files-spaces-personal-home', { params: { item: target || '/' } })
+            createLocationSpaces('files-spaces-personal', { params: { item: target || '/' } })
           )
       }
     },

--- a/packages/web-app-files/src/views/Personal.vue
+++ b/packages/web-app-files/src/views/Personal.vue
@@ -135,7 +135,7 @@ export default defineComponent({
     )
     return {
       ...useResourcesViewDefaults<Resource, any, any[]>(),
-      resourceTargetLocation: createLocationSpaces('files-spaces-personal-home'),
+      resourceTargetLocation: createLocationSpaces('files-spaces-personal'),
       hasShareJail: useCapabilityShareJailEnabled(),
       graphClient
     }
@@ -179,13 +179,12 @@ export default defineComponent({
   watch: {
     $route: {
       handler: async function (to, from) {
-        let storageId = this.user.id
-        console.log(this.user)
         const needsRedirectToHome =
           this.homeFolder !== '/' && isNil(to.params.item) && !to.path.endsWith('/')
-        const redirectWithStorageId = to.params.storageId === 'home'
+        const needsRedirectWithStorageId = to.params.storageId === 'home'
 
-        if (redirectWithStorageId) {
+        if (needsRedirectWithStorageId) {
+          let storageId = this.user.id
           if (this.hasShareJail) {
             const drivesResponse = await this.graphClient.drives.listMyDrives(
               '',
@@ -199,6 +198,7 @@ export default defineComponent({
             to,
             params: { ...to.params, storageId }
           })
+          return
         }
 
         if (needsRedirectToHome) {

--- a/packages/web-app-files/src/views/Personal.vue
+++ b/packages/web-app-files/src/views/Personal.vue
@@ -179,10 +179,7 @@ export default defineComponent({
   watch: {
     $route: {
       handler: async function (to, from) {
-        const needsRedirectToHome =
-          this.homeFolder !== '/' && isNil(to.params.item) && !to.path.endsWith('/')
         const needsRedirectWithStorageId = to.params.storageId === 'home'
-
         if (needsRedirectWithStorageId) {
           let storageId = this.user.id
           if (this.hasShareJail) {
@@ -190,19 +187,20 @@ export default defineComponent({
               '',
               'driveType eq personal'
             )
-
             storageId = drivesResponse.data.value[0].id
           }
 
-          await this.$router.replace({
+          return this.$router.replace({
             to,
-            params: { ...to.params, storageId }
+            params: { ...to.params, storageId },
+            query: to.query
           })
-          return
         }
 
+        const needsRedirectToHome =
+          this.homeFolder !== '/' && isNil(to.params.item) && !to.path.endsWith('/')
         if (needsRedirectToHome) {
-          this.$router.replace(
+          return this.$router.replace(
             {
               name: to.name,
               params: {
@@ -216,11 +214,9 @@ export default defineComponent({
               console.error(e)
             }
           )
-
-          return
         }
 
-        const sameRoute = to.name === from?.name
+        const sameRoute = to.name === from?.name && to.params?.storageId === from?.params?.storageId
         const sameItem = to.params?.item === from?.params?.item
         if (!sameRoute || !sameItem) {
           this.loadResourcesTask.perform(this, sameRoute)

--- a/packages/web-app-files/src/views/Personal.vue
+++ b/packages/web-app-files/src/views/Personal.vue
@@ -99,9 +99,9 @@ import Pagination from '../components/FilesList/Pagination.vue'
 import ContextActions from '../components/FilesList/ContextActions.vue'
 import { createLocationSpaces } from '../router'
 import { useResourcesViewDefaults } from '../composables'
-import { defineComponent } from '@vue/composition-api'
+import { defineComponent, unref } from '@vue/composition-api'
 import { Resource, move } from '../helpers/resource'
-import { useCapabilityShareJailEnabled, useStore } from 'web-pkg/src/composables'
+import { useCapabilityShareJailEnabled, useRouteParam, useStore } from 'web-pkg/src/composables'
 import { clientService } from 'web-pkg/src/services'
 
 const visibilityObserver = new VisibilityObserver()
@@ -133,9 +133,14 @@ export default defineComponent({
       store.getters.configuration.server,
       store.getters.getToken
     )
+    const storageId = useRouteParam('storageId')
     return {
       ...useResourcesViewDefaults<Resource, any, any[]>(),
-      resourceTargetLocation: createLocationSpaces('files-spaces-personal'),
+      resourceTargetLocation: createLocationSpaces('files-spaces-personal', {
+        params: {
+          storageId: unref(storageId)
+        }
+      }),
       hasShareJail: useCapabilityShareJailEnabled(),
       graphClient
     }

--- a/packages/web-app-files/src/views/Personal.vue
+++ b/packages/web-app-files/src/views/Personal.vue
@@ -99,7 +99,7 @@ import Pagination from '../components/FilesList/Pagination.vue'
 import ContextActions from '../components/FilesList/ContextActions.vue'
 import { createLocationSpaces } from '../router'
 import { useResourcesViewDefaults } from '../composables'
-import { defineComponent, unref } from '@vue/composition-api'
+import { defineComponent, unref, computed } from '@vue/composition-api'
 import { Resource, move } from '../helpers/resource'
 import { useCapabilityShareJailEnabled, useRouteParam, useStore } from 'web-pkg/src/composables'
 import { clientService } from 'web-pkg/src/services'
@@ -134,13 +134,16 @@ export default defineComponent({
       store.getters.getToken
     )
     const storageId = useRouteParam('storageId')
-    return {
-      ...useResourcesViewDefaults<Resource, any, any[]>(),
-      resourceTargetLocation: createLocationSpaces('files-spaces-personal', {
+    const resourceTargetLocation = computed(() => {
+      return createLocationSpaces('files-spaces-personal', {
         params: {
           storageId: unref(storageId)
         }
-      }),
+      })
+    })
+    return {
+      ...useResourcesViewDefaults<Resource, any, any[]>(),
+      resourceTargetLocation,
       hasShareJail: useCapabilityShareJailEnabled(),
       graphClient
     }

--- a/packages/web-app-files/src/views/Personal.vue
+++ b/packages/web-app-files/src/views/Personal.vue
@@ -179,7 +179,8 @@ export default defineComponent({
   watch: {
     $route: {
       handler: async function (to, from) {
-        const needsRedirectWithStorageId = to.params.storageId === 'home'
+        const needsRedirectWithStorageId =
+          to.params.storageId === 'home' || isNil(to.params.storageId)
         if (needsRedirectWithStorageId) {
           let storageId = this.user.id
           if (this.hasShareJail) {

--- a/packages/web-app-files/src/views/PrivateLink.vue
+++ b/packages/web-app-files/src/views/PrivateLink.vue
@@ -72,7 +72,7 @@ export default {
         query.scrollTo = resource.name
       }
       this.$router.push(
-        createLocationSpaces('files-spaces-personal-home', {
+        createLocationSpaces('files-spaces-personal', {
           params,
           query
         })

--- a/packages/web-app-files/src/views/PublicLink.vue
+++ b/packages/web-app-files/src/views/PublicLink.vue
@@ -103,16 +103,17 @@ export default {
         .then((files) => {
           this.passwordRequired = false
           this.setPublicLinkPassword(password)
-          const publicOperationName =
-            files[0].getProperty(this.$client.publicFiles.PUBLIC_LINK_PERMISSION) === '4'
-              ? 'files-public-drop'
-              : 'files-public-files'
+
+          let publicOperationName = 'files-public-files'
+          let publicOperationParams = { item: this.$route.params.token }
+          if (files[0].getProperty(this.$client.publicFiles.PUBLIC_LINK_PERMISSION) === '4') {
+            publicOperationName = 'files-public-drop'
+            publicOperationParams = { token: this.$route.params.token }
+          }
 
           this.$router.push(
             createLocationPublic(publicOperationName, {
-              params: {
-                item: this.$route.params.token
-              }
+              params: publicOperationParams
             })
           )
         })
@@ -130,6 +131,7 @@ export default {
               this.$refs.passwordInput.focus()
             })
           } else {
+            console.error(error)
             this.errorMessage = error
           }
         })

--- a/packages/web-app-files/src/views/shares/SharedViaLink.vue
+++ b/packages/web-app-files/src/views/shares/SharedViaLink.vue
@@ -72,6 +72,7 @@ import { useResourcesViewDefaults } from '../../composables'
 import { defineComponent } from '@vue/composition-api'
 import { Resource } from '../../helpers/resource'
 import { shareQuickLinkHelp } from '../../helpers/contextualHelpers'
+import { useStore } from 'web-pkg/src/composables'
 
 const visibilityObserver = new VisibilityObserver()
 
@@ -89,10 +90,13 @@ export default defineComponent({
   mixins: [FileActions, MixinResources, MixinMountSideBar, MixinFilesListFilter],
 
   setup() {
+    const store = useStore()
     return {
       ...useResourcesViewDefaults<Resource, any, any[]>(),
 
-      resourceTargetLocation: createLocationSpaces('files-spaces-personal')
+      resourceTargetLocation: createLocationSpaces('files-spaces-personal', {
+        params: { storageId: store.getters.user.id }
+      })
     }
   },
 

--- a/packages/web-app-files/src/views/shares/SharedViaLink.vue
+++ b/packages/web-app-files/src/views/shares/SharedViaLink.vue
@@ -92,7 +92,7 @@ export default defineComponent({
     return {
       ...useResourcesViewDefaults<Resource, any, any[]>(),
 
-      resourceTargetLocation: createLocationSpaces('files-spaces-personal-home')
+      resourceTargetLocation: createLocationSpaces('files-spaces-personal')
     }
   },
 

--- a/packages/web-app-files/src/views/shares/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithMe.vue
@@ -218,9 +218,7 @@ export default defineComponent({
 
     const hasShareJail = useCapabilityShareJailEnabled()
     const resourceTargetLocation = computed(() =>
-      createLocationSpaces(
-        unref(hasShareJail) ? 'files-spaces-share' : 'files-spaces-personal-home'
-      )
+      createLocationSpaces(unref(hasShareJail) ? 'files-spaces-share' : 'files-spaces-personal')
     )
     const resourceTargetParamMapping = computed(() =>
       unref(hasShareJail) ? { name: 'shareName', path: 'item' } : undefined

--- a/packages/web-app-files/src/views/shares/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithMe.vue
@@ -175,7 +175,7 @@ import MixinMountSideBar from '../../mixins/sidebar/mountSideBar'
 import { VisibilityObserver } from 'web-pkg/src/observer'
 import { ImageDimension, ImageType } from '../../constants'
 import { useSort, useResourcesViewDefaults } from '../../composables'
-import { useCapabilityShareJailEnabled, useRouteQuery } from 'web-pkg/src/composables'
+import { useCapabilityShareJailEnabled, useRouteQuery, useStore } from 'web-pkg/src/composables'
 import debounce from 'lodash-es/debounce'
 
 import AppLoadingSpinner from 'web-pkg/src/components/AppLoadingSpinner.vue'
@@ -216,9 +216,14 @@ export default defineComponent({
       any[]
     >()
 
+    const store = useStore()
     const hasShareJail = useCapabilityShareJailEnabled()
     const resourceTargetLocation = computed(() =>
-      createLocationSpaces(unref(hasShareJail) ? 'files-spaces-share' : 'files-spaces-personal')
+      unref(hasShareJail)
+        ? createLocationSpaces('files-spaces-share')
+        : createLocationSpaces('files-spaces-personal', {
+            params: { storageId: store.getters.user.id }
+          })
     )
     const resourceTargetParamMapping = computed(() =>
       unref(hasShareJail) ? { name: 'shareName', path: 'item' } : undefined

--- a/packages/web-app-files/src/views/shares/SharedWithOthers.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithOthers.vue
@@ -91,7 +91,7 @@ export default defineComponent({
   setup() {
     return {
       ...useResourcesViewDefaults<Resource, any, any[]>(),
-      resourceTargetLocation: createLocationSpaces('files-spaces-personal-home')
+      resourceTargetLocation: createLocationSpaces('files-spaces-personal')
     }
   },
 

--- a/packages/web-app-files/src/views/shares/SharedWithOthers.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithOthers.vue
@@ -72,6 +72,7 @@ import { createLocationSpaces } from '../../router'
 import { useResourcesViewDefaults } from '../../composables'
 import { defineComponent } from '@vue/composition-api'
 import { Resource } from '../../helpers/resource'
+import { useStore } from 'web-pkg/src/composables'
 
 const visibilityObserver = new VisibilityObserver()
 
@@ -89,9 +90,13 @@ export default defineComponent({
   mixins: [FileActions, MixinResources, MixinMountSideBar, MixinFilesListFilter],
 
   setup() {
+    const store = useStore()
     return {
       ...useResourcesViewDefaults<Resource, any, any[]>(),
-      resourceTargetLocation: createLocationSpaces('files-spaces-personal')
+
+      resourceTargetLocation: createLocationSpaces('files-spaces-personal', {
+        params: { storageId: store.getters.user.id }
+      })
     }
   },
 

--- a/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.js
+++ b/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.js
@@ -30,7 +30,7 @@ const elSelector = {
   newDrawioFileBtn: '.new-file-btn-drawio'
 }
 
-const personalHomeLocation = createLocationSpaces('files-spaces-personal-home')
+const personalHomeLocation = createLocationSpaces('files-spaces-personal')
 
 const newFileHandlers = [
   {

--- a/packages/web-app-files/tests/unit/components/FilesList/NotFoundMessage.spec.js
+++ b/packages/web-app-files/tests/unit/components/FilesList/NotFoundMessage.spec.js
@@ -16,7 +16,7 @@ const selectors = {
   reloadLinkButton: '#files-list-not-found-button-reload-link'
 }
 
-const spacesLocation = createLocationSpaces('files-spaces-personal-home')
+const spacesLocation = createLocationSpaces('files-spaces-personal')
 
 const store = new Vuex.Store({
   getters: {

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.js
@@ -188,18 +188,13 @@ function getResource({
 }
 
 const storeOptions = (data) => {
-  let {
+  const {
     user,
     outgoingCollaborators = [],
     incomingCollaborators = [],
-    owner,
     canShare = true,
     spaces = []
   } = data
-  if (!owner) {
-    owner = user
-  }
-
   return {
     actions: {
       createModal: jest.fn(),

--- a/packages/web-app-files/tests/unit/components/SideBar/SideBar.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/SideBar.spec.js
@@ -168,12 +168,7 @@ describe('SideBar', () => {
   })
 })
 
-function createWrapper({
-  item,
-  selectedItems,
-  mocks,
-  currentRouteName = 'files-spaces-personal-home'
-}) {
+function createWrapper({ item, selectedItems, mocks, currentRouteName = 'files-spaces-personal' }) {
   const localVue = createLocalVue()
   localVue.use(Vuex)
   localVue.use(VueCompositionAPI)

--- a/packages/web-app-files/tests/unit/mixins/actions/delete.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/actions/delete.spec.js
@@ -72,7 +72,7 @@ function getWrapper({ deletePermanent = false, invalidLocation = false } = {}) {
           ? createLocationShares('files-shares-via-link')
           : deletePermanent
           ? createLocationTrash('files-trash-personal')
-          : createLocationSpaces('files-spaces-personal-home'),
+          : createLocationSpaces('files-spaces-personal'),
         resolve: (r) => {
           return { href: r.name }
         }

--- a/packages/web-app-files/tests/unit/mixins/actions/emptyTrashBin.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/actions/emptyTrashBin.spec.js
@@ -71,7 +71,7 @@ function getWrapper({ invalidLocation = false, resolveClearTrashBin = true } = {
     mocks: {
       $router: {
         currentRoute: invalidLocation
-          ? createLocationSpaces('files-spaces-personal-home')
+          ? createLocationSpaces('files-spaces-personal')
           : createLocationTrash('files-trash-personal'),
         resolve: (r) => {
           return { href: r.name }

--- a/packages/web-app-files/tests/unit/mixins/actions/rename.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/actions/rename.spec.js
@@ -147,7 +147,7 @@ function getWrapper(renameFilePromise) {
     localVue,
     mocks: {
       $router: {
-        currentRoute: createLocationSpaces('files-spaces-personal-home'),
+        currentRoute: createLocationSpaces('files-spaces-personal'),
         resolve: (r) => {
           return { href: r.name }
         }

--- a/packages/web-app-files/tests/unit/mixins/actions/restore.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/actions/restore.spec.js
@@ -71,7 +71,7 @@ function getWrapper({ invalidLocation = false, resolveClearTrashBin: resolveRest
     mocks: {
       $router: {
         currentRoute: invalidLocation
-          ? createLocationSpaces('files-spaces-personal-home')
+          ? createLocationSpaces('files-spaces-personal')
           : createLocationTrash('files-trash-personal'),
         resolve: (r) => {
           return { href: r.name }

--- a/packages/web-app-files/tests/unit/search/filter.spec.ts
+++ b/packages/web-app-files/tests/unit/search/filter.spec.ts
@@ -59,7 +59,7 @@ describe('FilterProvider', () => {
   it('is only available on certain routes', () => {
     ;[
       { route: { name: 'foo' } },
-      { route: createLocationSpaces('files-spaces-personal-home'), available: true },
+      { route: createLocationSpaces('files-spaces-personal'), available: true },
       { route: { name: 'bar' } }
     ].forEach((v) => {
       const search = new FilterSearch(store, {

--- a/packages/web-app-files/tests/unit/views/LocationPicker.spec.js
+++ b/packages/web-app-files/tests/unit/views/LocationPicker.spec.js
@@ -185,11 +185,7 @@ describe('LocationPicker', () => {
         expect(spyLeaveLocationPicker).toHaveBeenCalledWith('/some/item')
         expect(spyRouterPush).toHaveBeenCalledTimes(1)
         expect(spyRouterPush).toHaveBeenCalledWith({
-          name: 'files-spaces-personal',
-          params: {
-            item: '/some/item',
-            storageId: 'home'
-          }
+          name: 'files-spaces-personal'
         })
       })
     })

--- a/packages/web-app-files/tests/unit/views/LocationPicker.spec.js
+++ b/packages/web-app-files/tests/unit/views/LocationPicker.spec.js
@@ -188,7 +188,7 @@ describe('LocationPicker', () => {
           name: 'files-spaces-personal-home',
           params: {
             item: '/some/item',
-            storage: 'home'
+            storageId: 'home'
           }
         })
       })

--- a/packages/web-app-files/tests/unit/views/LocationPicker.spec.js
+++ b/packages/web-app-files/tests/unit/views/LocationPicker.spec.js
@@ -185,7 +185,7 @@ describe('LocationPicker', () => {
         expect(spyLeaveLocationPicker).toHaveBeenCalledWith('/some/item')
         expect(spyRouterPush).toHaveBeenCalledTimes(1)
         expect(spyRouterPush).toHaveBeenCalledWith({
-          name: 'files-spaces-personal-home',
+          name: 'files-spaces-personal',
           params: {
             item: '/some/item',
             storageId: 'home'

--- a/packages/web-app-files/tests/unit/views/Personal.spec.js
+++ b/packages/web-app-files/tests/unit/views/Personal.spec.js
@@ -16,7 +16,7 @@ const router = {
   push: jest.fn(),
   afterEach: jest.fn(),
   currentRoute: {
-    ...createLocationSpaces('files-spaces-personal-home'),
+    ...createLocationSpaces('files-spaces-personal'),
     query: {}
   },
   resolve: (r) => {

--- a/packages/web-app-files/tests/unit/views/Personal.spec.js
+++ b/packages/web-app-files/tests/unit/views/Personal.spec.js
@@ -17,6 +17,7 @@ const router = {
   afterEach: jest.fn(),
   currentRoute: {
     ...createLocationSpaces('files-spaces-personal'),
+    params: { storageId: '1234' },
     query: {}
   },
   resolve: (r) => {

--- a/packages/web-app-files/tests/unit/views/shares/SharedViaLink.spec.js
+++ b/packages/web-app-files/tests/unit/views/shares/SharedViaLink.spec.js
@@ -3,6 +3,7 @@ import { getStore, localVue, createFile } from '../views.setup.js'
 import { createLocationSpaces } from '../../../../src/router'
 import FileActions from '@files/src/mixins/fileActions'
 import SharedViaLink from '@files/src/views/shares/SharedViaLink.vue'
+import Users from '@/__fixtures__/users'
 
 const component = { ...SharedViaLink, mounted: jest.fn() }
 
@@ -190,6 +191,7 @@ function createStore({ totalFilesCount, highlightedFile, selectedFiles } = {}) {
   return getStore({
     highlightedFile,
     totalFilesCount,
-    selectedFiles
+    selectedFiles,
+    user: { id: Users.alice.id }
   })
 }

--- a/packages/web-app-files/tests/unit/views/shares/SharedViaLink.spec.js
+++ b/packages/web-app-files/tests/unit/views/shares/SharedViaLink.spec.js
@@ -109,7 +109,7 @@ describe('SharedViaLink view', () => {
         expect(ocTableFiles.props().areThumbnailsDisplayed).toBe(false)
         expect(ocTableFiles.props().headerPosition).toBe(0)
         expect(ocTableFiles.props().targetRoute).toMatchObject(
-          createLocationSpaces('files-spaces-personal-home')
+          createLocationSpaces('files-spaces-personal')
         )
       })
       it('should set props on list-info component', () => {

--- a/packages/web-app-files/tests/unit/views/shares/SharedWithMe.spec.js
+++ b/packages/web-app-files/tests/unit/views/shares/SharedWithMe.spec.js
@@ -3,6 +3,7 @@ import { localVue, getStore, getRouter } from '../views.setup'
 import SharedWithMe from '@files/src/views/shares/SharedWithMe.vue'
 import { ShareStatus, ShareTypes } from '@files/src/helpers/share'
 import { extractDomSelector } from '../../../../src/helpers/resource'
+import Users from '@/__fixtures__/users'
 
 const stubs = {
   'app-bar': true,
@@ -54,7 +55,8 @@ describe('SharedWithMe view', () => {
             store: getStore({
               highlightedFile: file,
               activeFiles: [file],
-              totalFilesCount: { files: 0, folders: 1 }
+              totalFilesCount: { files: 0, folders: 1 },
+              user: { id: Users.alice.id }
             })
           })
           expect(wrapper.find(selectors.pendingTable).exists()).toBeFalsy()
@@ -68,7 +70,8 @@ describe('SharedWithMe view', () => {
             store: getStore({
               highlightedFile: file,
               activeFiles: [file],
-              totalFilesCount: { files: 0, folders: 1 }
+              totalFilesCount: { files: 0, folders: 1 },
+              user: { id: Users.alice.id }
             })
           })
           expect(wrapper.find(selectors.pendingTable).exists()).toBeTruthy()
@@ -88,7 +91,8 @@ describe('SharedWithMe view', () => {
           store: getStore({
             highlightedFile: pendingShares[0],
             activeFiles: pendingShares,
-            totalFilesCount: { files: 0, folders: pendingShares.length }
+            totalFilesCount: { files: 0, folders: pendingShares.length },
+            user: { id: Users.alice.id }
           })
         })
         describe('as long as the pending shares are collapsed', () => {
@@ -106,7 +110,8 @@ describe('SharedWithMe view', () => {
               store: getStore({
                 highlightedFile: pendingShares[0],
                 activeFiles: pendingShares,
-                totalFilesCount: { files: 0, folders: pendingShares.length }
+                totalFilesCount: { files: 0, folders: pendingShares.length },
+                user: { id: Users.alice.id }
               })
             })
             await wrapper.find(selectors.pendingExpand).trigger('click')
@@ -137,7 +142,8 @@ describe('SharedWithMe view', () => {
         store: getStore({
           highlightedFile: file,
           activeFiles: [file],
-          totalFilesCount: { files: 0, folders: 1 }
+          totalFilesCount: { files: 0, folders: 1 },
+          user: { id: Users.alice.id }
         })
       })
       it('should not show a "no content" message', () => {
@@ -159,7 +165,8 @@ describe('SharedWithMe view', () => {
         store: getStore({
           highlightedFile: file,
           activeFiles: [file],
-          totalFilesCount: { files: 0, folders: 1 }
+          totalFilesCount: { files: 0, folders: 1 },
+          user: { id: Users.alice.id }
         }),
         viewMode: ShareStatus.declined
       })
@@ -182,7 +189,8 @@ describe('SharedWithMe view', () => {
 function mountOptions({
   store = getStore({
     activeFiles: [],
-    totalFilesCount: { files: 0, folders: 0 }
+    totalFilesCount: { files: 0, folders: 0 },
+    user: { id: Users.alice.id }
   }),
   loading = false,
   viewMode = ShareStatus.accepted

--- a/packages/web-app-files/tests/unit/views/shares/SharedWithOthers.spec.js
+++ b/packages/web-app-files/tests/unit/views/shares/SharedWithOthers.spec.js
@@ -3,6 +3,7 @@ import { getStore, localVue } from '../views.setup.js'
 import FileActions from '@files/src/mixins/fileActions.js'
 import SharedWithOthers from '@files/src/views/shares/SharedWithOthers.vue'
 import SharedData from '@/__fixtures__/sharedFiles.js'
+import Users from '@/__fixtures__/users'
 import { createLocationShares } from '../../../../src/router'
 import { buildSharedResource } from '../../../../src/helpers/resources'
 import { Settings, DateTime } from 'luxon'
@@ -203,7 +204,8 @@ describe('SharedWithOthers view', () => {
   } = {}) {
     const store = getStore({
       selectedFiles,
-      totalFilesCount: { files: paginatedResources.length, folders: 0 }
+      totalFilesCount: { files: paginatedResources.length, folders: 0 },
+      user: { id: Users.alice.id }
     })
     const component = {
       ...SharedWithOthers,

--- a/packages/web-app-files/tests/unit/views/views.setup.js
+++ b/packages/web-app-files/tests/unit/views/views.setup.js
@@ -67,7 +67,7 @@ export const routes = [
   },
   {
     path: '/files/spaces/personal/home/',
-    name: 'files-spaces-personal-home'
+    name: 'files-spaces-personal'
   },
   {
     path: '/files/spaces/project/',

--- a/packages/web-app-files/tests/unit/views/views.setup.js
+++ b/packages/web-app-files/tests/unit/views/views.setup.js
@@ -124,6 +124,7 @@ export const getStore = function ({
     },
     getters: {
       configuration: () => ({
+        server: 'https://owncloud.test',
         currentTheme: {
           loginPage: {
             backgroundImg: loginBackgroundImg

--- a/packages/web-app-search/src/portals/SearchBar.vue
+++ b/packages/web-app-search/src/portals/SearchBar.vue
@@ -96,6 +96,10 @@ export default {
   },
 
   mounted() {
+    if (!this.availableProviders.length) {
+      return
+    }
+
     const input = this.$el.getElementsByTagName('input')[0]
     const routeTerm = get(this, '$route.query.term')
 

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -25,7 +25,7 @@
     "marked": "^4.0.12",
     "oidc-client": "1.11.5",
     "owncloud-design-system": "^13.1.0",
-    "owncloud-sdk": "~3.0.0-alpha.12",
+    "owncloud-sdk": "~3.0.0-alpha.13",
     "p-queue": "^6.6.2",
     "popper-max-size-modifier": "^0.2.0",
     "portal-vue": "^2.1.7",

--- a/packages/web-runtime/src/components/SidebarNav/SidebarNavItemHighlight.vue
+++ b/packages/web-runtime/src/components/SidebarNav/SidebarNavItemHighlight.vue
@@ -35,12 +35,16 @@ export default {
   },
   methods: {
     animateHighlightPosition(target, durationSeconds = 0.2) {
-      const initialId = this.getInitialId()
+      const highlightedElement = document.getElementById('highlighter')
+      if (!highlightedElement) {
+        return
+      }
+      const initialId = highlightedElement.getAttribute('data-initial-id')
       const currentElement = this.getNavigationItem(initialId)
       const targetElement = this.getNavigationItem(target)
       const distanceAbs = this.getDistanceBetweenElements(currentElement, targetElement)
       const distance = target < initialId ? -distanceAbs : distanceAbs
-      const style = this.getHighlightingElement().style
+      const style = highlightedElement.style
       style.setProperty('transition-duration', `${durationSeconds}s`)
       style.setProperty('transform', `translateY(${distance}px)`)
     },
@@ -58,12 +62,6 @@ export default {
       const aPosition = this.getPositionAtCenter(a)
       const bPosition = this.getPositionAtCenter(b)
       return Math.hypot(aPosition.x - bPosition.x, aPosition.y - bPosition.y)
-    },
-    getHighlightingElement() {
-      return document.getElementById('highlighter')
-    },
-    getInitialId() {
-      return this.getHighlightingElement().getAttribute('data-initial-id')
     }
   }
 }

--- a/packages/web-runtime/src/layouts/Application.vue
+++ b/packages/web-runtime/src/layouts/Application.vue
@@ -98,7 +98,7 @@ export default defineComponent({
         return []
       }
 
-      const { route: currentRoute } = this.$router.resolve(this.$route)
+      const { href: currentHref } = this.$router.resolve(this.$route)
       return items.map((item) => {
         const active = [item.route, ...(item.activeFor || [])]
           .filter(Boolean)
@@ -107,8 +107,8 @@ export default defineComponent({
               return true
             }
             try {
-              const { route: comparativeRoute } = this.$router.resolve(currentItem)
-              return currentRoute.name === comparativeRoute.name
+              const comparativeHref = this.$router.resolve(currentItem).href
+              return currentHref.startsWith(comparativeHref)
             } catch (e) {
               console.error(e)
               return false

--- a/packages/web-runtime/src/layouts/Application.vue
+++ b/packages/web-runtime/src/layouts/Application.vue
@@ -98,7 +98,7 @@ export default defineComponent({
         return []
       }
 
-      const { href: currentHref } = this.$router.resolve(this.$route)
+      const { route: currentRoute } = this.$router.resolve(this.$route)
       return items.map((item) => {
         const active = [item.route, ...(item.activeFor || [])]
           .filter(Boolean)
@@ -107,8 +107,8 @@ export default defineComponent({
               return true
             }
             try {
-              const comparativeHref = this.$router.resolve(currentItem).href
-              return currentHref.startsWith(comparativeHref)
+              const { route: comparativeRoute } = this.$router.resolve(currentItem)
+              return currentRoute.name === comparativeRoute.name
             } catch (e) {
               console.error(e)
               return false

--- a/tests/e2e/support/objects/app-files/page/spaces/personal.ts
+++ b/tests/e2e/support/objects/app-files/page/spaces/personal.ts
@@ -1,6 +1,6 @@
 import { Page } from 'playwright'
 
-const personalSpaceNavSelector = '//a[@data-nav-name="files-spaces-personal-home"]'
+const personalSpaceNavSelector = '//a[@data-nav-name="files-spaces-personal"]'
 
 export class Personal {
   #page: Page

--- a/yarn.lock
+++ b/yarn.lock
@@ -9730,9 +9730,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"owncloud-sdk@npm:~3.0.0-alpha.12":
-  version: 3.0.0-alpha.12
-  resolution: "owncloud-sdk@npm:3.0.0-alpha.12"
+"owncloud-sdk@npm:~3.0.0-alpha.13":
+  version: 3.0.0-alpha.13
+  resolution: "owncloud-sdk@npm:3.0.0-alpha.13"
   peerDependencies:
     axios: ^0.27.2
     cross-fetch: ^3.0.6
@@ -9745,7 +9745,7 @@ __metadata:
   dependenciesMeta:
     "@pact-foundation/pact":
       built: true
-  checksum: 2c9810e356c54e2809e6318fbe789eb76534e661fd01b927e9ca60771c9eb86c192c8403f4b8110b0b2c2d719ed6e0679a34d4d3bcf3061e42541432a6116ce1
+  checksum: beb4581642e4ef89c269a7de872c3f626ee0ed06301189cdec84575df73c68dd989dd6803d239f53def3213aa397779dd7c2d3cb8af3f82fabfde27abad869ba
   languageName: node
   linkType: hard
 
@@ -13782,7 +13782,7 @@ __metadata:
     marked: ^4.0.12
     oidc-client: 1.11.5
     owncloud-design-system: ^13.1.0
-    owncloud-sdk: ~3.0.0-alpha.12
+    owncloud-sdk: ~3.0.0-alpha.13
     p-queue: ^6.6.2
     popper-max-size-modifier: ^0.2.0
     portal-vue: ^2.1.7


### PR DESCRIPTION
## Description
We now include the personal space id in the URL instead of using a magic "home" alias. When using the old "home" alias the user gets redirected to the URL with their personal space id.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/7024

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 