### PR TITLE
Prevent rename button from getting covered

### DIFF
--- a/changelog/unreleased/bugfix-rename-button-visibility
+++ b/changelog/unreleased/bugfix-rename-button-visibility
@@ -1,0 +1,6 @@
+Bugfix: Prevent rename button from getting covered
+
+We've fixed a bug where the rename button next to the file name would get covered if there is not enough space available.
+
+https://github.com/owncloud/web/pull/7061
+https://github.com/owncloud/web/issues/7007

--- a/packages/web-app-files/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceTable.vue
@@ -774,7 +774,7 @@ export default defineComponent({
 .resource-table {
   &-resource-wrapper {
     &-limit-max-width {
-      max-width: 90%;
+      max-width: calc(100% - var(--oc-space-medium));
     }
 
     &:hover > .resource-table-edit-name {

--- a/packages/web-app-files/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceTable.vue
@@ -45,7 +45,10 @@
       />
     </template>
     <template #name="{ item }">
-      <div class="resource-table-resource-wrapper">
+      <div
+        class="resource-table-resource-wrapper"
+        :class="[{ 'resource-table-resource-wrapper-limit-max-width': hasRenameAction(item) }]"
+      >
         <oc-resource
           :key="`${item.path}-${resourceDomSelector(item)}-${item.thumbnail}`"
           :resource="item"
@@ -770,6 +773,10 @@ export default defineComponent({
 <style lang="scss">
 .resource-table {
   &-resource-wrapper {
+    &-limit-max-width {
+      max-width: 90%;
+    }
+
     &:hover > .resource-table-edit-name {
       svg {
         fill: var(--oc-color-text-default);

--- a/packages/web-app-files/tests/unit/components/__snapshots__/TrashBin.spec.js.snap
+++ b/packages/web-app-files/tests/unit/components/__snapshots__/TrashBin.spec.js.snap
@@ -17,7 +17,7 @@ exports[`Trashbin component when the view is not loading anymore when length of 
     <tr tabindex="-1" data-item-id="file-id-1234" draggable="false" class="oc-tbody-tr oc-tbody-tr-file-id-1234">
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-table-data-cell oc-table-data-cell-select oc-pl-m "><span><input id="resource-table-select-file-id-1234" type="checkbox" name="checkbox" class="oc-checkbox oc-rounded oc-checkbox-l" value="[object Object]"> <label for="resource-table-select-file-id-1234" class="oc-invisible-sr oc-cursor-pointer">Select folder</label></span></td>
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-expand oc-text-truncate oc-table-data-cell oc-table-data-cell-name">
-        <div class="resource-table-resource-wrapper">
+        <div class="resource-table-resource-wrapper resource-table-resource-wrapper-limit-max-width">
           <div class="oc-resource oc-text-overflow"><span><span class="oc-icon oc-icon-l oc-icon-passive oc-resource-icon oc-resource-icon-file"><!----></span></span>
             <div class="oc-resource-details oc-text-overflow"><span class="oc-text-overflow"><!----> <span data-test-resource-path="/file-path/1234" data-test-resource-name="file-path/file-name-1234" data-test-resource-type="folder" class="oc-resource-name"><span class="oc-text-truncate"><span class="oc-resource-basename">file-name-1234</span></span>
               <!----></span></span>
@@ -37,7 +37,7 @@ exports[`Trashbin component when the view is not loading anymore when length of 
     <tr tabindex="-1" data-item-id="file-id-5896" draggable="false" class="oc-tbody-tr oc-tbody-tr-file-id-5896">
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-table-data-cell oc-table-data-cell-select oc-pl-m "><span><input id="resource-table-select-file-id-5896" type="checkbox" name="checkbox" class="oc-checkbox oc-rounded oc-checkbox-l" value="[object Object]"> <label for="resource-table-select-file-id-5896" class="oc-invisible-sr oc-cursor-pointer">Select folder</label></span></td>
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-expand oc-text-truncate oc-table-data-cell oc-table-data-cell-name">
-        <div class="resource-table-resource-wrapper">
+        <div class="resource-table-resource-wrapper resource-table-resource-wrapper-limit-max-width">
           <div class="oc-resource oc-text-overflow"><span><span class="oc-icon oc-icon-l oc-icon-passive oc-resource-icon oc-resource-icon-file"><!----></span></span>
             <div class="oc-resource-details oc-text-overflow"><span class="oc-text-overflow"><!----> <span data-test-resource-path="/file-path/5896" data-test-resource-name="file-path/file-name-5896" data-test-resource-type="folder" class="oc-resource-name"><span class="oc-text-truncate"><span class="oc-resource-basename">file-name-5896</span></span>
               <!----></span></span>
@@ -57,7 +57,7 @@ exports[`Trashbin component when the view is not loading anymore when length of 
     <tr tabindex="-1" data-item-id="file-id-9856" draggable="false" class="oc-tbody-tr oc-tbody-tr-file-id-9856">
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-table-data-cell oc-table-data-cell-select oc-pl-m "><span><input id="resource-table-select-file-id-9856" type="checkbox" name="checkbox" class="oc-checkbox oc-rounded oc-checkbox-l" value="[object Object]"> <label for="resource-table-select-file-id-9856" class="oc-invisible-sr oc-cursor-pointer">Select folder</label></span></td>
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-expand oc-text-truncate oc-table-data-cell oc-table-data-cell-name">
-        <div class="resource-table-resource-wrapper">
+        <div class="resource-table-resource-wrapper resource-table-resource-wrapper-limit-max-width">
           <div class="oc-resource oc-text-overflow"><span><span class="oc-icon oc-icon-l oc-icon-passive oc-resource-icon oc-resource-icon-file"><!----></span></span>
             <div class="oc-resource-details oc-text-overflow"><span class="oc-text-overflow"><!----> <span data-test-resource-path="/file-path/9856" data-test-resource-name="file-path/file-name-9856" data-test-resource-type="folder" class="oc-resource-name"><span class="oc-text-truncate"><span class="oc-resource-basename">file-name-9856</span></span>
               <!----></span></span>

--- a/packages/web-app-files/tests/unit/views/shares/__snapshots__/SharedWithOthers.spec.js.snap
+++ b/packages/web-app-files/tests/unit/views/shares/__snapshots__/SharedWithOthers.spec.js.snap
@@ -27,7 +27,7 @@ exports[`SharedWithOthers view when the wrapper is not loading anymore when leng
         <oc-checkbox-stub id="resource-table-select-38" value="" option="[object Object]" label="Select folder" hidelabel="true" size="large"></oc-checkbox-stub>
       </td>
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-expand oc-text-truncate oc-table-data-cell oc-table-data-cell-name">
-        <div class="resource-table-resource-wrapper">
+        <div class="resource-table-resource-wrapper resource-table-resource-wrapper-limit-max-width">
           <oc-resource-stub folderlink="[object Object]" parentfolderlink="[object Object]" resource="[object Object]" parentfoldernamedefault="All files and folders" ispathdisplayed="true" isextensiondisplayed="true" isresourceclickable="true"></oc-resource-stub>
           <oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" class="resource-table-edit-name"><span class="oc-icon oc-icon-s oc-icon-passive"><!----></span></oc-button-stub>
         </div>
@@ -50,7 +50,7 @@ exports[`SharedWithOthers view when the wrapper is not loading anymore when leng
         <oc-checkbox-stub id="resource-table-select-64" value="" option="[object Object]" label="Select folder" hidelabel="true" size="large"></oc-checkbox-stub>
       </td>
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-expand oc-text-truncate oc-table-data-cell oc-table-data-cell-name">
-        <div class="resource-table-resource-wrapper">
+        <div class="resource-table-resource-wrapper resource-table-resource-wrapper-limit-max-width">
           <oc-resource-stub folderlink="[object Object]" parentfolderlink="[object Object]" resource="[object Object]" parentfoldernamedefault="All files and folders" ispathdisplayed="true" isextensiondisplayed="true" isresourceclickable="true"></oc-resource-stub>
           <oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" class="resource-table-edit-name"><span class="oc-icon oc-icon-s oc-icon-passive"><!----></span></oc-button-stub>
         </div>
@@ -73,7 +73,7 @@ exports[`SharedWithOthers view when the wrapper is not loading anymore when leng
         <oc-checkbox-stub id="resource-table-select-39" value="" option="[object Object]" label="Select folder" hidelabel="true" size="large"></oc-checkbox-stub>
       </td>
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-expand oc-text-truncate oc-table-data-cell oc-table-data-cell-name">
-        <div class="resource-table-resource-wrapper">
+        <div class="resource-table-resource-wrapper resource-table-resource-wrapper-limit-max-width">
           <oc-resource-stub folderlink="[object Object]" parentfolderlink="[object Object]" resource="[object Object]" parentfoldernamedefault="All files and folders" ispathdisplayed="true" isextensiondisplayed="true" isresourceclickable="true"></oc-resource-stub>
           <oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" class="resource-table-edit-name"><span class="oc-icon oc-icon-s oc-icon-passive"><!----></span></oc-button-stub>
         </div>
@@ -96,7 +96,7 @@ exports[`SharedWithOthers view when the wrapper is not loading anymore when leng
         <oc-checkbox-stub id="resource-table-select-30" value="" option="[object Object]" label="Select file" hidelabel="true" size="large"></oc-checkbox-stub>
       </td>
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-expand oc-text-truncate oc-table-data-cell oc-table-data-cell-name">
-        <div class="resource-table-resource-wrapper">
+        <div class="resource-table-resource-wrapper resource-table-resource-wrapper-limit-max-width">
           <oc-resource-stub folderlink="[object Object]" parentfolderlink="[object Object]" resource="[object Object]" parentfoldernamedefault="All files and folders" ispathdisplayed="true" isextensiondisplayed="true" isresourceclickable="true"></oc-resource-stub>
           <oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" class="resource-table-edit-name"><span class="oc-icon oc-icon-s oc-icon-passive"><!----></span></oc-button-stub>
         </div>

--- a/packages/web-runtime/tests/unit/components/__snapshots__/UploadInfo.spec.js.snap
+++ b/packages/web-runtime/tests/unit/components/__snapshots__/UploadInfo.spec.js.snap
@@ -58,7 +58,7 @@ exports[`UploadInfo component should show uploaded files without parent folder l
   <div class="upload-info-successful-uploads oc-px-m oc-pb-m oc-pt-m">
     <ul class="oc-list">
       <li class="oc-flex oc-flex-middle">
-        <oc-icon-stub name="check" filltype="fill" accessiblelabel="" type="span" size="small" variation="success" color=""></oc-icon-stub> <span class="oc-flex oc-flex-middle"><oc-resource-icon-stub resource="[object Object]" size="large" class="file_info__icon oc-mr-s"></oc-resource-icon-stub> <oc-resource-name-stub name="file" extension="" type="file" fullpath="" isextensiondisplayed="true" truncatename="true"></oc-resource-name-stub></span>
+        <oc-icon-stub name="check" filltype="fill" accessiblelabel="" type="span" size="small" variation="success" color=""></oc-icon-stub> <span class="oc-flex oc-flex-middle"><oc-resource-icon-stub resource="[object Object]" size="large" class="file_info__icon oc-mr-s"></oc-resource-icon-stub> <oc-resource-name-stub name="file" extension="" type="file" fullpath="" isextensiondisplayed="true"></oc-resource-name-stub></span>
       </li>
     </ul>
   </div>

--- a/packages/web-runtime/tests/unit/components/__snapshots__/UploadInfo.spec.js.snap
+++ b/packages/web-runtime/tests/unit/components/__snapshots__/UploadInfo.spec.js.snap
@@ -58,7 +58,7 @@ exports[`UploadInfo component should show uploaded files without parent folder l
   <div class="upload-info-successful-uploads oc-px-m oc-pb-m oc-pt-m">
     <ul class="oc-list">
       <li class="oc-flex oc-flex-middle">
-        <oc-icon-stub name="check" filltype="fill" accessiblelabel="" type="span" size="small" variation="success" color=""></oc-icon-stub> <span class="oc-flex oc-flex-middle"><oc-resource-icon-stub resource="[object Object]" size="large" class="file_info__icon oc-mr-s"></oc-resource-icon-stub> <oc-resource-name-stub name="file" extension="" type="file" fullpath="" isextensiondisplayed="true"></oc-resource-name-stub></span>
+        <oc-icon-stub name="check" filltype="fill" accessiblelabel="" type="span" size="small" variation="success" color=""></oc-icon-stub> <span class="oc-flex oc-flex-middle"><oc-resource-icon-stub resource="[object Object]" size="large" class="file_info__icon oc-mr-s"></oc-resource-icon-stub> <oc-resource-name-stub name="file" extension="" type="file" fullpath="" isextensiondisplayed="true" truncatename="true"></oc-resource-name-stub></span>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
## Description
We've fixed a bug where the rename button next to the file name would get covered if there is not enough space available.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7007

## Screenshots

Before:

![All files](https://user-images.githubusercontent.com/50302941/170260917-bd39073e-4d65-41e3-b0ce-c53c0eeb0c20.png)

After:

![All files](https://user-images.githubusercontent.com/50302941/170260930-31156818-64ce-482f-9188-307d4df2b91f.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
