### PR TITLE
[tests-only][full-ci] Get collaborator role using either button or span selector

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/SharingDialog/collaboratorsDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/SharingDialog/collaboratorsDialog.js
@@ -118,7 +118,7 @@ module.exports = {
       if (subSelectors === null) {
         subSelectors = {
           displayName: this.elements.collaboratorInformationSubName,
-          role: this.elements.collaboratorInformationSubRole,
+          role: this.elements.collaboratorInformationSubRoleBtn,
           additionalInfo: this.elements.collaboratorInformationSubAdditionalInfo,
           shareType: this.elements.collaboratorShareType
         }
@@ -142,16 +142,15 @@ module.exports = {
         const collaboratorResult = {}
         for (const attrName in subSelectors) {
           let attrElementId = null
-          await this.api.elementIdElement(
-            collaboratorElementId,
-            'css selector',
-            subSelectors[attrName],
-            (result) => {
-              if (result.status !== -1) {
-                attrElementId = result.value.ELEMENT
-              }
-            }
-          )
+
+          if (attrName === 'role') {
+            attrElementId = await this.getCollaboratorRoleElemId(collaboratorElementId)
+          } else {
+            attrElementId = await this.getElementIdElement(
+              collaboratorElementId,
+              subSelectors[attrName]
+            )
+          }
 
           if (attrElementId) {
             await this.api.elementIdText(attrElementId, (text) => {
@@ -167,6 +166,38 @@ module.exports = {
 
       results = await Promise.all(results)
       return results
+    },
+    getCollaboratorRoleElemId: async function (parentElemId) {
+      let elementId = null
+
+      elementId = await this.getElementIdElement(
+        parentElemId,
+        this.elements.collaboratorInformationSubRoleBtn
+      )
+
+      if (!elementId) {
+        elementId = await this.getElementIdElement(
+          parentElemId,
+          this.elements.collaboratorInformationSubRole
+        )
+      }
+      return elementId
+    },
+    /**
+     *
+     * @param {string} parentElemId Web Element ID
+     * @param {string} selector valid css selector
+     *
+     * @returns {Promise.<string>} Web Element ID
+     */
+    getElementIdElement: async function (parentElemId, selector) {
+      let elementId = null
+      await this.api.elementIdElement(parentElemId, 'css selector', selector, (result) => {
+        if (result.status !== -1) {
+          elementId = result.value.ELEMENT
+        }
+      })
+      return elementId
     },
     /**
      *
@@ -254,9 +285,13 @@ module.exports = {
       // within collaboratorsListItem
       selector: '.files-collaborators-collaborator-name'
     },
-    collaboratorInformationSubRole: {
+    collaboratorInformationSubRoleBtn: {
       // within collaboratorsListItem
       selector: '.files-recipient-role-select-btn:first-child'
+    },
+    collaboratorInformationSubRole: {
+      // within collaboratorsListItem
+      selector: '.files-collaborators-collaborator-role'
     },
     collaboratorInformationSubAdditionalInfo: {
       // within collaboratorsListItem

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -324,15 +324,20 @@ module.exports = {
      * @param {string} collaborator
      */
     getDisplayedPermission: async function (collaborator) {
-      await collaboratorDialog.expandShareRoleDropdown(collaborator)
-      await this.selectRole('Custom permissions')
-      // read the permissions from the checkboxes
-      const currentSharePermissions = await this.getSharePermissions()
+      let currentSharePermissions = {}
+      try {
+        await collaboratorDialog.expandShareRoleDropdown(collaborator)
+        await this.selectRole('Custom permissions')
+        // read the permissions from the checkboxes
+        currentSharePermissions = await this.getSharePermissions()
 
-      // Hide role select dropdown
-      this.moveToElement('@customPermissionsDrop', -9, 0)
-      this.api.mouseButtonClick()
-      this.waitForElementNotPresent('@customPermissionsDrop', 1000)
+        // Hide role select dropdown
+        await this.moveToElement('@customPermissionsDrop', -9, 0)
+        await this.api.mouseButtonClick()
+        await this.waitForElementNotPresent('@customPermissionsDrop', 1000)
+      } catch (e) {
+        console.info('Collaborator Role is not editable!')
+      }
       return currentSharePermissions
     },
     /**


### PR DESCRIPTION
## Description
The collaborator role can either be a dropdown or a plain text according to the share permissions. In this PR, I have refactored the `getCollaboratorsList` function to get the collaborator role either from a span or a button element.

Also, added the code that gets the permissions from a dropdown inside a try-catch block and returned empty permission if there is no dropdown elements.

## Related Issue
Changes made in https://github.com/owncloud/web/pull/7015
Closes https://github.com/owncloud/web/issues/7047

## Motivation and Context

## How Has This Been Tested?
 - local

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 