### PR TITLE
Prevent LOAD_INDICATORS from modifying store with empty changes

### DIFF
--- a/changelog/unreleased/enhancement-resourcetable-shareindicator-rendering
+++ b/changelog/unreleased/enhancement-resourcetable-shareindicator-rendering
@@ -1,0 +1,6 @@
+Enhancement: Rendering of share-indicators in ResourceTable
+
+We have improved the rendering speed of the ResourceTable by fixing some underlying logic that caused unnecessary re-renderings.
+
+https://github.com/owncloud/web/issues/7038
+https://github.com/owncloud/web/pull/7070

--- a/packages/web-app-files/src/store/mutations.js
+++ b/packages/web-app-files/src/store/mutations.js
@@ -230,7 +230,7 @@ export default {
     for (const resource of state.files) {
       const indicators = getIndicators(resource, state.sharesTree)
 
-      if (!indicators && !resource.indicators.length) {
+      if (!indicators.length && !resource.indicators.length) {
         continue
       }
 


### PR DESCRIPTION
## Description
This is a quick first step towards resolving #7038 (esp. resources that aren't shared, since their rendering gets sped up), further improvements need more sophisticated changes which will happen in a subsequent PR