### PR TITLE
[tests-only][full-ci] Wait for file container to load after login

### DIFF
--- a/tests/acceptance/helpers/loginHelper.js
+++ b/tests/acceptance/helpers/loginHelper.js
@@ -25,6 +25,8 @@ module.exports = {
     await client.page
       .webPage()
       .waitForElementVisible('@appContainer')
+      .api.page.FilesPageElement.filesList()
+      .waitForLoadingFinished()
       .then(() => {
         client.globals.currentUser = userId
       })


### PR DESCRIPTION
## Description
As per the findings in https://github.com/owncloud/web/issues/6999#issuecomment-1141722650, the flakiness in the test might be due to the DELETE action being performed before the files list is loaded completely.

This PR has added a wait for the files container to be loaded.

## Related Issue
- Closes https://github.com/owncloud/web/issues/6999

## Motivation and Context

## How Has This Been Tested?
- test environment: local

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 