### PR TITLE
Make contexthelpers opt-out, update employee keys in deployment example

### DIFF
--- a/changelog/unreleased/enhancement-enable-contexthelpers-default
+++ b/changelog/unreleased/enhancement-enable-contexthelpers-default
@@ -1,0 +1,6 @@
+Enhancement: Make contexthelpers opt-out
+
+The contextual helpers needed to actively be enabled in the configuration. 
+We have now enabled them by default and admins can disable them using the configuration.
+
+https://github.com/owncloud/web/pull/6750#issuecomment-1143753289

--- a/config/config.json.dist
+++ b/config/config.json.dist
@@ -15,8 +15,5 @@
     "search",
     "text-editor"
   ],
-  "applications" : [],
-  "options": {
-    "contextHelpers": true
-  }
+  "applications" : []
 }

--- a/config/config.json.sample-oc10
+++ b/config/config.json.sample-oc10
@@ -15,8 +15,5 @@
     "search",
     "text-editor",
     "draw-io"
-  ],
-  "options": {
-    "contextHelpers": true
-  }
+  ]
 }

--- a/config/config.json.sample-ocis
+++ b/config/config.json.sample-ocis
@@ -24,8 +24,5 @@
       "id": "settings",
       "path": "https://localhost:9200/settings.js"
     }
-  ],
-  "options": {
-    "contextHelpers": true
-  }
+  ]
 }

--- a/deployments/continuous-deployment-config/ocis_web/latest.yml
+++ b/deployments/continuous-deployment-config/ocis_web/latest.yml
@@ -24,8 +24,7 @@
       - https://github.com/kulmann.keys
       - https://github.com/micbar.keys
       - https://github.com/pascalwengerter.keys
-      - https://github.com/paulnebr.keys
-      - https://github.com/refs.keys
+      - https://github.com/lookacat.keys
       - https://github.com/wkloucek.keys
     docker_compose_projects:
       - name: web

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.js
@@ -117,9 +117,6 @@ function getWrapper({ selectedCollaborators = [], storageId, highlightedFile = f
           files_sharing: { federation: { incoming: true, outgoing: true } }
         }),
         configuration: jest.fn(() => ({
-          options: {
-            contextHelpers: true
-          },
           server: 'http://example.com/'
         }))
       }

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileLinks.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileLinks.spec.js
@@ -173,9 +173,6 @@ describe('FileLinks', () => {
     return new Vuex.Store({
       getters: {
         configuration: jest.fn(() => ({
-          options: {
-            contextHelpers: true
-          },
           server: 'http://example.com/',
           currentTheme: {
             general: {

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.js
@@ -235,7 +235,6 @@ const storeOptions = (data) => {
       getToken: jest.fn(() => 'GFwHKXdsMgoFwt'),
       configuration: jest.fn(() => ({
         options: {
-          contextHelpers: true,
           sidebar: {
             shares: {
               showAllOnLoad: false

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/SpaceMembers.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/SpaceMembers.spec.js
@@ -165,9 +165,6 @@ const storeOptions = (data, isInLoadingState) => {
     },
     getters: {
       configuration: jest.fn(() => ({
-        options: {
-          contextHelpers: true
-        },
         server: 'http://example.com/',
         currentTheme: {
           general: {

--- a/packages/web-runtime/src/store/config.js
+++ b/packages/web-runtime/src/store/config.js
@@ -38,6 +38,7 @@ const state = {
     }
   },
   options: {
+    contextHelpers: true,
     defaultExtension: 'files',
     disablePreviews: false,
     displayResourcesLazy: true,


### PR DESCRIPTION
## Related Issue
See changelog item

## Motivation and Context
Remove @refs and update @lookacat keys in the deployment example instance
