### PR TITLE
Upload progress estimation

### DIFF
--- a/changelog/unreleased/enhancement-upload-time-estimation
+++ b/changelog/unreleased/enhancement-upload-time-estimation
@@ -1,0 +1,6 @@
+Enhancement: Upload time estimation
+
+The estimated remaining time for an upload will now be displayed in the upload overlay.
+
+https://github.com/owncloud/web/pull/7088
+https://github.com/owncloud/web/issues/7066

--- a/packages/web-runtime/src/services/uppyService.ts
+++ b/packages/web-runtime/src/services/uppyService.ts
@@ -17,6 +17,7 @@ type UppyServiceTopics =
   | 'filesSelected'
   | 'progress'
   | 'addedForUpload'
+  | 'upload-progress'
 
 export class UppyService {
   uppy: Uppy
@@ -136,6 +137,9 @@ export class UppyService {
   private setUpEvents() {
     this.uppy.on('progress', (value) => {
       this.publish('progress', value)
+    })
+    this.uppy.on('upload-progress', (file, progress) => {
+      this.publish('upload-progress', { file, progress })
     })
     this.uppy.on('cancel-all', () => {
       this.publish('uploadCancelled')

--- a/packages/web-runtime/tests/unit/components/UploadInfo.spec.js
+++ b/packages/web-runtime/tests/unit/components/UploadInfo.spec.js
@@ -130,6 +130,18 @@ describe('UploadInfo component', () => {
       expect(uploadedItems.length).toBe(2)
     })
   })
+  describe('getRemainingTime method', () => {
+    it.each([
+      { ms: 1000, expected: 'Few seconds left' },
+      { ms: 1000 * 60 * 30, expected: '30 minutes left' },
+      { ms: 1000 * 60 * 60, expected: '1 hour left' },
+      { ms: 1000 * 60 * 60 * 2, expected: '2 hours left' }
+    ])('should return the proper string', ({ ms, expected }) => {
+      const wrapper = getShallowWrapper()
+      const estimatedTime = wrapper.vm.getRemainingTime(ms)
+      expect(estimatedTime).toBe(expected)
+    })
+  })
 })
 
 function createStore() {


### PR DESCRIPTION
## Description
The estimated remaining time for an upload will now be displayed in the upload overlay.

## Screenshots

![image](https://user-images.githubusercontent.com/50302941/172573262-56519800-9490-48b6-ad31-260ee6673cdd.png)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/web/issues/7069

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
