### PR TITLE
Configurable tours

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "rollup-plugin-ts": "^1.4.0",
     "rollup-plugin-visualizer": "^5.6.0",
     "rollup-plugin-vue": "^5.1.4",
+    "shepherd.js": "^9.1.0",
     "sync-fetch": "^0.3.1",
     "ts-jest": "^27.1.3",
     "ts-node": "^10.5.0",

--- a/packages/web-runtime/src/App.vue
+++ b/packages/web-runtime/src/App.vue
@@ -38,6 +38,7 @@ import LayoutLoading from './layouts/Loading.vue'
 import LayoutPlain from './layouts/Plain.vue'
 import { getBackendVersion, getWebVersion } from './container/versions'
 import { defineComponent } from '@vue/composition-api'
+import { autostartTours } from './helpers/tours'
 
 export default defineComponent({
   components: {
@@ -53,7 +54,12 @@ export default defineComponent({
   },
   computed: {
     ...mapState(['route', 'user', 'modal', 'sidebar']),
-    ...mapGetters(['configuration', 'capabilities', 'getSettingsValue']),
+    ...mapGetters([
+      'configuration',
+      'capabilities',
+      'getSettingsValue',
+      'currentTranslatedTourInfos'
+    ]),
     layout() {
       if (this.user.isAuthenticated && !this.user.userReady) {
         return LayoutLoading
@@ -93,6 +99,8 @@ export default defineComponent({
       handler: function (to) {
         this.announceRouteChange(to)
         document.title = this.extractPageTitleFromRoute(to)
+        if (this.currentTranslatedTourInfos.length > 0)
+          autostartTours(this.currentTranslatedTourInfos, to.name)
       }
     },
     capabilities: {
@@ -121,6 +129,7 @@ export default defineComponent({
         if (languageCode) {
           this.$language.current = languageCode
           document.documentElement.lang = languageCode
+          this.setCurrentTranslatedTourInfos(languageCode)
         }
       }
     }
@@ -148,7 +157,7 @@ export default defineComponent({
   },
 
   methods: {
-    ...mapActions(['fetchNotifications']),
+    ...mapActions(['fetchNotifications', 'setCurrentTranslatedTourInfos']),
 
     focusModal(component, event) {
       this.focus({

--- a/packages/web-runtime/src/components/Topbar/ThemeSwitcher.vue
+++ b/packages/web-runtime/src/components/Topbar/ThemeSwitcher.vue
@@ -5,6 +5,7 @@
     :aria-label="buttonLabel"
     appearance="raw"
     variation="inverse"
+    style="white-space: nowrap"
     @click="toggleTheme"
   >
     <span class="oc-visible@s" :aria-label="switchLabel" v-text="switchText" />

--- a/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -14,6 +14,7 @@
       <portal-target name="app.runtime.header" multiple></portal-target>
     </div>
     <div class="oc-topbar-right oc-flex oc-flex-middle oc-flex-between">
+      <tours />
       <theme-switcher v-if="darkThemeAvailable" />
       <feedback-link v-if="isFeedbackLinkEnabled" v-bind="feedbackLinkOptions" />
       <notifications v-if="isNotificationBellEnabled" />
@@ -31,6 +32,7 @@ import UserMenu from './UserMenu.vue'
 import Notifications from './Notifications.vue'
 import FeedbackLink from './FeedbackLink.vue'
 import ThemeSwitcher from './ThemeSwitcher.vue'
+import Tours from './Tours/Tours.vue'
 
 export default {
   components: {
@@ -38,7 +40,8 @@ export default {
     FeedbackLink,
     Notifications,
     ThemeSwitcher,
-    UserMenu
+    UserMenu,
+    Tours
   },
   mixins: [NavigationMixin],
   props: {

--- a/packages/web-runtime/src/components/Topbar/Tours/Tours.vue
+++ b/packages/web-runtime/src/components/Topbar/Tours/Tours.vue
@@ -1,0 +1,145 @@
+<template>
+  <div v-if="toursAllowed" id="tours">
+    <oc-button
+      v-if="tours.length === 1"
+      id="toursButton"
+      v-oc-tooltip="tours[0].tooltip"
+      size="small"
+      @click.stop="startTour(0)"
+    >
+      <oc-icon name="map" />
+      {{ tours[0].tourName }}
+    </oc-button>
+
+    <div v-else>
+      <oc-button id="toursButton" v-oc-tooltip="toursTooltip" size="small">
+        <oc-icon name="map" />
+        <translate>Tours</translate> </oc-button
+      ><oc-drop
+        ref="menu"
+        drop-id="tours"
+        toggle="#toursButton"
+        mode="click"
+        close-on-click
+        padding-size="small"
+      >
+        <oc-list class="user-menu-list">
+          <li
+            v-for="(tour, id) in tours"
+            :id="tour.tourName"
+            :key="`tour-${tour.title}-list-${id}`"
+            class="user-menu-list"
+            @click.stop="startTour(id)"
+          >
+            <oc-button v-oc-tooltip="tour.tooltip" appearance="raw">
+              <span class="profile-info-wrapper" :class="'oc-py-xs'">
+                {{ tour.tourName }}
+              </span></oc-button
+            >
+          </li></oc-list
+        >
+      </oc-drop>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+import { createTranslatedTour } from '../../../helpers/tours'
+
+export default {
+  computed: {
+    ...mapGetters(['currentTranslatedTourInfos']),
+
+    tours() {
+      return this.currentTranslatedTourInfos
+    },
+    language() {
+      return this.$language.current
+    },
+    toursAllowed() {
+      return this.tours.some((t) => this.tourAllowed(t))
+    },
+    toursTooltip() {
+      return this.$gettext('See tours through the interface')
+    }
+  },
+  methods: {
+    startTour(id) {
+      createTranslatedTour(this.tours[id]).start()
+    },
+
+    tourAllowed(tour) {
+      // if there are allowed locations, show based on them, otherwise check denied locations, otherwise show always
+      if (tour.allowedLocations?.length) return tour.allowedLocations.includes(this.$route.name)
+      else if (tour.deniedLocations?.length)
+        return !tour.deniedLocations?.includes(this.$route.name)
+      return true
+    }
+  }
+}
+</script>
+<style src="shepherd.js/dist/css/shepherd.css"></style>
+
+<style lang="scss">
+.guide-highlight {
+  background-color: var(--oc-color-background-highlight);
+}
+
+#tour {
+  height: 100%;
+  width: 100%;
+}
+.guide-img {
+  width: 100%;
+}
+.shepherd-element {
+  max-width: 700px !important;
+}
+
+.shepherd-header {
+  align-items: center !important;
+  background-color: var(--oc-color-swatch-brand-default) !important;
+  border: 1px solid var(--oc-color-swatch-brand-default) !important;
+  border: 0 !important;
+  box-shadow: 5px 0 25px rgb(0 0 0 / 30%) !important;
+  display: flex !important;
+  flex-flow: row wrap !important;
+  padding: var(--oc-space-small) var(--oc-space-medium) !important;
+  h3 {
+    color: var(--oc-color-swatch-inverse-default) !important;
+    font-size: 1rem !important;
+    font-weight: 700 !important;
+    margin: 0 !important;
+  }
+}
+.shepherd-text {
+  border-top: 1px solid var(--oc-color-swatch-brand-default) !important;
+}
+.shepherd-element {
+  border-radius: 15px !important;
+  background-color: var(--oc-color-background-default) !important;
+}
+
+.shepherd-text,
+.shepherd-footer {
+  background-color: var(--oc-color-background-default) !important;
+  border: 0 !important;
+  //box-shadow: 5px 0 25px rgb(0 0 0 / 30%) !important;
+  color: var(--oc-color-text-default) !important;
+  padding: var(--oc-space-medium) !important;
+}
+.shepherd-footer {
+  border: 0 !important;
+}
+.shepherd-button {
+  background-color: var(--oc-color-swatch-primary-default) !important;
+  border-color: var(--oc-color-swatch-primary-default) !important;
+}
+.shepherd-button-secondary {
+  background-color: initial !important;
+  color: var(--oc-color-swatch-passive-default) !important;
+  border: 1px solid transparent !important;
+  border-color: var(--oc-color-swatch-passive-default) !important;
+}
+</style>

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -224,6 +224,7 @@ export const announceTours = async ({
 }): Promise<void> => {
   const { tours } = await loadTours(runtimeConfiguration?.tours)
   await store.dispatch('setAllTranslatedTourInfos', tours)
+  await store.dispatch('setCurrentTranslatedTourInfos')
 }
 
 /**

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -5,6 +5,7 @@ import { Store } from 'vuex'
 import VueRouter from 'vue-router'
 import { VueConstructor } from 'vue'
 import { loadTheme } from '../helpers/theme'
+import { loadTours } from '../helpers/tours'
 import OwnCloud from 'owncloud-sdk'
 import { sync as routerSync } from 'vuex-router-sync'
 import getTextPlugin from 'vue-gettext'
@@ -207,6 +208,22 @@ export const announceTheme = async ({
   vue.use(designSystem, {
     tokens: store.getters.theme.designTokens
   })
+}
+
+/**
+ * announce runtime tours
+ *
+ * @param store
+ */
+export const announceTours = async ({
+  store,
+  runtimeConfiguration
+}: {
+  store: Store<unknown>
+  runtimeConfiguration?: RuntimeConfiguration
+}): Promise<void> => {
+  const { tours } = await loadTours(runtimeConfiguration?.tours)
+  await store.dispatch('setAllTranslatedTourInfos', tours)
 }
 
 /**

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -222,7 +222,7 @@ export const announceTours = async ({
   store: Store<unknown>
   runtimeConfiguration?: RuntimeConfiguration
 }): Promise<void> => {
-  const { tours } = await loadTours(runtimeConfiguration?.tours)
+  const { tours } = await loadTours(runtimeConfiguration?.options?.tours)
   await store.dispatch('setAllTranslatedTourInfos', tours)
   await store.dispatch('setCurrentTranslatedTourInfos')
 }

--- a/packages/web-runtime/src/helpers/tours.js
+++ b/packages/web-runtime/src/helpers/tours.js
@@ -56,7 +56,7 @@ export function createTranslatedTourInfos(tours) {
       }
       translatedTour.steps = []
       t.translations[language].steps.forEach((s, j) => {
-        const buttons = addButtons(s.buttons, s.moreInfoLink)
+        const buttons = addButtons(s.buttons, s.learnMoreLink)
         translatedTour.steps.push({
           title: s.title,
           text: s.text,
@@ -120,13 +120,13 @@ export function createTranslatedTour(tourInfo) {
   return tour
 }
 
-function addButtons(buttons, moreInfoLink) {
+function addButtons(buttons, learnMoreLink) {
   const actionButtons = []
 
-  moreInfoLink &&
+  learnMoreLink &&
     actionButtons.push({
       action() {
-        return window.open(moreInfoLink, '_blank').focus()
+        return window.open(learnMoreLink, '_blank').focus()
       },
       classes: 'oc-button oc-button-m oc-button-passive',
       text: $gettext('Learn more'),

--- a/packages/web-runtime/src/helpers/tours.js
+++ b/packages/web-runtime/src/helpers/tours.js
@@ -1,0 +1,162 @@
+import Shepherd from 'shepherd.js'
+import { $gettext } from 'files/src/router/utils'
+
+export const loadTours = async (locations = []) => {
+  const tours = []
+  for (const l of locations) {
+    if (l.split('.').pop() === 'json') {
+      try {
+        const response = await fetch(l)
+        if (response.ok) {
+          const tour = await response.json()
+          tours.push(tour)
+        }
+      } catch (e) {
+        console.error(`Failed to load tours '${l}' is not a valid json file.`)
+      }
+    }
+  }
+  return { tours }
+}
+/* autostarts the first tour of the tours array with autostart property if the current location matches tour settings for autostart */
+export function autostartTours(tourInfos, location) {
+  const autostartTours = tourInfos.filter((t) => t.autostart?.location === location)
+  if (autostartTours[0]) {
+    const t = autostartTours[0]
+    setTimeout(() => {
+      if (!(localStorage.getItem('tours/' + t.tourId) && location === t.autostart.location)) {
+        createTranslatedTour(t).start()
+        localStorage.setItem('tours/' + t.tourId, Date.now())
+      }
+    }, t.autostart.timeout)
+  }
+}
+
+export function createTranslatedTourInfos(tours) {
+  const createdTourInfos = {}
+  tours.forEach((t) => {
+    Object.keys(t.translations).forEach((language) => {
+      const translatedTour = {
+        tourName: t.translations[language].tourName,
+        confirmCancel: t.confirmCancel,
+        confirmCancelMessage: t.confirmCancelMessage,
+        classPrefix: t.classPrefix,
+        exitOnEsc: t.exitOnEsc,
+        useModalOverlay: t.useModalOverlay === true,
+        tooltip: t.translations[language].tooltip,
+        defaultStepOptions: {
+          ...(t.defaultStepOptions?.cancelIcon && {
+            cancelIcon: {
+              enabled: t.defaultStepOptions?.cancelIcon || false
+            }
+          }),
+          ...(t.defaultStepOptions?.classes && { classes: t.defaultStepOptions?.classes }),
+          ...(t.defaultStepOptions?.scrollTo && { scrollTo: t.defaultStepOptions.scrollTo })
+        }
+      }
+      translatedTour.steps = []
+      t.translations[language].steps.forEach((s, j) => {
+        const buttons = addButtons(s.buttons, s.moreInfoLink)
+        translatedTour.steps.push({
+          title: s.title,
+          text: s.text,
+          buttons: buttons,
+          id: j
+        })
+      })
+      translatedTour.tourId = t.tourId
+      translatedTour.autostart = t.autostart
+      translatedTour.allowedLocations = t.allowedLocations
+      translatedTour.deniedLocations = t.deniedLocations
+      translatedTour.defaultLanguage = t.defaultLanguage
+
+      if (!createdTourInfos[language]) createdTourInfos[language] = []
+      createdTourInfos[language].push(translatedTour)
+    })
+  })
+  return createdTourInfos
+}
+
+export function createTranslatedTour(tourInfo) {
+  const tour = new Shepherd.Tour({
+    tourName: tourInfo.tourName,
+    confirmCancel: tourInfo.confirmCancel,
+    confirmCancelMessage: tourInfo.confirmCancelMessage,
+    classPrefix: tourInfo.classPrefix,
+    exitOnEsc: tourInfo.exitOnEsc,
+    useModalOverlay: tourInfo.useModalOverlay === true,
+    tooltip: tourInfo.tooltip,
+    defaultStepOptions: {
+      ...(tourInfo.defaultStepOptions?.cancelIcon && {
+        cancelIcon: {
+          enabled: tourInfo.defaultStepOptions?.cancelIcon || false
+        }
+      }),
+      ...(tourInfo.defaultStepOptions?.classes && {
+        classes: tourInfo.defaultStepOptions?.classes
+      }),
+      ...(tourInfo.defaultStepOptions?.scrollTo && {
+        scrollTo: tourInfo.defaultStepOptions.scrollTo
+      })
+    }
+  })
+
+  tourInfo.steps.forEach((s, j) => {
+    const buttons = s.buttons
+
+    tour.addStep({
+      title: s.title,
+      text: s.text,
+      buttons: buttons,
+      id: j
+    })
+  })
+  tour.tourId = tourInfo.tourId
+  tour.autostart = tourInfo.autostart
+  tour.allowedLocations = tourInfo.allowedLocations
+  tour.deniedLocations = tourInfo.deniedLocations
+  tour.defaultLanguage = tourInfo.defaultLanguage
+
+  return tour
+}
+
+function addButtons(buttons, moreInfoLink) {
+  const actionButtons = []
+
+  moreInfoLink &&
+    actionButtons.push({
+      action() {
+        return window.open(moreInfoLink, '_blank').focus()
+      },
+      classes: 'oc-button oc-button-m oc-button-passive',
+      text: $gettext('Learn more'),
+      secondary: true
+    })
+
+  if (buttons.includes('back'))
+    actionButtons.push({
+      action() {
+        return this.back()
+      },
+      classes: 'oc-button oc-button-m oc-button-passive',
+      text: $gettext('Back'),
+      secondary: true
+    })
+
+  if (buttons.includes('next'))
+    actionButtons.push({
+      action() {
+        /* console.log(
+          Shepherd.activeTour.steps[
+            Shepherd.activeTour.steps.indexOf(Shepherd.activeTour.getCurrentStep()) + 1
+          ],
+          Shepherd.activeTour.steps
+        ) */
+        return this.next()
+      },
+      classes: 'oc-button oc-button-m oc-button-primary',
+      text: $gettext('Next')
+    })
+
+  return actionButtons
+}

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -21,7 +21,8 @@ import {
   announceVersions,
   applicationStore,
   announceUppyService,
-  startSentry
+  startSentry,
+  announceTours
 } from './container'
 
 export const bootstrap = async (configurationPath: string): Promise<void> => {
@@ -41,6 +42,7 @@ export const bootstrap = async (configurationPath: string): Promise<void> => {
   announceTranslations({ vue: Vue, supportedLanguages, translations })
   await announceTheme({ store, vue: Vue, designSystem, runtimeConfiguration })
   announceDefaults({ store, router })
+  await announceTours({ store, runtimeConfiguration })
 }
 
 export const renderSuccess = (): void => {

--- a/packages/web-runtime/src/store/index.js
+++ b/packages/web-runtime/src/store/index.js
@@ -10,6 +10,7 @@ import router from './router'
 import settings from './settings'
 import modal from './modal'
 import navigation from './navigation'
+import tours from './tours'
 
 const vuexPersistInSession = new VuexPersistence({
   key: 'webStateInSessionStorage',
@@ -37,7 +38,8 @@ export default {
     router,
     settings,
     modal,
-    navigation
+    navigation,
+    tours
   },
   strict
 }

--- a/packages/web-runtime/src/store/tours.js
+++ b/packages/web-runtime/src/store/tours.js
@@ -1,0 +1,50 @@
+import { createTranslatedTourInfos } from '../helpers/tours'
+
+const state = {
+  _tours: {},
+  translatedTourInfos: {},
+  currentTranslatedTourInfos: []
+}
+
+const mutations = {
+  SET_TOUR_INFOS(state, tourInfos) {
+    state._tourInfos = tourInfos
+  },
+  SET_TRANSLATED_TOUR_INFOS(state, translatedTourInfos) {
+    state.translatedTourInfos = translatedTourInfos
+  },
+  SET_CURRENT_TRANSLATED_TOUR_INFOS(state, currentTranslatedTourInfos) {
+    state.currentTranslatedTourInfos = currentTranslatedTourInfos
+  }
+}
+
+const getters = {
+  tours: (state) => {
+    return state.tourss
+  },
+  translatedTourInfos: (state) => {
+    return state.translatedTourInfos
+  },
+  currentTranslatedTourInfos: (state) => {
+    return state.currentTranslatedTourInfos
+  }
+}
+
+const actions = {
+  setAllTranslatedTourInfos(context, tourInfos) {
+    context.commit('SET_TOUR_INFOS', tourInfos)
+    const translatedTourInfos = createTranslatedTourInfos(tourInfos) || []
+    context.commit('SET_TRANSLATED_TOUR_INFOS', translatedTourInfos)
+  },
+  setCurrentTranslatedTourInfos(context, languageCode) {
+    const language = languageCode || document.documentElement.lang
+    const currentTranslatedTourInfos = context.state.translatedTourInfos[language] || []
+    context.commit('SET_CURRENT_TRANSLATED_TOUR_INFOS', currentTranslatedTourInfos)
+  }
+}
+export default {
+  state,
+  mutations,
+  getters,
+  actions
+}

--- a/packages/web-runtime/tours/example_tour.json
+++ b/packages/web-runtime/tours/example_tour.json
@@ -1,0 +1,72 @@
+{
+  "translations": {
+    "en": {
+      "tourName": "Example Tour",
+      "tooltip": "See new features",
+      "steps": [
+        {
+          "title": "Example News",
+          "text": "Discover the new features and try them yourself",
+          "buttons": ["back", "next"],
+          "learnMoreLink": "https://doc.owncloud.com/docs/next/"
+        },
+        {
+          "title": "1.  Example Feature",
+          "text": "<div><p>Example feature description </p><p>Example feature description 2 </p></div>",
+          "buttons": ["back", "next"],
+          "learnMoreLink": "https://doc.owncloud.com/docs/next/"
+        },
+        {
+          "title": "Coming soon",
+          "text": "<div><p>Other features will be coming in the coming months</p>\r\n    <p> Stay tuned!</p></div>",
+          "buttons": ["back", "next"]
+        }
+      ]
+    },
+    "de": {
+      "tourName": "Beispielstour",
+      "tooltip": "Entdecke neue Features",
+      "steps": [
+        {
+          "title": "Beispielsneugigkeiten!",
+          "text": "Entdecke neue Features und probiere sie aus",
+          "buttons": ["back", "next"],
+          "learnMoreLink": "https://doc.owncloud.com/docs/next/"
+        },
+        {
+          "title": "1.  Beispielsfeature",
+          "text": "<div><p> Beschreibung des Features </p><p> Beschreibung des Features 2</p></div>",
+          "buttons": ["back", "next"],
+          "learnMoreLink": "https://doc.owncloud.com/docs/next/"
+        },
+        {
+          "title": "Bald:",
+          "text": "<div><p>Mehr Festures werden in kommenden Monaten verfügbar sein</p>\r\n  <p> Bleib dran!</p></div>",
+          "buttons": ["back", "next"]
+        }
+      ]
+    }
+  },
+  "confirmCancel": false,
+  "confirmCancelMessage": "",
+  "classPrefix": "",
+  "defaultStepOptions": {
+    "cancelIcon": {
+      "enabled": true
+    },
+    "classes": "a",
+    "scrollTo": {
+      "behavior": "smooth",
+      "block": "center"
+    }
+  },
+  "exitOnEsc": true,
+  "allowedLocations": [],
+  "deniedLocations": ["files-operations-resolver-public-link", "files-public-files"],
+  "useModalOverlay": true,
+  "tourId": "Example Tour",
+  "autostart": {
+    "timeout": 3000,
+    "location": "files-spaces-personal-home"
+  }
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -94,6 +94,7 @@ const plugins = [
       { src: './packages/web-container/img/*', dest: 'img' },
       { src: './packages/web-container/*.{html,json,txt}' },
       { src: './packages/web-runtime/themes/**/*', dest: 'themes' },
+      { src: './packages/web-runtime/tours/*', dest: 'tours' },
       { src: `./config/${production ? 'config.json.dist' : 'config.json'}` }
     ]
   }),


### PR DESCRIPTION
## Description
Configurable tours 

Following implemented:
- Property "tours" in "options" in config.js for linking json files for tours saved in packages/web-runtime/tours 
 Example:` "options": {"tours": ["https://localhost:9200/tours/tour1.json", "https://localhost:9200/tours/tour2.json"],..}`
- Each json file in packages/web-runtime/tours  is considered as a tour and has the following properties:
  - `translations`: object with language codes as keys and translatable tour options (`tourName`, `tooltip`, `steps`) as values
  - options of tour from shepherd.js
  - `autostart` option including location (route name) and timeout in ms to trigger. Only triggering once (when triggered, saved to localStorage)
  - `allowLocations` option: array with locations in which the tour will be available. If set, the tour will not be available in other locations
  - `denyLocations` option: array with locations in which the tour will not be available. If set is not set, the tour will be available in all locations except of these locations. Is not considered if `allowLocations` is set

- By one tour the button in the topbar will be the button to start this tour, by several the  <oc-drop> component will be shown
- Buttons inside each step have hard-coded options `"back"`, `"next"

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <[Guide through the interface](https://github.com/owncloud/web/issues/6695)>

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:

## Screenshots:
![tours](https://user-images.githubusercontent.com/7430156/173312450-9f92db28-7eec-4afc-b76f-6d181c63577c.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] automatize showing buttons "next" and "back"
- [ ] implement the possibility to attach events to steps
