### PR TITLE
Fix complete-state of the upload overlay

### DIFF
--- a/changelog/unreleased/bugfix-upload-overlay-complete-state
+++ b/changelog/unreleased/bugfix-upload-overlay-complete-state
@@ -1,0 +1,6 @@
+Bugfix: Complete-state of the upload overlay
+
+We've fixed a bug where the complete-state of the upload overlay would show before the upload even started.
+
+https://github.com/owncloud/web/pull/7100
+https://github.com/owncloud/web/issues/7097

--- a/packages/web-runtime/src/components/UploadInfo.vue
+++ b/packages/web-runtime/src/components/UploadInfo.vue
@@ -166,7 +166,10 @@ export default {
       if (this.errors.length) {
         return this.$gettext('Upload failed')
       }
-      return this.$gettext('Upload complete')
+      if (!this.runningUploads) {
+        return this.$gettext('Upload complete')
+      }
+      return this.$gettext('Preparing upload...')
     },
     uploadingLabel() {
       if (this.errors.length) {


### PR DESCRIPTION
## Description
We've fixed a bug where the complete-state of the upload overlay would show before the upload even started.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7097

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
