### PR TITLE
Fix parent folder name in the upload overlay on public pages

### DIFF
--- a/changelog/unreleased/bugfix-upload-overlay-public-parent-folder
+++ b/changelog/unreleased/bugfix-upload-overlay-public-parent-folder
@@ -1,0 +1,6 @@
+Bugfix: Parent folder name on public links
+
+We've fixed a bug where the parent folder link in the upload overlay on public pages would show the link's token instead of "Public link".
+
+https://github.com/owncloud/web/pull/7104
+https://github.com/owncloud/web/issues/7101

--- a/packages/web-runtime/src/components/UploadInfo.vue
+++ b/packages/web-runtime/src/components/UploadInfo.vue
@@ -336,7 +336,7 @@ export default {
 
       this.uploads[file.meta.uploadId] = file
 
-      if (file.meta.route.name === 'files-public-files') {
+      if (file.meta.route?.name === 'files-public-files') {
         // Strip token to not display it in the overlay
         const strippedTokenPath = file.meta.currentFolder.split('/').slice(1).join('/')
         this.uploads[file.meta.uploadId].path = `${strippedTokenPath}${file.name}`

--- a/packages/web-runtime/src/components/UploadInfo.vue
+++ b/packages/web-runtime/src/components/UploadInfo.vue
@@ -335,7 +335,14 @@ export default {
       }
 
       this.uploads[file.meta.uploadId] = file
-      this.uploads[file.meta.uploadId].path = `${file.meta.currentFolder}${file.name}`
+
+      if (file.meta.route.name === 'files-public-files') {
+        // Strip token to not display it in the overlay
+        const strippedTokenPath = file.meta.currentFolder.split('/').slice(1).join('/')
+        this.uploads[file.meta.uploadId].path = `${strippedTokenPath}${file.name}`
+      } else {
+        this.uploads[file.meta.uploadId].path = `${file.meta.currentFolder}${file.name}`
+      }
       this.uploads[file.meta.uploadId].targetRoute = file.meta.route
 
       if (!file.isFolder) {
@@ -426,6 +433,10 @@ export default {
       if (this.hasShareJail && targetRoute?.name === 'files-spaces-share') {
         return targetRoute.params.shareName
       }
+
+      if (targetRoute?.name === 'files-public-files') {
+        return this.$gettext('Public link')
+      }
       return this.hasShareJail ? this.$gettext('Personal') : this.$gettext('All files and folders')
     },
     createFolderLink(path, storageId, targetRoute) {
@@ -447,6 +458,10 @@ export default {
       if (strippedPath) {
         route.params = { ...targetRoute.params }
         route.params.item = strippedPath
+      }
+
+      if (route.name === 'files-public-files') {
+        route.params.item = targetRoute.params.item
       }
 
       return route


### PR DESCRIPTION
## Description
We've fixed a bug where the parent folder link in the upload overlay on public pages would show the link's token instead of "Public link".

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7101


## Screenshots

![image](https://user-images.githubusercontent.com/50302941/172818391-96ba395b-5eb2-4745-a4f2-10fd567b5879.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
