### PR TITLE
Fix reload of space image/readme after being updated

### DIFF
--- a/changelog/unreleased/bugfix-space-image-readme-loading
+++ b/changelog/unreleased/bugfix-space-image-readme-loading
@@ -1,0 +1,5 @@
+Bugfix: Reload of an updated space-image and/or -readme
+
+We've fixed a bug where the image and/or readme for a space wouldn't reload automatically after being updated.
+
+https://github.com/owncloud/web/pull/7108

--- a/packages/web-app-files/src/views/spaces/Project.vue
+++ b/packages/web-app-files/src/views/spaces/Project.vue
@@ -263,7 +263,8 @@ export default defineComponent({
         if (!val) {
           return
         }
-        const webDavPathComponents = this.space.spaceImageData.webDavUrl.split('/')
+        const decodedUri = decodeURI(this.space.spaceImageData.webDavUrl)
+        const webDavPathComponents = decodedUri.split('/')
         const idComponent = webDavPathComponents.find((c) => c.startsWith(this.space.id))
         if (!idComponent) {
           return
@@ -295,7 +296,8 @@ export default defineComponent({
         if (!val) {
           return
         }
-        const webDavPathComponents = this.space.spaceReadmeData.webDavUrl.split('/')
+        const decodedUri = decodeURI(this.space.spaceReadmeData.webDavUrl)
+        const webDavPathComponents = decodedUri.split('/')
         const idComponent = webDavPathComponents.find((c) => c.startsWith(this.space.id))
         if (!idComponent) {
           return

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -206,7 +206,8 @@ export default defineComponent({
             continue
           }
 
-          const webDavPathComponents = space.spaceImageData.webDavUrl.split('/')
+          const decodedUri = decodeURI(space.spaceImageData.webDavUrl)
+          const webDavPathComponents = decodedUri.split('/')
           const idComponent = webDavPathComponents.find((c) => c.startsWith(space.id))
           if (!idComponent) {
             return


### PR DESCRIPTION
## Description
We've fixed a bug where the image and/or readme for a space wouldn't reload automatically after being updated.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
