### PR TITLE
Implement clickable folder links in upload overlay

### DIFF
--- a/changelog/unreleased/enhancement-upload-overlay-folder-links
+++ b/changelog/unreleased/enhancement-upload-overlay-folder-links
@@ -1,0 +1,6 @@
+Enhancement: Clickable folder links in upload overlay
+
+Uploaded folders can now be clicked in the upload overlay, which navigates the user to the clicked folder.
+
+https://github.com/owncloud/web/pull/7109
+https://github.com/owncloud/web/issues/7102

--- a/packages/web-runtime/src/components/UploadInfo.vue
+++ b/packages/web-runtime/src/components/UploadInfo.vue
@@ -107,7 +107,7 @@
             :resource="item"
             :is-path-displayed="true"
             :is-thumbnail-displayed="displayThumbnails"
-            :is-resource-clickable="false"
+            :is-resource-clickable="isResourceClickable(item)"
             :parent-folder-name-default="defaultParentFolderName(item)"
             :folder-link="folderLink(item)"
             :parent-folder-link="parentFolderLink(item)"
@@ -416,6 +416,9 @@ export default {
     },
     displayFileAsResource(file) {
       return !!file.targetRoute
+    },
+    isResourceClickable(file) {
+      return file.isFolder === true
     },
     folderLink(file) {
       return this.createFolderLink(file.path, file.storageId, file.targetRoute)

--- a/packages/web-runtime/tests/unit/components/UploadInfo.spec.js
+++ b/packages/web-runtime/tests/unit/components/UploadInfo.spec.js
@@ -129,6 +129,18 @@ describe('UploadInfo component', () => {
       const uploadedItems = wrapper.findAll('.upload-info-items li')
       expect(uploadedItems.length).toBe(2)
     })
+    it('folder is clickable', () => {
+      const wrapper = getShallowWrapper({
+        showInfo: true,
+        infoExpanded: true,
+        uploads: [{ name: 'file', type: 'folder', isFolder: true, targetRoute: {}, path: '' }]
+      })
+
+      const info = wrapper.find('.upload-info-items')
+      expect(info.exists()).toBeTruthy()
+      const resourceStub = wrapper.find('.upload-info-items li oc-resource-stub')
+      expect(resourceStub.props().isResourceClickable).toBeTruthy()
+    })
   })
   describe('getRemainingTime method', () => {
     it.each([


### PR DESCRIPTION
## Description
Uploaded folders can now be clicked in the upload overlay, which navigates the user to the clicked folder.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7102

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
