### PR TITLE
Use tus chunksize from backend

### DIFF
--- a/changelog/unreleased/enhancement-tus-backend-chunksize
+++ b/changelog/unreleased/enhancement-tus-backend-chunksize
@@ -1,5 +1,5 @@
 Enhancement: Use tus chunksize from backend
 
-Instead of using the tus chunksize from the web config, we now use the chunksize coming from the backend (if set).
+We now use the chunksize value coming from the backend for uploading via tus. If no chunksize is given, it will default to `Infinity`. The Web config `uploadChunkSize` has been removed as a result.
 
 https://github.com/owncloud/web/pull/7120

--- a/changelog/unreleased/enhancement-tus-backend-chunksize
+++ b/changelog/unreleased/enhancement-tus-backend-chunksize
@@ -1,0 +1,5 @@
+Enhancement: Use tus chunksize from backend
+
+Instead of using the tus chunksize from the web config, we now use the chunksize coming from the backend (if set).
+
+https://github.com/owncloud/web/pull/7120

--- a/packages/web-runtime/src/composables/upload/useUpload.ts
+++ b/packages/web-runtime/src/composables/upload/useUpload.ts
@@ -55,7 +55,6 @@ export function useUpload(options: UploadOptions): UploadResult {
   const tusHttpMethodOverride = useCapabilityFilesTusSupportHttpMethodOverride()
   const tusMaxChunkSize = useCapabilityFilesTusSupportMaxChunkSize()
   const tusExtension = useCapabilityFilesTusExtension()
-  const uploadChunkSize = computed((): number => store.getters.configuration.uploadChunkSize)
 
   const headers = computed((): { [key: string]: string } => {
     if (unref(isPublicLocation) || unref(isPublicDropLocation)) {
@@ -78,7 +77,6 @@ export function useUpload(options: UploadOptions): UploadResult {
       return {
         isTusSupported,
         tusMaxChunkSize: unref(tusMaxChunkSize),
-        uploadChunkSize: unref(uploadChunkSize),
         tusHttpMethodOverride: unref(tusHttpMethodOverride),
         tusExtension: unref(tusExtension),
         headers: unref(headers)

--- a/packages/web-runtime/src/services/uppyService.ts
+++ b/packages/web-runtime/src/services/uppyService.ts
@@ -43,11 +43,7 @@ export class UppyService {
     tusExtension: string
     headers: { [key: string]: string }
   }) {
-    const chunkSize =
-      tusMaxChunkSize > 0 && uploadChunkSize !== Infinity
-        ? Math.max(tusMaxChunkSize, uploadChunkSize)
-        : uploadChunkSize
-
+    const chunkSize = tusMaxChunkSize > 0 ? tusMaxChunkSize : uploadChunkSize
     const uploadDataDuringCreation = tusExtension.includes('creation-with-upload')
 
     const tusPluginOptions = {

--- a/packages/web-runtime/src/services/uppyService.ts
+++ b/packages/web-runtime/src/services/uppyService.ts
@@ -32,18 +32,16 @@ export class UppyService {
 
   useTus({
     tusMaxChunkSize,
-    uploadChunkSize,
     tusHttpMethodOverride,
     tusExtension,
     headers
   }: {
     tusMaxChunkSize: number
-    uploadChunkSize: number
     tusHttpMethodOverride: boolean
     tusExtension: string
     headers: { [key: string]: string }
   }) {
-    const chunkSize = tusMaxChunkSize || uploadChunkSize
+    const chunkSize = tusMaxChunkSize || Infinity
     const uploadDataDuringCreation = tusExtension.includes('creation-with-upload')
 
     const tusPluginOptions = {

--- a/packages/web-runtime/src/services/uppyService.ts
+++ b/packages/web-runtime/src/services/uppyService.ts
@@ -43,7 +43,7 @@ export class UppyService {
     tusExtension: string
     headers: { [key: string]: string }
   }) {
-    const chunkSize = tusMaxChunkSize > 0 ? tusMaxChunkSize : uploadChunkSize
+    const chunkSize = tusMaxChunkSize || uploadChunkSize
     const uploadDataDuringCreation = tusExtension.includes('creation-with-upload')
 
     const tusPluginOptions = {

--- a/packages/web-runtime/src/store/config.js
+++ b/packages/web-runtime/src/store/config.js
@@ -85,7 +85,6 @@ const mutations = {
     state.server = config.server.endsWith('/') ? config.server : config.server + '/'
     state.auth = config.auth
     state.openIdConnect = config.openIdConnect
-    state.uploadChunkSize = config.uploadChunkSize === undefined ? Infinity : config.uploadChunkSize
     state.state = config.state === undefined ? 'working' : config.state
     state.applications = config.applications === undefined ? [] : config.applications
     if (config.options !== undefined) {


### PR DESCRIPTION
## Description
Instead of using the tus chunksize from the web config, we now use the chunksize coming from the backend (if set).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
