### PR TITLE
[full-ci] Fix unloading user with oc10 backend

### DIFF
--- a/changelog/unreleased/bugfix-not-logged-out-if-oC10-backend
+++ b/changelog/unreleased/bugfix-not-logged-out-if-oC10-backend
@@ -4,3 +4,4 @@ We've fixed an issue, where the user won't be logged out if the backend is ownCl
 
 https://github.com/owncloud/web/pull/6939
 https://github.com/owncloud/web/issues/5886
+https://github.com/owncloud/web/pull/7128


### PR DESCRIPTION
## Description
While already being redirected to the logout URL of oc10 (killing the server side session) we had an intermediate issue of the user in oC Web not being unloaded. As a result, upon next login we still had the previous user available from the session storage. Fixed by not suppressing the user removal inside the oidc-client anymore, but instead deciding inside the `userUnloaded` event if we are in an oauth2 context and then redirect properly.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/5886 more than before

## Motivation and Context
Harden the oc10 integration.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
