### PR TITLE
Drop version from sample configs and ci configs (it's unused)

### DIFF
--- a/config/config.json.dist
+++ b/config/config.json.dist
@@ -1,7 +1,6 @@
 {
   "server" : "",
   "theme": "https://localhost:9200/themes/owncloud/theme.json",
-  "version": "0.1.0",
   "auth": {
     "clientId": "",
     "url": "",

--- a/config/config.json.sample-oc10
+++ b/config/config.json.sample-oc10
@@ -1,7 +1,6 @@
 {
   "server" : "http://localhost:8080",
   "theme": "https://localhost:9100/themes/owncloud/theme.json",
-  "version": "0.1.0",
   "auth": {
     "clientId": "UmCVsEIxdWmssxa6uVRRPC3txYBVN4qqxooJbsPhuuoPmHk9Pt9Oy68N4ZaKXUYy",
     "url": "http://localhost:8080/index.php/apps/oauth2/api/v1/token",

--- a/config/config.json.sample-ocis
+++ b/config/config.json.sample-ocis
@@ -1,7 +1,6 @@
 {
   "server": "https://localhost:9200",
   "theme": "https://localhost:9200/themes/owncloud/theme.json",
-  "version": "0.1.0",
   "openIdConnect": {
     "metadata_url": "https://localhost:9200/.well-known/openid-configuration",
     "authority": "https://localhost:9200",

--- a/dev/docker/ocis.web.config.json
+++ b/dev/docker/ocis.web.config.json
@@ -1,7 +1,6 @@
 {
   "server": "https://host.docker.internal:9200",
   "theme": "https://host.docker.internal:9200/themes/owncloud/theme.json",
-  "version": "0.1.0",
   "openIdConnect": {
     "metadata_url": "https://host.docker.internal:9200/.well-known/openid-configuration",
     "authority": "https://host.docker.internal:9200",

--- a/tests/drone/config-oc10-oauth.json
+++ b/tests/drone/config-oc10-oauth.json
@@ -1,7 +1,6 @@
 {
   "server": "http://owncloud",
   "theme": "http://owncloud/themes/owncloud/theme.json",
-  "version": "0.1.0",
   "auth": {
     "clientId": "Cxfj9F9ZZWQbQZps1E1M0BszMz6OOFq3lxjSuc8Uh4HLEYb9KIfyRMmgY5ibXXrU",
     "url": "http://owncloud/index.php/apps/oauth2/api/v1/token",

--- a/tests/drone/config-oc10-openid.json
+++ b/tests/drone/config-oc10-openid.json
@@ -1,7 +1,6 @@
 {
   "server": "http://owncloud/",
   "theme": "http://owncloud/themes/owncloud/theme.json",
-  "version": "0.1.0",
   "openIdConnect": {
     "metadata_url": "https://idp:9130/.well-known/openid-configuration",
     "authority": "https://idp:9130",

--- a/tests/drone/config-ocis.json
+++ b/tests/drone/config-ocis.json
@@ -1,7 +1,6 @@
 {
   "server": "https://ocis:9200",
   "theme": "https://ocis:9200/themes/owncloud/theme.json",
-  "version": "0.1.0",
   "openIdConnect": {
     "metadata_url": "https://ocis:9200/.well-known/openid-configuration",
     "authority": "https://ocis:9200",


### PR DESCRIPTION
The version in our `config.json` is not used. At least not anymore. Removing it from all sample configs and CI configs.