### PR TITLE
[full-ci] Allow additional mimeTypes via preview app config

### DIFF
--- a/changelog/unreleased/enhancement-preview-additional-mimetypes
+++ b/changelog/unreleased/enhancement-preview-additional-mimetypes
@@ -1,0 +1,6 @@
+Enhancement: Customize additional mimeTypes for preview app
+
+We've added support for customizing additional mimeTypes for the preview app. In case the backend supports more mimeTypes than our hardcoded list in the preview app, you can now announce them to ownCloud Web with additional config. See https://owncloud.dev/clients/web/deployments/oc10-app/#additional-configuration-for-certain-core-apps
+
+https://github.com/owncloud/web/issues/6933
+https://github.com/owncloud/web/pull/7131

--- a/docs/deployments/oc10-app.md
+++ b/docs/deployments/oc10-app.md
@@ -225,6 +225,31 @@ Make sure that Collabora Online works as expected in the Classic UI and add the 
 The URL in the example might need adaptations depending on the configuration of your ownCloud Server.
 {{< /hint >}}
 
+## Additional configuration for certain core apps
+There is additional configuration available for certain core apps. You can find them listed below.
+
+### Preview app
+In case the backend has additional preview providers configured there is no mechanism, yet, to announce those to the `Preview` app in ownCloud Web. As an intermediate solution you can add the additional supported mimeTypes to the `Preview` app by following these steps:
+1. Remove the `"preview"` string from the `"apps"` section in your `config.json` file
+2. Add the following config to your `config.json` file:
+```json
+"external_apps": [
+    {
+      "id": "preview",
+      "path": "web-app-preview",
+      "config": {
+        "mimeTypes": ["image/tiff", "image/webp"]
+      }
+    }
+  ],
+```
+
+If you already have an `"external_apps"` section, just add the preview app to the list. Please adjust the `"mimeTypes"` list according to your additional preview providers. See https://github.com/owncloud/files_mediaviewer#supporting-more-media-types for advise on how to add preview providers to the backend.
+
+{{< hint info >}}
+The reason why the `preview` app needs to be ported from the `apps` section to the `external_apps` section is that only the `external_apps` support additional configuration. There are plans to change the configuration of apps to give you a coherent admin experience in that regard. 
+{{< /hint >}}
+
 ## Accessing ownCloud Web
 After following all the steps, you should see a new entry in the application switcher called `New Design` which points to the ownCloud web.
 

--- a/packages/web-app-preview/src/App.vue
+++ b/packages/web-app-preview/src/App.vue
@@ -173,7 +173,7 @@ export default defineComponent({
       }
 
       return this.activeFiles.filter((file) => {
-        return Preview.mimeTypes.includes(file.mimeType?.toLowerCase())
+        return Preview.mimeTypes().includes(file.mimeType?.toLowerCase())
       })
     },
     activeFilteredFile() {

--- a/packages/web-app-preview/src/index.js
+++ b/packages/web-app-preview/src/index.js
@@ -6,6 +6,8 @@ function $gettext(msg) {
   return msg
 }
 
+const appId = 'preview'
+
 const routes = [
   {
     path: '/:filePath*',
@@ -33,13 +35,13 @@ const mimeTypes = () => {
     'image/png',
     'video/mp4',
     'video/webm',
-    ...(window.Vue.$store.getters.extensionConfigByAppId(appInfo.id).mimeTypes || [])
+    ...(window.Vue.$store.getters.extensionConfigByAppId(appId).mimeTypes || [])
   ]
 }
 
 const appInfo = {
   name: $gettext('Preview'),
-  id: 'preview',
+  id: appId,
   icon: 'eye',
   extensions: mimeTypes().map((mimeType) => ({
     canBeDefault: true,

--- a/packages/web-app-preview/src/index.js
+++ b/packages/web-app-preview/src/index.js
@@ -20,25 +20,28 @@ const routes = [
 ]
 
 const routeName = 'preview-media'
-const mimeTypes = [
-  'audio/flac',
-  'audio/mpeg',
-  'audio/ogg',
-  'audio/wav',
-  'audio/x-flac',
-  'audio/x-wav',
-  'image/gif',
-  'image/jpeg',
-  'image/png',
-  'video/mp4',
-  'video/webm'
-]
+const mimeTypes = () => {
+  return [
+    'audio/flac',
+    'audio/mpeg',
+    'audio/ogg',
+    'audio/wav',
+    'audio/x-flac',
+    'audio/x-wav',
+    'image/gif',
+    'image/jpeg',
+    'image/png',
+    'video/mp4',
+    'video/webm',
+    ...(window.Vue.$store.getters.extensionConfigByAppId(appInfo.id).mimeTypes || [])
+  ]
+}
 
 const appInfo = {
   name: $gettext('Preview'),
   id: 'preview',
   icon: 'eye',
-  extensions: mimeTypes.map((mimeType) => ({
+  extensions: mimeTypes().map((mimeType) => ({
     canBeDefault: true,
     mimeType,
     routeName,

--- a/packages/web-runtime/src/store/apps.js
+++ b/packages/web-runtime/src/store/apps.js
@@ -4,6 +4,7 @@ const state = {
     edit: false
   },
   fileEditors: [],
+  fileEditorConfigs: {},
   newFileHandlers: [],
   fileSideBars: [],
   customFilesListIndicators: [],
@@ -134,7 +135,10 @@ const getters = {
   fileSideBars: (state) => {
     return state.fileSideBars
   },
-  customFilesListIndicators: (state) => state.customFilesListIndicators
+  customFilesListIndicators: (state) => state.customFilesListIndicators,
+  extensionConfigByAppId: (state) => (appId) => {
+    return state.fileEditorConfigs[appId] || {}
+  }
 }
 
 export default {


### PR DESCRIPTION
## Description
As a mitigation for supported preview types not being announced by the backend, this PR adds support for adding additional mime types via the config.json.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/6933

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
