### PR TITLE
[tests-only][full-ci] Wait for upload success message

### DIFF
--- a/tests/acceptance/pageObjects/personalPage.js
+++ b/tests/acceptance/pageObjects/personalPage.js
@@ -161,12 +161,7 @@ module.exports = {
      */
     uploadFile: function (filePath) {
       return this.selectFileForUpload(filePath)
-        .waitForElementVisible(
-          '@fileUploadProgress',
-          this.api.globals.waitForNegativeConditionTimeout,
-          this.api.globals.waitForConditionPollInterval,
-          false
-        )
+        .waitForElementVisible('@fileUploadStatus')
         .closeFileFolderUploadProgress()
     },
 
@@ -216,12 +211,7 @@ module.exports = {
         .click('@uploadFilesButton')
         .waitForElementVisible('@fileUploadButton')
         .setValue('@folderUploadInput', folderName)
-        .waitForElementVisible(
-          '@fileUploadProgress',
-          this.api.globals.waitForNegativeConditionTimeout,
-          this.api.globals.waitForConditionPollInterval,
-          false
-        )
+        .waitForElementVisible('@fileUploadStatus')
         .closeFileFolderUploadProgress()
     },
     /**
@@ -417,6 +407,9 @@ module.exports = {
     },
     fileUploadProgress: {
       selector: '#upload-info'
+    },
+    fileUploadStatus: {
+      selector: '.upload-info-status .upload-info-success, .upload-info-status .upload-info-danger'
     },
     filesFoldersUploadProgressClose: {
       selector: '#upload-info #close-upload-info-btn'


### PR DESCRIPTION
## Description
Sometimes `uploadFolder` might fail to close the upload-info dialog due to change in element reference (for what may be the reason). In this PR, I have made upload functions to wait for upload-status message to be visible and then only close the dialog.

## Related Issue
- Fixes #7143

## Motivation and Context

## How Has This Been Tested?
- test environment: local

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
