### PR TITLE
Fix issue #7149 (indirect linkShareRole calculation)

### DIFF
--- a/changelog/unreleased/enhancement-redesign-link-sharing
+++ b/changelog/unreleased/enhancement-redesign-link-sharing
@@ -6,3 +6,5 @@ Additionally, creating new links now is less cumbersome and the default name, wh
 https://github.com/owncloud/web/pull/6749
 https://github.com/owncloud/web/pull/6885
 https://github.com/owncloud/web/pull/6961
+https://github.com/owncloud/web/issues/7149
+https://github.com/owncloud/web/pull/7150

--- a/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
@@ -53,7 +53,7 @@
             :available-role-options="availableRoleOptions"
             :can-rename="true"
             :expiration-date="expirationDate"
-            :is-folder-share="highlightedFile.isFolder"
+            :is-folder-share="link.indirect || highlightedFile.isFolder"
             :is-modifiable="canEdit && !link.indirect"
             :is-password-enforced="isPasswordEnforcedFor(link)"
             :link="link"
@@ -319,7 +319,7 @@ export default defineComponent({
     isPasswordEnforcedFor(link) {
       const currentRole = LinkShareRoles.getByBitmask(
         parseInt(link.permissions),
-        this.highlightedFile.isFolder
+        link.indirect || this.highlightedFile.isFolder
       )
 
       const canRead = currentRole.hasPermission(SharePermissions.read)


### PR DESCRIPTION
## Related Issue
- Fixes #7149 (indirect link shares used the currently highlighted resource's isFolder property, which ofc is wrong - an indirect link always exists on one of the parent folders)

