### PR TITLE
Render all non-video and non-audio mime types as images in preview app

### DIFF
--- a/changelog/unreleased/bugfix-preview-mimetype-mapping
+++ b/changelog/unreleased/bugfix-preview-mimetype-mapping
@@ -1,0 +1,5 @@
+Bugfix: Map unknown mime types to image rendering in Preview app
+
+Mime types that don't start with `video/`, `audio/` or `image/` were not rendered by the preview app. Files with unknown mime type category are now being rendered as images.
+
+https://github.com/owncloud/web/pull/7161

--- a/packages/web-app-preview/src/App.vue
+++ b/packages/web-app-preview/src/App.vue
@@ -215,16 +215,16 @@ export default defineComponent({
       return this.getUrlForResource(this.activeFilteredFile)
     },
 
-    isActiveFileTypeVideo() {
-      return this.activeFilteredFile.mimeType.toLowerCase().startsWith('video')
-    },
-
     isActiveFileTypeImage() {
-      return this.activeFilteredFile.mimeType.toLowerCase().startsWith('image')
+      return !this.isActiveFileTypeAudio && !this.isActiveFileTypeVideo
     },
 
     isActiveFileTypeAudio() {
       return this.activeFilteredFile.mimeType.toLowerCase().startsWith('audio')
+    },
+
+    isActiveFileTypeVideo() {
+      return this.activeFilteredFile.mimeType.toLowerCase().startsWith('video')
     },
 
     isUrlSigningEnabled() {


### PR DESCRIPTION
## Description
The preview app only rendered `image/`, `video/` and `audio/` mime types. Now all non-`audio/` and non-`video/` mime types are rendered as images.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
