### PR TITLE
External apps fixes

### DIFF
--- a/changelog/unreleased/bugfix-external-apps
+++ b/changelog/unreleased/bugfix-external-apps
@@ -1,0 +1,7 @@
+Bugfix: External apps fixes
+
+Bug introduced in #6870. A method used to communicate with the backend was not properly added to the extension after being moved to a different location.
+
+(bonus: app name back in the title)
+
+https://github.com/owncloud/web/pull/7166

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -103,6 +103,17 @@ export default {
       return this.$route.query.fileId
     }
   },
+  mounted() {
+    if (this.appName) {
+      document.title = [
+        this.currentFileContext.fileName,
+        this.appName,
+        this.configuration.currentTheme.general.name
+      ]
+        .filter(Boolean)
+        .join(' - ')
+    }
+  },
   async created() {
     await unauthenticatedUserReady(this.$router, this.$store)
 

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -130,9 +130,7 @@ export default {
         return
       }
 
-      const data = await response.json()
-
-      if (!data.app_url || !data.method) {
+      if (!response.data.app_url || !response.data.method) {
         this.errorMessage = this.$gettext('Error in app server response')
         this.loading = false
         this.loadingError = true
@@ -140,9 +138,9 @@ export default {
         return
       }
 
-      this.appUrl = data.app_url
-      this.method = data.method
-      if (data.form_parameters) this.formParameters = data.form_parameters
+      this.appUrl = response.data.app_url
+      this.method = response.data.method
+      if (response.data.form_parameters) this.formParameters = response.data.form_parameters
 
       if (this.method === 'POST' && this.formParameters) {
         this.$nextTick(() => this.$refs.subm.click())

--- a/packages/web-app-external/tests/unit/app.spec.js
+++ b/packages/web-app-external/tests/unit/app.spec.js
@@ -143,7 +143,7 @@ describe('The app provider extension', () => {
       Promise.resolve({
         ok: true,
         status: 200,
-        json: () => providerSuccessResponseGet
+        data: providerSuccessResponseGet
       })
     )
 
@@ -158,7 +158,7 @@ describe('The app provider extension', () => {
       Promise.resolve({
         ok: true,
         status: 200,
-        json: () => providerSuccessResponsePost
+        data: providerSuccessResponsePost
       })
     )
     const wrapper = createShallowMountWrapper(makeRequest)

--- a/packages/web-pkg/src/composables/appDefaults/useAppDefaults.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppDefaults.ts
@@ -15,7 +15,7 @@ import { useAppConfig, AppConfigResult } from './useAppConfig'
 import { useAppFileHandling, AppFileHandlingResult } from './useAppFileHandling'
 import { useAppFolderHandling, AppFolderHandlingResult } from './useAppFolderHandling'
 import { useAppDocumentTitle } from './useAppDocumentTitle'
-import { usePublicLinkPassword, usePublicLinkContext } from '../authContext'
+import { usePublicLinkPassword, usePublicLinkContext, useRequest } from '../authContext'
 import { useClientService } from '../clientService'
 
 // TODO: this file/folder contains file/folder loading logic extracted from preview and drawio extensions
@@ -76,6 +76,7 @@ export function useAppDefaults(options: AppDefaultsOptions): AppDefaultsResult {
       isPublicLinkContext,
       publicLinkPassword
     }),
-    ...useAppFolderHandling({ clientService, store, isPublicLinkContext, publicLinkPassword })
+    ...useAppFolderHandling({ clientService, store, isPublicLinkContext, publicLinkPassword }),
+    ...useRequest({ clientService, store, currentRoute: unref(currentRoute) })
   }
 }


### PR DESCRIPTION
#6870 brought a couple of issues.. One, is that external apps extension is completely broken, because `makeRequest` was moved to a different place and never imported into defaultApps.
The second is that the behavior of the method has also changed. (Draw.io is [still broken when importing visio files](https://github.com/owncloud/web/blob/e80a417fc0a4b8e4dd78d4a159499afa3ba26d9c/packages/web-app-draw-io/src/App.vue#L171-L177)).

The other - not as important - regression is that the app name no longer appears in the title.