### PR TITLE
Continue external apps fix

### DIFF
--- a/changelog/unreleased/bugfix-external-app-title
+++ b/changelog/unreleased/bugfix-external-app-title
@@ -1,0 +1,5 @@
+Bugfix: Re-introduce dynamic app name in document title
+
+The `external` app was missing the dynamic app name after some recent refactoring. It has been reintroduced.
+
+https://github.com/owncloud/web/pull/7173

--- a/changelog/unreleased/bugfix-external-apps
+++ b/changelog/unreleased/bugfix-external-apps
@@ -1,0 +1,6 @@
+Bugfix: External apps fixes
+
+Bug introduced in #6870. A method used to communicate with the backend was not properly added to the extension after being moved to a different location.
+
+https://github.com/owncloud/web/pull/7166
+https://github.com/owncloud/web/pull/7173

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -103,6 +103,17 @@ export default {
       return this.$route.query.fileId
     }
   },
+  mounted() {
+    if (this.appName) {
+      document.title = [
+        this.currentFileContext.fileName,
+        this.appName,
+        this.configuration.currentTheme.general.name
+      ]
+        .filter(Boolean)
+        .join(' - ')
+    }
+  },
   async created() {
     await unauthenticatedUserReady(this.$router, this.$store)
 

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -141,9 +141,7 @@ export default {
         return
       }
 
-      const data = await response.json()
-
-      if (!data.app_url || !data.method) {
+      if (!response.data.app_url || !response.data.method) {
         this.errorMessage = this.$gettext('Error in app server response')
         this.loading = false
         this.loadingError = true
@@ -151,9 +149,9 @@ export default {
         return
       }
 
-      this.appUrl = data.app_url
-      this.method = data.method
-      if (data.form_parameters) this.formParameters = data.form_parameters
+      this.appUrl = response.data.app_url
+      this.method = response.data.method
+      if (response.data.form_parameters) this.formParameters = response.data.form_parameters
 
       if (this.method === 'POST' && this.formParameters) {
         this.$nextTick(() => this.$refs.subm.click())

--- a/packages/web-app-external/tests/unit/app.spec.js
+++ b/packages/web-app-external/tests/unit/app.spec.js
@@ -143,7 +143,7 @@ describe('The app provider extension', () => {
       Promise.resolve({
         ok: true,
         status: 200,
-        json: () => providerSuccessResponseGet
+        data: providerSuccessResponseGet
       })
     )
 
@@ -158,7 +158,7 @@ describe('The app provider extension', () => {
       Promise.resolve({
         ok: true,
         status: 200,
-        json: () => providerSuccessResponsePost
+        data: providerSuccessResponsePost
       })
     )
     const wrapper = createShallowMountWrapper(makeRequest)
@@ -178,7 +178,8 @@ function createShallowMountWrapper(makeRequest, options = {}) {
       $route
     },
     computed: {
-      currentFileContext: () => $route.params
+      currentFileContext: () => $route.params,
+      applicationName: () => $route.query.app
     },
     methods: {
       getFileInfo: mockFileInfo,

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -30,7 +30,7 @@
           </li>
           <li
             v-for="(newFileHandler, key) in newFileHandlers"
-            :key="key"
+            :key="`file-creation-item-${key}`"
             class="create-list-file oc-menu-item-hover"
           >
             <oc-button
@@ -48,7 +48,7 @@
           <template v-if="mimetypesAllowedForCreation">
             <li
               v-for="(mimetype, key) in mimetypesAllowedForCreation"
-              :key="key"
+              :key="`file-creation-item-external-${key}`"
               class="create-list-file oc-menu-item-hover"
             >
               <oc-button

--- a/packages/web-pkg/src/composables/appDefaults/useAppDefaults.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppDefaults.ts
@@ -15,7 +15,7 @@ import { useAppConfig, AppConfigResult } from './useAppConfig'
 import { useAppFileHandling, AppFileHandlingResult } from './useAppFileHandling'
 import { useAppFolderHandling, AppFolderHandlingResult } from './useAppFolderHandling'
 import { useAppDocumentTitle } from './useAppDocumentTitle'
-import { usePublicLinkPassword, usePublicLinkContext } from '../authContext'
+import { usePublicLinkPassword, usePublicLinkContext, useRequest } from '../authContext'
 import { useClientService } from '../clientService'
 
 // TODO: this file/folder contains file/folder loading logic extracted from preview and drawio extensions
@@ -76,6 +76,7 @@ export function useAppDefaults(options: AppDefaultsOptions): AppDefaultsResult {
       isPublicLinkContext,
       publicLinkPassword
     }),
-    ...useAppFolderHandling({ clientService, store, isPublicLinkContext, publicLinkPassword })
+    ...useAppFolderHandling({ clientService, store, isPublicLinkContext, publicLinkPassword }),
+    ...useRequest({ clientService, store, currentRoute: unref(currentRoute) })
   }
 }

--- a/packages/web-pkg/src/composables/appDefaults/useAppDefaults.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppDefaults.ts
@@ -9,7 +9,8 @@ import {
   useAppNavigation,
   AppNavigationResult,
   contextQueryToFileContextProps,
-  contextRouteNameKey
+  contextRouteNameKey,
+  queryItemAsString
 } from './useAppNavigation'
 import { useAppConfig, AppConfigResult } from './useAppConfig'
 import { useAppFileHandling, AppFileHandlingResult } from './useAppFileHandling'
@@ -17,6 +18,7 @@ import { useAppFolderHandling, AppFolderHandlingResult } from './useAppFolderHan
 import { useAppDocumentTitle } from './useAppDocumentTitle'
 import { usePublicLinkPassword, usePublicLinkContext, useRequest } from '../authContext'
 import { useClientService } from '../clientService'
+import { MaybeRef } from '../../utils'
 
 // TODO: this file/folder contains file/folder loading logic extracted from preview and drawio extensions
 // Discussion how to progress from here can be found in this issue:
@@ -24,6 +26,7 @@ import { useClientService } from '../clientService'
 
 interface AppDefaultsOptions {
   applicationId: string
+  applicationName?: MaybeRef<string>
   clientService?: ClientService
 }
 
@@ -46,14 +49,6 @@ export function useAppDefaults(options: AppDefaultsOptions): AppDefaultsResult {
   const publicLinkPassword = usePublicLinkPassword({ store })
 
   const currentFileContext = computed((): FileContext => {
-    const queryItemAsString = (queryItem: string | string[]) => {
-      if (Array.isArray(queryItem)) {
-        return queryItem[0]
-      }
-
-      return queryItem
-    }
-
     const path = `/${unref(currentRoute).params.filePath?.split('/').filter(Boolean).join('/')}`
 
     return {
@@ -64,7 +59,13 @@ export function useAppDefaults(options: AppDefaultsOptions): AppDefaultsResult {
     }
   })
 
-  useAppDocumentTitle({ store, document, applicationId, currentFileContext })
+  useAppDocumentTitle({
+    store,
+    document,
+    applicationId,
+    applicationName: options.applicationName,
+    currentFileContext
+  })
 
   return {
     isPublicLinkContext,

--- a/packages/web-pkg/src/composables/appDefaults/useAppDocumentTitle.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppDocumentTitle.ts
@@ -4,11 +4,13 @@ import { FileContext } from './types'
 import { useAppMeta } from './useAppMeta'
 import { useDocumentTitle } from './useDocumentTitle'
 import { Store } from 'vuex'
+import { MaybeRef } from '../../utils'
 
 interface AppDocumentTitleOptions {
   store: Store<any>
   document: Document
   applicationId: string
+  applicationName?: MaybeRef<string>
   currentFileContext: Ref<FileContext>
 }
 
@@ -16,6 +18,7 @@ export function useAppDocumentTitle({
   store,
   document,
   applicationId,
+  applicationName,
   currentFileContext
 }: AppDocumentTitleOptions): void {
   const appMeta = useAppMeta({ applicationId, store })
@@ -24,7 +27,11 @@ export function useAppDocumentTitle({
     const fileName = basename(unref(unref(currentFileContext).fileName))
     const meta = unref(unref(appMeta).applicationMeta)
 
-    return [fileName, meta.name || meta.id, store.getters.configuration.currentTheme.general.name]
+    return [
+      fileName,
+      unref(applicationName) || meta.name || meta.id,
+      store.getters.configuration.currentTheme.general.name
+    ]
       .filter(Boolean)
       .join(' - ')
   })

--- a/packages/web-pkg/src/composables/appDefaults/useAppNavigation.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppNavigation.ts
@@ -51,7 +51,7 @@ export const contextQueryToFileContextProps = (
   }
 }
 
-const queryItemAsString = (queryItem: string | string[]) => {
+export const queryItemAsString = (queryItem: string | string[]) => {
   if (Array.isArray(queryItem)) {
     return queryItem[0]
   }


### PR DESCRIPTION
## Description
Continuation of https://github.com/owncloud/web/pull/7166 which provides an option to override the application name in the document title (and using it from the external app) to reduce code duplication.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
