### PR TITLE
Allow blocking file extensions of text-editor

### DIFF
--- a/changelog/unreleased/enhancement-text-editor-block-file-extensions
+++ b/changelog/unreleased/enhancement-text-editor-block-file-extensions
@@ -1,0 +1,6 @@
+Enhancement: Option to block file extensions from text-editor app
+
+We've added support to block certain file extensions from the text-editor app with additional config. See https://owncloud.dev/clients/web/deployments/oc10-app/#additional-configuration-for-certain-core-apps
+
+https://github.com/owncloud/web/issues/6661
+https://github.com/owncloud/web/pull/7174

--- a/docs/deployments/oc10-app.md
+++ b/docs/deployments/oc10-app.md
@@ -241,13 +241,37 @@ In case the backend has additional preview providers configured there is no mech
         "mimeTypes": ["image/tiff", "image/webp"]
       }
     }
-  ],
+  ]
 ```
 
 If you already have an `"external_apps"` section, just add the preview app to the list. Please adjust the `"mimeTypes"` list according to your additional preview providers. See https://github.com/owncloud/files_mediaviewer#supporting-more-media-types for advise on how to add preview providers to the backend.
 
+### Text-Editor app
+The `text-editor` app provides a list of file extensions that the app is associated with, both for opening files and for creating new files. 
+By default, only `.txt` and `.md` files appear in the file creation menu and offer the text-editor as default app on a left mouse click 
+in the file list. For other file types the text-editor app only appears in the right mouse click context menu. In case you want to change this 
+default set of primary file extensions for the text-editor you can overwrite it as follows:
+1. Remove the `"text-editor"` string from the `"apps"` section in your `config.json` file
+2. Add the following config to your `config.json` file:
+```json
+"external_apps": [
+    {
+      "id": "text-editor",
+      "path": "web-app-text-editor",
+      "config": {
+        "primaryExtensions": ["txt", "yaml"]
+      }
+    }
+  ]
+```
+With the above example config the text editor will offer creation of new files for `.txt` and `.yaml` files instead of `.txt` and `.md` files. 
+Also, a left mouse click on any `.txt` or `.yaml` file will open the respective file in the text-editor app. In this example, `.md` files would 
+not be opened in the text-editor by default anymore, but the text-editor will would appear in the context menu for the file as alternative app. 
+
+If you already have an `"external_apps"` section, just add the preview app to the list. Please adjust the `"mimeTypes"` list according to your additional preview providers. See https://github.com/owncloud/files_mediaviewer#supporting-more-media-types for advise on how to add preview providers to the backend.
+ 
 {{< hint info >}}
-The reason why the `preview` app needs to be ported from the `apps` section to the `external_apps` section is that only the `external_apps` support additional configuration. There are plans to change the configuration of apps to give you a coherent admin experience in that regard. 
+The reason why the app needs to be ported from the `apps` section to the `external_apps` section is that only the `external_apps` support additional configuration. There are plans to change the configuration of apps to give you a coherent admin experience in that regard. 
 {{< /hint >}}
 
 ## Accessing ownCloud Web

--- a/packages/web-app-text-editor/src/index.js
+++ b/packages/web-app-text-editor/src/index.js
@@ -6,6 +6,8 @@ function $gettext(msg) {
   return msg
 }
 
+const appId = 'text-editor'
+
 const routes = [
   {
     path: '/:filePath*',
@@ -19,41 +21,76 @@ const routes = [
   }
 ]
 
-const fileExtensionConfig = {
-  canBeDefault: true
+const fileExtensions = () => {
+  const extensions = [
+    {
+      extension: 'txt',
+      label: $gettext('Plain text file')
+    },
+    {
+      extension: 'md',
+      label: $gettext('Markdown file')
+    },
+    {
+      extension: 'js',
+      label: $gettext('JavaScript file')
+    },
+    {
+      extension: 'json',
+      label: $gettext('JSON file')
+    },
+    {
+      extension: 'xml',
+      label: $gettext('XML file')
+    },
+    {
+      extension: 'py',
+      label: $gettext('Python file')
+    },
+    {
+      extension: 'php',
+      label: $gettext('PHP file')
+    },
+    {
+      extension: 'yaml',
+      label: $gettext('YAML file')
+    }
+  ]
+
+  let primaryExtensions = window.Vue.$store.getters.extensionConfigByAppId(appId)
+    .primaryExtensions || ['txt', 'md']
+  if (typeof primaryExtensions === 'string') {
+    primaryExtensions = [primaryExtensions]
+  }
+  return extensions.reduce((acc, extensionItem) => {
+    if (primaryExtensions.includes(extensionItem.extension)) {
+      extensionItem.canBeDefault = true
+      extensionItem.newFileMenu = {
+        menuTitle($gettext) {
+          return $gettext(extensionItem.label)
+        }
+      }
+    }
+    acc.push(extensionItem)
+    return acc
+  }, [])
 }
 
 const appInfo = {
   name: $gettext('Text Editor'),
-  id: 'text-editor',
+  id: appId,
   icon: 'file-text',
   isFileEditor: true,
-  extensions: [
-    {
-      extension: 'txt',
-      newFileMenu: {
-        menuTitle($gettext) {
-          return $gettext('Plain text file')
-        }
-      },
-      ...fileExtensionConfig
-    },
-    {
-      extension: 'md',
-      newFileMenu: {
-        menuTitle($gettext) {
-          return $gettext('Markdown file')
-        }
-      },
-      ...fileExtensionConfig
+  extensions: fileExtensions().map((extensionItem) => {
+    return {
+      extension: extensionItem.extension,
+      ...(Object.prototype.hasOwnProperty.call(extensionItem, 'newFileMenu') && {
+        newFileMenu: extensionItem.newFileMenu
+      }),
+      ...(Object.prototype.hasOwnProperty.call(extensionItem, 'canBeDefault') && {
+        canBeDefault: extensionItem.canBeDefault
+      })
     }
-  ]
-}
-
-for (const ext of ['js', 'json', 'xml', 'py', 'php', 'yaml']) {
-  appInfo.extensions.push({
-    extension: ext,
-    ...fileExtensionConfig
   })
 }
 

--- a/packages/web-app-text-editor/src/index.js
+++ b/packages/web-app-text-editor/src/index.js
@@ -63,8 +63,9 @@ const fileExtensions = () => {
     primaryExtensions = [primaryExtensions]
   }
   return extensions.reduce((acc, extensionItem) => {
-    if (primaryExtensions.includes(extensionItem.extension)) {
-      extensionItem.canBeDefault = true
+    const isPrimary = primaryExtensions.includes(extensionItem.extension)
+    extensionItem.canBeDefault = isPrimary
+    if (isPrimary) {
       extensionItem.newFileMenu = {
         menuTitle($gettext) {
           return $gettext(extensionItem.label)


### PR DESCRIPTION
## Description
Allow to block file extensions of the text-editor app

## Related Issue
- Works towards https://github.com/owncloud/web/issues/6661

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
