### PR TITLE
Improve performance of share indicators

### DIFF
--- a/changelog/unreleased/enhancement-share-indicators-performance
+++ b/changelog/unreleased/enhancement-share-indicators-performance
@@ -1,0 +1,6 @@
+Enhancement: Improve performance of share indicators
+
+We've improved the performance of share indicators when loading resource tables as well as when adding or removing shares.
+
+https://github.com/owncloud/web/issues/7038
+https://github.com/owncloud/web/pull/7188

--- a/packages/web-app-files/src/services/folder/legacy/loaderPersonal.ts
+++ b/packages/web-app-files/src/services/folder/legacy/loaderPersonal.ts
@@ -39,19 +39,16 @@ export class FolderLoaderLegacyPersonal implements FolderLoader {
         resources = resources.map(buildResource)
 
         const currentFolder = resources.shift()
+        yield store.dispatch('Files/loadSharesTree', {
+          client,
+          path: currentFolder.path
+        })
 
         store.commit('Files/LOAD_FILES', {
           currentFolder,
-          files: resources
+          files: resources,
+          loadIndicators: true
         })
-
-        // load indicators
-        ;(() => {
-          store.dispatch('Files/loadIndicators', {
-            client: client,
-            currentFolder: currentFolder.path
-          })
-        })()
 
         // fetch user quota
         ;(async () => {

--- a/packages/web-app-files/src/services/folder/spaces/loaderPersonal.ts
+++ b/packages/web-app-files/src/services/folder/spaces/loaderPersonal.ts
@@ -36,18 +36,16 @@ export class FolderLoaderSpacesPersonal implements FolderLoader {
 
         const currentFolder = resources.shift()
 
-        store.commit('Files/LOAD_FILES', {
-          currentFolder,
-          files: resources
+        yield store.dispatch('Files/loadSharesTree', {
+          client: clientService.owncloudSdk,
+          path: currentFolder.path
         })
 
-        // load indicators
-        ;(() => {
-          store.dispatch('Files/loadIndicators', {
-            client: clientService.owncloudSdk,
-            currentFolder: currentFolder.path
-          })
-        })()
+        store.commit('Files/LOAD_FILES', {
+          currentFolder,
+          files: resources,
+          loadIndicators: true
+        })
 
         // fetch user quota
         ;(async () => {

--- a/packages/web-app-files/src/services/folder/spaces/loaderProject.ts
+++ b/packages/web-app-files/src/services/folder/spaces/loaderProject.ts
@@ -65,16 +65,17 @@ export class FolderLoaderSpacesProject implements FolderLoader {
       }
 
       const currentFolder = resources.shift()
+      yield store.dispatch('Files/loadSharesTree', {
+        client: clientService.owncloudSdk,
+        path: currentFolder.path
+      })
 
       ref.LOAD_FILES({
         currentFolder,
-        files: resources
+        files: resources,
+        loadIndicators: true
       })
-      ref.loadIndicators({
-        client: ref.$client,
-        currentFolder: currentFolder?.path,
-        storageId: space.id
-      })
+
       ref.UPSERT_SPACE(space)
 
       if (!sameRoute) {

--- a/packages/web-app-files/src/store/actions.js
+++ b/packages/web-app-files/src/store/actions.js
@@ -730,7 +730,7 @@ export default {
     // TODO: when we refactor the shares tree we want to modify shares tree nodes incrementally during adding and removing shares, not loading everything new from the backend.
     commit('SHARESTREE_PRUNE_OUTSIDE_PATH', dirname(currentFolder))
     await dispatch('loadSharesTree', { client, path: currentFolder, storageId })
-    commit('LOAD_INDICATORS')
+    commit('LOAD_INDICATORS', currentFolder)
   },
 
   loadAvatars({ commit, rootGetters }, { resource }) {

--- a/packages/web-app-files/src/store/mutations.js
+++ b/packages/web-app-files/src/store/mutations.js
@@ -53,8 +53,15 @@ export default {
   CLEAR_SPACES(state) {
     state.spaces = []
   },
-  LOAD_FILES(state, { currentFolder, files }) {
+  LOAD_FILES(state, { currentFolder, files, loadIndicators = false }) {
     state.currentFolder = currentFolder
+
+    if (loadIndicators) {
+      for (const file of files) {
+        file.indicators = getIndicators(file, state.sharesTree)
+      }
+    }
+
     state.files = files
   },
   SET_CURRENT_FOLDER(state, currentFolder) {
@@ -238,8 +245,9 @@ export default {
     state.versions = versions
   },
 
-  LOAD_INDICATORS(state) {
-    for (const resource of state.files) {
+  LOAD_INDICATORS(state, path) {
+    const files = state.files.filter((f) => f.path.startsWith(path))
+    for (const resource of files) {
       const indicators = getIndicators(resource, state.sharesTree)
 
       if (!indicators.length && !resource.indicators.length) {

--- a/packages/web-app-files/tests/unit/views/spaces/Project.spec.js
+++ b/packages/web-app-files/tests/unit/views/spaces/Project.spec.js
@@ -144,7 +144,7 @@ describe('Spaces project view', () => {
         })
       })
 
-      const wrapper = getMountedWrapper([], { id: 1 })
+      const wrapper = getMountedWrapper([Files['/'][0]], { id: 1 })
       await wrapper.vm.loadResourcesTask.last
 
       expect(wrapper.find(selectors.spaceImage).exists()).toBeFalsy()
@@ -285,7 +285,8 @@ function getMountedWrapper(spaceResources = [], spaceItem = null, imageContent =
           },
           actions: {
             loadIndicators: jest.fn(),
-            loadCurrentFileOutgoingShares: jest.fn()
+            loadCurrentFileOutgoingShares: jest.fn(),
+            loadSharesTree: jest.fn()
           },
           getters: {
             activeFiles: () => spaceResources,


### PR DESCRIPTION
## Description
We've improved the performance of share indicators when loading resource tables as well as when adding or removing shares.

In detail:

* Accessing a shared folder: The share indicators now get loaded initially with the resources. The store then gets updated once, including all indicators. Before, the store was updated after the initial load. Also, this happened for each resource, resulting in a re-render of each table row.
* Creating shares & public links: Instead of loading share indicators for all resources in the store, we now only load those for the current file (and files inside a folder).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/web/issues/7038

## Performance measurements

Tests were done with a shared folder including 800 files. Note that the measured time is generally longer when the measurement tool is running. This means the tool is fine for a before- & after-comparison, but not for evaluating the total time as it would be much faster without the measurement.

**Accessing the folder:**

Without optimization (~ 8,5 s):

![Pasted Graphic 1](https://user-images.githubusercontent.com/50302941/176133481-b313d262-45df-4ba0-952f-4b9151aedd9d.png)

With optimization (~ 6,5 s):

![Pasted Graphic](https://user-images.githubusercontent.com/50302941/176133408-77d89629-b6ea-4c77-878b-ed421b6a53b5.png)

**Creating a public link for a resource within the folder:**

Without optimization (~ 11 s):

![image](https://user-images.githubusercontent.com/50302941/176176302-65b150aa-3c83-47b7-b932-2252bdbb7d85.png)

With optimization (~ 6,5 s):

![image](https://user-images.githubusercontent.com/50302941/176175336-f2402bd6-3527-47c7-ab30-3754d82b9b31.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

