### PR TITLE
[full-ci] Migrate deny-acl UI code from CERNbox

### DIFF
--- a/changelog/unreleased/enhancement-deny-subfolder-share
+++ b/changelog/unreleased/enhancement-deny-subfolder-share
@@ -1,0 +1,5 @@
+Enhancement: Deny subfolders inside share
+
+Subfolders within non-link shares can now be denied for certain share receivers if the backend is capabable of negative ACLs.
+
+https://github.com/owncloud/web/pull/7190

--- a/changelog/unreleased/enhancement-deny-subfolder-share
+++ b/changelog/unreleased/enhancement-deny-subfolder-share
@@ -1,5 +1,7 @@
 Enhancement: Deny subfolders inside share
 
-Subfolders within non-link shares can now be denied for certain share receivers if the backend is capabable of negative ACLs.
+Sub-folders within user- and group-shares can now be denied for certain share receivers if the backend is capable of negative ACLs.
+Please note that the state of this feature is experimental and needs to be enabled in the backend.
 
 https://github.com/owncloud/web/pull/7190
+https://github.com/owncloud/web/issues/7180

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
@@ -170,7 +170,7 @@ export default defineComponent({
     inviteLabel() {
       if (this.selectedRole.hasCustomPermissions) {
         return this.$gettext('Invite with custom permissions')
-      } else if (this.selectedRole.permissions().includes(SharePermissions.deny)) {
+      } else if (this.selectedRole.permissions().includes(SharePermissions.denied)) {
         return this.$gettext('Deny access')
       } else {
         return this.$gettextInterpolate(this.$gettext('Invite as %{ name }'), {
@@ -189,7 +189,7 @@ export default defineComponent({
     },
     availableRoles() {
       if (this.resourceIsSpace) {
-        return SpacePeopleShareRoles.list(this.resource.canDeny())
+        return SpacePeopleShareRoles.list()
       }
 
       if (this.incomingParentShare.value && this.resourceIsSharable) {

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
@@ -170,6 +170,8 @@ export default defineComponent({
     inviteLabel() {
       if (this.selectedRole.hasCustomPermissions) {
         return this.$gettext('Invite with custom permissions')
+      } else if (this.selectedRole.permissions().includes(SharePermissions.deny)) {
+        return this.$gettext('Deny access')
       } else {
         return this.$gettextInterpolate(this.$gettext('Invite as %{ name }'), {
           name: this.$gettext(this.selectedRole.inlineLabel) || ''
@@ -187,7 +189,7 @@ export default defineComponent({
     },
     availableRoles() {
       if (this.resourceIsSpace) {
-        return SpacePeopleShareRoles.list()
+        return SpacePeopleShareRoles.list(this.resource.canDeny())
       }
 
       if (this.incomingParentShare.value && this.resourceIsSharable) {
@@ -199,7 +201,11 @@ export default defineComponent({
         )
       }
 
-      return PeopleShareRoles.list(this.resource.isFolder, this.allowCustomSharing !== false)
+      return PeopleShareRoles.list(
+        this.resource.isFolder,
+        this.allowCustomSharing !== false,
+        this.resource.canDeny()
+      )
     },
     availablePermissions() {
       if (this.incomingParentShare.value && this.resourceIsSharable) {
@@ -234,7 +240,10 @@ export default defineComponent({
       } else if (this.resourceIsSpace) {
         this.selectedRole = SpacePeopleShareRoles.list()[0]
       } else {
-        this.selectedRole = PeopleShareRoles.list(this.resource.isFolder)[0]
+        this.selectedRole = PeopleShareRoles.list(
+          this.resource.isFolder,
+          this.resource.canDeny()
+        )[0]
       }
 
       if (this.selectedRole.hasCustomPermissions) {

--- a/packages/web-app-files/src/helpers/resources.ts
+++ b/packages/web-app-files/src/helpers/resources.ts
@@ -272,7 +272,7 @@ export function buildSharedResource(
     resource.canShare = () => true
     resource.canRename = () => true
     resource.canBeDeleted = () => true
-    resource.canDeny = () => SharePermissions.deny.enabled(share.permissions)
+    resource.canDeny = () => SharePermissions.denied.enabled(share.permissions)
   }
 
   resource.extension = extractExtensionFromFile(resource)

--- a/packages/web-app-files/src/helpers/resources.ts
+++ b/packages/web-app-files/src/helpers/resources.ts
@@ -107,6 +107,9 @@ export function buildResource(resource): Resource {
     isReceivedShare: function () {
       return this.permissions.indexOf(DavPermission.Shared) >= 0
     },
+    canDeny: function () {
+      return this.permissions.indexOf(DavPermission.Deny) >= 0
+    },
     getDomSelector: () => extractDomSelector(id)
   }
 }
@@ -269,6 +272,7 @@ export function buildSharedResource(
     resource.canShare = () => true
     resource.canRename = () => true
     resource.canBeDeleted = () => true
+    resource.canDeny = () => SharePermissions.deny.enabled(share.permissions)
   }
 
   resource.extension = extractExtensionFromFile(resource)

--- a/packages/web-app-files/src/helpers/resources.ts
+++ b/packages/web-app-files/src/helpers/resources.ts
@@ -272,7 +272,6 @@ export function buildSharedResource(
     resource.canShare = () => true
     resource.canRename = () => true
     resource.canBeDeleted = () => true
-    resource.canDeny = () => SharePermissions.denied.enabled(share.permissions)
   }
 
   resource.extension = extractExtensionFromFile(resource)
@@ -280,6 +279,7 @@ export function buildSharedResource(
   resource.canUpload = () => SharePermissions.create.enabled(share.permissions)
   resource.isMounted = () => false
   resource.share = buildShare(share, resource, allowSharePermission)
+  resource.canDeny = () => SharePermissions.denied.enabled(share.permissions)
   resource.getDomSelector = () => extractDomSelector(share.id)
 
   return resource

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/RoleDropdown.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/RoleDropdown.spec.js
@@ -305,6 +305,7 @@ function getResource({
     shareTypes: [],
     downloadURL: '',
     isReceivedShare: () => isReceivedShare,
-    canShare: () => true
+    canShare: () => true,
+    canDeny: () => false
   }
 }

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.js
@@ -173,7 +173,8 @@ function getResource({
     isReceivedShare: () => true,
     canBeDeleted: () => true,
     canRename: () => true,
-    canShare: () => canShare
+    canShare: () => canShare,
+    canDeny: () => false
   }
 }
 

--- a/packages/web-client/src/helpers/resource/types.ts
+++ b/packages/web-client/src/helpers/resource/types.ts
@@ -34,6 +34,7 @@ export interface Resource {
   canRename?(): boolean
   canBeDeleted?(): boolean
   canBeRestored?(): boolean
+  canDeny?(): boolean
 
   isReceivedShare?(): boolean
   isMounted?(): boolean

--- a/packages/web-client/src/helpers/share/permission.ts
+++ b/packages/web-client/src/helpers/share/permission.ts
@@ -61,6 +61,8 @@ export abstract class SharePermissions {
 
   static readonly share = new SharePermission('share', SharePermissionBit.Share, $gettext('Share'))
 
+  static readonly deny = new SharePermission('deny', 64, $gettext('Deny'))
+
   static permissionsToBitmask(permissions: SharePermission[]): number {
     return (permissions || []).reduce((b: number, p: SharePermission) => b | p.bit, 0)
   }

--- a/packages/web-client/src/helpers/share/permission.ts
+++ b/packages/web-client/src/helpers/share/permission.ts
@@ -61,7 +61,7 @@ export abstract class SharePermissions {
 
   static readonly share = new SharePermission('share', SharePermissionBit.Share, $gettext('Share'))
 
-  static readonly deny = new SharePermission('deny', 64, $gettext('Deny'))
+  static readonly denied = new SharePermission('denied', 64, $gettext('Deny'))
 
   static permissionsToBitmask(permissions: SharePermission[]): number {
     return (permissions || []).reduce((b: number, p: SharePermission) => b | p.bit, 0)

--- a/packages/web-client/src/helpers/share/role.ts
+++ b/packages/web-client/src/helpers/share/role.ts
@@ -186,12 +186,12 @@ export const peopleRoleCustomFolder = new CustomShareRole(
   ]
 )
 export const peopleRoleDenyFolder = new PeopleShareRole(
-  'deny',
+  'denied',
   true,
-  $gettext('Deny'),
-  $gettext('deny'),
-  'user -unfollow',
-  [SharePermissions.deny]
+  $gettext('No access'),
+  $gettext('no access'),
+  'user-unfollow',
+  [SharePermissions.denied]
 )
 export const linkRoleInternalFile = new LinkShareRole(
   'none',

--- a/packages/web-client/src/helpers/share/role.ts
+++ b/packages/web-client/src/helpers/share/role.ts
@@ -185,6 +185,14 @@ export const peopleRoleCustomFolder = new CustomShareRole(
     SharePermissions.share
   ]
 )
+export const peopleRoleDenyFolder = new PeopleShareRole(
+  'deny',
+  true,
+  $gettext('Deny'),
+  $gettext('deny'),
+  'user -unfollow',
+  [SharePermissions.deny]
+)
 export const linkRoleInternalFile = new LinkShareRole(
   'none',
   false,
@@ -288,7 +296,8 @@ export abstract class SpacePeopleShareRoles {
   }
 
   static getByBitmask(bitmask: number): ShareRole {
-    return this.all.find((r) => r.bitmask(true) === bitmask)
+    return this.all // Retrieve all possible options always, even if deny is not enabled
+      .find((r) => r.bitmask(true) === bitmask)
   }
 }
 
@@ -302,8 +311,11 @@ export abstract class PeopleShareRoles {
 
   static readonly allWithCustom = [...this.all, peopleRoleCustomFile, peopleRoleCustomFolder]
 
-  static list(isFolder: boolean, hasCustom = true): ShareRole[] {
-    return (hasCustom ? this.allWithCustom : this.all).filter((r) => r.folder === isFolder)
+  static list(isFolder: boolean, hasCustom = true, canDeny = false): ShareRole[] {
+    return [
+      ...(hasCustom ? this.allWithCustom : this.all),
+      ...(canDeny ? [peopleRoleDenyFolder] : [])
+    ].filter((r) => r.folder === isFolder)
   }
 
   static custom(isFolder: boolean): ShareRole {
@@ -311,7 +323,7 @@ export abstract class PeopleShareRoles {
   }
 
   static getByBitmask(bitmask: number, isFolder: boolean, allowSharing: boolean): ShareRole {
-    const role = this.allWithCustom
+    const role = [...this.allWithCustom, peopleRoleDenyFolder] // Retrieve all possible options always, even if deny is not enabled
       .filter((r) => !r.hasCustomPermissions)
       .find((r) => r.folder === isFolder && r.bitmask(allowSharing) === bitmask)
     return role || this.custom(isFolder)
@@ -401,7 +413,8 @@ const shareRoleDescriptions = {
   [peopleRoleEditorFolder.bitmask(false)]: $gettext('Upload, edit, delete, download and preview'),
   [peopleRoleEditorFolder.bitmask(true)]: $gettext(
     'Upload, edit, delete, download, preview and share'
-  )
+  ),
+  [peopleRoleDenyFolder.bitmask(false)]: $gettext('Deny access')
 }
 
 /**

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -123,6 +123,7 @@ export function buildSpace(space) {
     isReceivedShare: function () {
       return false
     },
+    canDeny: () => false,
     getDomSelector: () => extractDomSelector(space.id)
   }
 }

--- a/packages/web-pkg/src/constants/dav.ts
+++ b/packages/web-pkg/src/constants/dav.ts
@@ -8,6 +8,7 @@ export abstract class DavPermission {
   static readonly Updateable: string = 'NV'
   static readonly FileUpdateable: string = 'W'
   static readonly FolderCreateable: string = 'CK'
+  static readonly Deny: string = 'Z'
 }
 
 export abstract class DavProperty {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1738,40 +1738,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/environment@npm:^27.4.6":
-  version: 27.4.6
-  resolution: "@jest/environment@npm:27.4.6"
+"@jest/environment@npm:^27.4.6, @jest/environment@npm:^27.5.1":
+  version: 27.5.1
+  resolution: "@jest/environment@npm:27.5.1"
   dependencies:
-    "@jest/fake-timers": ^27.4.6
-    "@jest/types": ^27.4.2
+    "@jest/fake-timers": ^27.5.1
+    "@jest/types": ^27.5.1
     "@types/node": "*"
-    jest-mock: ^27.4.6
-  checksum: c3aadcf6d42e55e35d8020f7cf5054c445775608e466fcfc37348359e54f2f79e0e39d029281836ae9082dc50eac81d1cf6b4fc3899adfb58afc68a7c72f8e3d
+    jest-mock: ^27.5.1
+  checksum: 2a9e18c35a015508dbec5b90b21c150230fa6c1c8cb8fabe029d46ee2ca4c40eb832fb636157da14c66590d0a4c8a2c053226b041f54a44507d6f6a89abefd66
   languageName: node
   linkType: hard
 
-"@jest/fake-timers@npm:^27.4.6":
-  version: 27.4.6
-  resolution: "@jest/fake-timers@npm:27.4.6"
+"@jest/fake-timers@npm:^27.4.6, @jest/fake-timers@npm:^27.5.1":
+  version: 27.5.1
+  resolution: "@jest/fake-timers@npm:27.5.1"
   dependencies:
-    "@jest/types": ^27.4.2
+    "@jest/types": ^27.5.1
     "@sinonjs/fake-timers": ^8.0.1
     "@types/node": "*"
-    jest-message-util: ^27.4.6
-    jest-mock: ^27.4.6
-    jest-util: ^27.4.2
-  checksum: 389f655d39f13fdd0448b554260cd41810cf824b99e9de057600869a708d34cfa74e7fdaba5fcd6e3295e7bfed08f1b3fc0735ca86f7c0b2281b25e534032876
+    jest-message-util: ^27.5.1
+    jest-mock: ^27.5.1
+    jest-util: ^27.5.1
+  checksum: 02a0561ed2f4586093facd4ae500b74694f187ac24d4a00e949a39a1c5325bca8932b4fcb0388a2c5ed0656506fc1cf51fd3e32cdd48cea7497ad9c6e028aba8
   languageName: node
   linkType: hard
 
-"@jest/globals@npm:^27.4.6":
-  version: 27.4.6
-  resolution: "@jest/globals@npm:27.4.6"
+"@jest/globals@npm:^27.0.0, @jest/globals@npm:^27.4.6":
+  version: 27.5.1
+  resolution: "@jest/globals@npm:27.5.1"
   dependencies:
-    "@jest/environment": ^27.4.6
-    "@jest/types": ^27.4.2
-    expect: ^27.4.6
-  checksum: a438645771f45557b3af6e371e65c88e109d7433d3d4ee5db908177f29be6d6d12b4cfe9279ae6475bc033b5ff2a97235659a75f2718855041dd3ed805ed2edd
+    "@jest/environment": ^27.5.1
+    "@jest/types": ^27.5.1
+    expect: ^27.5.1
+  checksum: 087f97047e9dcf555f76fe2ce54aee681e005eaa837a0c0c2d251df6b6412c892c9df54cb871b180342114389a5ff895a4e52e6e6d3d0015bf83c02a54f64c3c
   languageName: node
   linkType: hard
 
@@ -1871,16 +1871,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/types@npm:^27.2.5, @jest/types@npm:^27.4.2":
-  version: 27.4.2
-  resolution: "@jest/types@npm:27.4.2"
+"@jest/types@npm:^27.2.5, @jest/types@npm:^27.4.2, @jest/types@npm:^27.5.1":
+  version: 27.5.1
+  resolution: "@jest/types@npm:27.5.1"
   dependencies:
     "@types/istanbul-lib-coverage": ^2.0.0
     "@types/istanbul-reports": ^3.0.0
     "@types/node": "*"
     "@types/yargs": ^16.0.0
     chalk: ^4.0.0
-  checksum: 1191022023e32763063cc1c8b1143fa316fb05db2f9698280a7bdbafcabd989e5fd64f8eb875b8a2e54c53f25dba45ed2eea8ced394d9e484da0fda674cd17a5
+  checksum: d1f43cc946d87543ddd79d49547aab2399481d34025d5c5f2025d3d99c573e1d9832fa83cef25e9d9b07a8583500229d15bbb07b8e233d127d911d133e2f14b1
   languageName: node
   linkType: hard
 
@@ -2265,10 +2265,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@transloadit/prettier-bytes@npm:0.0.7":
-  version: 0.0.7
-  resolution: "@transloadit/prettier-bytes@npm:0.0.7"
-  checksum: af075e1b2b045cac55d5ab854b5c94273ef7f4bd825f05fe578559465f206d2a1535343b50170252a9efb31ffdc2d6420e64eb32d2faeabeeb8b7d81d5d46ef0
+"@transloadit/prettier-bytes@npm:0.0.9":
+  version: 0.0.9
+  resolution: "@transloadit/prettier-bytes@npm:0.0.9"
+  checksum: efa5a723c41e7bce7ad17d1affe6a43209df857e17dc2b12a7c7bd6d3c921df8298086dbfb62ed740ca3e617d8c7f47485bb311adb637b20f2f75a28b08bac4f
   languageName: node
   linkType: hard
 
@@ -2722,83 +2722,82 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@uppy/companion-client@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "@uppy/companion-client@npm:2.2.0"
+"@uppy/companion-client@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@uppy/companion-client@npm:3.0.1"
   dependencies:
-    "@uppy/utils": ^4.1.0
+    "@uppy/utils": ^5.0.1
     namespace-emitter: ^2.0.1
-  checksum: be8119970bcd947a51932a00378be02db230b21b72468518e419e4671156e7fd4e176f5da52e32684d6248d5fb7a268e922d57b8dcab8ac69d666d73b40686a2
+  checksum: d140a434c808c26b14c502472140339bead3f2898285c61dea8c3fadcdffcb00ee33d1d1177c96019e117282c8f28ca14ad8592cf3733a65e70fa1d2db066ea8
   languageName: node
   linkType: hard
 
-"@uppy/core@npm:^2.2.0":
-  version: 2.3.0
-  resolution: "@uppy/core@npm:2.3.0"
+"@uppy/core@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@uppy/core@npm:3.0.1"
   dependencies:
-    "@transloadit/prettier-bytes": 0.0.7
-    "@uppy/store-default": ^2.1.0
-    "@uppy/utils": ^4.1.0
+    "@transloadit/prettier-bytes": 0.0.9
+    "@uppy/store-default": ^3.0.1
+    "@uppy/utils": ^5.0.1
     lodash.throttle: ^4.1.1
     mime-match: ^1.0.2
     namespace-emitter: ^2.0.1
-    nanoid: ^3.1.25
+    nanoid: ^4.0.0
     preact: ^10.5.13
-  checksum: 2c4e28869c99643275f23769534f95e29ae8307c71ef40515f9705290d0b7e1e66e3b9ce5544777ce86969672a7df3b96e171843ceef84b24985ffef323133bf
+  checksum: 585d59694ce906cfa79559bd5ff0601327648938db8aacb44334e9f952c9d558a379ee307b155947ad298aea0e944d7b2918e50368a5d9ca962a67c2d268335b
   languageName: node
   linkType: hard
 
-"@uppy/drop-target@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "@uppy/drop-target@npm:1.1.3"
+"@uppy/drop-target@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@uppy/drop-target@npm:2.0.0"
   dependencies:
-    "@uppy/utils": ^4.0.7
+    "@uppy/utils": ^5.0.0
   peerDependencies:
-    "@uppy/core": ^2.1.9
-  checksum: e5fb6c1265d736e28d412ba4f0800b1785dcfa9a225448b9a9f9c43fb9e916ea08cb62c132643a83ee7b4dd57ab9cf892629c2d63fb0b1255900b5be1124eff5
+    "@uppy/core": ^3.0.0
+  checksum: 3edeffb937dca1f47a0d5ba18868938fe312ebca568981278f8448b325e6847c7d95401dba4de00a77ec13b5b76d009b946c4ca64e201ea25a60e6e286b00c6b
   languageName: node
   linkType: hard
 
-"@uppy/store-default@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@uppy/store-default@npm:2.1.0"
-  checksum: 6e5324837cf0d19c45a92d4195d49115a3343f93cb8a2c1becab894938645139fe8a289be0b69f5b9696a3a795ee6b5d210da6de11c2488b0d10cbfe9cf67fc6
+"@uppy/store-default@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@uppy/store-default@npm:3.0.1"
+  checksum: b4d8b63835810556aff9aa0de8bf13806b3301f7b31e36dff1b2c353b6fb6eb50f095335866ca41ff14fbc1f9566a74451e0505666d830b046e2bbc9c61213af
   languageName: node
   linkType: hard
 
-"@uppy/tus@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "@uppy/tus@npm:2.4.0"
+"@uppy/tus@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@uppy/tus@npm:3.0.1"
   dependencies:
-    "@uppy/companion-client": ^2.2.0
-    "@uppy/utils": ^4.1.0
-    tus-js-client: ^2.1.1
+    "@uppy/companion-client": ^3.0.1
+    "@uppy/utils": ^5.0.1
+    tus-js-client: ^3.0.0
   peerDependencies:
-    "@jest/globals": ^27.4.2
-    "@uppy/core": ^2.3.0
-  checksum: b86fd03283ee4c0c9bb28a6224534ba96fc70dd3156f3932a059f66637944a0d1f1edbf9a2dcfe3119024e7e79bdba833529f6d2a8fd00752841b6eb32361687
+    "@uppy/core": ^3.0.1
+  checksum: f2f018f9d1abb88d2563ef70fc040a27fb2e8c717547969d99639907bf57d28ba621b7ca5e034c3802442633353bcc02bada5ecc06b92af2d802399e90a315f8
   languageName: node
   linkType: hard
 
-"@uppy/utils@npm:^4.0.7, @uppy/utils@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@uppy/utils@npm:4.1.0"
+"@uppy/utils@npm:^5.0.0, @uppy/utils@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "@uppy/utils@npm:5.0.1"
   dependencies:
     lodash.throttle: ^4.1.1
-  checksum: ba1bf3a6e347a15901e53fb0252e008772cbb8654e5c21b074684f26d88916addd747bf595db8516f1749d250291554cd6d0eb2bb6f5a3a77da46b929e289824
+  checksum: f7450a7d523a99a2b9e6e6656f0294eba095e22e1f792509debf780f39542e094c6eadb7ed963685267ed991d652c418e98cb7f337ed644df502e68cc3cf788e
   languageName: node
   linkType: hard
 
-"@uppy/xhr-upload@npm:^2.1.0":
-  version: 2.1.1
-  resolution: "@uppy/xhr-upload@npm:2.1.1"
+"@uppy/xhr-upload@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@uppy/xhr-upload@npm:3.0.1"
   dependencies:
-    "@uppy/companion-client": ^2.2.0
-    "@uppy/utils": ^4.1.0
-    nanoid: ^3.1.25
+    "@uppy/companion-client": ^3.0.1
+    "@uppy/utils": ^5.0.1
+    nanoid: ^4.0.0
   peerDependencies:
-    "@uppy/core": ^2.3.0
-  checksum: 0b5f685e29730274193893467fe6f7248c49cff272fb53fae1076b10ae6340903cf330d88ebc9e3922b65f1d25d52b01a88ffa6022a9c977bd48f354aba54fe4
+    "@uppy/core": ^3.0.1
+  checksum: eda099ac7a16b50d62da17d912de0d14d6318ca29c3e0f242798ebf5e64ca71bba73faa3bd61eb20c0c3bbada424ed919f65b21c68f8ed9b1a076dacd77da4da
   languageName: node
   linkType: hard
 
@@ -3473,12 +3472,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.26.1":
-  version: 0.26.1
-  resolution: "axios@npm:0.26.1"
+"axios@npm:^0.27.1, axios@npm:^0.27.2":
+  version: 0.27.2
+  resolution: "axios@npm:0.27.2"
   dependencies:
-    follow-redirects: ^1.14.8
-  checksum: d9eb58ff4bc0b36a04783fc9ff760e9245c829a5a1052ee7ca6013410d427036b1d10d04e7380c02f3508c5eaf3485b1ae67bd2adbfec3683704745c8d7a6e1a
+    follow-redirects: ^1.14.9
+    form-data: ^4.0.0
+  checksum: 38cb7540465fe8c4102850c4368053c21683af85c5fdf0ea619f9628abbcb59415d1e22ebc8a6390d2bbc9b58a9806c874f139767389c862ec9b772235f06854
   languageName: node
   linkType: hard
 
@@ -3948,17 +3948,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer-from@npm:^0.1.1":
-  version: 0.1.2
-  resolution: "buffer-from@npm:0.1.2"
-  checksum: 50a1fa5da97d2081b7d945483c8967d3b89a096fa585eb55000bb2100e827c647c9370280ec9bd057da8f9fa5abc1d3b764228851a31fa8a67f659f70c0052d8
-  languageName: node
-  linkType: hard
-
 "buffer-from@npm:^1.0.0":
   version: 1.1.1
   resolution: "buffer-from@npm:1.1.1"
   checksum: ccc53b69736008bff764497367c4d24879ba7122bc619ee499ff47eef3a5b885ca496e87272e7ebffa0bec3804c83f84041c616f6e3318f40624e27c1d80f045
+  languageName: node
+  linkType: hard
+
+"buffer-from@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "buffer-from@npm:1.1.2"
+  checksum: 0448524a562b37d4d7ed9efd91685a5b77a50672c556ea254ac9a6d30e3403a517d8981f10e565db24e8339413b43c97ca2951f10e399c6125a0d8911f5679bb
   languageName: node
   linkType: hard
 
@@ -3976,6 +3976,13 @@ __metadata:
   version: 3.2.0
   resolution: "builtin-modules@npm:3.2.0"
   checksum: 0265aa1ba78e1a16f4e18668d815cb43fb364e6a6b8aa9189c6f44c7b894a551a43b323c40206959d2d4b2568c1f2805607ad6c88adc306a776ce6904cca6715
+  languageName: node
+  linkType: hard
+
+"byte-length@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "byte-length@npm:1.0.2"
+  checksum: 69e2b00a14a81f675ea9946135c42ee1a1d9f689d5ba1327eb6700fcde2ccacbd09b42f7e514de1d2b763960251d8c790b3d7304a5a1a27b1457e34c129be8c7
   languageName: node
   linkType: hard
 
@@ -6110,15 +6117,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect@npm:^27.4.6":
-  version: 27.4.6
-  resolution: "expect@npm:27.4.6"
+"expect@npm:^27.4.6, expect@npm:^27.5.1":
+  version: 27.5.1
+  resolution: "expect@npm:27.5.1"
   dependencies:
-    "@jest/types": ^27.4.2
-    jest-get-type: ^27.4.0
-    jest-matcher-utils: ^27.4.6
-    jest-message-util: ^27.4.6
-  checksum: 593eaa8ff34320f9a70f961bc25eeae932df4f48ebcc5ecc1033f1cddffd286fc42a2f312929222541cec1077de2604ff4fc6e97012afcbd36b333bfaba82f7f
+    "@jest/types": ^27.5.1
+    jest-get-type: ^27.5.1
+    jest-matcher-utils: ^27.5.1
+    jest-message-util: ^27.5.1
+  checksum: b2c66beb52de53ef1872165aace40224e722bca3c2274c54cfa74b6d617d55cf0ccdbf36783ccd64dbea501b280098ed33fd0b207d4f15bc03cd3c7a24364a6a
   languageName: node
   linkType: hard
 
@@ -6450,13 +6457,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.14.8":
-  version: 1.14.9
-  resolution: "follow-redirects@npm:1.14.9"
+"follow-redirects@npm:^1.14.9":
+  version: 1.15.1
+  resolution: "follow-redirects@npm:1.15.1"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: f5982e0eb481818642492d3ca35a86989c98af1128b8e1a62911a3410621bc15d2b079e8170b35b19d3bdee770b73ed431a257ed86195af773771145baa57845
+  checksum: 6aa4e3e3cdfa3b9314801a1cd192ba756a53479d9d8cca65bf4db3a3e8834e62139245cd2f9566147c8dfe2efff1700d3e6aefd103de4004a7b99985e71dd533
   languageName: node
   linkType: hard
 
@@ -6479,6 +6486,17 @@ __metadata:
     combined-stream: ^1.0.8
     mime-types: ^2.1.12
   checksum: b019e8d35c8afc14a2bd8a7a92fa4f525a4726b6d5a9740e8d2623c30e308fbb58dc8469f90415a856698933c8479b01646a9dff33c87cc4e76d72aedbbf860d
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "form-data@npm:4.0.0"
+  dependencies:
+    asynckit: ^0.4.0
+    combined-stream: ^1.0.8
+    mime-types: ^2.1.12
+  checksum: 01135bf8675f9d5c61ff18e2e2932f719ca4de964e3be90ef4c36aacfc7b9cb2fceb5eca0b7e0190e3383fe51c5b37f4cb80b62ca06a99aaabfcfd6ac7c9328c
   languageName: node
   linkType: hard
 
@@ -6758,10 +6776,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.2, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
-  version: 4.2.8
-  resolution: "graceful-fs@npm:4.2.8"
-  checksum: 5d224c8969ad0581d551dfabdb06882706b31af2561bd5e2034b4097e67cc27d05232849b8643866585fd0a41c7af152950f8776f4dd5579e9853733f31461c6
+"graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.2, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
+  version: 4.2.10
+  resolution: "graceful-fs@npm:4.2.10"
+  checksum: 3f109d70ae123951905d85032ebeae3c2a5a7a997430df00ea30df0e3a6c60cf6689b109654d6fdacd28810a053348c4d14642da1d075049e6be1ba5216218da
   languageName: node
   linkType: hard
 
@@ -7924,7 +7942,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-matcher-utils@npm:^27.0.0, jest-matcher-utils@npm:^27.2.5, jest-matcher-utils@npm:^27.4.6":
+"jest-matcher-utils@npm:^27.0.0, jest-matcher-utils@npm:^27.2.5, jest-matcher-utils@npm:^27.4.6, jest-matcher-utils@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-matcher-utils@npm:27.5.1"
   dependencies:
@@ -7936,20 +7954,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-message-util@npm:^27.2.5, jest-message-util@npm:^27.4.6":
-  version: 27.4.6
-  resolution: "jest-message-util@npm:27.4.6"
+"jest-message-util@npm:^27.2.5, jest-message-util@npm:^27.4.6, jest-message-util@npm:^27.5.1":
+  version: 27.5.1
+  resolution: "jest-message-util@npm:27.5.1"
   dependencies:
     "@babel/code-frame": ^7.12.13
-    "@jest/types": ^27.4.2
+    "@jest/types": ^27.5.1
     "@types/stack-utils": ^2.0.0
     chalk: ^4.0.0
-    graceful-fs: ^4.2.4
+    graceful-fs: ^4.2.9
     micromatch: ^4.0.4
-    pretty-format: ^27.4.6
+    pretty-format: ^27.5.1
     slash: ^3.0.0
     stack-utils: ^2.0.3
-  checksum: 1fdd542d091dbf7aa63a484feead97a921e3c4d6db3784fe2e6d83e9110ac06de5691fdc043da991ca1d0ce5d179ea8266c8d93b388f4bba7d80a267fdd946df
+  checksum: eb6d637d1411c71646de578c49826b6da8e33dd293e501967011de9d1916d53d845afbfb52a5b661ff1c495be7c13f751c48c7f30781fd94fbd64842e8195796
   languageName: node
   linkType: hard
 
@@ -7962,13 +7980,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-mock@npm:^27.4.6":
-  version: 27.4.6
-  resolution: "jest-mock@npm:27.4.6"
+"jest-mock@npm:^27.4.6, jest-mock@npm:^27.5.1":
+  version: 27.5.1
+  resolution: "jest-mock@npm:27.5.1"
   dependencies:
-    "@jest/types": ^27.4.2
+    "@jest/types": ^27.5.1
     "@types/node": "*"
-  checksum: 34df5ec502fa0db5ef36e2b2e96a522de730e7be907c6df5d4ec8ab1292d9be71f1e269e8bcdafd020239edaf3ca6f9c464eb0b4aca6986420a1f392976fc0ab
+  checksum: f5b5904bb1741b4a1687a5f492535b7b1758dc26534c72a5423305f8711292e96a601dec966df81bb313269fb52d47227e29f9c2e08324d79529172f67311be0
   languageName: node
   linkType: hard
 
@@ -8129,17 +8147,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-util@npm:^27.0.0, jest-util@npm:^27.4.2":
-  version: 27.4.2
-  resolution: "jest-util@npm:27.4.2"
+"jest-util@npm:^27.0.0, jest-util@npm:^27.4.2, jest-util@npm:^27.5.1":
+  version: 27.5.1
+  resolution: "jest-util@npm:27.5.1"
   dependencies:
-    "@jest/types": ^27.4.2
+    "@jest/types": ^27.5.1
     "@types/node": "*"
     chalk: ^4.0.0
     ci-info: ^3.2.0
-    graceful-fs: ^4.2.4
+    graceful-fs: ^4.2.9
     picomatch: ^2.2.3
-  checksum: bcf16881aff1421c5f7c2df2ef9492cf8cd92fcd0a2a99bec5ab16f7185ee19aea48eda41d9dfa7b5bf4354bdc21628f5931cd2e7281741e6d2983965efb631e
+  checksum: ac8d122f6daf7a035dcea156641fd3701aeba245417c40836a77e35b3341b9c02ddc5d904cfcd4ddbaa00ab854da76d3b911870cafdcdbaff90ea471de26c7d7
   languageName: node
   linkType: hard
 
@@ -8237,10 +8255,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-base64@npm:^2.1.9, js-base64@npm:^2.3.2, js-base64@npm:^2.6.1":
+"js-base64@npm:^2.1.9, js-base64@npm:^2.3.2":
   version: 2.6.4
   resolution: "js-base64@npm:2.6.4"
   checksum: 5f4084078d6c46f8529741d110df84b14fac3276b903760c21fa8cc8521370d607325dfe1c1a9fbbeaae1ff8e602665aaeef1362427d8fef704f9e3659472ce8
+  languageName: node
+  linkType: hard
+
+"js-base64@npm:^3.7.2":
+  version: 3.7.2
+  resolution: "js-base64@npm:3.7.2"
+  checksum: 573f28e9a27c3df60096d4d3f551bcb4fcb6d49161cf83396e9bad9b76f94736a70bb70b8808fe834dff2a388f76604ba09d6e153bbf181646e407720139fa5b
   languageName: node
   linkType: hard
 
@@ -9291,12 +9316,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.1.25, nanoid@npm:^3.1.32, nanoid@npm:^3.3.1":
+"nanoid@npm:^3.1.32, nanoid@npm:^3.3.1":
   version: 3.3.2
   resolution: "nanoid@npm:3.3.2"
   bin:
     nanoid: bin/nanoid.cjs
   checksum: 376717f0685251fad77850bd84c6b8d57837c71eeb1c05be7c742140cc1835a5a2953562add05166d6dbc8fb65f3fdffa356213037b967a470e1691dc3e7b9cc
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "nanoid@npm:4.0.0"
+  bin:
+    nanoid: bin/nanoid.js
+  checksum: 7d5946df5c6d383694195b781ae7b5067c149d164ec71e910d6b06676309c3459b68af570b944fb5ecd5065d19df464f05700d141d70bb712ff8ca06642fd8df
   languageName: node
   linkType: hard
 
@@ -9711,9 +9745,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"owncloud-design-system@npm:14.0.0-alpha.4":
-  version: 14.0.0-alpha.4
-  resolution: "owncloud-design-system@npm:14.0.0-alpha.4"
+"owncloud-design-system@npm:14.0.0-alpha.18":
+  version: 14.0.0-alpha.18
+  resolution: "owncloud-design-system@npm:14.0.0-alpha.18"
   peerDependencies:
     "@popperjs/core": ^2.4.0
     "@vue/composition-api": ^1.4.3
@@ -9730,7 +9764,7 @@ __metadata:
     vue-inline-svg: ^2.0.0
     vue-select: ^3.12.0
     webfontloader: ^1.6.28
-  checksum: b45901f01adcf50de706d89f66387a524c18d241b0123e745a6e4c167d1350f68f3ca3ebe636857fea12e58b6b6534c49bff9c2f82757548ed3d61b9774e78dc
+  checksum: ce57cd944ffd95cb6ff0dbb74aec603dc9ebe6d732129b4014b739cb961f24121079b01c21f4aeaf9e4acd49f06575ee1f23282a36a349a22eb2ca26471acde1
   languageName: node
   linkType: hard
 
@@ -10913,7 +10947,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proper-lockfile@npm:4.1.2":
+"proper-lockfile@npm:4.1.2, proper-lockfile@npm:^4.1.2":
   version: 4.1.2
   resolution: "proper-lockfile@npm:4.1.2"
   dependencies:
@@ -10921,16 +10955,6 @@ __metadata:
     retry: ^0.12.0
     signal-exit: ^3.0.2
   checksum: 00078ee6a61c216a56a6140c7d2a98c6c733b3678503002dc073ab8beca5d50ca271de4c85fca13b9b8ee2ff546c36674d1850509b84a04a5d0363bcb8638939
-  languageName: node
-  linkType: hard
-
-"proper-lockfile@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "proper-lockfile@npm:2.0.1"
-  dependencies:
-    graceful-fs: ^4.1.2
-    retry: ^0.10.0
-  checksum: 3cadc4fb7139e521df5ef63b54693fa26b22ad130728f32e768c4a360791ba3ba294b0ad389388ba91db89e34895ecad16a67a02202302cb7e42216f3c906526
   languageName: node
   linkType: hard
 
@@ -11491,13 +11515,6 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: c79ecaea36c872ee4a79e3db0d3d4160b593f2ca16e031d8283735acd01715a203607e9ded3f91f68899c2937fa0d49390cddbe0fb2852629212f3cda283f4a7
-  languageName: node
-  linkType: hard
-
-"retry@npm:^0.10.0":
-  version: 0.10.1
-  resolution: "retry@npm:0.10.1"
-  checksum: 133ef7c2028bcb09544a6fb9bed9f8266fffeaf72c855f73c2918ace9ef2abd7ccba03744564bcd1a8e948ed70518f8970852f46e649f9e3db6fefb0148cda35
   languageName: node
   linkType: hard
 
@@ -13111,18 +13128,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tus-js-client@npm:^2.1.1":
-  version: 2.3.1
-  resolution: "tus-js-client@npm:2.3.1"
+"tus-js-client@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "tus-js-client@npm:3.0.0"
   dependencies:
-    buffer-from: ^0.1.1
+    buffer-from: ^1.1.2
     combine-errors: ^3.0.3
     is-stream: ^2.0.0
-    js-base64: ^2.6.1
+    js-base64: ^3.7.2
     lodash.throttle: ^4.1.1
-    proper-lockfile: ^2.0.1
+    proper-lockfile: ^4.1.2
     url-parse: ^1.5.7
-  checksum: 684446bcc3c625e7aed5330f7b42de97ef515e07f7e7dcecd2eac056f9e93c6b0276ef02ac3662e439101f0ce0902ccb96a246262ee1d8e86f3d4027a7aed6dd
+  checksum: dda7921a0d55f3a15535590adb6eb98edfbf6c88dfbcad9bf1013cfa16bc2244fb937ad1d6bc05f34005ee103da31ccbae5ca650d46dc23d6e653946994c9015
   languageName: node
   linkType: hard
 
@@ -13752,17 +13769,18 @@ __metadata:
   resolution: "web-runtime@workspace:packages/web-runtime"
   dependencies:
     "@fortawesome/fontawesome-free": ^6.1.1
+    "@jest/globals": ^27.0.0
     "@popperjs/core": ^2.11.5
     "@sentry/browser": ^6.19.7
     "@sentry/integrations": ^6.19.7
     "@types/luxon": ^2.3.1
     "@types/semver": ^7.3.8
-    "@uppy/core": ^2.2.0
-    "@uppy/drop-target": ^1.1.3
-    "@uppy/tus": ^2.4.0
-    "@uppy/xhr-upload": ^2.1.0
+    "@uppy/core": ^3.0.1
+    "@uppy/drop-target": ^2.0.0
+    "@uppy/tus": ^3.0.1
+    "@uppy/xhr-upload": ^3.0.1
     "@vue/composition-api": ^1.6.2
-    axios: ^0.26.1
+    axios: ^0.27.1
     cross-fetch: ^3.0.6
     easygettext: "https://github.com/owncloud/easygettext/archive/refs/tags/v2.18.1-oc.tar.gz"
     filesize: ^9.0.11
@@ -13773,8 +13791,8 @@ __metadata:
     luxon: ^2.4.0
     marked: ^4.0.12
     oidc-client-ts: ^2.0.5
-    owncloud-design-system: 14.0.0-alpha.4
-    owncloud-sdk: ~3.0.0-alpha.14
+    owncloud-design-system: 14.0.0-alpha.18
+    owncloud-sdk: ~3.0.0-alpha.15
     p-queue: ^6.6.2
     popper-max-size-modifier: ^0.2.0
     portal-vue: ^2.1.7
@@ -13803,18 +13821,19 @@ __metadata:
     vuex-extensions: ^1.1.5
     vuex-router-sync: ^5.0.0
     web-pkg: "*"
-    webdav: 4.9.0
+    webdav: 4.10.0
     webfontloader: ^1.6.28
     xml-js: ^1.6.11
   languageName: unknown
   linkType: soft
 
-"webdav@npm:4.9.0":
-  version: 4.9.0
-  resolution: "webdav@npm:4.9.0"
+"webdav@npm:4.10.0":
+  version: 4.10.0
+  resolution: "webdav@npm:4.10.0"
   dependencies:
-    axios: ^0.26.1
+    axios: ^0.27.2
     base-64: ^1.0.0
+    byte-length: ^1.0.2
     fast-xml-parser: ^3.19.0
     he: ^1.2.0
     hot-patcher: ^0.5.0
@@ -13825,7 +13844,7 @@ __metadata:
     path-posix: ^1.0.0
     url-join: ^4.0.1
     url-parse: ^1.5.10
-  checksum: eb2c65bdc7d3a2037d3c27b2f5624421c2312ecccd1bf9edbfa9b99a7704973da9f046e5395b370cadea6502ad39da9cd2d15c85b425d0a92af8a24015e0fb5b
+  checksum: 0cfea9c233cfb8c490b6f6be01cb789f20fd01dbfe0ebc8f89057000390117a7cdbd55501c5fc248f54f2393d529cc60a058bf982d96e7e2507a7c99528444ab
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1738,40 +1738,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/environment@npm:^27.4.6, @jest/environment@npm:^27.5.1":
-  version: 27.5.1
-  resolution: "@jest/environment@npm:27.5.1"
+"@jest/environment@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "@jest/environment@npm:27.4.6"
   dependencies:
-    "@jest/fake-timers": ^27.5.1
-    "@jest/types": ^27.5.1
+    "@jest/fake-timers": ^27.4.6
+    "@jest/types": ^27.4.2
     "@types/node": "*"
-    jest-mock: ^27.5.1
-  checksum: 2a9e18c35a015508dbec5b90b21c150230fa6c1c8cb8fabe029d46ee2ca4c40eb832fb636157da14c66590d0a4c8a2c053226b041f54a44507d6f6a89abefd66
+    jest-mock: ^27.4.6
+  checksum: c3aadcf6d42e55e35d8020f7cf5054c445775608e466fcfc37348359e54f2f79e0e39d029281836ae9082dc50eac81d1cf6b4fc3899adfb58afc68a7c72f8e3d
   languageName: node
   linkType: hard
 
-"@jest/fake-timers@npm:^27.4.6, @jest/fake-timers@npm:^27.5.1":
-  version: 27.5.1
-  resolution: "@jest/fake-timers@npm:27.5.1"
+"@jest/fake-timers@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "@jest/fake-timers@npm:27.4.6"
   dependencies:
-    "@jest/types": ^27.5.1
+    "@jest/types": ^27.4.2
     "@sinonjs/fake-timers": ^8.0.1
     "@types/node": "*"
-    jest-message-util: ^27.5.1
-    jest-mock: ^27.5.1
-    jest-util: ^27.5.1
-  checksum: 02a0561ed2f4586093facd4ae500b74694f187ac24d4a00e949a39a1c5325bca8932b4fcb0388a2c5ed0656506fc1cf51fd3e32cdd48cea7497ad9c6e028aba8
+    jest-message-util: ^27.4.6
+    jest-mock: ^27.4.6
+    jest-util: ^27.4.2
+  checksum: 389f655d39f13fdd0448b554260cd41810cf824b99e9de057600869a708d34cfa74e7fdaba5fcd6e3295e7bfed08f1b3fc0735ca86f7c0b2281b25e534032876
   languageName: node
   linkType: hard
 
-"@jest/globals@npm:^27.0.0, @jest/globals@npm:^27.4.6":
-  version: 27.5.1
-  resolution: "@jest/globals@npm:27.5.1"
+"@jest/globals@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "@jest/globals@npm:27.4.6"
   dependencies:
-    "@jest/environment": ^27.5.1
-    "@jest/types": ^27.5.1
-    expect: ^27.5.1
-  checksum: 087f97047e9dcf555f76fe2ce54aee681e005eaa837a0c0c2d251df6b6412c892c9df54cb871b180342114389a5ff895a4e52e6e6d3d0015bf83c02a54f64c3c
+    "@jest/environment": ^27.4.6
+    "@jest/types": ^27.4.2
+    expect: ^27.4.6
+  checksum: a438645771f45557b3af6e371e65c88e109d7433d3d4ee5db908177f29be6d6d12b4cfe9279ae6475bc033b5ff2a97235659a75f2718855041dd3ed805ed2edd
   languageName: node
   linkType: hard
 
@@ -1871,16 +1871,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/types@npm:^27.2.5, @jest/types@npm:^27.4.2, @jest/types@npm:^27.5.1":
-  version: 27.5.1
-  resolution: "@jest/types@npm:27.5.1"
+"@jest/types@npm:^27.2.5, @jest/types@npm:^27.4.2":
+  version: 27.4.2
+  resolution: "@jest/types@npm:27.4.2"
   dependencies:
     "@types/istanbul-lib-coverage": ^2.0.0
     "@types/istanbul-reports": ^3.0.0
     "@types/node": "*"
     "@types/yargs": ^16.0.0
     chalk: ^4.0.0
-  checksum: d1f43cc946d87543ddd79d49547aab2399481d34025d5c5f2025d3d99c573e1d9832fa83cef25e9d9b07a8583500229d15bbb07b8e233d127d911d133e2f14b1
+  checksum: 1191022023e32763063cc1c8b1143fa316fb05db2f9698280a7bdbafcabd989e5fd64f8eb875b8a2e54c53f25dba45ed2eea8ced394d9e484da0fda674cd17a5
   languageName: node
   linkType: hard
 
@@ -2265,10 +2265,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@transloadit/prettier-bytes@npm:0.0.9":
-  version: 0.0.9
-  resolution: "@transloadit/prettier-bytes@npm:0.0.9"
-  checksum: efa5a723c41e7bce7ad17d1affe6a43209df857e17dc2b12a7c7bd6d3c921df8298086dbfb62ed740ca3e617d8c7f47485bb311adb637b20f2f75a28b08bac4f
+"@transloadit/prettier-bytes@npm:0.0.7":
+  version: 0.0.7
+  resolution: "@transloadit/prettier-bytes@npm:0.0.7"
+  checksum: af075e1b2b045cac55d5ab854b5c94273ef7f4bd825f05fe578559465f206d2a1535343b50170252a9efb31ffdc2d6420e64eb32d2faeabeeb8b7d81d5d46ef0
   languageName: node
   linkType: hard
 
@@ -2722,82 +2722,83 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@uppy/companion-client@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@uppy/companion-client@npm:3.0.1"
+"@uppy/companion-client@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@uppy/companion-client@npm:2.2.0"
   dependencies:
-    "@uppy/utils": ^5.0.1
+    "@uppy/utils": ^4.1.0
     namespace-emitter: ^2.0.1
-  checksum: d140a434c808c26b14c502472140339bead3f2898285c61dea8c3fadcdffcb00ee33d1d1177c96019e117282c8f28ca14ad8592cf3733a65e70fa1d2db066ea8
+  checksum: be8119970bcd947a51932a00378be02db230b21b72468518e419e4671156e7fd4e176f5da52e32684d6248d5fb7a268e922d57b8dcab8ac69d666d73b40686a2
   languageName: node
   linkType: hard
 
-"@uppy/core@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@uppy/core@npm:3.0.1"
+"@uppy/core@npm:^2.2.0":
+  version: 2.3.0
+  resolution: "@uppy/core@npm:2.3.0"
   dependencies:
-    "@transloadit/prettier-bytes": 0.0.9
-    "@uppy/store-default": ^3.0.1
-    "@uppy/utils": ^5.0.1
+    "@transloadit/prettier-bytes": 0.0.7
+    "@uppy/store-default": ^2.1.0
+    "@uppy/utils": ^4.1.0
     lodash.throttle: ^4.1.1
     mime-match: ^1.0.2
     namespace-emitter: ^2.0.1
-    nanoid: ^4.0.0
+    nanoid: ^3.1.25
     preact: ^10.5.13
-  checksum: 585d59694ce906cfa79559bd5ff0601327648938db8aacb44334e9f952c9d558a379ee307b155947ad298aea0e944d7b2918e50368a5d9ca962a67c2d268335b
+  checksum: 2c4e28869c99643275f23769534f95e29ae8307c71ef40515f9705290d0b7e1e66e3b9ce5544777ce86969672a7df3b96e171843ceef84b24985ffef323133bf
   languageName: node
   linkType: hard
 
-"@uppy/drop-target@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@uppy/drop-target@npm:2.0.0"
+"@uppy/drop-target@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "@uppy/drop-target@npm:1.1.3"
   dependencies:
-    "@uppy/utils": ^5.0.0
+    "@uppy/utils": ^4.0.7
   peerDependencies:
-    "@uppy/core": ^3.0.0
-  checksum: 3edeffb937dca1f47a0d5ba18868938fe312ebca568981278f8448b325e6847c7d95401dba4de00a77ec13b5b76d009b946c4ca64e201ea25a60e6e286b00c6b
+    "@uppy/core": ^2.1.9
+  checksum: e5fb6c1265d736e28d412ba4f0800b1785dcfa9a225448b9a9f9c43fb9e916ea08cb62c132643a83ee7b4dd57ab9cf892629c2d63fb0b1255900b5be1124eff5
   languageName: node
   linkType: hard
 
-"@uppy/store-default@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@uppy/store-default@npm:3.0.1"
-  checksum: b4d8b63835810556aff9aa0de8bf13806b3301f7b31e36dff1b2c353b6fb6eb50f095335866ca41ff14fbc1f9566a74451e0505666d830b046e2bbc9c61213af
+"@uppy/store-default@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@uppy/store-default@npm:2.1.0"
+  checksum: 6e5324837cf0d19c45a92d4195d49115a3343f93cb8a2c1becab894938645139fe8a289be0b69f5b9696a3a795ee6b5d210da6de11c2488b0d10cbfe9cf67fc6
   languageName: node
   linkType: hard
 
-"@uppy/tus@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@uppy/tus@npm:3.0.1"
+"@uppy/tus@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "@uppy/tus@npm:2.4.0"
   dependencies:
-    "@uppy/companion-client": ^3.0.1
-    "@uppy/utils": ^5.0.1
-    tus-js-client: ^3.0.0
+    "@uppy/companion-client": ^2.2.0
+    "@uppy/utils": ^4.1.0
+    tus-js-client: ^2.1.1
   peerDependencies:
-    "@uppy/core": ^3.0.1
-  checksum: f2f018f9d1abb88d2563ef70fc040a27fb2e8c717547969d99639907bf57d28ba621b7ca5e034c3802442633353bcc02bada5ecc06b92af2d802399e90a315f8
+    "@jest/globals": ^27.4.2
+    "@uppy/core": ^2.3.0
+  checksum: b86fd03283ee4c0c9bb28a6224534ba96fc70dd3156f3932a059f66637944a0d1f1edbf9a2dcfe3119024e7e79bdba833529f6d2a8fd00752841b6eb32361687
   languageName: node
   linkType: hard
 
-"@uppy/utils@npm:^5.0.0, @uppy/utils@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "@uppy/utils@npm:5.0.1"
+"@uppy/utils@npm:^4.0.7, @uppy/utils@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@uppy/utils@npm:4.1.0"
   dependencies:
     lodash.throttle: ^4.1.1
-  checksum: f7450a7d523a99a2b9e6e6656f0294eba095e22e1f792509debf780f39542e094c6eadb7ed963685267ed991d652c418e98cb7f337ed644df502e68cc3cf788e
+  checksum: ba1bf3a6e347a15901e53fb0252e008772cbb8654e5c21b074684f26d88916addd747bf595db8516f1749d250291554cd6d0eb2bb6f5a3a77da46b929e289824
   languageName: node
   linkType: hard
 
-"@uppy/xhr-upload@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@uppy/xhr-upload@npm:3.0.1"
+"@uppy/xhr-upload@npm:^2.1.0":
+  version: 2.1.1
+  resolution: "@uppy/xhr-upload@npm:2.1.1"
   dependencies:
-    "@uppy/companion-client": ^3.0.1
-    "@uppy/utils": ^5.0.1
-    nanoid: ^4.0.0
+    "@uppy/companion-client": ^2.2.0
+    "@uppy/utils": ^4.1.0
+    nanoid: ^3.1.25
   peerDependencies:
-    "@uppy/core": ^3.0.1
-  checksum: eda099ac7a16b50d62da17d912de0d14d6318ca29c3e0f242798ebf5e64ca71bba73faa3bd61eb20c0c3bbada424ed919f65b21c68f8ed9b1a076dacd77da4da
+    "@uppy/core": ^2.3.0
+  checksum: 0b5f685e29730274193893467fe6f7248c49cff272fb53fae1076b10ae6340903cf330d88ebc9e3922b65f1d25d52b01a88ffa6022a9c977bd48f354aba54fe4
   languageName: node
   linkType: hard
 
@@ -3472,13 +3473,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.27.1, axios@npm:^0.27.2":
-  version: 0.27.2
-  resolution: "axios@npm:0.27.2"
+"axios@npm:^0.26.1":
+  version: 0.26.1
+  resolution: "axios@npm:0.26.1"
   dependencies:
-    follow-redirects: ^1.14.9
-    form-data: ^4.0.0
-  checksum: 38cb7540465fe8c4102850c4368053c21683af85c5fdf0ea619f9628abbcb59415d1e22ebc8a6390d2bbc9b58a9806c874f139767389c862ec9b772235f06854
+    follow-redirects: ^1.14.8
+  checksum: d9eb58ff4bc0b36a04783fc9ff760e9245c829a5a1052ee7ca6013410d427036b1d10d04e7380c02f3508c5eaf3485b1ae67bd2adbfec3683704745c8d7a6e1a
   languageName: node
   linkType: hard
 
@@ -3948,17 +3948,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer-from@npm:^0.1.1":
+  version: 0.1.2
+  resolution: "buffer-from@npm:0.1.2"
+  checksum: 50a1fa5da97d2081b7d945483c8967d3b89a096fa585eb55000bb2100e827c647c9370280ec9bd057da8f9fa5abc1d3b764228851a31fa8a67f659f70c0052d8
+  languageName: node
+  linkType: hard
+
 "buffer-from@npm:^1.0.0":
   version: 1.1.1
   resolution: "buffer-from@npm:1.1.1"
   checksum: ccc53b69736008bff764497367c4d24879ba7122bc619ee499ff47eef3a5b885ca496e87272e7ebffa0bec3804c83f84041c616f6e3318f40624e27c1d80f045
-  languageName: node
-  linkType: hard
-
-"buffer-from@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "buffer-from@npm:1.1.2"
-  checksum: 0448524a562b37d4d7ed9efd91685a5b77a50672c556ea254ac9a6d30e3403a517d8981f10e565db24e8339413b43c97ca2951f10e399c6125a0d8911f5679bb
   languageName: node
   linkType: hard
 
@@ -3976,13 +3976,6 @@ __metadata:
   version: 3.2.0
   resolution: "builtin-modules@npm:3.2.0"
   checksum: 0265aa1ba78e1a16f4e18668d815cb43fb364e6a6b8aa9189c6f44c7b894a551a43b323c40206959d2d4b2568c1f2805607ad6c88adc306a776ce6904cca6715
-  languageName: node
-  linkType: hard
-
-"byte-length@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "byte-length@npm:1.0.2"
-  checksum: 69e2b00a14a81f675ea9946135c42ee1a1d9f689d5ba1327eb6700fcde2ccacbd09b42f7e514de1d2b763960251d8c790b3d7304a5a1a27b1457e34c129be8c7
   languageName: node
   linkType: hard
 
@@ -6117,15 +6110,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect@npm:^27.4.6, expect@npm:^27.5.1":
-  version: 27.5.1
-  resolution: "expect@npm:27.5.1"
+"expect@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "expect@npm:27.4.6"
   dependencies:
-    "@jest/types": ^27.5.1
-    jest-get-type: ^27.5.1
-    jest-matcher-utils: ^27.5.1
-    jest-message-util: ^27.5.1
-  checksum: b2c66beb52de53ef1872165aace40224e722bca3c2274c54cfa74b6d617d55cf0ccdbf36783ccd64dbea501b280098ed33fd0b207d4f15bc03cd3c7a24364a6a
+    "@jest/types": ^27.4.2
+    jest-get-type: ^27.4.0
+    jest-matcher-utils: ^27.4.6
+    jest-message-util: ^27.4.6
+  checksum: 593eaa8ff34320f9a70f961bc25eeae932df4f48ebcc5ecc1033f1cddffd286fc42a2f312929222541cec1077de2604ff4fc6e97012afcbd36b333bfaba82f7f
   languageName: node
   linkType: hard
 
@@ -6457,13 +6450,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.14.9":
-  version: 1.15.1
-  resolution: "follow-redirects@npm:1.15.1"
+"follow-redirects@npm:^1.14.8":
+  version: 1.14.9
+  resolution: "follow-redirects@npm:1.14.9"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 6aa4e3e3cdfa3b9314801a1cd192ba756a53479d9d8cca65bf4db3a3e8834e62139245cd2f9566147c8dfe2efff1700d3e6aefd103de4004a7b99985e71dd533
+  checksum: f5982e0eb481818642492d3ca35a86989c98af1128b8e1a62911a3410621bc15d2b079e8170b35b19d3bdee770b73ed431a257ed86195af773771145baa57845
   languageName: node
   linkType: hard
 
@@ -6486,17 +6479,6 @@ __metadata:
     combined-stream: ^1.0.8
     mime-types: ^2.1.12
   checksum: b019e8d35c8afc14a2bd8a7a92fa4f525a4726b6d5a9740e8d2623c30e308fbb58dc8469f90415a856698933c8479b01646a9dff33c87cc4e76d72aedbbf860d
-  languageName: node
-  linkType: hard
-
-"form-data@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "form-data@npm:4.0.0"
-  dependencies:
-    asynckit: ^0.4.0
-    combined-stream: ^1.0.8
-    mime-types: ^2.1.12
-  checksum: 01135bf8675f9d5c61ff18e2e2932f719ca4de964e3be90ef4c36aacfc7b9cb2fceb5eca0b7e0190e3383fe51c5b37f4cb80b62ca06a99aaabfcfd6ac7c9328c
   languageName: node
   linkType: hard
 
@@ -6776,10 +6758,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.2, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
-  version: 4.2.10
-  resolution: "graceful-fs@npm:4.2.10"
-  checksum: 3f109d70ae123951905d85032ebeae3c2a5a7a997430df00ea30df0e3a6c60cf6689b109654d6fdacd28810a053348c4d14642da1d075049e6be1ba5216218da
+"graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.2, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
+  version: 4.2.8
+  resolution: "graceful-fs@npm:4.2.8"
+  checksum: 5d224c8969ad0581d551dfabdb06882706b31af2561bd5e2034b4097e67cc27d05232849b8643866585fd0a41c7af152950f8776f4dd5579e9853733f31461c6
   languageName: node
   linkType: hard
 
@@ -7942,7 +7924,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-matcher-utils@npm:^27.0.0, jest-matcher-utils@npm:^27.2.5, jest-matcher-utils@npm:^27.4.6, jest-matcher-utils@npm:^27.5.1":
+"jest-matcher-utils@npm:^27.0.0, jest-matcher-utils@npm:^27.2.5, jest-matcher-utils@npm:^27.4.6":
   version: 27.5.1
   resolution: "jest-matcher-utils@npm:27.5.1"
   dependencies:
@@ -7954,20 +7936,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-message-util@npm:^27.2.5, jest-message-util@npm:^27.4.6, jest-message-util@npm:^27.5.1":
-  version: 27.5.1
-  resolution: "jest-message-util@npm:27.5.1"
+"jest-message-util@npm:^27.2.5, jest-message-util@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "jest-message-util@npm:27.4.6"
   dependencies:
     "@babel/code-frame": ^7.12.13
-    "@jest/types": ^27.5.1
+    "@jest/types": ^27.4.2
     "@types/stack-utils": ^2.0.0
     chalk: ^4.0.0
-    graceful-fs: ^4.2.9
+    graceful-fs: ^4.2.4
     micromatch: ^4.0.4
-    pretty-format: ^27.5.1
+    pretty-format: ^27.4.6
     slash: ^3.0.0
     stack-utils: ^2.0.3
-  checksum: eb6d637d1411c71646de578c49826b6da8e33dd293e501967011de9d1916d53d845afbfb52a5b661ff1c495be7c13f751c48c7f30781fd94fbd64842e8195796
+  checksum: 1fdd542d091dbf7aa63a484feead97a921e3c4d6db3784fe2e6d83e9110ac06de5691fdc043da991ca1d0ce5d179ea8266c8d93b388f4bba7d80a267fdd946df
   languageName: node
   linkType: hard
 
@@ -7980,13 +7962,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-mock@npm:^27.4.6, jest-mock@npm:^27.5.1":
-  version: 27.5.1
-  resolution: "jest-mock@npm:27.5.1"
+"jest-mock@npm:^27.4.6":
+  version: 27.4.6
+  resolution: "jest-mock@npm:27.4.6"
   dependencies:
-    "@jest/types": ^27.5.1
+    "@jest/types": ^27.4.2
     "@types/node": "*"
-  checksum: f5b5904bb1741b4a1687a5f492535b7b1758dc26534c72a5423305f8711292e96a601dec966df81bb313269fb52d47227e29f9c2e08324d79529172f67311be0
+  checksum: 34df5ec502fa0db5ef36e2b2e96a522de730e7be907c6df5d4ec8ab1292d9be71f1e269e8bcdafd020239edaf3ca6f9c464eb0b4aca6986420a1f392976fc0ab
   languageName: node
   linkType: hard
 
@@ -8147,17 +8129,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-util@npm:^27.0.0, jest-util@npm:^27.4.2, jest-util@npm:^27.5.1":
-  version: 27.5.1
-  resolution: "jest-util@npm:27.5.1"
+"jest-util@npm:^27.0.0, jest-util@npm:^27.4.2":
+  version: 27.4.2
+  resolution: "jest-util@npm:27.4.2"
   dependencies:
-    "@jest/types": ^27.5.1
+    "@jest/types": ^27.4.2
     "@types/node": "*"
     chalk: ^4.0.0
     ci-info: ^3.2.0
-    graceful-fs: ^4.2.9
+    graceful-fs: ^4.2.4
     picomatch: ^2.2.3
-  checksum: ac8d122f6daf7a035dcea156641fd3701aeba245417c40836a77e35b3341b9c02ddc5d904cfcd4ddbaa00ab854da76d3b911870cafdcdbaff90ea471de26c7d7
+  checksum: bcf16881aff1421c5f7c2df2ef9492cf8cd92fcd0a2a99bec5ab16f7185ee19aea48eda41d9dfa7b5bf4354bdc21628f5931cd2e7281741e6d2983965efb631e
   languageName: node
   linkType: hard
 
@@ -8255,17 +8237,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-base64@npm:^2.1.9, js-base64@npm:^2.3.2":
+"js-base64@npm:^2.1.9, js-base64@npm:^2.3.2, js-base64@npm:^2.6.1":
   version: 2.6.4
   resolution: "js-base64@npm:2.6.4"
   checksum: 5f4084078d6c46f8529741d110df84b14fac3276b903760c21fa8cc8521370d607325dfe1c1a9fbbeaae1ff8e602665aaeef1362427d8fef704f9e3659472ce8
-  languageName: node
-  linkType: hard
-
-"js-base64@npm:^3.7.2":
-  version: 3.7.2
-  resolution: "js-base64@npm:3.7.2"
-  checksum: 573f28e9a27c3df60096d4d3f551bcb4fcb6d49161cf83396e9bad9b76f94736a70bb70b8808fe834dff2a388f76604ba09d6e153bbf181646e407720139fa5b
   languageName: node
   linkType: hard
 
@@ -9316,21 +9291,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.1.32, nanoid@npm:^3.3.1":
+"nanoid@npm:^3.1.25, nanoid@npm:^3.1.32, nanoid@npm:^3.3.1":
   version: 3.3.2
   resolution: "nanoid@npm:3.3.2"
   bin:
     nanoid: bin/nanoid.cjs
   checksum: 376717f0685251fad77850bd84c6b8d57837c71eeb1c05be7c742140cc1835a5a2953562add05166d6dbc8fb65f3fdffa356213037b967a470e1691dc3e7b9cc
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "nanoid@npm:4.0.0"
-  bin:
-    nanoid: bin/nanoid.js
-  checksum: 7d5946df5c6d383694195b781ae7b5067c149d164ec71e910d6b06676309c3459b68af570b944fb5ecd5065d19df464f05700d141d70bb712ff8ca06642fd8df
   languageName: node
   linkType: hard
 
@@ -9745,9 +9711,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"owncloud-design-system@npm:14.0.0-alpha.18":
-  version: 14.0.0-alpha.18
-  resolution: "owncloud-design-system@npm:14.0.0-alpha.18"
+"owncloud-design-system@npm:14.0.0-alpha.4":
+  version: 14.0.0-alpha.4
+  resolution: "owncloud-design-system@npm:14.0.0-alpha.4"
   peerDependencies:
     "@popperjs/core": ^2.4.0
     "@vue/composition-api": ^1.4.3
@@ -9764,7 +9730,7 @@ __metadata:
     vue-inline-svg: ^2.0.0
     vue-select: ^3.12.0
     webfontloader: ^1.6.28
-  checksum: ce57cd944ffd95cb6ff0dbb74aec603dc9ebe6d732129b4014b739cb961f24121079b01c21f4aeaf9e4acd49f06575ee1f23282a36a349a22eb2ca26471acde1
+  checksum: b45901f01adcf50de706d89f66387a524c18d241b0123e745a6e4c167d1350f68f3ca3ebe636857fea12e58b6b6534c49bff9c2f82757548ed3d61b9774e78dc
   languageName: node
   linkType: hard
 
@@ -10947,7 +10913,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proper-lockfile@npm:4.1.2, proper-lockfile@npm:^4.1.2":
+"proper-lockfile@npm:4.1.2":
   version: 4.1.2
   resolution: "proper-lockfile@npm:4.1.2"
   dependencies:
@@ -10955,6 +10921,16 @@ __metadata:
     retry: ^0.12.0
     signal-exit: ^3.0.2
   checksum: 00078ee6a61c216a56a6140c7d2a98c6c733b3678503002dc073ab8beca5d50ca271de4c85fca13b9b8ee2ff546c36674d1850509b84a04a5d0363bcb8638939
+  languageName: node
+  linkType: hard
+
+"proper-lockfile@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "proper-lockfile@npm:2.0.1"
+  dependencies:
+    graceful-fs: ^4.1.2
+    retry: ^0.10.0
+  checksum: 3cadc4fb7139e521df5ef63b54693fa26b22ad130728f32e768c4a360791ba3ba294b0ad389388ba91db89e34895ecad16a67a02202302cb7e42216f3c906526
   languageName: node
   linkType: hard
 
@@ -11515,6 +11491,13 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: c79ecaea36c872ee4a79e3db0d3d4160b593f2ca16e031d8283735acd01715a203607e9ded3f91f68899c2937fa0d49390cddbe0fb2852629212f3cda283f4a7
+  languageName: node
+  linkType: hard
+
+"retry@npm:^0.10.0":
+  version: 0.10.1
+  resolution: "retry@npm:0.10.1"
+  checksum: 133ef7c2028bcb09544a6fb9bed9f8266fffeaf72c855f73c2918ace9ef2abd7ccba03744564bcd1a8e948ed70518f8970852f46e649f9e3db6fefb0148cda35
   languageName: node
   linkType: hard
 
@@ -13128,18 +13111,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tus-js-client@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "tus-js-client@npm:3.0.0"
+"tus-js-client@npm:^2.1.1":
+  version: 2.3.1
+  resolution: "tus-js-client@npm:2.3.1"
   dependencies:
-    buffer-from: ^1.1.2
+    buffer-from: ^0.1.1
     combine-errors: ^3.0.3
     is-stream: ^2.0.0
-    js-base64: ^3.7.2
+    js-base64: ^2.6.1
     lodash.throttle: ^4.1.1
-    proper-lockfile: ^4.1.2
+    proper-lockfile: ^2.0.1
     url-parse: ^1.5.7
-  checksum: dda7921a0d55f3a15535590adb6eb98edfbf6c88dfbcad9bf1013cfa16bc2244fb937ad1d6bc05f34005ee103da31ccbae5ca650d46dc23d6e653946994c9015
+  checksum: 684446bcc3c625e7aed5330f7b42de97ef515e07f7e7dcecd2eac056f9e93c6b0276ef02ac3662e439101f0ce0902ccb96a246262ee1d8e86f3d4027a7aed6dd
   languageName: node
   linkType: hard
 
@@ -13769,18 +13752,17 @@ __metadata:
   resolution: "web-runtime@workspace:packages/web-runtime"
   dependencies:
     "@fortawesome/fontawesome-free": ^6.1.1
-    "@jest/globals": ^27.0.0
     "@popperjs/core": ^2.11.5
     "@sentry/browser": ^6.19.7
     "@sentry/integrations": ^6.19.7
     "@types/luxon": ^2.3.1
     "@types/semver": ^7.3.8
-    "@uppy/core": ^3.0.1
-    "@uppy/drop-target": ^2.0.0
-    "@uppy/tus": ^3.0.1
-    "@uppy/xhr-upload": ^3.0.1
+    "@uppy/core": ^2.2.0
+    "@uppy/drop-target": ^1.1.3
+    "@uppy/tus": ^2.4.0
+    "@uppy/xhr-upload": ^2.1.0
     "@vue/composition-api": ^1.6.2
-    axios: ^0.27.1
+    axios: ^0.26.1
     cross-fetch: ^3.0.6
     easygettext: "https://github.com/owncloud/easygettext/archive/refs/tags/v2.18.1-oc.tar.gz"
     filesize: ^9.0.11
@@ -13791,8 +13773,8 @@ __metadata:
     luxon: ^2.4.0
     marked: ^4.0.12
     oidc-client-ts: ^2.0.5
-    owncloud-design-system: 14.0.0-alpha.18
-    owncloud-sdk: ~3.0.0-alpha.15
+    owncloud-design-system: 14.0.0-alpha.4
+    owncloud-sdk: ~3.0.0-alpha.14
     p-queue: ^6.6.2
     popper-max-size-modifier: ^0.2.0
     portal-vue: ^2.1.7
@@ -13821,19 +13803,18 @@ __metadata:
     vuex-extensions: ^1.1.5
     vuex-router-sync: ^5.0.0
     web-pkg: "*"
-    webdav: 4.10.0
+    webdav: 4.9.0
     webfontloader: ^1.6.28
     xml-js: ^1.6.11
   languageName: unknown
   linkType: soft
 
-"webdav@npm:4.10.0":
-  version: 4.10.0
-  resolution: "webdav@npm:4.10.0"
+"webdav@npm:4.9.0":
+  version: 4.9.0
+  resolution: "webdav@npm:4.9.0"
   dependencies:
-    axios: ^0.27.2
+    axios: ^0.26.1
     base-64: ^1.0.0
-    byte-length: ^1.0.2
     fast-xml-parser: ^3.19.0
     he: ^1.2.0
     hot-patcher: ^0.5.0
@@ -13844,7 +13825,7 @@ __metadata:
     path-posix: ^1.0.0
     url-join: ^4.0.1
     url-parse: ^1.5.10
-  checksum: 0cfea9c233cfb8c490b6f6be01cb789f20fd01dbfe0ebc8f89057000390117a7cdbd55501c5fc248f54f2393d529cc60a058bf982d96e7e2507a7c99528444ab
+  checksum: eb2c65bdc7d3a2037d3c27b2f5624421c2312ecccd1bf9edbfa9b99a7704973da9f046e5395b370cadea6502ad39da9cd2d15c85b425d0a92af8a24015e0fb5b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Porting over https://github.com/cernbox/web/commit/1d75877919e862fdecfdff3bae366ede3951ba1a

## Description
See changelog item

## Types of changes
- [X] New feature (non-breaking change which adds functionality)

## Open tasks:
- [ ] Merged https://github.com/cs3org/reva/pull/3011
- [ ] Corresponding Reva-bump in oCIS
- [ ] Adding capability-based rendering of "deny" option incl. polishing of code changes
- [ ] Adding unit & E2E tests
