### PR TITLE
Unselect on focus outside of the table

### DIFF
--- a/packages/web-app-files/src/App.vue
+++ b/packages/web-app-files/src/App.vue
@@ -1,6 +1,12 @@
 <template>
   <main id="files" class="oc-flex oc-height-1-1">
-    <div ref="filesListWrapper" tabindex="-1" class="files-list-wrapper oc-width-expand">
+    <div
+      id="files-list-wrapper"
+      ref="filesListWrapper"
+      tabindex="-1"
+      class="files-list-wrapper oc-width-expand"
+      @click="unselectOnClick"
+    >
       <router-view id="files-view" tabindex="0" />
     </div>
     <side-bar
@@ -68,6 +74,15 @@ export default defineComponent({
         to: this.$refs.filesSidebar?.$el,
         revert: event === 'beforeDestroy'
       })
+    },
+    /* on click instead of on focus since child element got the higher tabindex and focuses first */
+    unselectOnClick(e) {
+      if (
+        e.target?.id === 'files-view' ||
+        e.target?.className.includes('oc-files-appbar-batch-actions') ||
+        e.target?.className === 'oc-flex oc-flex-between'
+      )
+        this.resetFileSelection()
     }
   }
 })

--- a/packages/web-runtime/src/components/SidebarNav/SidebarNav.vue
+++ b/packages/web-runtime/src/components/SidebarNav/SidebarNav.vue
@@ -5,6 +5,8 @@
       'oc-app-navigation-collapsed': navigation.closed,
       'oc-app-navigation-expanded': !navigation.closed
     }"
+    tabindex="-1"
+    @focus="unselectOnFocus"
   >
     <oc-button
       appearance="raw"
@@ -52,6 +54,19 @@ export default {
       required: true
     }
   },
+  computed: {
+    ...mapState(['navigation']),
+
+    toggleSidebarButtonClass() {
+      return this.navigation.closed
+        ? 'toggle-sidebar-button-collapsed'
+        : 'toggle-sidebar-button-expanded oc-pr-s'
+    },
+
+    toggleSidebarButtonIcon() {
+      return this.navigation.closed ? 'arrow-drop-right' : 'arrow-drop-left'
+    }
+  },
   mounted() {
     const navItem = document.getElementsByClassName('oc-sidebar-nav-item-link')[0]
     const highlighter = document.getElementById('nav-highlighter')
@@ -72,21 +87,9 @@ export default {
       resizeObserver.disconnect()
     })
   },
-  computed: {
-    ...mapState(['navigation']),
-
-    toggleSidebarButtonClass() {
-      return this.navigation.closed
-        ? 'toggle-sidebar-button-collapsed'
-        : 'toggle-sidebar-button-expanded oc-pr-s'
-    },
-
-    toggleSidebarButtonIcon() {
-      return this.navigation.closed ? 'arrow-drop-right' : 'arrow-drop-left'
-    }
-  },
   methods: {
     ...mapActions(['openNavigation', 'closeNavigation']),
+    ...mapActions('Files', ['resetFileSelection']),
 
     toggleSidebarButtonClick() {
       return this.navigation.closed ? this.openNavigation() : this.closeNavigation()
@@ -94,6 +97,9 @@ export default {
 
     getUuid() {
       return uuid.v4().replaceAll('-', '')
+    },
+    unselectOnFocus(e) {
+      this.resetFileSelection()
     }
   }
 }

--- a/packages/web-runtime/tests/unit/components/SidebarNav/__snapshots__/SidebarNav.spec.js.snap
+++ b/packages/web-runtime/tests/unit/components/SidebarNav/__snapshots__/SidebarNav.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OcSidebarNav renders navItems into a list 1`] = `
-<div id="web-nav-sidebar" class="oc-app-navigation-expanded"><button aria-label="Toggle sidebar" type="button" class="toggle-sidebar-button oc-py-s oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw toggle-sidebar-button-expanded oc-pr-s">
+<div id="web-nav-sidebar" tabindex="-1" class="oc-app-navigation-expanded"><button aria-label="Toggle sidebar" type="button" class="toggle-sidebar-button oc-py-s oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw toggle-sidebar-button-expanded oc-pr-s">
     <oc-icon-stub name="arrow-drop-left" filltype="line" accessiblelabel="" type="span" size="large" variation="passive" color=""></oc-icon-stub>
   </button>
   <nav aria-label="Sidebar navigation menu" class="oc-sidebar-nav oc-my-m oc-px-xs">
@@ -16,7 +16,7 @@ exports[`OcSidebarNav renders navItems into a list 1`] = `
 `;
 
 exports[`OcSidebarNav toggles back into open state upon button click 1`] = `
-<div id="web-nav-sidebar" class="oc-app-navigation-expanded"><button aria-label="Toggle sidebar" type="button" class="toggle-sidebar-button oc-py-s oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw toggle-sidebar-button-expanded oc-pr-s">
+<div id="web-nav-sidebar" tabindex="-1" class="oc-app-navigation-expanded"><button aria-label="Toggle sidebar" type="button" class="toggle-sidebar-button oc-py-s oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw toggle-sidebar-button-expanded oc-pr-s">
     <oc-icon-stub name="arrow-drop-left" filltype="line" accessiblelabel="" type="span" size="large" variation="passive" color=""></oc-icon-stub>
   </button>
   <nav aria-label="Sidebar navigation menu" class="oc-sidebar-nav oc-my-m oc-px-xs">
@@ -31,7 +31,7 @@ exports[`OcSidebarNav toggles back into open state upon button click 1`] = `
 `;
 
 exports[`OcSidebarNav toggles into closed state upon button click 1`] = `
-<div id="web-nav-sidebar" class="oc-app-navigation-collapsed"><button aria-label="Toggle sidebar" type="button" class="toggle-sidebar-button oc-py-s oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw toggle-sidebar-button-collapsed">
+<div id="web-nav-sidebar" tabindex="-1" class="oc-app-navigation-collapsed"><button aria-label="Toggle sidebar" type="button" class="toggle-sidebar-button oc-py-s oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw toggle-sidebar-button-collapsed">
     <oc-icon-stub name="arrow-drop-right" filltype="line" accessiblelabel="" type="span" size="large" variation="passive" color=""></oc-icon-stub>
   </button>
   <nav aria-label="Sidebar navigation menu" class="oc-sidebar-nav oc-my-m oc-px-xs">


### PR DESCRIPTION
## Description
Selected files get unselected on focus on navigation sidebar and filesListWrapper outside of the table (but not if focusable elements inside like buttons get focused)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
Usability improvement: allows more performant unselecting one or multiple selected files with one click. The user doesn't need to move the mouse to X button or checkboxes (Fitt's law implication: smaller targets require more time to click on them, clicking somewhere outside is quicker).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):
![unselect](https://user-images.githubusercontent.com/7430156/177619333-ca582379-0500-4156-8059-14a587b597be.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
