### PR TITLE
Bugfix: Shared with others page apps not working with oc10 as backend

### DIFF
--- a/changelog/unreleased/bugfix-shared-with-others-page-apps-not-working-oc10
+++ b/changelog/unreleased/bugfix-shared-with-others-page-apps-not-working-oc10
@@ -1,0 +1,7 @@
+Bugfix: Shared with others page apps not working with oc10 as backend
+
+We've fixed a bug where apps like preview, pdf-viewer or text-editor weren't working while browsing
+the shared with others page with oc10 as backend.
+
+https://github.com/owncloud/web/pull/7228
+https://github.com/owncloud/web/issues/7049

--- a/packages/web-app-files/src/helpers/resources.ts
+++ b/packages/web-app-files/src/helpers/resources.ts
@@ -354,7 +354,7 @@ export function buildSharedResource(
     fileId: share.item_source,
     storageId: extractStorageId(share.item_source),
     type: share.item_type,
-    mimeType: parseInt(share.state) === 0 ? share.mimetype : '',
+    mimeType: share.mimetype,
     isFolder,
     sdate: DateTime.fromSeconds(parseInt(share.stime)).toRFC2822(),
     indicators: [],

--- a/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
+++ b/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
@@ -8,9 +8,6 @@ Level-3 headings should be used for the references to the relevant issues. Inclu
 
 Other free text and markdown formatting can be used elsewhere in the document if needed. But if you want to explain something about the issue, then please post that in the issue itself.
 
-### [Preview from share-with-others page doesn't work in oc10](https://github.com/owncloud/web/issues/7049)
-- [webUIPreview/mediaPreview.feature:143](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPreview/imageMediaViewer.feature#L143)
-
 ### [user session of a blocked user is not cleared properly](https://github.com/owncloud/web/issues/4795)
 -   [webUILogin/adminBlocksUser.feature:20](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/adminBlocksUser.feature#L20)
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Bugfix: Shared with others page apps not working with oc10 as backend

We've fixed a bug where apps like preview, pdf-viewer or text-editor weren't working while browsing
the shared with others page with oc10 as backend.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7049

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
