### PR TITLE
Add exit redirect

### DIFF
--- a/changelog/unreleased/bugfix-token-renewal
+++ b/changelog/unreleased/bugfix-token-renewal
@@ -11,3 +11,4 @@ used that's not needed.
 
 https://github.com/owncloud/web/issues/7030
 https://github.com/owncloud/web/pull/7072
+https://github.com/owncloud/web/pull/7242

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -94,6 +94,7 @@ export class AuthService {
           return (window.location =
             `${this.configurationManager.serverUrl}/index.php/logout` as any)
         }
+        return (window.location = this.userManager.settings.post_logout_redirect_uri as any)
       })
       this.userManager.events.addSilentRenewError(async (error) => {
         console.error('Silent Renew Error：', error)


### PR DESCRIPTION
## Description
For OIDC auth scenarios the `exit` link on the access denied page was not doing anything. Fixed by redirecting to the post logout redirect uri when logging out a user.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
