### PR TITLE
fix quicklink action storageid retrieval

### DIFF
--- a/changelog/unreleased/enhancement-ocis-resharing
+++ b/changelog/unreleased/enhancement-ocis-resharing
@@ -5,3 +5,5 @@ Besides that we also send roles, space-ref and path as separate values to the sh
 
 https://github.com/owncloud/web/pull/7086
 https://github.com/owncloud/web/issues/6894
+https://github.com/owncloud/web/pull/7243
+https://github.com/owncloud/web/issues/7225

--- a/packages/web-app-files/src/mixins/actions/createQuicklink.js
+++ b/packages/web-app-files/src/mixins/actions/createQuicklink.js
@@ -32,9 +32,10 @@ export default {
   methods: {
     async $_createQuicklink_trigger({ resources }) {
       const store = this.$store
+      const [resource] = resources
       await createQuicklink({
-        resource: resources[0],
-        storageId: this.$route.params.storageId,
+        resource,
+        storageId: this.$route.params.storageId || resource?.fileId || resource?.id,
         store
       })
 


### PR DESCRIPTION
with the recent integration of resharing for ocis we missed to update the quicklink creation action mixin.
This is fixed with a fallback chain to retrieve the corresponding storageid.

Fixes #7225