### PR TITLE
Enable tracing nightly

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -3115,6 +3115,7 @@ def uploadTracingResult(ctx):
             "status": status,
             "event": [
                 "pull_request",
+                "cron",
             ],
         },
     }]


### PR DESCRIPTION
When we run tests at night and the tests fail, we don't get a trace https://drone.owncloud.com/owncloud/web/26735/10/12

To find out what happened, I enabled night tracing. 
I didn't make the tracing result public, we can get the tracing from `uploadTracingResult`.