### PR TITLE
[tests-only][full-ci] Check share permissions in the webUI after changing

### DIFF
--- a/tests/acceptance/features/webUISharingPermissionsUsers/sharePermissionsUsers.feature
+++ b/tests/acceptance/features/webUISharingPermissionsUsers/sharePermissionsUsers.feature
@@ -109,7 +109,8 @@ Feature: Sharing files and folders with internal users with different permission
     And user "Brian" has logged in using the webUI
     Then custom permission "<displayed-permissions>" should be set for user "Alice Hansen" for file "lorem.txt" on the webUI
     When the user sets custom permission for current role of collaborator "Alice Hansen" for file "lorem.txt" to "share" using the webUI
-    Then user "Alice" should have received a share with these details in the server:
+    Then custom permission "<permissions>" should be set for user "Alice Hansen" for file "lorem.txt" on the webUI
+    And user "Alice" should have received a share with these details in the server:
       | field       | value             |
       | uid_owner   | Brian             |
       | share_with  | Alice             |


### PR DESCRIPTION
## Description
Acceptance test `webUISharingPermissionsUsers/sharePermissionsUsers.feature:122` was failing on the Then step that asserts share properties. The main reason for the failure was that the `permissions` was not changed from 1 to 17 at the time of assertion.

In this PR, I have added a permission check in the webUI after the permission has changed.

## Related Issue
- Fixes #7203


## How Has This Been Tested?
- test environment: local

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
