### PR TITLE
[tests-only] skip the scenario related to ocis issue 2249 with ocis backend

### DIFF
--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -30,9 +30,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUIFavorites/unfavoriteFile.feature:102](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature#L102)
 -   [webUIResharing1/reshareUsers.feature:194](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIResharing1/reshareUsers.feature#L194)
 
-### [file_path property is not unique for a share created with same resource name i.e already present in sharee](https://github.com/owncloud/ocis/issues/2249)
--   [webUIRenameFiles/renameFiles.feature:209](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFiles/renameFiles.feature#L209)
-
 ### [when sharer renames the shared resource, sharee get the updated name](https://github.com/owncloud/ocis/issues/2256)
 -   [webUIRenameFiles/renameFiles.feature:234](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFiles/renameFiles.feature#L234)
 

--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -205,7 +205,7 @@ Feature: rename files
     And as "Alice" file "simple-folder/a-renamed-file.txt" should exist in the server
     And as "Alice" file "simple-folder/lorem.txt" should not exist in the server
 
-  @issue-2249
+  @issue-2249 @notToImplementOnOCIS
   Scenario: Rename a file and folder in shared with me page
     Given user "Brian" has been created with default attributes and without skeleton files in the server
     And user "Brian" has created folder "simple-folder" in the server


### PR DESCRIPTION
## Description
Issue https://github.com/owncloud/ocis/issues/2249 is not valid for the ocis feature. See comment https://github.com/owncloud/ocis/issues/2249#issuecomment-1184207463

With this PR:
- the related scenario is skipped for the tests running with ocis backend
- the related scenario line is removed from the expected failures list

Related:
- fixes: https://github.com/owncloud/ocis/issues/2249

Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>