### PR TITLE
Fix printing backend version to browser console

### DIFF
--- a/changelog/unreleased/bugfix-print-backend-version
+++ b/changelog/unreleased/bugfix-print-backend-version
@@ -1,0 +1,6 @@
+Bugfix: Print backend version
+
+We fixed a regression with printing version information to the browser console (the backend version was not showing up anymore). Since loading the public link / user context is blocking the boot process of applications after a [recent PR](https://github.com/owncloud/web/pull/7072) has been merged, we are now able to reliably print the backend version on the first page load after login as well (was not possible before).
+
+https://github.com/owncloud/web/issues/7272
+https://github.com/owncloud/web/pull/7284

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -50,7 +50,6 @@ export const bootstrap = async (configurationPath: string): Promise<void> => {
 }
 
 export const renderSuccess = (): void => {
-  announceVersions({ store })
   const applications = Array.from(applicationStore.values())
   const instance = new Vue({
     el: '#owncloud',
@@ -71,6 +70,7 @@ export const renderSuccess = (): void => {
       if (!newValue || newValue === oldValue) {
         return
       }
+      announceVersions({ store })
       await announceApplicationsReady({ applications })
     },
     {


### PR DESCRIPTION
## Description
Move announcing the frontend and backend versions (e.g. to browser console) to after the context has been initialized, because we need capabilities for the backend version. Since this is realiably blocking now, we actually also have the backend version printed on the first page load after login (was never working before).

## Related Issue
- Fixes https://github.com/owncloud/web/issues/7272

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
