### PR TITLE
[tests-only][full-ci] Fix expiration date picker element selector

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/expirationDatePicker.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/expirationDatePicker.js
@@ -164,14 +164,23 @@ module.exports = {
      * @param {string} shareType link|collaborator
      * @returns {Promise<boolean>} returns true if succeeds to set provided expiration date
      */
-    setExpirationDate: async function (value, shareType = 'collaborator') {
+    setExpirationDate: async function (
+      value,
+      shareType = 'collaborator',
+      editCollaborator = false
+    ) {
       if (value === '') {
         return this.click('@publicLinkDeleteExpirationDateButton')
       }
       const dateToSet = new Date(Date.parse(value))
       if (shareType === 'link') {
         client.execute(
-          `document.querySelector('#oc-files-file-link-expire-date').__vue__.$refs.calendar.move(new Date(Date.parse('${value}')))`,
+          `document.querySelector('.link-expiry-picker').__vue__.$refs.calendar.move(new Date(Date.parse('${value}')))`,
+          []
+        )
+      } else if (editCollaborator) {
+        client.execute(
+          `document.querySelector('.collaborator-edit-dropdown-options-list .files-recipient-expiration-datepicker').__vue__.$refs.calendar.move(new Date(Date.parse('${value}')))`,
           []
         )
       } else {

--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -514,7 +514,7 @@ module.exports = {
       const dateToSet = calculateDate(days)
       const isExpiryDateChanged = await collaboratorDialog
         .expandExpirationDatePicker(collaborator)
-        .setExpirationDate(dateToSet)
+        .setExpirationDate(dateToSet, 'collaborator', true)
       if (!isExpiryDateChanged) {
         console.log('WARNING: Cannot create share with disabled expiration date!')
       }


### PR DESCRIPTION
## Description
The cause of the intermittent failure of `webUISharingPublicExpire/shareByPublicLinkExpiringLinks.feature:11` test has been reported here https://github.com/owncloud/web/issues/7227#issuecomment-1186802393.

With the latest web, the public link expiration date picker has a new selector. I have changed the selector to a new value in this PR.
Also, the expiration date picker while editing user/group share is in a different dropdown list and this PR has added a new condition to select the correct date picker element while editing user/group share.
It removes error logs like below:
```diff
- Error while running .executeScript() protocol action: An error occurred while executing user supplied JavaScript. – 
- javascript error: Cannot read properties of undefined (rea...
```

With these changes, the intermittent test failure seems pretty much stable.

## Related Issue
- Fixes #7227

## How Has This Been Tested?
- test environment: local

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
