### PR TITLE
Replace oidc-callback url with redirect url for clean browser history

### DIFF
--- a/changelog/unreleased/bugfix-oidc-callback-browser-history
+++ b/changelog/unreleased/bugfix-oidc-callback-browser-history
@@ -1,0 +1,6 @@
+Bugfix: Don't leak oidc callback url into browser history
+
+We've made sure that the oidc callback url does not appear in the browser history after the user has been redirected back from the IdP to ownCloud Web.
+
+https://github.com/owncloud/web/issues/3071
+https://github.com/owncloud/web/pull/7293

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -132,7 +132,7 @@ export class AuthService {
       await this.userManager.signinRedirectCallback(url)
 
       const redirectUrl = this.userManager.getAndClearPostLoginRedirectUrl()
-      return this.router.push({ path: redirectUrl })
+      return this.router.replace({ path: redirectUrl })
     } catch (e) {
       console.warn('error during authentication:', e)
       return this.handleAuthError(this.router.currentRoute)


### PR DESCRIPTION
## Description
Replace oidc-callback url with redirect url for clean browser history.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/3071

## Motivation and Context
- **UX:** We don't want the user to go back to the oidc-callback 
- **Security:** We don't want to leak possibly sensitive data into the browser history

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
