### PR TITLE
Use id as fileId in space resource entities

### DIFF
--- a/changelog/unreleased/bugfix-personal-shares-in-project-space
+++ b/changelog/unreleased/bugfix-personal-shares-in-project-space
@@ -1,0 +1,6 @@
+Bugfix: Personal shares leaked into project space
+
+Due to a bug in how we handle spaces as resources internally we loaded personal shares when listing project space shares.
+
+https://github.com/owncloud/web/issues/7268
+https://github.com/owncloud/web/pull/7294

--- a/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
@@ -106,7 +106,6 @@
   </div>
 </template>
 <script lang="ts">
-import { dirname } from 'path'
 import { defineComponent } from '@vue/composition-api'
 import { DateTime } from 'luxon'
 import { mapGetters, mapActions, mapState } from 'vuex'
@@ -373,23 +372,6 @@ export default defineComponent({
 
     toggleIndirectLinkListCollapsed() {
       this.indirectLinkListCollapsed = !this.indirectLinkListCollapsed
-    },
-
-    reloadLinks() {
-      this.loadCurrentFileOutgoingShares({
-        client: this.$client,
-        graphClient: this.graphClient,
-        path: this.highlightedFile.path,
-        $gettext: this.$gettext,
-        ...(this.currentStorageId && { storageId: this.currentStorageId }),
-        resource: this.highlightedFile
-      })
-      this.loadSharesTree({
-        client: this.$client,
-        path: this.highlightedFile.path === '' ? '/' : dirname(this.highlightedFile.path),
-        $gettext: this.$gettext,
-        ...(this.currentStorageId && { storageId: this.currentStorageId })
-      })
     },
 
     isPasswordEnforcedFor(link) {

--- a/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
@@ -35,6 +35,9 @@ export default defineComponent({
       ...useGraphClient()
     }
   },
+  computed: {
+    ...mapGetters('Files', ['highlightedFile'])
+  },
   watch: {
     highlightedFile: {
       handler: function (newItem, oldItem) {
@@ -44,9 +47,6 @@ export default defineComponent({
       },
       immediate: true
     }
-  },
-  computed: {
-    ...mapGetters('Files', ['highlightedFile'])
   },
   methods: {
     ...mapActions('Files', [

--- a/packages/web-app-files/src/helpers/resources.ts
+++ b/packages/web-app-files/src/helpers/resources.ts
@@ -146,7 +146,7 @@ export function buildSpace(space) {
   }
   return {
     id: space.id,
-    fileId: '',
+    fileId: space.id,
     storageId: space.id,
     mimeType: '',
     name: space.name,

--- a/packages/web-app-files/src/services/folder/spaces/loaderProject.ts
+++ b/packages/web-app-files/src/services/folder/spaces/loaderProject.ts
@@ -71,7 +71,8 @@ export class FolderLoaderSpacesProject implements FolderLoader {
       const hasShareJail = useCapabilityShareJailEnabled(store)
       yield store.dispatch('Files/loadSharesTree', {
         client: clientService.owncloudSdk,
-        path: currentFolder.path
+        path: currentFolder.path,
+        storageId: space.fileId
       })
 
       for (const file of resources) {


### PR DESCRIPTION
## Description
We're using the `fileId` of resources in various requests, but the space lacks a value in the `fileId` field. Fixed in this PR.

Also killed some dead method in the `FileLinks.vue` component.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7268

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
