### PR TITLE
Fix spacing of the upload progress bar

### DIFF
--- a/changelog/unreleased/bugfix-upload-overlay-progress-bar-spacing
+++ b/changelog/unreleased/bugfix-upload-overlay-progress-bar-spacing
@@ -1,0 +1,5 @@
+Bugfix: Upload overlay progress bar spacing
+
+We've fixed spacing issues with the upload overlay progress bar.
+
+https://github.com/owncloud/web/pull/7297

--- a/packages/web-runtime/src/components/UploadInfo.vue
+++ b/packages/web-runtime/src/components/UploadInfo.vue
@@ -77,7 +77,7 @@
         </oc-button>
       </div>
     </div>
-    <div v-if="runningUploads" class="upload-info-progress oc-mx-m oc-mb-m oc-mt-s">
+    <div v-if="runningUploads" class="upload-info-progress oc-mx-m oc-pb-m oc-mt-s">
       <oc-progress
         :value="totalProgress"
         :max="100"


### PR DESCRIPTION
## Description
We've fixed spacing issues with the upload overlay progress bar.

## Screenshots (if appropriate):

Before:

![image](https://user-images.githubusercontent.com/50302941/179741297-1019138f-2945-4b47-a2fc-b5054766a569.png)

After:

![Show details](https://user-images.githubusercontent.com/50302941/179741306-9b2d3b3f-ee54-4cd2-8096-836046778cdf.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
