### PR TITLE
Remove lazy table loading delay

### DIFF
--- a/changelog/unreleased/bugfix-remove-lazy-table-loading-delay
+++ b/changelog/unreleased/bugfix-remove-lazy-table-loading-delay
@@ -1,0 +1,6 @@
+Bugfix: Remove lazy table loading delay
+
+We've removed the lazy loading delay on the OcTable to improve the overall performance.
+
+https://github.com/owncloud/web/issues/7038
+https://github.com/owncloud/web/pull/7298

--- a/changelog/unreleased/enhancement-update-ods
+++ b/changelog/unreleased/enhancement-update-ods
@@ -1,8 +1,9 @@
-Enhancement: Update ODS to v14.0.0-alpha.4
+Enhancement: Update ODS to v14.0.0-alpha.5
 
-We updated the ownCloud Design System to version 14.0.0-alpha.4. Please refer to the full changelog in the ODS release (linked) for more details. Summary:
+We updated the ownCloud Design System to version 14.0.0-alpha.5. Please refer to the full changelog in the ODS release (linked) for more details. Summary:
 
 - Bugfix - Remove click event on OcIcon: #2216
+- Bugfix - Lazy loading render performance: #2260
 - Change - Remove OcAlert component: #2210
 - Change - Remove transition animations: #2210
 - Change - Revamp animations: #2210
@@ -11,5 +12,5 @@ We updated the ownCloud Design System to version 14.0.0-alpha.4. Please refer to
 - Enhancement - Progress bar indeterminate state: #2200
 - Enhancement - Redesign notifications: #2210
 
-https://github.com/owncloud/web/pull/7139
-https://github.com/owncloud/owncloud-design-system/releases/tag/14.0.0-alpha.2
+https://github.com/owncloud/web/pull/7298
+https://github.com/owncloud/owncloud-design-system/releases/tag/14.0.0-alpha.5

--- a/packages/web-app-files/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceTable.vue
@@ -535,9 +535,7 @@ export default defineComponent({
       if (this.configuration?.options?.displayResourcesLazy) {
         fields.forEach((field) =>
           Object.assign(field, {
-            lazy: {
-              delay: 250
-            }
+            lazy: true
           })
         )
       }

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -24,7 +24,7 @@
     "luxon": "^2.4.0",
     "marked": "^4.0.12",
     "oidc-client-ts": "^2.0.5",
-    "owncloud-design-system": "14.0.0-alpha.4",
+    "owncloud-design-system": "14.0.0-alpha.5",
     "owncloud-sdk": "~3.0.0-alpha.14",
     "p-queue": "^6.6.2",
     "popper-max-size-modifier": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9711,9 +9711,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"owncloud-design-system@npm:14.0.0-alpha.4":
-  version: 14.0.0-alpha.4
-  resolution: "owncloud-design-system@npm:14.0.0-alpha.4"
+"owncloud-design-system@npm:14.0.0-alpha.5":
+  version: 14.0.0-alpha.5
+  resolution: "owncloud-design-system@npm:14.0.0-alpha.5"
   peerDependencies:
     "@popperjs/core": ^2.4.0
     "@vue/composition-api": ^1.4.3
@@ -9721,7 +9721,7 @@ __metadata:
     focus-trap: ^6.4.0
     focus-trap-vue: ^1.1.1
     fuse.js: ^6.4.6
-    luxon: ^2.0.2
+    luxon: ^3.0.1
     postcss-import: ^12.0.1
     postcss-url: ^9.0.0
     tippy.js: ^6.3.7
@@ -9730,7 +9730,7 @@ __metadata:
     vue-inline-svg: ^2.0.0
     vue-select: ^3.12.0
     webfontloader: ^1.6.28
-  checksum: b45901f01adcf50de706d89f66387a524c18d241b0123e745a6e4c167d1350f68f3ca3ebe636857fea12e58b6b6534c49bff9c2f82757548ed3d61b9774e78dc
+  checksum: bb077ebcadc8bbd812c18ce2d0cc86f53c9f7d48731bddcd630b6ae876932e2020a182f0d4768a8dec10db03624f30cf21731d7f75b874138491a582c735a575
   languageName: node
   linkType: hard
 
@@ -13773,7 +13773,7 @@ __metadata:
     luxon: ^2.4.0
     marked: ^4.0.12
     oidc-client-ts: ^2.0.5
-    owncloud-design-system: 14.0.0-alpha.4
+    owncloud-design-system: 14.0.0-alpha.5
     owncloud-sdk: ~3.0.0-alpha.14
     p-queue: ^6.6.2
     popper-max-size-modifier: ^0.2.0


### PR DESCRIPTION
## Description
We've removed the lazy loading delay on the OcTable to improve the overall performance.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/web/issues/7038

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
