### PR TITLE
Improve table lazy loading performance

### DIFF
--- a/changelog/unreleased/bugfix-remove-lazy-table-loading-delay
+++ b/changelog/unreleased/bugfix-remove-lazy-table-loading-delay
@@ -1,6 +1,0 @@
-Bugfix: Remove lazy table loading delay
-
-We've removed the lazy loading delay on the OcTable to improve the overall performance.
-
-https://github.com/owncloud/web/issues/7038
-https://github.com/owncloud/web/pull/7298

--- a/changelog/unreleased/bugfix-table-lazy-loading-performance
+++ b/changelog/unreleased/bugfix-table-lazy-loading-performance
@@ -1,0 +1,7 @@
+Bugfix: Table lazy loading performance
+
+We've drastically increased the performance of the files table by removing the lazy loading delay and by moving the loading visualization from the OcTd to the OcTr component.
+
+https://github.com/owncloud/web/issues/7038
+https://github.com/owncloud/web/pull/7298
+https://github.com/owncloud/web/pull/7312

--- a/changelog/unreleased/enhancement-update-ods
+++ b/changelog/unreleased/enhancement-update-ods
@@ -1,6 +1,6 @@
-Enhancement: Update ODS to v14.0.0-alpha.5
+Enhancement: Update ODS to v14.0.0-alpha.7
 
-We updated the ownCloud Design System to version 14.0.0-alpha.5. Please refer to the full changelog in the ODS release (linked) for more details. Summary:
+We updated the ownCloud Design System to version 14.0.0-alpha.7. Please refer to the full changelog in the ODS release (linked) for more details. Summary:
 
 - Bugfix - Remove click event on OcIcon: #2216
 - Bugfix - Lazy loading render performance: #2260
@@ -11,6 +11,7 @@ We updated the ownCloud Design System to version 14.0.0-alpha.5. Please refer to
 - Enhancement - OcCheckbox add outline: #2218
 - Enhancement - Progress bar indeterminate state: #2200
 - Enhancement - Redesign notifications: #2210
+- Enhancement - Use oc colors for selected background and deselect icon: #2262
 
-https://github.com/owncloud/web/pull/7298
-https://github.com/owncloud/owncloud-design-system/releases/tag/14.0.0-alpha.5
+https://github.com/owncloud/web/pull/7312
+https://github.com/owncloud/owncloud-design-system/releases/tag/v14.0.0-alpha.7

--- a/packages/web-app-files/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceTable.vue
@@ -13,6 +13,7 @@
     :selection="selection"
     :sort-by="sortBy"
     :sort-dir="sortDir"
+    :lazy="lazyLoading"
     padding-x="medium"
     @highlight="fileClicked"
     @rowMounted="rowMounted"
@@ -532,15 +533,10 @@ export default defineComponent({
         })
       }
 
-      if (this.configuration?.options?.displayResourcesLazy) {
-        fields.forEach((field) =>
-          Object.assign(field, {
-            lazy: true
-          })
-        )
-      }
-
       return fields
+    },
+    lazyLoading() {
+      return this.configuration?.options?.displayResourcesLazy
     },
     areAllResourcesSelected() {
       return this.selection.length === this.resources.length

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -24,7 +24,7 @@
     "luxon": "^2.4.0",
     "marked": "^4.0.12",
     "oidc-client-ts": "^2.0.5",
-    "owncloud-design-system": "14.0.0-alpha.5",
+    "owncloud-design-system": "14.0.0-alpha.7",
     "owncloud-sdk": "~3.0.0-alpha.15",
     "p-queue": "^6.6.2",
     "popper-max-size-modifier": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9711,9 +9711,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"owncloud-design-system@npm:14.0.0-alpha.5":
-  version: 14.0.0-alpha.5
-  resolution: "owncloud-design-system@npm:14.0.0-alpha.5"
+"owncloud-design-system@npm:14.0.0-alpha.7":
+  version: 14.0.0-alpha.7
+  resolution: "owncloud-design-system@npm:14.0.0-alpha.7"
   peerDependencies:
     "@popperjs/core": ^2.4.0
     "@vue/composition-api": ^1.4.3
@@ -9730,7 +9730,7 @@ __metadata:
     vue-inline-svg: ^2.0.0
     vue-select: ^3.12.0
     webfontloader: ^1.6.28
-  checksum: bb077ebcadc8bbd812c18ce2d0cc86f53c9f7d48731bddcd630b6ae876932e2020a182f0d4768a8dec10db03624f30cf21731d7f75b874138491a582c735a575
+  checksum: b799e4942c0f347b739ead8fed1020343fb5a1c1d467c4082c474e484b7025bc39ec9e880fe9ea1d0e68fbc4a4a77002be7c5cb4b1fa2dbded39f736f4a0cf6f
   languageName: node
   linkType: hard
 
@@ -13773,7 +13773,7 @@ __metadata:
     luxon: ^2.4.0
     marked: ^4.0.12
     oidc-client-ts: ^2.0.5
-    owncloud-design-system: 14.0.0-alpha.5
+    owncloud-design-system: 14.0.0-alpha.7
     owncloud-sdk: ~3.0.0-alpha.15
     p-queue: ^6.6.2
     popper-max-size-modifier: ^0.2.0


### PR DESCRIPTION
## Description
We've increased the performance of the files table by moving the loading visualization from the OcTd to the OcTr component.

A file list with 1000 files now takes ~1,6 seconds for a complete page load, whereas before it was roughly ~3 seconds.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/web/issues/7038

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
