### PR TITLE
fix: resize observer disconnect in sidebar highlighter

### DIFF
--- a/changelog/unreleased/bugfix-repair-navigtion-highlighter
+++ b/changelog/unreleased/bugfix-repair-navigtion-highlighter
@@ -4,3 +4,4 @@ We've refactored the navigation highlighter to fix several small glitches.
 
 https://github.com/owncloud/web/pull/7210
 https://github.com/owncloud/web/pull/7270
+https://github.com/owncloud/web/pull/7324

--- a/packages/web-runtime/src/components/SidebarNav/SidebarNav.vue
+++ b/packages/web-runtime/src/components/SidebarNav/SidebarNav.vue
@@ -56,28 +56,6 @@ export default {
       required: true
     }
   },
-  mounted() {
-    const navItem = document.getElementsByClassName('oc-sidebar-nav-item-link')[0]
-    const highlighter = document.getElementById('nav-highlighter')
-
-    if (!highlighter || !navItem) {
-      return
-    }
-
-    const resizeObserver = new ResizeObserver((data) => {
-      const width = data[0].borderBoxSize[0].inlineSize
-      highlighter.style.setProperty('transition-duration', `0.05s`)
-      if (width === 0) return
-      highlighter.style.setProperty('width', `${width}px`)
-    }).observe(navItem)
-    if (navItem.clientWidth === 0) return
-    highlighter.style.setProperty('width', `${navItem.clientWidth}px`)
-    highlighter.style.setProperty('height', `${navItem.clientHeight}px`)
-
-    this.$on('beforeDestroy', () => {
-      resizeObserver.disconnect()
-    })
-  },
   computed: {
     ...mapState(['navigation']),
 
@@ -94,6 +72,31 @@ export default {
     isAnyNavItemActive() {
       return this.navItems.some((i) => i.active === true)
     }
+  },
+  mounted() {
+    const navItem = document.getElementsByClassName('oc-sidebar-nav-item-link')[0]
+    const highlighter = document.getElementById('nav-highlighter')
+
+    if (!highlighter || !navItem) {
+      return
+    }
+
+    const resizeObserver = new ResizeObserver((data) => {
+      const width = data[0].borderBoxSize[0].inlineSize
+      highlighter.style.setProperty('transition-duration', `0.05s`)
+      if (width) {
+        highlighter.style.setProperty('width', `${width}px`)
+      }
+    })
+    resizeObserver.observe(navItem)
+    if (navItem.clientWidth) {
+      highlighter.style.setProperty('width', `${navItem.clientWidth}px`)
+      highlighter.style.setProperty('height', `${navItem.clientHeight}px`)
+    }
+
+    this.$on('beforeDestroy', () => {
+      resizeObserver.disconnect()
+    })
   },
   methods: {
     ...mapActions(['openNavigation', 'closeNavigation']),


### PR DESCRIPTION
## Description
ResizeObserver in the sidebar nav highlighter was not set correctly, hence the console error messages when switching to a view without sidebar (see screenshot). Also inverted the early returns into conditional setters, because we **always** want to reach the code block where we add the beforeDestroy event listener.

<img width="559" alt="Screenshot 2022-07-25 at 11 11 54" src="https://user-images.githubusercontent.com/3532843/180744007-ea250d34-4e45-4774-b832-0ade4c73b9cb.png">

## Motivation and Context
Keep the browser console clean, correctly terminate resize observer.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
