### PR TITLE
Rearange declined shares

### DIFF
--- a/changelog/unreleased/enhancement-declined-shares-not-easily-accessible
+++ b/changelog/unreleased/enhancement-declined-shares-not-easily-accessible
@@ -1,0 +1,10 @@
+Enhancement: Declined shares are not easily accessible
+
+We've redesigned the 'Shared with me' page,
+so the 'Declined shares' section is now displayed under the 'Accepted shares' section.
+There is no need to click the toggle button anymore which makes the 'Declined shares' easily accessible.
+
+https://github.com/owncloud/web/pull/7356
+https://github.com/owncloud/web/issues/7342
+
+

--- a/changelog/unreleased/enhancement-declined-shares-now-easily-accessible
+++ b/changelog/unreleased/enhancement-declined-shares-now-easily-accessible
@@ -1,4 +1,4 @@
-Enhancement: Declined shares are not easily accessible
+Enhancement: Declined shares are now easily accessible
 
 We've redesigned the 'Shared with me' page,
 so the 'Declined shares' section is now displayed under the 'Accepted shares' section.

--- a/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
+++ b/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
@@ -61,7 +61,7 @@
         <context-actions :items="itemsSelected" />
       </template>
       <template #footer>
-        <div v-if="showMoreLessToggle && hasMore" class="oc-width-1-1 oc-text-center oc-mt">
+        <div v-if="showMoreToggle && hasMore" class="oc-width-1-1 oc-text-center oc-mt">
           <oc-button
             id="files-shared-with-me-show-all"
             appearance="raw"
@@ -153,9 +153,13 @@ export default defineComponent({
       type: Function,
       required: true
     },
-    showMoreLessToggle: {
+    showMoreToggle: {
       type: Boolean,
       default: false
+    },
+    showMoreToggleCount: {
+      type: Number,
+      default: 3
     },
     resourceClickable: {
       type: Boolean,
@@ -224,13 +228,13 @@ export default defineComponent({
       return this.showMore ? this.$gettext('Show less') : this.$gettext('Show more')
     },
     hasMore() {
-      return this.items.length > 3
+      return this.items.length > this.showMoreToggleCount
     },
     resourceItems() {
-      if (!this.showMoreLessToggle || this.showMore) {
+      if (!this.showMoreToggle || this.showMore) {
         return this.items
       }
-      return this.items.slice(0, 3)
+      return this.items.slice(0, this.showMoreToggleCount)
     }
   },
   beforeDestroy() {

--- a/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
+++ b/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
@@ -75,7 +75,7 @@
           </oc-button>
         </div>
         <list-info
-          v-else-if="items.length > 0"
+          v-else
           class="oc-width-1-1 oc-my-s"
           :files="countFiles"
           :folders="countFolders"
@@ -104,6 +104,7 @@ import { createLocationSpaces } from '../../router'
 import ListInfo from '../../components/FilesList/ListInfo.vue'
 import { ShareStatus } from '../../helpers/share'
 import ContextActions from '../../components/FilesList/ContextActions.vue'
+import NoContentMessage from 'web-pkg/src/components/NoContentMessage.vue'
 
 const visibilityObserver = new VisibilityObserver()
 
@@ -111,7 +112,8 @@ export default defineComponent({
   components: {
     ResourceTable,
     ContextActions,
-    ListInfo
+    ListInfo,
+    NoContentMessage
   },
 
   mixins: [

--- a/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
+++ b/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
@@ -5,7 +5,7 @@
       <span class="oc-text-initial">({{ items.length }})</span>
     </h2>
 
-    <no-content-message v-if="!items.length > 0" class="files-empty oc-flex-stretch" icon="group">
+    <no-content-message v-if="!items.length" class="files-empty oc-flex-stretch" icon="group">
       <template #message>
         <span>{{ emptyMessage }}</span>
       </template>
@@ -278,3 +278,9 @@ export default defineComponent({
   }
 })
 </script>
+
+<style lang="scss" scoped>
+.files-empty {
+  height: auto;
+}
+</style>

--- a/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
+++ b/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
@@ -1,0 +1,305 @@
+<template>
+  <div>
+    <h2 class="oc-px-m oc-py-s">
+      {{ title }}
+      <span class="oc-text-initial">({{ items.length }})</span>
+    </h2>
+
+    <no-content-message
+      v-if="!items.length > 0"
+      :id="noContentMessageId"
+      class="files-empty oc-flex-stretch"
+      icon="group"
+    >
+      <template #message>
+        <span>{{ emptyMessage }}</span>
+      </template>
+    </no-content-message>
+    <resource-table
+      v-else
+      :id="tableId"
+      v-model="itemsSelected"
+      :data-test-share-status="shareStatus"
+      class="files-table"
+      :class="{ 'files-table-squashed': !sidebarClosed }"
+      :fields-displayed="displayedFields"
+      sidebar-closed
+      :are-thumbnails-displayed="displayThumbnails"
+      :resources="resourceItems"
+      :are-resources-clickable="resourceClickable"
+      :target-route="resourceTargetLocation"
+      :target-route-param-mapping="resourceTargetParamMapping"
+      :target-route-query-mapping="resourceTargetQueryMapping"
+      :header-position="fileListHeaderY"
+      :sort-by="sortBy"
+      :sort-dir="sortDir"
+      @fileClick="$_fileActions_triggerDefaultAction"
+      @rowMounted="rowMounted"
+      @sort="sortHandler"
+    >
+      <template #status="{ resource }">
+        <div
+          :key="resource.getDomSelector() + resource.status"
+          class="oc-text-nowrap oc-flex oc-flex-middle oc-flex-right"
+        >
+          <oc-button
+            v-if="showAcceptButton"
+            size="small"
+            variation="success"
+            class="file-row-share-status-accept"
+            @click.stop="$_acceptShare_trigger({ resources: [resource] })"
+          >
+            <oc-icon size="small" name="check" />
+            <translate>Accept</translate>
+          </oc-button>
+          <oc-button
+            v-if="showDeclineButton"
+            size="small"
+            class="file-row-share-decline oc-ml-s"
+            @click.stop="$_declineShare_trigger({ resources: [resource] })"
+          >
+            <oc-icon size="small" name="close" />
+            <translate>Decline</translate>
+          </oc-button>
+        </div>
+      </template>
+      <template #contextMenu>
+        <context-actions :items="itemsSelected" />
+      </template>
+      <template #footer>
+        <div v-if="showMoreLessToggle && hasMore" class="oc-width-1-1 oc-text-center oc-mt">
+          <oc-button
+            id="files-shared-with-me-pending-show-all"
+            appearance="raw"
+            gap-size="xsmall"
+            size="small"
+            :data-test-expand="(!showMore).toString()"
+            @click="toggleShowMore"
+          >
+            {{ toggleMoreLabel }}
+            <oc-icon :name="'arrow-' + (showMore ? 'up' : 'down') + '-s'" fill-type="line" />
+          </oc-button>
+        </div>
+        <list-info
+          v-else-if="items.length > 0"
+          class="oc-width-1-1 oc-my-s"
+          :files="countFiles"
+          :folders="countFolders"
+        />
+      </template>
+    </resource-table>
+  </div>
+</template>
+
+<script lang="ts">
+import ResourceTable from '../FilesList/ResourceTable.vue'
+import { computed, defineComponent, unref } from '@vue/composition-api'
+import debounce from 'lodash-es/debounce'
+import { ImageDimension, ImageType } from '../../constants'
+import { VisibilityObserver } from 'web-pkg/src/observer'
+import { mapActions, mapGetters, mapMutations, mapState } from 'vuex'
+import FileActions from '../../mixins/fileActions'
+import MixinAcceptShare from '../../mixins/actions/acceptShare'
+import MixinDeclineShare from '../../mixins/actions/declineShare'
+import MixinFilesListFilter from '../../mixins/filesListFilter'
+import MixinMountSideBar from '../../mixins/sidebar/mountSideBar'
+import { useResourcesViewDefaults } from '../../composables'
+import { Resource } from '../../helpers/resource'
+import { useCapabilityShareJailEnabled, useStore } from 'web-pkg/src/composables'
+import { createLocationSpaces } from '../../router'
+import ListInfo from '../../components/FilesList/ListInfo.vue'
+import { ShareStatus } from '../../helpers/share'
+import ContextActions from '../../components/FilesList/ContextActions.vue'
+
+const visibilityObserver = new VisibilityObserver()
+
+export default defineComponent({
+  components: {
+    ResourceTable,
+    ContextActions,
+    ListInfo
+  },
+
+  mixins: [
+    FileActions,
+    MixinAcceptShare,
+    MixinDeclineShare,
+    MixinMountSideBar,
+    MixinFilesListFilter
+  ],
+  props: {
+    title: {
+      type: String,
+      required: true
+    },
+    emptyMessage: {
+      type: String,
+      required: false,
+      default: ''
+    },
+    items: {
+      type: Array,
+      required: true
+    },
+    shareStatus: {
+      type: Number,
+      required: true
+    },
+    sortBy: {
+      type: String,
+      required: true
+    },
+    sortDir: {
+      type: String,
+      required: true
+    },
+    sortHandler: {
+      type: Function,
+      required: true
+    },
+    showMoreLessToggle: {
+      type: Boolean,
+      default: false
+    }
+  },
+  setup() {
+    const { fileListHeaderY } = useResourcesViewDefaults<Resource, any, any[]>()
+
+    const store = useStore()
+    const hasShareJail = useCapabilityShareJailEnabled()
+    const resourceTargetLocation = computed(() =>
+      unref(hasShareJail)
+        ? createLocationSpaces('files-spaces-share')
+        : createLocationSpaces('files-spaces-personal', {
+            params: { storageId: store.getters.user.id }
+          })
+    )
+    const resourceTargetParamMapping = computed(() =>
+      unref(hasShareJail) ? { name: 'shareName', path: 'item' } : undefined
+    )
+    const resourceTargetQueryMapping = computed(() =>
+      unref(hasShareJail) ? { id: 'shareId' } : undefined
+    )
+
+    return {
+      resourceTargetLocation,
+      resourceTargetParamMapping,
+      resourceTargetQueryMapping,
+      fileListHeaderY
+    }
+  },
+
+  data: () => ({
+    ShareStatus,
+    showMore: false
+  }),
+
+  computed: {
+    ...mapGetters('Files', ['selectedFiles']),
+    ...mapGetters(['configuration']),
+    ...mapState('Files/sidebar', { sidebarClosed: 'closed' }),
+
+    displayedFields() {
+      return ['name', 'status', 'owner', 'sdate', 'sharedWith']
+    },
+    countFiles() {
+      return this.items.filter((s) => s.type !== 'folder').length
+    },
+    countFolders() {
+      return this.items.filter((s) => s.type === 'folder').length
+    },
+    showAcceptButton() {
+      return this.shareStatus === ShareStatus.declined || this.shareStatus === ShareStatus.pending
+    },
+    showDeclineButton() {
+      return this.shareStatus === ShareStatus.accepted || this.shareStatus === ShareStatus.pending
+    },
+    itemsSelected: {
+      get() {
+        return this.selectedFiles.filter((r) => r.status === this.shareStatus)
+      },
+      set(resources) {
+        this.SET_FILE_SELECTION(resources.filter((r) => r.status === this.shareStatus))
+      }
+    },
+    displayThumbnails() {
+      return (
+        !this.configuration?.options?.disablePreviews && this.shareStatus === ShareStatus.accepted
+      )
+    },
+    resourceClickable() {
+      return this.shareStatus === ShareStatus.accepted
+    },
+    toggleMoreLabel() {
+      return this.showMore ? this.$gettext('Show less') : this.$gettext('Show more')
+    },
+    hasMore() {
+      return this.items.length > 3
+    },
+    resourceItems() {
+      if (!this.showMoreLessToggle || this.showMore) {
+        return this.items
+      }
+      return this.items.slice(0, 3)
+    },
+    tableId() {
+      switch (this.shareStatus) {
+        case ShareStatus.pending:
+          return 'files-shared-with-me-pending-table'
+        case ShareStatus.accepted:
+          return 'files-shared-with-me-accepted-table'
+        case ShareStatus.declined:
+          return 'files-shared-with-me-declined-table'
+        default:
+          return ''
+      }
+    },
+    noContentMessageId() {
+      switch (this.shareStatus) {
+        case ShareStatus.pending:
+          return 'files-shared-with-me-pending-empty'
+        case ShareStatus.accepted:
+          return 'files-shared-with-me-accepted-empty'
+        case ShareStatus.declined:
+          return 'files-shared-with-me-declined-empty'
+        default:
+          return ''
+      }
+    }
+  },
+  beforeDestroy() {
+    visibilityObserver.disconnect()
+  },
+  methods: {
+    ...mapActions('Files', ['loadIndicators', 'loadPreview', 'loadAvatars']),
+    ...mapMutations('Files', ['LOAD_FILES', 'SET_FILE_SELECTION', 'CLEAR_CURRENT_FILES_LIST']),
+
+    rowMounted(resource, component) {
+      const debounced = debounce(({ unobserve }) => {
+        unobserve()
+        this.loadAvatars({ resource })
+
+        if (!this.displayThumbnails) {
+          return
+        }
+
+        this.loadPreview({
+          resource,
+          isPublic: false,
+          dimensions: ImageDimension.Thumbnail,
+          type: ImageType.Thumbnail
+        })
+      }, 250)
+
+      visibilityObserver.observe(component.$el, {
+        onEnter: debounced,
+        onExit: debounced.cancel
+      })
+    },
+
+    toggleShowMore() {
+      this.showMore = !this.showMore
+    }
+  }
+})
+</script>

--- a/packages/web-app-files/src/views/shares/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithMe.vue
@@ -3,267 +3,62 @@
     <app-bar :has-shares-navigation="true" :has-bulk-actions="true" />
     <app-loading-spinner v-if="areResourcesLoading" />
     <template v-else>
-      <!-- Pending shares -->
-      <div v-if="hasPending">
-        <h2 class="oc-px-m oc-py-s">
-          {{ pendingTitle }}
-          <span class="oc-text-initial">({{ pendingCount }})</span>
-        </h2>
+      <shared-with-me-section
+        v-if="pendingItems.length > 0"
+        :title="pendingTitle"
+        :items="pendingItems"
+        :share-status="ShareStatus.pending"
+        :sort-by="pendingSortBy"
+        :sort-dir="pendingSortDir"
+        :sort-handler="acceptedHandleSort"
+        :show-more-less-toggle="true"
+      ></shared-with-me-section>
 
-        <resource-table
-          id="files-shared-with-me-pending-table"
-          v-model="pendingSelected"
-          :data-test-share-status="ShareStatus.pending"
-          class="files-table"
-          :class="{ 'files-table-squashed': !sidebarClosed }"
-          :fields-displayed="displayedFields"
-          :are-thumbnails-displayed="false"
-          :resources="showMorePending ? pendingItems : pendingItems.slice(0, 3)"
-          :are-resources-clickable="false"
-          :header-position="fileListHeaderY"
-          :sort-by="pendingSortBy"
-          :sort-dir="pendingSortDir"
-          @sort="pendingHandleSort"
-        >
-          <template #status="{ resource }">
-            <div
-              :key="resource.getDomSelector() + resource.status"
-              class="oc-text-nowrap oc-flex oc-flex-middle oc-flex-right"
-            >
-              <oc-button
-                size="small"
-                variation="success"
-                class="file-row-share-status-accept"
-                @click.stop="$_acceptShare_trigger({ resources: [resource] })"
-              >
-                <oc-icon size="small" name="check" />
-                <translate>Accept</translate>
-              </oc-button>
-              <oc-button
-                size="small"
-                class="file-row-share-decline oc-ml-s"
-                @click.stop="$_declineShare_trigger({ resources: [resource] })"
-              >
-                <oc-icon size="small" name="close" />
-                <translate>Decline</translate>
-              </oc-button>
-            </div>
-          </template>
-          <template #contextMenu="{ resource }">
-            <context-actions
-              v-if="isResourceInPendingSelection(resource)"
-              :items="pendingSelected"
-            />
-          </template>
-          <template v-if="pendingHasMore" #footer>
-            <div class="oc-width-1-1 oc-text-center oc-mt">
-              <oc-button
-                id="files-shared-with-me-pending-show-all"
-                appearance="raw"
-                gap-size="xsmall"
-                size="small"
-                :data-test-expand="(!showMorePending).toString()"
-                @click="togglePendingShowMore"
-              >
-                {{ pendingToggleMoreLabel }}
-                <oc-icon
-                  :name="'arrow-' + (showMorePending ? 'up' : 'down') + '-s'"
-                  fill-type="line"
-                />
-              </oc-button>
-            </div>
-          </template>
-        </resource-table>
-      </div>
+      <shared-with-me-section
+        :title="acceptedTitle"
+        :empty-message="acceptedEmptyMessage"
+        :items="acceptedItems"
+        :share-status="ShareStatus.accepted"
+        :sort-by="acceptedSortBy"
+        :sort-dir="acceptedSortDir"
+        :sort-handler="acceptedHandleSort"
+      ></shared-with-me-section>
 
-      <div>
-        <!-- Accepted shares -->
-        <h2 class="oc-px-m oc-py-s">
-          {{ acceptedTitle }}
-          <span class="oc-text-initial">({{ acceptedCount }})</span>
-        </h2>
-
-        <no-content-message
-          v-if="!hasAccepted"
-          id="files-shared-with-me-accepted-empty"
-          class="files-empty oc-flex-stretch"
-          icon="group"
-        >
-          <template #message>
-            <span>{{ acceptedEmptyMessage }}</span>
-          </template>
-        </no-content-message>
-        <resource-table
-          v-else
-          id="files-shared-with-me-accepted-table"
-          v-model="acceptedSelected"
-          :data-test-share-status="ShareStatus.accepted"
-          class="files-table"
-          :class="{ 'files-table-squashed': !sidebarClosed }"
-          :fields-displayed="displayedFields"
-          :are-thumbnails-displayed="displayThumbnails"
-          :resources="acceptedItems"
-          :are-resources-clickable="true"
-          :target-route="resourceTargetLocation"
-          :target-route-param-mapping="resourceTargetParamMapping"
-          :target-route-query-mapping="resourceTargetQueryMapping"
-          :header-position="fileListHeaderY"
-          :sort-by="acceptedSortBy"
-          :sort-dir="acceptedSortDir"
-          @fileClick="$_fileActions_triggerDefaultAction"
-          @rowMounted="rowMounted"
-          @sort="acceptedHandleSort"
-        >
-          <template #status="{ resource }">
-            <div
-              :key="resource.getDomSelector() + resource.status"
-              class="oc-text-nowrap oc-flex oc-flex-middle oc-flex-right"
-            >
-              <oc-button
-                size="small"
-                class="file-row-share-status-decline"
-                @click.stop="$_declineShare_trigger({ resources: [resource] })"
-              >
-                <oc-icon size="small" name="close" />
-                <translate>Decline</translate>
-              </oc-button>
-            </div>
-          </template>
-          <template #contextMenu="{ resource }">
-            <context-actions
-              v-if="isResourceInAcceptedSelection(resource)"
-              :items="acceptedSelected"
-            />
-          </template>
-          <template #footer>
-            <list-info
-              v-if="hasAccepted"
-              class="oc-width-1-1 oc-my-s"
-              :files="acceptedCountFiles"
-              :folders="acceptedCountFolders"
-            />
-          </template>
-        </resource-table>
-      </div>
-
-      <div>
-        <!-- Declined shares -->
-        <h2 class="oc-px-m oc-py-s">
-          {{ declinedTitle }}
-          <span class="oc-text-initial">({{ declinedCount }})</span>
-        </h2>
-
-        <no-content-message
-          v-if="!hasDeclined"
-          id="files-shared-with-me-declined-empty"
-          class="files-empty oc-flex-stretch"
-          icon="group"
-        >
-          <template #message>
-            <span>{{ declinedEmptyMessage }}</span>
-          </template>
-        </no-content-message>
-        <resource-table
-          v-else
-          id="files-shared-with-me-declined-table"
-          v-model="declinedSelected"
-          :data-test-share-status="ShareStatus.declined"
-          class="files-table"
-          :class="{ 'files-table-squashed': !sidebarClosed }"
-          :fields-displayed="displayedFields"
-          :are-thumbnails-displayed="false"
-          :resources="declinedItems"
-          :are-resources-clickable="false"
-          :target-route="resourceTargetLocation"
-          :target-route-param-mapping="resourceTargetParamMapping"
-          :target-route-query-mapping="resourceTargetQueryMapping"
-          :header-position="fileListHeaderY"
-          :sort-by="declinedSortBy"
-          :sort-dir="declinedSortDir"
-          @fileClick="$_fileActions_triggerDefaultAction"
-          @rowMounted="rowMounted"
-          @sort="declinedHandleSort"
-        >
-          <template #status="{ resource }">
-            <div
-              :key="resource.getDomSelector() + resource.status"
-              class="oc-text-nowrap oc-flex oc-flex-middle oc-flex-right"
-            >
-              <oc-button
-                size="small"
-                variation="success"
-                class="file-row-share-status-accept"
-                @click.stop="$_acceptShare_trigger({ resources: [resource] })"
-              >
-                <oc-icon size="small" name="check" />
-                <translate>Accept</translate>
-              </oc-button>
-            </div>
-          </template>
-          <template #contextMenu="{ resource }">
-            <context-actions
-              v-if="isResourceInDeclinedSelection(resource)"
-              :items="declinedSelected"
-            />
-          </template>
-          <template #footer>
-            <list-info
-              v-if="hasDeclined"
-              class="oc-width-1-1 oc-my-s"
-              :files="declinedCountFiles"
-              :folders="declinedCountFolders"
-            />
-          </template>
-        </resource-table>
-      </div>
+      <shared-with-me-section
+        :title="declinedTitle"
+        :empty-message="declinedEmptyMessage"
+        :items="declinedItems"
+        :share-status="ShareStatus.declined"
+        :resource-clickable="false"
+        :sort-by="declinedSortBy"
+        :sort-dir="declinedSortDir"
+        :sort-handler="declinedHandleSort"
+      ></shared-with-me-section>
     </template>
   </div>
 </template>
 
 <script lang="ts">
-import { mapGetters, mapState, mapActions, mapMutations } from 'vuex'
-import ResourceTable from '../../components/FilesList/ResourceTable.vue'
-import FileActions from '../../mixins/fileActions'
-import MixinAcceptShare from '../../mixins/actions/acceptShare'
-import MixinDeclineShare from '../../mixins/actions/declineShare'
-import MixinFilesListFilter from '../../mixins/filesListFilter'
-import MixinMountSideBar from '../../mixins/sidebar/mountSideBar'
-import { VisibilityObserver } from 'web-pkg/src/observer'
-import { ImageDimension, ImageType } from '../../constants'
+import { mapGetters, mapState } from 'vuex'
 import { useSort, useResourcesViewDefaults } from '../../composables'
 import { useCapabilityShareJailEnabled, useStore } from 'web-pkg/src/composables'
-import debounce from 'lodash-es/debounce'
 
 import AppLoadingSpinner from 'web-pkg/src/components/AppLoadingSpinner.vue'
-import NoContentMessage from 'web-pkg/src/components/NoContentMessage.vue'
 import AppBar from '../../components/AppBar/AppBar.vue'
-import ListInfo from '../../components/FilesList/ListInfo.vue'
-import ContextActions from '../../components/FilesList/ContextActions.vue'
+import SharedWithMeSection from '../../components/Shares/SharedWithMeSection.vue'
 import { ShareStatus } from '../../helpers/share'
 import { computed, defineComponent, unref } from '@vue/composition-api'
 import { createLocationSpaces } from '../../router'
 import { Resource } from '../../helpers/resource'
 
-const visibilityObserver = new VisibilityObserver()
 const displayedFields = ['name', 'status', 'owner', 'sdate', 'sharedWith']
 
 export default defineComponent({
   components: {
     AppBar,
-    ResourceTable,
     AppLoadingSpinner,
-    NoContentMessage,
-    ListInfo,
-    ContextActions
+    SharedWithMeSection
   },
-
-  mixins: [
-    FileActions,
-    MixinAcceptShare,
-    MixinDeclineShare,
-    MixinMountSideBar,
-    MixinFilesListFilter
-  ],
 
   setup() {
     const { fileListHeaderY, storeItems, fields, loadResourcesTask, areResourcesLoading } =
@@ -363,8 +158,7 @@ export default defineComponent({
   },
 
   data: () => ({
-    ShareStatus,
-    showMorePending: false
+    ShareStatus
   }),
 
   computed: {
@@ -372,68 +166,12 @@ export default defineComponent({
     ...mapGetters(['configuration']),
     ...mapState('Files/sidebar', { sidebarClosed: 'closed' }),
 
-    pendingSelected: {
-      get() {
-        return this.selectedFiles.filter((r) => r.status === ShareStatus.pending)
-      },
-      set(resources) {
-        // this will (intentionally) reset the file selection to pending shares only.
-        this.SET_FILE_SELECTION(resources.filter((r) => r.status === ShareStatus.pending))
-      }
-    },
-
-    acceptedSelected: {
-      get() {
-        return this.selectedFiles.filter((r) => r.status === ShareStatus.accepted)
-      },
-      set(resources) {
-        // this will (intentionally) reset the file selection to pending shares only.
-        this.SET_FILE_SELECTION(resources.filter((r) => r.status === ShareStatus.accepted))
-      }
-    },
-
-    declinedSelected: {
-      get() {
-        return this.selectedFiles.filter((r) => r.status === ShareStatus.declined)
-      },
-      set(resources) {
-        // this will (intentionally) reset the file selection to pending shares only.
-        this.SET_FILE_SELECTION(resources.filter((r) => r.status === ShareStatus.declined))
-      }
-    },
     pendingTitle() {
       return this.$gettext('Pending shares')
-    },
-    pendingHasMore() {
-      return this.pendingCount > 3
-    },
-    pendingToggleMoreLabel() {
-      return this.showMorePending ? this.$gettext('Show less') : this.$gettext('Show more')
-    },
-    hasPending() {
-      return this.pendingCount > 0
-    },
-    pendingCount() {
-      return this.pendingItems.length
     },
 
     acceptedTitle() {
       return this.$gettext('Accepted shares')
-    },
-    acceptedHasMore() {
-      return this.acceptedCount > 3
-    },
-    hasAccepted() {
-      return this.acceptedCount > 0
-    },
-    acceptedCount() {
-      return this.acceptedItems.length
-    },
-    acceptedCountFiles() {
-      return this.acceptedItems.filter((s) => s.type !== 'folder').length
-    },
-    acceptedCountFolders() {
-      return this.acceptedItems.filter((s) => s.type === 'folder').length
     },
     acceptedEmptyMessage() {
       return this.$gettext("You are not collaborating on other people's resources.")
@@ -442,81 +180,13 @@ export default defineComponent({
     declinedTitle() {
       return this.$gettext('Declined shares')
     },
-    declinedHasMore() {
-      return this.declinedCount > 3
-    },
-    hasDeclined() {
-      return this.declinedCount > 0
-    },
-    declinedCount() {
-      return this.declinedItems.length
-    },
-    declinedCountFiles() {
-      return this.declinedItems.filter((s) => s.type !== 'folder').length
-    },
-    declinedCountFolders() {
-      return this.declinedItems.filter((s) => s.type === 'folder').length
-    },
     declinedEmptyMessage() {
       return this.$gettext("You don't have any previously declined shares.")
-    },
-
-    displayThumbnails() {
-      return !this.configuration?.options?.disablePreviews
     }
   },
 
   created() {
     this.loadResourcesTask.perform()
-  },
-
-  beforeDestroy() {
-    visibilityObserver.disconnect()
-  },
-
-  methods: {
-    ...mapActions('Files', ['loadIndicators', 'loadPreview', 'loadAvatars']),
-    ...mapActions(['showMessage']),
-    ...mapMutations('Files', ['LOAD_FILES', 'SET_FILE_SELECTION', 'CLEAR_CURRENT_FILES_LIST']),
-
-    rowMounted(resource, component) {
-      const debounced = debounce(({ unobserve }) => {
-        unobserve()
-        this.loadAvatars({ resource })
-
-        if (!this.displayThumbnails) {
-          return
-        }
-
-        this.loadPreview({
-          resource,
-          isPublic: false,
-          dimensions: ImageDimension.Thumbnail,
-          type: ImageType.Thumbnail
-        })
-      }, 250)
-
-      visibilityObserver.observe(component.$el, {
-        onEnter: debounced,
-        onExit: debounced.cancel
-      })
-    },
-
-    togglePendingShowMore() {
-      this.showMorePending = !this.showMorePending
-    },
-
-    isResourceInPendingSelection(resource) {
-      return this.pendingSelected?.includes(resource)
-    },
-
-    isResourceInAcceptedSelection(resource) {
-      return this.acceptedSelected?.includes(resource)
-    },
-
-    isResourceInDeclinedSelection(resource) {
-      return this.declinedSelected?.includes(resource)
-    }
   }
 })
 </script>

--- a/packages/web-app-files/src/views/shares/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithMe.vue
@@ -85,7 +85,7 @@
 
         <no-content-message
           v-if="!hasAccepted"
-          id="files-shared-with-me-shares-empty"
+          id="files-shared-with-me-accepted-empty"
           class="files-empty oc-flex-stretch"
           icon="group"
         >
@@ -95,7 +95,7 @@
         </no-content-message>
         <resource-table
           v-else
-          id="files-shared-with-me-shares-table"
+          id="files-shared-with-me-accepted-table"
           v-model="acceptedSelected"
           :data-test-share-status="ShareStatus.accepted"
           class="files-table"
@@ -120,17 +120,6 @@
               class="oc-text-nowrap oc-flex oc-flex-middle oc-flex-right"
             >
               <oc-button
-                v-if="resource.status === ShareStatus.declined"
-                size="small"
-                variation="success"
-                class="file-row-share-status-accept"
-                @click.stop="$_acceptShare_trigger({ resources: [resource] })"
-              >
-                <oc-icon size="small" name="check" />
-                <translate>Accept</translate>
-              </oc-button>
-              <oc-button
-                v-if="resource.status === ShareStatus.accepted"
                 size="small"
                 class="file-row-share-status-decline"
                 @click.stop="$_declineShare_trigger({ resources: [resource] })"
@@ -166,7 +155,7 @@
 
         <no-content-message
           v-if="!hasDeclined"
-          id="files-shared-with-me-shares-empty"
+          id="files-shared-with-me-declined-empty"
           class="files-empty oc-flex-stretch"
           icon="group"
         >
@@ -176,7 +165,7 @@
         </no-content-message>
         <resource-table
           v-else
-          id="files-shared-with-me-shares-table"
+          id="files-shared-with-me-declined-table"
           v-model="declinedSelected"
           :data-test-share-status="ShareStatus.declined"
           class="files-table"
@@ -201,7 +190,6 @@
               class="oc-text-nowrap oc-flex oc-flex-middle oc-flex-right"
             >
               <oc-button
-                v-if="resource.status === ShareStatus.declined"
                 size="small"
                 variation="success"
                 class="file-row-share-status-accept"
@@ -209,15 +197,6 @@
               >
                 <oc-icon size="small" name="check" />
                 <translate>Accept</translate>
-              </oc-button>
-              <oc-button
-                v-if="resource.status === ShareStatus.accepted"
-                size="small"
-                class="file-row-share-status-decline"
-                @click.stop="$_declineShare_trigger({ resources: [resource] })"
-              >
-                <oc-icon size="small" name="close" />
-                <translate>Decline</translate>
               </oc-button>
             </div>
           </template>
@@ -459,6 +438,7 @@ export default defineComponent({
     acceptedEmptyMessage() {
       return this.$gettext("You are not collaborating on other people's resources.")
     },
+
     declinedTitle() {
       return this.$gettext('Declined shares')
     },
@@ -472,14 +452,15 @@ export default defineComponent({
       return this.declinedItems.length
     },
     declinedCountFiles() {
-      return this.acceptedItems.filter((s) => s.type !== 'folder').length
+      return this.declinedItems.filter((s) => s.type !== 'folder').length
     },
     declinedCountFolders() {
-      return this.acceptedItems.filter((s) => s.type === 'folder').length
+      return this.declinedItems.filter((s) => s.type === 'folder').length
     },
     declinedEmptyMessage() {
       return this.$gettext("You don't have any previously declined shares.")
     },
+
     displayThumbnails() {
       return !this.configuration?.options?.disablePreviews
     }

--- a/packages/web-app-files/src/views/shares/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithMe.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="oc-flex oc-flex-column">
     <app-bar :has-shares-navigation="true" :has-bulk-actions="true" />
-    <app-loading-spinner v-if="areResourcesLoading" />
+    <app-loading-spinner v-if="loadResourcesTask.isRunning" />
     <template v-else>
       <shared-with-me-section
         v-if="pendingItems.length > 0"
@@ -41,17 +41,13 @@
 <script lang="ts">
 import { mapGetters, mapState } from 'vuex'
 import { useSort, useResourcesViewDefaults } from '../../composables'
-import { useCapabilityShareJailEnabled, useStore } from 'web-pkg/src/composables'
 
 import AppLoadingSpinner from 'web-pkg/src/components/AppLoadingSpinner.vue'
 import AppBar from '../../components/AppBar/AppBar.vue'
 import SharedWithMeSection from '../../components/Shares/SharedWithMeSection.vue'
 import { ShareStatus } from '../../helpers/share'
 import { computed, defineComponent, unref } from '@vue/composition-api'
-import { createLocationSpaces } from '../../router'
 import { Resource } from '../../helpers/resource'
-
-const displayedFields = ['name', 'status', 'owner', 'sdate', 'sharedWith']
 
 export default defineComponent({
   components: {
@@ -61,24 +57,11 @@ export default defineComponent({
   },
 
   setup() {
-    const { fileListHeaderY, storeItems, fields, loadResourcesTask, areResourcesLoading } =
-      useResourcesViewDefaults<Resource, any, any[]>()
-
-    const store = useStore()
-    const hasShareJail = useCapabilityShareJailEnabled()
-    const resourceTargetLocation = computed(() =>
-      unref(hasShareJail)
-        ? createLocationSpaces('files-spaces-share')
-        : createLocationSpaces('files-spaces-personal', {
-            params: { storageId: store.getters.user.id }
-          })
-    )
-    const resourceTargetParamMapping = computed(() =>
-      unref(hasShareJail) ? { name: 'shareName', path: 'item' } : undefined
-    )
-    const resourceTargetQueryMapping = computed(() =>
-      unref(hasShareJail) ? { id: 'shareId' } : undefined
-    )
+    const { storeItems, fields, loadResourcesTask } = useResourcesViewDefaults<
+      Resource,
+      any,
+      any[]
+    >()
 
     // pending shares
     const pending = computed(() =>
@@ -130,9 +113,7 @@ export default defineComponent({
 
     return {
       // defaults
-      fileListHeaderY,
       loadResourcesTask,
-      areResourcesLoading,
 
       // view specific
       pendingHandleSort,
@@ -148,12 +129,7 @@ export default defineComponent({
       declinedHandleSort,
       declinedSortBy,
       declinedSortDir,
-      declinedItems,
-
-      displayedFields,
-      resourceTargetLocation,
-      resourceTargetParamMapping,
-      resourceTargetQueryMapping
+      declinedItems
     }
   },
 

--- a/packages/web-app-files/src/views/shares/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithMe.vue
@@ -5,16 +5,20 @@
     <template v-else>
       <shared-with-me-section
         v-if="pendingItems.length > 0"
+        id="files-shared-with-me-pending-section"
         :title="pendingTitle"
         :items="pendingItems"
         :share-status="ShareStatus.pending"
         :sort-by="pendingSortBy"
         :sort-dir="pendingSortDir"
-        :sort-handler="acceptedHandleSort"
+        :sort-handler="pendingHandleSort"
         :show-more-less-toggle="true"
+        :resource-clickable="false"
+        :display-thumbnails="false"
       ></shared-with-me-section>
 
       <shared-with-me-section
+        id="files-shared-with-me-accepted-section"
         :title="acceptedTitle"
         :empty-message="acceptedEmptyMessage"
         :items="acceptedItems"
@@ -22,9 +26,12 @@
         :sort-by="acceptedSortBy"
         :sort-dir="acceptedSortDir"
         :sort-handler="acceptedHandleSort"
+        :resource-clickable="true"
+        :display-thumbnails="displayThumbnails"
       ></shared-with-me-section>
 
       <shared-with-me-section
+        id="files-shared-with-me-declined-section"
         :title="declinedTitle"
         :empty-message="declinedEmptyMessage"
         :items="declinedItems"
@@ -33,6 +40,7 @@
         :sort-by="declinedSortBy"
         :sort-dir="declinedSortDir"
         :sort-handler="declinedHandleSort"
+        :display-thumbnails="false"
       ></shared-with-me-section>
     </template>
   </div>
@@ -158,6 +166,9 @@ export default defineComponent({
     },
     declinedEmptyMessage() {
       return this.$gettext("You don't have any previously declined shares.")
+    },
+    displayThumbnails() {
+      return !this.configuration?.options?.disablePreviews
     }
   },
 

--- a/packages/web-app-files/src/views/shares/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithMe.vue
@@ -15,7 +15,7 @@
         :show-more-toggle="true"
         :resource-clickable="false"
         :display-thumbnails="false"
-      ></shared-with-me-section>
+      />
 
       <shared-with-me-section
         id="files-shared-with-me-accepted-section"
@@ -28,7 +28,7 @@
         :sort-handler="acceptedHandleSort"
         :resource-clickable="true"
         :display-thumbnails="displayThumbnails"
-      ></shared-with-me-section>
+      />
 
       <shared-with-me-section
         id="files-shared-with-me-declined-section"
@@ -42,7 +42,7 @@
         :show-more-toggle="true"
         :display-thumbnails="false"
         :resource-clickable="false"
-      ></shared-with-me-section>
+      />
     </template>
   </div>
 </template>

--- a/packages/web-app-files/src/views/shares/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithMe.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="oc-flex oc-flex-column">
     <app-bar :has-shares-navigation="true" :has-bulk-actions="true" />
-    <app-loading-spinner v-if="loadResourcesTask.isRunning" />
+    <app-loading-spinner v-if="areResourcesLoading" />
     <template v-else>
       <shared-with-me-section
         v-if="pendingItems.length > 0"
@@ -65,7 +65,7 @@ export default defineComponent({
   },
 
   setup() {
-    const { storeItems, fields, loadResourcesTask } = useResourcesViewDefaults<
+    const { storeItems, fields, loadResourcesTask, areResourcesLoading } = useResourcesViewDefaults<
       Resource,
       any,
       any[]
@@ -122,6 +122,7 @@ export default defineComponent({
     return {
       // defaults
       loadResourcesTask,
+      areResourcesLoading,
 
       // view specific
       pendingHandleSort,

--- a/packages/web-app-files/src/views/shares/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithMe.vue
@@ -12,7 +12,7 @@
         :sort-by="pendingSortBy"
         :sort-dir="pendingSortDir"
         :sort-handler="pendingHandleSort"
-        :show-more-less-toggle="true"
+        :show-more-toggle="true"
         :resource-clickable="false"
         :display-thumbnails="false"
       ></shared-with-me-section>
@@ -36,11 +36,12 @@
         :empty-message="declinedEmptyMessage"
         :items="declinedItems"
         :share-status="ShareStatus.declined"
-        :resource-clickable="false"
         :sort-by="declinedSortBy"
         :sort-dir="declinedSortDir"
         :sort-handler="declinedHandleSort"
+        :show-more-toggle="true"
         :display-thumbnails="false"
+        :resource-clickable="false"
       ></shared-with-me-section>
     </template>
   </div>

--- a/packages/web-app-files/tests/unit/views/shares/SharedWithMe.spec.js
+++ b/packages/web-app-files/tests/unit/views/shares/SharedWithMe.spec.js
@@ -19,9 +19,12 @@ const selectors = {
   pendingTableRow: '#files-shared-with-me-pending-table tbody > tr.oc-tbody-tr',
   pendingExpand: '#files-shared-with-me-pending-show-all[data-test-expand="true"]',
   pendingCollapse: '#files-shared-with-me-pending-show-all[data-test-expand="false"]',
-  sharesNoContentMessage: '#files-shared-with-me-shares-empty',
-  sharesTable: '#files-shared-with-me-shares-table',
-  sharesTableRow: '#files-shared-with-me-shares-table tbody > tr.oc-tbody-tr',
+  acceptedNoContentMessage: '#files-shared-with-me-accepted-empty',
+  declinedNoContentMessage: '#files-shared-with-me-declined-empty',
+  acceptedTable: '#files-shared-with-me-accepted-table',
+  declinedTable: '#files-shared-with-me-declined-table',
+  acceptedTableRow: '#files-shared-with-me-accepted-table tbody > tr.oc-tbody-tr',
+  declinedTableRow: '#files-shared-with-me-declined-table tbody > tr.oc-tbody-tr',
   sharesToggleViewMode: '#files-shared-with-me-toggle-view-mode'
 }
 
@@ -36,8 +39,10 @@ describe('SharedWithMe view', () => {
     it('should not show other components', () => {
       const wrapper = getMountedWrapper({ loading: true })
       expect(wrapper.find(selectors.pendingTable).exists()).toBeFalsy()
-      expect(wrapper.find(selectors.sharesTable).exists()).toBeFalsy()
-      expect(wrapper.find(selectors.sharesNoContentMessage).exists()).toBeFalsy()
+      expect(wrapper.find(selectors.acceptedTable).exists()).toBeFalsy()
+      expect(wrapper.find(selectors.declinedTable).exists()).toBeFalsy()
+      expect(wrapper.find(selectors.acceptedNoContentMessage).exists()).toBeFalsy()
+      expect(wrapper.find(selectors.declinedNoContentMessage).exists()).toBeFalsy()
     })
   })
 
@@ -129,10 +134,10 @@ describe('SharedWithMe view', () => {
     describe('when there are no accepted shares to be displayed', () => {
       const wrapper = getMountedWrapper()
       it('should show a "no content" message', () => {
-        expect(wrapper.find(selectors.sharesNoContentMessage).exists()).toBeTruthy()
+        expect(wrapper.find(selectors.acceptedNoContentMessage).exists()).toBeTruthy()
       })
       it('should not show the accepted shares list', () => {
-        expect(wrapper.find(selectors.sharesTable).exists()).toBeFalsy()
+        expect(wrapper.find(selectors.acceptedTable).exists()).toBeFalsy()
       })
     })
 
@@ -147,15 +152,11 @@ describe('SharedWithMe view', () => {
         })
       })
       it('should not show a "no content" message', () => {
-        expect(wrapper.find(selectors.sharesNoContentMessage).exists()).toBeFalsy()
+        expect(wrapper.find(selectors.acceptedNoContentMessage).exists()).toBeFalsy()
       })
       it('should show the accepted shares list', () => {
-        expect(wrapper.find(selectors.sharesTable).exists()).toBeTruthy()
-        expect(wrapper.findAll(selectors.sharesTableRow).length).toBeGreaterThan(0)
-      })
-      it('should show a link to the declined shares', () => {
-        const link = wrapper.find(selectors.sharesToggleViewMode)
-        expect(link.attributes()['data-test-set-view-mode']).toBe(ShareStatus.declined.toString())
+        expect(wrapper.find(selectors.acceptedTable).exists()).toBeTruthy()
+        expect(wrapper.findAll(selectors.acceptedTableRow).length).toBeGreaterThan(0)
       })
     })
 
@@ -171,16 +172,12 @@ describe('SharedWithMe view', () => {
         viewMode: ShareStatus.declined
       })
       it('should not show a "no content" message', async () => {
-        const noContentMessage = await wrapper.find(selectors.sharesNoContentMessage)
+        const noContentMessage = await wrapper.find(selectors.declinedNoContentMessage)
         expect(noContentMessage.exists()).toBeFalsy()
       })
       it('should show the declined shares list', () => {
-        expect(wrapper.find(selectors.sharesTable).exists()).toBeTruthy()
-        expect(wrapper.findAll(selectors.sharesTableRow).length).toBeGreaterThan(0)
-      })
-      it('should show a link to the accepted shares', () => {
-        const link = wrapper.find(selectors.sharesToggleViewMode)
-        expect(link.attributes()['data-test-set-view-mode']).toBe(ShareStatus.accepted.toString())
+        expect(wrapper.find(selectors.declinedTable).exists()).toBeTruthy()
+        expect(wrapper.findAll(selectors.declinedTableRow).length).toBeGreaterThan(0)
       })
     })
   })

--- a/packages/web-app-files/tests/unit/views/shares/SharedWithMe.spec.js
+++ b/packages/web-app-files/tests/unit/views/shares/SharedWithMe.spec.js
@@ -11,20 +11,23 @@ const stubs = {
   translate: true,
   'oc-pagination': true,
   'oc-spinner': true,
-  'context-actions': true
+  'context-actions': true,
+  'no-content-message': true
 }
 
 const selectors = {
-  pendingTable: '#files-shared-with-me-pending-table',
-  pendingTableRow: '#files-shared-with-me-pending-table tbody > tr.oc-tbody-tr',
-  pendingExpand: '#files-shared-with-me-pending-show-all[data-test-expand="true"]',
-  pendingCollapse: '#files-shared-with-me-pending-show-all[data-test-expand="false"]',
-  acceptedNoContentMessage: '#files-shared-with-me-accepted-empty',
-  declinedNoContentMessage: '#files-shared-with-me-declined-empty',
-  acceptedTable: '#files-shared-with-me-accepted-table',
-  declinedTable: '#files-shared-with-me-declined-table',
-  acceptedTableRow: '#files-shared-with-me-accepted-table tbody > tr.oc-tbody-tr',
-  declinedTableRow: '#files-shared-with-me-declined-table tbody > tr.oc-tbody-tr',
+  pendingTable: '#files-shared-with-me-pending-section .files-table',
+  pendingTableRow: '#files-shared-with-me-pending-section tbody > tr.oc-tbody-tr',
+  pendingExpand:
+    '#files-shared-with-me-pending-section #files-shared-with-me-show-all[data-test-expand="true"]',
+  pendingCollapse:
+    '#files-shared-with-me-pending-section #files-shared-with-me-show-all[data-test-expand="false"]',
+  acceptedNoContentMessage: '#files-shared-with-me-accepted-section .files-empty',
+  declinedNoContentMessage: '#files-shared-with-me-declined-section .files-empty',
+  acceptedTable: '#files-shared-with-me-accepted-section .files-table',
+  declinedTable: '#files-shared-with-me-declined-section .files-table',
+  acceptedTableRow: '#files-shared-with-me-accepted-section tbody > tr.oc-tbody-tr',
+  declinedTableRow: '#files-shared-with-me-declined-section tbody > tr.oc-tbody-tr',
   sharesToggleViewMode: '#files-shared-with-me-toggle-view-mode'
 }
 
@@ -209,7 +212,12 @@ function mountOptions({
       loadResourcesTask: {
         perform: jest.fn()
       },
-      handleSort: jest.fn()
+      pendingHandleSort: jest.fn(),
+      acceptedHandleSort: jest.fn(),
+      declinedHandleSort: jest.fn(),
+      pendingSortBy: '',
+      acceptedSortBy: '',
+      declinedSortBy: ''
     })
   }
 }

--- a/tests/e2e/support/objects/app-files/share/actions.ts
+++ b/tests/e2e/support/objects/app-files/share/actions.ts
@@ -8,7 +8,7 @@ const invitationInput = '#files-share-invite-input'
 const filesCollaboratorRolesSelector = '//*[@id="files-collaborators-role-button-new"]'
 const collaboratorRoleItemSelector = `//*[@id="files-role-%s"]`
 const shareInvitationButton = '#new-collaborators-form-create-button'
-const filesSharedWithMe = `#files-shared-with-me-shares-table [data-test-resource-name="%s"]`
+const filesSharedWithMeAccepted = `#files-shared-with-me-accepted-table [data-test-resource-name="%s"]`
 const collaboratorUserItem = `//*[@data-testid="collaborator-user-item-%s"]`
 const shareAcceptDeclineButton = `//*[@data-test-resource-name="%s"]/ancestor::tr//button[contains(@class, "file-row-share-%s")]`
 const quickShareButton = `//*[@data-test-resource-name="%s"]/ancestor::tr//button[contains(@class, "files-quick-action-collaborators")]`
@@ -93,7 +93,7 @@ export const acceptShare = async (args: acceptShareArgs): Promise<void> => {
   await Promise.all([
     page.locator(util.format(shareAcceptDeclineButton, name, 'status-accept')).click(),
     page.waitForResponse((resp) => resp.url().includes('shares') && resp.status() === 200),
-    page.locator(util.format(filesSharedWithMe, args.name)).waitFor()
+    page.locator(util.format(filesSharedWithMeAccepted, args.name)).waitFor()
   ])
 }
 

--- a/tests/e2e/support/objects/app-files/share/actions.ts
+++ b/tests/e2e/support/objects/app-files/share/actions.ts
@@ -8,7 +8,7 @@ const invitationInput = '#files-share-invite-input'
 const filesCollaboratorRolesSelector = '//*[@id="files-collaborators-role-button-new"]'
 const collaboratorRoleItemSelector = `//*[@id="files-role-%s"]`
 const shareInvitationButton = '#new-collaborators-form-create-button'
-const filesSharedWithMeAccepted = `#files-shared-with-me-accepted-table [data-test-resource-name="%s"]`
+const filesSharedWithMeAccepted = `#files-shared-with-me-accepted-section [data-test-resource-name="%s"]`
 const collaboratorUserItem = `//*[@data-testid="collaborator-user-item-%s"]`
 const shareAcceptDeclineButton = `//*[@data-test-resource-name="%s"]/ancestor::tr//button[contains(@class, "file-row-share-%s")]`
 const quickShareButton = `//*[@data-test-resource-name="%s"]/ancestor::tr//button[contains(@class, "files-quick-action-collaborators")]`


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Enhancement: Declined shares are not easily accessible

We've redesigned the 'Shared with me' page,
so the 'Declined shares' section is now displayed under the 'Accepted shares' section.
There is no need to click the toggle button anymore which makes the 'Declined shares' easily accessible.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7342

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
