### PR TITLE
fix: loading state in projects view

### DIFF
--- a/changelog/unreleased/bugfix-loading-state-in-views
+++ b/changelog/unreleased/bugfix-loading-state-in-views
@@ -3,3 +3,4 @@ Bugfix: Loading state in views
 We fixed a small glitch in views of the files app, where the view would show a state like "Resource not found" in the brief moment before the resource loading started. Now the views correctly start in a loading state.
 
 https://github.com/owncloud/web/pull/7325
+https://github.com/owncloud/web/pull/7366

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -178,11 +178,15 @@ export default defineComponent({
       loadedSpaces = loadedSpaces.map(buildSpace)
       ref.LOAD_FILES({ currentFolder: null, files: loadedSpaces })
     })
+    const areResourcesLoading = computed(() => {
+      return loadResourcesTask.isRunning || !loadResourcesTask.last
+    })
 
     return {
       spaces,
       graphClient,
       loadResourcesTask,
+      areResourcesLoading,
       accessToken
     }
   },


### PR DESCRIPTION
## Description
Followup of https://github.com/owncloud/web/pull/7325 which introduced a broken loading state for the project spaces overview.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
