### PR TITLE
fix: add warning icon to delete link confirm dialog

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
@@ -522,6 +522,7 @@ export default defineComponent({
     deleteLinkConfirmation({ link }) {
       const modal = {
         variation: 'danger',
+        icon: 'alarm-warning',
         title: this.$gettext('Delete link'),
         message: this.$gettext(
           'Are you sure you want to delete this link? Recreating the same link again is not possible.'

--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -332,10 +332,10 @@ export default {
     $_ocCollaborators_deleteShare_trigger(share) {
       const modal = {
         variation: 'danger',
+        icon: 'alarm-warning',
         title: this.$gettext('Remove share'),
         cancelText: this.$gettext('Cancel'),
         confirmText: this.$gettext('Remove'),
-        icon: 'alarm-warning',
         message: this.$gettext('Are you sure you want to remove this share?'),
         hasInput: false,
         onCancel: this.hideModal,

--- a/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
@@ -92,10 +92,10 @@ export default defineComponent({
     $_ocCollaborators_deleteShare_trigger(share) {
       const modal = {
         variation: 'danger',
+        icon: 'alarm-warning',
         title: this.$gettext('Remove share'),
         cancelText: this.$gettext('Cancel'),
         confirmText: this.$gettext('Remove'),
-        icon: 'alarm-warning',
         message: this.$gettext('Are you sure you want to remove this share?'),
         hasInput: false,
         onCancel: this.hideModal,

--- a/packages/web-app-files/src/helpers/resource/copyMove.ts
+++ b/packages/web-app-files/src/helpers/resource/copyMove.ts
@@ -31,6 +31,7 @@ const resolveFileExists = (
     let doForAllConflicts = false
     const modal = {
       variation: 'danger',
+      icon: 'alarm-warning',
       title: $gettext('File already exists'),
       message: $gettextInterpolate(
         resource.isFolder

--- a/packages/web-app-files/src/mixins/actions/emptyTrashBin.js
+++ b/packages/web-app-files/src/mixins/actions/emptyTrashBin.js
@@ -42,10 +42,10 @@ export default {
     $_emptyTrashBin_trigger() {
       const modal = {
         variation: 'danger',
+        icon: 'alarm-warning',
         title: this.$gettext('Empty trash bin'),
         cancelText: this.$gettext('Cancel'),
         confirmText: this.$gettext('Delete'),
-        icon: 'alarm-warning',
         message: this.$gettext(
           'Are you sure you want to permanently delete your items in the trash bin? You can’t undo this action.'
         ),

--- a/packages/web-app-files/src/mixins/spaces/actions/delete.js
+++ b/packages/web-app-files/src/mixins/spaces/actions/delete.js
@@ -46,10 +46,10 @@ export default {
 
       const modal = {
         variation: 'danger',
+        icon: 'alarm-warning',
         title: this.$gettext('Delete space') + ' ' + resources[0].name,
         cancelText: this.$gettext('Cancel'),
         confirmText: this.$gettext('Delete'),
-        icon: 'alarm-warning',
         message: this.$gettext('Are you sure you want to delete this space?'),
         hasInput: false,
         onCancel: this.hideModal,

--- a/packages/web-app-files/src/mixins/spaces/actions/disable.js
+++ b/packages/web-app-files/src/mixins/spaces/actions/disable.js
@@ -47,10 +47,10 @@ export default {
 
       const modal = {
         variation: 'danger',
+        icon: 'alarm-warning',
         title: this.$gettext('Disable space') + ' ' + resources[0].name,
         cancelText: this.$gettext('Cancel'),
         confirmText: this.$gettext('Disable'),
-        icon: 'alarm-warning',
         message: this.$gettext('Are you sure you want to disable this space?'),
         hasInput: false,
         onCancel: this.hideModal,


### PR DESCRIPTION
## Description
While closing https://github.com/owncloud/web/issues/1872#issuecomment-1200886554 I saw that the delete link confirmation dialog was missing the warning icon in the title section of the modal. Added it and checked all other danger variation modals of the files app as well.

Didn't add a changelog item on purpose, because it's only an additional icon that was missing before.

## Related Issue
- Related to https://github.com/owncloud/web/issues/1872

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
