### PR TITLE
Load filelist before uploading contents

### DIFF
--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -629,7 +629,8 @@ export default defineComponent({
       return null
     },
 
-    onFilesSelected(files: File[]) {
+    async onFilesSelected(files: File[]) {
+      await bus.asyncPublish('app.files.list.load')
       const conflicts = []
       const uppyResources: UppyResource[] = this.inputFilesToUppyFiles(files)
       const quotaExceeded = this.checkQuotaExceeded(uppyResources)

--- a/packages/web-app-files/src/views/Personal.vue
+++ b/packages/web-app-files/src/views/Personal.vue
@@ -235,8 +235,8 @@ export default defineComponent({
   },
 
   mounted() {
-    const loadResourcesEventToken = bus.subscribe('app.files.list.load', (path) => {
-      this.loadResourcesTask.perform(this, this.$route.params.item === path, path)
+    const loadResourcesEventToken = bus.subscribe('app.files.list.load', async (path) => {
+      await this.loadResourcesTask.perform(this, this.$route.params.item === path, path)
     })
 
     this.$on('beforeDestroy', () => bus.unsubscribe('app.files.list.load', loadResourcesEventToken))

--- a/packages/web-pkg/src/event/bus.ts
+++ b/packages/web-pkg/src/event/bus.ts
@@ -25,6 +25,14 @@ export class EventBus {
     subscriptions.forEach((subscription) => subscription.callback(data))
   }
 
+  public async asyncPublish(topic: string, data?: unknown): Promise<void> {
+    const subscriptions = this.topics.get(topic) || []
+
+    for (const sub of subscriptions) {
+      await sub.callback(data)
+    }
+  }
+
   public unsubscribe(topic: string, token: string): void {
     if (!this.topics.has(topic)) {
       return


### PR DESCRIPTION
## Description
Load the filelist before uploading contents to ensure the conflict modal shows if a resource already exists on the server side.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/3262

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
