### PR TITLE
Fix selected item bottom glue

### DIFF
--- a/changelog/unreleased/bugfix-selected-item-bottom-glue
+++ b/changelog/unreleased/bugfix-selected-item-bottom-glue
@@ -1,0 +1,6 @@
+Bugfix: Selected item bottom glue
+
+We've fixed a bug where the selected item would be glued to the bottom when scrolling up via keyboard navigation. Also, the scrollTo param has been fixed and is now working again.
+
+https://github.com/owncloud/web/pull/7393
+https://github.com/owncloud/web/issues/7318

--- a/packages/web-app-files/src/mixins/filesListScrolling.js
+++ b/packages/web-app-files/src/mixins/filesListScrolling.js
@@ -2,7 +2,22 @@ export default {
   methods: {
     scrollToResource(resource) {
       const resourceElement = document.querySelectorAll(`[data-item-id='${resource.id}']`)[0]
-      resourceElement.scrollIntoView({ block: 'end' })
+
+      // bottom reached
+      if (resourceElement.getBoundingClientRect().bottom > window.innerHeight) {
+        resourceElement.scrollIntoView(false)
+        return
+      }
+
+      const topbarElement = document.getElementsByClassName('files-topbar')[0]
+      // topbar height + th height + height of one row = offset needed when scrolling top
+      const topOffset = topbarElement.offsetHeight + resourceElement.offsetHeight * 2
+
+      // top reached
+      if (resourceElement.getBoundingClientRect().top < topOffset) {
+        const fileListWrapperElement = document.getElementsByClassName('files-list-wrapper')[0]
+        fileListWrapperElement.scrollBy(0, -resourceElement.offsetHeight)
+      }
     }
   }
 }

--- a/packages/web-app-files/src/services/folder/legacy/loaderPersonal.ts
+++ b/packages/web-app-files/src/services/folder/legacy/loaderPersonal.ts
@@ -69,7 +69,6 @@ export class FolderLoaderLegacyPersonal implements FolderLoader {
       ref.refreshFileListHeaderPosition()
 
       ref.accessibleBreadcrumb_focusAndAnnounceBreadcrumb(sameRoute)
-      ref.scrollToResourceFromRoute()
     }).restartable()
   }
 }

--- a/packages/web-app-files/src/services/folder/spaces/loaderPersonal.ts
+++ b/packages/web-app-files/src/services/folder/spaces/loaderPersonal.ts
@@ -65,7 +65,6 @@ export class FolderLoaderSpacesPersonal implements FolderLoader {
       ref.refreshFileListHeaderPosition()
 
       ref.accessibleBreadcrumb_focusAndAnnounceBreadcrumb(sameRoute)
-      ref.scrollToResourceFromRoute()
     }).restartable()
   }
 }

--- a/packages/web-app-files/src/views/Personal.vue
+++ b/packages/web-app-files/src/views/Personal.vue
@@ -227,7 +227,9 @@ export default defineComponent({
         const sameRoute = to.name === from?.name && to.params?.storageId === from?.params?.storageId
         const sameItem = to.params?.item === from?.params?.item
         if (!sameRoute || !sameItem) {
-          this.loadResourcesTask.perform(this, sameRoute)
+          await this.loadResourcesTask.perform(this, sameRoute)
+          // this can't be done in the task because the table will be rendered afterwards
+          this.scrollToResourceFromRoute()
         }
       },
       immediate: true
@@ -301,15 +303,13 @@ export default defineComponent({
       const resourceName = this.$route.query.scrollTo
 
       if (resourceName && this.paginatedResources.length > 0) {
-        this.$nextTick(() => {
-          const resource = this.paginatedResources.find((r) => r.name === resourceName)
+        const resource = this.paginatedResources.find((r) => r.name === resourceName)
 
-          if (resource) {
-            this.selectedResources = [resource]
-            this.$_mountSideBar_showDefaultPanel(resource)
-            this.scrollToResource(resource)
-          }
-        })
+        if (resource) {
+          this.selectedResources = [resource]
+          this.$_mountSideBar_showDefaultPanel(resource)
+          this.scrollToResource(resource)
+        }
       }
     }
   }

--- a/packages/web-app-files/src/views/shares/SharedResource.vue
+++ b/packages/web-app-files/src/views/shares/SharedResource.vue
@@ -195,8 +195,10 @@ export default defineComponent({
 
   watch: {
     $route: {
-      handler: function () {
-        this.loadResourcesTask.perform(this, this.shareId, this.relativePath)
+      handler: async function () {
+        await this.loadResourcesTask.perform(this, this.shareId, this.relativePath)
+        // this can't be done in the task because the table will be rendered afterwards
+        this.scrollToResourceFromRoute()
       },
       immediate: true
     }
@@ -271,15 +273,13 @@ export default defineComponent({
       const resourceName = this.$route.query.scrollTo
 
       if (resourceName && this.paginatedResources.length > 0) {
-        this.$nextTick(() => {
-          const resource = this.paginatedResources.find((r) => r.name === resourceName)
+        const resource = this.paginatedResources.find((r) => r.name === resourceName)
 
-          if (resource) {
-            this.selectedResources = [resource]
-            this.$_mountSideBar_showDefaultPanel(resource)
-            this.scrollToResource(resource)
-          }
-        })
+        if (resource) {
+          this.selectedResources = [resource]
+          this.$_mountSideBar_showDefaultPanel(resource)
+          this.scrollToResource(resource)
+        }
       }
     }
   }


### PR DESCRIPTION
## Description
We've fixed a bug where the selected item would be glued to the bottom when scrolling up via keyboard navigation. Also, the scrollTo param has been fixed and is now working again.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7318

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
