### PR TITLE
Suppress active panel error logs

### DIFF
--- a/changelog/unreleased/bugfix-suppress-active-panel-error-log
+++ b/changelog/unreleased/bugfix-suppress-active-panel-error-log
@@ -1,0 +1,5 @@
+Bugfix: Suppress active panel error log
+
+We now suppress error logs which occurred when opening the sidebar without an active panel.
+
+https://github.com/owncloud/web/pull/7394

--- a/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
@@ -72,7 +72,7 @@ export default defineComponent({
   watch: {
     sharesLoading: {
       handler: function () {
-        if (this.loading) {
+        if (this.loading || !this.activePanel) {
           return
         }
         this.$nextTick(() => {


### PR DESCRIPTION
## Description
We now suppress error logs which occurred when opening the sidebar without an active panel.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
