### PR TITLE
Add storage ID when navigating to a shared parent directory

### DIFF
--- a/changelog/unreleased/bugfix-storage-id-shared-parent-directory
+++ b/changelog/unreleased/bugfix-storage-id-shared-parent-directory
@@ -1,0 +1,5 @@
+Bugfix: Add storage ID when navigating to a shared parent directory
+
+We've added the missing storage ID when navigating to a shared parent directory.
+
+https://github.com/owncloud/web/pull/7396

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -187,7 +187,7 @@ export default defineComponent({
       }
 
       return createLocationSpaces('files-spaces-personal', {
-        params: { item: unref(sharedParentDir) }
+        params: { storageId: unref(currentStorageId), item: unref(sharedParentDir) }
       })
     })
 

--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -408,7 +408,7 @@ export default {
         }
 
         return createLocationSpaces('files-spaces-personal', {
-          params: { item: parentShare.path }
+          params: { storageId: this.currentStorageId, item: parentShare.path }
         })
       }
 


### PR DESCRIPTION
## Description
We've added the missing storage ID when navigating to a shared parent directory.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
