### PR TITLE
Respect space quota permission

### DIFF
--- a/changelog/unreleased/bugfix-space-quota-permission
+++ b/changelog/unreleased/bugfix-space-quota-permission
@@ -1,0 +1,6 @@
+Bugfix: Respect space quota permission
+
+By taking the space quota permission into account, we've fixed a bug where a regular space member could see the "Edit space quota" action.
+
+https://github.com/owncloud/web/issues/7400
+https://github.com/owncloud/web/pull/7401

--- a/packages/web-app-files/src/helpers/resources.ts
+++ b/packages/web-app-files/src/helpers/resources.ts
@@ -220,10 +220,6 @@ export function buildSpace(space) {
       ]
       return user && allowedRoles.includes(user.uuid)
     },
-    canEditQuota: function ({ user }: { user?: User } = {}) {
-      const allowedRoles = [...this.spaceRoles[spaceRoleManager.name]]
-      return user && allowedRoles.includes(user.uuid)
-    },
     canCreate: function () {
       return true
     },

--- a/packages/web-app-files/src/mixins/spaces/actions/editQuota.js
+++ b/packages/web-app-files/src/mixins/spaces/actions/editQuota.js
@@ -29,6 +29,10 @@ export default {
               return false
             }
 
+            if (!this.$permissionManager.canEditSpaceQuota()) {
+              return false
+            }
+
             return resources[0].canEditQuota({ user: this.user })
           },
           componentType: 'oc-button',

--- a/packages/web-app-files/src/mixins/spaces/actions/editQuota.js
+++ b/packages/web-app-files/src/mixins/spaces/actions/editQuota.js
@@ -29,11 +29,7 @@ export default {
               return false
             }
 
-            if (!this.$permissionManager.canEditSpaceQuota()) {
-              return false
-            }
-
-            return resources[0].canEditQuota({ user: this.user })
+            return this.$permissionManager.canEditSpaceQuota()
           },
           componentType: 'oc-button',
           class: 'oc-files-actions-edit-quota-trigger'

--- a/packages/web-app-files/tests/unit/mixins/spaces/editQuota.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/spaces/editQuota.spec.js
@@ -20,7 +20,7 @@ describe('editQuota', () => {
       const wrapper = getWrapper()
       expect(wrapper.vm.$_editQuota_items[0].isEnabled({ resources: [] })).toBe(false)
     })
-    it('should be true when the current user has the "role-management"-permission', () => {
+    it('should be true when the current user has the "set-space-quota"-permission', () => {
       const spaceMock = {
         id: '1',
         quota: {},
@@ -33,7 +33,7 @@ describe('editQuota', () => {
         wrapper.vm.$_editQuota_items[0].isEnabled({ resources: [buildSpace(spaceMock)] })
       ).toBe(true)
     })
-    it('should be false when the current user does not have the "role-management"-permission', () => {
+    it('should be false when the current user does not have the "set-space-quota"-permission', () => {
       const spaceMock = {
         id: '1',
         quota: {},

--- a/packages/web-app-files/tests/unit/mixins/spaces/editQuota.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/spaces/editQuota.spec.js
@@ -20,7 +20,7 @@ describe('editQuota', () => {
       const wrapper = getWrapper()
       expect(wrapper.vm.$_editQuota_items[0].isEnabled({ resources: [] })).toBe(false)
     })
-    it('should be true when the current user is a manager', () => {
+    it('should be true when the current user has the "role-management"-permission', () => {
       const spaceMock = {
         id: '1',
         quota: {},
@@ -28,20 +28,20 @@ describe('editQuota', () => {
           permissions: [{ roles: ['manager'], grantedTo: [{ user: { id: 1 } }] }]
         }
       }
-      const wrapper = getWrapper()
+      const wrapper = getWrapper({ canEditSpaceQuota: true })
       expect(
         wrapper.vm.$_editQuota_items[0].isEnabled({ resources: [buildSpace(spaceMock)] })
       ).toBe(true)
     })
-    it('should be false when the current user is a viewer', () => {
+    it('should be false when the current user does not have the "role-management"-permission', () => {
       const spaceMock = {
         id: '1',
         quota: {},
         root: {
-          permissions: [{ roles: ['viewer'], grantedTo: [{ user: { id: 1 } }] }]
+          permissions: [{ roles: ['manager'], grantedTo: [{ user: { id: 1 } }] }]
         }
       }
-      const wrapper = getWrapper()
+      const wrapper = getWrapper({ canEditSpaceQuota: false })
       expect(
         wrapper.vm.$_editQuota_items[0].isEnabled({ resources: [buildSpace(spaceMock)] })
       ).toBe(false)
@@ -49,9 +49,14 @@ describe('editQuota', () => {
   })
 })
 
-function getWrapper() {
+function getWrapper({ canEditSpaceQuota = false } = {}) {
   return mount(Component, {
     localVue,
+    mocks: {
+      $permissionManager: {
+        canEditSpaceQuota: () => canEditSpaceQuota
+      }
+    },
     store: createStore(Vuex.Store, {
       modules: {
         user: {

--- a/packages/web-pkg/src/services/permissionManager.ts
+++ b/packages/web-pkg/src/services/permissionManager.ts
@@ -1,5 +1,5 @@
 import { Store } from 'vuex'
-interface RoleSetting {
+interface Permission {
   description: string
   displayName: string
   id: string
@@ -15,7 +15,7 @@ interface RoleSetting {
 }
 interface Role {
   name: 'admin' | 'spaceadmin' | 'user' | 'guest'
-  settings: Array<RoleSetting>
+  settings: Array<Permission>
 }
 interface User {
   role: Role

--- a/packages/web-pkg/src/services/permissionManager.ts
+++ b/packages/web-pkg/src/services/permissionManager.ts
@@ -1,6 +1,21 @@
 import { Store } from 'vuex'
+interface RoleSetting {
+  description: string
+  displayName: string
+  id: string
+  name: string
+  permissionValue: {
+    constraint: string
+    operation: string
+  }
+  resource: {
+    id: string
+    type: string
+  }
+}
 interface Role {
   name: 'admin' | 'spaceadmin' | 'user' | 'guest'
+  settings: Array<RoleSetting>
 }
 interface User {
   role: Role
@@ -19,6 +34,10 @@ export class PermissionManager {
 
   public hasSpaceManagement() {
     return ['admin', 'spaceadmin'].includes(this.user.role?.name)
+  }
+
+  public canEditSpaceQuota() {
+    return !!this.user.role?.settings.find((s) => s.name === 'role-management')
   }
 
   get user(): User {

--- a/packages/web-pkg/src/services/permissionManager.ts
+++ b/packages/web-pkg/src/services/permissionManager.ts
@@ -37,7 +37,7 @@ export class PermissionManager {
   }
 
   public canEditSpaceQuota() {
-    return !!this.user.role?.settings.find((s) => s.name === 'role-management')
+    return !!this.user.role?.settings.find((s) => s.name === 'set-space-quota')
   }
 
   get user(): User {


### PR DESCRIPTION
## Description
By taking the space quota permission into account, we've fixed a bug where a regular space member could see the "Edit space quota" action.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7400

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
