### PR TITLE
[ci] Update build ocis script

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2392,8 +2392,7 @@ def cacheOcisPipeline(ctx):
             "base": dir["base"],
             "path": config["app"],
         },
-        "steps": skipIfUnchanged(ctx, "cache") +
-                 buildOCISCache() +
+        "steps": buildOCISCache() +
                  cacheOcis() +
                  listRemoteCache(),
         "volumes": [{

--- a/.drone.star
+++ b/.drone.star
@@ -2437,6 +2437,13 @@ def getOcis():
 def buildOCISCache():
     return [
         {
+            "name": "check-for-exisiting-cache",
+            "image": OC_UBUNTU,
+            "commands": [
+                "bash ./tests/drone/check-for-existing-oCIS-cache.sh",
+            ],
+        },
+        {
             "name": "generate-ocis",
             "image": OC_CI_NODEJS,
             "environment": {

--- a/tests/drone/build-ocis.sh
+++ b/tests/drone/build-ocis.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-STEP=$1 # which step to run
+# {string} which step to run
+# options: nodejs, golang
+STEP=$1
 
 REPO_URL=https://github.com/owncloud/ocis.git
 BASE_PATH=/var/www/owncloud/ocis-build/
@@ -24,7 +26,7 @@ else # golang
 		echo "oCIS build failed."
 		exit 1
 	fi
-	mkdir -p $BASE_PATH"$OCIS_COMMITID"
-	cp bin/ocis $BASE_PATH"$OCIS_COMMITID"/
-	ls -la $BASE_PATH"$OCIS_COMMITID"/
+	mkdir -p "$BASE_PATH""$OCIS_COMMITID"
+	cp bin/ocis "$BASE_PATH""$OCIS_COMMITID"/
+	ls -la "$BASE_PATH""$OCIS_COMMITID"/
 fi

--- a/tests/drone/build-ocis.sh
+++ b/tests/drone/build-ocis.sh
@@ -2,40 +2,29 @@
 
 STEP=$1 # which step to run
 
+REPO_URL=https://github.com/owncloud/ocis.git
+BASE_PATH=/var/www/owncloud/ocis-build/
+
 source .drone.env
-echo "checking oCIS version - $OCIS_COMMITID in cache"
 
-url="https://cache.owncloud.com/owncloud/web/ocis-build/$OCIS_COMMITID/ocis"
-
-echo "downloading ocis from $url"
-
-if curl --output /dev/null --silent --head --fail "$url"
+if [ "$STEP" == "nodejs" ]
 then
-	echo "oCIS binary for $OCIS_COMMITID already available in cache"
-	echo "Skipping the caching pipeline..."
-	# https://discourse.drone.io/t/how-to-exit-a-pipeline-early-without-failing/3951
-	# exit a Pipeline early without failing
-	exit 78
-else
-	if [ "$STEP" == "nodejs" ]
+	mkdir -p "$GOPATH"/src/github.com/owncloud/
+	cd "$GOPATH"/src/github.com/owncloud/ || exit
+	git clone -b "$OCIS_BRANCH" --single-branch --no-tags $REPO_URL
+	cd ocis || exit
+	git checkout "$OCIS_COMMITID"
+	make ci-node-generate
+else # golang
+	cd "$GOPATH"/src/github.com/owncloud/ocis/ocis || exit
+	if make build
 	then
-		mkdir -p "$GOPATH"/src/github.com/owncloud/
-		cd "$GOPATH"/src/github.com/owncloud/ || exit
-		git clone -b "$OCIS_BRANCH" --single-branch --no-tags https://github.com/owncloud/ocis
-		cd ocis || exit
-		git checkout "$OCIS_COMMITID"
-		make ci-node-generate
-	else # golang
-		cd "$GOPATH"/src/github.com/owncloud/ocis/ocis || exit
-		if make build
-		then
-			echo "oCIS build successful."
-		else
-			echo "oCIS build failed."
-			exit 1
-		fi
-		mkdir -p /var/www/owncloud/ocis-build/"$OCIS_COMMITID"
-		cp bin/ocis /var/www/owncloud/ocis-build/"$OCIS_COMMITID"/
-		ls -la /var/www/owncloud/ocis-build/"$OCIS_COMMITID"/
+		echo "oCIS build successful."
+	else
+		echo "oCIS build failed."
+		exit 1
 	fi
+	mkdir -p $BASE_PATH"$OCIS_COMMITID"
+	cp bin/ocis $BASE_PATH"$OCIS_COMMITID"/
+	ls -la $BASE_PATH"$OCIS_COMMITID"/
 fi

--- a/tests/drone/build-ocis.sh
+++ b/tests/drone/build-ocis.sh
@@ -2,41 +2,40 @@
 
 STEP=$1 # which step to run
 
-if test -f runUnitTestsOnly
-then echo 'skipping build-ocis'
+source .drone.env
+echo "checking oCIS version - $OCIS_COMMITID in cache"
+
+url="https://cache.owncloud.com/owncloud/web/ocis-build/$OCIS_COMMITID/ocis"
+
+echo "downloading ocis from $url"
+
+if curl --output /dev/null --silent --head --fail "$url"
+then
+	echo "oCIS binary for $OCIS_COMMITID already available in cache"
+	echo "Skipping the caching pipeline..."
+	# https://discourse.drone.io/t/how-to-exit-a-pipeline-early-without-failing/3951
+	# exit a Pipeline early without failing
+	exit 78
 else
-	source .drone.env
-	echo "checking ocis version - $OCIS_COMMITID in cache"
-
-	url="https://cache.owncloud.com/owncloud/web/ocis-build/$OCIS_COMMITID/ocis"
-
-	echo "downloading ocis from $url"
-
-	if curl --output /dev/null --silent --head --fail "$url"
+	if [ "$STEP" == "nodejs" ]
 	then
-		echo "ocis binary for $OCIS_COMMITID already available in cache"
-		exit 0
-	else
-		if [ "$STEP" == "nodejs" ]
+		mkdir -p "$GOPATH"/src/github.com/owncloud/
+		cd "$GOPATH"/src/github.com/owncloud/ || exit
+		git clone -b "$OCIS_BRANCH" --single-branch --no-tags https://github.com/owncloud/ocis
+		cd ocis || exit
+		git checkout "$OCIS_COMMITID"
+		make ci-node-generate
+	else # golang
+		cd "$GOPATH"/src/github.com/owncloud/ocis/ocis || exit
+		if make build
 		then
-			mkdir -p "$GOPATH"/src/github.com/owncloud/
-			cd "$GOPATH"/src/github.com/owncloud/ || exit
-			git clone -b "$OCIS_BRANCH" --single-branch --no-tags https://github.com/owncloud/ocis
-			cd ocis || exit
-			git checkout "$OCIS_COMMITID"
-			make ci-node-generate
-		else # golang
-			cd "$GOPATH"/src/github.com/owncloud/ocis/ocis || exit
-			if make build
-			then
-				echo "oCIS build successful."
-			else
-				echo "oCIS build failed."
-				exit 1
-			fi
-			mkdir -p /var/www/owncloud/ocis-build/"$OCIS_COMMITID"
-			cp bin/ocis /var/www/owncloud/ocis-build/"$OCIS_COMMITID"/
-			ls -la /var/www/owncloud/ocis-build/"$OCIS_COMMITID"/
+			echo "oCIS build successful."
+		else
+			echo "oCIS build failed."
+			exit 1
 		fi
+		mkdir -p /var/www/owncloud/ocis-build/"$OCIS_COMMITID"
+		cp bin/ocis /var/www/owncloud/ocis-build/"$OCIS_COMMITID"/
+		ls -la /var/www/owncloud/ocis-build/"$OCIS_COMMITID"/
 	fi
 fi

--- a/tests/drone/check-for-existing-oCIS-cache.sh
+++ b/tests/drone/check-for-existing-oCIS-cache.sh
@@ -1,21 +1,19 @@
 #!/bin/bash
 
-STEP=$1 # which step to run
-
 source .drone.env
-echo "checking oCIS version - $OCIS_COMMITID in cache"
 
 url="https://cache.owncloud.com/owncloud/web/ocis-build/$OCIS_COMMITID/ocis"
 
-echo "downloading ocis from $url"
+echo "Checking oCIS version - $OCIS_COMMITID in cache."
+echo "Downloading oCIS from '$url'."
 
 if curl --output /dev/null --silent --head --fail "$url"
 then
-	echo "oCIS binary for $OCIS_COMMITID already available in cache"
+	echo "oCIS binary for $OCIS_COMMITID already available in cache."
 	echo "Skipping the caching pipeline..."
 	# https://discourse.drone.io/t/how-to-exit-a-pipeline-early-without-failing/3951
 	# exit a Pipeline early without failing
 	exit 78
 else
-    echo "oCIS binary for $OCIS_COMMITID not available in cache"
+	echo "oCIS binary for $OCIS_COMMITID not available in cache."
 fi

--- a/tests/drone/check-for-existing-oCIS-cache.sh
+++ b/tests/drone/check-for-existing-oCIS-cache.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+STEP=$1 # which step to run
+
+source .drone.env
+echo "checking oCIS version - $OCIS_COMMITID in cache"
+
+url="https://cache.owncloud.com/owncloud/web/ocis-build/$OCIS_COMMITID/ocis"
+
+echo "downloading ocis from $url"
+
+if curl --output /dev/null --silent --head --fail "$url"
+then
+	echo "oCIS binary for $OCIS_COMMITID already available in cache"
+	echo "Skipping the caching pipeline..."
+	# https://discourse.drone.io/t/how-to-exit-a-pipeline-early-without-failing/3951
+	# exit a Pipeline early without failing
+	exit 78
+else
+    echo "oCIS binary for $OCIS_COMMITID not available in cache"
+fi


### PR DESCRIPTION
Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>

## Description
- Remove `unitTestsOnly` file check (removed a long time ago from the drone star)
- Exit the pipeline early without failure if the cache for oCIS is already available
- Skip If Unchanged check for oCIS cache pipeline is removed. Since oCIS is pinned to a commit id, we ping the cache server to decide whether to proceed further or not. The oCIS cache is kept as a long-term cache so that the whole pipeline steps are executed only if the commit id changes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- ci

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

