### PR TITLE
[tests-only][full-ci] wait for `uploadCompleteDialog` to confirm the upload of overwritten file

### DIFF
--- a/tests/acceptance/pageObjects/personalPage.js
+++ b/tests/acceptance/pageObjects/personalPage.js
@@ -243,6 +243,7 @@ module.exports = {
         .click('@dialogConfirmBtnEnabled')
         .waitForElementNotPresent('@dialog')
         .waitForAjaxCallsToStartAndFinish()
+        .waitForElementVisible('@fileUploadStatus')
       return this
     },
     checkForButtonDisabled: function () {

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -215,7 +215,7 @@ When('the user uploads a created file {string} using the webUI', function (eleme
 
 When('the user uploads a created file {string} with overwrite using the webUI', function (element) {
   const uploadPath = path.join(client.globals.mountedUploadDir, element)
-  client.page
+  return client.page
     .personalPage()
     .selectFileForUpload(uploadPath)
     .then(() => client.page.personalPage().confirmFileOverwrite())


### PR DESCRIPTION
## Description
This is a test PR to check if the `Scenario: conflict with a big file (when chunking is implemented this upload should be chunked)` fails or not after waiting for the `Upload complete` dialog if it does then how often it does. 

The PR can be merged only when we have strong evidence to say that the added wait for the `Upload complete` dialog prevents the test scenario to fail.


## Related Issue
 https://github.com/owncloud/web/issues/7369


## Motivation and Context
As soon as the overwritten file gets uploaded, a tiny `Upload complete` dialog appears on the button right corner of the web UI and IMO we can add a piece of code to check for the appearance of that dialogue too to ensure that the overwritten file gets uploaded successfully. 

So in this PR, I've added that code inside confirmFileOverwrite() function.


## How Has This Been Tested?
- Locally
- On CI

## Screenshots:
![Screenshot from 2022-08-09 11-13-38](https://user-images.githubusercontent.com/66173400/183577652-90e65e3e-de7c-4f75-9089-744f7017c8d6.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 