### PR TITLE
fix: context fallback to user instead of undefined

### DIFF
--- a/changelog/unreleased/bugfix-default-to-user-context
+++ b/changelog/unreleased/bugfix-default-to-user-context
@@ -1,0 +1,5 @@
+Bugfix: Default to user context
+
+We've fixed a bug where routes without explicit `auth` requirement (i.e. user context) and without any context route in the URL were recognized as neither user-context nor public-link-context. In such situations we now expect that the session requires a user and redirect to the login page.
+
+https://github.com/owncloud/web/pull/7437

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.js
@@ -209,6 +209,7 @@ function createWrapper(
       capitalizedTimestamp: () => 'ABSOLUTE_TIME'
     },
     mocks: {
+      isPublicLinkContext: publicLinkContext,
       $route: {
         meta: {
           auth: !publicLinkContext

--- a/packages/web-pkg/src/components/AppTopBar.vue
+++ b/packages/web-pkg/src/components/AppTopBar.vue
@@ -29,7 +29,8 @@ export default defineComponent({
   name: 'AppTopBar',
   props: {
     resource: {
-      type: Object
+      type: Object,
+      default: null
     }
   }
 })

--- a/packages/web-pkg/src/composables/appDefaults/useAppNavigation.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppNavigation.ts
@@ -66,6 +66,10 @@ export function useAppNavigation({
   const navigateToContext = (context: MaybeRef<FileContext>) => {
     const { fileName, routeName, routeParams, routeQuery } = unref(context)
 
+    if (!unref(routeName)) {
+      return router.push({ path: '/' })
+    }
+
     return router.push({
       name: unref(routeName),
       params: unref(routeParams),

--- a/packages/web-runtime/src/App.vue
+++ b/packages/web-runtime/src/App.vue
@@ -66,11 +66,11 @@ export default defineComponent({
         return LayoutPlain
       }
 
-      if (isUserContext(this.$router, this.$route) && !this.isUserContextReady) {
-        return LayoutLoading
+      if (isPublicLinkContext(this.$router, this.$route)) {
+        return this.isPublicLinkContextReady ? LayoutApplication : LayoutLoading
       }
-      if (isPublicLinkContext(this.$router, this.$route) && !this.isPublicLinkContextReady) {
-        return LayoutLoading
+      if (isUserContext(this.$router, this.$route)) {
+        return this.isUserContextReady ? LayoutApplication : LayoutLoading
       }
 
       return LayoutApplication

--- a/packages/web-runtime/src/router/helpers.ts
+++ b/packages/web-runtime/src/router/helpers.ts
@@ -49,7 +49,7 @@ export const isUserContext = (router: Router, to: Route): boolean => {
   }
 
   const contextRoute = getContextRoute(router, to)
-  return contextRoute && contextRoute.meta?.auth !== false
+  return !contextRoute || contextRoute.meta?.auth !== false
 }
 
 /**

--- a/packages/web-runtime/src/router/setupAuthGuard.ts
+++ b/packages/web-runtime/src/router/setupAuthGuard.ts
@@ -14,19 +14,22 @@ export const setupAuthGuard = (router: Router) => {
     const authService = (Vue as any).$authService
     await authService.initializeContext(to)
 
-    if (isUserContext(router, to) && !store.getters['runtime/auth/isUserContextReady']) {
-      return next({ path: '/login', query: { redirectUrl: to.fullPath } })
+    if (isPublicLinkContext(router, to)) {
+      if (!store.getters['runtime/auth/isPublicLinkContextReady']) {
+        const publicLinkToken = extractPublicLinkToken(to)
+        return next({
+          name: 'resolvePublicLink',
+          params: { token: publicLinkToken },
+          query: { redirectUrl: to.fullPath }
+        })
+      }
+      return next()
     }
-    if (
-      isPublicLinkContext(router, to) &&
-      !store.getters['runtime/auth/isPublicLinkContextReady']
-    ) {
-      const publicLinkToken = extractPublicLinkToken(to)
-      return next({
-        name: 'resolvePublicLink',
-        params: { token: publicLinkToken },
-        query: { redirectUrl: to.fullPath }
-      })
+    if (isUserContext(router, to)) {
+      if (!store.getters['runtime/auth/isUserContextReady']) {
+        return next({ path: '/login', query: { redirectUrl: to.fullPath } })
+      }
+      return next()
     }
     return next()
   })


### PR DESCRIPTION
## Description
We've fixed a bug where routes without explicit `auth` requirement (i.e. user context) and without any context route in the URL were recognized as neither user-context nor public-link-context. In such situations we now expect that the session requires a user and redirect to the login page (instead of staying stuck on a most likely broken page).

## Motivation / context
We want to provide an endpoint in `ocis` that let's e.g. the desktop client query a URL for opening a document (via app provider / external app) in web. The desktop client has the file id and the app provider is capable of determining a default app if no app name is provided. But neither the desktop client nor the ocis backend know what route the file might have come from if opened via files app. Opening a file in web from the desktop client is always supposed to open in an authenticated session / user session (user needs to log in if not already done before).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
