### PR TITLE
Fix 'Shared via'-indicator for links

### DIFF
--- a/changelog/unreleased/bugfix-shared-via-indicator-for-links
+++ b/changelog/unreleased/bugfix-shared-via-indicator-for-links
@@ -1,0 +1,6 @@
+Bugfix: "Shared via"-indicator for links
+
+We've fixed a bug where the "Shared via"-indicator would be empty or not be displayed at all for public links.
+
+https://github.com/owncloud/web/issues/7478
+https://github.com/owncloud/web/pull/7479

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -231,9 +231,6 @@ export default defineComponent({
     detailsTableLabel() {
       return this.$gettext('Overview of the information about the selected file')
     },
-    shareDateLabel() {
-      return this.$gettext('Shared')
-    },
     sharedViaLabel() {
       return this.$gettext('Shared via')
     },
@@ -258,7 +255,7 @@ export default defineComponent({
         this.showShares &&
         !this.sharesTreeLoading &&
         this.file.path !== this.sharedParentDir &&
-        this.sharedParentDir !== null
+        this.sharedParentDir
       )
     },
     showShares() {
@@ -364,7 +361,10 @@ export default defineComponent({
         return
       }
       const userShares = this.sharesTree[sharePathParentOrCurrent]?.filter((s) =>
-        ShareTypes.containsAnyValue(ShareTypes.individuals, [s.shareType])
+        ShareTypes.containsAnyValue(
+          [...ShareTypes.individuals, ...ShareTypes.unauthenticated],
+          [s.shareType]
+        )
       )
       if (userShares.length === 0) {
         return

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -360,17 +360,17 @@ export default defineComponent({
       if (sharePathParentOrCurrent === null) {
         return
       }
-      const userShares = this.sharesTree[sharePathParentOrCurrent]?.filter((s) =>
+      const shares = this.sharesTree[sharePathParentOrCurrent]?.filter((s) =>
         ShareTypes.containsAnyValue(
           [...ShareTypes.individuals, ...ShareTypes.unauthenticated],
           [s.shareType]
         )
       )
-      if (userShares.length === 0) {
+      if (shares.length === 0) {
         return
       }
 
-      this.sharedItem = userShares[0]
+      this.sharedItem = shares[0]
       this.sharedByName = this.sharedItem.owner?.name
       this.sharedByDisplayName = this.sharedItem.owner?.displayName
       if (this.sharedItem.owner?.additionalInfo) {

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.js.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.js.snap
@@ -15,12 +15,7 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
         <th scope="col" class="oc-pr-s">Last modified</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
-      <tr data-testid="shared-via">
-        <th scope="col" class="oc-pr-s">Shared via</th>
-        <td>
-          <router-link-stub><span></span></router-link-stub>
-        </td>
-      </tr>
+      <!---->
       <!---->
       <tr data-testid="ownerDisplayName">
         <th scope="col" class="oc-pr-s">Owner</th>
@@ -59,12 +54,7 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
         <th scope="col" class="oc-pr-s">Last modified</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
-      <tr data-testid="shared-via">
-        <th scope="col" class="oc-pr-s">Shared via</th>
-        <td>
-          <router-link-stub><span>/Shares/123.png</span></router-link-stub>
-        </td>
-      </tr>
+      <!---->
       <tr data-testid="shared-by">
         <th scope="col" class="oc-pr-s">Shared by</th>
         <td><span>Marie Curie</span></td>
@@ -139,12 +129,7 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
         <th scope="col" class="oc-pr-s">Last modified</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
-      <tr data-testid="shared-via">
-        <th scope="col" class="oc-pr-s">Shared via</th>
-        <td>
-          <router-link-stub><span></span></router-link-stub>
-        </td>
-      </tr>
+      <!---->
       <!---->
       <tr data-testid="ownerDisplayName">
         <th scope="col" class="oc-pr-s">Owner</th>
@@ -180,12 +165,7 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
         <th scope="col" class="oc-pr-s">Last modified</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
-      <tr data-testid="shared-via">
-        <th scope="col" class="oc-pr-s">Shared via</th>
-        <td>
-          <router-link-stub><span></span></router-link-stub>
-        </td>
-      </tr>
+      <!---->
       <!---->
       <tr data-testid="ownerDisplayName">
         <th scope="col" class="oc-pr-s">Owner</th>


### PR DESCRIPTION
## Description
We've fixed a bug where the "Shared via"-indicator would be empty or not be displayed at all for public links.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7478

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
