### PR TITLE
Fix missing space image in sidebar

### DIFF
--- a/changelog/unreleased/bugfix-space-image-sidebar
+++ b/changelog/unreleased/bugfix-space-image-sidebar
@@ -1,0 +1,6 @@
+Bugfix: Missing space image in sidebar
+
+We've fixed a bug where the image of a space was not showing in the sidebar.
+
+https://github.com/owncloud/web/issues/7480
+https://github.com/owncloud/web/pull/7481

--- a/packages/web-app-files/src/components/SideBar/Details/SpaceDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/SpaceDetails.vue
@@ -75,6 +75,7 @@ import { ImageDimension } from '../../../constants'
 import { useAccessToken, useStore } from 'web-pkg/src/composables'
 import SpaceQuota from '../../SpaceQuota.vue'
 import { formatDateFromISO } from 'web-pkg/src/helpers'
+import { configurationManager } from 'web-pkg/src/configuration'
 
 export default defineComponent({
   name: 'SpaceDetails',
@@ -91,13 +92,17 @@ export default defineComponent({
         return
       }
 
-      const webDavPathComponents = ref.space.spaceImageData.webDavUrl.split('/')
+      const webDavPathComponents = decodeURI(ref.space.spaceImageData.webDavUrl).split('/')
+      const idComponent = webDavPathComponents.find((c) => c.startsWith(ref.space.id))
+      if (!idComponent) {
+        return
+      }
       const path = webDavPathComponents
-        .slice(webDavPathComponents.indexOf(ref.space.id) + 1)
+        .slice(webDavPathComponents.indexOf(idComponent) + 1)
         .join('/')
 
       const fileInfo = yield ref.$client.files.fileInfo(
-        buildWebDavSpacesPath(ref.space.id, decodeURIComponent(path))
+        buildWebDavSpacesPath(idComponent, decodeURIComponent(path))
       )
       const resource = buildResource(fileInfo)
 
@@ -105,7 +110,7 @@ export default defineComponent({
         resource,
         isPublic: false,
         dimensions: ImageDimension.Preview,
-        server: ref.configuration.server,
+        server: configurationManager.serverUrl,
         userId: ref.user.id,
         token: unref(accessToken)
       })


### PR DESCRIPTION
## Description
We've fixed a bug where the image of a space was not showing in the sidebar. It was broken because a) the image URL and b) the server URL were wrong. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7480

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
