### PR TITLE
[tests-only]  e2etest for spaces publiclink- Part2

### DIFF
--- a/tests/e2e/config.js
+++ b/tests/e2e/config.js
@@ -25,7 +25,7 @@ exports.config = {
   // cucumber
   retry: process.env.RETRY || 0,
   // playwright
-  slowMo: parseInt(process.env.SLOW_MO) || 100,
+  slowMo: parseInt(process.env.SLOW_MO) || 0,
   timeout: parseInt(process.env.TIMEOUT) || 60,
   headless: process.env.HEADLESS === 'true',
   acceptDownloads: process.env.DOWNLOADS !== 'false',

--- a/tests/e2e/config.js
+++ b/tests/e2e/config.js
@@ -25,7 +25,7 @@ exports.config = {
   // cucumber
   retry: process.env.RETRY || 0,
   // playwright
-  slowMo: parseInt(process.env.SLOW_MO) || 0,
+  slowMo: parseInt(process.env.SLOW_MO) || 100,
   timeout: parseInt(process.env.TIMEOUT) || 60,
   headless: process.env.HEADLESS === 'true',
   acceptDownloads: process.env.DOWNLOADS !== 'false',

--- a/tests/e2e/cucumber/features/integrations/spaces/publicLink.ocis.feature
+++ b/tests/e2e/cucumber/features/integrations/spaces/publicLink.ocis.feature
@@ -22,6 +22,7 @@ Feature: spaces public link
             | resource    | type   |
             | spaceFolder | folder |
         And "Alice" creates a public link for the resource "spaceFolder" using the sidebar panel
+        And "Alice" renames the most recently created public link of resource "spaceFolder" to "folderLink"
         And "Alice" adds following users to the project space
             | user  | role    |
             | Brian | editor  |
@@ -39,9 +40,11 @@ Feature: spaces public link
         Then public link named "spaceLink" should be visible to "Marie"
         And "Marie" 'should' be able to edit the public link named "spaceLink"
         When "Marie" changes the permission of the public link named "spaceLink" to "editor"
+        Then public link named "folderLink" of the resource "spaceFolder" should be visible to "Marie" 
+        And "Marie" 'should' be able to edit the public link named "folderLink"
         And "Marie" logs out
         When "Carol" logs in
         And "Carol" navigates to the projects space page
         And "Carol" navigates to the project space "team.1"
-        Then public link named "spaceLink" should be visible to "Carol"
+        Then public link named "folderLink" of the resource "spaceFolder" should be visible to "Carol"
         And "Carol" logs out

--- a/tests/e2e/cucumber/features/integrations/spaces/publicLink.ocis.feature
+++ b/tests/e2e/cucumber/features/integrations/spaces/publicLink.ocis.feature
@@ -29,7 +29,7 @@ Feature: spaces public link
             | Carol | viewer  |
             | Marie | manager |
         And "Alice" logs out
-        And "Brian" logs in
+        When "Brian" logs in
         And "Brian" navigates to the projects space page
         And "Brian" navigates to the project space "team.1"
         Then public link named "spaceLink" should be visible to "Brian"
@@ -38,15 +38,13 @@ Feature: spaces public link
         When "Marie" logs in
         And "Marie" navigates to the projects space page
         And "Marie" navigates to the project space "team.1"
-        Then public link named "spaceLink" should be visible to "Marie"
-        And "Marie" should be able to edit the public link named "spaceLink"
-        When "Marie" edits the public link named "spaceLink" of the space changing role to "editor"
-        Then public link named "folderLink" of the resource "spaceFolder" should be visible to "Marie"
-        And "Marie" should be able to edit the public link named "folderLink"
-        When "Marie" edits the public link named "folderLink" of resource "spaceFolder" changing role to "editor"
+        And "Marie" edits the public link named "spaceLink" of the space changing role to "editor"
+        And "Marie" edits the public link named "folderLink" of resource "spaceFolder" changing role to "editor"
         And "Marie" logs out
         When "Carol" logs in
         And "Carol" navigates to the projects space page
         And "Carol" navigates to the project space "team.1"
-        Then public link named "folderLink" of the resource "spaceFolder" should be visible to "Carol"
+        And public link named "spaceLink" should be visible to "Carol"
+        But "Carol" should not be able to edit the public link named "spaceLink"
+        And public link named "folderLink" of the resource "spaceFolder" should be visible to "Carol"
         And "Carol" logs out

--- a/tests/e2e/cucumber/features/integrations/spaces/publicLink.ocis.feature
+++ b/tests/e2e/cucumber/features/integrations/spaces/publicLink.ocis.feature
@@ -6,6 +6,7 @@ Feature: spaces public link
             | Alice |
             | Brian |
             | Carol |
+            | marie |
         And "Admin" assigns following roles to the users
             | id    | role       |
             | Alice | SpaceAdmin |
@@ -22,13 +23,18 @@ Feature: spaces public link
             | spaceFolder | folder |
         And "Alice" creates a public link for the resource "spaceFolder" using the sidebar panel
         And "Alice" adds following users to the project space
-            | user  | role   |
-            | Brian | editor |
-            | Carol | viewer |
+            | user  | role    |
+            | Brian | editor  |
+            | Carol | viewer  |
+            | marie | manager |
         When "Brian" logs in
         And "Brian" navigates to the projects space page
         And "Brian" navigates to the project space "team.1"
         Then public link named "spaceLink" should be visible to "Brian"
         But "Brian" 'should not' be able to edit the public link named "spaceLink"
         And "Brian" logs out
-
+        When "Marie" logs in
+        And "Marie" navigates to the projects space page
+        And "Marie" navigates to the project space "team.1"
+        Then public link named "spaceLink" should be visible to "Marie"
+        And "Marie" 'should' be able to edit the public link named "spaceLink"

--- a/tests/e2e/cucumber/features/integrations/spaces/publicLink.ocis.feature
+++ b/tests/e2e/cucumber/features/integrations/spaces/publicLink.ocis.feature
@@ -6,7 +6,7 @@ Feature: spaces public link
             | Alice |
             | Brian |
             | Carol |
-            | marie |
+            | Marie |
         And "Admin" assigns following roles to the users
             | id    | role       |
             | Alice | SpaceAdmin |
@@ -26,7 +26,7 @@ Feature: spaces public link
             | user  | role    |
             | Brian | editor  |
             | Carol | viewer  |
-            | marie | manager |
+            | Marie | manager |
         When "Brian" logs in
         And "Brian" navigates to the projects space page
         And "Brian" navigates to the project space "team.1"
@@ -38,3 +38,10 @@ Feature: spaces public link
         And "Marie" navigates to the project space "team.1"
         Then public link named "spaceLink" should be visible to "Marie"
         And "Marie" 'should' be able to edit the public link named "spaceLink"
+        When "Marie" changes the permission of the public link named "spaceLink" to "editor"
+        And "Marie" logs out
+        When "Carol" logs in
+        And "Carol" navigates to the projects space page
+        And "Carol" navigates to the project space "team.1"
+        Then public link named "spaceLink" should be visible to "Carol"
+        And "Carol" logs out

--- a/tests/e2e/cucumber/features/integrations/spaces/publicLink.ocis.feature
+++ b/tests/e2e/cucumber/features/integrations/spaces/publicLink.ocis.feature
@@ -28,20 +28,22 @@ Feature: spaces public link
             | Brian | editor  |
             | Carol | viewer  |
             | Marie | manager |
-        When "Brian" logs in
+        And "Alice" logs out
+        And "Brian" logs in
         And "Brian" navigates to the projects space page
         And "Brian" navigates to the project space "team.1"
         Then public link named "spaceLink" should be visible to "Brian"
-        But "Brian" 'should not' be able to edit the public link named "spaceLink"
+        But "Brian" should not be able to edit the public link named "spaceLink"
         And "Brian" logs out
         When "Marie" logs in
         And "Marie" navigates to the projects space page
         And "Marie" navigates to the project space "team.1"
         Then public link named "spaceLink" should be visible to "Marie"
-        And "Marie" 'should' be able to edit the public link named "spaceLink"
-        When "Marie" changes the permission of the public link named "spaceLink" to "editor"
-        Then public link named "folderLink" of the resource "spaceFolder" should be visible to "Marie" 
-        And "Marie" 'should' be able to edit the public link named "folderLink"
+        And "Marie" should be able to edit the public link named "spaceLink"
+        When "Marie" edits the public link named "spaceLink" of the space changing role to "editor"
+        Then public link named "folderLink" of the resource "spaceFolder" should be visible to "Marie"
+        And "Marie" should be able to edit the public link named "folderLink"
+        When "Marie" edits the public link named "folderLink" of resource "spaceFolder" changing role to "editor"
         And "Marie" logs out
         When "Carol" logs in
         And "Carol" navigates to the projects space page

--- a/tests/e2e/cucumber/steps/app-files/link.ts
+++ b/tests/e2e/cucumber/steps/app-files/link.ts
@@ -123,3 +123,12 @@ Then(
     expect(isVisible).toBe(shouldOrShouldNot !== 'should not')
   }
 )
+
+When(
+  '{string} changes the permission of the public link named {string} to {string}',
+  async function (this: World, stepUser: string, name: string, role: any): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const linkObject = new objects.applicationFiles.Link({ page })
+    const newPermission = await linkObject.changeRole({ name, role, space: true })
+  }
+)

--- a/tests/e2e/cucumber/steps/app-files/link.ts
+++ b/tests/e2e/cucumber/steps/app-files/link.ts
@@ -104,7 +104,17 @@ Then(
   async function (this: World, linkName: string, stepUser: any): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const linkObject = new objects.applicationFiles.Link({ page })
-    const publicLinkUrls = await linkObject.getPublicLinkUrl(linkName)
+    const publicLinkUrls = await linkObject.getPublicLinkUrl({ linkName, space: true })
+    expect(publicLinkUrls[0]).toBe(publicLinkUrls[1])
+  }
+)
+
+Then(
+  'public link named {string} of the resource {string} should be visible to {string}',
+  async function (this: World, linkName: string, resource: string, stepUser: any): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const linkObject = new objects.applicationFiles.Link({ page })
+    const publicLinkUrls = await linkObject.getPublicLinkUrl({ linkName, resource })
     expect(publicLinkUrls[0]).toBe(publicLinkUrls[1])
   }
 )

--- a/tests/e2e/cucumber/steps/app-files/link.ts
+++ b/tests/e2e/cucumber/steps/app-files/link.ts
@@ -79,13 +79,13 @@ When(
   async function (
     this: World,
     stepUser: string,
-    name: any,
+    linkName: any,
     resource: string,
     role: string
   ): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const linkObject = new objects.applicationFiles.Link({ page })
-    const actualRole = await linkObject.changeRole({ name, resource, role })
+    const actualRole = await linkObject.changeRole({ linkName, resource, role })
     expect(role).toBe(actualRole.toLowerCase())
   }
 )
@@ -120,7 +120,7 @@ Then(
 )
 
 Then(
-  '{string} {string} be able to edit the public link named {string}',
+  /^"([^"]*)" (should|should not) be able to edit the public link named "([^"]*)"$/,
   async function (
     this: World,
     stepUser: any,
@@ -135,10 +135,11 @@ Then(
 )
 
 When(
-  '{string} changes the permission of the public link named {string} to {string}',
-  async function (this: World, stepUser: string, name: string, role: any): Promise<void> {
+  '{string} edits the public link named {string} of the space changing role to {string}',
+  async function (this: World, stepUser: string, linkName: string, role: any): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const linkObject = new objects.applicationFiles.Link({ page })
-    const newPermission = await linkObject.changeRole({ name, role, space: true })
+    const newPermission = await linkObject.changeRole({ linkName, role, space: true })
+    expect(role).toBe(newPermission.toLowerCase())
   }
 )

--- a/tests/e2e/support/objects/app-files/link/actions.ts
+++ b/tests/e2e/support/objects/app-files/link/actions.ts
@@ -50,6 +50,8 @@ export type deleteLinkArgs = {
 export type PublicLinkAndItsEditButtonVisibilityArgs = {
   page: Page
   linkName: string
+  resource?: string
+  space?: boolean
 }
 const publicLinkSetRoleButton = `#files-role-%s`
 const linkExpiryDatepicker = '.link-expiry-picker'
@@ -193,9 +195,19 @@ export const deleteLink = async (args: deleteLinkArgs): Promise<void> => {
 export const getPublicLinkVisibility = async (
   args: PublicLinkAndItsEditButtonVisibilityArgs
 ): Promise<string> => {
-  const { page, linkName } = args
-  await sidebar.open({ page: page })
-  await sidebar.openPanel({ page: page, name: 'space-share' })
+  const { page, linkName, resource, space } = args
+  if (!space) {
+    const resourcePaths = resource.split('/')
+    const resourceName = resourcePaths.pop()
+    if (resourcePaths.length) {
+      await clickResource({ page: page, path: resourcePaths.join('/') })
+    }
+    await sidebar.open({ page: page, resource: resourceName })
+    await sidebar.openPanel({ page: page, name: 'sharing' })
+  } else {
+    await sidebar.open({ page: page })
+    await sidebar.openPanel({ page: page, name: 'space-share' })
+  }
   return await page.locator(util.format(publicLink, linkName)).textContent()
 }
 

--- a/tests/e2e/support/objects/app-files/link/actions.ts
+++ b/tests/e2e/support/objects/app-files/link/actions.ts
@@ -103,15 +103,18 @@ export const waitForPopupNotPresent = async (page): Promise<void> => {
 
 export const changeRole = async (args: changeRoleArgs): Promise<string> => {
   const { page, resource, linkName, role, space } = args
+  let shareType = 'space-share'
+  let resourceName = null
   if (!space) {
     const resourcePaths = resource.split('/')
-    const resourceName = resourcePaths.pop()
+    resourceName = resourcePaths.pop()
+    shareType = 'sharing'
     if (resourcePaths.length) {
       await clickResource({ page: page, path: resourcePaths.join('/') })
     }
-    await sidebar.open({ page: page, resource: resourceName })
-    await sidebar.openPanel({ page: page, name: 'sharing' })
   }
+  await sidebar.open({ page: page, resource: resourceName })
+  await sidebar.openPanel({ page: page, name: shareType })
   await page.locator(util.format(publicLinkEditRoleButton, linkName)).click()
   await page.locator(util.format(publicLinkSetRoleButton, role.toLowerCase())).click()
   const message = await page.locator(linkUpdateDialog).textContent()
@@ -196,18 +199,18 @@ export const getPublicLinkVisibility = async (
   args: publicLinkAndItsEditButtonVisibilityArgs
 ): Promise<string> => {
   const { page, linkName, resource, space } = args
+  let shareType = 'space-share'
+  let resourceName = null
   if (!space) {
+    shareType = 'sharing'
     const resourcePaths = resource.split('/')
-    const resourceName = resourcePaths.pop()
+    resourceName = resourcePaths.pop()
     if (resourcePaths.length) {
       await clickResource({ page: page, path: resourcePaths.join('/') })
     }
-    await sidebar.open({ page: page, resource: resourceName })
-    await sidebar.openPanel({ page: page, name: 'sharing' })
-  } else {
-    await sidebar.open({ page: page })
-    await sidebar.openPanel({ page: page, name: 'space-share' })
   }
+  await sidebar.open({ page: page, resource: resourceName })
+  await sidebar.openPanel({ page: page, name: shareType })
   return await page.locator(util.format(publicLink, linkName)).textContent()
 }
 

--- a/tests/e2e/support/objects/app-files/link/actions.ts
+++ b/tests/e2e/support/objects/app-files/link/actions.ts
@@ -35,9 +35,10 @@ export type addPasswordArgs = {
 
 export type changeRoleArgs = {
   page: Page
-  resource: string
+  resource?: string
   name: string
   role: string
+  space?: boolean
 }
 
 export type deleteLinkArgs = {
@@ -99,14 +100,16 @@ export const waitForPopupNotPresent = async (page): Promise<void> => {
 }
 
 export const changeRole = async (args: changeRoleArgs): Promise<string> => {
-  const { page, resource, name, role } = args
-  const resourcePaths = resource.split('/')
-  const resourceName = resourcePaths.pop()
-  if (resourcePaths.length) {
-    await clickResource({ page: page, path: resourcePaths.join('/') })
+  const { page, resource, name, role, space } = args
+  if (!space) {
+    const resourcePaths = resource.split('/')
+    const resourceName = resourcePaths.pop()
+    if (resourcePaths.length) {
+      await clickResource({ page: page, path: resourcePaths.join('/') })
+    }
+    await sidebar.open({ page: page, resource: resourceName })
+    await sidebar.openPanel({ page: page, name: 'sharing' })
   }
-  await sidebar.open({ page: page, resource: resourceName })
-  await sidebar.openPanel({ page: page, name: 'sharing' })
   await page.locator(util.format(publicLinkEditRoleButton, name)).click()
   await page.locator(util.format(publicLinkSetRoleButton, role.toLowerCase())).click()
   const message = await page.locator(linkUpdateDialog).textContent()

--- a/tests/e2e/support/objects/app-files/link/actions.ts
+++ b/tests/e2e/support/objects/app-files/link/actions.ts
@@ -36,7 +36,7 @@ export type addPasswordArgs = {
 export type changeRoleArgs = {
   page: Page
   resource?: string
-  name: string
+  linkName: string
   role: string
   space?: boolean
 }
@@ -47,7 +47,7 @@ export type deleteLinkArgs = {
   name: string
 }
 
-export type PublicLinkAndItsEditButtonVisibilityArgs = {
+export type publicLinkAndItsEditButtonVisibilityArgs = {
   page: Page
   linkName: string
   resource?: string
@@ -102,7 +102,7 @@ export const waitForPopupNotPresent = async (page): Promise<void> => {
 }
 
 export const changeRole = async (args: changeRoleArgs): Promise<string> => {
-  const { page, resource, name, role, space } = args
+  const { page, resource, linkName, role, space } = args
   if (!space) {
     const resourcePaths = resource.split('/')
     const resourceName = resourcePaths.pop()
@@ -112,7 +112,7 @@ export const changeRole = async (args: changeRoleArgs): Promise<string> => {
     await sidebar.open({ page: page, resource: resourceName })
     await sidebar.openPanel({ page: page, name: 'sharing' })
   }
-  await page.locator(util.format(publicLinkEditRoleButton, name)).click()
+  await page.locator(util.format(publicLinkEditRoleButton, linkName)).click()
   await page.locator(util.format(publicLinkSetRoleButton, role.toLowerCase())).click()
   const message = await page.locator(linkUpdateDialog).textContent()
   expect(message.trim()).toBe('Link was updated successfully')
@@ -193,7 +193,7 @@ export const deleteLink = async (args: deleteLinkArgs): Promise<void> => {
 }
 
 export const getPublicLinkVisibility = async (
-  args: PublicLinkAndItsEditButtonVisibilityArgs
+  args: publicLinkAndItsEditButtonVisibilityArgs
 ): Promise<string> => {
   const { page, linkName, resource, space } = args
   if (!space) {
@@ -212,7 +212,7 @@ export const getPublicLinkVisibility = async (
 }
 
 export const getLinkEditButtonVisibility = async (
-  args: PublicLinkAndItsEditButtonVisibilityArgs
+  args: publicLinkAndItsEditButtonVisibilityArgs
 ): Promise<boolean> => {
   const { page, linkName } = args
   return await page.locator(util.format(editPublicLinkButton, linkName)).isVisible()

--- a/tests/e2e/support/objects/app-files/link/index.ts
+++ b/tests/e2e/support/objects/app-files/link/index.ts
@@ -13,7 +13,8 @@ import {
   deleteLink,
   deleteLinkArgs,
   getLinkEditButtonVisibility,
-  getPublicLinkVisibility
+  getPublicLinkVisibility,
+  PublicLinkAndItsEditButtonVisibilityArgs
 } from './actions'
 import { LinksEnvironment } from '../../../environment'
 
@@ -82,11 +83,13 @@ export class Link {
     await this.#page.goto(startUrl)
   }
 
-  async getPublicLinkUrl(linkName): Promise<string[]> {
-    const linkUrl = this.#linksEnvironment.getLink({ name: linkName })
+  async getPublicLinkUrl(
+    args: Omit<PublicLinkAndItsEditButtonVisibilityArgs, 'page'>
+  ): Promise<string[]> {
+    const linkUrl = this.#linksEnvironment.getLink({ name: args.linkName })
     const publicLink = await getPublicLinkVisibility({
-      page: this.#page,
-      linkName
+      ...args,
+      page: this.#page
     })
     return [linkUrl.url, publicLink]
   }

--- a/tests/e2e/support/objects/app-files/link/index.ts
+++ b/tests/e2e/support/objects/app-files/link/index.ts
@@ -14,7 +14,7 @@ import {
   deleteLinkArgs,
   getLinkEditButtonVisibility,
   getPublicLinkVisibility,
-  PublicLinkAndItsEditButtonVisibilityArgs
+  publicLinkAndItsEditButtonVisibilityArgs
 } from './actions'
 import { LinksEnvironment } from '../../../environment'
 
@@ -84,7 +84,7 @@ export class Link {
   }
 
   async getPublicLinkUrl(
-    args: Omit<PublicLinkAndItsEditButtonVisibilityArgs, 'page'>
+    args: Omit<publicLinkAndItsEditButtonVisibilityArgs, 'page'>
   ): Promise<string[]> {
     const linkUrl = this.#linksEnvironment.getLink({ name: args.linkName })
     const publicLink = await getPublicLinkVisibility({

--- a/tests/e2e/support/objects/app-files/spaces/actions.ts
+++ b/tests/e2e/support/objects/app-files/spaces/actions.ts
@@ -284,5 +284,5 @@ export const createPublicLinkForSpace = async (
   const { page } = args
   await sidebar.open({ page: page })
   await sidebar.openPanel({ page: page, name: 'space-share' })
-  return await createLink({ page: page, space: true })
+  return createLink({ page: page, space: true })
 }

--- a/tests/e2e/support/store/user.ts
+++ b/tests/e2e/support/store/user.ts
@@ -36,5 +36,14 @@ export const userStore = new Map<string, User>([
       password: '1234',
       email: 'carol@example.org'
     }
+  ],
+  [
+    'marie',
+    {
+      id: 'marie',
+      displayName: 'Marie Skłodowska Curie',
+      password: '1234',
+      email: 'marie@example.org'
+    }
   ]
 ])


### PR DESCRIPTION
## Description
e2e test for the public link space stories has been added in this PR. Specifically, this PR adds tests for a manager member regarding his permissions with a public link.

## Related Issue
https://github.com/owncloud/web/issues/7407

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...
- 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
