### PR TITLE
Add resource name to the WebDAV properties

### DIFF
--- a/changelog/unreleased/enhancement-resource-name-webdav-property
+++ b/changelog/unreleased/enhancement-resource-name-webdav-property
@@ -1,0 +1,5 @@
+Enhancement: Add resource name to the WebDAV properties
+
+We've added the resource name to the WebDAV properties.
+
+https://github.com/owncloud/web/pull/7485

--- a/packages/web-app-files/src/helpers/resources.ts
+++ b/packages/web-app-files/src/helpers/resources.ts
@@ -49,13 +49,16 @@ export function buildResource(resource): Resource {
   }
 
   const id = resource.fileInfo[DavProperty.FileId]
+  const name = resource.fileInfo[DavProperty.Name]
+    ? resource.fileInfo[DavProperty.Name]
+    : path.basename(resource.name)
 
   return {
     id,
     fileId: resource.fileInfo[DavProperty.FileId],
     storageId: extractStorageId(resource.fileInfo[DavProperty.FileId]),
     mimeType: resource.fileInfo[DavProperty.MimeType],
-    name: path.basename(resource.name),
+    name,
     extension: isFolder ? '' : extension,
     path: resourcePath,
     webDavPath: resource.name,

--- a/packages/web-app-files/src/helpers/resources.ts
+++ b/packages/web-app-files/src/helpers/resources.ts
@@ -34,8 +34,9 @@ export function renameResource(resource, newName, newPath) {
 }
 
 export function buildResource(resource): Resource {
+  const name = resource.fileInfo[DavProperty.Name] || path.basename(resource.name)
   const isFolder = resource.type === 'dir' || resource.type === 'folder'
-  const extension = extractExtensionFromFile(resource)
+  const extension = extractExtensionFromFile({ ...resource, name })
   let resourcePath
 
   if (resource.name.startsWith('/files') || resource.name.startsWith('/space')) {
@@ -49,9 +50,6 @@ export function buildResource(resource): Resource {
   }
 
   const id = resource.fileInfo[DavProperty.FileId]
-  const name = resource.fileInfo[DavProperty.Name]
-    ? resource.fileInfo[DavProperty.Name]
-    : path.basename(resource.name)
 
   return {
     id,

--- a/packages/web-pkg/src/constants/dav.ts
+++ b/packages/web-pkg/src/constants/dav.ts
@@ -14,6 +14,7 @@ export abstract class DavProperty {
   static readonly Permissions: string = '{http://owncloud.org/ns}permissions'
   static readonly IsFavorite: string = '{http://owncloud.org/ns}favorite'
   static readonly FileId: string = '{http://owncloud.org/ns}fileid'
+  static readonly Name: string = '{http://owncloud.org/ns}name'
   static readonly OwnerId: string = '{http://owncloud.org/ns}owner-id'
   static readonly OwnerDisplayName: string = '{http://owncloud.org/ns}owner-display-name'
   static readonly PrivateLink: string = '{http://owncloud.org/ns}privatelink'
@@ -49,6 +50,7 @@ export abstract class DavProperties {
     DavProperty.Permissions,
     DavProperty.IsFavorite,
     DavProperty.FileId,
+    DavProperty.Name,
     DavProperty.OwnerId,
     DavProperty.OwnerDisplayName,
     DavProperty.ShareTypes,


### PR DESCRIPTION
## Description
We've added the resource name to the WebDAV properties. It is being used for building the resource (if given).

I also modified the extractFileExtension method to work with it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
