### PR TITLE
Prevent unnecessary PROPFIND request during upload

### DIFF
--- a/changelog/unreleased/bugfix-prevent-unnecessary-propfind-during-upload
+++ b/changelog/unreleased/bugfix-prevent-unnecessary-propfind-during-upload
@@ -1,0 +1,6 @@
+Bugfix: Prevent unnecessary PROPFIND request during upload
+
+We've removed the unnecessary PROPFIND request at the start of each upload, increasing upload performance especially in larger folders.
+
+https://github.com/owncloud/web/issues/7486
+https://github.com/owncloud/web/pull/7488

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -345,13 +345,7 @@ export default defineComponent({
           }
         }
 
-        let pathFileWasUploadedTo = file.meta.currentFolder
-        if (file.meta.relativeFolder) {
-          pathFileWasUploadedTo += file.meta.relativeFolder
-        }
-
-        const fileIsInCurrentPath = pathFileWasUploadedTo === this.currentPath
-
+        const fileIsInCurrentPath = file.meta.currentFolder === this.currentPath
         if (fileIsInCurrentPath) {
           bus.publish('app.files.list.load')
         }
@@ -788,12 +782,6 @@ export default defineComponent({
       this.$uppyService.publish('uploadStarted')
       await this.createDirectoryTree(files)
       this.$uppyService.publish('addedForUpload', files)
-
-      const reloadRequired = !!files.find((f) => f.meta.currentFolder === this.currentPath)
-      if (reloadRequired) {
-        bus.publish('app.files.list.load')
-      }
-
       this.$uppyService.uploadFiles(files)
     },
 


### PR DESCRIPTION
## Description
We've removed the unnecessary PROPFIND request at the start of each upload, increasing upload performance especially in larger folders.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7486

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
