### PR TITLE
Fix line break for 'Paste here'-button

### DIFF
--- a/changelog/unreleased/enhancement-replace-locationpicker-clipboard
+++ b/changelog/unreleased/enhancement-replace-locationpicker-clipboard
@@ -4,4 +4,5 @@ We've replaced the locationpicker in batchactions and contextmenu with
 the new cut/copy/paste clipboard actions.
 
 https://github.com/owncloud/web/pull/7309
+https://github.com/owncloud/web/pull/7503
 https://github.com/owncloud/web/issues/6892

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -858,8 +858,6 @@ export default defineComponent({
 #new-file-menu-drop {
   min-width: 230px;
 }
-</style>
-<style lang="scss">
 #create-list,
 #upload-list,
 #new-file-menu-drop {
@@ -868,8 +866,11 @@ export default defineComponent({
   }
 }
 #clipboard-btns {
+  flex-flow: inherit;
+
   :nth-child(1) {
     border-right: 0px !important;
+    white-space: nowrap;
   }
   :nth-child(2) {
     border-left: 0px !important;


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7494

## Screenshots:
![Pasted Graphic](https://user-images.githubusercontent.com/50302941/185904585-c4377dcf-1d93-4708-9603-a073d33acdb1.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
