### PR TITLE
Fix file name for shared files in text editor

### DIFF
--- a/changelog/unreleased/bugfix-file-name-in-text-editor
+++ b/changelog/unreleased/bugfix-file-name-in-text-editor
@@ -1,0 +1,6 @@
+Bugfix: File name in text editor
+
+We've fixed a bug in the text editor where the UUID of a shared resource was being displayed instead of the file name.
+
+https://github.com/owncloud/web/pull/7516
+https://github.com/owncloud/web/issues/7292

--- a/packages/web-app-text-editor/src/App.vue
+++ b/packages/web-app-text-editor/src/App.vue
@@ -102,7 +102,10 @@ export default defineComponent({
     const loadFileTask = useTask(function* () {
       const filePath = unref(currentFileContext).path
 
-      resource.value = yield getFileResource(unref(filePath), [DavProperty.Permissions])
+      resource.value = yield getFileResource(unref(filePath), [
+        DavProperty.Permissions,
+        DavProperty.Name
+      ])
       isReadOnly.value = ![DavPermission.Updateable, DavPermission.FileUpdateable].some(
         (p) => (resource.value.permissions || '').indexOf(p) > -1
       )


### PR DESCRIPTION
## Description
We've fixed a bug in the text editor where the UUID of a shared resource was being displayed instead of the file name.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7292

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
