### PR TITLE
fix: preview loading in share jail

### DIFF
--- a/changelog/unreleased/bugfix-file-name-in-text-editor
+++ b/changelog/unreleased/bugfix-file-name-in-text-editor
@@ -4,3 +4,4 @@ We've fixed a bug in the text editor where the UUID of a shared resource was bei
 
 https://github.com/owncloud/web/pull/7516
 https://github.com/owncloud/web/issues/7292
+https://github.com/owncloud/web/pull/7518

--- a/packages/web-app-files/src/components/SideBar/SideBar.vue
+++ b/packages/web-app-files/src/components/SideBar/SideBar.vue
@@ -234,14 +234,6 @@ export default defineComponent({
             this.highlightedFile.webDavPath,
             DavProperties.Default
           )
-          if (
-            this.hasShareJail &&
-            (isLocationSharesActive(this.$router, 'files-shares-with-me') ||
-              (isLocationSpacesActive(this.$router, 'files-spaces-share') &&
-                this.highlightedFile.path === '/'))
-          ) {
-            item.name = this.highlightedFile.name
-          }
         }
 
         this.selectedFile = buildResource(item)

--- a/packages/web-pkg/src/helpers/preview/privatePreviewBlob.ts
+++ b/packages/web-pkg/src/helpers/preview/privatePreviewBlob.ts
@@ -9,7 +9,6 @@ interface PrivatePreviewBlobOptions {
   userId: string
   resource: {
     id: string
-    path: string
     webDavPath: string
     etag?: string
   }


### PR DESCRIPTION
## Description
Fixes preview loading in the right sidebar.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/7517

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
