### PR TITLE
Fix sidebar loading for the current folder

### DIFF
--- a/changelog/unreleased/bugfix-sidebar-for-current-folder
+++ b/changelog/unreleased/bugfix-sidebar-for-current-folder
@@ -1,0 +1,6 @@
+Bugfix: Sidebar for current folder
+
+We've fixed a bug where the right sidebar for the current folder could not be opened when another resource was selected.
+
+https://github.com/owncloud/web/issues/7519
+https://github.com/owncloud/web/pull/7527

--- a/packages/web-app-files/src/mixins/actions/showDetails.js
+++ b/packages/web-app-files/src/mixins/actions/showDetails.js
@@ -1,4 +1,4 @@
-import { mapActions } from 'vuex'
+import { mapActions, mapMutations } from 'vuex'
 import { isLocationTrashActive } from '../../router'
 import isFilesAppActive from './helpers/isFilesAppActive'
 
@@ -36,8 +36,10 @@ export default {
   },
   methods: {
     ...mapActions('Files/sidebar', { openSidebar: 'open' }),
+    ...mapMutations('Files', ['SET_FILE_SELECTION']),
 
-    async $_showDetails_trigger() {
+    async $_showDetails_trigger({ resources }) {
+      this.SET_FILE_SELECTION(resources)
       await this.openSidebar()
     }
   }

--- a/packages/web-app-files/src/mixins/actions/showShares.ts
+++ b/packages/web-app-files/src/mixins/actions/showShares.ts
@@ -2,6 +2,7 @@ import quickActions, { canShare } from '../../quickActions'
 import { isLocationSharesActive, isLocationTrashActive } from '../../router'
 import { ShareStatus } from 'web-client/src/helpers/share'
 import isFilesAppActive from './helpers/isFilesAppActive'
+import { mapMutations } from 'vuex'
 
 export default {
   mixins: [isFilesAppActive],
@@ -43,7 +44,10 @@ export default {
     }
   },
   methods: {
+    ...mapMutations('Files', ['SET_FILE_SELECTION']),
+
     async $_showShares_trigger({ resources }) {
+      this.SET_FILE_SELECTION(resources)
       await this.$store.dispatch('Files/sidebar/openWithPanel', 'sharing-item#peopleShares')
     }
   }


### PR DESCRIPTION
## Description
We've fixed a bug where the right sidebar for the current folder could not be opened when another resource was selected.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7519

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
