### PR TITLE
Fix glitchy left sidebar when switching apps

### DIFF
--- a/changelog/unreleased/bugfix-left-sidebar-app-switch
+++ b/changelog/unreleased/bugfix-left-sidebar-app-switch
@@ -1,0 +1,6 @@
+Bugfix: Left sidebar when switching apps
+
+We've fixed a bug where the active state of the left sidebar would glitch visually when switching apps.
+
+https://github.com/owncloud/web/issues/7526
+https://github.com/owncloud/web/pull/7529

--- a/packages/web-runtime/src/components/SidebarNav/SidebarNav.vue
+++ b/packages/web-runtime/src/components/SidebarNav/SidebarNav.vue
@@ -74,25 +74,23 @@ export default {
     }
   },
   mounted() {
-    const navItem = document.getElementsByClassName('oc-sidebar-nav-item-link')[0]
+    const navBar = document.getElementById('web-nav-sidebar')
     const highlighter = document.getElementById('nav-highlighter')
 
-    if (!highlighter || !navItem) {
+    if (!highlighter || !navBar) {
       return
     }
 
-    const resizeObserver = new ResizeObserver((data) => {
-      const width = data[0].borderBoxSize[0].inlineSize
-      highlighter.style.setProperty('transition-duration', `0.05s`)
-      if (width) {
-        highlighter.style.setProperty('width', `${width}px`)
+    const resizeObserver = new ResizeObserver(() => {
+      const navItem = document.getElementsByClassName('oc-sidebar-nav-item-link')[0]
+      if (!navItem) {
+        return
       }
-    })
-    resizeObserver.observe(navItem)
-    if (navItem.clientWidth) {
+      highlighter.style.setProperty('transition-duration', `0.05s`)
       highlighter.style.setProperty('width', `${navItem.clientWidth}px`)
       highlighter.style.setProperty('height', `${navItem.clientHeight}px`)
-    }
+    })
+    resizeObserver.observe(navBar)
 
     this.$on('beforeDestroy', () => {
       resizeObserver.disconnect()
@@ -149,7 +147,7 @@ export default {
   max-width: 230px !important;
 }
 .oc-app-navigation-collapsed {
-  min-width: 58px !important;
-  max-width: 58px !important;
+  min-width: 62px !important;
+  max-width: 62px !important;
 }
 </style>


### PR DESCRIPTION
## Description
We've fixed a bug where the active state of the left sidebar would glitch visually when switching apps.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7526

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
