### PR TITLE
Adjust spacing of the files list options menu

### DIFF
--- a/changelog/unreleased/enhancemnet-files-list-options-menu-spacing
+++ b/changelog/unreleased/enhancemnet-files-list-options-menu-spacing
@@ -1,0 +1,6 @@
+Enhancement: Adjust spacing of the files list options menu
+
+We've adjusted the spacing of the files list options menu to visually match with the other menus.
+
+https://github.com/owncloud/web/pull/7570
+https://github.com/owncloud/web/issues/7541

--- a/packages/web-app-files/src/components/AppBar/ViewOptions.vue
+++ b/packages/web-app-files/src/components/AppBar/ViewOptions.vue
@@ -16,24 +16,24 @@
       toggle="#files-view-options-btn"
       mode="click"
       class="oc-width-auto"
-      padding-size="small"
+      padding-size="medium"
     >
       <oc-list>
-        <li class="files-view-options-list-item">
+        <li class="files-view-options-list-item oc-mb-m">
           <oc-switch
             v-model="hiddenFilesShownModel"
             data-testid="files-switch-hidden-files"
             :label="$gettext('Show hidden files')"
           />
         </li>
-        <li class="files-view-options-list-item">
+        <li class="files-view-options-list-item oc-my-m">
           <oc-switch
             v-model="fileExtensionsShownModel"
             data-testid="files-switch-files-extensions-files"
             :label="$gettext('Show file extensions')"
           />
         </li>
-        <li class="files-view-options-list-item">
+        <li class="files-view-options-list-item oc-mt-m">
           <oc-page-size
             v-model="itemsPerPage"
             data-testid="files-pagination-size"


### PR DESCRIPTION
## Description
We've adjusted the spacing of the files list options menu to visually match with the other menus.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7541

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/50302941/187903724-c185b218-fccc-42aa-b159-9d1bc35efe49.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
