### PR TITLE
fix: don't apply hover and focus nav item style to active item

### DIFF
--- a/changelog/unreleased/enhancement-left-sidebar-hover
+++ b/changelog/unreleased/enhancement-left-sidebar-hover
@@ -4,3 +4,4 @@ We've added a hover effect to the left sidebar items.
 
 https://github.com/owncloud/web/issues/7540
 https://github.com/owncloud/web/pull/7567
+https://github.com/owncloud/web/pull/7575

--- a/packages/web-runtime/src/components/SidebarNav/SidebarNav.vue
+++ b/packages/web-runtime/src/components/SidebarNav/SidebarNav.vue
@@ -142,7 +142,7 @@ export default {
     justify-content: flex-end !important;
   }
 
-  .oc-sidebar-nav li a {
+  .oc-sidebar-nav li a:not(.active) {
     &:hover,
     &:focus {
       text-decoration: none !important;

--- a/packages/web-runtime/src/components/SidebarNav/SidebarNavItem.vue
+++ b/packages/web-runtime/src/components/SidebarNav/SidebarNavItem.vue
@@ -9,11 +9,7 @@
       type="router-link"
       appearance="raw"
       :variation="active ? 'inverse' : 'passive'"
-      :class="[
-        'oc-sidebar-nav-item-link',
-        { active: active },
-        { 'oc-background-primary-gradient': active }
-      ]"
+      :class="['oc-sidebar-nav-item-link', { active: active }]"
       :to="target"
       :data-nav-id="index"
       :data-nav-name="navName"


### PR DESCRIPTION
## Description
We had a glitchy left sidebar active item animation from a PR merged today. See https://github.com/owncloud/web/pull/7567#issuecomment-1234444330
This PR fixes it. Thanks @diocas for spotting and reporting it!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
