### PR TITLE
Spaces fixes

### DIFF
--- a/changelog/unreleased/bugfix-redirect-space-access-removal
+++ b/changelog/unreleased/bugfix-redirect-space-access-removal
@@ -1,0 +1,6 @@
+Bugfix: Redirect after removing self from space members
+
+When a user removes themselves from the members of a project space we now properly redirect to the project spaces overviewe page instead of showing an error message.
+
+https://github.com/owncloud/web/issues/7534
+https://github.com/owncloud/web/pull/7576

--- a/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
@@ -124,7 +124,8 @@ export default defineComponent({
         client: this.$client,
         graphClient: this.graphClient,
         share: share,
-        path: this.highlightedFile.path
+        path: this.highlightedFile.path,
+        reloadResource: false
       })
         .then(() => {
           this.hideModal()
@@ -141,6 +142,7 @@ export default defineComponent({
         })
         .catch((error) => {
           console.error(error)
+          this.hideModal()
           this.showMessage({
             title: this.$gettext('Failed to remove share'),
             status: 'danger'

--- a/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
@@ -119,35 +119,34 @@ export default defineComponent({
       this.createModal(modal)
     },
 
-    $_ocCollaborators_deleteShare(share) {
-      this.deleteShare({
-        client: this.$client,
-        graphClient: this.graphClient,
-        share: share,
-        path: this.highlightedFile.path,
-        reloadResource: false
-      })
-        .then(() => {
-          this.hideModal()
-          this.showMessage({
-            title: this.$gettext('Share was removed successfully')
-          })
-          // current user was removed from the share.
-          if (share.collaborator.name === this.user.id) {
-            if (isLocationSpacesActive(this.$router, 'files-spaces-projects')) {
-              return this.$router.go()
-            }
-            return this.$router.push(createLocationSpaces('files-spaces-projects'))
+    async $_ocCollaborators_deleteShare(share) {
+      try {
+        await this.deleteShare({
+          client: this.$client,
+          graphClient: this.graphClient,
+          share: share,
+          path: this.highlightedFile.path,
+          reloadResource: false
+        })
+        this.showMessage({
+          title: this.$gettext('Share was removed successfully')
+        })
+        // current user was removed from the share.
+        if (share.collaborator.name === this.user.id) {
+          if (isLocationSpacesActive(this.$router, 'files-spaces-projects')) {
+            return this.$router.go()
           }
+          return this.$router.push(createLocationSpaces('files-spaces-projects'))
+        }
+      } catch (error) {
+        console.error(error)
+        this.showMessage({
+          title: this.$gettext('Failed to remove share'),
+          status: 'danger'
         })
-        .catch((error) => {
-          console.error(error)
-          this.hideModal()
-          this.showMessage({
-            title: this.$gettext('Failed to remove share'),
-            status: 'danger'
-          })
-        })
+      } finally {
+        this.hideModal()
+      }
     }
   }
 })

--- a/packages/web-app-files/src/mixins/spaces/actions/disable.js
+++ b/packages/web-app-files/src/mixins/spaces/actions/disable.js
@@ -74,8 +74,11 @@ export default {
           this.showMessage({
             title: this.$gettext('Space was disabled successfully')
           })
+          if (isLocationSpacesActive(this.$router, 'files-spaces-projects')) {
+            return
+          }
           if (isLocationSpacesActive(this.$router, 'files-spaces-project')) {
-            this.$router.push(createLocationSpaces('files-spaces-projects'))
+            return this.$router.push(createLocationSpaces('files-spaces-projects'))
           }
         })
         .catch((error) => {

--- a/packages/web-app-files/src/store/actions.ts
+++ b/packages/web-app-files/src/store/actions.ts
@@ -542,7 +542,7 @@ export default {
         )
       })
   },
-  deleteShare(context, { client, graphClient, share, path, storageId }) {
+  deleteShare(context, { client, graphClient, share, path, storageId, reloadResource = true }) {
     const additionalParams: any = {}
     if (share.shareType === ShareTypes.space.value) {
       additionalParams.shareWith = share.collaborator.name
@@ -554,7 +554,7 @@ export default {
       if (share.shareType !== ShareTypes.space.value) {
         context.dispatch('updateCurrentFileShareTypes')
         context.dispatch('loadIndicators', { client, currentFolder: path, storageId })
-      } else {
+      } else if (reloadResource) {
         context.commit('CURRENT_FILE_OUTGOING_SHARES_LOADING', true)
 
         return graphClient.drives.getDrive(share.id).then((response) => {


### PR DESCRIPTION
## Description
Two small fixes regarding spaces:
- when leaving a space, don't try to refetch it (causes 404, stops action with an error message)
- when disabling a space match with `projects` route first and return early. the `files-spaces-project` route without a storageId param is a prefix match to the `files-spaces-projects` route, thus it was still trying to redirect to the spaces overview despite already being there.

Fixes https://github.com/owncloud/web/issues/7534

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
