### PR TITLE
[full-ci] Fix sharesTree loading

### DIFF
--- a/changelog/unreleased/bugfix-shares-tree-loading
+++ b/changelog/unreleased/bugfix-shares-tree-loading
@@ -1,6 +1,11 @@
-Bugfix: Hide share actions for space viewers/editors
+Bugfix: Shares tree loading
 
-We now make sure that an empty string will never be used as key for the shares tree. This fixes several issues with wrong share permissions being loaded and also improves performance in folders.
+We've improved loading of the shares tree:
+
+* It now happens more globally in the sidebar component instead of in each sidebar panel.
+* Shares won't be loaded for resources without a path anymore.
+
+These changes massively improve the sidebar performance and fix several issues with (re-)share permissions.
 
 https://github.com/owncloud/web/issues/7506
 https://github.com/owncloud/web/issues/7593

--- a/changelog/unreleased/bugfix-shares-tree-loading
+++ b/changelog/unreleased/bugfix-shares-tree-loading
@@ -9,4 +9,5 @@ These changes massively improve the sidebar performance and fix several issues w
 
 https://github.com/owncloud/web/issues/7506
 https://github.com/owncloud/web/issues/7593
+https://github.com/owncloud/web/issues/7592
 https://github.com/owncloud/web/pull/7580

--- a/changelog/unreleased/bugfix-shares-tree-loading
+++ b/changelog/unreleased/bugfix-shares-tree-loading
@@ -1,0 +1,7 @@
+Bugfix: Hide share actions for space viewers/editors
+
+We now make sure that an empty string will never be used as key for the shares tree. This fixes several issues with wrong share permissions being loaded and also improves performance in folders.
+
+https://github.com/owncloud/web/issues/7506
+https://github.com/owncloud/web/issues/7593
+https://github.com/owncloud/web/pull/7580

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -352,39 +352,40 @@ export default defineComponent({
   watch: {
     file() {
       this.loadData()
-      this.refreshShareDetailsTree()
     },
-    sharesTree() {
-      // missing early return
-      this.sharedItem = null
-      this.shareIndicators = getIndicators(this.file, this.sharesTree)
-      const sharePathParentOrCurrent = this.getParentSharePath(this.file.path, this.sharesTree)
-      if (sharePathParentOrCurrent === null) {
-        return
-      }
-      const shares = this.sharesTree[sharePathParentOrCurrent]?.filter((s) =>
-        ShareTypes.containsAnyValue(
-          [...ShareTypes.individuals, ...ShareTypes.unauthenticated],
-          [s.shareType]
+    sharesTree: {
+      handler() {
+        // missing early return
+        this.sharedItem = null
+        this.shareIndicators = getIndicators(this.file, this.sharesTree)
+        const sharePathParentOrCurrent = this.getParentSharePath(this.file.path, this.sharesTree)
+        if (sharePathParentOrCurrent === null) {
+          return
+        }
+        const shares = this.sharesTree[sharePathParentOrCurrent]?.filter((s) =>
+          ShareTypes.containsAnyValue(
+            [...ShareTypes.individuals, ...ShareTypes.unauthenticated],
+            [s.shareType]
+          )
         )
-      )
-      if (shares.length === 0) {
-        return
-      }
+        if (shares.length === 0) {
+          return
+        }
 
-      this.sharedItem = shares[0]
-      this.sharedByName = this.sharedItem.owner?.name
-      this.sharedByDisplayName = this.sharedItem.owner?.displayName
-      if (this.sharedItem.owner?.additionalInfo) {
-        this.sharedByDisplayName += ' (' + this.sharedItem.owner.additionalInfo + ')'
-      }
-      this.sharedTime = this.sharedItem.stime
-      this.sharedParentDir = sharePathParentOrCurrent
+        this.sharedItem = shares[0]
+        this.sharedByName = this.sharedItem.owner?.name
+        this.sharedByDisplayName = this.sharedItem.owner?.displayName
+        if (this.sharedItem.owner?.additionalInfo) {
+          this.sharedByDisplayName += ' (' + this.sharedItem.owner.additionalInfo + ')'
+        }
+        this.sharedTime = this.sharedItem.stime
+        this.sharedParentDir = sharePathParentOrCurrent
+      },
+      immediate: true
     }
   },
   mounted() {
     this.loadData()
-    this.refreshShareDetailsTree()
   },
   asyncComputed: {
     preview: {
@@ -405,16 +406,8 @@ export default defineComponent({
     }
   },
   methods: {
-    ...mapActions('Files', ['loadPreview', 'loadVersions', 'loadSharesTree']),
-    async refreshShareDetailsTree() {
-      await this.loadSharesTree({
-        client: this.$client,
-        path: this.file.path,
-        $gettext: this.$gettext,
-        storageId: this.file.fileId
-      })
-      this.shareIndicators = getIndicators(this.file, this.sharesTree)
-    },
+    ...mapActions('Files', ['loadPreview', 'loadVersions']),
+
     getParentSharePath(childPath, shares) {
       let currentPath = childPath
       if (!currentPath) {

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -380,6 +380,7 @@ export default defineComponent({
         }
         this.sharedTime = this.sharedItem.stime
         this.sharedParentDir = sharePathParentOrCurrent
+        this.shareIndicators = getIndicators(this.file, this.sharesTree)
       },
       immediate: true
     }

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -380,7 +380,6 @@ export default defineComponent({
         }
         this.sharedTime = this.sharedItem.stime
         this.sharedParentDir = sharePathParentOrCurrent
-        this.shareIndicators = getIndicators(this.file, this.sharesTree)
       },
       immediate: true
     }

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
@@ -217,13 +217,6 @@ export default defineComponent({
       return this.$gettextInterpolate(translated, context)
     },
 
-    shareExpirationText() {
-      const translated = this.$gettext('Expires %{ expiryDateRelative }')
-      return this.$gettextInterpolate(translated, {
-        expiryDateRelative: this.expirationDateRelative
-      })
-    },
-
     screenreaderShareExpiration() {
       const translated = this.$gettext('Share expires %{ expiryDateRelative } (%{ expiryDate })')
       return this.$gettextInterpolate(translated, {
@@ -258,11 +251,6 @@ export default defineComponent({
       return this.sharedParentRoute?.params?.item.split('/').pop()
     },
 
-    shareDetailsHelperContent() {
-      return {
-        text: this.$gettext('Invite persons or groups to access this file or folder.')
-      }
-    },
     editDropDownToggleId() {
       return uuid.v4()
     },

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
@@ -183,7 +183,7 @@ export default defineComponent({
     },
     share() {
       // the root share has an empty key in the shares tree. That's the reason why we retrieve the share by an empty key here
-      return this.sharesTree['']?.find((s) => s.incoming)
+      return this.sharesTree['/']?.find((s) => s.incoming)
     },
     allowCustomSharing() {
       return this.capabilities?.files_sharing?.allow_custom

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
@@ -118,11 +118,11 @@ import {
 import * as uuid from 'uuid'
 import { defineComponent } from '@vue/runtime-core'
 import { PropType } from '@vue/composition-api'
-import { useIncomingParentShare } from '../../../../composables/parentShare'
 
 export default defineComponent({
   name: 'RoleDropdown',
   components: { RoleItem },
+  inject: ['incomingParentShare'],
   props: {
     resource: {
       type: Object,
@@ -147,9 +147,6 @@ export default defineComponent({
       type: Boolean,
       required: true
     }
-  },
-  setup() {
-    return { ...useIncomingParentShare() }
   },
   data() {
     return {
@@ -193,9 +190,9 @@ export default defineComponent({
         return SpacePeopleShareRoles.list()
       }
 
-      if (this.incomingParentShare && this.resourceIsSharable) {
+      if (this.incomingParentShare.value && this.resourceIsSharable) {
         return PeopleShareRoles.filterByBitmask(
-          parseInt(this.incomingParentShare.permissions),
+          parseInt(this.incomingParentShare.value.permissions),
           this.resource.isFolder,
           this.allowSharePermission,
           this.allowCustomSharing !== false
@@ -205,8 +202,10 @@ export default defineComponent({
       return PeopleShareRoles.list(this.resource.isFolder, this.allowCustomSharing !== false)
     },
     availablePermissions() {
-      if (this.incomingParentShare && this.resourceIsSharable) {
-        return SharePermissions.bitmaskToPermissions(parseInt(this.incomingParentShare.permissions))
+      if (this.incomingParentShare.value && this.resourceIsSharable) {
+        return SharePermissions.bitmaskToPermissions(
+          parseInt(this.incomingParentShare.value.permissions)
+        )
       }
       return this.customPermissionsRole.permissions(this.allowSharePermission)
     },
@@ -223,8 +222,7 @@ export default defineComponent({
     window.removeEventListener('keydown', this.cycleRoles)
   },
 
-  async mounted() {
-    await this.loadIncomingParentShare.perform(this.resource)
+  mounted() {
     this.applyRoleAndPermissions()
     window.addEventListener('keydown', this.cycleRoles)
   },

--- a/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
@@ -184,7 +184,7 @@ export default defineComponent({
 
     share() {
       // the root share has an empty key in the shares tree. That's the reason why we retrieve the share by an empty key here
-      return this.sharesTree['']?.find((s) => s.incoming)
+      return this.sharesTree['/']?.find((s) => s.incoming)
     },
 
     expirationDate() {

--- a/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
@@ -129,7 +129,6 @@ import { useGraphClient } from 'web-client/src/composables'
 import CreateQuickLink from './Links/CreateQuickLink.vue'
 import { isLocationSpacesActive } from '../../../router'
 import { getLocaleFromLanguage } from 'web-pkg/src/helpers'
-import { useIncomingParentShare } from '../../../composables/parentShare'
 
 export default defineComponent({
   name: 'FileLinks',
@@ -138,6 +137,7 @@ export default defineComponent({
     DetailsAndEdit,
     NameAndCopy
   },
+  inject: ['incomingParentShare'],
   setup() {
     const store = useStore()
 
@@ -147,7 +147,6 @@ export default defineComponent({
 
     return {
       ...useGraphClient(),
-      ...useIncomingParentShare(),
       hasSpaces: useCapabilitySpacesEnabled(),
       hasShareJail: useCapabilityShareJailEnabled(),
       hasResharing: useCapabilityFilesSharingResharing(),
@@ -215,9 +214,9 @@ export default defineComponent({
     },
 
     availableRoleOptions() {
-      if (this.incomingParentShare && this.canCreatePublicLinks) {
+      if (this.incomingParentShare.value && this.canCreatePublicLinks) {
         return LinkShareRoles.filterByBitmask(
-          parseInt(this.incomingParentShare.permissions),
+          parseInt(this.incomingParentShare.value.permissions),
           this.highlightedFile.isFolder,
           this.hasPublicLinkEditing,
           this.hasPublicLinkAliasSupport
@@ -347,9 +346,6 @@ export default defineComponent({
 
       return this.$route.params.storageId || null
     }
-  },
-  async mounted() {
-    await this.loadIncomingParentShare.perform(this.highlightedFile)
   },
   methods: {
     ...mapActions('Files', ['addLink', 'updateLink', 'removeLink']),

--- a/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
@@ -320,9 +320,6 @@ export default defineComponent({
         return []
       }
 
-      // remove root entry
-      parentPaths.pop()
-
       parentPaths.forEach((parentPath) => {
         const shares = cloneStateObject(this.sharesTree[parentPath])
         if (shares) {

--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -188,35 +188,6 @@ export default {
       return this.collaborators.length > 0
     },
 
-    /**
-     * Returns all incoming shares, direct and indirect
-     *
-     * @return {Array.<Object>} list of incoming shares
-     */
-    $_allIncomingShares() {
-      // direct incoming shares
-      const allShares = [...this.incomingShares]
-
-      // indirect incoming shares
-      const parentPaths = getParentPaths(this.highlightedFile.path, true)
-      if (parentPaths.length === 0) {
-        return []
-      }
-
-      parentPaths.forEach((parentPath) => {
-        const shares = this.sharesTree[parentPath]
-        if (shares) {
-          shares.forEach((share) => {
-            if (share.incoming) {
-              allShares.push(share)
-            }
-          })
-        }
-      })
-
-      return allShares
-    },
-
     collaborators() {
       return [...this.currentFileOutgoingCollaborators, ...this.indirectOutgoingShares]
         .sort(this.collaboratorsComparator)
@@ -287,20 +258,6 @@ export default {
       const translatedFile = this.$gettext("You don't have permission to share this file.")
       const translatedFolder = this.$gettext("You don't have permission to share this folder.")
       return this.highlightedFile.type === 'file' ? translatedFile : translatedFolder
-    },
-
-    currentUsersPermissions() {
-      if (this.$_allIncomingShares.length > 0) {
-        let permissions = 0
-
-        for (const share of this.$_allIncomingShares) {
-          permissions |= share.permissions
-        }
-
-        return permissions
-      }
-
-      return null
     },
     currentUserIsMemberOfSpace() {
       return this.currentSpace?.spaceMemberIds?.includes(this.user.uuid)

--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -203,9 +203,6 @@ export default {
         return []
       }
 
-      // remove root entry
-      parentPaths.pop()
-
       parentPaths.forEach((parentPath) => {
         const shares = this.sharesTree[parentPath]
         if (shares) {
@@ -259,9 +256,6 @@ export default {
       if (parentPaths.length === 0) {
         return []
       }
-
-      // remove root entry
-      parentPaths.pop()
 
       parentPaths.forEach((parentPath) => {
         const shares = this.sharesTree[parentPath]

--- a/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
@@ -18,7 +18,7 @@ import { computed, defineComponent, unref, watch } from '@vue/composition-api'
 import FileLinks from './FileLinks.vue'
 import FileShares from './FileShares.vue'
 import SpaceMembers from './SpaceMembers.vue'
-import { mapActions, mapGetters, mapState } from 'vuex'
+import { mapGetters, mapState } from 'vuex'
 import { useDebouncedRef, useStore } from 'web-pkg/src/composables'
 import { useIncomingParentShare } from '../../../composables/parentShare'
 
@@ -85,15 +85,11 @@ export default defineComponent({
           if (!ref || !this.$refs[ref]) {
             return
           }
-
           this.$emit('scrollToElement', { element: this.$refs[ref].$el, panelName })
         })
       },
       immediate: true
     }
-  },
-  methods: {
-    ...mapActions('Files', ['loadCurrentFileOutgoingShares'])
   }
 })
 </script>

--- a/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
@@ -18,9 +18,7 @@ import { computed, defineComponent, unref, watch } from '@vue/composition-api'
 import FileLinks from './FileLinks.vue'
 import FileShares from './FileShares.vue'
 import SpaceMembers from './SpaceMembers.vue'
-import { mapGetters, mapState } from 'vuex'
-import { useGraphClient } from 'web-client/src/composables'
-import { useTask } from 'vue-concurrency'
+import { mapActions, mapGetters, mapState } from 'vuex'
 import { useDebouncedRef, useStore } from 'web-pkg/src/composables'
 import { useIncomingParentShare } from '../../../composables/parentShare'
 
@@ -62,27 +60,13 @@ export default defineComponent({
         sharesTreeLoading.value
     })
 
-    const { graphClient } = useGraphClient()
-
-    const loadSpaceMembersTask = useTask(function* (signal, ref) {
-      yield ref.loadCurrentFileOutgoingShares({
-        client: ref.$client,
-        graphClient,
-        path: ref.space.id,
-        storageId: ref.space.id,
-        resource: ref.space
-      })
-    })
-
     return {
       ...useIncomingParentShare(),
-      graphClient,
-      loadSpaceMembersTask,
       sharesLoading
     }
   },
   computed: {
-    ...mapGetters('Files', ['highlightedFile', 'currentFileOutgoingSharesLoading']),
+    ...mapGetters('Files', ['currentFileOutgoingSharesLoading']),
     ...mapState('Files', ['incomingSharesLoading', 'sharesTreeLoading'])
   },
   watch: {
@@ -100,19 +84,15 @@ export default defineComponent({
           if (!ref || !this.$refs[ref]) {
             return
           }
+          console.log('wa',  this.$refs[ref].$el)
           this.$emit('scrollToElement', { element: this.$refs[ref].$el, panelName })
         })
       },
       immediate: true
-    },
-    highlightedFile: {
-      handler: function (newItem, oldItem) {
-        if (oldItem !== newItem && this.showSpaceMembers) {
-          this.loadSpaceMembersTask.perform(this)
-        }
-      },
-      immediate: true
     }
+  },
+  methods: {
+    ...mapActions('Files', ['loadCurrentFileOutgoingShares'])
   }
 })
 </script>

--- a/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
@@ -14,12 +14,12 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, unref, watch } from '@vue/composition-api'
+import { computed, defineComponent, unref } from '@vue/composition-api'
 import FileLinks from './FileLinks.vue'
 import FileShares from './FileShares.vue'
 import SpaceMembers from './SpaceMembers.vue'
 import { mapGetters, mapState } from 'vuex'
-import { useDebouncedRef, useStore } from 'web-pkg/src/composables'
+import { useStore } from 'web-pkg/src/composables'
 import { useIncomingParentShare } from '../../../composables/parentShare'
 
 export default defineComponent({
@@ -44,21 +44,14 @@ export default defineComponent({
     const currentFileOutgoingSharesLoading = computed(
       () => store.getters['Files/currentFileOutgoingSharesLoading']
     )
-    const incomingSharesLoading = computed(() => store.state.Files.incomingSharesLoading)
-    const sharesTreeLoading = computed(() => store.state.Files.sharesTreeLoading)
-    const sharesLoading = useDebouncedRef(
-      currentFileOutgoingSharesLoading.value ||
-        incomingSharesLoading.value ||
-        sharesTreeLoading.value,
-      250
+    const incomingSharesLoading = computed(() => store.getters['Files/incomingSharesLoading'])
+    const sharesTreeLoading = computed(() => store.getters['Files/sharesTreeLoading'])
+    const sharesLoading = computed(
+      () =>
+        unref(currentFileOutgoingSharesLoading) ||
+        unref(incomingSharesLoading) ||
+        unref(sharesTreeLoading)
     )
-
-    watch([currentFileOutgoingSharesLoading, incomingSharesLoading, sharesTreeLoading], () => {
-      sharesLoading.value =
-        currentFileOutgoingSharesLoading.value ||
-        incomingSharesLoading.value ||
-        sharesTreeLoading.value
-    })
 
     return {
       ...useIncomingParentShare(),

--- a/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
@@ -71,11 +71,12 @@ export default defineComponent({
   },
   watch: {
     sharesLoading: {
-      handler: function (sharesLoading) {
+      handler: function (sharesLoading, old) {
         if (!sharesLoading) {
           this.loadIncomingParentShare.perform(this.displayedItem.value)
         }
-        if (this.loading || !unref(this.activePanel)) {
+        // FIXME: !old can be removed as soon as https://github.com/owncloud/web/issues/7621 has been fixed
+        if (this.loading || !unref(this.activePanel) || !old) {
           return
         }
         this.$nextTick(() => {
@@ -84,7 +85,7 @@ export default defineComponent({
           if (!ref || !this.$refs[ref]) {
             return
           }
-          console.log('wa',  this.$refs[ref].$el)
+
           this.$emit('scrollToElement', { element: this.$refs[ref].$el, panelName })
         })
       },

--- a/packages/web-app-files/src/components/SideBar/SideBar.vue
+++ b/packages/web-app-files/src/components/SideBar/SideBar.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script lang="ts">
-import { mapGetters, mapState } from 'vuex'
+import { mapActions, mapGetters, mapState } from 'vuex'
 import SideBar from 'web-pkg/src/components/sideBar/SideBar.vue'
 import FileInfo from './FileInfo.vue'
 import SpaceInfo from './SpaceInfo.vue'
@@ -53,6 +53,7 @@ import {
 } from 'web-pkg/src/composables'
 import { bus } from 'web-pkg/src/instance'
 import { SideBarEventTopics } from '../../composables/sideBar'
+import _ from 'lodash'
 
 export default defineComponent({
   components: { FileInfo, SpaceInfo, SideBar },
@@ -118,7 +119,7 @@ export default defineComponent({
   },
 
   computed: {
-    ...mapGetters('Files', ['highlightedFile', 'selectedFiles']),
+    ...mapGetters('Files', ['highlightedFile', 'selectedFiles', 'currentFolder']),
     ...mapGetters(['fileSideBars', 'capabilities']),
     ...mapState(['user']),
     availablePanels(): Panel[] {
@@ -197,6 +198,10 @@ export default defineComponent({
         return
       }
 
+      if (oldFile && _.isEqual(newFile, oldFile)) {
+        return
+      }
+
       this.fetchFileInfo()
     },
 
@@ -214,6 +219,12 @@ export default defineComponent({
     }
   },
   methods: {
+    ...mapActions('Files', [
+      'loadSharesTree',
+      'loadCurrentFileOutgoingShares',
+      'loadIncomingShares'
+    ]),
+
     async fetchFileInfo() {
       if (!this.highlightedFile) {
         this.selectedFile = {}
@@ -247,11 +258,39 @@ export default defineComponent({
 
         this.selectedFile = buildResource(item)
         this.$set(this.selectedFile, 'thumbnail', this.highlightedFile.thumbnail || null)
+        this.loadShares()
       } catch (error) {
         this.selectedFile = { ...this.highlightedFile }
         console.error(error)
       }
       this.loading = false
+    },
+
+    loadShares() {
+      this.loadCurrentFileOutgoingShares({
+        client: this.$client,
+        graphClient: this.graphClient,
+        path: this.highlightedFile.path,
+        $gettext: this.$gettext,
+        storageId: this.highlightedFile.fileId,
+        resource: this.highlightedFile
+      })
+      this.loadIncomingShares({
+        client: this.$client,
+        path: this.highlightedFile.path,
+        $gettext: this.$gettext,
+        storageId: this.highlightedFile.fileId
+      })
+
+      // shares tree is already being loaded for the current folder (except for root)
+      if (!this.currentFolder || this.currentFolder.path === '/') {
+        this.loadSharesTree({
+          client: this.$client,
+          path: this.highlightedFile.path === '' ? '/' : this.highlightedFile.path,
+          $gettext: this.$gettext,
+          storageId: this.highlightedFile.fileId
+        })
+      }
     }
   }
 })

--- a/packages/web-app-files/src/components/SideBar/SideBar.vue
+++ b/packages/web-app-files/src/components/SideBar/SideBar.vue
@@ -53,7 +53,7 @@ import {
 } from 'web-pkg/src/composables'
 import { bus } from 'web-pkg/src/instance'
 import { SideBarEventTopics } from '../../composables/sideBar'
-import _ from 'lodash'
+import isEqual from 'lodash-es/isEqual'
 import { useGraphClient } from 'web-client/src/composables'
 
 export default defineComponent({
@@ -201,7 +201,7 @@ export default defineComponent({
         return
       }
 
-      if (oldFile && _.isEqual(newFile, oldFile)) {
+      if (oldFile && isEqual(newFile, oldFile)) {
         return
       }
 

--- a/packages/web-app-files/src/components/SideBar/SideBar.vue
+++ b/packages/web-app-files/src/components/SideBar/SideBar.vue
@@ -54,6 +54,7 @@ import {
 import { bus } from 'web-pkg/src/instance'
 import { SideBarEventTopics } from '../../composables/sideBar'
 import _ from 'lodash'
+import { useGraphClient } from 'web-client/src/composables'
 
 export default defineComponent({
   components: { FileInfo, SpaceInfo, SideBar },
@@ -78,6 +79,7 @@ export default defineComponent({
 
   setup() {
     const store = useStore()
+    const { graphClient } = useGraphClient()
 
     const closeSideBar = () => {
       bus.publish(SideBarEventTopics.close)
@@ -105,7 +107,8 @@ export default defineComponent({
       setActiveSideBarPanel,
       closeSideBar,
       destroySideBar,
-      focusSideBar
+      focusSideBar,
+      graphClient
     }
   },
 
@@ -236,6 +239,7 @@ export default defineComponent({
         isLocationTrashActive(this.$router, 'files-trash-spaces-project') ||
         this.highlightedFileIsSpace
       ) {
+        this.loadShares()
         this.selectedFile = { ...this.highlightedFile }
         return
       }
@@ -271,7 +275,6 @@ export default defineComponent({
         client: this.$client,
         graphClient: this.graphClient,
         path: this.highlightedFile.path,
-        $gettext: this.$gettext,
         storageId: this.highlightedFile.fileId,
         resource: this.highlightedFile
       })

--- a/packages/web-app-files/src/composables/parentShare/index.ts
+++ b/packages/web-app-files/src/composables/parentShare/index.ts
@@ -1,0 +1,1 @@
+export * from './useIncomingParentShare'

--- a/packages/web-app-files/src/composables/parentShare/useIncomingParentShare.ts
+++ b/packages/web-app-files/src/composables/parentShare/useIncomingParentShare.ts
@@ -1,7 +1,5 @@
 import { buildShare } from '../../helpers/resources'
 import { useStore } from 'web-pkg/src/composables'
-import { useActiveLocation } from '../router'
-import { isLocationSharesActive } from '../../router'
 import { computed, ref, unref } from '@vue/composition-api'
 import { useTask } from 'vue-concurrency'
 import { clientService } from 'web-pkg/src/services'
@@ -10,7 +8,6 @@ export function useIncomingParentShare() {
   const store = useStore()
   const incomingParentShare = ref(null)
   const sharesTree = computed(() => store.state.Files.sharesTree)
-  const isSharedWithMeLocation = useActiveLocation(isLocationSharesActive, 'files-shares-with-me')
 
   const loadIncomingParentShare = useTask(function* (signal, resource) {
     let parentShare
@@ -20,11 +17,6 @@ export function useIncomingParentShare() {
         incomingParentShare.value = parentShare
         return
       }
-    }
-
-    if (unref(isSharedWithMeLocation)) {
-      incomingParentShare.value = resource.share
-      return
     }
 
     if (resource.shareId) {

--- a/packages/web-app-files/src/composables/parentShare/useIncomingParentShare.ts
+++ b/packages/web-app-files/src/composables/parentShare/useIncomingParentShare.ts
@@ -1,0 +1,47 @@
+import { buildShare } from '../../helpers/resources'
+import { useStore } from 'web-pkg/src/composables'
+import { useActiveLocation } from '../router'
+import { isLocationSharesActive } from '../../router'
+import { computed, ref, unref } from '@vue/composition-api'
+import { useTask } from 'vue-concurrency'
+import { clientService } from 'web-pkg/src/services'
+
+export function useIncomingParentShare() {
+  const store = useStore()
+  const incomingParentShare = ref(null)
+  const sharesTree = computed(() => store.state.Files.sharesTree)
+  const isSharedWithMeLocation = useActiveLocation(isLocationSharesActive, 'files-shares-with-me')
+
+  const loadIncomingParentShare = useTask(function* (signal, resource) {
+    console.log('resource', resource)
+    let parentShare
+    for (const shares of Object.values(unref(sharesTree)) as any) {
+      parentShare = shares.find((s) => s.incoming)
+      if (parentShare) {
+        console.log('via incoming:', parentShare)
+        incomingParentShare.value = parentShare
+        return
+      }
+    }
+
+    if (unref(isSharedWithMeLocation)) {
+      incomingParentShare.value = resource.share
+      console.log('via share obj', incomingParentShare.value)
+      return
+    }
+
+    if (resource.shareId) {
+      const parentShare = yield clientService.owncloudSdk.shares.getShare(resource.shareId)
+      if (parentShare) {
+        incomingParentShare.value = buildShare(parentShare.shareInfo, resource, true)
+        console.log('via share id', incomingParentShare.value)
+        return
+      }
+    }
+
+    console.log('No parent share')
+    incomingParentShare.value = null
+  })
+
+  return { loadIncomingParentShare, incomingParentShare }
+}

--- a/packages/web-app-files/src/composables/parentShare/useIncomingParentShare.ts
+++ b/packages/web-app-files/src/composables/parentShare/useIncomingParentShare.ts
@@ -13,12 +13,10 @@ export function useIncomingParentShare() {
   const isSharedWithMeLocation = useActiveLocation(isLocationSharesActive, 'files-shares-with-me')
 
   const loadIncomingParentShare = useTask(function* (signal, resource) {
-    console.log('resource', resource)
     let parentShare
     for (const shares of Object.values(unref(sharesTree)) as any) {
       parentShare = shares.find((s) => s.incoming)
       if (parentShare) {
-        console.log('via incoming:', parentShare)
         incomingParentShare.value = parentShare
         return
       }
@@ -26,7 +24,6 @@ export function useIncomingParentShare() {
 
     if (unref(isSharedWithMeLocation)) {
       incomingParentShare.value = resource.share
-      console.log('via share obj', incomingParentShare.value)
       return
     }
 
@@ -34,12 +31,10 @@ export function useIncomingParentShare() {
       const parentShare = yield clientService.owncloudSdk.shares.getShare(resource.shareId)
       if (parentShare) {
         incomingParentShare.value = buildShare(parentShare.shareInfo, resource, true)
-        console.log('via share id', incomingParentShare.value)
         return
       }
     }
 
-    console.log('No parent share')
     incomingParentShare.value = null
   })
 

--- a/packages/web-app-files/src/composables/parentShare/useIncomingParentShare.ts
+++ b/packages/web-app-files/src/composables/parentShare/useIncomingParentShare.ts
@@ -7,7 +7,7 @@ import { clientService } from 'web-pkg/src/services'
 export function useIncomingParentShare() {
   const store = useStore()
   const incomingParentShare = ref(null)
-  const sharesTree = computed(() => store.state.Files.sharesTree)
+  const sharesTree = computed(() => store.getters['Files/sharesTree'])
 
   const loadIncomingParentShare = useTask(function* (signal, resource) {
     let parentShare
@@ -20,7 +20,7 @@ export function useIncomingParentShare() {
     }
 
     if (resource.shareId) {
-      const parentShare = yield clientService.owncloudSdk.shares.getShare(resource.shareId)
+      parentShare = yield clientService.owncloudSdk.shares.getShare(resource.shareId)
       if (parentShare) {
         incomingParentShare.value = buildShare(parentShare.shareInfo, resource, true)
         return

--- a/packages/web-app-files/src/helpers/path.js
+++ b/packages/web-app-files/src/helpers/path.js
@@ -21,12 +21,16 @@ export function getParentPaths(path = '', includeCurrent = false) {
   const paths = []
   const sections = s.split('/')
 
-  if (includeCurrent) {
+  if (includeCurrent && s) {
     paths.push(s)
   }
 
   sections.pop()
   while (sections.length > 0) {
+    if (!sections.join('/')) {
+      sections.pop()
+      continue
+    }
     paths.push(sections.join('/'))
     sections.pop()
   }

--- a/packages/web-app-files/src/helpers/path.js
+++ b/packages/web-app-files/src/helpers/path.js
@@ -21,7 +21,7 @@ export function getParentPaths(path = '', includeCurrent = false) {
   const paths = []
   const sections = s.split('/')
 
-  if (includeCurrent && s) {
+  if (includeCurrent) {
     paths.push(s)
   }
 

--- a/packages/web-app-files/src/helpers/path.js
+++ b/packages/web-app-files/src/helpers/path.js
@@ -19,7 +19,7 @@ export function getParentPaths(path = '', includeCurrent = false) {
   }
 
   const paths = []
-  const sections = s.split('/').filter(Boolean)
+  const sections = s.split('/')
 
   if (includeCurrent) {
     paths.push(s)
@@ -27,6 +27,10 @@ export function getParentPaths(path = '', includeCurrent = false) {
 
   sections.pop()
   while (sections.length > 0) {
+    if (!sections.join('/')) {
+      sections.pop()
+      continue
+    }
     paths.push(sections.join('/'))
     sections.pop()
   }

--- a/packages/web-app-files/src/helpers/path.js
+++ b/packages/web-app-files/src/helpers/path.js
@@ -19,7 +19,7 @@ export function getParentPaths(path = '', includeCurrent = false) {
   }
 
   const paths = []
-  const sections = s.split('/')
+  const sections = s.split('/').filter(Boolean)
 
   if (includeCurrent) {
     paths.push(s)
@@ -27,10 +27,6 @@ export function getParentPaths(path = '', includeCurrent = false) {
 
   sections.pop()
   while (sections.length > 0) {
-    if (!sections.join('/')) {
-      sections.pop()
-      continue
-    }
     paths.push(sections.join('/'))
     sections.pop()
   }

--- a/packages/web-app-files/src/helpers/resources.ts
+++ b/packages/web-app-files/src/helpers/resources.ts
@@ -70,6 +70,7 @@ export function buildResource(resource): Resource {
     permissions: (resource.fileInfo[DavProperty.Permissions] as string) || '',
     starred: resource.fileInfo[DavProperty.IsFavorite] !== '0',
     etag: resource.fileInfo[DavProperty.ETag],
+    shareId: resource.fileInfo[DavProperty.ShareId],
     sharePermissions: resource.fileInfo[DavProperty.SharePermissions],
     shareTypes: (function () {
       if (resource.fileInfo[DavProperty.ShareTypes]) {

--- a/packages/web-app-files/src/helpers/resources.ts
+++ b/packages/web-app-files/src/helpers/resources.ts
@@ -70,7 +70,6 @@ export function buildResource(resource): Resource {
     permissions: (resource.fileInfo[DavProperty.Permissions] as string) || '',
     starred: resource.fileInfo[DavProperty.IsFavorite] !== '0',
     etag: resource.fileInfo[DavProperty.ETag],
-    shareId: resource.fileInfo[DavProperty.ShareId],
     sharePermissions: resource.fileInfo[DavProperty.SharePermissions],
     shareTypes: (function () {
       if (resource.fileInfo[DavProperty.ShareTypes]) {

--- a/packages/web-app-files/src/helpers/statusIndicators.js
+++ b/packages/web-app-files/src/helpers/statusIndicators.js
@@ -68,9 +68,6 @@ const shareTypesIndirect = (path, sharesTree) => {
     return []
   }
 
-  // remove root entry
-  parentPaths.pop()
-
   const shareTypes = {}
 
   parentPaths.forEach((parentPath) => {

--- a/packages/web-app-files/src/mixins/actions/rename.js
+++ b/packages/web-app-files/src/mixins/actions/rename.js
@@ -73,7 +73,8 @@ export default {
         const parentPaths = getParentPaths(resources[0].path, false).map((path) => {
           return prefix + path
         })
-        parentResources = await this.$client.files.list(parentPaths[0], 1)
+        const parentPathRoot = parentPaths[0] ?? prefix
+        parentResources = await this.$client.files.list(parentPathRoot, 1)
         parentResources = parentResources.map(buildResource)
       }
 

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.js.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.js.snap
@@ -123,7 +123,10 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
     <div data-testid="preview" class="details-preview oc-flex oc-flex-middle oc-flex-center oc-mb" style="background-image: none;">
       <oc-spinner-stub></oc-spinner-stub>
     </div>
-    <!---->
+    <div data-testid="sharingInfo" class="oc-flex oc-flex-middle oc-my-m">
+      <oc-status-indicators-stub resource="[object Object]" indicators="[object Object]"></oc-status-indicators-stub>
+      <p class="oc-my-rm oc-mx-s">This file has been shared.</p>
+    </div>
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
         <th scope="col" class="oc-pr-s">Last modified</th>
@@ -159,7 +162,10 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
     <div data-testid="preview" class="details-preview oc-flex oc-flex-middle oc-flex-center oc-mb" style="background-image: none;">
       <oc-spinner-stub></oc-spinner-stub>
     </div>
-    <!---->
+    <div data-testid="sharingInfo" class="oc-flex oc-flex-middle oc-my-m">
+      <oc-status-indicators-stub resource="[object Object]" indicators="[object Object]"></oc-status-indicators-stub>
+      <p class="oc-my-rm oc-mx-s">This file has been shared.</p>
+    </div>
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
         <th scope="col" class="oc-pr-s">Last modified</th>
@@ -215,7 +221,10 @@ exports[`Details SideBar Panel displays a resource of type file on a public page
     <div data-testid="preview" class="details-preview oc-flex oc-flex-middle oc-flex-center oc-mb" style="background-image: none;">
       <oc-spinner-stub></oc-spinner-stub>
     </div>
-    <!---->
+    <div data-testid="sharingInfo" class="oc-flex oc-flex-middle oc-my-m">
+      <oc-status-indicators-stub resource="[object Object]" indicators="[object Object]"></oc-status-indicators-stub>
+      <p class="oc-my-rm oc-mx-s">This file has been shared.</p>
+    </div>
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
         <th scope="col" class="oc-pr-s">Last modified</th>
@@ -251,7 +260,10 @@ exports[`Details SideBar Panel displays a resource of type file on a public page
     <div data-testid="preview" class="details-preview oc-flex oc-flex-middle oc-flex-center oc-mb" style="background-image: none;">
       <oc-spinner-stub></oc-spinner-stub>
     </div>
-    <!---->
+    <div data-testid="sharingInfo" class="oc-flex oc-flex-middle oc-my-m">
+      <oc-status-indicators-stub resource="[object Object]" indicators="[object Object]"></oc-status-indicators-stub>
+      <p class="oc-my-rm oc-mx-s">This file has been shared.</p>
+    </div>
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
         <th scope="col" class="oc-pr-s">Last modified</th>
@@ -343,7 +355,10 @@ exports[`Details SideBar Panel displays a resource of type folder on a private p
     <div class="details-icon-wrapper oc-width-1-1 oc-flex oc-flex-middle oc-flex-center oc-mb">
       <oc-resource-icon-stub resource="[object Object]" size="xxxlarge" class="details-icon"></oc-resource-icon-stub>
     </div>
-    <!---->
+    <div data-testid="sharingInfo" class="oc-flex oc-flex-middle oc-my-m">
+      <oc-status-indicators-stub resource="[object Object]" indicators="[object Object]"></oc-status-indicators-stub>
+      <p class="oc-my-rm oc-mx-s">This folder has been shared.</p>
+    </div>
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
         <th scope="col" class="oc-pr-s">Last modified</th>
@@ -379,7 +394,10 @@ exports[`Details SideBar Panel displays a resource of type folder on a private p
     <div class="details-icon-wrapper oc-width-1-1 oc-flex oc-flex-middle oc-flex-center oc-mb">
       <oc-resource-icon-stub resource="[object Object]" size="xxxlarge" class="details-icon"></oc-resource-icon-stub>
     </div>
-    <!---->
+    <div data-testid="sharingInfo" class="oc-flex oc-flex-middle oc-my-m">
+      <oc-status-indicators-stub resource="[object Object]" indicators="[object Object]"></oc-status-indicators-stub>
+      <p class="oc-my-rm oc-mx-s">This folder has been shared.</p>
+    </div>
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
         <th scope="col" class="oc-pr-s">Last modified</th>
@@ -435,7 +453,10 @@ exports[`Details SideBar Panel displays a resource of type folder on a public pa
     <div class="details-icon-wrapper oc-width-1-1 oc-flex oc-flex-middle oc-flex-center oc-mb">
       <oc-resource-icon-stub resource="[object Object]" size="xxxlarge" class="details-icon"></oc-resource-icon-stub>
     </div>
-    <!---->
+    <div data-testid="sharingInfo" class="oc-flex oc-flex-middle oc-my-m">
+      <oc-status-indicators-stub resource="[object Object]" indicators="[object Object]"></oc-status-indicators-stub>
+      <p class="oc-my-rm oc-mx-s">This folder has been shared.</p>
+    </div>
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
         <th scope="col" class="oc-pr-s">Last modified</th>
@@ -471,7 +492,10 @@ exports[`Details SideBar Panel displays a resource of type folder on a public pa
     <div class="details-icon-wrapper oc-width-1-1 oc-flex oc-flex-middle oc-flex-center oc-mb">
       <oc-resource-icon-stub resource="[object Object]" size="xxxlarge" class="details-icon"></oc-resource-icon-stub>
     </div>
-    <!---->
+    <div data-testid="sharingInfo" class="oc-flex oc-flex-middle oc-my-m">
+      <oc-status-indicators-stub resource="[object Object]" indicators="[object Object]"></oc-status-indicators-stub>
+      <p class="oc-my-rm oc-mx-s">This folder has been shared.</p>
+    </div>
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
         <th scope="col" class="oc-pr-s">Last modified</th>

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/RoleDropdown.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/RoleDropdown.spec.js
@@ -274,7 +274,13 @@ function getMountOptions({
     },
     store: getStore(sharesTree),
     localVue,
-    stubs
+    stubs,
+    mocks: {
+      loadIncomingParentShare: {
+        perform: jest.fn()
+      },
+      incomingParentShare: null
+    }
   }
 }
 

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/RoleDropdown.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/RoleDropdown.spec.js
@@ -275,11 +275,8 @@ function getMountOptions({
     store: getStore(sharesTree),
     localVue,
     stubs,
-    mocks: {
-      loadIncomingParentShare: {
-        perform: jest.fn()
-      },
-      incomingParentShare: null
+    provide: {
+      incomingParentShare: {}
     }
   }
 }

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileLinks.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileLinks.spec.js
@@ -212,6 +212,10 @@ describe('FileLinks', () => {
         ...stubs
       },
       mocks: {
+        loadIncomingParentShare: {
+          perform: jest.fn()
+        },
+        incomingParentShare: null,
         $route: {
           params: {}
         },
@@ -230,6 +234,10 @@ describe('FileLinks', () => {
       localVue,
       store: store,
       mocks: {
+        loadIncomingParentShare: {
+          perform: jest.fn()
+        },
+        incomingParentShare: null,
         $route: {
           params: {}
         },

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileLinks.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileLinks.spec.js
@@ -208,14 +208,13 @@ describe('FileLinks', () => {
     return shallowMount(FileLinks, {
       localVue,
       store: store,
+      provide: {
+        incomingParentShare: {}
+      },
       stubs: {
         ...stubs
       },
       mocks: {
-        loadIncomingParentShare: {
-          perform: jest.fn()
-        },
-        incomingParentShare: null,
         $route: {
           params: {}
         },
@@ -233,11 +232,10 @@ describe('FileLinks', () => {
     return mount(FileLinks, {
       localVue,
       store: store,
+      provide: {
+        incomingParentShare: {}
+      },
       mocks: {
-        loadIncomingParentShare: {
-          perform: jest.fn()
-        },
-        incomingParentShare: null,
         $route: {
           params: {}
         },

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.js
@@ -10,6 +10,7 @@ import Collaborators from '@/__fixtures__/collaborators'
 import { spaceRoleManager } from 'web-client/src/helpers/share'
 import * as reactivityComposables from 'web-pkg/src/composables/reactivity'
 import * as routerComposables from 'web-pkg/src/composables/router'
+import { useActiveLocation } from '@files/src/composables/router'
 import FileShares from '@files/src/components/SideBar/Shares/FileShares.vue'
 import { buildSpace } from 'web-client/src/helpers'
 import { clientService } from 'web-pkg/src/services'
@@ -26,6 +27,7 @@ localVue.use(GetTextPlugin, {
 
 jest.mock('web-pkg/src/composables/reactivity')
 jest.mock('web-pkg/src/composables/router')
+jest.mock('@files/src/composables/router')
 
 const user = Users.alice
 const collaborators = [Collaborators[0], Collaborators[1]]
@@ -275,6 +277,7 @@ const storeOptions = (data) => {
 
 function getMountedWrapper(data) {
   routerComposables.useRouteParam.mockReturnValue(() => storageId)
+  useActiveLocation.mockReturnValue(() => false)
 
   return mount(FileShares, {
     localVue,
@@ -302,6 +305,7 @@ function getMountedWrapper(data) {
 function getShallowMountedWrapper(data, loading = false) {
   reactivityComposables.useDebouncedRef.mockImplementationOnce(() => loading)
   routerComposables.useRouteParam.mockReturnValue(() => storageId)
+  useActiveLocation.mockReturnValue(() => false)
 
   return shallowMount(FileShares, {
     localVue,

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.js
@@ -10,7 +10,6 @@ import Collaborators from '@/__fixtures__/collaborators'
 import { spaceRoleManager } from 'web-client/src/helpers/share'
 import * as reactivityComposables from 'web-pkg/src/composables/reactivity'
 import * as routerComposables from 'web-pkg/src/composables/router'
-import { useActiveLocation } from '@files/src/composables/router'
 import FileShares from '@files/src/components/SideBar/Shares/FileShares.vue'
 import { buildSpace } from 'web-client/src/helpers'
 import { clientService } from 'web-pkg/src/services'
@@ -27,7 +26,6 @@ localVue.use(GetTextPlugin, {
 
 jest.mock('web-pkg/src/composables/reactivity')
 jest.mock('web-pkg/src/composables/router')
-jest.mock('@files/src/composables/router')
 
 const user = Users.alice
 const collaborators = [Collaborators[0], Collaborators[1]]
@@ -277,10 +275,12 @@ const storeOptions = (data) => {
 
 function getMountedWrapper(data) {
   routerComposables.useRouteParam.mockReturnValue(() => storageId)
-  useActiveLocation.mockReturnValue(() => false)
 
   return mount(FileShares, {
     localVue,
+    provide: {
+      incomingParentShare: {}
+    },
     setup: () => ({
       currentStorageId: storageId
     }),
@@ -305,7 +305,6 @@ function getMountedWrapper(data) {
 function getShallowMountedWrapper(data, loading = false) {
   reactivityComposables.useDebouncedRef.mockImplementationOnce(() => loading)
   routerComposables.useRouteParam.mockReturnValue(() => storageId)
-  useActiveLocation.mockReturnValue(() => false)
 
   return shallowMount(FileShares, {
     localVue,
@@ -313,6 +312,9 @@ function getShallowMountedWrapper(data, loading = false) {
       currentStorageId: storageId,
       hasResharing: false
     }),
+    provide: {
+      incomingParentShare: {}
+    },
     store: createStore(data),
     stubs: {
       ...stubs,

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/SharesPanel.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/SharesPanel.spec.js
@@ -18,14 +18,6 @@ const ocLoaderStubSelector = 'oc-loader-stub'
 
 jest.mock('web-pkg/src/composables/reactivity')
 describe('SharesPanel', () => {
-  it('reloads shares if highlighted file is changed', async () => {
-    const spyOnReloadShares = jest.spyOn(SharesPanel.methods, '$_reloadShares').mockImplementation()
-    const wrapper = getShallowWrapper()
-    wrapper.vm.$store.commit('Files/SET_HIGHLIGHTED_FILE', { name: '2' })
-    await wrapper.vm.$nextTick()
-    expect(spyOnReloadShares).toHaveBeenCalledTimes(2)
-  })
-
   describe('when loading is set to true', () => {
     it('should show the oc loader', () => {
       const wrapper = getShallowWrapper({ sharesLoading: true })
@@ -47,7 +39,8 @@ describe('SharesPanel', () => {
     return shallowMount(SharesPanel, {
       localVue,
       provide: {
-        activePanel: null
+        activePanel: null,
+        displayedItem: {}
       },
       store: new Vuex.Store({
         modules: {

--- a/packages/web-app-files/tests/unit/helpers/path.spec.js
+++ b/packages/web-app-files/tests/unit/helpers/path.spec.js
@@ -13,7 +13,7 @@ describe('build an array of parent paths from a provided path', () => {
 
   it('should prepend resulting paths with a "/" if none was given', () => {
     const paths = getParentPaths('a/b/c', false)
-    expect(paths).toEqual(['/a/b', '/a', ''])
+    expect(paths).toEqual(['/a/b', '/a'])
   })
 
   it('should make no difference between "a/b/c" and "/a/b/c" with includeCurrent=false', () => {
@@ -36,11 +36,11 @@ describe('build an array of parent paths from a provided path', () => {
 
   it('should not interpret a trailing slash as yet another path segment', () => {
     const paths = getParentPaths('/a/b/c/', true)
-    expect(paths).toEqual(['/a/b/c', '/a/b', '/a', ''])
+    expect(paths).toEqual(['/a/b/c', '/a/b', '/a'])
   })
 
   it('should include the provided path in the result if includeCurrent=true', () => {
     const paths = getParentPaths('a/b/c', true)
-    expect(paths).toEqual(['/a/b/c', '/a/b', '/a', ''])
+    expect(paths).toEqual(['/a/b/c', '/a/b', '/a'])
   })
 })

--- a/tests/e2e/support/objects/app-files/share/actions.ts
+++ b/tests/e2e/support/objects/app-files/share/actions.ts
@@ -87,7 +87,7 @@ export const inviteMembers = async (args: inviteMembersArgs): Promise<void> => {
     ])
     await shareInputLocator.focus()
     await page.waitForSelector('.vs--open')
-    await page.locator(invitationInput).press('Enter')
+    await page.locator('.vs__dropdown-option').click()
 
     await page.locator(filesCollaboratorRolesSelector).click()
     await page.locator(util.format(collaboratorRoleItemSelector, role)).click()

--- a/tests/e2e/support/objects/app-files/share/actions.ts
+++ b/tests/e2e/support/objects/app-files/share/actions.ts
@@ -81,6 +81,7 @@ export const inviteMembers = async (args: inviteMembersArgs): Promise<void> => {
   const { page, role, recipients } = args
   for (const recipient of recipients) {
     const shareInputLocator = page.locator(invitationInput)
+    await shareInputLocator.click()
     await Promise.all([
       page.waitForResponse((resp) => resp.url().includes('sharees') && resp.status() === 200),
       shareInputLocator.fill(recipient.id)


### PR DESCRIPTION
## Description
We've improved loading of the shares tree:

* It now happens more globally in the sidebar component instead of in each sidebar panel.
* Shares won't be loaded for resources without a path anymore.

These changes massively improve the sidebar performance and fix several issues with (re-)share permissions.

Note: Needs ocis with the latest Reva update to include the `shareId`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7506
- Fixes https://github.com/owncloud/web/issues/7593
- Fixes https://github.com/owncloud/web/issues/7592

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
