### PR TITLE
Fix links capabilities checks

### DIFF
--- a/changelog/unreleased/bugfix-typo-reading-capabilities-pl
+++ b/changelog/unreleased/bugfix-typo-reading-capabilities-pl
@@ -1,0 +1,3 @@
+Bugfix: Typo when reading public links capabilities
+
+https://github.com/owncloud/web/pull/7595

--- a/packages/web-pkg/src/composables/capability/useCapability.ts
+++ b/packages/web-pkg/src/composables/capability/useCapability.ts
@@ -53,10 +53,10 @@ export const useCapabilityFilesTusExtension = createCapabilityComposable<string>
   ''
 )
 export const useCapabilityFilesSharingPublicCanEdit = createCapabilityComposable(
-  'files.files_sharing.public.can_edit',
+  'files_sharing.public.can_edit',
   false
 )
 export const useCapabilityFilesSharingPublicAlias = createCapabilityComposable(
-  'files.files_sharing.public.alias',
+  'files_sharing.public.alias',
   false
 )


### PR DESCRIPTION
Typo in the capabilities path which prevents showing the extra roles for public links