### PR TITLE
[full-ci]  Performance improvements

### DIFF
--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -47,7 +47,7 @@ export const bootstrapApp = async (configurationPath: string): Promise<void> => 
   const store = await announceStore({ runtimeConfiguration })
   announcePermissionManager({ app, store })
 
-  await initializeApplications({
+  const applicationsPromise = await initializeApplications({
     runtimeConfiguration,
     configurationManager,
     store,
@@ -55,13 +55,14 @@ export const bootstrapApp = async (configurationPath: string): Promise<void> => 
     router,
     translations
   })
+  const themePromise = announceTheme({ store, app, designSystem, runtimeConfiguration })
+  await Promise.all([applicationsPromise, themePromise])
 
   announceTranslations({ app, availableLanguages: supportedLanguages, translations })
   announceClientService({ app, runtimeConfiguration })
   announceUppyService({ app })
   await announceClient(runtimeConfiguration)
   await announceAuthService({ app, configurationManager, store, router })
-  await announceTheme({ store, app, designSystem, runtimeConfiguration })
   announceDefaults({ store, router })
 
   app.use(router)


### PR DESCRIPTION
Attempt to improve the performance number 2. As opposed to the previous PR (done a couple of months ago), this one touches less things (doesn't improve as much, but also doesn't make assumptions about execution dependencies that might change in the future).

But again, the objective here is to parallelise calls to the server... Currently, web does a lot of sequential calls. When these take long to reply (the case in CERNBox, maybe not as visible in a clean and small ocis deployment), these add up.

I've made the OCS calls for the sharing indicators in parallel with the PROPFIND request. This might be good enough for us while we wait for the async/vue3 table updates (even in that case, I still believe it makes sense to do all of them in parallel...).
The change here is that I do not wait for the PROPFIND request to retrieve a resource path, since this might've been passed as parameter.
~~This change is only in the legacy loader.~~

It would be beneficial to do some research to see what other places would benefit for parallelisation. 