### PR TITLE
Reduce pagination options

### DIFF
--- a/changelog/unreleased/enhancement-reduce-pagination-options
+++ b/changelog/unreleased/enhancement-reduce-pagination-options
@@ -1,0 +1,7 @@
+Enhancement: Reduce pagination options
+
+We've reduced the pagination options by removing the options to display 1000 and all files. These may be added again later after further improving the files table performance.
+
+https://github.com/owncloud/web/issues/7038
+https://github.com/owncloud/web/pull/7597
+

--- a/packages/web-app-files/src/components/AppBar/ViewOptions.vue
+++ b/packages/web-app-files/src/components/AppBar/ViewOptions.vue
@@ -38,7 +38,7 @@
             v-model="itemsPerPage"
             data-testid="files-pagination-size"
             :label="$gettext('Items per page')"
-            :options="[100, 500, 1000, $gettext('All')]"
+            :options="[100, 500]"
             class="files-pagination-size"
           />
         </li>


### PR DESCRIPTION
## Description
We've reduced the pagination options by removing the options to display 1000 and all files. These may be added again later after further improving the files table performance.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/web/issues/7038

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
