### PR TITLE
Fix: merge share with group and group member into one share

### DIFF
--- a/changelog/unreleased/bugfix-merge-share-with-group-and-group-member
+++ b/changelog/unreleased/bugfix-merge-share-with-group-and-group-member
@@ -1,0 +1,6 @@
+Bugfix: Merge share with group and group member into one
+
+We've fixed a bug that the share with a group and share of the same resource with a member of this group was shown as 2 shares in "Shared with me" view.
+
+https://github.com/owncloud/web/issues/7582
+https://github.com/owncloud/web/pull/7598

--- a/packages/web-app-files/src/helpers/resources.ts
+++ b/packages/web-app-files/src/helpers/resources.ts
@@ -139,7 +139,7 @@ export function aggregateResourceShares(
   hasShareJail
 ): Resource[] {
   shares.sort((a, b) => a.path.localeCompare(b.path))
-  if (incomingShares) { 
+  if (incomingShares) {
     shares = addSharedWithToShares(shares)
     return orderBy(shares, ['file_target', 'permissions'], ['asc', 'desc']).map((share) =>
       buildSharedResource(share, incomingShares, allowSharePermission, hasShareJail)

--- a/packages/web-app-files/src/helpers/resources.ts
+++ b/packages/web-app-files/src/helpers/resources.ts
@@ -138,14 +138,14 @@ export function aggregateResourceShares(
   allowSharePermission,
   hasShareJail
 ): Resource[] {
-  if (incomingShares) {
+  shares.sort((a, b) => a.path.localeCompare(b.path))
+  if (incomingShares) { 
     shares = addSharedWithToShares(shares)
     return orderBy(shares, ['file_target', 'permissions'], ['asc', 'desc']).map((share) =>
       buildSharedResource(share, incomingShares, allowSharePermission, hasShareJail)
     )
   }
 
-  shares.sort((a, b) => a.path.localeCompare(b.path))
   const resources = addSharedWithToShares(shares)
   return resources.map((share) =>
     buildSharedResource(share, incomingShares, allowSharePermission, hasShareJail)


### PR DESCRIPTION
Sorts the list of incoming shares by path and allows merging of share with group and group member into one share through listing them next to each other

## Description
Does sorting by path for all shares. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7582

## Motivation and Context
If incoming shares are not sorted, shares with group and user - member of this group are not getting merged into one share.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [] Documentation ticket raised: <link> 


