### PR TITLE
fix: use short language codes

### DIFF
--- a/changelog/unreleased/bugfix-expiration-date-de_DE
+++ b/changelog/unreleased/bugfix-expiration-date-de_DE
@@ -1,0 +1,6 @@
+Bugfix: Expiration date picker with long language codes
+
+We've fixed a bug where the expiration date picker in the sharing sidebar wouldn't open if the user selected a language with long language code, e.g. de_DE.
+
+https://github.com/owncloud/web/issues/7622
+https://github.com/owncloud/web/pull/7623

--- a/packages/web-runtime/src/App.vue
+++ b/packages/web-runtime/src/App.vue
@@ -124,6 +124,9 @@ export default defineComponent({
             languageCode = language
           }
         }
+        if (languageCode?.indexOf('_')) {
+          languageCode = languageCode.split('_')[0]
+        }
         if (languageCode) {
           this.$language.current = languageCode
           document.documentElement.lang = languageCode


### PR DESCRIPTION
## Description
This PR fixes a bug where the expiration date picker in the sharing sidebar wouldn't open at all if the user selected a language with long language code (e.g. `de_DE`). Since this is only possible with oc10.11-rc.1 at the moment this issue didn't surface before testing oc web with that release candidate.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7622

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
