### PR TITLE
Include `x-oc-mtime` header in upload requests

### DIFF
--- a/changelog/unreleased/bugfix-upload-modify-time
+++ b/changelog/unreleased/bugfix-upload-modify-time
@@ -1,0 +1,6 @@
+Bugfix: Upload modify time
+
+We've included the `x-oc-mtime` header in upload requests to tell the backend the proper modify date of uploaded resources.
+
+https://github.com/owncloud/web/pull/7630
+https://github.com/owncloud/web/issues/7628

--- a/packages/web-runtime/src/services/uppyService.ts
+++ b/packages/web-runtime/src/services/uppyService.ts
@@ -21,6 +21,10 @@ type UppyServiceTopics =
   | 'drag-out'
   | 'drop'
 
+export type uppyHeaders = {
+  [name: string]: string | number
+}
+
 export class UppyService {
   uppy: Uppy
   uploadInputs: HTMLInputElement[] = []
@@ -36,17 +40,20 @@ export class UppyService {
     tusMaxChunkSize,
     tusHttpMethodOverride,
     tusExtension,
-    onBeforeRequest
+    onBeforeRequest,
+    headers
   }: {
     tusMaxChunkSize: number
     tusHttpMethodOverride: boolean
     tusExtension: string
     onBeforeRequest: () => void
+    headers: () => uppyHeaders
   }) {
     const chunkSize = tusMaxChunkSize || Infinity
     const uploadDataDuringCreation = tusExtension.includes('creation-with-upload')
 
     const tusPluginOptions = {
+      headers,
       chunkSize: chunkSize,
       removeFingerprintOnSuccess: true,
       overridePatchMethod: !!tusHttpMethodOverride,
@@ -72,9 +79,7 @@ export class UppyService {
   useXhr({
     headers
   }: {
-    headers: () => {
-      [name: string]: string | number
-    }
+    headers: () => uppyHeaders
   }) {
     const xhrPluginOptions: XHRUploadOptions = {
       endpoint: '',

--- a/packages/web-runtime/src/services/uppyService.ts
+++ b/packages/web-runtime/src/services/uppyService.ts
@@ -76,11 +76,7 @@ export class UppyService {
     this.uppy.use(CustomTus, tusPluginOptions as unknown as TusOptions)
   }
 
-  useXhr({
-    headers
-  }: {
-    headers: () => uppyHeaders
-  }) {
+  useXhr({ headers }: { headers: () => uppyHeaders }) {
     const xhrPluginOptions: XHRUploadOptions = {
       endpoint: '',
       method: 'put',


### PR DESCRIPTION
## Description
We've included the `x-oc-mtime` header in upload requests to tell the backend the proper modify date of uploaded resources.

Fyi: This is not yet being supported for tus by ocis (https://github.com/owncloud/ocis/issues/4559)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7628

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
