### PR TITLE
Fix sidebar toggle icon

### DIFF
--- a/changelog/unreleased/bugfix-sidebar-toggle-icon
+++ b/changelog/unreleased/bugfix-sidebar-toggle-icon
@@ -1,0 +1,5 @@
+Bugfix: Sidebar toggle icon
+
+We've fixed a bug where the sidebar toggle icon would not detect the "open"-state of the sidebar.
+
+https://github.com/owncloud/web/pull/7632

--- a/packages/web-app-files/src/components/AppBar/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar/AppBar.vue
@@ -28,7 +28,7 @@
         <shares-navigation v-if="hasSharesNavigation" />
         <div v-if="hasViewOptions || hasSidebarToggle" class="oc-flex">
           <view-options v-if="hasViewOptions" />
-          <sidebar-toggle v-if="hasSidebarToggle" />
+          <sidebar-toggle v-if="hasSidebarToggle" :side-bar-open="sideBarOpen" />
         </div>
       </div>
       <div class="files-app-bar-actions">


### PR DESCRIPTION
## Description
We've fixed a bug where the sidebar toggle icon would not detect the "open"-state of the sidebar.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
