### PR TITLE
Fix 'Private link'-button alignment

### DIFF
--- a/changelog/unreleased/bugfix-private-link-alignment
+++ b/changelog/unreleased/bugfix-private-link-alignment
@@ -1,0 +1,6 @@
+Bugfix: "Private link"-button alignment
+
+We've fixed the alignment of the "Private link"-button in the sidebar.
+
+https://github.com/owncloud/web/pull/7640
+https://github.com/owncloud/web/issues/7618

--- a/packages/web-app-files/src/components/SideBar/FileInfo.vue
+++ b/packages/web-app-files/src/components/SideBar/FileInfo.vue
@@ -1,23 +1,25 @@
 <template>
-  <div class="file_info">
-    <oc-resource-icon
-      v-if="isSubPanelActive"
-      :resource="file"
-      size="large"
-      class="file_info__icon"
-    />
-    <div class="file_info__body oc-text-overflow">
-      <h3 data-testid="files-info-name">
-        <oc-resource-name
-          :name="file.name"
-          :extension="file.extension"
-          :type="file.type"
-          :full-path="file.webDavPath"
-          :is-extension-displayed="areFileExtensionsShown"
-          :is-path-displayed="false"
-          :truncate-name="false"
-        />
-      </h3>
+  <div class="file_info oc-flex oc-flex-between">
+    <div class="oc-flex oc-flex-middle">
+      <oc-resource-icon
+        v-if="isSubPanelActive"
+        :resource="file"
+        size="large"
+        class="file_info__icon oc-mr-s"
+      />
+      <div class="file_info__body oc-text-overflow">
+        <h3 data-testid="files-info-name">
+          <oc-resource-name
+            :name="file.name"
+            :extension="file.extension"
+            :type="file.type"
+            :full-path="file.webDavPath"
+            :is-extension-displayed="areFileExtensionsShown"
+            :is-path-displayed="false"
+            :truncate-name="false"
+          />
+        </h3>
+      </div>
     </div>
     <private-link-item v-if="privateLinkEnabled" class="oc-ml-s" />
   </div>
@@ -100,11 +102,6 @@ export default {
 
 <style lang="scss">
 .file_info {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  align-items: center;
-  grid-gap: 5px;
-
   button {
     white-space: nowrap;
   }


### PR DESCRIPTION
## Description
We've fixed the alignment of the "Private link"-button in the sidebar.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7618

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
