### PR TITLE
Fix `mtime` header for tus requests

### DIFF
--- a/changelog/unreleased/bugfix-upload-modify-time
+++ b/changelog/unreleased/bugfix-upload-modify-time
@@ -3,4 +3,5 @@ Bugfix: Upload modify time
 We've included the `x-oc-mtime` header in upload requests to tell the backend the proper modify date of uploaded resources.
 
 https://github.com/owncloud/web/pull/7630
+https://github.com/owncloud/web/pull/7641
 https://github.com/owncloud/web/issues/7628

--- a/packages/web-runtime/src/composables/upload/useUpload.ts
+++ b/packages/web-runtime/src/composables/upload/useUpload.ts
@@ -10,7 +10,7 @@ import {
   useStore
 } from 'web-pkg/src/composables'
 import { computed, Ref, unref, watch } from '@vue/composition-api'
-import { UppyService, uppyHeaders } from '../../services/uppyService'
+import { UppyService } from '../../services/uppyService'
 import * as uuid from 'uuid'
 
 export interface UppyResource {
@@ -79,18 +79,10 @@ export function useUpload(options: UploadOptions): UploadResult {
       onBeforeRequest: (req) => {
         req.setHeader('Authorization', unref(headers).Authorization)
       },
-      headers: (file) => {
-        const reqHeaders = {
-          'x-oc-mtime': file.data.lastModified / 1000,
-          ...unref(headers)
-        } as uppyHeaders
-
-        if (unref(isTusSupported)) {
-          // Tus includes auth headers before each request
-          delete reqHeaders.Authorization
-        }
-        return reqHeaders
-      },
+      headers: (file) => ({
+        'x-oc-mtime': file.data.lastModified / 1000,
+        ...unref(headers)
+      }),
       ...(isTusSupported && {
         tusMaxChunkSize: unref(tusMaxChunkSize),
         tusHttpMethodOverride: unref(tusHttpMethodOverride),

--- a/packages/web-runtime/src/services/uppyService.ts
+++ b/packages/web-runtime/src/services/uppyService.ts
@@ -40,20 +40,17 @@ export class UppyService {
     tusMaxChunkSize,
     tusHttpMethodOverride,
     tusExtension,
-    onBeforeRequest,
-    headers
+    onBeforeRequest
   }: {
     tusMaxChunkSize: number
     tusHttpMethodOverride: boolean
     tusExtension: string
     onBeforeRequest: () => void
-    headers: () => uppyHeaders
   }) {
     const chunkSize = tusMaxChunkSize || Infinity
     const uploadDataDuringCreation = tusExtension.includes('creation-with-upload')
 
     const tusPluginOptions = {
-      headers,
       chunkSize: chunkSize,
       removeFingerprintOnSuccess: true,
       overridePatchMethod: !!tusHttpMethodOverride,
@@ -180,6 +177,11 @@ export class UppyService {
     })
     this.uppy.on('file-added', (file) => {
       const addedFile = file as unknown as UppyResource
+      if (this.uppy.getPlugin('Tus')) {
+        this.uppy.setFileMeta(addedFile.id, {
+          mtime: (addedFile.data as any).lastModified / 1000
+        })
+      }
       if (this.uppy.getPlugin('XHRUpload')) {
         const escapedName = encodeURIComponent(addedFile.name)
         this.uppy.setFileState(addedFile.id, {


### PR DESCRIPTION
## Description
Turns out, headers such as `mtime` have to be passed via `upload-metadata` to tus. See https://github.com/owncloud/ocis/issues/4559#issuecomment-1246512408.

I removed the `header` object from the tus plugin again, as it has no use.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
