### PR TITLE
[full-ci] Fix spaces on the 'Shared via link'-page

### DIFF
--- a/changelog/unreleased/bugfix-spaces-on-share-via-link-page
+++ b/changelog/unreleased/bugfix-spaces-on-share-via-link-page
@@ -1,0 +1,6 @@
+Bugfix: Spaces on "Shared via link"-page
+
+Spaces on the "Shared via link"-page are now being displayed correctly. Also, the sidebar for those has been fixed.
+
+https://github.com/owncloud/web/pull/7651
+https://github.com/owncloud/web/issues/7103

--- a/packages/web-app-files/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceTable.vue
@@ -54,7 +54,7 @@
         <oc-resource
           :key="`${item.path}-${resourceDomSelector(item)}-${item.thumbnail}`"
           :resource="item"
-          :is-path-displayed="arePathsDisplayed"
+          :is-path-displayed="getArePathsDisplayed(item)"
           :parent-folder-name-default="getDefaultParentFolderName(item)"
           :is-thumbnail-displayed="areThumbnailsDisplayed"
           :is-extension-displayed="areFileExtensionsShown"
@@ -583,11 +583,15 @@ export default defineComponent({
       this.$_rename_trigger({ resources: [item] })
     },
     openSharingSidebar(file) {
-      if (file.share?.shareType === ShareTypes.link.value) {
-        bus.publish(SideBarEventTopics.openWithPanel, 'sharing-item#linkShares')
-        return
+      let panelToOpen
+      if (file.type === 'space') {
+        panelToOpen = 'space-share-item'
+      } else if (file.share?.shareType === ShareTypes.link.value) {
+        panelToOpen = 'sharing-item#linkShares'
+      } else {
+        panelToOpen = 'sharing-item#peopleShares'
       }
-      bus.publish(SideBarEventTopics.openWithPanel, 'sharing-item#peopleShares')
+      bus.publish(SideBarEventTopics.openWithPanel, panelToOpen)
     },
     folderLink(file) {
       return this.createFolderLink(file.path, file)
@@ -822,6 +826,9 @@ export default defineComponent({
       }
 
       return this.$gettext('Personal')
+    },
+    getArePathsDisplayed(resource) {
+      return this.arePathsDisplayed && resource.type !== 'space'
     }
   }
 })

--- a/packages/web-app-files/src/fileSideBars.ts
+++ b/packages/web-app-files/src/fileSideBars.ts
@@ -6,7 +6,7 @@ import SharesPanel from './components/SideBar/Shares/SharesPanel.vue'
 import NoSelection from './components/SideBar/NoSelection.vue'
 import SpaceActions from './components/SideBar/Actions/SpaceActions.vue'
 import SpaceDetails from './components/SideBar/Details/SpaceDetails.vue'
-import { isLocationSpacesActive, isLocationTrashActive, isLocationPublicActive } from './router'
+import { isLocationTrashActive, isLocationPublicActive } from './router'
 import { spaceRoleEditor, spaceRoleManager } from 'web-client/src/helpers/share'
 
 import { Panel } from '../../web-pkg/src/components/sideBar'
@@ -72,12 +72,12 @@ const panelGenerators: (({
       return multipleSelection && !rootFolder
     }
   }),
-  ({ router, highlightedFile }) => ({
+  ({ highlightedFile }) => ({
     app: 'details-space-item',
     icon: 'questionnaire-line',
     title: $gettext('Details'),
     component: SpaceDetails,
-    default: isLocationSpacesActive(router, 'files-spaces-projects'),
+    default: highlightedFile?.type === 'space',
     get enabled() {
       return highlightedFile?.type === 'space'
     }

--- a/packages/web-app-files/src/helpers/resources.ts
+++ b/packages/web-app-files/src/helpers/resources.ts
@@ -146,7 +146,9 @@ export function aggregateResourceShares(
   spaces = []
 ): Resource[] {
   shares.sort((a, b) => a.path.localeCompare(b.path))
-  shares = addMatchingSpaceToShares(shares, spaces)
+  if (spaces.length) {
+    shares = addMatchingSpaceToShares(shares, spaces)
+  }
   if (incomingShares) {
     shares = addSharedWithToShares(shares)
     return orderBy(shares, ['file_target', 'permissions'], ['asc', 'desc']).map((share) =>

--- a/packages/web-app-files/src/helpers/resources.ts
+++ b/packages/web-app-files/src/helpers/resources.ts
@@ -136,14 +136,17 @@ export function attachIndicators(resource, sharesTree) {
  * @param {Boolean} incomingShares Asserts whether the shares are incoming
  * @param {Boolean} allowSharePermission Asserts whether the reshare permission is available
  * @param {Boolean} hasShareJail Asserts whether the share jail is available backend side
+ * @param {Array} spaces A list of spaces the current user has access to
  */
 export function aggregateResourceShares(
   shares,
   incomingShares = false,
   allowSharePermission,
-  hasShareJail
+  hasShareJail,
+  spaces = []
 ): Resource[] {
   shares.sort((a, b) => a.path.localeCompare(b.path))
+  shares = addMatchingSpaceToShares(shares, spaces)
   if (incomingShares) {
     shares = addSharedWithToShares(shares)
     return orderBy(shares, ['file_target', 'permissions'], ['asc', 'desc']).map((share) =>
@@ -210,6 +213,16 @@ function addSharedWithToShares(shares) {
   return resources
 }
 
+function addMatchingSpaceToShares(shares, spaces) {
+  const resources = []
+  for (const share of shares) {
+    const storageId = extractStorageId(share.item_source)
+    const matchingSpace = spaces.find((s) => s.id === storageId)
+    resources.push({ ...share, matchingSpace })
+  }
+  return resources
+}
+
 export function buildSharedResource(
   share,
   incomingShares = false,
@@ -217,7 +230,7 @@ export function buildSharedResource(
   hasShareJail = false
 ): Resource {
   const isFolder = share.item_type === 'folder'
-  const resource: Resource = {
+  let resource: Resource = {
     id: share.id,
     fileId: share.item_source,
     storageId: extractStorageId(share.item_source),
@@ -281,6 +294,10 @@ export function buildSharedResource(
   resource.share = buildShare(share, resource, allowSharePermission)
   resource.canDeny = () => SharePermissions.denied.enabled(share.permissions)
   resource.getDomSelector = () => extractDomSelector(share.id)
+
+  if (share.matchingSpace) {
+    resource = { ...resource, ...share.matchingSpace }
+  }
 
   return resource
 }

--- a/packages/web-app-files/src/helpers/resources.ts
+++ b/packages/web-app-files/src/helpers/resources.ts
@@ -216,8 +216,11 @@ function addSharedWithToShares(shares) {
 function addMatchingSpaceToShares(shares, spaces) {
   const resources = []
   for (const share of shares) {
-    const storageId = extractStorageId(share.item_source)
-    const matchingSpace = spaces.find((s) => s.id === storageId)
+    let matchingSpace
+    if (share.path === '/') {
+      const storageId = extractStorageId(share.item_source)
+      matchingSpace = spaces.find((s) => s.id === storageId && s.driveType === 'project')
+    }
     resources.push({ ...share, matchingSpace })
   }
   return resources

--- a/packages/web-app-files/src/mixins/actions/navigate.ts
+++ b/packages/web-app-files/src/mixins/actions/navigate.ts
@@ -37,7 +37,7 @@ export default {
               return false
             }
 
-            if (!resources[0].isFolder) {
+            if (!resources[0].isFolder || resources[0].type === 'space') {
               return false
             }
 

--- a/packages/web-app-files/src/services/folder/loaderSharedViaLink.ts
+++ b/packages/web-app-files/src/services/folder/loaderSharedViaLink.ts
@@ -45,10 +45,12 @@ export class FolderLoaderSharedViaLink implements FolderLoader {
       })
 
       resources = resources.map((r) => r.shareInfo)
-
-      // FIXME: Wait until spaces are loaded? We already load them in the runtime
-      yield store.dispatch('runtime/spaces/loadSpaces', { graphClient })
-      const spaces = store.getters['runtime/spaces/spaces']
+      let spaces = []
+      if (store.getters.capabilities?.spaces?.enabled) {
+        // FIXME: Wait until spaces are loaded? We already load them in the runtime
+        yield store.dispatch('runtime/spaces/loadSpaces', { graphClient })
+        spaces = store.getters['runtime/spaces/spaces']
+      }
 
       if (resources.length) {
         resources = aggregateResourceShares(

--- a/packages/web-app-files/src/services/folder/loaderSharedViaLink.ts
+++ b/packages/web-app-files/src/services/folder/loaderSharedViaLink.ts
@@ -35,9 +35,6 @@ export class FolderLoaderSharedViaLink implements FolderLoader {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     return useTask(function* (signal1, signal2) {
       store.commit('Files/CLEAR_CURRENT_FILES_LIST')
-      const accessToken = store.getters['runtime/auth/accessToken']
-      const serverUrl = configurationManager.serverUrl
-      const graphClient = clientService.graphAuthenticated(serverUrl, accessToken)
 
       let resources = yield client.shares.getShares('', {
         share_types: ShareTypes.link.value.toString(),
@@ -47,6 +44,9 @@ export class FolderLoaderSharedViaLink implements FolderLoader {
       resources = resources.map((r) => r.shareInfo)
       let spaces = []
       if (store.getters.capabilities?.spaces?.enabled) {
+        const accessToken = store.getters['runtime/auth/accessToken']
+        const serverUrl = configurationManager.serverUrl
+        const graphClient = clientService.graphAuthenticated(serverUrl, accessToken)
         // FIXME: Wait until spaces are loaded? We already load them in the runtime
         yield store.dispatch('runtime/spaces/loadSpaces', { graphClient })
         spaces = store.getters['runtime/spaces/spaces']

--- a/packages/web-client/src/helpers/resource/types.ts
+++ b/packages/web-client/src/helpers/resource/types.ts
@@ -12,6 +12,10 @@ export interface Resource {
   type?: string
   status?: number
   spaceRoles?: any[]
+  spaceQuota?: any[]
+  spaceMemberIds?: any[]
+  spaceImageData?: any[]
+  spaceReadmeData?: any[]
   mimeType?: string
   isFolder?: boolean
   sdate?: string
@@ -35,11 +39,18 @@ export interface Resource {
   canBeDeleted?(): boolean
   canBeRestored?(): boolean
   canDeny?(): boolean
+  canEditDescription?(): boolean
+  canRestore?(): boolean
+  canDisable?(): boolean
+  canEditImage?(): boolean
+  canEditReadme?(): boolean
 
   isReceivedShare?(): boolean
   isMounted?(): boolean
 
   getDomSelector?(): string
+
+  matchingSpace?: any
 
   resourceOwner?: User
   owner?: User[]


### PR DESCRIPTION
## Description
Spaces on the "Shared via link"-page are now being displayed correctly. Also, the sidebar for those has been fixed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7103

## Screenshots:
![image](https://user-images.githubusercontent.com/50302941/190664928-a2544b04-9c77-4b87-b901-d73e06b6aa9b.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
