### PR TITLE
feat: add composable for translations

### DIFF
--- a/packages/web-pkg/src/composables/translations/index.ts
+++ b/packages/web-pkg/src/composables/translations/index.ts
@@ -1,0 +1,1 @@
+export * from './useTranslations'

--- a/packages/web-pkg/src/composables/translations/useTranslations.ts
+++ b/packages/web-pkg/src/composables/translations/useTranslations.ts
@@ -1,0 +1,11 @@
+import { getCurrentInstance } from '@vue/composition-api'
+
+export const useTranslations = () => {
+  const p = getCurrentInstance().proxy as any
+  return {
+    $gettext: p.$gettext,
+    $pgettext: p.$pgettext,
+    $ngettext: p.$ngettext,
+    $gettextInterpolate: p.$gettextInterpolate
+  }
+}


### PR DESCRIPTION
## Description
With this composable you can inject our `$gettext` helper functions into code that's not Vue options API (e.g. setup functions, classes, ...).
Usage: `const { $gettext, $gettextInterpolate } = useTranslations()`. cc @lookacat since you needed this in another PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
