### PR TITLE
Disable shares tree cache for flat file lists

### DIFF
--- a/changelog/unreleased/bugfix-shares-loading
+++ b/changelog/unreleased/bugfix-shares-loading
@@ -16,3 +16,4 @@ https://github.com/owncloud/web/issues/7593
 https://github.com/owncloud/web/issues/7592
 https://github.com/owncloud/web/pull/7580
 https://github.com/owncloud/web/pull/7638
+https://github.com/owncloud/web/pull/7656

--- a/packages/web-app-files/src/components/SideBar/SideBar.vue
+++ b/packages/web-app-files/src/components/SideBar/SideBar.vue
@@ -298,7 +298,11 @@ export default defineComponent({
         storageId: this.highlightedFile.fileId,
         includeRoot: true,
         // cache must not be used on flat file lists that gather resources form various locations
-        useCached: !(this.isSharedWithOthersLocation || this.isSharedViaLinkLocation)
+        useCached: !(
+          this.isSharedWithOthersLocation ||
+          this.isSharedViaLinkLocation ||
+          this.isFavoritesLocation
+        )
       })
     }
   }

--- a/packages/web-app-files/src/components/SideBar/SideBar.vue
+++ b/packages/web-app-files/src/components/SideBar/SideBar.vue
@@ -299,6 +299,7 @@ export default defineComponent({
         includeRoot: true,
         // cache must not be used on flat file lists that gather resources form various locations
         useCached: !(
+          this.isSharedWithMeLocation ||
           this.isSharedWithOthersLocation ||
           this.isSharedViaLinkLocation ||
           this.isFavoritesLocation

--- a/packages/web-app-files/src/components/SideBar/SideBar.vue
+++ b/packages/web-app-files/src/components/SideBar/SideBar.vue
@@ -296,7 +296,9 @@ export default defineComponent({
         client: this.$client,
         path: this.highlightedFile.path,
         storageId: this.highlightedFile.fileId,
-        includeRoot: true
+        includeRoot: true,
+        // cache must not be used on flat file lists that gather resources form various locations
+        useCached: !(this.isSharedWithOthersLocation || this.isSharedViaLinkLocation)
       })
     }
   }

--- a/packages/web-app-files/src/components/SideBar/SideBar.vue
+++ b/packages/web-app-files/src/components/SideBar/SideBar.vue
@@ -113,6 +113,7 @@ export default defineComponent({
       ),
       isSharedViaLinkLocation: useActiveLocation(isLocationSharesActive, 'files-shares-via-link'),
       isFavoritesLocation: useActiveLocation(isLocationCommonActive, 'files-common-favorites'),
+      isSearchLocation: useActiveLocation(isLocationCommonActive, 'files-common-search'),
       hasShareJail: useCapabilityShareJailEnabled(),
       publicLinkPassword: usePublicLinkPassword({ store }),
       setActiveSideBarPanel,
@@ -225,6 +226,7 @@ export default defineComponent({
         this.isSharedWithMeLocation ||
         this.isSharedWithOthersLocation ||
         this.isSharedViaLinkLocation ||
+        this.isSearchLocation ||
         this.isFavoritesLocation
       this.fetchFileInfo(loadShares)
     },
@@ -302,6 +304,7 @@ export default defineComponent({
           this.isSharedWithMeLocation ||
           this.isSharedWithOthersLocation ||
           this.isSharedViaLinkLocation ||
+          this.isSearchLocation ||
           this.isFavoritesLocation
         )
       })

--- a/packages/web-app-files/src/composables/parentShare/useIncomingParentShare.ts
+++ b/packages/web-app-files/src/composables/parentShare/useIncomingParentShare.ts
@@ -12,7 +12,7 @@ export function useIncomingParentShare() {
   const loadIncomingParentShare = useTask(function* (signal, resource) {
     let parentShare
     for (const shares of Object.values(unref(sharesTree)) as any) {
-      parentShare = shares.find((s) => s.incoming)
+      parentShare = shares.find((s) => !s.outgoing)
       if (parentShare) {
         incomingParentShare.value = parentShare
         return

--- a/packages/web-app-files/src/store/actions.ts
+++ b/packages/web-app-files/src/store/actions.ts
@@ -426,7 +426,6 @@ export default {
       const spaceRef = indirect ? null : storageId
       // no need to fetch cached paths again, only adjust the "indirect" state
       if (context.getters.sharesTree[queryPath] && useCached) {
-        console.log('USE CACHGED FOR:', queryPath)
         sharesTree[queryPath] = context.getters.sharesTree[queryPath].map((s) => {
           if (!indirect) {
             const arr = s.outgoing ? outgoingShares : incomingShares

--- a/packages/web-app-files/src/store/actions.ts
+++ b/packages/web-app-files/src/store/actions.ts
@@ -365,7 +365,7 @@ export default {
    * This will add new entries into the shares tree and will
    * not remove unrelated existing ones.
    */
-  loadSharesTree(context, { client, path, storageId, includeRoot = false }) {
+  loadSharesTree(context, { client, path, storageId, includeRoot = false, useCached = true }) {
     context.commit('SHARESTREE_ERROR', null)
     // prune shares tree cache for all unrelated paths, keeping only
     // existing relevant parent entries
@@ -425,7 +425,8 @@ export default {
       // FIXME: We need the storageId of each parent resource here
       const spaceRef = indirect ? null : storageId
       // no need to fetch cached paths again, only adjust the "indirect" state
-      if (context.getters.sharesTree[queryPath]) {
+      if (context.getters.sharesTree[queryPath] && useCached) {
+        console.log('USE CACHGED FOR:', queryPath)
         sharesTree[queryPath] = context.getters.sharesTree[queryPath].map((s) => {
           if (!indirect) {
             const arr = s.outgoing ? outgoingShares : incomingShares


### PR DESCRIPTION
## Description
Shares tree caching is a problem in flat file lists that gather resources from various places (like "Shared with others", "Shared via link", ...). This is an issue because the caching currently happens purely based on the filename. However, these lists can contain multiple resources with the same name.

In the future, we should think about something else that also includes the storage ID. This is necessary anyway because of https://github.com/owncloud/web/issues/7655.

However, we don't have any performance impact by disabling the cache here as we can't navigate into folders anyway.

## Motivation and Context
Followup for https://github.com/owncloud/web/pull/7638

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
