### PR TITLE
Fix sidebar for received shares in search file list

### DIFF
--- a/changelog/unreleased/bugfix-search-sidebar-shares
+++ b/changelog/unreleased/bugfix-search-sidebar-shares
@@ -1,0 +1,6 @@
+Bugfix: Sidebar for received shares in search file list
+
+We've fixed a bug where the sidebar for received shares in the search file list was broken.
+
+https://github.com/owncloud/web/pull/7662
+https://github.com/owncloud/web/issues/7661

--- a/packages/web-app-files/src/components/SideBar/SideBar.vue
+++ b/packages/web-app-files/src/components/SideBar/SideBar.vue
@@ -106,6 +106,7 @@ export default defineComponent({
 
     return {
       isSpacesProjectsLocation: useActiveLocation(isLocationSpacesActive, 'files-spaces-projects'),
+      isSpacesShareLocation: useActiveLocation(isLocationSpacesActive, 'files-spaces-share'),
       isSharedWithMeLocation: useActiveLocation(isLocationSharesActive, 'files-shares-with-me'),
       isSharedWithOthersLocation: useActiveLocation(
         isLocationSharesActive,
@@ -114,6 +115,7 @@ export default defineComponent({
       isSharedViaLinkLocation: useActiveLocation(isLocationSharesActive, 'files-shares-via-link'),
       isFavoritesLocation: useActiveLocation(isLocationCommonActive, 'files-common-favorites'),
       isSearchLocation: useActiveLocation(isLocationCommonActive, 'files-common-search'),
+      isPublicFilesLocation: useActiveLocation(isLocationPublicActive, 'files-public-files'),
       hasShareJail: useCapabilityShareJailEnabled(),
       publicLinkPassword: usePublicLinkPassword({ store }),
       setActiveSideBarPanel,
@@ -185,15 +187,15 @@ export default defineComponent({
     },
     isRootFolder() {
       const pathSegments = this.highlightedFile?.path?.split('/').filter(Boolean) || []
-      if (isLocationPublicActive(this.$router, 'files-public-files')) {
+      if (this.isPublicFilesLocation) {
         // root node of a public link has the public link token as path
         // root path `/` like for personal home doesn't exist for public links
         return pathSegments.length === 1
       }
-      if (isLocationSharesActive(this.$router, 'files-shares-with-me')) {
+      if (this.isSharedWithMeLocation || this.isSearchLocation) {
         return !this.highlightedFile
       }
-      if (this.hasShareJail && isLocationSpacesActive(this.$router, 'files-spaces-share')) {
+      if (this.hasShareJail && this.isSpacesShareLocation) {
         return false
       }
       return !pathSegments.length


### PR DESCRIPTION
## Description
We've fixed a bug where the sidebar for received shares in the search file list was broken.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7661

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
