### PR TITLE
Fetch resources before uploading or creating resources

### DIFF
--- a/changelog/unreleased/bugfix-fetch-resources-before-upload
+++ b/changelog/unreleased/bugfix-fetch-resources-before-upload
@@ -1,0 +1,6 @@
+Bugfix: Fetch resources before uploading/creating resources
+
+We now fetch resources before uploading or creating resources to ensure the conflict modal shows if a resource already exists on the server side.
+
+https://github.com/owncloud/web/pull/7664
+https://github.com/owncloud/web/issues/3262

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -832,9 +832,9 @@ export default defineComponent({
 
     async displayOverwriteDialog(
       files: UppyResource[],
-      conflicts,
+      conflicts: { name: string; type: string }[],
       resolveFileExistsMethod: FileExistsResolver,
-      existingNames
+      existingNames: string[]
     ) {
       let count = 0
       const allConflictsCount = conflicts.length

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -698,7 +698,7 @@ export default defineComponent({
         return this.$gettext('File name cannot end with whitespace')
       }
 
-      const exists = existingResources.exists(fileName)
+      const exists = existingResources.includes(fileName)
 
       if (exists) {
         const translated = this.$gettext('%{name} already exists')

--- a/packages/web-app-files/src/helpers/resource/copyMove.ts
+++ b/packages/web-app-files/src/helpers/resource/copyMove.ts
@@ -271,7 +271,7 @@ export const copy = (
   )
 }
 
-export const resolveFileNameDuplicate = (name, extension, existingFiles, iteration = 1) => {
+export const resolveFileNameDuplicate = (name, extension, existingNames, iteration = 1) => {
   let potentialName
   if (extension.length === 0) {
     potentialName = `${name} (${iteration})`
@@ -279,9 +279,9 @@ export const resolveFileNameDuplicate = (name, extension, existingFiles, iterati
     const nameWithoutExtension = extractNameWithoutExtension({ name, extension } as Resource)
     potentialName = `${nameWithoutExtension} (${iteration}).${extension}`
   }
-  const hasConflict = existingFiles.some((f) => f.name === potentialName)
+  const hasConflict = existingNames.includes(potentialName)
   if (!hasConflict) return potentialName
-  return resolveFileNameDuplicate(name, extension, existingFiles, iteration + 1)
+  return resolveFileNameDuplicate(name, extension, existingNames, iteration + 1)
 }
 
 const clientListFilesInFolder = (
@@ -394,8 +394,8 @@ const copyMoveResource = async (
       }
       if (resolveStrategy === ResolveStrategy.KEEP_BOTH) {
         targetName = resolveFileNameDuplicate(resource.name, resource.extension, [
-          ...movedResources,
-          ...targetFolderResources
+          ...movedResources.map((r) => r.name),
+          ...targetFolderResources.map((r) => r.name)
         ])
         resource.name = targetName
       }

--- a/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.js
+++ b/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.js
@@ -234,7 +234,8 @@ describe('CreateAndUpload component', () => {
         await wrapper.vm.displayOverwriteDialog(
           [uppyResourceOne],
           [conflict],
-          resolveFileConflictMethod
+          resolveFileConflictMethod,
+          []
         )
 
         expect(resolveFileConflictMethod).toHaveBeenCalledTimes(1)

--- a/packages/web-app-files/tests/unit/helpers/resource/copyMove.spec.ts
+++ b/packages/web-app-files/tests/unit/helpers/resource/copyMove.spec.ts
@@ -31,7 +31,11 @@ describe('copyMove', () => {
     { name: 'b.png', extension: 'png', expectName: 'b (2).png', existing: [{ name: 'b (1).png' }] }
   ])('should name duplicate file correctly', (dataSet) => {
     const existing = dataSet.existing ? [...resourcesToMove, ...dataSet.existing] : resourcesToMove
-    const result = Resource.resolveFileNameDuplicate(dataSet.name, dataSet.extension, existing)
+    const result = Resource.resolveFileNameDuplicate(
+      dataSet.name,
+      dataSet.extension,
+      existing.map((r) => r.name)
+    )
     expect(result).toEqual(dataSet.expectName)
   })
   it.each([


### PR DESCRIPTION
## Description
Fetch resources before uploading or creating resources to ensure the conflict modal shows if a resource already exists on the server side.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/3262

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
