### PR TITLE
Fix `sharesTree` loading state on error

### DIFF
--- a/changelog/unreleased/bugfix-shares-loading
+++ b/changelog/unreleased/bugfix-shares-loading
@@ -17,3 +17,4 @@ https://github.com/owncloud/web/issues/7592
 https://github.com/owncloud/web/pull/7580
 https://github.com/owncloud/web/pull/7638
 https://github.com/owncloud/web/pull/7656
+https://github.com/owncloud/web/pull/7668

--- a/packages/web-app-files/src/store/actions.ts
+++ b/packages/web-app-files/src/store/actions.ts
@@ -409,7 +409,6 @@ export default {
         .catch((error) => {
           console.error('SHARESTREE_ERROR', error)
           context.commit('SHARESTREE_ERROR', error.message)
-          context.commit('SHARESTREE_LOADING', false)
         })
     }
 


### PR DESCRIPTION
## Description
This fixes a bug where the loading state of the `sharesTree` was set to `false` once an error occurred. That's not correct as it can happen anytime during the (ongoing) loading process. We already set the loading state to `false` once the tree has been loaded eventually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
