### PR TITLE
Add missing git library for oC10 docker compose setup

### DIFF
--- a/dev/docker/oc10.Dockerfile
+++ b/dev/docker/oc10.Dockerfile
@@ -5,5 +5,6 @@ RUN apt -qqy update \
   && apt -qqy --no-install-recommends install \
     bash \
     make \
+    git \
   && rm -rf /var/lib/apt/lists/* \
   && apt -qyy clean


### PR DESCRIPTION
## Description
With the current latest `owncloud/server` image (used in docker compose file), git library is not available. So, running oC10 using docker compose was failing.
This PR adds the missing git library needed for pre-setups.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/7672

## Motivation and Context
Able to run oC10 setup using docker compose

## How Has This Been Tested?
- test environment: locally

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
