### PR TITLE
add on demand virus scanning

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=e72e9aee1d918e86a7393c9727432cd372a4dc7f
+OCIS_COMMITID=8b63d2d00a5a6e81b9ba67bf438a1743a1792c4b
 OCIS_BRANCH=experimental

--- a/packages/web-app-files/src/components/FilesList/ContextActions.vue
+++ b/packages/web-app-files/src/components/FilesList/ContextActions.vue
@@ -163,7 +163,7 @@ export default {
         ...this.$_setSpaceImage_items,
         ...this.$_setSpaceReadme_items,
         ...this.$_navigate_space_items,
-        ...this.$_virus_scan
+        ...this.$_virus_scan_items
       ].filter((item) => item.isEnabled(this.filterParams))
     },
 

--- a/packages/web-app-files/src/components/FilesList/ContextActions.vue
+++ b/packages/web-app-files/src/components/FilesList/ContextActions.vue
@@ -27,6 +27,7 @@ import ShowShares from '../../mixins/actions/showShares'
 import SetSpaceImage from '../../mixins/spaces/actions/setImage'
 import SetSpaceReadme from '../../mixins/spaces/actions/setReadme'
 import SpaceNavigate from '../../mixins/spaces/actions/navigate'
+import VirusScan from '../../mixins/actions/virusScan'
 import { PropType } from '@vue/composition-api'
 import { Resource } from 'web-client'
 
@@ -55,7 +56,8 @@ export default {
     ShowShares,
     SetSpaceImage,
     SetSpaceReadme,
-    SpaceNavigate
+    SpaceNavigate,
+    VirusScan
   ],
 
   props: {
@@ -160,7 +162,8 @@ export default {
         ...this.$_declineShare_items,
         ...this.$_setSpaceImage_items,
         ...this.$_setSpaceReadme_items,
-        ...this.$_navigate_space_items
+        ...this.$_navigate_space_items,
+        ...this.$_virus_scan
       ].filter((item) => item.isEnabled(this.filterParams))
     },
 

--- a/packages/web-app-files/src/mixins/actions/virusScan.ts
+++ b/packages/web-app-files/src/mixins/actions/virusScan.ts
@@ -1,0 +1,51 @@
+import { clientService } from 'web-pkg/src/services'
+import { isLocationSpacesActive } from '../../router'
+
+export default {
+  computed: {
+    $_virus_scan() {
+      return [
+        {
+          name: 'virus-scan',
+          icon: 'virus',
+          label: () => this.$gettext('Scan for viruses'),
+          handler: this.$_virus_scan_trigger,
+          isEnabled: ({ resources }) => {
+            if (resources.length === 0) {
+              return false
+            }
+
+            if (resources[0].isFolder) {
+              return false
+            }
+
+            if (
+              !isLocationSpacesActive(this.$router, 'files-spaces-personal') &&
+              !isLocationSpacesActive(this.$router, 'files-spaces-project')
+            ) {
+              return false
+            }
+
+            if (
+              isLocationSpacesActive(this.$router, 'files-spaces-share') &&
+              resources[0].path === '/'
+            ) {
+              return false
+            }
+
+            return true
+          },
+          componentType: 'button',
+          class: 'oc-files-actions-virus-scan-trigger'
+        }
+      ]
+    }
+  },
+  methods: {
+    async $_virus_scan_trigger({ resources }) {
+      const accessToken = this.$store.getters['runtime/auth/accessToken']
+      const httpClient = clientService.httpAuthenticated(accessToken)
+      await httpClient.get(`/remote.php/dav/postprocessing/virusscan/${resources[0].fileId}`)
+    }
+  }
+}

--- a/packages/web-app-files/src/mixins/actions/virusScan.ts
+++ b/packages/web-app-files/src/mixins/actions/virusScan.ts
@@ -3,7 +3,7 @@ import { isLocationSpacesActive } from '../../router'
 
 export default {
   computed: {
-    $_virus_scan() {
+    $_virus_scan_items() {
       return [
         {
           name: 'virus-scan',
@@ -45,7 +45,10 @@ export default {
     async $_virus_scan_trigger({ resources }) {
       const accessToken = this.$store.getters['runtime/auth/accessToken']
       const httpClient = clientService.httpAuthenticated(accessToken)
-      await httpClient.get(`/remote.php/dav/postprocessing/virusscan/${resources[0].fileId}`)
+      const { server } = this.$store.getters.configuration
+      await httpClient.get(
+        `${server}remote.php/dav/postprocessing/virusscan/${resources[0].fileId}`
+      )
     }
   }
 }


### PR DESCRIPTION
## Description
experimental feature, since we have virus scanning on ocis experimental we've now also have the ability to scan files "on demand". This PR adds the corresponding context action to do so.

## Related Issue
- experimental

## Motivation and Context
users should get the ability to check if files are infected. In theory this shouldnt be needed that often becaused the upload scan removes infected files immediately... but in cases where the virus is not known at the moment of uploading "on demand"  scanning helps. This can happen if the virus database is updated!

## How Has This Been Tested?
- local testing

## Screenshots (if appropriate):
<img width="829" alt="Bildschirmfoto 2022-09-23 um 11 18 00" src="https://user-images.githubusercontent.com/49308105/191929842-7ea403d2-da49-4b83-86a0-a6c71c672774.png">

## Types of changes
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
