### PR TITLE
add option to inject css and js files

### DIFF
--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -231,11 +231,11 @@ export const announceTheme = async ({
  *
  * @param runtimeConfiguration
  */
-export const announceCustomizations = async ({
+export const announceCustomizations = ({
   runtimeConfiguration
 }: {
   runtimeConfiguration?: RuntimeConfiguration
-}): Promise<void> => {
+}): void => {
   const { scripts = [], styles = [] } = runtimeConfiguration
 
   scripts.forEach(({ src = '', async = false }) => {

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -227,6 +227,34 @@ export const announceTheme = async ({
 }
 
 /**
+ * announce customizations is used to hook into the spa app and inject custom css and js resources.
+ *
+ * @param runtimeConfiguration
+ */
+export const announceCustomizations = async ({
+  runtimeConfiguration
+}: {
+  runtimeConfiguration?: RuntimeConfiguration
+}): Promise<void> => {
+  const { scripts = [], styles = [] } = runtimeConfiguration
+
+  scripts.forEach(({ src = '', async = false }) => {
+    const script = document.createElement('script')
+    script.src = src
+    script.async = async
+    document.head.appendChild(script)
+  })
+
+  styles.forEach(({ href = '' }) => {
+    const link = document.createElement('link')
+    link.href = href
+    link.type = 'text/css'
+    link.rel = 'stylesheet'
+    document.head.appendChild(link)
+  })
+}
+
+/**
  * announce runtime translations by injecting them into the getTextPlugin
  *
  * @param vue

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -25,6 +25,7 @@ import {
   announceUppyService,
   announceAuthService,
   announcePermissionManager,
+  announceCustomizations,
   startSentry
 } from './container'
 
@@ -46,6 +47,7 @@ export const bootstrap = async (configurationPath: string): Promise<void> => {
   await announceAuthService({ vue: Vue, configurationManager, store, router })
   announceTranslations({ vue: Vue, supportedLanguages, translations })
   await announceTheme({ store, vue: Vue, designSystem, runtimeConfiguration })
+  await announceCustomizations({ runtimeConfiguration })
   announceDefaults({ store, router })
 }
 

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -47,7 +47,7 @@ export const bootstrap = async (configurationPath: string): Promise<void> => {
   await announceAuthService({ vue: Vue, configurationManager, store, router })
   announceTranslations({ vue: Vue, supportedLanguages, translations })
   await announceTheme({ store, vue: Vue, designSystem, runtimeConfiguration })
-  await announceCustomizations({ runtimeConfiguration })
+  announceCustomizations({ runtimeConfiguration })
   announceDefaults({ store, router })
 }
 


### PR DESCRIPTION
This PR introduces the ability to configure scripts and style resources that will be injected into the SPA application.
This enables for example injection of small self containing scripts or style adjustments without rebuilding web or build a custom application.

needs https://github.com/owncloud/ocis/pull/4664