### PR TITLE
[tests-only] fix flaky acceptance share perm. scenario

### DIFF
--- a/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/sharingDialog.js
@@ -301,7 +301,10 @@ module.exports = {
         }
       }
 
-      await this.click('@customPermissionsConfirmBtn')
+      await this.initAjaxCounters()
+        .click('@customPermissionsConfirmBtn')
+        .waitForOutstandingAjaxCalls()
+        .waitForAnimationToFinish() // wait for confirm dialog to settle down
     },
     /**
      * Toggle the checkbox to set a certain permission for a share


### PR DESCRIPTION
## Description
Following measures were used to reduce the flakiness:

- Wait for the ajax calls that are initialized by the confirm button click
- wait for animations to be finished i.e. settling down the confirm dialog for the custom permissions. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7705

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot:
