### PR TITLE
Fix folder conflict dialog issues

### DIFF
--- a/changelog/unreleased/bugfix-folder-conflict
+++ b/changelog/unreleased/bugfix-folder-conflict
@@ -1,0 +1,9 @@
+Bugfix: Folder conflict dialog
+
+* Fixed "Keep both" and "Skip" options in Firefox
+* Fixed "Keep both" and "Skip" options when uploading via the "Upload"-menu
+* Fixed broken "Upload"-menu after skipping all files (= no files uploaded)
+* Fixed issues when uploading a folder into another folder which has or starts with the same name
+
+https://github.com/owncloud/web/pull/7724
+https://github.com/owncloud/web/issues/7680

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -824,20 +824,24 @@ export default defineComponent({
         for (const file of filesInFolder) {
           const newFolderName = resolveFileNameDuplicate(folder, '', this.files)
           file.meta.relativeFolder = file.meta.relativeFolder.replace(
-            `/${folder}`,
+            new RegExp(`/${folder}` + '$'),
             `/${newFolderName}`
           )
           file.meta.relativePath = file.meta.relativePath.replace(
-            `/${folder}/`,
+            new RegExp(`/${folder}/` + '$'),
             `/${newFolderName}/`
           )
-          file.meta.tusEndpoint = file.meta.tusEndpoint.replace(`/${folder}`, `/${newFolderName}`)
-          const data = file.data as any
-          data.relativePath = data.relativePath.replace(`/${folder}/`, `/${newFolderName}/`)
+          file.meta.tusEndpoint = file.meta.tusEndpoint.replace(
+            new RegExp(`/${folder}` + '$'),
+            `/${newFolderName}`
+          )
         }
       }
 
-      if (files.length === 0) return
+      if (files.length === 0) {
+        return this.$uppyService.clearInputs()
+      }
+
       return this.handleUppyFileUpload(this.space, this.item, files)
     }
   }

--- a/packages/web-app-files/src/composables/upload/useUploadHelpers.ts
+++ b/packages/web-app-files/src/composables/upload/useUploadHelpers.ts
@@ -32,6 +32,19 @@ export function useUploadHelpers(options: UploadHelpersOptions): UploadHelpersRe
   }
 }
 
+/**
+ * Get the relative path of the file when the file was inside a directory on the client computer.
+ * @param file
+ */
+const getRelativeFilePath = (file: File): string | undefined => {
+  const relativePath = file.webkitRelativePath || (file as any).relativePath
+  if (!relativePath) {
+    return undefined
+  }
+
+  return urlJoin(relativePath)
+}
+
 const inputFilesToUppyFiles = ({ route, space, currentFolder }: inputFileOptions) => {
   return (files: File[]): UppyResource[] => {
     const uppyFiles: UppyResource[] = []
@@ -41,8 +54,7 @@ const inputFilesToUppyFiles = ({ route, space, currentFolder }: inputFileOptions
     const topLevelFolderIds = {}
 
     for (const file of files) {
-      // Get the relative path of the file when the file was inside a directory on the client computer
-      const relativeFilePath = file.webkitRelativePath || (file as any).relativePath || null
+      const relativeFilePath = getRelativeFilePath(file)
       // Directory without filename
       const directory =
         !relativeFilePath || path.dirname(relativeFilePath) === '.'

--- a/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.js
+++ b/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.js
@@ -389,7 +389,10 @@ function getShallowWrapper(route = {}, store = {}) {
         }
       },
       isUserContext: jest.fn(() => false),
-      hasSpaces: true
+      hasSpaces: true,
+      $uppyService: {
+        clearInputs: jest.fn()
+      }
     },
     propsData: {
       currentPath: ''


### PR DESCRIPTION
## Description
* Fixed "Keep both" and "Skip" options in Firefox
* Fixed "Keep both" and "Skip" options when uploading via the "Upload"-menu
* Fixed broken "Upload"-menu after skipping all files (= no files uploaded)
* Fixed issues when uploading a folder into another folder which has or starts with the same name

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7680

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
