### PR TITLE
Fix 'Copy Quicklink'-translations

### DIFF
--- a/changelog/unreleased/bugfix-copy-quicklink-translations
+++ b/changelog/unreleased/bugfix-copy-quicklink-translations
@@ -1,0 +1,6 @@
+Bugfix: "Copy Quicklink"-translations
+
+We've fixed a bug where the translation for the "Copy Quicklink"-notification was not working.
+
+https://github.com/owncloud/web/pull/7731
+https://github.com/owncloud/web/issues/7720

--- a/packages/web-app-files/src/helpers/share/link.ts
+++ b/packages/web-app-files/src/helpers/share/link.ts
@@ -4,29 +4,26 @@ import { Store } from 'vuex'
 import { clientService } from 'web-pkg/src/services'
 import copyToClipboard from 'copy-to-clipboard'
 
-const $gettext = (str) => {
-  return str
-}
-
 interface CreateQuicklink {
   store: Store<any>
   storageId?: any
   resource: any
   password?: string
+  $gettext: (string) => string
 }
 
 export const createQuicklink = async (args: CreateQuicklink): Promise<Share> => {
+  const { resource, store, password, $gettext } = args
   const params: { [key: string]: unknown } = {
     name: $gettext('Quicklink'),
     permissions: 1,
     quicklink: true
   }
 
-  if (args.password) {
-    params.password = args.password
+  if (password) {
+    params.password = password
   }
 
-  const { resource, store } = args
   const expirationDate = store.state.user.capabilities.files_sharing.public.expire_date
 
   if (expirationDate.enforced) {
@@ -51,7 +48,7 @@ export const createQuicklink = async (args: CreateQuicklink): Promise<Share> => 
   copyToClipboard(link.url)
 
   await store.dispatch('showMessage', {
-    title: $gettext('Quicklink copied into your clipboard')
+    title: $gettext('The quicklink has been copied to your clipboard.')
   })
 
   return link

--- a/packages/web-app-files/src/mixins/actions/createQuicklink.ts
+++ b/packages/web-app-files/src/mixins/actions/createQuicklink.ts
@@ -40,7 +40,8 @@ export default {
       await createQuicklink({
         resource,
         storageId: this.space?.id || resource?.fileId || resource?.id,
-        store
+        store,
+        $gettext: this.$gettext
       })
 
       bus.publish(SideBarEventTopics.openWithPanel, 'sharing-item#linkShares')

--- a/tests/acceptance/features/webUISharingPublicBasic/publicLinkCreate.feature
+++ b/tests/acceptance/features/webUISharingPublicBasic/publicLinkCreate.feature
@@ -175,7 +175,7 @@ Feature: Create public link shares
       | name        | Quicklink      |
     And the following success message should be displayed on the webUI
       """
-      Quicklink copied into your clipboard
+      The quicklink has been copied to your clipboard.
       """
 
   # This test is skipped in OCIS as the sharing jail has been implemented


### PR DESCRIPTION
## Description
We've fixed a bug where the translation for the "Copy Quicklink"-notification was not working.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7720
- Fixes https://github.com/owncloud/web/issues/7553

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
