### PR TITLE
Remove the 'close sidebar'-calls on delete

### DIFF
--- a/changelog/unreleased/bugfix-remove-close-sidebar-calls-on-delete
+++ b/changelog/unreleased/bugfix-remove-close-sidebar-calls-on-delete
@@ -1,0 +1,6 @@
+Bugfix: Remove the "close sidebar"-calls on delete
+
+We've removed the "close sidebar"-calls when deleting a resource as the mutations are not available as well as not needed anymore.
+
+https://github.com/owncloud/web/issues/7699
+https://github.com/owncloud/web/pull/7733

--- a/packages/web-app-files/src/store/actions.ts
+++ b/packages/web-app-files/src/store/actions.ts
@@ -176,20 +176,17 @@ export default {
       promises.push(promise)
     }
     return Promise.all(promises).then(() => {
-      context.dispatch('sidebar/close')
       context.commit('REMOVE_FILES', removedFiles)
       context.commit('REMOVE_FILES_FROM_SEARCHED', removedFiles)
       context.commit('RESET_SELECTION')
     })
   },
-  async clearTrashBin(context) {
-    await context.dispatch('sidebar/close')
+  clearTrashBin(context) {
     context.commit('CLEAR_FILES')
     context.commit('RESET_SELECTION')
     context.commit('CLEAR_FILES_SEARCHED')
   },
-  async removeFilesFromTrashbin(context, files) {
-    await context.dispatch('sidebar/close')
+  removeFilesFromTrashbin(context, files) {
     context.commit('REMOVE_FILES', files)
     context.commit('REMOVE_FILES_FROM_SEARCHED', files)
     context.commit('RESET_SELECTION')


### PR DESCRIPTION
## Description
We've removed the "close sidebar"-calls when deleting a resource as the mutations are not available as well as not needed anymore.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7699

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
