### PR TITLE
Fix file name reactivity in sidebar

### DIFF
--- a/changelog/unreleased/bugfix-file-name-reactivity
+++ b/changelog/unreleased/bugfix-file-name-reactivity
@@ -1,0 +1,6 @@
+Bugfix: File name reactivity
+
+We've fixed a bug where the file name would not update reactively in the sidebar after changing it.
+
+https://github.com/owncloud/web/pull/7734
+https://github.com/owncloud/web/issues/7713

--- a/packages/web-app-files/src/components/SideBar/FileInfo.vue
+++ b/packages/web-app-files/src/components/SideBar/FileInfo.vue
@@ -34,7 +34,6 @@ export default {
   components: {
     PrivateLinkItem
   },
-  inject: ['displayedItem'],
   props: {
     isSubPanelActive: {
       type: Boolean,
@@ -43,6 +42,7 @@ export default {
   },
   computed: {
     ...mapGetters(['capabilities']),
+    ...mapGetters('Files', ['highlightedFile']),
     ...mapState('Files', ['areFileExtensionsShown']),
 
     privateLinkEnabled() {
@@ -50,7 +50,7 @@ export default {
     },
 
     file() {
-      return this.displayedItem.value
+      return this.highlightedFile
     }
   }
 }


### PR DESCRIPTION
## Description
We've fixed a bug where the file name would not update reactively in the sidebar after changing it.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7713

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
