### PR TITLE
Disable shares loading on public and trash locations

### DIFF
--- a/changelog/unreleased/bugfix-disable-shares-loading-on-public-and-trash-locations
+++ b/changelog/unreleased/bugfix-disable-shares-loading-on-public-and-trash-locations
@@ -1,0 +1,6 @@
+Bugfix: Disable shares loading on public and trash locations
+
+We've disabled shares loading on public and trash locations as it's not needed.
+
+https://github.com/owncloud/web/pull/7739
+https://github.com/owncloud/web/issues/7667

--- a/packages/web-app-files/src/components/SideBar/SideBar.vue
+++ b/packages/web-app-files/src/components/SideBar/SideBar.vue
@@ -42,7 +42,7 @@ import {
   isLocationCommonActive,
   isLocationPublicActive,
   isLocationSharesActive,
-  isLocationSpacesActive
+  isLocationTrashActive
 } from '../../router'
 import { computed, defineComponent, PropType } from '@vue/composition-api'
 import {
@@ -112,7 +112,6 @@ export default defineComponent({
     const { webdav } = useClientService()
 
     return {
-      isSpacesProjectsLocation: useActiveLocation(isLocationSpacesActive, 'files-spaces-projects'),
       isSharedWithMeLocation: useActiveLocation(isLocationSharesActive, 'files-shares-with-me'),
       isSharedWithOthersLocation: useActiveLocation(
         isLocationSharesActive,
@@ -122,6 +121,7 @@ export default defineComponent({
       isFavoritesLocation: useActiveLocation(isLocationCommonActive, 'files-common-favorites'),
       isSearchLocation: useActiveLocation(isLocationCommonActive, 'files-common-search'),
       isPublicFilesLocation: useActiveLocation(isLocationPublicActive, 'files-public-link'),
+      isTrashLocation: useActiveLocation(isLocationTrashActive, 'files-trash-generic'),
       hasShareJail: useCapabilityShareJailEnabled(),
       publicLinkPassword: usePublicLinkPassword({ store }),
       setActiveSideBarPanel,
@@ -142,7 +142,7 @@ export default defineComponent({
   },
 
   computed: {
-    ...mapGetters('Files', ['highlightedFile', 'selectedFiles']),
+    ...mapGetters('Files', ['highlightedFile', 'selectedFiles', 'currentFolder']),
     ...mapGetters(['fileSideBars', 'capabilities']),
     ...mapGetters('runtime/spaces', ['spaces']),
     ...mapState(['user']),
@@ -203,6 +203,9 @@ export default defineComponent({
     },
     highlightedFileIsSpace() {
       return this.highlightedFile?.type === 'space'
+    },
+    sharesLoadingDisabledOnCurrentRoute() {
+      return this.isPublicFilesLocation || this.isTrashLocation
     }
   },
   watch: {
@@ -214,13 +217,7 @@ export default defineComponent({
         }
 
         const loadShares =
-          !!oldFile ||
-          this.isSpacesProjectsLocation ||
-          this.isSharedWithMeLocation ||
-          this.isSharedWithOthersLocation ||
-          this.isSharedViaLinkLocation ||
-          this.isSearchLocation ||
-          this.isFavoritesLocation
+          !this.sharesLoadingDisabledOnCurrentRoute && (!!oldFile || !this.currentFolder)
         this.fetchFileInfo(loadShares)
       },
       deep: true


### PR DESCRIPTION
## Description
We've disabled shares loading on public and trash locations as it's not needed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7667

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
