### PR TITLE
Fix disappearing quicklink in sidebar

### DIFF
--- a/changelog/unreleased/bugfix-disappearing-quicklink-in-sidebar
+++ b/changelog/unreleased/bugfix-disappearing-quicklink-in-sidebar
@@ -1,0 +1,6 @@
+Bugfix: Disappearing quicklink in sidebar
+
+We've fixed a bug where existing quicklinks would disappear when performing the "Create quicklink"-action.
+
+https://github.com/owncloud/web/pull/7740
+https://github.com/owncloud/web/issues/7736

--- a/packages/web-app-files/src/store/actions.ts
+++ b/packages/web-app-files/src/store/actions.ts
@@ -471,7 +471,12 @@ export default {
     // kind of bruteforce for now: remove the shares for the current folder and children, reload shares tree for the current folder.
     // TODO: when we refactor the shares tree we want to modify shares tree nodes incrementally during adding and removing shares, not loading everything new from the backend.
     commit('SHARESTREE_PRUNE_OUTSIDE_PATH', dirname(currentFolder))
-    await dispatch('loadSharesTree', { client, path: currentFolder, storageId })
+    await dispatch('loadSharesTree', {
+      client,
+      path: currentFolder,
+      storageId,
+      includeRoot: currentFolder === '/'
+    })
     commit('LOAD_INDICATORS', currentFolder)
   },
 


### PR DESCRIPTION
## Description
We've fixed a bug where existing quicklinks would disappear when performing the "Create quicklink"-action.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7736

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
