### PR TITLE
Reload file list after last share removal

### DIFF
--- a/changelog/unreleased/bugfix-reload-file-list-after-share-removal
+++ b/changelog/unreleased/bugfix-reload-file-list-after-share-removal
@@ -1,0 +1,5 @@
+Bugfix: Reload file list after last share removal
+
+We've fixed a bug where the file list would not update after removing the last share or link. Also, we now prevent the shares tree from being loaded again if the removed share was not the last one.
+
+https://github.com/owncloud/web/pull/7748

--- a/packages/web-app-files/src/store/actions.ts
+++ b/packages/web-app-files/src/store/actions.ts
@@ -304,11 +304,14 @@ export default {
         )
       })
   },
-  deleteShare(context, { client, share, path, storageId }) {
+  deleteShare(context, { client, share, path, storageId, loadIndicators = false }) {
     return client.shares.deleteShare(share.id, {} as any).then(() => {
       context.commit('CURRENT_FILE_OUTGOING_SHARES_REMOVE', share)
       context.dispatch('updateCurrentFileShareTypes')
-      context.dispatch('loadIndicators', { client, currentFolder: path, storageId })
+
+      if (loadIndicators) {
+        context.dispatch('loadIndicators', { client, currentFolder: path, storageId })
+      }
     })
   },
   /**
@@ -455,11 +458,14 @@ export default {
         })
     })
   },
-  removeLink(context, { share, client, path, storageId }) {
-    client.shares.deleteShare(share.id).then(() => {
+  removeLink(context, { share, client, path, storageId, loadIndicators = false }) {
+    return client.shares.deleteShare(share.id).then(() => {
       context.commit('CURRENT_FILE_OUTGOING_SHARES_REMOVE', share)
       context.dispatch('updateCurrentFileShareTypes')
-      context.dispatch('loadIndicators', { client, currentFolder: path, storageId })
+
+      if (loadIndicators) {
+        context.dispatch('loadIndicators', { client, currentFolder: path, storageId })
+      }
     })
   },
 


### PR DESCRIPTION
## Description
We've fixed a bug where the file list would not update after removing the last share or link. Also, we now prevent the shares tree from being loaded again if the removed share was not the last one.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/KoKo22/issues/69

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
