### PR TITLE
revive refresh token

### DIFF
--- a/changelog/unreleased/bugfix-silent-refresh-token-renewal
+++ b/changelog/unreleased/bugfix-silent-refresh-token-renewal
@@ -1,0 +1,6 @@
+Bugfix: Try to obtain refresh token before the error case
+
+We've added a fallback strategy to try to revive the refresh token one more last time.
+This is for the rare case where the application is running in the background and the browsers throttles the token refresh mechanism.
+
+https://github.com/owncloud/web/pull/7756

--- a/packages/web-runtime/src/services/auth/userManager.ts
+++ b/packages/web-runtime/src/services/auth/userManager.ts
@@ -75,6 +75,7 @@ export class UserManager extends OidcUserManager {
       })
     }
 
+    Log.setLogger(console)
     Log.setLevel(Log.INFO)
 
     super(openIdConfig)


### PR DESCRIPTION
## Description
This pr adds the ability to try to refresh the refresh token one last time before sending the user to the "log out" view.
This scenario only happens in rare cases where the browser sits in the background and the native browser throttling could happen.

Please read https://developer.chrome.com/blog/timer-throttling-in-chrome-88/ for a more detailed explanation.

The problematic part is `oidc-auth-ts` which uses an internal timer to organize all tasks, the timer then uses `setInterval` which gets throttled. If this happens the timer gets out of sync and the `accessTokenExpired` event gets emitted.

In those cases the code now tries to refresh the token one more time before it sends the user to the error view. Please note that the oidc server needs to be setup correct and the access token lifespan should't be too short.

## Related Issue
- none

## Motivation and Context
be able to keep the web intact if it runs in the background.

## How Has This Been Tested?
- manual setup in docker compose with ocis and keycloak

## Screenshots (if appropriate):
<img width="1075" alt="Bildschirmfoto 2022-10-09 um 13 40 14" src="https://user-images.githubusercontent.com/49308105/194758803-56d55fc9-faed-4855-a10d-511543e29752.png">

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Technical debt
- [ ] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- lets discuss if this is something to hit the master or should go into experimental quarantine.
