### PR TITLE
[tests-only][full-ci]Skip `Shares` folder on root related tests on ocis

### DIFF
--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -33,17 +33,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 ### [when sharer renames the shared resource, sharee get the updated name](https://github.com/owncloud/ocis/issues/2256)
 -   [webUIRenameFiles/renameFiles.feature:234](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFiles/renameFiles.feature#L234)
 
-### [No share indicators inside share jail](https://github.com/owncloud/web/issues/6894)
--   [webUISharingInternalUsersSharingIndicator/shareWithUsers.feature:100](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalUsersSharingIndicator/shareWithUsers.feature#L100)
--   [webUISharingInternalUsersSharingIndicator/shareWithUsers.feature:121](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalUsersSharingIndicator/shareWithUsers.feature#L121)
--   [webUISharingPublicManagement/publicLinkIndicator.feature:64](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkIndicator.feature#L64)
--   [webUISharingPublicManagement/publicLinkIndicator.feature:81](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkIndicator.feature#L81)
--   [webUISharingPublicManagement/publicLinkIndicator.feature:98](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/publicLinkIndicator.feature#L98)
--   [webUISharingInternalGroupsSharingIndicator/shareWithGroups.feature:61](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalGroupsSharingIndicator/shareWithGroups.feature#L61)
--   [webUISharingInternalGroupsSharingIndicator/shareWithGroups.feature:80](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalGroupsSharingIndicator/shareWithGroups.feature#L80)
--   [webUISharingInternalGroupsSharingIndicator/shareWithGroups.feature:42](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalGroupsSharingIndicator/shareWithGroups.feature#L42)
--   [webUISharingInternalUsersSharingIndicator/shareWithUsers.feature:80](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalUsersSharingIndicator/shareWithUsers.feature#L80)
-
 ### [Scoped links](https://github.com/owncloud/web/issues/6844)
 -   [webUIFilesCopy/copyPrivateLinks.feature:20](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesCopy/copyPrivateLinks.feature#L20)
 -   [webUIFilesCopy/copyPrivateLinks.feature:21](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesCopy/copyPrivateLinks.feature#L21)

--- a/tests/acceptance/features/webUISharingInternalGroupsSharingIndicator/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroupsSharingIndicator/shareWithGroups.feature
@@ -38,6 +38,8 @@ Feature: Sharing files and folders with internal groups
       | fileName   | expectedIndicators |
       | inside.txt | user-indirect      |
 
+  # this scenario is skipped on ocis because it opens share folder which in not possible in OCIS
+  # but it works for OC10 see issue https://github.com/owncloud/web/issues/6896 for more detail
   @skipOnOCIS @issue-2060 @issue-6894
   Scenario: sharing indicator of items inside a re-shared folder
     Given user "Alice" has created folder "simple-folder" in the server
@@ -57,6 +59,8 @@ Feature: Sharing files and folders with internal groups
       | simple-empty-folder | user-indirect      |
       | lorem.txt           | user-indirect      |
 
+  # this scenario is skipped on ocis because it opens share folder which in not possible in OCIS
+  # but it works for OC10 see issue https://github.com/owncloud/web/issues/6896 for more detail
   @skipOnOCIS @issue-2060
   Scenario: sharing indicator of items inside a re-shared subfolder
     Given user "Alice" has created folder "simple-folder" in the server
@@ -76,6 +80,8 @@ Feature: Sharing files and folders with internal groups
       | simple-empty-folder | user-direct        |
       | lorem.txt           | user-indirect      |
 
+  # this scenario is skipped on ocis because it opens share folder which in not possible in OCIS
+  # but it works for OC10 see issue https://github.com/owncloud/web/issues/6896 for more detail
   @skipOnOCIS @issue-2060
   Scenario: sharing indicator of items inside an incoming shared folder
     Given user "Alice" has created folder "simple-folder" in the server

--- a/tests/acceptance/features/webUISharingInternalGroupsSharingIndicator/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroupsSharingIndicator/shareWithGroups.feature
@@ -38,7 +38,7 @@ Feature: Sharing files and folders with internal groups
       | fileName   | expectedIndicators |
       | inside.txt | user-indirect      |
 
-  @issue-2060 @issue-6894
+  @skipOnOCIS @issue-2060 @issue-6894
   Scenario: sharing indicator of items inside a re-shared folder
     Given user "Alice" has created folder "simple-folder" in the server
     And user "Alice" has created folder "simple-folder/simple-empty-folder" in the server
@@ -57,7 +57,7 @@ Feature: Sharing files and folders with internal groups
       | simple-empty-folder | user-indirect      |
       | lorem.txt           | user-indirect      |
 
-  @issue-2060
+  @skipOnOCIS @issue-2060
   Scenario: sharing indicator of items inside a re-shared subfolder
     Given user "Alice" has created folder "simple-folder" in the server
     And user "Alice" has created folder "simple-folder/simple-empty-folder" in the server
@@ -76,7 +76,7 @@ Feature: Sharing files and folders with internal groups
       | simple-empty-folder | user-direct        |
       | lorem.txt           | user-indirect      |
 
-  @issue-2060
+  @skipOnOCIS @issue-2060
   Scenario: sharing indicator of items inside an incoming shared folder
     Given user "Alice" has created folder "simple-folder" in the server
     And user "Alice" has created folder "simple-folder/simple-empty-folder" in the server

--- a/tests/acceptance/features/webUISharingInternalUsersSharingIndicator/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersSharingIndicator/shareWithUsers.feature
@@ -76,6 +76,8 @@ Feature: Sharing files and folders with internal users
       | new-folder | user-indirect      |
       | lorem.txt  | user-indirect      |
 
+  # this scenario is skipped on ocis because it opens share folder which in not possible in OCIS
+  # but it works for OC10 see issue https://github.com/owncloud/web/issues/6896 for more detail
   @skipOnOCIS @issue-4167 @issue-6894
   Scenario: sharing indicator of items inside a re-shared folder
     Given user "Carol" has been created with default attributes and without skeleton files in the server
@@ -96,6 +98,8 @@ Feature: Sharing files and folders with internal users
       | simple-empty-folder | user-indirect      |
       | lorem.txt           | user-indirect      |
 
+  # this scenario is skipped on ocis because it opens share folder which in not possible in OCIS
+  # but it works for OC10 see issue https://github.com/owncloud/web/issues/6896 for more detail
   @skipOnOCIS @issue-4167
   Scenario: sharing indicator of items inside a re-shared subfolder
     Given user "Carol" has been created with default attributes and without skeleton files in the server
@@ -117,6 +121,8 @@ Feature: Sharing files and folders with internal users
       | simple-empty-folder | user-direct        |
       | lorem.txt           | user-indirect      |
 
+  # this scenario is skipped on ocis because it opens share folder which in not possible in OCIS
+  # but it works for OC10 see issue https://github.com/owncloud/web/issues/6896 for more detail
   @skipOnOCIS @issue-2060 @issue-4167 @ocis-issue-891
   Scenario: sharing indicator of items inside an incoming shared folder
     Given user "Alice" has created folder "/simple-folder/simple-empty-folder" in the server

--- a/tests/acceptance/features/webUISharingInternalUsersSharingIndicator/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersSharingIndicator/shareWithUsers.feature
@@ -76,7 +76,7 @@ Feature: Sharing files and folders with internal users
       | new-folder | user-indirect      |
       | lorem.txt  | user-indirect      |
 
-  @issue-4167 @issue-6894
+  @skipOnOCIS @issue-4167 @issue-6894
   Scenario: sharing indicator of items inside a re-shared folder
     Given user "Carol" has been created with default attributes and without skeleton files in the server
     And user "Alice" has created folder "/simple-folder/simple-empty-folder" in the server
@@ -96,7 +96,7 @@ Feature: Sharing files and folders with internal users
       | simple-empty-folder | user-indirect      |
       | lorem.txt           | user-indirect      |
 
-  @issue-4167
+  @skipOnOCIS @issue-4167
   Scenario: sharing indicator of items inside a re-shared subfolder
     Given user "Carol" has been created with default attributes and without skeleton files in the server
     And user "Alice" has created folder "/simple-folder/simple-empty-folder" in the server
@@ -117,7 +117,7 @@ Feature: Sharing files and folders with internal users
       | simple-empty-folder | user-direct        |
       | lorem.txt           | user-indirect      |
 
-  @issue-2060 @issue-4167 @ocis-issue-891
+  @skipOnOCIS @issue-2060 @issue-4167 @ocis-issue-891
   Scenario: sharing indicator of items inside an incoming shared folder
     Given user "Alice" has created folder "/simple-folder/simple-empty-folder" in the server
     And user "Alice" has created file "/simple-folder/lorem.txt" in the server

--- a/tests/acceptance/features/webUISharingPublicManagement/publicLinkIndicator.feature
+++ b/tests/acceptance/features/webUISharingPublicManagement/publicLinkIndicator.feature
@@ -60,7 +60,7 @@ Feature: Public link share indicator
       | sub-folder   | link-indirect,user-indirect |
       | textfile.txt | link-indirect,user-indirect |
 
-  @issue-2060
+  @skipOnOCIS @issue-2060
   Scenario: sharing indicators public link from reshare
     Given user "Brian" has been created with default attributes and without skeleton files in the server
     And user "Alice" has created folder "/simple-folder/sub-folder" in the server
@@ -77,7 +77,7 @@ Feature: Public link share indicator
       | sub-folder   | link-indirect,user-indirect |
       | textfile.txt | link-indirect,user-indirect |
 
-  @issue-2060
+  @skipOnOCIS @issue-2060
   Scenario: sharing indicators public link from child of reshare
     Given user "Brian" has been created with default attributes and without skeleton files in the server
     And user "Alice" has created folder "/simple-folder/sub-folder" in the server
@@ -94,7 +94,7 @@ Feature: Public link share indicator
       | sub-folder   | link-direct,user-indirect |
       | textfile.txt | user-indirect             |
 
-  @issue-2060
+  @skipOnOCIS @issue-2060
   Scenario: no sharing indicator visible in file list from public link
     Given user "Brian" has been created with default attributes and without skeleton files in the server
     And user "Carol" has been created with default attributes and without skeleton files in the server

--- a/tests/acceptance/features/webUISharingPublicManagement/publicLinkIndicator.feature
+++ b/tests/acceptance/features/webUISharingPublicManagement/publicLinkIndicator.feature
@@ -60,6 +60,9 @@ Feature: Public link share indicator
       | sub-folder   | link-indirect,user-indirect |
       | textfile.txt | link-indirect,user-indirect |
 
+
+  # this scenario is skipped on ocis because it makes request to shared folder in root (All Files) which in not possible in OCIS
+  # but it works for OC10 see issue https://github.com/owncloud/web/issues/6896 for more detail
   @skipOnOCIS @issue-2060
   Scenario: sharing indicators public link from reshare
     Given user "Brian" has been created with default attributes and without skeleton files in the server
@@ -77,6 +80,8 @@ Feature: Public link share indicator
       | sub-folder   | link-indirect,user-indirect |
       | textfile.txt | link-indirect,user-indirect |
 
+  # this scenario is skipped on ocis because it makes request to shared folder in root (All Files) which in not possible in OCIS
+  # but it works for OC10 see issue https://github.com/owncloud/web/issues/6896 for more detail
   @skipOnOCIS @issue-2060
   Scenario: sharing indicators public link from child of reshare
     Given user "Brian" has been created with default attributes and without skeleton files in the server
@@ -94,6 +99,8 @@ Feature: Public link share indicator
       | sub-folder   | link-direct,user-indirect |
       | textfile.txt | user-indirect             |
 
+  # this scenario is skipped on ocis because it makes request to shared folder in root (All Files) which in not possible in OCIS
+  # but it works for OC10 see issue https://github.com/owncloud/web/issues/6896 for more detail
   @skipOnOCIS @issue-2060
   Scenario: no sharing indicator visible in file list from public link
     Given user "Brian" has been created with default attributes and without skeleton files in the server


### PR DESCRIPTION
### Description
This PR skips the tests related to `Shares` folder based on this issue https://github.com/owncloud/ocis/issues/4678
Since there is no `Shares` folder generated onwebUI on `ocis` on root like `oc10` those tests fails. The related scenarios can be implemented on playwright (future).

### For more information
https://github.com/owncloud/ocis/issues/4678#issuecomment-1274369466

### Related Issue
https://github.com/owncloud/ocis/issues/4678