### PR TITLE
Hide actions in space trash bins in case of insufficient permissions

### DIFF
--- a/changelog/unreleased/bugfix-space-trashbin-actions
+++ b/changelog/unreleased/bugfix-space-trashbin-actions
@@ -1,0 +1,6 @@
+Bugfix: Hide actions in space trash bins
+
+Actions in space trash bins are now hidden if the current user has insufficient permissions.
+
+https://github.com/owncloud/web/pull/7768
+https://github.com/owncloud/web/issues/7702

--- a/packages/web-app-files/src/mixins/actions/delete.js
+++ b/packages/web-app-files/src/mixins/actions/delete.js
@@ -6,12 +6,13 @@ import {
   isLocationTrashActive,
   isLocationCommonActive
 } from '../../router'
+import { isProjectSpaceResource } from 'web-client/src/helpers'
 
 export default {
   mixins: [MixinDeleteResources],
   computed: {
     ...mapState('Files', ['currentFolder']),
-    ...mapGetters(['capabilities']),
+    ...mapGetters(['capabilities', 'user']),
     $_delete_items() {
       return [
         {
@@ -60,6 +61,13 @@ export default {
             if (this.capabilities?.files?.permanent_deletion === false) {
               return false
             }
+
+            const { manager, editor } = this.space?.spaceRoles
+            const isProjectSpace = isProjectSpaceResource(this.space)
+            if (isProjectSpace && ![...manager, ...editor].includes(this.user.uuid)) {
+              return false
+            }
+
             return resources.length > 0
           },
           componentType: 'button',

--- a/packages/web-app-files/src/mixins/actions/delete.js
+++ b/packages/web-app-files/src/mixins/actions/delete.js
@@ -62,9 +62,8 @@ export default {
               return false
             }
 
-            const isProjectSpace = isProjectSpaceResource(this.space)
             if (
-              isProjectSpace &&
+              isProjectSpaceResource(this.space) &&
               !this.space.isEditor(this.user.uuid) &&
               !this.space.isManager(this.user.uuid)
             ) {

--- a/packages/web-app-files/src/mixins/actions/delete.js
+++ b/packages/web-app-files/src/mixins/actions/delete.js
@@ -62,9 +62,12 @@ export default {
               return false
             }
 
-            const { manager, editor } = this.space?.spaceRoles
             const isProjectSpace = isProjectSpaceResource(this.space)
-            if (isProjectSpace && ![...manager, ...editor].includes(this.user.uuid)) {
+            if (
+              isProjectSpace &&
+              !this.space.isEditor(this.user.uuid) &&
+              !this.space.isManager(this.user.uuid)
+            ) {
               return false
             }
 

--- a/packages/web-app-files/src/mixins/actions/emptyTrashBin.js
+++ b/packages/web-app-files/src/mixins/actions/emptyTrashBin.js
@@ -23,9 +23,8 @@ export default {
               return false
             }
 
-            const isProjectSpace = isProjectSpaceResource(this.space)
             if (
-              isProjectSpace &&
+              isProjectSpaceResource(this.space) &&
               !this.space.isEditor(this.user.uuid) &&
               !this.space.isManager(this.user.uuid)
             ) {

--- a/packages/web-app-files/src/mixins/actions/emptyTrashBin.js
+++ b/packages/web-app-files/src/mixins/actions/emptyTrashBin.js
@@ -23,9 +23,12 @@ export default {
               return false
             }
 
-            const { manager, editor } = this.space?.spaceRoles
             const isProjectSpace = isProjectSpaceResource(this.space)
-            if (isProjectSpace && ![...manager, ...editor].includes(this.user.uuid)) {
+            if (
+              isProjectSpace &&
+              !this.space.isEditor(this.user.uuid) &&
+              !this.space.isManager(this.user.uuid)
+            ) {
               return false
             }
 

--- a/packages/web-app-files/src/mixins/actions/emptyTrashBin.js
+++ b/packages/web-app-files/src/mixins/actions/emptyTrashBin.js
@@ -1,6 +1,7 @@
 import { mapActions, mapGetters, mapState } from 'vuex'
 import { isLocationTrashActive } from '../../router'
 import { buildWebDavFilesTrashPath, buildWebDavSpacesTrashPath } from '../../helpers/resources'
+import { isProjectSpaceResource } from 'web-client/src/helpers'
 
 export default {
   computed: {
@@ -21,6 +22,13 @@ export default {
             if (this.capabilities?.files?.permanent_deletion === false) {
               return false
             }
+
+            const { manager, editor } = this.space?.spaceRoles
+            const isProjectSpace = isProjectSpaceResource(this.space)
+            if (isProjectSpace && ![...manager, ...editor].includes(this.user.uuid)) {
+              return false
+            }
+
             // empty trash bin is not available for individual resources, but only for the trash bin as a whole
             return resources.length === 0
           },

--- a/packages/web-app-files/src/mixins/actions/restore.ts
+++ b/packages/web-app-files/src/mixins/actions/restore.ts
@@ -29,9 +29,8 @@ export default {
               return false
             }
 
-            const isProjectSpace = isProjectSpaceResource(this.space)
             if (
-              isProjectSpace &&
+              isProjectSpaceResource(this.space) &&
               !this.space.isEditor(this.user.uuid) &&
               !this.space.isManager(this.user.uuid)
             ) {

--- a/packages/web-app-files/src/mixins/actions/restore.ts
+++ b/packages/web-app-files/src/mixins/actions/restore.ts
@@ -7,7 +7,7 @@ import {
   buildWebDavSpacesTrashPath
 } from '../../helpers/resources'
 import { clientService } from 'web-pkg/src/services'
-import { buildWebDavSpacesPath } from 'web-client/src/helpers'
+import { buildWebDavSpacesPath, isProjectSpaceResource } from 'web-client/src/helpers'
 
 export default {
   computed: {
@@ -26,6 +26,12 @@ export default {
               return false
             }
             if (!resources.every((r) => r.canBeRestored())) {
+              return false
+            }
+
+            const { manager, editor } = this.space?.spaceRoles
+            const isProjectSpace = isProjectSpaceResource(this.space)
+            if (isProjectSpace && ![...manager, ...editor].includes(this.user.uuid)) {
               return false
             }
 

--- a/packages/web-app-files/src/mixins/actions/restore.ts
+++ b/packages/web-app-files/src/mixins/actions/restore.ts
@@ -29,9 +29,12 @@ export default {
               return false
             }
 
-            const { manager, editor } = this.space?.spaceRoles
             const isProjectSpace = isProjectSpaceResource(this.space)
-            if (isProjectSpace && ![...manager, ...editor].includes(this.user.uuid)) {
+            if (
+              isProjectSpace &&
+              !this.space.isEditor(this.user.uuid) &&
+              !this.space.isManager(this.user.uuid)
+            ) {
               return false
             }
 

--- a/packages/web-app-files/src/views/spaces/GenericTrash.vue
+++ b/packages/web-app-files/src/views/spaces/GenericTrash.vue
@@ -34,6 +34,7 @@
           :sort-by="sortBy"
           :sort-dir="sortDir"
           :space="space"
+          :has-actions="showActions"
           @sort="handleSort"
         >
           <template #contextMenu="{ resource }">
@@ -78,7 +79,7 @@ import { computed, defineComponent, PropType } from '@vue/composition-api'
 import { Resource } from 'web-client'
 import { useCapabilityShareJailEnabled, useTranslations } from 'web-pkg/src/composables'
 import { createLocationTrash } from '../../router'
-import { SpaceResource } from 'web-client/src/helpers'
+import { isProjectSpaceResource, SpaceResource } from 'web-client/src/helpers'
 
 export default defineComponent({
   name: 'GenericTrash',
@@ -125,6 +126,7 @@ export default defineComponent({
   computed: {
     ...mapState('Files', ['files']),
     ...mapGetters('Files', ['highlightedFile', 'totalFilesCount']),
+    ...mapGetters(['user']),
 
     isEmpty() {
       return this.paginatedResources.length < 1
@@ -148,6 +150,11 @@ export default defineComponent({
           onClick: () => bus.publish('app.files.list.load')
         }
       ]
+    },
+
+    showActions() {
+      const { manager, editor } = this.space?.spaceRoles
+      return !isProjectSpaceResource(this.space) || [...manager, ...editor].includes(this.user.uuid)
     }
   },
 

--- a/packages/web-app-files/src/views/spaces/GenericTrash.vue
+++ b/packages/web-app-files/src/views/spaces/GenericTrash.vue
@@ -153,8 +153,11 @@ export default defineComponent({
     },
 
     showActions() {
-      const { manager, editor } = this.space?.spaceRoles
-      return !isProjectSpaceResource(this.space) || [...manager, ...editor].includes(this.user.uuid)
+      return (
+        !isProjectSpaceResource(this.space) ||
+        this.space.isEditor(this.user.uuid) ||
+        this.space.isManager(this.user.uuid)
+      )
     }
   },
 

--- a/packages/web-app-files/tests/unit/mixins/actions/delete.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/actions/delete.spec.js
@@ -67,6 +67,7 @@ function getWrapper({ deletePermanent = false, invalidLocation = false } = {}) {
     localVue,
     store,
     mocks: {
+      space: { driveType: 'personal', spaceRoles: { viewer: [], editor: [], manager: [] } },
       $router: {
         currentRoute: invalidLocation
           ? createLocationShares('files-shares-via-link')

--- a/packages/web-app-files/tests/unit/mixins/actions/emptyTrashBin.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/actions/emptyTrashBin.spec.js
@@ -30,6 +30,14 @@ describe('emptyTrashBin', () => {
       const wrapper = getWrapper({ invalidLocation: true })
       expect(wrapper.vm.$_emptyTrashBin_items[0].isEnabled({ resources: [] })).toBe(false)
     })
+    it('should be false in a space trash bin with insufficient permissions', () => {
+      const wrapper = getWrapper({ driveType: 'project' })
+      expect(
+        wrapper.vm.$_emptyTrashBin_items[0].isEnabled({
+          resources: [{ canBeRestored: () => true }]
+        })
+      ).toBe(false)
+    })
   })
 
   describe('method "$_emptyTrashBin_trigger"', () => {
@@ -65,7 +73,11 @@ describe('emptyTrashBin', () => {
   })
 })
 
-function getWrapper({ invalidLocation = false, resolveClearTrashBin = true } = {}) {
+function getWrapper({
+  invalidLocation = false,
+  resolveClearTrashBin = true,
+  driveType = 'personal'
+} = {}) {
   return mount(Component, {
     localVue,
     mocks: {
@@ -79,6 +91,7 @@ function getWrapper({ invalidLocation = false, resolveClearTrashBin = true } = {
       },
       $gettext: jest.fn(),
       $pgettext: jest.fn(),
+      space: { driveType, spaceRoles: { viewer: [], editor: [], manager: [] } },
       $client: {
         ...sdkMock,
         fileTrash: {

--- a/packages/web-app-files/tests/unit/mixins/actions/emptyTrashBin.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/actions/emptyTrashBin.spec.js
@@ -91,7 +91,7 @@ function getWrapper({
       },
       $gettext: jest.fn(),
       $pgettext: jest.fn(),
-      space: { driveType, spaceRoles: { viewer: [], editor: [], manager: [] } },
+      space: { driveType, isEditor: () => false, isManager: () => false },
       $client: {
         ...sdkMock,
         fileTrash: {

--- a/packages/web-app-files/tests/unit/mixins/actions/restore.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/actions/restore.spec.js
@@ -38,6 +38,12 @@ describe('restore', () => {
       const wrapper = getWrapper({ invalidLocation: true })
       expect(wrapper.vm.$_restore_items[0].isEnabled({ resources: [{}] })).toBe(false)
     })
+    it('should be false in a space trash bin with insufficient permissions', () => {
+      const wrapper = getWrapper({ driveType: 'project' })
+      expect(
+        wrapper.vm.$_restore_items[0].isEnabled({ resources: [{ canBeRestored: () => true }] })
+      ).toBe(false)
+    })
   })
 
   describe('method "$_restore_trigger"', () => {
@@ -65,7 +71,11 @@ describe('restore', () => {
   })
 })
 
-function getWrapper({ invalidLocation = false, resolveClearTrashBin: resolveRestore = true } = {}) {
+function getWrapper({
+  invalidLocation = false,
+  resolveClearTrashBin: resolveRestore = true,
+  driveType = 'personal'
+} = {}) {
   return mount(Component, {
     localVue,
     mocks: {
@@ -79,6 +89,7 @@ function getWrapper({ invalidLocation = false, resolveClearTrashBin: resolveRest
       },
       $gettext: jest.fn(),
       $gettextInterpolate: jest.fn(),
+      space: { driveType, spaceRoles: { viewer: [], editor: [], manager: [] } },
       $client: {
         ...sdkMock,
         fileTrash: {

--- a/packages/web-app-files/tests/unit/mixins/actions/restore.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/actions/restore.spec.js
@@ -89,7 +89,7 @@ function getWrapper({
       },
       $gettext: jest.fn(),
       $gettextInterpolate: jest.fn(),
-      space: { driveType, spaceRoles: { viewer: [], editor: [], manager: [] } },
+      space: { driveType, isEditor: () => false, isManager: () => false },
       $client: {
         ...sdkMock,
         fileTrash: {

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -1,6 +1,6 @@
 import { User } from '../user'
 import { buildWebDavSpacesPath, extractDomSelector, Resource } from '../resource'
-import { SpacePeopleShareRoles, spaceRoleEditor, spaceRoleManager } from '../share'
+import { SpacePeopleShareRoles, spaceRoleEditor, spaceRoleManager, spaceRoleViewer } from '../share'
 import { PublicSpaceResource, ShareSpaceResource, SpaceResource, SHARE_JAIL_ID } from './types'
 import { DavProperty } from 'web-pkg/src/constants'
 import { buildWebDavPublicPath } from 'files/src/helpers/resources'
@@ -197,6 +197,15 @@ export function buildSpace(data): SpaceResource {
     },
     getWebDavUrl(resource: Resource): string {
       return urlJoin(this.webDavUrl, resource.path)
+    },
+    isViewer(uuid: string): boolean {
+      return this.spaceRoles[spaceRoleViewer.name].includes(uuid)
+    },
+    isEditor(uuid: string): boolean {
+      return this.spaceRoles[spaceRoleEditor.name].includes(uuid)
+    },
+    isManager(uuid: string): boolean {
+      return this.spaceRoles[spaceRoleManager.name].includes(uuid)
     }
   }
   Object.defineProperty(s, 'nodeId', {

--- a/packages/web-client/src/helpers/space/types.ts
+++ b/packages/web-client/src/helpers/space/types.ts
@@ -38,6 +38,9 @@ export const isPersonalSpaceResource = (resource: Resource): resource is Persona
 
 export interface ProjectSpaceResource extends SpaceResource {
   __projectSpaceResource?: any
+  isViewer(uuid: string): boolean
+  isEditor(uuid: string): boolean
+  isManager(uuid: string): boolean
 }
 export const isProjectSpaceResource = (resource: Resource): resource is ProjectSpaceResource => {
   return resource.driveType === 'project'

--- a/tests/e2e/cucumber/steps/app-files/resource.ts
+++ b/tests/e2e/cucumber/steps/app-files/resource.ts
@@ -167,11 +167,14 @@ Then(
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const resourceObject = new objects.applicationFiles.Resource({ page })
     for (const info of stepTable.hashes()) {
-      const message = await resourceObject.deleteTrashBin({ resource: info.resource })
-      const paths = info.resource.split('/')
       if (actionType === 'should not') {
-        expect(message).toBe(`failed to delete "${paths[paths.length - 1]}"`)
+        const isVisible = await resourceObject.isDeleteTrashBinButtonVisible({
+          resource: info.resource
+        })
+        expect(isVisible).toBe(false)
       } else {
+        const message = await resourceObject.deleteTrashBin({ resource: info.resource })
+        const paths = info.resource.split('/')
         expect(message).toBe(`"${paths[paths.length - 1]}" was deleted successfully`)
       }
     }
@@ -190,14 +193,16 @@ Then(
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const resourceObject = new objects.applicationFiles.Resource({ page })
     for (const info of stepTable.hashes()) {
-      const message = await resourceObject.restoreTrashBin({
-        resource: info.resource,
-        actionType
-      })
-      const paths = info.resource.split('/')
       if (actionType === 'should not') {
-        expect(message).toBe(`failed to restore "${paths[paths.length - 1]}"`)
+        const isVisible = await resourceObject.isRestoreTrashBinButtonVisible({
+          resource: info.resource
+        })
+        expect(isVisible).toBe(false)
       } else {
+        const message = await resourceObject.restoreTrashBin({
+          resource: info.resource
+        })
+        const paths = info.resource.split('/')
         expect(message).toBe(`${paths[paths.length - 1]} was restored successfully`)
       }
     }

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -478,7 +478,6 @@ export const getDeleteResourceButtonVisibility = async (
   const resourceCheckbox = page.locator(
     util.format(checkBoxForTrashbin, `/${resource.replace(/^\/+/, '')}`)
   )
-  await new Promise((resolve) => setTimeout(resolve, 5000))
   if (!(await resourceCheckbox.isChecked())) {
     await resourceCheckbox.check()
   }
@@ -519,7 +518,6 @@ export const getRestoreResourceButtonVisibility = async (
   const resourceCheckbox = page.locator(
     util.format(checkBoxForTrashbin, `/${resource.replace(/^\/+/, '')}`)
   )
-  await new Promise((resolve) => setTimeout(resolve, 5000))
   if (!(await resourceCheckbox.isChecked())) {
     await resourceCheckbox.check()
   }

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -471,9 +471,22 @@ export const deleteResourceTrashbin = async (args: deleteResourceArgs): Promise<
   return message.trim().toLowerCase()
 }
 
+export const getDeleteResourceButtonVisibility = async (
+  args: deleteResourceArgs
+): Promise<boolean> => {
+  const { page, resource } = args
+  const resourceCheckbox = page.locator(
+    util.format(checkBoxForTrashbin, `/${resource.replace(/^\/+/, '')}`)
+  )
+  await new Promise((resolve) => setTimeout(resolve, 5000))
+  if (!(await resourceCheckbox.isChecked())) {
+    await resourceCheckbox.check()
+  }
+  return await page.locator(permanentDeleteButton).isVisible()
+}
+
 export interface restoreResourceTrashbinArgs {
   resource: string
-  actionType: string
   page: Page
 }
 
@@ -497,6 +510,20 @@ export const restoreResourceTrashbin = async (
 
   const message = await page.locator(notificationMessageDialog).textContent()
   return message.trim().toLowerCase()
+}
+
+export const getRestoreResourceButtonVisibility = async (
+  args: restoreResourceTrashbinArgs
+): Promise<boolean> => {
+  const { page, resource } = args
+  const resourceCheckbox = page.locator(
+    util.format(checkBoxForTrashbin, `/${resource.replace(/^\/+/, '')}`)
+  )
+  await new Promise((resolve) => setTimeout(resolve, 5000))
+  if (!(await resourceCheckbox.isChecked())) {
+    await resourceCheckbox.check()
+  }
+  return await page.locator(restoreResourceButton).isVisible()
 }
 
 export interface searchResourceGlobalSearchArgs {

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -28,7 +28,9 @@ import {
   editResources,
   editResourcesArgs,
   openFileInViewer,
-  openFileInViewerArgs
+  openFileInViewerArgs,
+  getDeleteResourceButtonVisibility,
+  getRestoreResourceButtonVisibility
 } from './actions'
 
 export class Resource {
@@ -115,11 +117,21 @@ export class Resource {
     return message
   }
 
+  async isDeleteTrashBinButtonVisible(args: Omit<deleteResourceArgs, 'page'>): Promise<boolean> {
+    return await getDeleteResourceButtonVisibility({ ...args, page: this.#page })
+  }
+
   async restoreTrashBin(args: Omit<restoreResourceTrashbinArgs, 'page'>): Promise<string> {
     const startUrl = this.#page.url()
     const message = await restoreResourceTrashbin({ ...args, page: this.#page })
     await this.#page.goto(startUrl)
     return message
+  }
+
+  async isRestoreTrashBinButtonVisible(
+    args: Omit<restoreResourceTrashbinArgs, 'page'>
+  ): Promise<boolean> {
+    return await getRestoreResourceButtonVisibility({ ...args, page: this.#page })
   }
 
   async searchResource(args: Omit<searchResourceGlobalSearchArgs, 'page'>): Promise<void> {


### PR DESCRIPTION
## Description
Actions in space trash bins are now hidden if the current user has insufficient permissions.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7702

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
