### PR TITLE
[full-ci] Resolve internal/private links on shares

### DIFF
--- a/changelog/unreleased/enhancement-internal-links
+++ b/changelog/unreleased/enhancement-internal-links
@@ -1,8 +1,8 @@
 Enhancement: Resolve internal links
 
 Public links with the role "internal" can now be resolved.
-Note: Internal links to shares can not be resolved as of now. This will follow in a subsequent PR.
 
-https://github.com/owncloud/web/pull/7405
 https://github.com/owncloud/web/issues/7304
 https://github.com/owncloud/web/issues/6844
+https://github.com/owncloud/web/pull/7405
+https://github.com/owncloud/web/pull/7769

--- a/changelog/unreleased/enhancement-private-links
+++ b/changelog/unreleased/enhancement-private-links
@@ -1,7 +1,7 @@
 Enhancement: Resolve private links
 
 Private links can now be resolved.
-Note: Private links to shares in oCIS can not be resolved as of now. This will follow in a subsequent PR.
 
-https://github.com/owncloud/web/pull/7405
 https://github.com/owncloud/web/issues/7707
+https://github.com/owncloud/web/pull/7405
+https://github.com/owncloud/web/pull/7769

--- a/packages/web-app-files/src/helpers/resource/resource.ts
+++ b/packages/web-app-files/src/helpers/resource/resource.ts
@@ -1,11 +1,19 @@
 import { Resource } from 'web-client'
 import fileExtensions from '../extensions/fileExtensions'
 
-export const extractStorageId = (id?: string): string => {
+const extractIdSegment = (id: string, index: number): string => {
   if (!id || typeof id !== 'string') {
     return ''
   }
-  return id.indexOf('!') >= 0 ? id.split('!')[0] : ''
+  return id.indexOf('!') >= 0 ? id.split('!')[index] : ''
+}
+
+export const extractStorageId = (id?: string): string => {
+  return extractIdSegment(id, 0)
+}
+
+export const extractNodeId = (id?: string): string => {
+  return extractIdSegment(id, 1)
 }
 
 export const extractNameWithoutExtension = (resource?: Resource): string => {

--- a/packages/web-app-files/src/helpers/resources.ts
+++ b/packages/web-app-files/src/helpers/resources.ts
@@ -14,7 +14,7 @@ import {
   spaceRoleManager,
   spaceRoleViewer
 } from 'web-client/src/helpers/share'
-import { extractExtensionFromFile, extractStorageId } from './resource'
+import { extractExtensionFromFile, extractNodeId, extractStorageId } from './resource'
 import { buildWebDavSpacesPath, extractDomSelector } from 'web-client/src/helpers/resource'
 import { Resource, SpaceResource, SHARE_JAIL_ID } from 'web-client/src/helpers'
 import { urlJoin } from 'web-pkg/src/utils'
@@ -44,7 +44,7 @@ export function buildResource(resource): Resource {
   }
 
   const id = resource.fileInfo[DavProperty.FileId]
-  return {
+  const r = {
     id,
     fileId: id,
     storageId: extractStorageId(id),
@@ -106,6 +106,12 @@ export function buildResource(resource): Resource {
     },
     getDomSelector: () => extractDomSelector(id)
   }
+  Object.defineProperty(r, 'nodeId', {
+    get() {
+      return extractNodeId(this.id)
+    }
+  })
+  return r
 }
 
 export function buildWebDavPublicPath(publicLinkToken, path = '') {

--- a/packages/web-client/src/helpers/resource/types.ts
+++ b/packages/web-client/src/helpers/resource/types.ts
@@ -6,6 +6,7 @@ export interface Resource {
   fileId?: string
   parentFolderId?: string
   storageId?: string
+  readonly nodeId?: string
   name?: string
   path: string
   webDavPath?: string

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -5,6 +5,7 @@ import { PublicSpaceResource, ShareSpaceResource, SpaceResource, SHARE_JAIL_ID }
 import { DavProperty } from 'web-pkg/src/constants'
 import { buildWebDavPublicPath } from 'files/src/helpers/resources'
 import { urlJoin } from 'web-pkg/src/utils'
+import { extractNodeId } from 'files/src/helpers/resource'
 
 export function buildPublicSpaceResource(data): PublicSpaceResource {
   const publicLinkPassword = data.publicLinkPassword
@@ -94,7 +95,7 @@ export function buildSpace(data): SpaceResource {
   })
   const webDavUrl = urlJoin(data.serverUrl, 'remote.php/dav', webDavPath)
 
-  return {
+  const s = {
     id: data.id,
     fileId: data.id,
     storageId: data.id,
@@ -125,6 +126,7 @@ export function buildSpace(data): SpaceResource {
     ownerDisplayName: '',
     ownerId: data.owner?.user?.id,
     disabled,
+    root: data.root,
     spaceQuota: data.quota,
     spaceRoles,
     spaceImageData,
@@ -197,4 +199,10 @@ export function buildSpace(data): SpaceResource {
       return urlJoin(this.webDavUrl, resource.path)
     }
   }
+  Object.defineProperty(s, 'nodeId', {
+    get() {
+      return extractNodeId(this.id)
+    }
+  })
+  return s
 }

--- a/packages/web-client/src/helpers/space/types.ts
+++ b/packages/web-client/src/helpers/space/types.ts
@@ -10,9 +10,21 @@ import { Resource } from '../resource'
 
 export const SHARE_JAIL_ID = 'a0ca6a90-a365-4782-871e-d44447bbc668'
 
+export interface SpaceResourceRemoteItem {
+  id: string
+  name: string
+}
+
+export interface SpaceResourceRoot {
+  id: string
+  remoteItem: SpaceResourceRemoteItem
+  webDavUrl: string
+}
+
 export interface SpaceResource extends Resource {
   disabled?: boolean
   webDavUrl: string
+  root: SpaceResourceRoot
   getWebDavUrl(resource: Resource): string
   getDriveAliasAndItem(resource: Resource): string
 }
@@ -37,6 +49,15 @@ export interface ShareSpaceResource extends SpaceResource {
 }
 export const isShareSpaceResource = (resource: Resource): resource is ShareSpaceResource => {
   return resource.driveType === 'share'
+}
+
+export interface MountPointSpaceResource extends SpaceResource {
+  __mountPointSpaceResource?: any
+}
+export const isMountPointSpaceResource = (
+  resource: Resource
+): resource is MountPointSpaceResource => {
+  return resource.driveType === 'mountpoint'
 }
 
 export interface PublicSpaceResource extends SpaceResource {

--- a/packages/web-runtime/src/pages/resolveFileLink.vue
+++ b/packages/web-runtime/src/pages/resolveFileLink.vue
@@ -31,21 +31,34 @@
   </div>
 </template>
 
-<script type="ts">
+<script lang="ts">
 import {
   useRoute,
   useRouteParam,
   useStore,
   useTranslations,
-  useRouter, queryItemAsString, useCapabilitySpacesEnabled
-} from "web-pkg/src/composables";
-import { unref, defineComponent, computed, onMounted } from "@vue/composition-api";
-import { clientService } from "web-pkg/src/services";
-import { createLocationSpaces } from "files/src/router";
-import {dirname} from "path";
-import {createFileRouteOptions} from "web-pkg/src/helpers/router";
-import {useTask} from "vue-concurrency";
-import {isPersonalSpaceResource} from "web-client/src/helpers";
+  useRouter,
+  queryItemAsString,
+  useCapabilitySpacesEnabled
+} from 'web-pkg/src/composables'
+import { unref, defineComponent, computed, onMounted } from '@vue/composition-api'
+import { clientService } from 'web-pkg/src/services'
+import { createLocationSpaces } from 'files/src/router'
+import { dirname } from 'path'
+import { createFileRouteOptions } from 'web-pkg/src/helpers/router'
+import { useTask } from 'vue-concurrency'
+import {
+  buildShareSpaceResource,
+  buildSpace,
+  buildWebDavSpacesPath,
+  isMountPointSpaceResource,
+  isPersonalSpaceResource,
+  Resource,
+  SpaceResource
+} from 'web-client/src/helpers'
+import { DavProperty } from 'web-pkg/src/constants'
+import { urlJoin } from 'web-pkg/src/utils'
+import { configurationManager } from 'web-pkg/src/configuration'
 
 export default defineComponent({
   name: 'ResolveFileLink',
@@ -67,17 +80,37 @@ export default defineComponent({
     })
 
     const resolveFileLinkTask = useTask(function* (signal, id) {
-      let path = yield clientService.owncloudSdk.files.getPathForFileId(id)
-      const matchingSpace = getMatchingSpace(id)
-      if (!matchingSpace) {
-        return
-      }
+      let path, resource
+      let matchingSpace = getMatchingSpace(id)
+      if (matchingSpace) {
+        path = yield clientService.owncloudSdk.files.getPathForFileId(id)
+        resource = yield clientService.webdav.getFileInfo(matchingSpace, { path })
+      } else {
+        // no matching space found => the file doesn't lie in own spaces => it's a share.
+        // do PROPFINDs on parents until root of accepted share is found in `mountpoint` spaces
+        let mountPoint = findMatchingMountPoint(id)
+        resource = yield fetchFileInfoById(id)
+        const sharePathSegments = mountPoint ? [] : [resource.name]
+        let tmpResource = resource
+        while (!mountPoint) {
+          tmpResource = yield fetchFileInfoById(tmpResource.parentFolderId)
+          mountPoint = findMatchingMountPoint(tmpResource.id)
+          if (!mountPoint) {
+            sharePathSegments.unshift(tmpResource.name)
+          }
+        }
 
-      const resource = yield clientService.webdav.getFileInfo(matchingSpace, { path })
+        matchingSpace = buildShareSpaceResource({
+          shareId: mountPoint.nodeId,
+          shareName: mountPoint.name,
+          serverUrl: configurationManager.serverUrl
+        })
+        path = urlJoin(...sharePathSegments)
+      }
 
       let fileId
       let scrollTo
-      if (resource.type !== 'file') {
+      if (resource.type === 'folder') {
         fileId = resource.fileId
       } else {
         fileId = resource.parentFolderId
@@ -95,16 +128,43 @@ export default defineComponent({
 
     const getMatchingSpace = (id) => {
       if (!unref(hasSpaces)) {
-        return store.getters['runtime/spaces/spaces'].find((space) => isPersonalSpaceResource(space))
+        return store.getters['runtime/spaces/spaces'].find((space) =>
+          isPersonalSpaceResource(space)
+        )
       }
       return store.getters['runtime/spaces/spaces'].find((space) => id.startsWith(space.id))
+    }
+
+    const fetchFileInfoById = async (id: string | number): Promise<Resource> => {
+      const space = buildSpace({
+        id,
+        webDavPath: buildWebDavSpacesPath(id)
+      })
+      return await clientService.webdav.getFileInfo(
+        space,
+        {},
+        {
+          davProperties: [
+            DavProperty.FileId,
+            DavProperty.FileParent,
+            DavProperty.Name,
+            DavProperty.ResourceType
+          ]
+        }
+      )
+    }
+
+    const findMatchingMountPoint = (id: string | number): SpaceResource => {
+      return store.getters['runtime/spaces/spaces'].find(
+        (space) => isMountPointSpaceResource(space) && space.root?.remoteItem?.id === id
+      )
     }
 
     const loading = computed(() => {
       return !resolveFileLinkTask.last || resolveFileLinkTask.isRunning
     })
 
-    const errorMessage = computed( () => {
+    const errorMessage = computed(() => {
       if (resolveFileLinkTask.isError) {
         return resolveFileLinkTask.last.error
       }

--- a/packages/web-runtime/src/pages/resolvePrivateLink.vue
+++ b/packages/web-runtime/src/pages/resolvePrivateLink.vue
@@ -61,7 +61,7 @@ import { urlJoin } from 'web-pkg/src/utils'
 import { configurationManager } from 'web-pkg/src/configuration'
 
 export default defineComponent({
-  name: 'ResolveFileLink',
+  name: 'ResolvePrivateLink',
   setup() {
     const store = useStore()
     const router = useRouter()
@@ -76,10 +76,10 @@ export default defineComponent({
     })
 
     onMounted(() => {
-      resolveFileLinkTask.perform(queryItemAsString(unref(id)))
+      resolvePrivateLinkTask.perform(queryItemAsString(unref(id)))
     })
 
-    const resolveFileLinkTask = useTask(function* (signal, id) {
+    const resolvePrivateLinkTask = useTask(function* (signal, id) {
       let path, resource
       let matchingSpace = getMatchingSpace(id)
       if (matchingSpace) {
@@ -161,12 +161,12 @@ export default defineComponent({
     }
 
     const loading = computed(() => {
-      return !resolveFileLinkTask.last || resolveFileLinkTask.isRunning
+      return !resolvePrivateLinkTask.last || resolvePrivateLinkTask.isRunning
     })
 
     const errorMessage = computed(() => {
-      if (resolveFileLinkTask.isError) {
-        return resolveFileLinkTask.last.error
+      if (resolvePrivateLinkTask.isError) {
+        return resolvePrivateLinkTask.last.error
       }
       return null
     })

--- a/packages/web-runtime/src/router/index.ts
+++ b/packages/web-runtime/src/router/index.ts
@@ -6,7 +6,7 @@ import LoginPage from '../pages/login.vue'
 import LogoutPage from '../pages/logout.vue'
 import OidcCallbackPage from '../pages/oidcCallback.vue'
 import ResolvePublicLinkPage from '../pages/resolvePublicLink.vue'
-import ResolveFileLinkPage from '../pages/resolveFileLink.vue'
+import ResolvePrivateLinkPage from '../pages/resolvePrivateLink.vue'
 import { setupAuthGuard } from './setupAuthGuard'
 import { patchRouter } from './patchCleanPath'
 
@@ -63,7 +63,7 @@ export const router = patchRouter(
       {
         path: '/f/:fileId',
         name: 'resolvePrivateLink',
-        component: ResolveFileLinkPage,
+        component: ResolvePrivateLinkPage,
         meta: { title: $gettext('Private link') }
       },
       {

--- a/packages/web-runtime/tests/unit/pages/resolveFileLink.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/resolveFileLink.spec.ts
@@ -1,3 +1,0 @@
-describe('resolveFileLink view', () => {
-  it.todo('Write tests')
-})

--- a/packages/web-runtime/tests/unit/pages/resolvePrivateLink.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/resolvePrivateLink.spec.ts
@@ -1,0 +1,3 @@
+describe('resolvePrivateLink view', () => {
+  it.todo('Write tests')
+})


### PR DESCRIPTION
## Description
This PR adds the (a little bit hacky) ability to resolve private links / public links with "internal" role which point to files/folders within an accepted incoming share.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/7707
- Fixes https://github.com/owncloud/web/issues/6844
- Fixes https://github.com/owncloud/web/issues/7304

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
