### PR TITLE
Fix routing for re-shares

### DIFF
--- a/changelog/unreleased/bugfix-routing-for-re-shares
+++ b/changelog/unreleased/bugfix-routing-for-re-shares
@@ -1,0 +1,6 @@
+Bugfix: Routing for re-shares
+
+We've fixed a bug where routing into re-shares and their parent folders from the "Shared with others/via link" page was broken.
+
+https://github.com/owncloud/web/pull/7771
+https://github.com/owncloud/web/issues/7347

--- a/packages/web-app-files/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceTable.vue
@@ -601,6 +601,12 @@ export default defineComponent({
           shareName: basename(resource.shareRoot),
           serverUrl: configurationManager.serverUrl
         })
+      } else if (!resource.shareId && !this.getInternalSpace(resource.storageId)) {
+        if (path === '/') {
+          return createLocationShares('files-shares-with-me')
+        }
+        // FIXME: This is a hacky way to resolve re-shares, but we don't have other options currently
+        return { name: 'resolvePrivateLink', params: { fileId } }
       } else {
         space = this.getMatchingSpace(resource)
       }
@@ -783,10 +789,12 @@ export default defineComponent({
         ownerName: resource.owner[0].displayName
       })
     },
+    getInternalSpace(storageId) {
+      return this.space || this.spaces.find((space) => space.id === storageId)
+    },
     getMatchingSpace(resource: Resource): SpaceResource {
       return (
-        this.space ||
-        this.spaces.find((space) => space.id === resource.storageId) ||
+        this.getInternalSpace(resource.storageId) ||
         buildShareSpaceResource({
           shareId: resource.shareId,
           shareName: resource.name,
@@ -810,6 +818,10 @@ export default defineComponent({
         return resource.path === '/'
           ? this.$gettext('Shared with me')
           : basename(resource.shareRoot)
+      }
+
+      if (!this.getInternalSpace(resource.storageId)) {
+        return this.$gettext('Shared with me')
       }
 
       return this.$gettext('Personal')


### PR DESCRIPTION
## Description
We've fixed a bug where routing into re-shares and their parent folders from the "Shared with others/via link" page was broken.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7347

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
