### PR TITLE
[ci][full-ci] Make notify pipeline dependent on build pipeline

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -830,7 +830,7 @@ def stagePipelines(ctx):
     return unit_test_pipelines + pipelinesDependsOn(e2e_pipelines + acceptance_pipelines, unit_test_pipelines)
 
 def afterPipelines(ctx):
-    return build(ctx) + notify()
+    return build(ctx) + pipelinesDependsOn(notify(), build(ctx))
 
 def yarnCache(ctx):
     return [{


### PR DESCRIPTION
## Description
Run `notify` pipeline after the `build` pipeline is finished. This will also notify about the status of `build` pipeline.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/6075

## Motivation and Context

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
