### PR TITLE
fix: file list update after copying resources

### DIFF
--- a/changelog/unreleased/enhancement-id-based-routing
+++ b/changelog/unreleased/enhancement-id-based-routing
@@ -12,3 +12,4 @@ https://github.com/owncloud/web/issues/6247
 https://github.com/owncloud/web/pull/7725
 https://github.com/owncloud/web/issues/7714
 https://github.com/owncloud/web/issues/7715
+https://github.com/owncloud/web/pull/7797

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -324,8 +324,7 @@ export default defineComponent({
         showMessage: this.showMessage,
         $gettext: this.$gettext,
         $gettextInterpolate: this.$gettextInterpolate,
-        $ngettext: this.$ngettext,
-        upsertResource: this.UPSERT_RESOURCE
+        $ngettext: this.$ngettext
       }).then(() => {
         ;(document.activeElement as HTMLElement).blur()
       })

--- a/packages/web-app-files/src/components/FilesList/KeyboardActions.vue
+++ b/packages/web-app-files/src/components/FilesList/KeyboardActions.vue
@@ -79,7 +79,6 @@ export default defineComponent({
       'toggleFileSelection'
     ]),
     ...mapMutations('Files', {
-      upsertResource: 'UPSERT_RESOURCE',
       setLatestSelectedFile: 'SET_LATEST_SELECTED_FILE_ID',
       setFileSelection: 'SET_FILE_SELECTION',
       addFileSelection: 'ADD_FILE_SELECTION'
@@ -264,8 +263,7 @@ export default defineComponent({
         showMessage: this.showMessage,
         $gettext: this.$gettext,
         $gettextInterpolate: this.$gettextInterpolate,
-        $ngettext: this.$ngettext,
-        upsertResource: this.upsertResource
+        $ngettext: this.$ngettext
       })
     },
 

--- a/packages/web-app-files/src/helpers/resource/actions/transfer.ts
+++ b/packages/web-app-files/src/helpers/resource/actions/transfer.ts
@@ -121,7 +121,7 @@ export class ResourceTransfer extends ConflictDialog {
     const movedResources: Resource[] = []
 
     for (let resource of this.resourcesToMove) {
-      // shallow copy of resources to prevent modifing existing rows
+      // shallow copy of resources to prevent modifying existing rows
       resource = { ...resource }
       const hasConflict = resolvedConflicts.some((e) => e.resource.id === resource.id)
       let targetName = resource.name
@@ -164,6 +164,8 @@ export class ResourceTransfer extends ConflictDialog {
             { path: join(this.targetFolder.path, targetName) },
             { overwrite: overwriteTarget }
           )
+          resource.id = undefined
+          resource.fileId = undefined
         } else if (transferType === TransferType.MOVE) {
           await this.clientService.webdav.moveFiles(
             this.sourceSpace,

--- a/packages/web-app-files/src/mixins/actions/paste.js
+++ b/packages/web-app-files/src/mixins/actions/paste.js
@@ -3,7 +3,7 @@ import {
   isLocationPublicActive,
   isLocationSpacesActive
 } from '../../router'
-import { mapActions, mapMutations, mapGetters } from 'vuex'
+import { mapActions, mapGetters } from 'vuex'
 
 export default {
   computed: {
@@ -58,7 +58,6 @@ export default {
   methods: {
     ...mapActions(['showMessage', 'createModal', 'hideModal']),
     ...mapActions('Files', ['pasteSelectedFiles']),
-    ...mapMutations('Files', ['UPSERT_RESOURCE']),
 
     $_paste_trigger() {
       this.pasteSelectedFiles({
@@ -69,8 +68,7 @@ export default {
         showMessage: this.showMessage,
         $gettext: this.$gettext,
         $gettextInterpolate: this.$gettextInterpolate,
-        $ngettext: this.$ngettext,
-        upsertResource: this.UPSERT_RESOURCE
+        $ngettext: this.$ngettext
       })
     }
   }

--- a/packages/web-app-files/src/store/actions.ts
+++ b/packages/web-app-files/src/store/actions.ts
@@ -72,8 +72,7 @@ export default {
       showMessage,
       $gettext,
       $gettextInterpolate,
-      $ngettext,
-      upsertResource
+      $ngettext
     }
   ) {
     const copyMove = new ResourceTransfer(
@@ -105,7 +104,7 @@ export default {
             targetSpace,
             resource
           )
-          upsertResource(movedResource)
+          context.commit('UPSERT_RESOURCE', movedResource)
         })()
       )
     }


### PR DESCRIPTION
## Description
Fixing an issue with file list updates after coyping resources that was introduced when we added path correction based on fileIds.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7774

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
