### PR TITLE
Make search results sortable

### DIFF
--- a/changelog/unreleased/enhancement-sort-search-results
+++ b/changelog/unreleased/enhancement-sort-search-results
@@ -1,0 +1,6 @@
+Enhancement: Make search results sortable
+
+The files table on the search-result-page is now sortable.
+
+https://github.com/owncloud/web/pull/7801
+https://github.com/owncloud/web/issues/7798

--- a/packages/web-app-files/src/components/Search/List.vue
+++ b/packages/web-app-files/src/components/Search/List.vue
@@ -27,8 +27,11 @@
           :are-thumbnails-displayed="displayThumbnails"
           :has-actions="true"
           :is-selectable="false"
+          :sort-by="sortBy"
+          :sort-dir="sortDir"
           @fileClick="$_fileActions_triggerDefaultAction"
           @rowMounted="rowMounted"
+          @sort="handleSort"
         >
           <template #contextMenu="{ resource }">
             <context-actions

--- a/packages/web-app-search/src/views/List.vue
+++ b/packages/web-app-search/src/views/List.vue
@@ -25,7 +25,11 @@ export default {
   },
   watch: {
     '$route.query': {
-      handler: function () {
+      handler: function (newVal, oldVal) {
+        if (newVal?.term === oldVal?.term) {
+          return
+        }
+
         this.$nextTick(() => {
           this.debouncedSearch()
         })


### PR DESCRIPTION
## Description
The files table on the search-result-page is now sortable.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7798

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

