### PR TITLE
feat: resolve public link into user context if available

### DIFF
--- a/changelog/unreleased/enhancement-resolve-public-link-into-user-context
+++ b/changelog/unreleased/enhancement-resolve-public-link-into-user-context
@@ -1,0 +1,5 @@
+Enhancement: Redirect public link into user context
+
+If the current browser window already has an active user session we direct a public link into the correct context (via the private link). For now this only works for backends that support the token-info endpoint (oCIS) and it is limited to the current browser window. New windows / tabs don't have a user context in the session storage and thus can't detect a user. We want to enhance this in the future.
+
+https://github.com/owncloud/web/pull/7802


### PR DESCRIPTION
## Description
If we already have an active user session (only possible in current tab/window) we redirect any public link to the private link and thus into the correct space.
Not possible yet for fresh browser tabs. To be enhanced soon but further research needed....

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
