### PR TITLE
Update resource tags

### DIFF
--- a/packages/web-app-files/src/components/SideBar/TagsPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/TagsPanel.vue
@@ -96,6 +96,11 @@ export default defineComponent({
       return this.displayedItem.value
     }
   },
+  watch: {
+    resource() {
+      this.revertChanges()
+    }
+  },
   mounted() {
     this.editAssignedTags = [...this.resource.tags]
     this.loadAllTagsTask.perform(this)


### PR DESCRIPTION
## Description
Resource tags in resource sidebar haven't updated when changing resource.
This PR fixes that behavior and displays the tags for the selected resource.