### PR TITLE
Fix sidebar when no highlighted resource is present

### DIFF
--- a/changelog/unreleased/bugfix-sidebar-without-highlighted-resource
+++ b/changelog/unreleased/bugfix-sidebar-without-highlighted-resource
@@ -1,0 +1,6 @@
+Bugfix: Sidebar without highlighted resource
+
+Sidebar panels that require a resource now won't be loaded without such. This fixes a bug where navigating with an open sidebar would break it.
+
+https://github.com/owncloud/web/issues/7781
+https://github.com/owncloud/web/pull/7826

--- a/packages/web-app-files/src/components/SideBar/SideBar.vue
+++ b/packages/web-app-files/src/components/SideBar/SideBar.vue
@@ -22,7 +22,7 @@
   >
     <template #header>
       <file-info
-        v-if="isSingleResource && !highlightedFileIsSpace"
+        v-if="highlightedFile && isSingleResource && !highlightedFileIsSpace"
         class="sidebar-panel__file_info"
         :is-sub-panel-active="!!activePanel"
       />

--- a/packages/web-app-files/src/fileSideBars.ts
+++ b/packages/web-app-files/src/fileSideBars.ts
@@ -47,10 +47,10 @@ const panelGenerators: (({
     component: NoSelection,
     default: () => true,
     get enabled() {
-      return rootFolder && highlightedFile?.type !== 'space'
+      return !highlightedFile || (rootFolder && highlightedFile?.type !== 'space')
     }
   }),
-  ({ router, multipleSelection, rootFolder }) => ({
+  ({ router, multipleSelection, rootFolder, highlightedFile }) => ({
     app: 'details-item',
     icon: 'questionnaire-line',
     title: $gettext('Details'),
@@ -58,7 +58,10 @@ const panelGenerators: (({
     default: !isLocationTrashActive(router, 'files-trash-generic'),
     get enabled() {
       return (
-        !isLocationTrashActive(router, 'files-trash-generic') && !multipleSelection && !rootFolder
+        !isLocationTrashActive(router, 'files-trash-generic') &&
+        !multipleSelection &&
+        !rootFolder &&
+        highlightedFile
       )
     }
   }),
@@ -91,14 +94,14 @@ const panelGenerators: (({
       return highlightedFile?.type === 'space' && !multipleSelection
     }
   }),
-  ({ router, multipleSelection, rootFolder }) => ({
+  ({ router, multipleSelection, rootFolder, highlightedFile }) => ({
     app: 'actions-item',
     icon: 'slideshow-3',
     title: $gettext('Actions'),
     component: FileActions,
     default: isLocationTrashActive(router, 'files-trash-generic'),
     get enabled() {
-      return !multipleSelection && !rootFolder
+      return !multipleSelection && !rootFolder && highlightedFile
     }
   }),
   ({ multipleSelection, highlightedFile, user }) => ({
@@ -119,7 +122,7 @@ const panelGenerators: (({
       ].includes(user.uuid)
     }
   }),
-  ({ capabilities, router, multipleSelection, rootFolder }) => ({
+  ({ capabilities, router, multipleSelection, rootFolder, highlightedFile }) => ({
     app: 'sharing-item',
     icon: 'user-add',
     iconFillType: 'line',
@@ -135,7 +138,7 @@ const panelGenerators: (({
       }
     },
     get enabled() {
-      if (multipleSelection || rootFolder) {
+      if (multipleSelection || rootFolder || !highlightedFile) {
         return false
       }
       if (


### PR DESCRIPTION
## Description
Sidebar panels that require a resource now won't be loaded without such. This fixes a bug where navigating with an open sidebar would break it.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7781

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
