### PR TITLE
[tests-only][e2e] Wait until the search indexing is finished

### DIFF
--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -533,6 +533,10 @@ export const searchResourceGlobalSearch = async (
   args: searchResourceGlobalSearchArgs
 ): Promise<void> => {
   const { page, keyword } = args
+
+  // .reload() waits nicely for search indexing to be finished
+  await page.reload()
+
   await Promise.all([
     page.waitForResponse((resp) => resp.status() === 207 && resp.request().method() === 'REPORT'),
     page.locator(globalSearchInput).fill(keyword)


### PR DESCRIPTION
## Description
Sometimes the global search e2e test can fail intermittently due to the fact that after uploading files, the search index takes some time to be updated. If the test runs faster than this "some time", then the test will fail.

It seems that we either need to reload the page or wait for some time in order to get the updated search index. This PR has added `page.reload()` just before performing the search action. `page.reload()` seems to be fasterand reliable than using explicit wait.

The wait was also added in the acceptance test (acceptance) due to same issue, see https://github.com/owncloud/web/commit/f77d04015c66770718637f4668ce293166cb6874

## Related Issue
- https://github.com/owncloud/ocis/issues/4849


## How Has This Been Tested?
- test environment: local

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
