### PR TITLE
Fix selectable share permissions for re-shares

### DIFF
--- a/changelog/unreleased/bugfix-share-permissions-for-reshares
+++ b/changelog/unreleased/bugfix-share-permissions-for-reshares
@@ -1,0 +1,6 @@
+Bugfix: Share permissions for re-shares
+
+We've fixed a bug where the selectable roles on a re-share could exceed the parent share's permissions in certain scenarios.
+
+https://github.com/owncloud/web/issues/7657
+https://github.com/owncloud/web/pull/7844

--- a/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
@@ -579,9 +579,9 @@ export default defineComponent({
     },
 
     getAvailableRoleOptions(link) {
-      if (this.share?.incoming && this.canCreatePublicLinks) {
+      if (this.incomingParentShare.value && this.canCreatePublicLinks) {
         return LinkShareRoles.filterByBitmask(
-          parseInt(this.share.permissions),
+          this.incomingParentShare.value.permissions,
           this.highlightedFile.isFolder,
           this.hasPublicLinkEditing,
           this.hasPublicLinkAliasSupport,

--- a/packages/web-app-files/src/composables/parentShare/useIncomingParentShare.ts
+++ b/packages/web-app-files/src/composables/parentShare/useIncomingParentShare.ts
@@ -1,13 +1,23 @@
 import { buildShare } from '../../helpers/resources'
-import { useStore } from 'web-pkg/src/composables'
+import { useCapabilitySpacesEnabled, useStore } from 'web-pkg/src/composables'
 import { computed, ref, unref } from '@vue/composition-api'
 import { useTask } from 'vue-concurrency'
 import { clientService } from 'web-pkg/src/services'
+import {
+  buildSpace,
+  buildWebDavSpacesPath,
+  isMountPointSpaceResource,
+  isPersonalSpaceResource,
+  Resource,
+  SpaceResource
+} from 'web-client/src/helpers'
+import { DavProperty } from 'web-client/src/webdav/constants'
 
 export function useIncomingParentShare() {
   const store = useStore()
   const incomingParentShare = ref(null)
   const sharesTree = computed(() => store.getters['Files/sharesTree'])
+  const hasSpaces = useCapabilitySpacesEnabled(store)
 
   const loadIncomingParentShare = useTask(function* (signal, resource) {
     let parentShare
@@ -27,8 +37,70 @@ export function useIncomingParentShare() {
       }
     }
 
+    const matchingSpace = getMatchingSpace(resource.id)
+    if (!matchingSpace) {
+      // no matching space found => the file doesn't lie in own spaces => it's a share.
+      try {
+        incomingParentShare.value = yield getParentShare(resource)
+      } catch (e) {
+        incomingParentShare.value = null
+        return
+      }
+
+      return
+    }
+
     incomingParentShare.value = null
   })
+
+  const getParentShare = async (resource) => {
+    // do PROPFINDs on parents until root of accepted share is found in `mountpoint` spaces
+    let mountPoint = findMatchingMountPoint(resource.id)
+    const sharePathSegments = mountPoint ? [] : [resource.name]
+    let tmpResource = resource
+    while (!mountPoint) {
+      tmpResource = await fetchFileInfoById(tmpResource.parentFolderId)
+      mountPoint = findMatchingMountPoint(tmpResource.id)
+      if (!mountPoint) {
+        sharePathSegments.unshift(tmpResource.name)
+      }
+    }
+
+    const parentShare = await clientService.owncloudSdk.shares.getShare(mountPoint.nodeId)
+    return buildShare(parentShare.shareInfo, tmpResource, true)
+  }
+
+  const getMatchingSpace = (id) => {
+    if (!unref(hasSpaces)) {
+      return store.getters['runtime/spaces/spaces'].find((space) => isPersonalSpaceResource(space))
+    }
+    return store.getters['runtime/spaces/spaces'].find((space) => id.startsWith(space.id))
+  }
+
+  const fetchFileInfoById = async (id: string | number): Promise<Resource> => {
+    const space = buildSpace({
+      id,
+      webDavPath: buildWebDavSpacesPath(id)
+    })
+    return await clientService.webdav.getFileInfo(
+      space,
+      {},
+      {
+        davProperties: [
+          DavProperty.FileId,
+          DavProperty.FileParent,
+          DavProperty.Name,
+          DavProperty.ResourceType
+        ]
+      }
+    )
+  }
+
+  const findMatchingMountPoint = (id: string | number): SpaceResource => {
+    return store.getters['runtime/spaces/spaces'].find(
+      (space) => isMountPointSpaceResource(space) && space.root?.remoteItem?.id === id
+    )
+  }
 
   return { loadIncomingParentShare, incomingParentShare }
 }


### PR DESCRIPTION
## Description
We've fixed a bug where the selectable roles on a re-share could exceed the parent share's permissions in certain scenarios.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7657

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
