### PR TITLE
Hide search bar in public link context

### DIFF
--- a/changelog/unreleased/bugfix-hide-search-bar-in-public-links
+++ b/changelog/unreleased/bugfix-hide-search-bar-in-public-links
@@ -1,0 +1,6 @@
+Bugfix: Hide search bar in public link context
+
+The search bar in a public link context has been hidden because it requires authentication.
+
+https://github.com/owncloud/web/issues/7603
+https://github.com/owncloud/web/pull/7849

--- a/packages/web-app-search/src/portals/SearchBar.vue
+++ b/packages/web-app-search/src/portals/SearchBar.vue
@@ -99,12 +99,18 @@ import { providerStore } from '../service'
 import { createLocationCommon } from 'web-app-files/src/router'
 import Mark from 'mark.js'
 import debounce from 'lodash-es/debounce'
+import { useStore, useUserContext } from 'web-pkg/src/composables'
 import { eventBus } from 'web-pkg/src/services/eventBus'
 import { defineComponent } from '@vue/composition-api'
-import {mapGetters} from "vuex";
 
 export default defineComponent({
   name: 'SearchBar',
+  setup() {
+   const store = useStore()
+    return {
+      isUserContext: useUserContext({ store })
+    }
+  },
 
   data() {
     return {
@@ -122,8 +128,6 @@ export default defineComponent({
     }
   },
   computed: {
-    ...mapGetters(['user']),
-
     showNoResults() {
       return this.searchResults.every(({ result }) => !result.values.length)
     },
@@ -131,7 +135,7 @@ export default defineComponent({
       return this.providerStore.availableProviders
     },
     isSearchBarEnabled() {
-      return this.availableProviders.length && this.user?.id
+      return this.availableProviders.length && this.isUserContext
     },
     displayProviders() {
       /**

--- a/packages/web-app-search/src/portals/SearchBar.vue
+++ b/packages/web-app-search/src/portals/SearchBar.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="availableProviders.length"
+    v-if="isSearchBarEnabled"
     id="files-global-search"
     ref="searchBar"
     class="oc-flex"
@@ -101,6 +101,7 @@ import Mark from 'mark.js'
 import debounce from 'lodash-es/debounce'
 import { eventBus } from 'web-pkg/src/services/eventBus'
 import { defineComponent } from '@vue/composition-api'
+import {mapGetters} from "vuex";
 
 export default defineComponent({
   name: 'SearchBar',
@@ -121,11 +122,16 @@ export default defineComponent({
     }
   },
   computed: {
+    ...mapGetters(['user']),
+
     showNoResults() {
       return this.searchResults.every(({ result }) => !result.values.length)
     },
     availableProviders() {
       return this.providerStore.availableProviders
+    },
+    isSearchBarEnabled() {
+      return this.availableProviders.length && this.user?.id
     },
     displayProviders() {
       /**
@@ -191,11 +197,15 @@ export default defineComponent({
   },
 
   mounted() {
-    this.resizeObserver.observe(this.$refs.searchBar)
+    if (this.isSearchBarEnabled) {
+      this.resizeObserver.observe(this.$refs.searchBar)
+    }
   },
 
   beforeDestroy() {
-    this.resizeObserver.unobserve(this.$refs.searchBar)
+    if (this.isSearchBarEnabled) {
+      this.resizeObserver.unobserve(this.$refs.searchBar)
+    }
   },
 
   methods: {

--- a/packages/web-app-search/tests/unit/portals/SearchBar.spec.ts
+++ b/packages/web-app-search/tests/unit/portals/SearchBar.spec.ts
@@ -4,10 +4,13 @@ import SearchBar from '../../../src/portals/SearchBar.vue'
 import AsyncComputed from 'vue-async-computed'
 import { createLocationCommon } from 'web-app-files/src/router'
 import flushPromises from 'flush-promises'
+import { createStore } from 'vuex-extensions'
+import Vuex from 'vuex'
 
 const localVue = createLocalVue()
 localVue.use(DesignSystem)
 localVue.use(AsyncComputed)
+localVue.use(Vuex)
 
 let wrapper: Wrapper<any>
 
@@ -87,8 +90,12 @@ afterEach(() => {
 })
 
 describe('Search Bar portal component', () => {
-  test('does not render a search field if not all requirements are fulfilled', () => {
+  test('does not render a search field if no availableProviders given', () => {
     wrapper = getMountedWrapper({ data: { providerStore: { availableProviders: [] } } })
+    expect(wrapper.element.innerHTML).toBeFalsy()
+  })
+  test('does not render a search field if no user given', () => {
+    wrapper = getMountedWrapper({ user: { id: '' } })
     expect(wrapper.element.innerHTML).toBeFalsy()
   })
   test('updates the search term on input', () => {
@@ -236,7 +243,7 @@ describe('Search Bar portal component', () => {
   })
 })
 
-function getMountedWrapper({ data = {}, mocks = {} } = {}) {
+function getMountedWrapper({ data = {}, mocks = {}, user = { id: 'einstein' } } = {}) {
   return mount(SearchBar, {
     localVue,
     attachTo: document.body,
@@ -262,6 +269,11 @@ function getMountedWrapper({ data = {}, mocks = {} } = {}) {
     },
     stubs: {
       'router-link': true
-    }
+    },
+    store: createStore(Vuex.Store, {
+      getters: {
+        user: () => user
+      }
+    })
   })
 }

--- a/packages/web-app-search/tests/unit/portals/SearchBar.spec.ts
+++ b/packages/web-app-search/tests/unit/portals/SearchBar.spec.ts
@@ -6,11 +6,13 @@ import { createLocationCommon } from 'web-app-files/src/router'
 import flushPromises from 'flush-promises'
 import { createStore } from 'vuex-extensions'
 import Vuex from 'vuex'
+import CompositionAPI from '@vue/composition-api'
 
 const localVue = createLocalVue()
 localVue.use(DesignSystem)
 localVue.use(AsyncComputed)
 localVue.use(Vuex)
+localVue.use(CompositionAPI)
 
 let wrapper: Wrapper<any>
 
@@ -95,7 +97,7 @@ describe('Search Bar portal component', () => {
     expect(wrapper.element.innerHTML).toBeFalsy()
   })
   test('does not render a search field if no user given', () => {
-    wrapper = getMountedWrapper({ user: { id: '' } })
+    wrapper = getMountedWrapper({ isUserContextReady: false })
     expect(wrapper.element.innerHTML).toBeFalsy()
   })
   test('updates the search term on input', () => {
@@ -243,7 +245,7 @@ describe('Search Bar portal component', () => {
   })
 })
 
-function getMountedWrapper({ data = {}, mocks = {}, user = { id: 'einstein' } } = {}) {
+function getMountedWrapper({ data = {}, mocks = {}, isUserContextReady = true } = {}) {
   return mount(SearchBar, {
     localVue,
     attachTo: document.body,
@@ -271,8 +273,18 @@ function getMountedWrapper({ data = {}, mocks = {}, user = { id: 'einstein' } } 
       'router-link': true
     },
     store: createStore(Vuex.Store, {
-      getters: {
-        user: () => user
+      modules: {
+        runtime: {
+          namespaced: true,
+          modules: {
+            auth: {
+              namespaced: true,
+              getters: {
+                isUserContextReady: () => isUserContextReady
+              }
+            }
+          }
+        }
       }
     })
   })


### PR DESCRIPTION
## Description
The search bar in a public link context has been hidden because it requires authentication.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7603

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
