### PR TITLE
Fix link indicator on 'Shared with me'-page

### DIFF
--- a/changelog/unreleased/bugfix-link-indicator-shared-with-me
+++ b/changelog/unreleased/bugfix-link-indicator-shared-with-me
@@ -1,0 +1,6 @@
+Bugfix: Link indicator on "Shared with me"-page
+
+Link indicators in the sidebar on the "Shared with me"-page will now be displayed correctly.
+
+https://github.com/owncloud/web/issues/7697
+https://github.com/owncloud/web/pull/7853

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -146,7 +146,7 @@
   </div>
 </template>
 <script lang="ts">
-import { ComputedRef, defineComponent, inject, ref } from '@vue/composition-api'
+import { ComputedRef, defineComponent, inject } from '@vue/composition-api'
 import { mapActions, mapGetters } from 'vuex'
 import { ImageDimension } from '../../../constants'
 import { loadPreview } from 'web-pkg/src/helpers/preview'
@@ -168,30 +168,19 @@ import { createFileRouteOptions } from 'web-pkg/src/helpers/router'
 
 export default defineComponent({
   name: 'FileDetails',
-  inject: {
-    displayedItem: { from: 'displayedItem' }
-  },
   setup() {
-    const sharedParentDir = ref('')
-    const sharedParentFileId = ref('')
     const store = useStore()
 
     return {
-      sharedParentDir,
-      sharedParentFileId,
       isPublicLinkContext: usePublicLinkContext({ store }),
       accessToken: useAccessToken({ store }),
-      space: inject<ComputedRef<Resource>>('displayedSpace')
+      space: inject<ComputedRef<Resource>>('displayedSpace'),
+      file: inject<ComputedRef<Resource>>('displayedItem')
     }
   },
 
   data: () => ({
     loading: false,
-    sharedByName: '',
-    sharedByDisplayName: '',
-    sharedTime: 0,
-    sharedItem: null,
-    shareIndicators: [],
     copiedDirect: false,
     copiedEos: false,
     timeout: null
@@ -201,9 +190,6 @@ export default defineComponent({
     ...mapGetters('Files', ['versions', 'sharesTree', 'sharesTreeLoading', 'highlightedFile']),
     ...mapGetters(['user', 'configuration']),
 
-    file() {
-      return this.displayedItem.value
-    },
     matchingSpace() {
       return this.space || this.spaces.find((space) => space.id === this.file.storageId)
     },
@@ -365,46 +351,48 @@ export default defineComponent({
         this.file.owner?.[0].username === this.user.id ||
         this.file.shareOwner === this.user.id
       )
+    },
+    shareIndicators() {
+      return getIndicators(this.file, this.sharesTree)
+    },
+    shares() {
+      if (this.sharedParentDir === null) {
+        return []
+      }
+      return this.sharesTree[this.sharedParentDir]?.filter((s) =>
+        ShareTypes.containsAnyValue(
+          [...ShareTypes.individuals, ...ShareTypes.unauthenticated],
+          [s.shareType]
+        )
+      )
+    },
+    sharedItem() {
+      return this.shares.length ? this.shares[0] : null
+    },
+    sharedByName() {
+      return this.sharedItem?.owner?.name
+    },
+    sharedByDisplayName() {
+      let sharedByDisplayName = this.sharedItem?.owner?.displayName
+      if (this.sharedItem?.owner?.additionalInfo) {
+        sharedByDisplayName += ' (' + this.sharedItem.owner.additionalInfo + ')'
+      }
+      return sharedByDisplayName
+    },
+    sharedParentDir() {
+      return this.getParentSharePath(this.file.path, this.sharesTree)
+    },
+    sharedParentFileId() {
+      return this.sharedItem?.file?.source
     }
   },
   watch: {
-    file() {
-      this.loadData()
-    },
-    sharesTree: {
-      handler() {
-        // missing early return
-        this.sharedItem = null
-        this.shareIndicators = getIndicators(this.highlightedFile, this.sharesTree)
-        const sharePathParentOrCurrent = this.getParentSharePath(this.file.path, this.sharesTree)
-        if (sharePathParentOrCurrent === null) {
-          return
-        }
-        const shares = this.sharesTree[sharePathParentOrCurrent]?.filter((s) =>
-          ShareTypes.containsAnyValue(
-            [...ShareTypes.individuals, ...ShareTypes.unauthenticated],
-            [s.shareType]
-          )
-        )
-        if (shares.length === 0) {
-          return
-        }
-
-        this.sharedItem = shares[0]
-        this.sharedByName = this.sharedItem.owner?.name
-        this.sharedByDisplayName = this.sharedItem.owner?.displayName
-        if (this.sharedItem.owner?.additionalInfo) {
-          this.sharedByDisplayName += ' (' + this.sharedItem.owner.additionalInfo + ')'
-        }
-        this.sharedTime = this.sharedItem.stime
-        this.sharedParentDir = sharePathParentOrCurrent
-        this.sharedParentFileId = shares[0].file?.source
+    file: {
+      handler: function () {
+        this.loadData()
       },
       immediate: true
     }
-  },
-  mounted() {
-    this.loadData()
   },
   asyncComputed: {
     preview: {

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.ts
@@ -169,6 +169,17 @@ function createWrapper(
         }
       },
       modules: {
+        runtime: {
+          namespaced: true,
+          modules: {
+            spaces: {
+              namespaced: true,
+              getters: {
+                spaces: () => []
+              }
+            }
+          }
+        },
         Files: {
           namespaced: true,
           state: {
@@ -215,12 +226,8 @@ function createWrapper(
           auth: !publicLinkContext
         }
       },
-      $router: jest.fn()
-    },
-    provide: {
-      displayedItem: {
-        value: testResource
-      }
+      $router: jest.fn(),
+      file: testResource
     }
   })
 }

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.ts.snap
@@ -15,7 +15,12 @@ exports[`Details SideBar Panel displays a resource of type file on a private pag
         <th scope="col" class="oc-pr-s">Last modified</th>
         <td><span>ABSOLUTE_TIME</span></td>
       </tr>
-      <!---->
+      <tr data-testid="shared-via">
+        <th scope="col" class="oc-pr-s">Shared via</th>
+        <td>
+          <router-link-stub to="[object Object]"><span>/Shares</span></router-link-stub>
+        </td>
+      </tr>
       <!---->
       <tr data-testid="ownerDisplayName">
         <th scope="col" class="oc-pr-s">Owner</th>


### PR DESCRIPTION
## Description
Link indicators in the sidebar on the "Shared with me"-page will now be displayed correctly.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7697

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
