### PR TITLE
Allow non 200 app external axios responses 

### DIFF
--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -120,7 +120,7 @@ export default defineComponent({
         switch (response.status) {
           case 425:
             this.errorMessage = this.$gettext(
-              'The requested file is not yet available, please try again later.'
+              'This file is currently being processed and is not yet available for use. Please try again shortly.'
             )
             break
           default:

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -112,13 +112,24 @@ export default defineComponent({
         ...(this.applicationName && { app_name: this.applicationName })
       })
       const url = `${baseUrl}?${query}`
-      const response = await this.makeRequest('POST', url)
+      const response = await this.makeRequest('POST', url, {
+        validateStatus: () => true
+      })
 
       if (response.status !== 200) {
-        this.errorMessage = response.message
+        switch (response.status) {
+          case 425:
+            this.errorMessage = this.$gettext(
+              'The requested file is not yet available, please try again later.'
+            )
+            break
+          default:
+            this.errorMessage = response.data?.message
+        }
+
         this.loading = false
         this.loadingError = true
-        console.error('Error fetching app information', response.status, this.errorMessage)
+        console.error('Error fetching app information', response.status, response.data.message)
         return
       }
 

--- a/packages/web-app-external/tests/unit/__snapshots__/app.spec.ts.snap
+++ b/packages/web-app-external/tests/unit/__snapshots__/app.spec.ts.snap
@@ -25,7 +25,7 @@ exports[`The app provider extension should be able to load an iFrame via post 1`
 exports[`The app provider extension should fail for unauthenticated users 1`] = `
 <main class="oc-height-1-1 oc-flex oc-flex-center oc-flex-middle">
   <h1 class="oc-invisible-sr">"exampleApp" app page</h1>
-  <errorscreen-stub message="Login Required"></errorscreen-stub>
+  <errorscreen-stub message="Error retrieving file information"></errorscreen-stub>
   <!---->
   <!---->
 </main>
@@ -43,7 +43,7 @@ exports[`The app provider extension should show a loading spinner while loading 
 exports[`The app provider extension should show a meaningful message if an error occurs during loading 1`] = `
 <main class="oc-height-1-1 oc-flex oc-flex-center oc-flex-middle">
   <h1 class="oc-invisible-sr">"exampleApp" app page</h1>
-  <errorscreen-stub message="We encountered an internal error"></errorscreen-stub>
+  <errorscreen-stub message="Error retrieving file information"></errorscreen-stub>
   <!---->
   <!---->
 </main>


### PR DESCRIPTION
## Description
Axios blocked all non 200 responses when opening an external application.
This pr allows axios to continue and handles the error cases on its own.