### PR TITLE
continue on non 2xx responses

### DIFF
--- a/changelog/unreleased/bugfix-external-app-error-handling
+++ b/changelog/unreleased/bugfix-external-app-error-handling
@@ -1,0 +1,6 @@
+Bugfix: Handle non 2xx external app responses
+
+Axios no longer skips on non 200 status responses in app-external.
+If the status is not 2xx, the application now displays a proper error message.
+
+https://github.com/owncloud/web/pull/7861

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -112,7 +112,9 @@ export default defineComponent({
         ...(this.applicationName && { app_name: this.applicationName })
       })
       const url = `${baseUrl}?${query}`
-      const response = await this.makeRequest('POST', url)
+      const response = await this.makeRequest('POST', url, {
+        validateStatus: () => true
+      })
 
       if (response.status !== 200) {
         this.errorMessage = response.message

--- a/packages/web-runtime/src/helpers/additionalTranslations.ts
+++ b/packages/web-runtime/src/helpers/additionalTranslations.ts
@@ -4,7 +4,9 @@ function $gettext(msg: string): string {
 }
 
 export const additionalTranslations = {
-  fileNotAvailable: $gettext('The requested file is not yet available, please try again later.'),
+  fileInProcessing: $gettext(
+    'This file is currently being processed and is not yet available for use. Please try again shortly.'
+  ),
   activities: $gettext('Activities'),
   noActivities: $gettext('No activities'),
   virusDetectedActivity: $gettext(

--- a/packages/web-runtime/src/helpers/additionalTranslations.ts
+++ b/packages/web-runtime/src/helpers/additionalTranslations.ts
@@ -4,6 +4,7 @@ function $gettext(msg: string): string {
 }
 
 export const additionalTranslations = {
+  fileNotAvailable: $gettext('The requested file is not yet available, please try again later.'),
   activities: $gettext('Activities'),
   noActivities: $gettext('No activities'),
   virusDetectedActivity: $gettext(


### PR DESCRIPTION
## Description
Axios stopped execution if the response code was not 2xx, in those cases the app error message was never shown as expected. This pr allows axios to continue and does the error handling on its own.