### PR TITLE
Disable share renaming

### DIFF
--- a/changelog/unreleased/enhancement-disable-share-renaming
+++ b/changelog/unreleased/enhancement-disable-share-renaming
@@ -1,0 +1,5 @@
+Enhancement: Disable share renaming
+
+Renaming of shares has been disabled temporarily until it works as expected.
+
+https://github.com/owncloud/web/pull/7865

--- a/packages/web-app-files/src/mixins/actions/rename.ts
+++ b/packages/web-app-files/src/mixins/actions/rename.ts
@@ -41,6 +41,12 @@ export default {
               return false
             }
 
+            // FIXME: Remove this check as soon as renaming shares works as expected
+            const rootShareIncluded = resources.some((r) => r.shareId && r.path === '/')
+            if (rootShareIncluded) {
+              return false
+            }
+
             const renameDisabled = resources.some((resource) => {
               return !resource.canRename()
             })

--- a/packages/web-app-files/src/mixins/actions/rename.ts
+++ b/packages/web-app-files/src/mixins/actions/rename.ts
@@ -42,6 +42,7 @@ export default {
             }
 
             // FIXME: Remove this check as soon as renaming shares works as expected
+            // see https://github.com/owncloud/ocis/issues/4866
             const rootShareIncluded = resources.some((r) => r.shareId && r.path === '/')
             if (rootShareIncluded) {
               return false


### PR DESCRIPTION
## Description
Renaming of shares has been disabled temporarily until it works as expected. Also see https://github.com/owncloud/ocis/issues/4866

**Note:** We need to merge this before GA if the issue has not been solved until then.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
