### PR TITLE
Fix share editing after selecting a space

### DIFF
--- a/changelog/unreleased/bugfix-share-editing-not-possible
+++ b/changelog/unreleased/bugfix-share-editing-not-possible
@@ -1,0 +1,6 @@
+Bugfix: Share editing after selecting a space
+
+We've fixed a bug where editing or deleting shares in the personal space was not possible if a project space was selected previously.
+
+https://github.com/owncloud/web/pull/7873
+https://github.com/owncloud/web/issues/7872

--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -83,7 +83,7 @@ import {
   shareInviteCollaboratorHelpCern
 } from '../../../helpers/contextualHelpers'
 import { computed, defineComponent, PropType } from '@vue/composition-api'
-import { SpaceResource } from 'web-client/src/helpers'
+import { isProjectSpaceResource, SpaceResource } from 'web-client/src/helpers'
 import { createFileRouteOptions } from 'web-pkg/src/helpers/router'
 
 export default defineComponent({
@@ -347,6 +347,8 @@ export default defineComponent({
 
     isShareModifiable(collaborator) {
       if (
+        this.space &&
+        isProjectSpaceResource(this.space) &&
         this.currentUserIsMemberOfSpace &&
         !this.space?.spaceRoles.manager.includes(this.user.uuid)
       ) {


### PR DESCRIPTION
## Description
We've fixed a bug where editing or deleting shares in the personal space was not possible if a project space was selected previously.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7872

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
