### PR TITLE
Hide share indicators on public page

### DIFF
--- a/changelog/unreleased/bugfix-hide-share-indicators-on-public-page
+++ b/changelog/unreleased/bugfix-hide-share-indicators-on-public-page
@@ -1,0 +1,6 @@
+Bugfix: Hide share indicators on public page
+
+Share indicators are now being hidden on public link pages.
+
+https://github.com/owncloud/web/pull/7889
+https://github.com/owncloud/web/issues/7888

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -19,7 +19,7 @@
         <oc-resource-icon class="details-icon" :resource="file" size="xxxlarge" />
       </div>
       <div
-        v-if="shareIndicators.length"
+        v-if="!isPublicLinkContext && shareIndicators.length"
         key="file-shares"
         data-testid="sharingInfo"
         class="oc-flex oc-flex-middle oc-my-m"

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/__snapshots__/FileDetails.spec.ts.snap
@@ -226,10 +226,7 @@ exports[`Details SideBar Panel displays a resource of type file on a public page
     <div data-testid="preview" class="details-preview oc-flex oc-flex-middle oc-flex-center oc-mb" style="background-image: none;">
       <oc-spinner-stub></oc-spinner-stub>
     </div>
-    <div data-testid="sharingInfo" class="oc-flex oc-flex-middle oc-my-m">
-      <oc-status-indicators-stub resource="[object Object]" indicators="[object Object]"></oc-status-indicators-stub>
-      <p class="oc-my-rm oc-mx-s">This file has been shared.</p>
-    </div>
+    <!---->
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
         <th scope="col" class="oc-pr-s">Last modified</th>
@@ -265,10 +262,7 @@ exports[`Details SideBar Panel displays a resource of type file on a public page
     <div data-testid="preview" class="details-preview oc-flex oc-flex-middle oc-flex-center oc-mb" style="background-image: none;">
       <oc-spinner-stub></oc-spinner-stub>
     </div>
-    <div data-testid="sharingInfo" class="oc-flex oc-flex-middle oc-my-m">
-      <oc-status-indicators-stub resource="[object Object]" indicators="[object Object]"></oc-status-indicators-stub>
-      <p class="oc-my-rm oc-mx-s">This file has been shared.</p>
-    </div>
+    <!---->
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
         <th scope="col" class="oc-pr-s">Last modified</th>
@@ -458,10 +452,7 @@ exports[`Details SideBar Panel displays a resource of type folder on a public pa
     <div class="details-icon-wrapper oc-width-1-1 oc-flex oc-flex-middle oc-flex-center oc-mb">
       <oc-resource-icon-stub resource="[object Object]" size="xxxlarge" class="details-icon"></oc-resource-icon-stub>
     </div>
-    <div data-testid="sharingInfo" class="oc-flex oc-flex-middle oc-my-m">
-      <oc-status-indicators-stub resource="[object Object]" indicators="[object Object]"></oc-status-indicators-stub>
-      <p class="oc-my-rm oc-mx-s">This folder has been shared.</p>
-    </div>
+    <!---->
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
         <th scope="col" class="oc-pr-s">Last modified</th>
@@ -497,10 +488,7 @@ exports[`Details SideBar Panel displays a resource of type folder on a public pa
     <div class="details-icon-wrapper oc-width-1-1 oc-flex oc-flex-middle oc-flex-center oc-mb">
       <oc-resource-icon-stub resource="[object Object]" size="xxxlarge" class="details-icon"></oc-resource-icon-stub>
     </div>
-    <div data-testid="sharingInfo" class="oc-flex oc-flex-middle oc-my-m">
-      <oc-status-indicators-stub resource="[object Object]" indicators="[object Object]"></oc-status-indicators-stub>
-      <p class="oc-my-rm oc-mx-s">This folder has been shared.</p>
-    </div>
+    <!---->
     <table aria-label="Overview of the information about the selected file" class="details-table">
       <tr data-testid="timestamp">
         <th scope="col" class="oc-pr-s">Last modified</th>


### PR DESCRIPTION
## Description
Share indicators are now being hidden on public link pages.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7888

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
