### PR TITLE
Add validation for space names

### DIFF
--- a/changelog/unreleased/enhancement-validate-space-names
+++ b/changelog/unreleased/enhancement-validate-space-names
@@ -1,0 +1,5 @@
+Enhancement: Validate space names
+
+Spaces names are now being validated when creating or renaming spaces. The following special characters are not allowed: / \ . : ? * " > < |
+
+https://github.com/owncloud/web/pull/7890

--- a/packages/web-app-files/src/components/AppBar/CreateSpace.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateSpace.vue
@@ -59,8 +59,17 @@ export default defineComponent({
 
     checkSpaceName(name) {
       if (name.trim() === '') {
-        this.setModalInputErrorMessage(this.$gettext('Space name cannot be empty'))
-        return
+        return this.setModalInputErrorMessage(this.$gettext('Space name cannot be empty'))
+      }
+      if (name.length > 255) {
+        return this.setModalInputErrorMessage(
+          this.$gettext('Space name cannot exceed 255 characters')
+        )
+      }
+      if (/[/\\.:?*"><|]/.test(name)) {
+        return this.setModalInputErrorMessage(
+          this.$gettext('Space name cannot contain the following characters: / \\ . : ? * " > < |')
+        )
       }
       return this.setModalInputErrorMessage(null)
     },

--- a/packages/web-app-files/src/mixins/spaces/actions/rename.js
+++ b/packages/web-app-files/src/mixins/spaces/actions/rename.js
@@ -62,6 +62,16 @@ export default {
       if (name.trim() === '') {
         return this.setModalInputErrorMessage(this.$gettext('Space name cannot be empty'))
       }
+      if (name.length > 255) {
+        return this.setModalInputErrorMessage(
+          this.$gettext('Space name cannot exceed 255 characters')
+        )
+      }
+      if (/[/\\.:?*"><|]/.test(name)) {
+        return this.setModalInputErrorMessage(
+          this.$gettext('Space name cannot contain the following characters: / \\ . : ? * " > < |')
+        )
+      }
       return this.setModalInputErrorMessage(null)
     },
 

--- a/packages/web-app-files/tests/unit/components/AppBar/CreateSpace.spec.js
+++ b/packages/web-app-files/tests/unit/components/AppBar/CreateSpace.spec.js
@@ -33,6 +33,16 @@ describe('CreateSpace component', () => {
     expect(spyInputErrorMessageStub).toHaveBeenCalledWith('Space name cannot be empty')
   })
 
+  it('should throw an error with an space name longer than 255 characters', async () => {
+    const wrapper = getMountedWrapper()
+    wrapper.vm.setModalInputErrorMessage = jest.fn()
+
+    const spyInputErrorMessageStub = jest.spyOn(wrapper.vm, 'setModalInputErrorMessage')
+    await wrapper.vm.checkSpaceName('n'.repeat(256))
+
+    expect(spyInputErrorMessageStub).toHaveBeenCalledTimes(1)
+  })
+
   it.each(['/', '\\', '.', ':', '?', '*', '"', '>', '<', '|'])(
     'should show an error message when trying to create a space with a special character',
     (specialChar) => {

--- a/packages/web-app-files/tests/unit/components/AppBar/CreateSpace.spec.js
+++ b/packages/web-app-files/tests/unit/components/AppBar/CreateSpace.spec.js
@@ -32,6 +32,19 @@ describe('CreateSpace component', () => {
 
     expect(spyInputErrorMessageStub).toHaveBeenCalledWith('Space name cannot be empty')
   })
+
+  it.each(['/', '\\', '.', ':', '?', '*', '"', '>', '<', '|'])(
+    'should show an error message when trying to create a space with a special character',
+    (specialChar) => {
+      const wrapper = getMountedWrapper()
+      wrapper.vm.setModalInputErrorMessage = jest.fn()
+
+      const spyInputErrorMessageStub = jest.spyOn(wrapper.vm, 'setModalInputErrorMessage')
+      wrapper.vm.checkSpaceName(specialChar)
+
+      expect(spyInputErrorMessageStub).toHaveBeenCalledTimes(1)
+    }
+  )
 })
 
 function getMountedWrapper() {

--- a/packages/web-app-files/tests/unit/mixins/spaces/rename.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/spaces/rename.spec.js
@@ -41,6 +41,13 @@ describe('rename', () => {
 
       expect(spyInputErrorMessageStub).toHaveBeenCalledTimes(1)
     })
+    it('should throw an error with an space name longer than 255 characters', async () => {
+      const wrapper = getWrapper()
+      const spyInputErrorMessageStub = jest.spyOn(wrapper.vm, 'setModalInputErrorMessage')
+      await wrapper.vm.$_rename_checkName('n'.repeat(256))
+
+      expect(spyInputErrorMessageStub).toHaveBeenCalledTimes(1)
+    })
     it.each(['/', '\\', '.', ':', '?', '*', '"', '>', '<', '|'])(
       'should show an error message when trying to create a space with a special character',
       (specialChar) => {

--- a/packages/web-app-files/tests/unit/mixins/spaces/rename.spec.js
+++ b/packages/web-app-files/tests/unit/mixins/spaces/rename.spec.js
@@ -41,6 +41,18 @@ describe('rename', () => {
 
       expect(spyInputErrorMessageStub).toHaveBeenCalledTimes(1)
     })
+    it.each(['/', '\\', '.', ':', '?', '*', '"', '>', '<', '|'])(
+      'should show an error message when trying to create a space with a special character',
+      (specialChar) => {
+        const wrapper = getWrapper()
+        wrapper.vm.setModalInputErrorMessage = jest.fn()
+
+        const spyInputErrorMessageStub = jest.spyOn(wrapper.vm, 'setModalInputErrorMessage')
+        wrapper.vm.$_rename_checkName(specialChar)
+
+        expect(spyInputErrorMessageStub).toHaveBeenCalledTimes(1)
+      }
+    )
   })
 
   describe('method "$_rename_renameSpace"', () => {


### PR DESCRIPTION
## Description
Spaces names are now being validated when creating or renaming spaces. The following special characters are not allowed: `/ \ . : ? * " > < |`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/4925

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
