### PR TITLE
feat: respect denial capability

### DIFF
--- a/changelog/unreleased/enhancement-capability-share-denial
+++ b/changelog/unreleased/enhancement-capability-share-denial
@@ -1,0 +1,6 @@
+Enhancement: Respect the new sharing denials capability (experimental)
+
+The oCIS backend has added a new capability, files_sharing.enable_denials, which announces to clients if the experimental "No access" sharing role is supposed to be available. This capability is now respected by web, so that users only see the experimental "No access" role if the backend allows it.
+
+https://github.com/owncloud/web/pull/7892
+https://github.com/owncloud/ocis/pull/4903

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.js
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.js
@@ -25,7 +25,8 @@ const folderMock = {
   name: 'lorem.txt',
   privateLink: 'some-link',
   canShare: jest.fn(() => true),
-  path: '/documents'
+  path: '/documents',
+  canDeny: () => false
 }
 
 const spaceMock = {

--- a/packages/web-pkg/src/composables/capability/useCapability.ts
+++ b/packages/web-pkg/src/composables/capability/useCapability.ts
@@ -52,6 +52,14 @@ export const useCapabilityFilesTusExtension = createCapabilityComposable<string>
   'files.tus_support.extension',
   ''
 )
+export const useCapabilityFilesSharingCanDenyAccess = createCapabilityComposable(
+  'files_sharing.deny_access',
+  false
+)
+export const useCapabilityFilesSharingAllowCustomPermissions = createCapabilityComposable(
+  'files_sharing.allow_custom',
+  true
+)
 export const useCapabilityFilesSharingPublicCanEdit = createCapabilityComposable(
   'files_sharing.public.can_edit',
   false


### PR DESCRIPTION
## Description
Since https://github.com/owncloud/ocis/pull/4903 has been merged today, web shows the experimental sharing denial feature (via the "No access" role) by default. oCIS added a capability to announce to clients whether or not the feature is available and should be shown to users. With this PR web now respects that capability.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
