### PR TITLE
Fix issues with the 'Keep both'-conflict option

### DIFF
--- a/changelog/unreleased/bugfix-keep-both-conflict-option
+++ b/changelog/unreleased/bugfix-keep-both-conflict-option
@@ -1,0 +1,6 @@
+Bugfix: "Keep both"-conflict option
+
+We've fixed an issue with the "Keep both"-conflict option where uploaded folders would get mixed up.
+
+https://github.com/owncloud/web/issues/7903
+https://github.com/owncloud/web/pull/7905

--- a/packages/web-app-files/src/helpers/resource/actions/upload.ts
+++ b/packages/web-app-files/src/helpers/resource/actions/upload.ts
@@ -163,15 +163,15 @@ export class ResourcesUpload extends ConflictDialog {
       for (const file of filesInFolder) {
         const newFolderName = resolveFileNameDuplicate(folder, '', this.currentFiles)
         file.meta.relativeFolder = file.meta.relativeFolder.replace(
-          new RegExp(`/${folder}` + '$'),
+          new RegExp(`/${folder}`),
           `/${newFolderName}`
         )
         file.meta.relativePath = file.meta.relativePath.replace(
-          new RegExp(`/${folder}/` + '$'),
+          new RegExp(`/${folder}/`),
           `/${newFolderName}/`
         )
         file.meta.tusEndpoint = file.meta.tusEndpoint.replace(
-          new RegExp(`/${folder}` + '$'),
+          new RegExp(`/${folder}`),
           `/${newFolderName}`
         )
       }


### PR DESCRIPTION
## Description
We've fixed an issue with the "Keep both"-conflict option where uploaded folders would get mixed up.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7903

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
