### PR TITLE
Increase default XHR timeout and make it configurable

### DIFF
--- a/changelog/unreleased/enhancement-xhr-timeout
+++ b/changelog/unreleased/enhancement-xhr-timeout
@@ -1,0 +1,6 @@
+Enhancement: XHR upload timeout
+
+The default timeout for XHR uploads has been increased from 30 to 60 seconds. Also, it can now be configured via the `config.json` file (in ms).
+
+https://github.com/owncloud/web/issues/7900
+https://github.com/owncloud/web/pull/7912

--- a/config/config.json.sample-oc10
+++ b/config/config.json.sample-oc10
@@ -14,5 +14,12 @@
     "search",
     "text-editor",
     "draw-io"
-  ]
+  ],
+  "options" : {
+    "upload": {
+      "xhr": {
+        "timeout": 30000
+      }
+    }
+  }
 }

--- a/config/config.json.sample-oc10
+++ b/config/config.json.sample-oc10
@@ -18,7 +18,7 @@
   "options" : {
     "upload": {
       "xhr": {
-        "timeout": 30000
+        "timeout": 60000
       }
     }
   }

--- a/config/config.json.sample-ocis
+++ b/config/config.json.sample-ocis
@@ -30,6 +30,11 @@
       "image/png",
       "image/jpeg",
       "text/plain"
-    ]
+    ],
+    "upload": {
+      "xhr": {
+        "timeout": 30000
+      }
+    }
   }
 }

--- a/config/config.json.sample-ocis
+++ b/config/config.json.sample-ocis
@@ -33,7 +33,7 @@
     ],
     "upload": {
       "xhr": {
-        "timeout": 30000
+        "timeout": 60000
       }
     }
   }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -62,6 +62,7 @@ substring of a value of the authenticated user. Examples are `/Shares`, `/{{.Id}
 hovers the row with his mouse. Defaults to `false`.
 - `option.routing` This accepts an object with the following fields to customize the routing behaviour:
   - `options.routing.idBased` Enable or disable fileIds being added to the URL. Defaults to `true` because otherwise e.g. spaces with name clashes can't be resolved correctly. Only disable this if you can guarantee server side that spaces of the same namespace can't have name clashes.   
+- `options.upload.xhr.timeout` Specifies the timeout for XHR uploads in milliseconds.
 
 ### Sentry
 

--- a/packages/web-runtime/src/composables/upload/useUpload.ts
+++ b/packages/web-runtime/src/composables/upload/useUpload.ts
@@ -104,7 +104,8 @@ export function useUpload(options: UploadOptions): UploadResult {
       ...(isTusSupported && {
         tusMaxChunkSize: unref(tusMaxChunkSize),
         tusHttpMethodOverride: unref(tusHttpMethodOverride),
-        tusExtension: unref(tusExtension)
+        tusExtension: unref(tusExtension),
+        xhrTimeout: store.getters.configuration?.options?.upload?.xhr?.timeout || 60000
       })
     }
   })

--- a/packages/web-runtime/src/composables/upload/useUpload.ts
+++ b/packages/web-runtime/src/composables/upload/useUpload.ts
@@ -104,7 +104,9 @@ export function useUpload(options: UploadOptions): UploadResult {
       ...(isTusSupported && {
         tusMaxChunkSize: unref(tusMaxChunkSize),
         tusHttpMethodOverride: unref(tusHttpMethodOverride),
-        tusExtension: unref(tusExtension),
+        tusExtension: unref(tusExtension)
+      }),
+      ...(!isTusSupported && {
         xhrTimeout: store.getters.configuration?.options?.upload?.xhr?.timeout || 60000
       })
     }

--- a/packages/web-runtime/src/services/uppyService.ts
+++ b/packages/web-runtime/src/services/uppyService.ts
@@ -74,12 +74,13 @@ export class UppyService {
     this.uppy.use(CustomTus, tusPluginOptions as unknown as TusOptions)
   }
 
-  useXhr({ headers }: { headers: () => uppyHeaders }) {
+  useXhr({ headers, xhrTimeout }: { headers: () => uppyHeaders; xhrTimeout: number }) {
     const xhrPluginOptions: XHRUploadOptions = {
       endpoint: '',
       method: 'put',
       headers,
       formData: false,
+      timeout: xhrTimeout,
       getResponseData() {
         return {}
       }


### PR DESCRIPTION
## Description
The default timeout for XHR uploads has been increased from 30 to 60 seconds. Also, it can now be configured via the `config.json` file (in ms).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7900

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
