### PR TITLE
feat: prefer alias links over private links in UI

### DIFF
--- a/changelog/unreleased/bugfix-prefer-alias-links-over-private-links
+++ b/changelog/unreleased/bugfix-prefer-alias-links-over-private-links
@@ -1,0 +1,5 @@
+Bugfix: Prefer alias links over private links
+
+The private link capability has recently been enabled in oCIS to announce to clients that private links are available. However, if alias links are available the web ui is supposed to only show alias links. Thus the "copy private link" button has been disabled when alias links are available.
+
+https://github.com/owncloud/web/pull/7916

--- a/packages/web-app-files/src/components/SideBar/FileInfo.vue
+++ b/packages/web-app-files/src/components/SideBar/FileInfo.vue
@@ -46,6 +46,11 @@ export default {
     ...mapState('Files', ['areFileExtensionsShown']),
 
     privateLinkEnabled() {
+      if (this.capabilities.files_sharing?.public?.alias) {
+        // alias links are the next UI concept iteration for "file pointers"
+        // i.e. ignore private link capability if alias links are supported
+        return false
+      }
       return this.capabilities.files.privateLinks && this.file.privateLink
     },
 


### PR DESCRIPTION
## Description
Private link capability has been merged in ocis, see https://github.com/owncloud/ocis/pull/4599
The web ui is not supposed to show the `copy private link` button, the private link concept is only supposed to be used for cross-client links to files. The web ui concept for "file pointers" is the new alias link. Hence this PR disables the private link copy button in the web ui when the alias link capability is enabled.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
