### PR TITLE
give search more time to finish indexing

### DIFF
--- a/tests/acceptance/pageObjects/webPage.js
+++ b/tests/acceptance/pageObjects/webPage.js
@@ -14,7 +14,7 @@ module.exports = {
      */
     search: async function (searchTerm) {
       // wait for search indexing to be finished
-      await this.pause(1000)
+      await this.pause(2000)
       return this.initAjaxCounters()
         .isVisible(
           {


### PR DESCRIPTION
give search tests more time before starting the actual search, search in ocis increased the debounce time and indexing now takes longer.

https://github.com/owncloud/ocis/pull/4964