### PR TITLE
Disable 'Paste'-action in read-only folders

### DIFF
--- a/changelog/unreleased/bugfix-paste-without-write-permissions
+++ b/changelog/unreleased/bugfix-paste-without-write-permissions
@@ -1,0 +1,6 @@
+Bugfix: "Paste"-action without write permissions
+
+The "Paste"-action is now disabled in read-only folders/shares.
+
+https://github.com/owncloud/web/pull/7925
+https://github.com/owncloud/web/issues/7922

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -114,26 +114,19 @@
       </oc-list>
     </oc-drop>
     <div
+      v-if="showPasteHereButton"
       id="clipboard-btns"
       v-oc-tooltip="
-        uploadOrFileCreationBlocked ? $gettext('You have no permissions to paste files here!') : ''
+        uploadOrFileCreationBlocked ? $gettext('You have no permission to paste files here!') : ''
       "
       class="oc-button-group"
       :class="{ disabled: uploadOrFileCreationBlocked }"
     >
-      <oc-button
-        v-if="showPasteHereButton"
-        :disabled="uploadOrFileCreationBlocked"
-        @click="pasteFilesHere"
-      >
+      <oc-button :disabled="uploadOrFileCreationBlocked" @click="pasteFilesHere">
         <oc-icon fill-type="line" name="clipboard" />
         <span v-translate>Paste here</span>
       </oc-button>
-      <oc-button
-        v-if="showPasteHereButton"
-        :disabled="uploadOrFileCreationBlocked"
-        @click="clearClipboardFiles"
-      >
+      <oc-button :disabled="uploadOrFileCreationBlocked" @click="clearClipboardFiles">
         <oc-icon fill-type="line" name="close" />
       </oc-button>
     </div>

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -113,12 +113,27 @@
         </li>
       </oc-list>
     </oc-drop>
-    <div id="clipboard-btns" class="oc-button-group">
-      <oc-button v-if="showPasteHereButton" @click="pasteFilesHere">
+    <div
+      id="clipboard-btns"
+      v-oc-tooltip="
+        uploadOrFileCreationBlocked ? $gettext('You have no permissions to paste files here!') : ''
+      "
+      class="oc-button-group"
+      :class="{ disabled: uploadOrFileCreationBlocked }"
+    >
+      <oc-button
+        v-if="showPasteHereButton"
+        :disabled="uploadOrFileCreationBlocked"
+        @click="pasteFilesHere"
+      >
         <oc-icon fill-type="line" name="clipboard" />
         <span v-translate>Paste here</span>
       </oc-button>
-      <oc-button v-if="showPasteHereButton" @click="clearClipboardFiles">
+      <oc-button
+        v-if="showPasteHereButton"
+        :disabled="uploadOrFileCreationBlocked"
+        @click="clearClipboardFiles"
+      >
         <oc-icon fill-type="line" name="close" />
       </oc-button>
     </div>
@@ -682,6 +697,14 @@ export default defineComponent({
 
   :nth-child(2) {
     border-left: 0px !important;
+  }
+}
+
+#clipboard-btns.disabled {
+  opacity: 0.6;
+
+  button {
+    opacity: 1;
   }
 }
 


### PR DESCRIPTION
## Description
The "Paste"-action is now disabled in read-only folders/shares.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7922

## Screenshot

![image](https://user-images.githubusercontent.com/50302941/199983346-5a530686-7108-47c7-a99f-1d082d208d78.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
