### PR TITLE
Embedded links

### DIFF
--- a/changelog/unreleased/enhancement-embedded-links
+++ b/changelog/unreleased/enhancement-embedded-links
@@ -1,0 +1,7 @@
+Enhancement: Add embedded links
+
+We've added the possibility to add links to the application menu that are rendered inside the Web application frame.
+Moreover, it's now possible to use urls for icons and to filter for whom the link should be visible by group or role.
+
+https://github.com/owncloud/web/issues/7260
+https://github.com/owncloud/web/pull/7934

--- a/packages/web-pkg/src/composables/translations/index.ts
+++ b/packages/web-pkg/src/composables/translations/index.ts
@@ -1,1 +1,2 @@
+export * from './useCurrentLanguage'
 export * from './useTranslations'

--- a/packages/web-pkg/src/composables/translations/useCurrentLanguage.ts
+++ b/packages/web-pkg/src/composables/translations/useCurrentLanguage.ts
@@ -1,0 +1,6 @@
+import { getCurrentInstance } from '@vue/composition-api'
+
+export const useCurrentLanguage = () => {
+  const p = getCurrentInstance().proxy as any
+  return p.$language.current
+}

--- a/packages/web-pkg/src/http/client.ts
+++ b/packages/web-pkg/src/http/client.ts
@@ -30,15 +30,15 @@ export class HttpClient {
     return this.instance.options(url, this.obtainConfig(config))
   }
 
-  public patch(url: string, data?: never, config?: AxiosRequestConfig): Promise<AxiosResponse> {
+  public patch(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<AxiosResponse> {
     return this.instance.patch(url, data, this.obtainConfig(config))
   }
 
-  public post(url: string, data?: never, config?: AxiosRequestConfig): Promise<AxiosResponse> {
+  public post(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<AxiosResponse> {
     return this.instance.post(url, data, this.obtainConfig(config))
   }
 
-  public put(url: string, data?: never, config?: AxiosRequestConfig): Promise<AxiosResponse> {
+  public put(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<AxiosResponse> {
     return this.instance.put(url, data, this.obtainConfig(config))
   }
 

--- a/packages/web-runtime/src/components/Topbar/ApplicationsMenu.vue
+++ b/packages/web-runtime/src/components/Topbar/ApplicationsMenu.vue
@@ -36,7 +36,8 @@
             :variation="n.active ? 'inverse' : 'passive'"
           >
             <span class="icon-box">
-              <oc-icon :name="n.icon" />
+              <img v-if="n.iconUrl" :src="n.iconUrl" />
+              <oc-icon v-else :name="n.icon" />
             </span>
             <span v-text="$gettext(n.title)" />
             <oc-icon v-if="n.active" name="check" class="active-check" />

--- a/packages/web-runtime/src/components/Topbar/ApplicationsMenu.vue
+++ b/packages/web-runtime/src/components/Topbar/ApplicationsMenu.vue
@@ -48,16 +48,18 @@
   </nav>
 </template>
 
-<script>
+<script lang="ts">
 import { clientService } from 'web-pkg/src/services'
 import { configurationManager } from 'web-pkg/src/configuration'
 import { mapGetters } from 'vuex'
 import { urlJoin } from 'web-client/src/utils'
+import { defineComponent, PropType } from '@vue/composition-api'
+import { LinkConfig } from '../../store/config'
 
-export default {
+export default defineComponent({
   props: {
     applicationsList: {
-      type: Array,
+      type: Array as PropType<LinkConfig[]>,
       required: false,
       default: () => []
     }
@@ -88,7 +90,7 @@ export default {
       return httpClient.post(url, { isDefault: false })
     }
   }
-}
+})
 </script>
 
 <style lang="scss" scoped>

--- a/packages/web-runtime/src/components/Topbar/ApplicationsMenu.vue
+++ b/packages/web-runtime/src/components/Topbar/ApplicationsMenu.vue
@@ -54,12 +54,12 @@ import { configurationManager } from 'web-pkg/src/configuration'
 import { mapGetters } from 'vuex'
 import { urlJoin } from 'web-client/src/utils'
 import { defineComponent, PropType } from '@vue/composition-api'
-import { LinkConfig } from '../../store/config'
+import { Link } from '../../store/config'
 
 export default defineComponent({
   props: {
     applicationsList: {
-      type: Array as PropType<LinkConfig[]>,
+      type: Array as PropType<Link[]>,
       required: false,
       default: () => []
     }

--- a/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -22,7 +22,7 @@
   </header>
 </template>
 
-<script>
+<script lang="ts">
 import { mapGetters } from 'vuex'
 import NavigationMixin from '../../mixins/navigationMixin'
 
@@ -31,8 +31,9 @@ import UserMenu from './UserMenu.vue'
 import Notifications from './Notifications.vue'
 import FeedbackLink from './FeedbackLink.vue'
 import ThemeSwitcher from './ThemeSwitcher.vue'
+import { defineComponent } from '@vue/composition-api'
 
-export default {
+export default defineComponent({
   components: {
     ApplicationsMenu,
     FeedbackLink,
@@ -104,7 +105,7 @@ export default {
       return this.user?.id
     }
   }
-}
+})
 </script>
 
 <style lang="scss">

--- a/packages/web-runtime/src/mixins/navigationMixin.ts
+++ b/packages/web-runtime/src/mixins/navigationMixin.ts
@@ -1,5 +1,5 @@
 import { mapGetters } from 'vuex'
-import { LinkConfig } from '../store/config'
+import { LinkConfig, Link } from '../store/config'
 
 const applicationContainerTarget = 'application-container'
 
@@ -18,6 +18,12 @@ const checkLink = (link: LinkConfig) => {
   //   }
   // }
   return true
+}
+
+export const getTranslatedTitle = (link: LinkConfig, lang: string): string => {
+  // TODO: move language resolution to a common function
+  // FIXME: need to handle logic for variants like en_US vs en_GB
+  return link?.title?.[lang] || link?.title?.['en'] || link.name
 }
 
 export default {
@@ -49,16 +55,10 @@ export default {
           return isNavItemPermitted(permittedMenus, app)
         })
         .filter(checkLink)
-        .map((item): LinkConfig => {
-          const lang = this.$language.current
-          // TODO: move language resolution to a common function
-          // FIXME: need to handle logic for variants like en_US vs en_GB
-          let title = item.title ? item.title.en : item.name
+        .map((item): Link => {
           let icon
           let iconUrl
-          if (item.title && item.title[lang]) {
-            title = item.title[lang]
-          }
+
 
           if (!item.icon) {
             icon = 'deprecated' // "broken" icon
@@ -69,10 +69,10 @@ export default {
             iconUrl = item.icon
           }
 
-          const app: LinkConfig = {
+          const app: Link = {
             icon: icon,
             iconUrl: iconUrl,
-            title: title
+            title: getTranslatedTitle(item, this.$language.current)
           }
 
           if (item.url) {

--- a/packages/web-runtime/src/mixins/navigationMixin.ts
+++ b/packages/web-runtime/src/mixins/navigationMixin.ts
@@ -1,4 +1,5 @@
 import { mapGetters } from 'vuex'
+import { LinkConfig } from '../store/config'
 
 export default {
   computed: {
@@ -28,7 +29,7 @@ export default {
           }
           return isNavItemPermitted(permittedMenus, app)
         })
-        .map((item) => {
+        .map((item): LinkConfig => {
           const lang = this.$language.current
           // TODO: move language resolution to a common function
           // FIXME: need to handle logic for variants like en_US vs en_GB
@@ -48,7 +49,7 @@ export default {
             iconUrl = item.icon
           }
 
-          const app = {
+          const app: LinkConfig = {
             icon: icon,
             iconUrl: iconUrl,
             title: title

--- a/packages/web-runtime/src/mixins/navigationMixin.ts
+++ b/packages/web-runtime/src/mixins/navigationMixin.ts
@@ -1,6 +1,25 @@
 import { mapGetters } from 'vuex'
 import { LinkConfig } from '../store/config'
 
+const applicationContainerTarget = 'application-container'
+
+// FIXME: do not use english title but a name or an id
+// We cannot do that right now because oCIS does not pass through id or name
+export const getLinkIdentifier = (link: LinkConfig) => link.title.en
+// FIXME: see above
+const checkLink = (link: LinkConfig) => {
+  // if (link.target === applicationContainerTarget) {
+  //   if (!link.name) {
+  //     console.warn(
+  //       `Error: Menu Item with target "application-container" needs "name" specified and will not show up until it's added.`,
+  //       link
+  //     )
+  //     return false
+  //   }
+  // }
+  return true
+}
+
 export default {
   computed: {
     ...mapGetters(['getNavItemsByExtension'])
@@ -29,6 +48,7 @@ export default {
           }
           return isNavItemPermitted(permittedMenus, app)
         })
+        .filter(checkLink)
         .map((item): LinkConfig => {
           const lang = this.$language.current
           // TODO: move language resolution to a common function
@@ -56,10 +76,15 @@ export default {
           }
 
           if (item.url) {
-            app.url = item.url
-            app.target = ['_blank', '_self', '_parent', '_top'].includes(item.target)
-              ? item.target
-              : '_blank'
+            if (item.target === applicationContainerTarget) {
+              app.target = '_self'
+              app.path = `/e/${getLinkIdentifier(item)}`
+            } else {
+              app.url = item.url
+              app.target = ['_blank', '_self', '_parent', '_top'].includes(item.target)
+                ? item.target
+                : '_blank'
+            }
           } else if (item.path) {
             app.path = item.path
             app.active = activeRoutePath?.startsWith(app.path)

--- a/packages/web-runtime/src/pages/embeddedLink.vue
+++ b/packages/web-runtime/src/pages/embeddedLink.vue
@@ -1,0 +1,78 @@
+<template>
+  <div
+    class="oc-link-embedded oc-height-viewport oc-flex oc-flex-column oc-flex-center oc-flex-middle"
+  >
+    <iframe v-if="iframeSrc" :src="iframeSrc" />
+    <template v-else>
+      <div class="oc-card oc-text-center oc-width-large">
+        <div class="oc-card-header oc-link-resolve-error-title">
+          <h2 key="embedded-link-error">
+            <translate>External link error</translate>
+          </h2>
+        </div>
+        <div class="oc-card-body oc-link-embedded-error-message">
+          <p class="oc-text-xlarge">
+            <translate>This external link does not exist.</translate>
+          </p>
+        </div>
+        <div class="oc-card-footer oc-pt-rm">
+          <p>{{ footerSlogan }}</p>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, unref } from '@vue/composition-api'
+import { useRouteParam, useStore } from 'web-pkg/src'
+import { LinkConfig } from '../store/config'
+import { getLinkIdentifier } from '../mixins/navigationMixin'
+
+export default defineComponent({
+  name: 'ExternalLink',
+  setup() {
+    const store = useStore()
+    const linkId = useRouteParam('linkId')
+
+    const footerSlogan = computed(() => {
+      return store.getters.configuration.currentTheme.general.slogan
+    })
+
+    const iframeSrc = computed(() => {
+      const link = (store.getters.configuration.applications as LinkConfig[]).find((app) => {
+        return getLinkIdentifier(app) === unref(linkId)
+      })
+      if (!link) {
+        return
+      }
+
+      return link.url
+    })
+
+    return {
+      footerSlogan,
+      iframeSrc
+    }
+  }
+})
+</script>
+
+<style lang="scss">
+.oc-link-embedded {
+  iframe {
+    width: 100%;
+    height: 100%;
+  }
+
+  .oc-card {
+    background: var(--oc-color-background-highlight);
+    border-radius: 15px;
+  }
+
+  .oc-card-header h2,
+  .oc-card-footer p {
+    margin: 0;
+  }
+}
+</style>

--- a/packages/web-runtime/src/pages/embeddedLink.vue
+++ b/packages/web-runtime/src/pages/embeddedLink.vue
@@ -7,12 +7,12 @@
       <div class="oc-card oc-text-center oc-width-large">
         <div class="oc-card-header oc-link-resolve-error-title">
           <h2 key="embedded-link-error">
-            <translate>External link error</translate>
+            <translate>Embedded link error</translate>
           </h2>
         </div>
         <div class="oc-card-body oc-link-embedded-error-message">
           <p class="oc-text-xlarge">
-            <translate>This external link does not exist.</translate>
+            <translate>This embedded link does not exist.</translate>
           </p>
         </div>
         <div class="oc-card-footer oc-pt-rm">
@@ -32,7 +32,7 @@ import { useDocumentTitle } from 'web-pkg/src/composables/appDefaults/useDocumen
 import { useCurrentLanguage } from 'web-pkg/src/composables/translations'
 
 export default defineComponent({
-  name: 'ExternalLink',
+  name: 'EmbeddedLink',
   setup() {
     const store = useStore()
     const linkId = useRouteParam('linkId')

--- a/packages/web-runtime/src/pages/embeddedLink.vue
+++ b/packages/web-runtime/src/pages/embeddedLink.vue
@@ -27,28 +27,35 @@
 import { computed, defineComponent, unref } from '@vue/composition-api'
 import { useRouteParam, useStore } from 'web-pkg/src'
 import { LinkConfig } from '../store/config'
-import { getLinkIdentifier } from '../mixins/navigationMixin'
+import { getLinkIdentifier, getTranslatedTitle } from '../mixins/navigationMixin'
+import { useDocumentTitle } from 'web-pkg/src/composables/appDefaults/useDocumentTitle'
+import { useCurrentLanguage } from 'web-pkg/src/composables/translations'
 
 export default defineComponent({
   name: 'ExternalLink',
   setup() {
     const store = useStore()
     const linkId = useRouteParam('linkId')
+    const currentLanguage = useCurrentLanguage()
 
     const footerSlogan = computed(() => {
       return store.getters.configuration.currentTheme.general.slogan
     })
 
-    const iframeSrc = computed(() => {
-      const link = (store.getters.configuration.applications as LinkConfig[]).find((app) => {
+    const link = computed(() => {
+      return (store.getters.configuration.applications as LinkConfig[]).find((app) => {
         return getLinkIdentifier(app) === unref(linkId)
       })
-      if (!link) {
-        return
-      }
-
-      return link.url
     })
+
+    const iframeSrc = computed(() => {
+      return unref(link)?.url
+    })
+
+    const titleSegments = computed(() => {
+      return [getTranslatedTitle(unref(link), unref(currentLanguage))]
+    })
+    useDocumentTitle({ titleSegments })
 
     return {
       footerSlogan,

--- a/packages/web-runtime/src/router/index.ts
+++ b/packages/web-runtime/src/router/index.ts
@@ -7,6 +7,7 @@ import LogoutPage from '../pages/logout.vue'
 import OidcCallbackPage from '../pages/oidcCallback.vue'
 import ResolvePublicLinkPage from '../pages/resolvePublicLink.vue'
 import ResolvePrivateLinkPage from '../pages/resolvePrivateLink.vue'
+import EmbeddedLinkPage from '../pages/embeddedLink.vue'
 import { setupAuthGuard } from './setupAuthGuard'
 import { patchRouter } from './patchCleanPath'
 
@@ -83,6 +84,12 @@ export const router = patchRouter(
         name: 'account',
         component: Account,
         meta: { title: $gettext('Account'), authContext: 'user' }
+      },
+      {
+        path: '/e/:linkId',
+        name: 'embeddedLink',
+        component: EmbeddedLinkPage,
+        meta: { authContext: 'user' }
       }
     ]
   })

--- a/packages/web-runtime/src/store/config.ts
+++ b/packages/web-runtime/src/store/config.ts
@@ -1,8 +1,8 @@
 import isEmpty from 'lodash-es/isEmpty'
 
 export interface LinkConfig {
-  id?: string
-  title: string
+  name?: string
+  title: Record<string, string>
   icon: string
   url?: string
   target?: string

--- a/packages/web-runtime/src/store/config.ts
+++ b/packages/web-runtime/src/store/config.ts
@@ -1,6 +1,20 @@
 import isEmpty from 'lodash-es/isEmpty'
 
+export interface LinkConfig {
+  id?: string
+  title: string
+  icon: string
+  url?: string
+  target?: string
+  path?: string
+
+  // internal
+  iconUrl?: string
+  active?: boolean
+}
+
 const state = {
+  applications: [] as LinkConfig[],
   state: null,
   server: '',
   // auth is the legacy configuration
@@ -80,8 +94,11 @@ const actions = {
   }
 }
 
+// parameter state shadows the module scope state
+type StateType = typeof state
+
 const mutations = {
-  LOAD_CONFIG(state, config) {
+  LOAD_CONFIG(state: StateType, config) {
     state.server = config.server.endsWith('/') ? config.server : config.server + '/'
     state.auth = config.auth
     state.openIdConnect = config.openIdConnect
@@ -91,14 +108,11 @@ const mutations = {
       // Merge default options and provided options. Config options take precedence over defaults.
       state.options = { ...state.options, ...config.options }
     }
-    if (config.corrupted) {
-      state.corrupted = config.corrupted
-    }
   },
-  LOAD_THEME(state, theme) {
+  LOAD_THEME(state: StateType, theme) {
     state.currentTheme = theme
   },
-  LOAD_THEMES(state, theme) {
+  LOAD_THEMES(state: StateType, theme) {
     state.themes = theme
   }
 }

--- a/packages/web-runtime/src/store/config.ts
+++ b/packages/web-runtime/src/store/config.ts
@@ -96,7 +96,7 @@ const actions = {
   }
 }
 
-// parameter state shadows the module scope state
+// parameter `state` shadows the module scope `state` variable
 type StateType = typeof state
 
 const mutations = {

--- a/packages/web-runtime/src/store/config.ts
+++ b/packages/web-runtime/src/store/config.ts
@@ -7,6 +7,9 @@ export interface LinkConfig {
   url?: string
   target?: string
   path?: string
+
+  groupsEnabled?: string[]
+  rolesEnabled?: string[]
 }
 
 export interface Link extends Omit<LinkConfig, 'title'> {

--- a/packages/web-runtime/src/store/config.ts
+++ b/packages/web-runtime/src/store/config.ts
@@ -7,10 +7,12 @@ export interface LinkConfig {
   url?: string
   target?: string
   path?: string
+}
 
-  // internal
+export interface Link extends Omit<LinkConfig, 'title'> {
   iconUrl?: string
   active?: boolean
+  title?: string
 }
 
 const state = {


### PR DESCRIPTION
## Description
This PR extends the configuration possibilities for apps/external links.

- `icon` can be a url now
- `target` can be set to `application-container` to render the link inside the application layout frame
- `groupsEnabled` or `rolesEnabled` can be defined to filter for whom the link should be visible

Currently either `groupsEnabled` or `rolesEnabled` can be used. 
If we want allow using both at the same time: what should we do, if one matches and the other doesn't? 
That would have high potential for spaghetti code ...

## Related Issue
- Fixes https://github.com/owncloud/web/issues/7260#event-7753240251

## Motivation and Context
We want to make it easy (enough) to embed external pages in the application layout frame, so they can be viewed without leaving oC Web and without requiring their own app.

## How Has This Been Tested?
```json
{
 ...
  "applications": [
    {
      "title": {
        "en": "What is my ip?"
      },
      "icon": "https://cdn-icons-png.flaticon.com/512/1/1694.png",
      "url": "https://api.ipify.org/?format=json",
      "target": "application-container"
    }
  ]
...
}
```
🙈 


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
Currently we use the english title as identifier in urls, instead we should use a proper identifier. 

- [ ] decide for `id` or `name` as identifier
- [ ] add identifier to Application struct in oCIS: https://github.com/owncloud/ocis/blob/b71eeb9f54a1cdb39eb6ce80cd8be645d0f80805/services/web/pkg/config/config.go#L54
- [ ] use it in `getLinkIdentifier`
- [ ] check for `groupsEnabled` and `rolesEnabled` in `EmbeddedLink` page