### PR TITLE
Fix editing text files on public pages

### DIFF
--- a/changelog/unreleased/bugfix-edit-text-files-on-public-pages
+++ b/changelog/unreleased/bugfix-edit-text-files-on-public-pages
@@ -1,0 +1,6 @@
+Bugfix: Editing text files on public pages
+
+We've fixed a bug where editing text files on public pages was not possible with the oC10 backend.
+
+https://github.com/owncloud/web/pull/7936
+https://github.com/owncloud/web/issues/7932

--- a/packages/web-client/src/webdav/getFileContents.ts
+++ b/packages/web-client/src/webdav/getFileContents.ts
@@ -35,6 +35,7 @@ export const GetFileContentsFactory = ({ sdk }: WebDavOptions) => {
           body: await res[responseType](),
           headers: {
             ETag: res.headers.get('etag'),
+            'OC-ETag': res.headers.get('oc-etag'),
             'OC-FileId': res.headers.get('oc-fileid')
           }
         }


### PR DESCRIPTION
## Description
We've fixed a bug where editing text files on public pages was not possible with the oC10 backend.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7932

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
