### PR TITLE
Add origin checks to all Draw.io events

### DIFF
--- a/changelog/unreleased/bugfix-origin-event-check
+++ b/changelog/unreleased/bugfix-origin-event-check
@@ -1,4 +1,4 @@
-Enhancement: Add origin check to Draw.io events
+Bugfix: Add origin check to Draw.io events
 
 Origin checks have been added to all Draw.io events due to security reasons.
 

--- a/changelog/unreleased/enhancement-origin-event-check
+++ b/changelog/unreleased/enhancement-origin-event-check
@@ -1,0 +1,6 @@
+Enhancement: Add origin check to Draw.io events
+
+Origin checks have been added to all Draw.io events due to security reasons.
+
+https://github.com/owncloud/web/pull/7941
+https://github.com/owncloud/web/issues/7933

--- a/packages/web-app-draw-io/src/App.vue
+++ b/packages/web-app-draw-io/src/App.vue
@@ -64,7 +64,7 @@ export default defineComponent({
   watch: {
     currentFileContext: {
       handler: function () {
-        this.load()
+        this.checkPermissions()
       },
       immediate: true
     }
@@ -74,6 +74,9 @@ export default defineComponent({
     this.fileExtension = this.filePath.split('.').pop()
     window.addEventListener('message', (event) => {
       if (event.data.length > 0) {
+        if (event.origin !== this.config.url) {
+          return
+        }
         const payload = JSON.parse(event.data)
         switch (payload.event) {
           case 'init':
@@ -115,7 +118,7 @@ export default defineComponent({
           message: error,
           modified: false
         }),
-        '*'
+        this.config.url
       )
     },
     async checkPermissions() {
@@ -142,7 +145,7 @@ export default defineComponent({
             xml: response.body,
             autosave: this.config.autosave
           }),
-          '*'
+          this.config.url
         )
       } catch (error) {
         this.errorPopup(error)
@@ -183,7 +186,7 @@ export default defineComponent({
                 xml: reader.result,
                 autosave: this.config.autosave
               }),
-              '*'
+              this.config.url
             )
           }
           reader.readAsDataURL(blob)
@@ -208,7 +211,7 @@ export default defineComponent({
                 message: message,
                 modified: false
               }),
-              '*'
+              this.config.url
             )
           } else {
             this.successPopup(message)

--- a/packages/web-app-draw-io/src/App.vue
+++ b/packages/web-app-draw-io/src/App.vue
@@ -47,6 +47,11 @@ export default defineComponent({
       } = this.applicationConfig
       return { url, theme, autosave: autosave ? 1 : 0 }
     },
+    urlHost() {
+      const url = new URL(this.config.url)
+      const urlHost = `${url.protocol}//${url.hostname}`
+      return url.port ? `${urlHost}:${url.port}` : urlHost
+    },
     iframeSource() {
       const query = qs.stringify({
         embed: 1,
@@ -118,7 +123,7 @@ export default defineComponent({
           message: error,
           modified: false
         }),
-        this.config.url
+        this.urlHost
       )
     },
     async checkPermissions() {
@@ -145,7 +150,7 @@ export default defineComponent({
             xml: response.body,
             autosave: this.config.autosave
           }),
-          this.config.url
+          this.urlHost
         )
       } catch (error) {
         this.errorPopup(error)
@@ -186,7 +191,7 @@ export default defineComponent({
                 xml: reader.result,
                 autosave: this.config.autosave
               }),
-              this.config.url
+              this.urlHost
             )
           }
           reader.readAsDataURL(blob)
@@ -211,7 +216,7 @@ export default defineComponent({
                 message: message,
                 modified: false
               }),
-              this.config.url
+              this.urlHost
             )
           } else {
             this.successPopup(message)


### PR DESCRIPTION
## Description
Origin checks have been added to all Draw.io events due to security reasons.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7933

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Security
- [ ] Tests
