### PR TITLE
[full-ci] Warn when using incompatible browser

### DIFF
--- a/changelog/unreleased/enhancement-warn-unsuported-browsers
+++ b/changelog/unreleased/enhancement-warn-unsuported-browsers
@@ -1,0 +1,8 @@
+Enhancement: Warn users when using unsupported browsers
+
+We've added a warning message if the browser is older than our supported configuration, instead of just failing and showing blue/white screens or generic errors.
+Users still have the option to proceed and open the page if they want to. By proceeding to the page, the setting is set for 30 days, afterwards the warning is shown again. 
+
+When building web, it's possible to pass a documentation url for users to know more about this issue, by setting the env variable DOCUMENTATION_URL.
+
+https://github.com/owncloud/web/pull/7942

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "autoprefixer": "10.4.13",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "29.3.1",
+    "browserslist-useragent-regexp": "^3.0.2",
     "commander": "8.3.0",
     "core-js": "3.26.1",
     "cucumber-html-reporter": "5.5.0",

--- a/packages/web-container/index.html.ejs
+++ b/packages/web-container/index.html.ejs
@@ -22,16 +22,13 @@
     }
     .splash-banner {
       display: flex;
-      flex-direction: row;
+      flex-direction: column;
       justify-content: center;
       align-items: center;
       padding: 0.5rem;
       height: 100%;
     }
-    #splash-loading{
-      height: 100%;
-    }
-    .splash-loading-hide {
+    .splash-hide {
       display: none;
     }
     #loading {
@@ -44,6 +41,9 @@
       animation: spin 1s ease-in-out infinite;
       -webkit-animation: spin 1s linear infinite;
     }
+    #splash-incompatible button {
+      margin: 30px 0;
+    }
 
     @keyframes spin {
       to { -webkit-transform: rotate(360deg); }
@@ -54,7 +54,34 @@
   </style>
 </head>
 <body>
-  <div id="splash-loading" class="splash-banner splash-loading-hide">
+  <div id="splash-incompatible" class="splash-banner splash-hide">
+    <div class="oc-card oc-border oc-rounded oc-width-large oc-text-center">
+      <div class="oc-card-header">
+        <div class="oc-flex oc-flex-middle oc-flex-center">
+          <span class="oc-mr-s oc-icon oc-icon-m oc-icon-warning">
+            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+    	     <g xmlns="http://www.w3.org/2000/svg">
+              <path fill="none" d="M0 0h24v24H0z"></path>
+              <path d="M12 22C6.477 22 2 17.523 2 12S6.477 2 12 2s10 4.477 10 10-4.477 10-10 10zm0-2a8 8 0 1 0 0-16 8 8 0 0 0 0 16zM11 7h2v2h-2V7zm0 4h2v6h-2v-6z"></path>
+             </g>
+            </svg>
+           </span>
+          <h2>Your browser is not supported</h2>
+        </div>
+      </div>
+      <div class="oc-card-body oc-link-resolve-error-message">
+        <p>Your browser version is considered old and might not work correctly.</p>
+        <p>We recommend you update to a newer version.</p>
+      </div>
+    </div>
+    <button class='oc-button oc-button-primary oc-button-primary-filled oc-rounded' onclick='forceOldBrowser()'>I want to continue anyway</button>
+    <% if (data.config.documentation_url) { %>
+    <p>
+      <a href='<%= data.config.documentation_url %>' target='_blank'>Click here to know more</a>
+    </p>
+    <% } %>
+  </div>
+  <div id="splash-loading" class="splash-banner splash-hide">
     <div id="loading"></div>
   </div>
   <div id="owncloud"></div>
@@ -63,32 +90,61 @@
   </noscript>
   <script>
     var loader = document.getElementById('splash-loading')
+    var browserError = document.getElementById('splash-incompatible')
+
     var loaderTimer = setTimeout(function () {
-      loader.classList.remove('splash-loading-hide')
+      loader.classList.remove('splash-hide')
     }, 1000);
 
     function displayError() {
-      loader.classList.remove('splash-loading-hide')
+      loader.classList.remove('splash-hide')
       loader.innerHTML = "<h3>Oops. Something went wrong.</h3>"
     }
 
-    if (typeof requirejs === 'undefined') {
-      displayError()
-    } else {
-      requirejs.config({
-        baseUrl: <%- JSON.stringify(data.roots.js) %>,
-        paths: <%- JSON.stringify(data.bundle.js) %>,
-        ...<%- JSON.stringify(data.config.requirejs) %>
-      })
+    function displayBrowserError() {
+      clearTimeout(loaderTimer)
+      loader.classList.add('splash-hide')
+      browserError.classList.remove('splash-hide')
+    }
 
-      requirejs(['web-runtime'], function (runtime) {
-        clearTimeout(loaderTimer)
-        document.getElementById('splash-loading').classList.add('splash-loading-hide')
-        runtime.bootstrap('config.json').then(runtime.renderSuccess).catch(runtime.renderFailure)
-      }, function(e) {
+    function forceOldBrowser() {
+      localStorage.setItem("forceAllowOldBrowser", JSON.stringify({expiry: new Date().getTime() + 30*24*60*60*1000}))
+      browserError.classList.add('splash-hide')
+      init()
+    }
+
+    function init() {
+      if (typeof requirejs === 'undefined') {
         displayError()
-        throw e
-      })
+      } else {
+        requirejs.config({
+          baseUrl: <%- JSON.stringify(data.roots.js) %>,
+          paths: <%- JSON.stringify(data.bundle.js) %>,
+          ...<%- JSON.stringify(data.config.requirejs) %>
+        })
+
+        requirejs(['web-runtime'], function (runtime) {
+          clearTimeout(loaderTimer)
+          document.getElementById('splash-loading').classList.add('splash-hide')
+          runtime.bootstrap('config.json').then(runtime.renderSuccess).catch(runtime.renderFailure)
+        }, function(e) {
+          displayError()
+          throw e
+        })
+      }
+    }
+
+    const supportedBrowsers = <%= data.supportedBrowsersRegex %>
+    const forceAllowOldBrowser = localStorage.getItem("forceAllowOldBrowser") || false
+    const validForceAllowOldBrowser = forceAllowOldBrowser && JSON.parse(localStorage.getItem("forceAllowOldBrowser")).expiry > new Date().getTime()
+
+    if (forceAllowOldBrowser && !validForceAllowOldBrowser)
+      localStorage.removeItem("forceAllowOldBrowser")
+
+    if (!validForceAllowOldBrowser && !supportedBrowsers.test(navigator.userAgent)) {
+      displayBrowserError()
+    } else {
+      init()
     }
 
   </script>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,7 @@ importers:
       autoprefixer: 10.4.13
       babel-core: 7.0.0-bridge.0
       babel-jest: 29.3.1
+      browserslist-useragent-regexp: ^3.0.2
       caf: '*'
       commander: 8.3.0
       core-js: 3.26.1
@@ -135,6 +136,7 @@ importers:
       autoprefixer: 10.4.13_postcss@8.4.19
       babel-core: 7.0.0-bridge.0_@babel+core@7.20.2
       babel-jest: 29.3.1_@babel+core@7.20.2
+      browserslist-useragent-regexp: 3.0.2
       commander: 8.3.0
       core-js: 3.26.1
       cucumber-html-reporter: 5.5.0
@@ -5997,6 +5999,11 @@ packages:
       mri: 1.1.4
     dev: true
 
+  /argue-cli/1.2.1:
+    resolution: {integrity: sha512-Em3HDMlqiVLNOgXUCYz5NG1mx/44aijsxUOO8elmfvAN4/3ar1S3WPTua7WGhsMbeQm8clOwpDZ09sN7C2FnOg==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
   /aria-query/5.0.2:
     resolution: {integrity: sha512-eigU3vhqSO+Z8BKDnVLN/ompjhf3pYzecKXz8+whRy+9gZu8n1TCGfwzQUUPnqdHl9ax1Hr9031orZ+UOEYr7Q==}
     engines: {node: '>=6.0'}
@@ -6906,6 +6913,19 @@ packages:
       object-path: 0.11.8
       semver: 7.3.8
       ua-parser-js: 1.0.32
+    dev: true
+
+  /browserslist-useragent-regexp/3.0.2:
+    resolution: {integrity: sha512-hOvTo9ObY+2PvCLxydvam5WD9hlvWB4bFzRLxc/M5OdJfzjgfsQ9wEF7EpJJP7UJUAnKJdJK28XsSrl5d1DfoA==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+    dependencies:
+      '@types/node': 16.18.3
+      argue-cli: 1.2.1
+      browserslist: 4.21.4
+      chalk: 4.1.2
+      easy-table: 1.2.0
+      useragent: 2.3.0
     dev: true
 
   /browserslist/4.20.2:
@@ -9988,6 +10008,14 @@ packages:
   /durations/3.4.2:
     resolution: {integrity: sha512-V/lf7y33dGaypZZetVI1eu7BmvkbC4dItq12OElLRpKuaU5JxQstV2zHwLv8P7cNbQ+KL1WD80zMCTx5dNC4dg==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /easy-table/1.2.0:
+    resolution: {integrity: sha512-OFzVOv03YpvtcWGe5AayU5G2hgybsg3iqA6drU8UaoZyB9jLGMTrz9+asnLp/E+6qPh88yEI1gvyZFZ41dmgww==}
+    dependencies:
+      ansi-regex: 5.0.1
+    optionalDependencies:
+      wcwidth: 1.0.1
     dev: true
 
   /ecc-jsbn/0.1.2:
@@ -16541,6 +16569,11 @@ packages:
     resolution: {integrity: sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==}
     dev: true
 
+  /os-tmpdir/1.0.2:
+    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /ospec/3.1.0:
     resolution: {integrity: sha512-+nGtjV3vlADp+UGfL51miAh/hB4awPBkQrArhcgG4trAaoA2gKt5bf9w0m9ch9zOr555cHWaCHZEDiBOkNZSxw==}
     hasBin: true
@@ -19341,6 +19374,11 @@ packages:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
     dev: true
 
+  /semver/5.5.1:
+    resolution: {integrity: sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==}
+    hasBin: true
+    dev: true
+
   /semver/5.7.1:
     resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
     hasBin: true
@@ -20581,6 +20619,13 @@ packages:
     dependencies:
       '@popperjs/core': 2.11.5
 
+  /tmp/0.0.33:
+    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
+    engines: {node: '>=0.6.0'}
+    dependencies:
+      os-tmpdir: 1.0.2
+    dev: true
+
   /tmp/0.2.1:
     resolution: {integrity: sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==}
     engines: {node: '>=8.17.0'}
@@ -21196,6 +21241,16 @@ packages:
   /use/3.1.1:
     resolution: {integrity: sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /useragent/2.3.0:
+    resolution: {integrity: sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==}
+    dependencies:
+      lru-cache: 4.1.5
+      request: 2.88.2
+      semver: 5.5.1
+      tmp: 0.0.33
+      yamlparser: 0.0.2
     dev: true
 
   /utf8/3.0.0:
@@ -21832,6 +21887,7 @@ packages:
 
   /wcwidth/1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+    requiresBuild: true
     dependencies:
       defaults: 1.0.4
     dev: true
@@ -22330,6 +22386,10 @@ packages:
   /yaml/2.1.3:
     resolution: {integrity: sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==}
     engines: {node: '>= 14'}
+    dev: true
+
+  /yamlparser/0.0.2:
+    resolution: {integrity: sha512-Cou9FCGblEENtn1/8La5wkDM/ISMh2bzu5Wh7dYzCzA0o9jD4YGyLkUJxe84oPBGoB92f+Oy4ZjVhA8S0C2wlQ==}
     dev: true
 
   /yargs-parser/13.1.2:

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -24,6 +24,7 @@ import copy from '@rollup-extras/plugin-copy'
 import packageJson from './package.json' assert { type: "json" }
 import {fileURLToPath} from 'url'
 import { dirname, resolve as pathResolve } from 'path'
+import { getUserAgentRegExp } from 'browserslist-useragent-regexp'
 
 
 const production = !process.env.ROLLUP_WATCH
@@ -31,10 +32,12 @@ const sourcemap = process.env.SOURCE_MAP === 'true'
 
 const { version } = packageJson
 const compilationTimestamp = new Date().getTime()
+const supportedBrowsersRegex = getUserAgentRegExp({allowHigherVersions: true})
 
 const config = {
   requirejs: {},
-  cdn: process.env.CDN === 'true'
+  cdn: process.env.CDN === 'true',
+  documentation_url: process.env.DOCUMENTATION_URL
 }
 if (process.env.REQUIRE_TIMEOUT) {
   config.requirejs.waitSeconds = parseInt(process.env.REQUIRE_TIMEOUT)
@@ -183,7 +186,8 @@ const plugins = [
                 js: 'js'
               },
               config: config,
-              compilationTimestamp: compilationTimestamp
+              compilationTimestamp: compilationTimestamp,
+              supportedBrowsersRegex: supportedBrowsersRegex
             }
           },
           {},

--- a/tests/acceptance/pageObjects/publicLinkPasswordPage.js
+++ b/tests/acceptance/pageObjects/publicLinkPasswordPage.js
@@ -54,14 +54,15 @@ module.exports = {
       selector: '.oc-login-authorize-button'
     },
     resourceProtectedText: {
-      selector: '//*[@class="oc-card-header"]',
+      selector: '//*[contains(@class, "oc-link-resolve")]//*[@class="oc-card-header"]',
       locateStrategy: 'xpath'
     },
     linkResolveErrorTitle: {
       selector: '.oc-link-resolve-error-title'
     },
     publicLinkPasswordSection: {
-      selector: '//*[@class="oc-card-header"]//*[text()="This resource is password-protected"]',
+      selector:
+        '//*[contains(@class, "oc-link-resolve")]//*[@class="oc-card-header"]//*[text()="This resource is password-protected"]',
       locateStrategy: 'xpath'
     }
   }


### PR DESCRIPTION
<img width="912" alt="Screenshot 2022-11-09 at 16 39 36" src="https://user-images.githubusercontent.com/2589871/200874263-c4a42a75-3710-4cdd-a7ab-3fd113e32f9c.png">

We had many users complaining that things were not working and there was no clear reason why... So we decided to warn them.

There's a new compilation env variable to set a link to documentation, in case you have it.
Also, in case the browser still somewhat supports most of the code, users can still force launch it to check it.

I've opened the PR to see your comments, suggestions and interest, but @elizavetaRa is still going to confirm with our users that it displays the error properly (e.g maybe the css will not be well formatted or the regex won't match?)
If there are necessary changes, we'll update the PR.