### PR TITLE
UI improvements

### DIFF
--- a/changelog/unreleased/bugfix-ui-sorting-quickactions
+++ b/changelog/unreleased/bugfix-ui-sorting-quickactions
@@ -1,0 +1,6 @@
+Bugfix: UI fixes for sorting and quickactions
+
+Ensure the sorting of "shared with" in "shared with me" view is correct when they have been shared simultaneously with users and groups.
+Prevent the context actions to disappear when `hoverableQuickActions` is set to true.
+
+https://github.com/owncloud/web/pull/7966

--- a/packages/web-app-files/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceTable.vue
@@ -882,13 +882,13 @@ export default defineComponent({
 
 .hoverable-quick-actions.files-table {
   @media (pointer: fine) {
-    tr {
+    tr:not([class*='oc-table-highlighted']) {
       .resource-table-edit-name,
       .resource-table-actions div:first-child {
         visibility: hidden;
       }
     }
-    tr:hover {
+    tr:not([class*='oc-table-highlighted']):hover {
       .resource-table-edit-name,
       .resource-table-actions div:first-child {
         visibility: visible;

--- a/packages/web-app-files/src/helpers/ui/resourceTable.ts
+++ b/packages/web-app-files/src/helpers/ui/resourceTable.ts
@@ -25,7 +25,19 @@ export const determineSortFields = (firstResource): SortField[] => {
       name: 'sharedWith',
       sortable: (sharedWith) => {
         if (sharedWith.length > 0) {
-          return sharedWith[0].displayName
+          // Ensure the sharees are always sorted and that users
+          // take precedence over groups. Then return a string with
+          // all elements to ensure shares with multiple shares do
+          // not appear mixed within others with a single one
+          return sharedWith
+            .sort((a, b) => {
+              if (a.shareType !== b.shareType) {
+                return a.shareType < b.shareType ? -1 : 1
+              }
+              return a.displayName < b.displayName ? -1 : 1
+            })
+            .map((e) => e.displayName)
+            .join()
         }
         return false
       },


### PR DESCRIPTION
This PR fixes a bug: if `hoverableQuickActions: true`, the context menus disappear if the mouse exits them or the table row area.

...and improves the sorting in the shared with view.
In the current behaviour it only sorts by the first sharee name, which means we might have rows with multiple sharees (user + groups) appearing in the middle of other rows that only have the user in the sharees. 
This was particularly visible and bad because we even allow multiple groups to appear in this list (as opposed to ocis which seems to be showing only the first group?).

(like in all PRs, I can add the changelog if you think this is ok to be merged)