### PR TITLE
Introduce 'upload finished'-state in upload overlay

### DIFF
--- a/changelog/unreleased/bugfix-upload-finalizing-state
+++ b/changelog/unreleased/bugfix-upload-finalizing-state
@@ -1,0 +1,8 @@
+Bugfix: Introduce "upload finalizing"-state in upload overlay
+
+The "upload finalizing"-state has been introduced to the upload overlay. This state is relevant during the time window when all data has been transferred to the server (= progress bar is at 100%), but the server still needs to write all data to the storage.
+
+The "cancel"- and "pause"-actions are disabled during the "upload finalizing"-state as the data transfer is technically finished. Previously, when pausing and resuming when being in this state, the upload would be marked as successful instantly, despite the server still writing to the storage.
+
+https://github.com/owncloud/web/issues/7956
+https://github.com/owncloud/web/pull/7974

--- a/changelog/unreleased/bugfix-upload-finishing-state
+++ b/changelog/unreleased/bugfix-upload-finishing-state
@@ -1,8 +1,0 @@
-Bugfix: Introduce "upload finished"-state in upload overlay
-
-The "upload finished"-state has been introduced to the upload overlay. This state is relevant during the time window when all data has been transferred to the server (= progress bar is at 100%), but the server still needs to write all data to the storage.
-
-The "cancel"- and "pause"-actions are disabled during the "upload finished"-state as the data transfer is technically finished. Previously, when pausing and resuming when being in this state, the upload would be marked as successful instantly, despite the server still writing to the storage.
-
-https://github.com/owncloud/web/issues/7956
-https://github.com/owncloud/web/pull/7974

--- a/changelog/unreleased/bugfix-upload-finishing-state
+++ b/changelog/unreleased/bugfix-upload-finishing-state
@@ -1,0 +1,8 @@
+Bugfix: Introduce "upload finished"-state in upload overlay
+
+The "upload finished"-state has been introduced to the upload overlay. This state is relevant during the time window when all data has been transferred to the server (= progress bar is at 100%), but the server still needs to write all data to the storage.
+
+The "cancel"- and "pause"-actions are disabled during the "upload finished"-state as the data transfer is technically finished. Previously, when pausing and resuming when being in this state, the upload would be marked as successful instantly, despite the server still writing to the storage.
+
+https://github.com/owncloud/web/issues/7956
+https://github.com/owncloud/web/pull/7974

--- a/packages/web-runtime/src/components/UploadInfo.vue
+++ b/packages/web-runtime/src/components/UploadInfo.vue
@@ -53,7 +53,7 @@
           <oc-icon name="restart" fill-type="line" />
         </oc-button>
         <oc-button
-          v-if="runningUploads && uploadsPausable && !inPreparation"
+          v-if="runningUploads && uploadsPausable && !inPreparation && !uploadsWritingToStorage"
           id="pause-upload-info-btn"
           v-oc-tooltip="uploadsPaused ? $gettext('Resume upload') : $gettext('Pause upload')"
           class="oc-ml-s"
@@ -63,7 +63,7 @@
           <oc-icon :name="uploadsPaused ? 'play-circle' : 'pause-circle'" fill-type="line" />
         </oc-button>
         <oc-button
-          v-if="runningUploads && !inPreparation"
+          v-if="runningUploads && !inPreparation && !uploadsWritingToStorage"
           id="cancel-upload-info-btn"
           v-oc-tooltip="$gettext('Cancel upload')"
           class="oc-ml-s"
@@ -162,6 +162,7 @@ export default defineComponent({
     totalProgress: 0, // current uploads progress (0-100)
     uploadsPaused: false, // all uploads paused?
     uploadsCancelled: false, // all uploads cancelled?
+    uploadsWritingToStorage: false, // uploads transferred but still need to be written to storage
     inPreparation: true, // preparation before upload
     runningUploads: 0, // all uploads (not files!) that are in progress currently
     bytesTotal: 0,
@@ -236,6 +237,7 @@ export default defineComponent({
 
       this.showInfo = true
       this.runningUploads += 1
+      this.uploadsWritingToStorage = false
     })
     this.$uppyService.subscribe('addedForUpload', (files) => {
       this.filesInProgressCount += files.filter((f) => !f.isFolder).length
@@ -297,6 +299,9 @@ export default defineComponent({
       const remainingMilliseconds = totalTimeNeededInMilliseconds - timeElapsed
 
       this.remainingTime = this.getRemainingTime(remainingMilliseconds)
+      if (progressPercent === 100) {
+        this.uploadsWritingToStorage = true
+      }
     })
     this.$uppyService.subscribe('uploadError', ({ file, error }) => {
       if (this.errors[file.meta.uploadId]) {
@@ -425,6 +430,7 @@ export default defineComponent({
       this.timeStarted = null
       this.remainingTime = undefined
       this.inPreparation = true
+      this.uploadsWritingToStorage = false
     },
     displayFileAsResource(file) {
       return !!file.targetRoute

--- a/packages/web-runtime/src/components/UploadInfo.vue
+++ b/packages/web-runtime/src/components/UploadInfo.vue
@@ -53,7 +53,7 @@
           <oc-icon name="restart" fill-type="line" />
         </oc-button>
         <oc-button
-          v-if="runningUploads && uploadsPausable && !inPreparation && !uploadsWritingToStorage"
+          v-if="runningUploads && uploadsPausable && !inPreparation && !inFinalization"
           id="pause-upload-info-btn"
           v-oc-tooltip="uploadsPaused ? $gettext('Resume upload') : $gettext('Pause upload')"
           class="oc-ml-s"
@@ -63,7 +63,7 @@
           <oc-icon :name="uploadsPaused ? 'play-circle' : 'pause-circle'" fill-type="line" />
         </oc-button>
         <oc-button
-          v-if="runningUploads && !inPreparation && !uploadsWritingToStorage"
+          v-if="runningUploads && !inPreparation && !inFinalization"
           id="cancel-upload-info-btn"
           v-oc-tooltip="$gettext('Cancel upload')"
           class="oc-ml-s"
@@ -162,7 +162,7 @@ export default defineComponent({
     totalProgress: 0, // current uploads progress (0-100)
     uploadsPaused: false, // all uploads paused?
     uploadsCancelled: false, // all uploads cancelled?
-    uploadsWritingToStorage: false, // uploads transferred but still need to be written to storage
+    inFinalization: false, // uploads transferred but still need to be finalized
     inPreparation: true, // preparation before upload
     runningUploads: 0, // all uploads (not files!) that are in progress currently
     bytesTotal: 0,
@@ -237,7 +237,7 @@ export default defineComponent({
 
       this.showInfo = true
       this.runningUploads += 1
-      this.uploadsWritingToStorage = false
+      this.inFinalization = false
     })
     this.$uppyService.subscribe('addedForUpload', (files) => {
       this.filesInProgressCount += files.filter((f) => !f.isFolder).length
@@ -300,7 +300,7 @@ export default defineComponent({
 
       this.remainingTime = this.getRemainingTime(remainingMilliseconds)
       if (progressPercent === 100) {
-        this.uploadsWritingToStorage = true
+        this.inFinalization = true
       }
     })
     this.$uppyService.subscribe('uploadError', ({ file, error }) => {
@@ -430,7 +430,7 @@ export default defineComponent({
       this.timeStarted = null
       this.remainingTime = undefined
       this.inPreparation = true
-      this.uploadsWritingToStorage = false
+      this.inFinalization = false
     },
     displayFileAsResource(file) {
       return !!file.targetRoute

--- a/packages/web-runtime/tests/unit/components/UploadInfo.spec.ts
+++ b/packages/web-runtime/tests/unit/components/UploadInfo.spec.ts
@@ -220,7 +220,8 @@ function getShallowWrapper({
   successful = [],
   errors = {},
   uploadsCancelled = false,
-  inPreparation = false
+  inPreparation = false,
+  uploadsWritingToStorage = false
 } = {}) {
   const mocks = {
     ...defaultComponentMocks({ gettext: false })
@@ -248,7 +249,8 @@ function getShallowWrapper({
           successful,
           errors,
           uploadsCancelled,
-          inPreparation
+          inPreparation,
+          uploadsWritingToStorage
         }
       }
     })

--- a/packages/web-runtime/tests/unit/components/UploadInfo.spec.ts
+++ b/packages/web-runtime/tests/unit/components/UploadInfo.spec.ts
@@ -221,7 +221,7 @@ function getShallowWrapper({
   errors = {},
   uploadsCancelled = false,
   inPreparation = false,
-  uploadsWritingToStorage = false
+  inFinalization = false
 } = {}) {
   const mocks = {
     ...defaultComponentMocks({ gettext: false })
@@ -250,7 +250,7 @@ function getShallowWrapper({
           errors,
           uploadsCancelled,
           inPreparation,
-          uploadsWritingToStorage
+          inFinalization
         }
       }
     })


### PR DESCRIPTION
## Description
The "upload finished"-state has been introduced to the upload overlay. This state is relevant during the time window when all data has been transferred to the server (= progress bar is at 100%), but the server still needs to write all data to the storage.

The "cancel"- and "pause"-actions are disabled during the "upload finished"-state as the data transfer is technically finished. Previously, when pausing and resuming when being in this state, the upload would be marked as successful instantly, despite the server still writing to the storage.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7956

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/50302941/201897957-e40b3ab5-c55d-4948-96c6-facd7d3479ef.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
