### PR TITLE
Add viewMode toggle for condensed resource table

### DIFF
--- a/changelog/unreleased/enhancement-condensed-files-view
+++ b/changelog/unreleased/enhancement-condensed-files-view
@@ -1,0 +1,7 @@
+Enhancement: Add switch to enable condensed resource table
+
+We've added a switch to have a more condensed resource table. 
+The change gets saved to the route and persisted across resource navigation.
+
+https://github.com/owncloud/web/pull/7976
+https://github.com/owncloud/web/issues/6380

--- a/packages/design-system/changelog/unreleased/enhancement-condensed-menu-item
+++ b/packages/design-system/changelog/unreleased/enhancement-condensed-menu-item
@@ -1,0 +1,5 @@
+Enhancement: Add condensed menu icon 
+
+We added a new menu icon for the switch between condensed and regular resource table.
+
+https://github.com/owncloud/web/pull/7976

--- a/packages/design-system/src/assets/icons/menu-line-condensed.svg
+++ b/packages/design-system/src/assets/icons/menu-line-condensed.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+    <g>
+        <path d="M3 5H21V7H3V5ZM3 9H21V11H3V9ZM3 17H21V19H3V17Z" />
+        <path d="M21 13H3V15H21V13Z" />
+    </g>
+</svg>

--- a/packages/web-app-files/src/components/AppBar/ViewOptions.vue
+++ b/packages/web-app-files/src/components/AppBar/ViewOptions.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="oc-flex oc-flex-middle">
-    <div class="oc-button-group oc-visible@s oc-mr-s">
+    <div data-testid="viewmode-switch-buttons" class="oc-button-group oc-visible@s oc-mr-s">
       <oc-button
         :appearance="viewModeCurrent === ViewModeConstants.condensedTable ? 'filled' : 'outline'"
         @click="setViewMode(ViewModeConstants.condensedTable)"

--- a/packages/web-app-files/src/components/AppBar/ViewOptions.vue
+++ b/packages/web-app-files/src/components/AppBar/ViewOptions.vue
@@ -2,14 +2,18 @@
   <div class="oc-flex oc-flex-middle">
     <div class="oc-button-group oc-visible@s oc-mr-s">
       <oc-button
-        :appearance="viewModeCurrent === 'resource-table-condensed' ? 'filled' : 'outline'"
-        @click="setViewMode('resource-table-condensed')"
+        :appearance="
+          viewModeCurrent === ViewModeConstants.viewModeResourceTableCondensed
+            ? 'filled'
+            : 'outline'
+        "
+        @click="setViewMode(ViewModeConstants.viewModeResourceTableCondensed)"
       >
         <oc-icon name="menu-line-condensed" fill-type="none" size="small" />
       </oc-button>
       <oc-button
-        :appearance="viewModeCurrent === 'resource-table' ? 'filled' : 'outline'"
-        @click="setViewMode('resource-table')"
+        :appearance="viewModeCurrent === ViewModeConstants.viewModeDefault ? 'filled' : 'outline'"
+        @click="setViewMode(ViewModeConstants.viewModeDefault)"
       >
         <oc-icon name="align-justify" fill-type="none" size="small" />
       </oc-button>
@@ -64,8 +68,7 @@
 <script>
 import { mapMutations, mapState } from 'vuex'
 import { useRouteQueryPersisted } from 'web-pkg/src/composables'
-import { ViewModeConstants } from 'web-app-files/src/composables/viewMode'
-import { PaginationConstants } from '../../composables'
+import { PaginationConstants, ViewModeConstants } from '../../composables'
 
 export default {
   setup() {
@@ -79,6 +82,7 @@ export default {
     })
 
     return {
+      ViewModeConstants,
       viewModeCurrent: viewModeQuery,
       itemsPerPage: perPageQuery
     }

--- a/packages/web-app-files/src/components/AppBar/ViewOptions.vue
+++ b/packages/web-app-files/src/components/AppBar/ViewOptions.vue
@@ -2,18 +2,14 @@
   <div class="oc-flex oc-flex-middle">
     <div class="oc-button-group oc-visible@s oc-mr-s">
       <oc-button
-        :appearance="
-          viewModeCurrent === ViewModeConstants.viewModeResourceTableCondensed
-            ? 'filled'
-            : 'outline'
-        "
-        @click="setViewMode(ViewModeConstants.viewModeResourceTableCondensed)"
+        :appearance="viewModeCurrent === ViewModeConstants.condensedTable ? 'filled' : 'outline'"
+        @click="setViewMode(ViewModeConstants.condensedTable)"
       >
         <oc-icon name="menu-line-condensed" fill-type="none" size="small" />
       </oc-button>
       <oc-button
-        :appearance="viewModeCurrent === ViewModeConstants.viewModeDefault ? 'filled' : 'outline'"
-        @click="setViewMode(ViewModeConstants.viewModeDefault)"
+        :appearance="viewModeCurrent === ViewModeConstants.default ? 'filled' : 'outline'"
+        @click="setViewMode(ViewModeConstants.default)"
       >
         <oc-icon name="align-justify" fill-type="none" size="small" />
       </oc-button>
@@ -77,8 +73,8 @@ export default {
       defaultValue: PaginationConstants.perPageDefault
     })
     const viewModeQuery = useRouteQueryPersisted({
-      name: ViewModeConstants.viewModeQueryName,
-      defaultValue: ViewModeConstants.viewModeDefault
+      name: ViewModeConstants.queryName,
+      defaultValue: ViewModeConstants.default
     })
 
     return {

--- a/packages/web-app-files/src/components/AppBar/ViewOptions.vue
+++ b/packages/web-app-files/src/components/AppBar/ViewOptions.vue
@@ -11,7 +11,7 @@
         :appearance="viewModeCurrent === ViewModeConstants.default ? 'filled' : 'outline'"
         @click="setViewMode(ViewModeConstants.default)"
       >
-        <oc-icon name="align-justify" fill-type="none" size="small" />
+        <oc-icon name="menu-line" fill-type="none" size="small" />
       </oc-button>
     </div>
     <oc-button

--- a/packages/web-app-files/src/components/AppBar/ViewOptions.vue
+++ b/packages/web-app-files/src/components/AppBar/ViewOptions.vue
@@ -5,7 +5,7 @@
         :appearance="viewModeCurrent === 'resource-table-condensed' ? 'filled' : 'outline'"
         @click="setViewMode('resource-table-condensed')"
       >
-        <oc-icon name="align-vertically" fill-type="none" />
+        <oc-icon name="menu-line-condensed" fill-type="none" />
       </oc-button>
       <oc-button
         :appearance="viewModeCurrent === 'resource-table' ? 'filled' : 'outline'"

--- a/packages/web-app-files/src/components/AppBar/ViewOptions.vue
+++ b/packages/web-app-files/src/components/AppBar/ViewOptions.vue
@@ -1,5 +1,19 @@
 <template>
-  <div>
+  <div class="oc-flex oc-flex-middle">
+    <div class="oc-button-group oc-visible@s oc-mr-s">
+      <oc-button
+        :appearance="viewModeCurrent === 'resource-table-condensed' ? 'filled' : 'outline'"
+        @click="setViewMode('resource-table-condensed')"
+      >
+        <oc-icon name="align-vertically" fill-type="none" />
+      </oc-button>
+      <oc-button
+        :appearance="viewModeCurrent === 'resource-table' ? 'filled' : 'outline'"
+        @click="setViewMode('resource-table')"
+      >
+        <oc-icon name="align-justify" fill-type="none" />
+      </oc-button>
+    </div>
     <oc-button
       id="files-view-options-btn"
       key="files-view-options-btn"
@@ -50,6 +64,7 @@
 <script>
 import { mapMutations, mapState } from 'vuex'
 import { useRouteQueryPersisted } from 'web-pkg/src/composables'
+import { ViewModeConstants } from 'web-app-files/src/composables/viewMode'
 import { PaginationConstants } from '../../composables'
 
 export default {
@@ -58,8 +73,13 @@ export default {
       name: PaginationConstants.perPageQueryName,
       defaultValue: PaginationConstants.perPageDefault
     })
+    const viewModeQuery = useRouteQueryPersisted({
+      name: ViewModeConstants.viewModeQueryName,
+      defaultValue: ViewModeConstants.viewModeDefault
+    })
 
     return {
+      viewModeCurrent: viewModeQuery,
       itemsPerPage: perPageQuery
     }
   },
@@ -90,7 +110,10 @@ export default {
     }
   },
   methods: {
-    ...mapMutations('Files', ['SET_HIDDEN_FILES_VISIBILITY', 'SET_FILE_EXTENSIONS_VISIBILITY'])
+    ...mapMutations('Files', ['SET_HIDDEN_FILES_VISIBILITY', 'SET_FILE_EXTENSIONS_VISIBILITY']),
+    setViewMode(mode) {
+      this.viewModeCurrent = mode
+    }
   }
 }
 </script>

--- a/packages/web-app-files/src/components/AppBar/ViewOptions.vue
+++ b/packages/web-app-files/src/components/AppBar/ViewOptions.vue
@@ -5,13 +5,13 @@
         :appearance="viewModeCurrent === 'resource-table-condensed' ? 'filled' : 'outline'"
         @click="setViewMode('resource-table-condensed')"
       >
-        <oc-icon name="menu-line-condensed" fill-type="none" />
+        <oc-icon name="menu-line-condensed" fill-type="none" size="small" />
       </oc-button>
       <oc-button
         :appearance="viewModeCurrent === 'resource-table' ? 'filled' : 'outline'"
         @click="setViewMode('resource-table')"
       >
-        <oc-icon name="align-justify" fill-type="none" />
+        <oc-icon name="align-justify" fill-type="none" size="small" />
       </oc-button>
     </div>
     <oc-button

--- a/packages/web-app-files/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceTable.vue
@@ -2,7 +2,7 @@
   <oc-table
     :class="[
       hoverableQuickActions && 'hoverable-quick-actions',
-      { condensed: viewMode === ViewModeConstants.viewModeResourceTableCondensed }
+      { condensed: viewMode === ViewModeConstants.condensedTable }
     ]"
     :data="resources"
     :fields="fields"
@@ -325,7 +325,7 @@ export default defineComponent({
     },
     viewMode: {
       type: String,
-      default: ViewModeConstants.viewModeDefault
+      default: ViewModeConstants.default
     },
     /**
      * Enable hover effect

--- a/packages/web-app-files/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceTable.vue
@@ -1,6 +1,9 @@
 <template>
   <oc-table
-    :class="hoverableQuickActions && 'hoverable-quick-actions'"
+    :class="[
+      hoverableQuickActions && 'hoverable-quick-actions',
+      { condensed: viewMode === 'resource-table-condensed' }
+    ]"
     :data="resources"
     :fields="fields"
     :highlighted="selectedIds"
@@ -317,6 +320,10 @@ export default defineComponent({
       type: Boolean,
       required: false,
       default: false
+    },
+    viewMode: {
+      type: String,
+      default: 'resource-table'
     },
     /**
      * Enable hover effect
@@ -833,6 +840,15 @@ export default defineComponent({
 })
 </script>
 <style lang="scss">
+.oc-table.condensed > tbody > tr {
+  height: 0 !important;
+  font-size: 0.7rem !important;
+  button,
+  span,
+  p {
+    font-size: 0.7rem !important;
+  }
+}
 .resource-table {
   &-resource-cut {
     opacity: 0.6;

--- a/packages/web-app-files/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceTable.vue
@@ -842,12 +842,6 @@ export default defineComponent({
 <style lang="scss">
 .oc-table.condensed > tbody > tr {
   height: 0 !important;
-  font-size: 0.7rem !important;
-  button,
-  span,
-  p {
-    font-size: 0.7rem !important;
-  }
 }
 .resource-table {
   &-resource-cut {

--- a/packages/web-app-files/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceTable.vue
@@ -2,7 +2,7 @@
   <oc-table
     :class="[
       hoverableQuickActions && 'hoverable-quick-actions',
-      { condensed: viewMode === 'resource-table-condensed' }
+      { condensed: viewMode === ViewModeConstants.viewModeResourceTableCondensed }
     ]"
     :data="resources"
     :fields="fields"
@@ -184,6 +184,8 @@ import {
   useCapabilityProjectSpacesEnabled,
   useCapabilityShareJailEnabled
 } from 'web-pkg/src/composables'
+import { ViewModeConstants } from 'web-app-files/src/composables/viewMode'
+
 import Rename from '../../mixins/actions/rename'
 import { defineComponent, PropType } from 'vue'
 import { Resource } from 'web-client'
@@ -323,7 +325,7 @@ export default defineComponent({
     },
     viewMode: {
       type: String,
-      default: 'resource-table'
+      default: ViewModeConstants.viewModeDefault
     },
     /**
      * Enable hover effect
@@ -374,6 +376,7 @@ export default defineComponent({
   },
   setup() {
     return {
+      ViewModeConstants,
       hasShareJail: useCapabilityShareJailEnabled(),
       hasProjectSpaces: useCapabilityProjectSpacesEnabled()
     }

--- a/packages/web-app-files/src/composables/index.ts
+++ b/packages/web-app-files/src/composables/index.ts
@@ -4,6 +4,7 @@ export * from './resourcesViewDefaults'
 export * from './router'
 export * from './selection'
 export * from './sort'
+export * from './viewMode'
 
 declare module 'vue/types/vue' {
   interface Vue {

--- a/packages/web-app-files/src/composables/resourcesViewDefaults/useResourcesViewDefaults.ts
+++ b/packages/web-app-files/src/composables/resourcesViewDefaults/useResourcesViewDefaults.ts
@@ -68,7 +68,7 @@ export const useResourcesViewDefaults = <T, TT, TU extends any[]>(
     fields
   })
 
-  const currentViewModeQuery = useRouteQuery('view-mode', ViewModeConstants.viewModeDefault)
+  const currentViewModeQuery = useRouteQuery('view-mode', ViewModeConstants.default)
   const currentViewMode = computed((): string => queryItemAsString(currentViewModeQuery.value))
   const viewMode = useViewMode(currentViewMode)
 

--- a/packages/web-app-files/src/composables/resourcesViewDefaults/useResourcesViewDefaults.ts
+++ b/packages/web-app-files/src/composables/resourcesViewDefaults/useResourcesViewDefaults.ts
@@ -12,6 +12,7 @@ import { Resource } from 'web-client'
 import { useSelectedResources, SelectedResourcesResult } from '../selection'
 import { ReadOnlyRef } from 'web-pkg'
 import { ScrollToResult, useScrollTo } from '../scrollTo'
+import { useViewMode } from '../viewMode'
 
 interface ResourcesViewDefaultsOptions<T, U extends any[]> {
   loadResourcesTask?: Task<T, U>
@@ -30,6 +31,7 @@ type ResourcesViewDefaultsResult<T, TT, TU extends any[]> = {
   handleSort({ sortBy, sortDir }: { sortBy: string; sortDir: SortDir }): void
   sortBy: ReadOnlyRef<string>
   sortDir: ReadOnlyRef<SortDir>
+  viewMode: ReadOnlyRef<string>
 
   selectedResources: Ref<Resource[]>
   selectedResourcesIds: Ref<(string | number)[]>
@@ -61,6 +63,10 @@ export const useResourcesViewDefaults = <T, TT, TU extends any[]>(
     fields
   })
 
+  const currentViewMode = useRouteQuery('view-mode', 'resource-table')
+  const someViewMode = computed((): string => String(currentViewMode.value))
+  const viewMode = useViewMode(someViewMode)
+
   const paginationPageQuery = useRouteQuery('page', '1')
   const paginationPage = computed((): number => parseInt(String(paginationPageQuery.value)))
   const { items: paginatedResources, total: paginationPages } = usePagination({
@@ -80,6 +86,7 @@ export const useResourcesViewDefaults = <T, TT, TU extends any[]>(
     areResourcesLoading,
     storeItems,
     fields,
+    viewMode,
     paginatedResources,
     paginationPages,
     paginationPage,

--- a/packages/web-app-files/src/composables/resourcesViewDefaults/useResourcesViewDefaults.ts
+++ b/packages/web-app-files/src/composables/resourcesViewDefaults/useResourcesViewDefaults.ts
@@ -5,14 +5,19 @@ import { usePagination, useFileListHeaderPosition, SortField } from '../'
 import { useSort, SortDir } from '../sort/'
 import { useSideBar } from '../sideBar'
 
-import { useMutationSubscription, useRouteQuery, useStore } from 'web-pkg/src/composables'
+import {
+  queryItemAsString,
+  useMutationSubscription,
+  useRouteQuery,
+  useStore
+} from 'web-pkg/src/composables'
 import { determineSortFields } from '../../helpers/ui/resourceTable'
 import { Task } from 'vue-concurrency'
 import { Resource } from 'web-client'
 import { useSelectedResources, SelectedResourcesResult } from '../selection'
 import { ReadOnlyRef } from 'web-pkg'
 import { ScrollToResult, useScrollTo } from '../scrollTo'
-import { useViewMode } from '../viewMode'
+import { useViewMode, ViewModeConstants } from '../viewMode'
 
 interface ResourcesViewDefaultsOptions<T, U extends any[]> {
   loadResourcesTask?: Task<T, U>
@@ -63,9 +68,9 @@ export const useResourcesViewDefaults = <T, TT, TU extends any[]>(
     fields
   })
 
-  const currentViewMode = useRouteQuery('view-mode', 'resource-table')
-  const someViewMode = computed((): string => String(currentViewMode.value))
-  const viewMode = useViewMode(someViewMode)
+  const currentViewModeQuery = useRouteQuery('view-mode', ViewModeConstants.viewModeDefault)
+  const currentViewMode = computed((): string => queryItemAsString(currentViewModeQuery.value))
+  const viewMode = useViewMode(currentViewMode)
 
   const paginationPageQuery = useRouteQuery('page', '1')
   const paginationPage = computed((): number => parseInt(String(paginationPageQuery.value)))

--- a/packages/web-app-files/src/composables/viewMode/constants.ts
+++ b/packages/web-app-files/src/composables/viewMode/constants.ts
@@ -1,0 +1,4 @@
+export abstract class ViewModeConstants {
+  static readonly viewModeDefault: string = 'resource-table'
+  static readonly viewModeQueryName: string = 'view-mode'
+}

--- a/packages/web-app-files/src/composables/viewMode/constants.ts
+++ b/packages/web-app-files/src/composables/viewMode/constants.ts
@@ -1,4 +1,5 @@
 export abstract class ViewModeConstants {
   static readonly viewModeDefault: string = 'resource-table'
   static readonly viewModeQueryName: string = 'view-mode'
+  static readonly viewModeResourceTableCondensed: string = 'resource-table-condensed'
 }

--- a/packages/web-app-files/src/composables/viewMode/constants.ts
+++ b/packages/web-app-files/src/composables/viewMode/constants.ts
@@ -1,5 +1,5 @@
 export abstract class ViewModeConstants {
-  static readonly viewModeDefault: string = 'resource-table'
-  static readonly viewModeQueryName: string = 'view-mode'
-  static readonly viewModeResourceTableCondensed: string = 'resource-table-condensed'
+  static readonly default: string = 'resource-table'
+  static readonly queryName: string = 'view-mode'
+  static readonly condensedTable: string = 'resource-table-condensed'
 }

--- a/packages/web-app-files/src/composables/viewMode/index.ts
+++ b/packages/web-app-files/src/composables/viewMode/index.ts
@@ -1,0 +1,2 @@
+export * from './constants'
+export * from './useViewMode'

--- a/packages/web-app-files/src/composables/viewMode/useViewMode.ts
+++ b/packages/web-app-files/src/composables/viewMode/useViewMode.ts
@@ -1,5 +1,5 @@
 import { computed, ComputedRef, unref } from 'vue'
-import { useRouteQueryPersisted } from 'web-pkg/src/composables'
+import { queryItemAsString, useRouteQueryPersisted } from 'web-pkg/src/composables'
 import { ViewModeConstants } from './constants'
 
 export function useViewMode<T>(options: ComputedRef<string>): ComputedRef<string> {
@@ -7,9 +7,9 @@ export function useViewMode<T>(options: ComputedRef<string>): ComputedRef<string
     return computed(() => unref(options))
   }
 
-  const perPageQuery = useRouteQueryPersisted({
+  const viewModeQuery = useRouteQueryPersisted({
     name: ViewModeConstants.viewModeQueryName,
     defaultValue: ViewModeConstants.viewModeDefault
   })
-  return computed(() => String(unref(perPageQuery)))
+  return computed(() => queryItemAsString(unref(viewModeQuery)))
 }

--- a/packages/web-app-files/src/composables/viewMode/useViewMode.ts
+++ b/packages/web-app-files/src/composables/viewMode/useViewMode.ts
@@ -1,0 +1,15 @@
+import { computed, ComputedRef, unref } from 'vue'
+import { useRouteQueryPersisted } from 'web-pkg/src/composables'
+import { ViewModeConstants } from './constants'
+
+export function useViewMode<T>(options: ComputedRef<string>): ComputedRef<string> {
+  if (options) {
+    return computed(() => unref(options))
+  }
+
+  const perPageQuery = useRouteQueryPersisted({
+    name: ViewModeConstants.viewModeQueryName,
+    defaultValue: ViewModeConstants.viewModeDefault
+  })
+  return computed(() => String(unref(perPageQuery)))
+}

--- a/packages/web-app-files/src/composables/viewMode/useViewMode.ts
+++ b/packages/web-app-files/src/composables/viewMode/useViewMode.ts
@@ -8,8 +8,8 @@ export function useViewMode<T>(options: ComputedRef<string>): ComputedRef<string
   }
 
   const viewModeQuery = useRouteQueryPersisted({
-    name: ViewModeConstants.viewModeQueryName,
-    defaultValue: ViewModeConstants.viewModeDefault
+    name: ViewModeConstants.queryName,
+    defaultValue: ViewModeConstants.default
   })
   return computed(() => queryItemAsString(unref(viewModeQuery)))
 }

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -49,6 +49,7 @@
           v-model="selectedResourcesIds"
           class="files-table"
           :class="{ 'files-table-squashed': sideBarOpen }"
+          :view-mode="viewMode"
           :are-thumbnails-displayed="displayThumbnails"
           :resources="paginatedResources"
           :target-route-callback="resourceTargetRouteCallback"

--- a/packages/web-app-files/tests/mocks/useResourcesViewDefaultsMock.ts
+++ b/packages/web-app-files/tests/mocks/useResourcesViewDefaultsMock.ts
@@ -30,6 +30,7 @@ export const useResourcesViewDefaultsMock = (
     sideBarActivePanel: ref(''),
     scrollToResource: jest.fn(),
     scrollToResourceFromRoute: jest.fn(),
+    viewMode: ref('resource-table'),
     ...options
   }
 }

--- a/packages/web-app-files/tests/unit/components/AppBar/ViewOptions.spec.js
+++ b/packages/web-app-files/tests/unit/components/AppBar/ViewOptions.spec.js
@@ -1,7 +1,9 @@
-import { shallowMount, createLocalVue } from '@vue/test-utils'
+import { mount, shallowMount, createLocalVue } from '@vue/test-utils'
 import Vuex from 'vuex'
 import VueRouter from 'vue-router'
 import merge from 'lodash-es/merge'
+
+import DesignSystem from '@ownclouders/design-system'
 
 import Store from 'web-app-files/src/store'
 import stubs from '@/tests/unit/stubs'
@@ -94,5 +96,47 @@ describe('ViewOptions', () => {
     wrapper.find('[data-testid="files-switch-hidden-files"]').vm.$emit('change', false)
 
     expect(mockedStore.modules.Files.mutations.SET_HIDDEN_FILES_VISIBILITY).toHaveBeenCalled()
+  })
+
+  it('initially shows normal resource-table by default', () => {
+    const wrapper = shallowMount(ViewOptions, {
+      store,
+      router,
+      localVue,
+      stubs: stubs,
+      directives: { OcTooltip }
+    })
+    const viewModeSwitchButtons = wrapper.find('[data-testid="viewmode-switch-buttons"]')
+
+    expect(viewModeSwitchButtons).toMatchSnapshot()
+  })
+  it('toggles between normal and condensed resource-table upon clicking the respective buttons', async () => {
+    localVue.use(DesignSystem)
+
+    const wrapper = mount(ViewOptions, {
+      store,
+      router,
+      localVue,
+      stubs: {
+        ...stubs,
+        'oc-button': false
+      },
+      directives: { OcTooltip }
+    })
+
+    const viewModeSwitchButtons = wrapper.find('[data-testid="viewmode-switch-buttons"]')
+    console.log(viewModeSwitchButtons.html())
+
+    await wrapper
+      .findAll('[data-testid="viewmode-switch-buttons"] > .oc-button')
+      .at(0)
+      .trigger('click')
+    expect(viewModeSwitchButtons).toMatchSnapshot()
+
+    await wrapper
+      .findAll('[data-testid="viewmode-switch-buttons"] > .oc-button')
+      .at(1)
+      .trigger('click')
+    expect(viewModeSwitchButtons).toMatchSnapshot()
   })
 })

--- a/packages/web-app-files/tests/unit/components/AppBar/__snapshots__/ViewOptions.spec.js.snap
+++ b/packages/web-app-files/tests/unit/components/AppBar/__snapshots__/ViewOptions.spec.js.snap
@@ -6,7 +6,7 @@ exports[`ViewOptions initially shows normal resource-table by default 1`] = `
     <oc-icon-stub name="menu-line-condensed" fill-type="none" size="small"></oc-icon-stub>
   </oc-button-stub>
   <oc-button-stub appearance="filled">
-    <oc-icon-stub name="align-justify" fill-type="none" size="small"></oc-icon-stub>
+    <oc-icon-stub name="menu-line" fill-type="none" size="small"></oc-icon-stub>
   </oc-button-stub>
 </div>
 `;
@@ -15,7 +15,7 @@ exports[`ViewOptions toggles between normal and condensed resource-table upon cl
 <div data-testid="viewmode-switch-buttons" class="oc-button-group oc-visible@s oc-mr-s"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-filled">
     <oc-icon-stub name="menu-line-condensed" filltype="none" accessiblelabel="" type="span" size="small" variation="passive" color=""></oc-icon-stub>
   </button> <button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-outline">
-    <oc-icon-stub name="align-justify" filltype="none" accessiblelabel="" type="span" size="small" variation="passive" color=""></oc-icon-stub>
+    <oc-icon-stub name="menu-line" filltype="none" accessiblelabel="" type="span" size="small" variation="passive" color=""></oc-icon-stub>
   </button></div>
 `;
 
@@ -23,6 +23,6 @@ exports[`ViewOptions toggles between normal and condensed resource-table upon cl
 <div data-testid="viewmode-switch-buttons" class="oc-button-group oc-visible@s oc-mr-s"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-outline">
     <oc-icon-stub name="menu-line-condensed" filltype="none" accessiblelabel="" type="span" size="small" variation="passive" color=""></oc-icon-stub>
   </button> <button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-filled">
-    <oc-icon-stub name="align-justify" filltype="none" accessiblelabel="" type="span" size="small" variation="passive" color=""></oc-icon-stub>
+    <oc-icon-stub name="menu-line" filltype="none" accessiblelabel="" type="span" size="small" variation="passive" color=""></oc-icon-stub>
   </button></div>
 `;

--- a/packages/web-app-files/tests/unit/components/AppBar/__snapshots__/ViewOptions.spec.js.snap
+++ b/packages/web-app-files/tests/unit/components/AppBar/__snapshots__/ViewOptions.spec.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ViewOptions initially shows normal resource-table by default 1`] = `
+<div data-testid="viewmode-switch-buttons" class="oc-button-group oc-visible@s oc-mr-s">
+  <oc-button-stub appearance="outline">
+    <oc-icon-stub name="menu-line-condensed" fill-type="none" size="small"></oc-icon-stub>
+  </oc-button-stub>
+  <oc-button-stub appearance="filled">
+    <oc-icon-stub name="align-justify" fill-type="none" size="small"></oc-icon-stub>
+  </oc-button-stub>
+</div>
+`;
+
+exports[`ViewOptions toggles between normal and condensed resource-table upon clicking the respective buttons 1`] = `
+<div data-testid="viewmode-switch-buttons" class="oc-button-group oc-visible@s oc-mr-s"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-filled">
+    <oc-icon-stub name="menu-line-condensed" filltype="none" accessiblelabel="" type="span" size="small" variation="passive" color=""></oc-icon-stub>
+  </button> <button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-outline">
+    <oc-icon-stub name="align-justify" filltype="none" accessiblelabel="" type="span" size="small" variation="passive" color=""></oc-icon-stub>
+  </button></div>
+`;
+
+exports[`ViewOptions toggles between normal and condensed resource-table upon clicking the respective buttons 2`] = `
+<div data-testid="viewmode-switch-buttons" class="oc-button-group oc-visible@s oc-mr-s"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-outline">
+    <oc-icon-stub name="menu-line-condensed" filltype="none" accessiblelabel="" type="span" size="small" variation="passive" color=""></oc-icon-stub>
+  </button> <button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-filled">
+    <oc-icon-stub name="align-justify" filltype="none" accessiblelabel="" type="span" size="small" variation="passive" color=""></oc-icon-stub>
+  </button></div>
+`;


### PR DESCRIPTION
## Description
Adds route-query based toggle between "normal" and "condensed" resource table

## Related Issue
- Fixes part of #6380

## Screenshots (if appropriate):
<img width="810" alt="Screenshot 2022-11-15 at 22 34 49" src="https://user-images.githubusercontent.com/16822008/202029210-13230f96-4a0c-408e-bf1f-f8dc8a371b54.png">

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Open tasks:
- [ ] Review/feedback/approval by @tbsbdr / @kulmann / @elizavetaRa 
