### PR TITLE
[full-ci] Improve UX of the conflict dialog

### DIFF
--- a/changelog/unreleased/enhancement-conflict-dialog-ux
+++ b/changelog/unreleased/enhancement-conflict-dialog-ux
@@ -1,0 +1,10 @@
+Bugfix: Conflict dialog UX
+
+The UX of the conflict dialog has been improved slightly:
+
+* The name of the conflicting resource is now written in quotes
+* The title of the dialog now tells the difference between files and folders
+* The "Skip"-dialog now tells the difference between files and folders
+
+https://github.com/owncloud/web/pull/7983
+https://github.com/owncloud/web/issues/7682

--- a/changelog/unreleased/enhancement-conflict-dialog-ux
+++ b/changelog/unreleased/enhancement-conflict-dialog-ux
@@ -1,4 +1,4 @@
-Bugfix: Conflict dialog UX
+Enhancement: Conflict dialog UX
 
 The UX of the conflict dialog has been improved slightly:
 

--- a/packages/web-app-files/src/helpers/resource/actions/transfer.ts
+++ b/packages/web-app-files/src/helpers/resource/actions/transfer.ts
@@ -113,7 +113,6 @@ export class ResourceTransfer extends ConflictDialog {
 
     const resolvedConflicts = await this.resolveAllConflicts(
       this.resourcesToMove,
-      this.targetSpace,
       this.targetFolder,
       targetFolderResources
     )

--- a/packages/web-app-files/src/helpers/resource/conflictHandling/conflictDialog.ts
+++ b/packages/web-app-files/src/helpers/resource/conflictHandling/conflictDialog.ts
@@ -76,11 +76,15 @@ export class ConflictDialog {
     suggestMerge = false,
     separateSkipHandling = false // separate skip-handling between files and folders
   ): Promise<ResolveConflict> {
-    const translatedSkipLabel = !separateSkipHandling
-      ? this.$gettext('Apply to all %{count} conflicts')
-      : resource.isFolder
-      ? this.$gettext('Apply to all %{count} folders')
-      : this.$gettext('Apply to all %{count} files')
+    let translatedSkipLabel
+
+    if (!separateSkipHandling) {
+      translatedSkipLabel = this.$gettext('Apply to all %{count} conflicts')
+    } else if (resource.isFolder) {
+      translatedSkipLabel = this.$gettext('Apply to all %{count} folders')
+    } else {
+      translatedSkipLabel = this.$gettext('Apply to all %{count} files')
+    }
 
     return new Promise<ResolveConflict>((resolve) => {
       let doForAllConflicts = false

--- a/packages/web-app-files/tests/unit/helpers/resource/conflictHandling/conflictDialog.spec.ts
+++ b/packages/web-app-files/tests/unit/helpers/resource/conflictHandling/conflictDialog.spec.ts
@@ -1,0 +1,40 @@
+import { mockDeep } from 'jest-mock-extended'
+import { Resource } from 'web-client'
+import { ConflictDialog, ResolveConflict } from 'web-app-files/src/helpers/resource'
+
+const getConflictDialogInstance = ({ createModal = jest.fn() } = {}) => {
+  return new ConflictDialog(createModal, jest.fn(), jest.fn(), jest.fn(), jest.fn(), jest.fn())
+}
+
+describe('conflict dialog', () => {
+  describe('method "resolveAllConflicts"', () => {
+    it('should return the resolved conflicts including the resource(s) and the strategy', async () => {
+      const conflictDialog = getConflictDialogInstance()
+      const strategy = mockDeep<ResolveConflict>()
+      conflictDialog.resolveFileExists = jest.fn().mockImplementation(() => ({
+        strategy,
+        doForAllConflicts: false
+      }))
+      const resource = mockDeep<Resource>({ name: 'someFile.txt' })
+      const targetFolder = mockDeep<Resource>({ path: '/' })
+      const targetFolderResources = [mockDeep<Resource>({ path: '/someFile.txt' })]
+      const resolvedConflicts = await conflictDialog.resolveAllConflicts(
+        [resource],
+        targetFolder,
+        targetFolderResources
+      )
+
+      expect(resolvedConflicts.length).toBe(1)
+      expect(resolvedConflicts[0].resource).toEqual(resource)
+      expect(resolvedConflicts[0].strategy).toEqual(strategy)
+    })
+  })
+  describe('method "resolveFileExists"', () => {
+    it('should create the modal in the end', () => {
+      const createModal = jest.fn()
+      const conflictDialog = getConflictDialogInstance({ createModal })
+      conflictDialog.resolveFileExists(mockDeep<Resource>(), 2, true)
+      expect(createModal).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/packages/web-app-files/tests/unit/helpers/resource/resourcesTransfer.spec.ts
+++ b/packages/web-app-files/tests/unit/helpers/resource/resourcesTransfer.spec.ts
@@ -137,12 +137,7 @@ describe('resourcesTransfer', () => {
     resourcesTransfer.resolveFileExists = jest
       .fn()
       .mockImplementation(() => Promise.resolve({ strategy: 0 } as ResolveConflict))
-    await resourcesTransfer.resolveAllConflicts(
-      resourcesToMove,
-      targetSpace,
-      targetFolder,
-      targetFolderItems
-    )
+    await resourcesTransfer.resolveAllConflicts(resourcesToMove, targetFolder, targetFolderItems)
 
     expect(resourcesTransfer.resolveFileExists).toHaveBeenCalled()
   })

--- a/tests/acceptance/features/webUIFilesCopy/copy.feature
+++ b/tests/acceptance/features/webUIFilesCopy/copy.feature
@@ -32,7 +32,7 @@ Feature: copy files and folders
     And user "Alice" has logged in using the webUI
     And the user has browsed to the personal page
     When the user tries to copy file "strängé filename (duplicate #2 &).txt" into folder "strängé नेपाली folder" using the webUI
-    Then the "modal error" message with header 'File with name strängé filename (duplicate #2 &).txt already exists.' should be displayed on the webUI
+    Then the "modal error" message with header 'File with name "strängé filename (duplicate #2 &).txt" already exists.' should be displayed on the webUI
 
   @smokeTest @ocisSmokeTest
   Scenario: Copy multiple files at once

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -45,7 +45,7 @@ Feature: move files
     And user "Alice" has uploaded file "lorem.txt" to "simple-folder/lorem.txt" in the server
     And the user has browsed to the personal page
     When the user tries to move file "lorem.txt" into folder "simple-folder" using the webUI
-    Then the "modal error" message with header 'File with name lorem.txt already exists.' should be displayed on the webUI
+    Then the "modal error" message with header 'File with name "lorem.txt" already exists.' should be displayed on the webUI
 
   @smokeTest @ocisSmokeTest  @disablePreviews
   Scenario: Move multiple files at once

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
@@ -35,7 +35,7 @@ Feature: move folders
     And user "Alice" has logged in using the webUI
     And the user has browsed to the personal page
     When the user tries to move folder "simple-empty-folder" into folder "simple-folder" using the webUI
-    Then the "modal error" message with header 'Folder with name simple-empty-folder already exists.' should be displayed on the webUI
+    Then the "modal error" message with header 'Folder with name "simple-empty-folder" already exists.' should be displayed on the webUI
 
   @smokeTest
   Scenario: Move multiple folders at once


### PR DESCRIPTION
## Description
The UX of the conflict dialog has been improved slightly:

* The name of the conflicting resource is now written in quotes
* The title of the dialog now tells the difference between files and folders
* The "Skip"-dialog now tells the difference between files and folders

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7682

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Unit tests after https://github.com/owncloud/web/pull/7975 has been merged