### PR TITLE
[tests-only][full-ci]Remove check for expiration date in december month

### DIFF
--- a/tests/acceptance/features/webUISharingPublicExpire/shareByPublicLinkExpiringLinks.feature
+++ b/tests/acceptance/features/webUISharingPublicExpire/shareByPublicLinkExpiringLinks.feature
@@ -58,7 +58,7 @@ Feature: Share by public link
       | file    | lorem.txt       |
       | folder  | simple-folder   |
 
-  @issue-ocis-1328 @skipOnOCIS @skipOnOC10 # skipped on oc10 due to https://github.com/owncloud/web/issues/7513
+  @issue-ocis-1328 @skipOnOCIS
   Scenario: user cannot change the expiry date of an existing public link to a date that is past the enforced max expiry date
     Given the setting "shareapi_default_expire_date" of app "core" has been set to "yes" in the server
     And the setting "shareapi_enforce_expire_date" of app "core" has been set to "yes" in the server

--- a/tests/acceptance/pageObjects/FilesPageElement/expirationDatePicker.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/expirationDatePicker.js
@@ -99,26 +99,8 @@ module.exports = {
     isExpiryDateDisabled: async function (pastDate) {
       let disabled = false
       const yearSelector = this.getSelectorExpiryDateYear(pastDate)
-      const month = pastDate.toLocaleString('default', { month: 'long' })
       const monthSelector = this.getSelectorExpiryDateMonth(pastDate)
       const daySelector = this.getSelectorExpiryDateDay(pastDate)
-
-      if (month === 'December') {
-        await this.waitForElementVisible(daySelector).getAttribute(
-          daySelector,
-          'class',
-          (result) => {
-            if (result.value.includes('is-disabled') === true) {
-              disabled = true
-            }
-          }
-        )
-        if (disabled) {
-          return disabled
-        } else {
-          return false
-        }
-      }
 
       await this.waitForElementVisible('@datepickerTitle')
         .click('@datepickerTitle')


### PR DESCRIPTION
### Description
This PR removes check for the month of `December`. May be previously in the month of december the UI would not give us to click the month of december (basically it is disabled). As of now through web UI we can click even if its the month of december.

### Build check during the month of december
https://drone.owncloud.com/owncloud/web/29968/10/18

 ### Related Issue
https://github.com/owncloud/web/issues/7227