### PR TITLE
Prevent retrying uploads with status code 5xx

### DIFF
--- a/changelog/unreleased/bugfix-no-upload-retry-on-status-5xx
+++ b/changelog/unreleased/bugfix-no-upload-retry-on-status-5xx
@@ -1,0 +1,6 @@
+Bugfix: Prevent retrying uploads with status code 5xx
+
+Uploads with status code 5xx can't be retried on the server side, hence the automatic retry has been disabled in such cases.
+
+https://github.com/owncloud/web/pull/7985
+https://github.com/owncloud/web/issues/7971

--- a/packages/web-runtime/src/services/uppyService.ts
+++ b/packages/web-runtime/src/services/uppyService.ts
@@ -57,7 +57,14 @@ export class UppyService {
       overridePatchMethod: !!tusHttpMethodOverride,
       retryDelays: [0, 500, 1000],
       uploadDataDuringCreation,
-      onBeforeRequest
+      onBeforeRequest,
+      onShouldRetry: (err, retryAttempt, options, next) => {
+        // status code 5xx means the upload is gone on the server side
+        if (err?.originalResponse?.getStatus() >= 500) {
+          return false
+        }
+        return next(err)
+      }
     }
 
     const xhrPlugin = this.uppy.getPlugin('XHRUpload')


### PR DESCRIPTION
## Description
Uploads with status code 5xx can't be retried on the server side, hence the automatic retry has been disabled in such cases.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7971

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

