### PR TITLE
Fix error message display in text editor

### DIFF
--- a/changelog/unreleased/bugfix-text-editor-error-messages
+++ b/changelog/unreleased/bugfix-text-editor-error-messages
@@ -1,0 +1,6 @@
+Bugfix: Display error messages in text editor
+
+Error messages in and when leaving the text editor are now being displayed properly.
+
+https://github.com/owncloud/web/issues/7960
+https://github.com/owncloud/web/pull/8001

--- a/packages/web-app-text-editor/src/App.vue
+++ b/packages/web-app-text-editor/src/App.vue
@@ -48,10 +48,11 @@ import { useTask } from 'vue-concurrency'
 import { computed, onMounted, onBeforeUnmount, ref, unref, Ref, watch } from '@vue/composition-api'
 import { mapActions } from 'vuex'
 import { DavPermission, DavProperty } from 'web-client/src/webdav/constants'
-import { useAppDefaults } from 'web-pkg/src/composables'
+import { useAppDefaults, useStore, useTranslations } from 'web-pkg/src/composables'
 import AppTopBar from 'web-pkg/src/components/AppTopBar.vue'
 import { defineComponent } from '@vue/composition-api'
 import { Resource } from 'web-client'
+import { isProjectSpaceResource } from 'web-client/src/helpers'
 
 export default defineComponent({
   name: 'TextEditor',
@@ -71,8 +72,8 @@ export default defineComponent({
           this.hideModal()
           next()
         },
-        onConfirm: () => {
-          this.save()
+        onConfirm: async () => {
+          await this.save()
           this.hideModal()
           next()
         }
@@ -99,6 +100,16 @@ export default defineComponent({
     const currentETag = ref()
     const isReadOnly = ref(true)
     const resource: Ref<Resource> = ref()
+    const store = useStore()
+    const { $gettext, $gettextInterpolate } = useTranslations()
+
+    const errorPopup = (error) => {
+      store.dispatch('showMessage', {
+        title: $gettext('An error occurred'),
+        desc: error,
+        status: 'danger'
+      })
+    }
 
     const loadFileTask = useTask(function* () {
       resource.value = yield getFileInfo(currentFileContext, {
@@ -127,20 +138,39 @@ export default defineComponent({
       } catch (e) {
         switch (e.statusCode) {
           case 412:
-            this.errorPopup(
-              this.$gettext(
+            errorPopup(
+              $gettext(
                 'This file was updated outside this window. Please refresh the page (all changes will be lost).'
               )
             )
             break
           case 500:
-            this.errorPopup(this.$gettext('Error when contacting the server'))
+            errorPopup($gettext('Error when contacting the server'))
+            break
+          case 507:
+            const space = store.getters['runtime/spaces/spaces'].find(
+              (space) => space.id === unref(resource).storageId && isProjectSpaceResource(space)
+            )
+            if (space) {
+              errorPopup(
+                // FIXME: translation
+                // $gettextInterpolate(
+                //   'There is not enough quota on "%{spaceName}" to save this file',
+                //   { spaceName: space.name }
+                // )
+                $gettext('Error when contacting the server')
+              )
+              break
+            }
+            // FIXME: translation
+            // errorPopup($gettext('There is not enough quota to save this file'))
+            errorPopup($gettext('Error when contacting the server'))
             break
           case 401:
-            this.errorPopup(this.$gettext("You're not authorized to save this file"))
+            errorPopup($gettext("You're not authorized to save this file"))
             break
           default:
-            this.errorPopup(e.message || e)
+            errorPopup(e.message || e)
         }
       }
     }).restartable()
@@ -196,8 +226,8 @@ export default defineComponent({
       document.removeEventListener('keydown', handleSKey, false)
     })
 
-    const save = function () {
-      saveFileTask.perform()
+    const save = async function () {
+      await saveFileTask.perform()
     }
 
     const handleSKey = function (e) {
@@ -239,15 +269,7 @@ export default defineComponent({
     }
   },
   methods: {
-    ...mapActions(['createModal', 'hideModal', 'showMessage']),
-
-    errorPopup(error) {
-      this.showMessage({
-        title: this.$gettext('An error occurred'),
-        desc: error,
-        status: 'danger'
-      })
-    }
+    ...mapActions(['createModal', 'hideModal'])
   }
 })
 </script>


### PR DESCRIPTION
## Description
Error messages in and when leaving the text editor are now being displayed properly.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7960

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
