### PR TITLE
Fix missing password form on public drop page

### DIFF
--- a/changelog/unreleased/bugfix-missing-public-password-form
+++ b/changelog/unreleased/bugfix-missing-public-password-form
@@ -1,0 +1,6 @@
+Bugfix: Missing password form on public drop page
+
+We've fixed a bug where the password form on a public drop page would not show after setting a required password.
+
+https://github.com/owncloud/web/pull/8007
+https://github.com/owncloud/web/issues/7670

--- a/packages/web-app-files/src/views/FilesDrop.vue
+++ b/packages/web-app-files/src/views/FilesDrop.vue
@@ -47,6 +47,7 @@ import { usePublicLinkPassword, useStore } from 'web-pkg/src/composables'
 import { eventBus } from 'web-pkg/src/services/eventBus'
 import { linkRoleUploaderFolder } from 'web-client/src/helpers/share'
 import { defineComponent } from '@vue/composition-api'
+import { authService } from 'web-runtime/src/services/auth'
 
 export default defineComponent({
   components: {
@@ -151,7 +152,7 @@ export default defineComponent({
         .catch((error) => {
           // likely missing password, redirect to public link password prompt
           if (error.statusCode === 401) {
-            return this.$authService.handleAuthError(this.$router.currentRoute)
+            return authService.handleAuthError(this.$router.currentRoute)
           }
           console.error(error)
           this.errorMessage = error

--- a/packages/web-app-files/src/views/FilesDrop.vue
+++ b/packages/web-app-files/src/views/FilesDrop.vue
@@ -47,7 +47,6 @@ import { usePublicLinkPassword, useStore } from 'web-pkg/src/composables'
 import { eventBus } from 'web-pkg/src/services/eventBus'
 import { linkRoleUploaderFolder } from 'web-client/src/helpers/share'
 import { defineComponent } from '@vue/composition-api'
-import { authService } from 'web-runtime/src/services/auth'
 
 export default defineComponent({
   components: {
@@ -152,7 +151,7 @@ export default defineComponent({
         .catch((error) => {
           // likely missing password, redirect to public link password prompt
           if (error.statusCode === 401) {
-            return authService.handleAuthError(this.$router.currentRoute)
+            return this.$authService.handleAuthError(this.$router.currentRoute)
           }
           console.error(error)
           this.errorMessage = error

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -322,6 +322,7 @@ export const announceAuthService = ({
   router: VueRouter
 }): void => {
   authService.initialize(configurationManager, clientService, store, router)
+  vue.prototype.$authService = authService
   set(vue, '$authService', authService)
 }
 


### PR DESCRIPTION
## Description
We've fixed a bug where the password form on a public drop page would not show after setting a required password.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7670

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
