### PR TITLE
Fix quota check when replacing files

### DIFF
--- a/changelog/unreleased/bugfix-quota-check-when-replacing-files
+++ b/changelog/unreleased/bugfix-quota-check-when-replacing-files
@@ -1,0 +1,6 @@
+Bugfix: Quota check when replacing files
+
+An issue with the quota check when replacing an existing file while having enough quota has been fixed.
+
+https://github.com/owncloud/web/issues/7962
+https://github.com/owncloud/web/pull/8015

--- a/packages/web-app-files/src/helpers/resource/actions/upload.ts
+++ b/packages/web-app-files/src/helpers/resource/actions/upload.ts
@@ -210,6 +210,13 @@ export class ResourcesUpload extends ConflictDialog {
     const uploadSizeSpaceMapping = uppyResources.reduce((acc, uppyResource) => {
       let targetUploadSpace
 
+      const existingFile = this.currentFiles.find(
+        (c) => !uppyResource.meta.relativeFolder && c.name === uppyResource.name
+      )
+      if (existingFile?.size >= uppyResource.data.size) {
+        return acc
+      }
+
       if (uppyResource.meta.routeName === locationPublicLink.name) {
         return acc
       }

--- a/packages/web-app-files/src/helpers/resource/actions/upload.ts
+++ b/packages/web-app-files/src/helpers/resource/actions/upload.ts
@@ -210,13 +210,6 @@ export class ResourcesUpload extends ConflictDialog {
     const uploadSizeSpaceMapping = uppyResources.reduce((acc, uppyResource) => {
       let targetUploadSpace
 
-      const existingFile = this.currentFiles.find(
-        (c) => !uppyResource.meta.relativeFolder && c.name === uppyResource.name
-      )
-      if (existingFile?.size >= uppyResource.data.size) {
-        return acc
-      }
-
       if (uppyResource.meta.routeName === locationPublicLink.name) {
         return acc
       }
@@ -229,6 +222,11 @@ export class ResourcesUpload extends ConflictDialog {
         return acc
       }
 
+      const existingFile = this.currentFiles.find(
+        (c) => !uppyResource.meta.relativeFolder && c.name === uppyResource.name
+      )
+      const existingFileSize = existingFile ? Number(existingFile.size) : 0
+
       const matchingMappingRecord = acc.find(
         (mappingRecord) => mappingRecord.space.id === targetUploadSpace.id
       )
@@ -236,12 +234,12 @@ export class ResourcesUpload extends ConflictDialog {
       if (!matchingMappingRecord) {
         acc.push({
           space: targetUploadSpace,
-          uploadSize: uppyResource.data.size
+          uploadSize: uppyResource.data.size - existingFileSize
         })
         return acc
       }
 
-      matchingMappingRecord.uploadSize += uppyResource.data.size
+      matchingMappingRecord.uploadSize = uppyResource.data.size - existingFileSize
 
       return acc
     }, [])


### PR DESCRIPTION
## Description
An issue with the quota check when replacing an existing file while having enough quota has been fixed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7962

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
