### PR TITLE
chore: bump design system to v14.0.0 final

### DIFF
--- a/changelog/6.0.0_2022-11-24/enhancement-update-ods
+++ b/changelog/6.0.0_2022-11-24/enhancement-update-ods
@@ -1,6 +1,6 @@
-Enhancement: Update ODS to v14.0.0-alpha.25
+Enhancement: Update ODS to v14.0.1
 
-We updated the ownCloud Design System to version 14.0.0-alpha.25. Please refer to the full changelog in the ODS release (linked) for more details. Summary:
+We updated the ownCloud Design System to version 14.0.1. Please refer to the full changelog in the ODS release (linked) for more details. Summary:
 
 * Bugfix - Omit special characters in user avatar initials: [#2070](https://github.com/owncloud/owncloud-design-system/issues/2070)
 * Bugfix - Avatar link icon: [#2269](https://github.com/owncloud/owncloud-design-system/pull/2269)
@@ -33,5 +33,6 @@ We updated the ownCloud Design System to version 14.0.0-alpha.25. Please refer t
 * Enhancement - Remove border on buttons: [#2345](https://github.com/owncloud/owncloud-design-system/pull/2345)
 * Enhancement - Input background color: [#2352](https://github.com/owncloud/owncloud-design-system/pull/2352)
 
-https://github.com/owncloud/web/pull/7915
-https://github.com/owncloud/owncloud-design-system/releases/tag/v14.0.0-alpha.25
+https://github.com/owncloud/web/pull/8028
+https://github.com/owncloud/owncloud-design-system/releases/tag/v14.0.0
+https://github.com/owncloud/owncloud-design-system/releases/tag/v14.0.1

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -24,7 +24,7 @@
     "luxon": "^2.4.0",
     "marked": "^4.0.12",
     "oidc-client-ts": "^2.1.0",
-    "owncloud-design-system": "14.0.0-alpha.25",
+    "owncloud-design-system": "14.0.1",
     "owncloud-sdk": "~3.0.0-alpha.17",
     "p-queue": "^6.6.2",
     "popper-max-size-modifier": "^0.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -487,7 +487,7 @@ importers:
       luxon: ^2.4.0
       marked: ^4.0.12
       oidc-client-ts: ^2.1.0
-      owncloud-design-system: 14.0.0-alpha.25
+      owncloud-design-system: 14.0.1
       owncloud-sdk: ~3.0.0-alpha.17
       p-queue: ^6.6.2
       popper-max-size-modifier: ^0.2.0
@@ -541,7 +541,7 @@ importers:
       luxon: 2.4.0
       marked: 4.0.12
       oidc-client-ts: 2.1.0
-      owncloud-design-system: 14.0.0-alpha.25_qjo64ckxpkihsz2u7asmuqxitq
+      owncloud-design-system: 14.0.1_qjo64ckxpkihsz2u7asmuqxitq
       owncloud-sdk: 3.0.0-alpha.17_qgpf6seimtkgc6dfu7oqfstxh4
       p-queue: 6.6.2
       popper-max-size-modifier: 0.2.0_@popperjs+core@2.11.5
@@ -11733,8 +11733,8 @@ packages:
       glob: 7.2.0
     dev: true
 
-  /owncloud-design-system/14.0.0-alpha.25_qjo64ckxpkihsz2u7asmuqxitq:
-    resolution: {integrity: sha512-JRaH6dYJ7HmjZbVC0i7EPhcEVoFJDB94Gen/MdKHulzGLvthKH4p/jtb4CbhEnzNpK3xvFGAy5Sq9K6SpIAVwA==}
+  /owncloud-design-system/14.0.1_qjo64ckxpkihsz2u7asmuqxitq:
+    resolution: {integrity: sha512-3KnShcluYMuyRCJ3r3SWq/BYUN1v0OJHwWdfx0zCR3McY0hTZDiyR3OzR9saVnxN2y0srYM17rsYwRZBBKFU7A==}
     engines: {node: '>= 14.0.0', npm: '>= 3.0.0'}
     peerDependencies:
       '@popperjs/core': ^2.4.0


### PR DESCRIPTION
Bump the design system to the v14.0.1 final release.