### PR TITLE
Fix saving a file multiple times with the text editor

### DIFF
--- a/changelog/unreleased/bugfix-text-editor-multple-save
+++ b/changelog/unreleased/bugfix-text-editor-multple-save
@@ -1,0 +1,6 @@
+Bugfix: Saving a file multiple times with the text editor
+
+An issue with saving a file multiple times via text editor has been fixed.
+
+https://github.com/owncloud/web/pull/8030
+https://github.com/owncloud/web/issues/8029

--- a/packages/web-app-text-editor/src/App.vue
+++ b/packages/web-app-text-editor/src/App.vue
@@ -134,7 +134,7 @@ export default defineComponent({
           previousEntityTag: unref(currentETag)
         })
         serverContent.value = newContent
-        currentETag.value = putFileContentsResponse['OC-ETag']
+        currentETag.value = putFileContentsResponse.etag
       } catch (e) {
         switch (e.statusCode) {
           case 412:


### PR DESCRIPTION
## Description
Fixes an issue with saving a file multiple times via text editor.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8029

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
