### PR TITLE
Fix-8008: Don't open sharing sidebar after creating/copying quicklink

### DIFF
--- a/changelog/unreleased/enhancement-no-sidebar-when-copying-quicklink
+++ b/changelog/unreleased/enhancement-no-sidebar-when-copying-quicklink
@@ -1,0 +1,6 @@
+Enhancement: Don't open sidebar when copying quicklink
+
+Following user feedback, we don't open the sharing sidebar anymore after copying/creating a quicklink.
+
+https://github.com/owncloud/web/issues/8008
+https://github.com/owncloud/web/pull/8036

--- a/packages/web-app-files/src/mixins/actions/createQuicklink.ts
+++ b/packages/web-app-files/src/mixins/actions/createQuicklink.ts
@@ -3,8 +3,6 @@ import { createQuicklink } from '../../helpers/share'
 import { ShareStatus } from 'web-client/src/helpers/share'
 
 import { isLocationSharesActive } from '../../router'
-import { eventBus } from 'web-pkg/src/services/eventBus'
-import { SideBarEventTopics } from '../../composables/sideBar'
 
 export default {
   computed: {
@@ -43,8 +41,6 @@ export default {
         store,
         $gettext: this.$gettext
       })
-
-      eventBus.publish(SideBarEventTopics.openWithPanel, 'sharing#linkShares')
     }
   }
 }

--- a/packages/web-app-files/src/quickActions.js
+++ b/packages/web-app-files/src/quickActions.js
@@ -67,12 +67,10 @@ export default {
       if (passwordEnforced) {
         return showQuickLinkPasswordModal(ctx, async (password) => {
           await createQuicklink({ ...ctx, resource: ctx.item, password })
-          eventBus.publish(SideBarEventTopics.openWithPanel, 'sharing#linkShares')
         })
       }
 
       await createQuicklink({ ...ctx, resource: ctx.item })
-      eventBus.publish(SideBarEventTopics.openWithPanel, 'sharing#linkShares')
     },
     displayed: canShare
   }


### PR DESCRIPTION
## Description
Green unit tests, let's see how tightly e2e/acceptance tests are woven into this

## Related Issue
- Fixes #8008
