### PR TITLE
Fix resolving drives in search results

### DIFF
--- a/changelog/unreleased/bugfix-resolving-drives-in-search
+++ b/changelog/unreleased/bugfix-resolving-drives-in-search
@@ -1,0 +1,6 @@
+Bugfix: Resolving drives in search
+
+We've fixed a bug where folder listing was not reloaded when being in a space/share root and navigating into another space/share root via search.
+
+https://github.com/owncloud/web/pull/8045
+https://github.com/owncloud/web/issues/8034

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -318,6 +318,11 @@ export default defineComponent({
       handler: function () {
         this.performLoaderTask(true)
       }
+    },
+    space: {
+      handler: function () {
+        this.performLoaderTask(true)
+      }
     }
   },
 
@@ -348,6 +353,10 @@ export default defineComponent({
     ]),
 
     async performLoaderTask(sameRoute: boolean, path?: string, fileId?: string | number) {
+      if (this.loadResourcesTask.isRunning) {
+        return
+      }
+
       const options: FolderLoaderOptions = { loadShares: !isPublicSpaceResource(this.space) }
       await this.loadResourcesTask.perform(
         this.space,

--- a/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
@@ -10,6 +10,8 @@ import { useResourcesViewDefaults } from 'web-app-files/src/composables'
 import { useResourcesViewDefaultsMock } from 'web-app-files/tests/mocks/useResourcesViewDefaultsMock'
 import { ref } from '@vue/composition-api'
 import { defaultStubs } from 'web-test-helpers/src/mocks/defaultStubs'
+import { mockDeep } from 'jest-mock-extended'
+import { SpaceResource } from 'web-client/src/helpers'
 
 jest.mock('web-app-files/src/composables')
 
@@ -59,6 +61,26 @@ describe('GenericSpace view', () => {
       const { wrapper } = getMountedWrapper({ files })
       expect(wrapper.find('.no-content-message').exists()).toBeFalsy()
       expect(wrapper.find('resource-table-stub').exists()).toBeTruthy()
+    })
+  })
+  describe('loader task', () => {
+    it('re-loads the resources on item change', async () => {
+      const loaderSpy = jest.spyOn((GenericSpace as any).methods, 'performLoaderTask')
+      const { wrapper } = getMountedWrapper()
+      await wrapper.vm.loadResourcesTask.last
+      expect(loaderSpy).toHaveBeenCalledTimes(1)
+      wrapper.setProps({ item: 'newItem' })
+      await wrapper.vm.loadResourcesTask.last
+      expect(loaderSpy).toHaveBeenCalledTimes(2)
+    })
+    it('re-loads the resources on space change', async () => {
+      const loaderSpy = jest.spyOn((GenericSpace as any).methods, 'performLoaderTask')
+      const { wrapper } = getMountedWrapper()
+      await wrapper.vm.loadResourcesTask.last
+      expect(loaderSpy).toHaveBeenCalledTimes(1)
+      wrapper.setProps({ space: mockDeep<SpaceResource>() })
+      await wrapper.vm.loadResourcesTask.last
+      expect(loaderSpy).toHaveBeenCalledTimes(2)
     })
   })
 })


### PR DESCRIPTION
## Description
We've fixed a bug where folder listing was not reloaded when being in a space/share root and navigating into another space/share root via search.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8034

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests