### PR TITLE
[full-ci] ci: only deploy from merge commits to master

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2730,8 +2730,6 @@ def deploy(ctx, config, rebuild):
         "trigger": {
             "ref": [
                 "refs/heads/master",
-                "refs/heads/stable-*",
-                "refs/tags/v*",
             ],
         },
     }


### PR DESCRIPTION
In https://github.com/owncloud/web/pull/8048 I accidentally also added the `stable-*` trigger to the continuous deployment. That should only happen from master. Omitted the tags as well, because we don't want to deploy tags on the stable branch either.