### PR TITLE
Retry failed uploads on re-upload

### DIFF
--- a/changelog/unreleased/enhancement-retry-failed-uploads
+++ b/changelog/unreleased/enhancement-retry-failed-uploads
@@ -1,0 +1,6 @@
+Enhancement: Retry failed uploads on re-upload
+
+When re-uploading a file that failed uploading before, the upload is now being retried instead of being started from scratch again. This fixes some issues with the overlay and preserves the upload progress.
+
+https://github.com/owncloud/web/pull/8055
+https://github.com/owncloud/web/issues/7944

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -214,6 +214,7 @@ export default defineComponent({
         uppyService
       }),
       ...useUploadHelpers({
+        uppyService,
         space: computed(() => props.space),
         currentFolder: computed(() => props.item),
         currentFolderId: computed(() => props.itemId)

--- a/packages/web-app-files/src/composables/upload/useUploadHelpers.ts
+++ b/packages/web-app-files/src/composables/upload/useUploadHelpers.ts
@@ -6,11 +6,12 @@ import * as uuid from 'uuid'
 import path from 'path'
 import { SpaceResource } from 'web-client/src/helpers'
 import { urlJoin } from 'web-client/src/utils'
-
+import { UppyService } from 'web-runtime/src/services/uppyService'
 interface UploadHelpersOptions {
   space: ComputedRef<SpaceResource>
   currentFolder?: ComputedRef<string>
   currentFolderId?: ComputedRef<string | number>
+  uppyService: UppyService
 }
 
 interface UploadHelpersResult {
@@ -18,6 +19,7 @@ interface UploadHelpersResult {
 }
 
 interface inputFileOptions {
+  uppyService: UppyService
   route: Ref<Route>
   space: Ref<SpaceResource>
   currentFolder: Ref<string>
@@ -27,6 +29,7 @@ interface inputFileOptions {
 export function useUploadHelpers(options: UploadHelpersOptions): UploadHelpersResult {
   return {
     inputFilesToUppyFiles: inputFilesToUppyFiles({
+      uppyService: options.uppyService,
       route: useRoute(),
       space: options.space,
       currentFolder: options.currentFolder,
@@ -49,6 +52,7 @@ const getRelativeFilePath = (file: File): string | undefined => {
 }
 
 const inputFilesToUppyFiles = ({
+  uppyService,
   route,
   space,
   currentFolder,
@@ -86,6 +90,7 @@ const inputFilesToUppyFiles = ({
         source: 'file input',
         name: file.name,
         type: file.type,
+        size: file.size,
         data: file,
         meta: {
           // current path & space
@@ -96,6 +101,7 @@ const inputFilesToUppyFiles = ({
           currentFolder: unref(currentFolder),
           currentFolderId: unref(currentFolderId),
           // upload data
+          uppyId: uppyService.generateUploadId(file),
           relativeFolder: directory,
           relativePath: relativeFilePath, // uppy needs this property to be named relativePath
           tusEndpoint,

--- a/packages/web-app-files/tests/unit/composables/upload/useUploadHelpers.spec.ts
+++ b/packages/web-app-files/tests/unit/composables/upload/useUploadHelpers.spec.ts
@@ -3,6 +3,7 @@ import { createWrapper } from './spec'
 import { mockDeep } from 'jest-mock-extended'
 import { SpaceResource } from 'web-client/src/helpers'
 import { ComputedRef, computed } from 'vue'
+import { UppyService } from 'web-runtime/src/services/uppyService'
 
 describe('useUploadHelpers', () => {
   const currentPathMock = 'path'
@@ -17,6 +18,7 @@ describe('useUploadHelpers', () => {
       () => {
         const fileName = 'filename'
         const { inputFilesToUppyFiles } = useUploadHelpers({
+          uppyService: mockDeep<UppyService>(),
           space: mockDeep<ComputedRef<SpaceResource>>(),
           currentFolder: computed(() => '')
         })

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -11,6 +11,7 @@
     "@sentry/browser": "^6.19.7",
     "@sentry/integrations": "^6.19.7",
     "@uppy/core": "^3.0.2",
+    "@uppy/utils": "^5.0.2",
     "@uppy/drop-target": "^2.0.0",
     "@uppy/tus": "^3.0.1",
     "@uppy/xhr-upload": "^3.0.1",

--- a/packages/web-runtime/src/composables/upload/useUpload.ts
+++ b/packages/web-runtime/src/composables/upload/useUpload.ts
@@ -21,6 +21,7 @@ export interface UppyResource {
   source: string
   name: string
   type: string
+  size: number
   data: Blob
   meta: {
     // IMPORTANT: must only contain primitive types, complex types won't be serialized properly!
@@ -33,6 +34,7 @@ export interface UppyResource {
     currentFolderId?: string | number
     fileId?: string | number
     // upload data
+    uppyId?: string
     relativeFolder: string
     relativePath: string
     tusEndpoint: string

--- a/packages/web-runtime/src/services/uppyService.ts
+++ b/packages/web-runtime/src/services/uppyService.ts
@@ -1,4 +1,4 @@
-import Uppy from '@uppy/core'
+import Uppy, { UppyFile } from '@uppy/core'
 import { TusOptions } from '@uppy/tus'
 import XHRUpload, { XHRUploadOptions } from '@uppy/xhr-upload'
 import { eventBus } from 'web-pkg/src/services/eventBus'
@@ -6,6 +6,8 @@ import { UppyResource } from '../composables/upload'
 import { CustomDropTarget } from '../composables/upload/uppyPlugins/customDropTarget'
 import { CustomTus } from '../composables/upload/uppyPlugins/customTus'
 import { urlJoin } from 'web-client/src/utils'
+import getFileType from '@uppy/utils/lib/getFileType'
+import generateFileID from '@uppy/utils/lib/generateFileID'
 
 type UppyServiceTopics =
   | 'uploadStarted'
@@ -217,6 +219,23 @@ export class UppyService {
 
   removeUploadInput(el: HTMLInputElement) {
     this.uploadInputs = this.uploadInputs.filter((input) => input !== el)
+  }
+
+  generateUploadId(file: File): string {
+    return generateFileID({
+      name: file.name,
+      size: file.size,
+      type: getFileType(file as unknown as UppyFile),
+      data: file
+    } as unknown as UppyFile)
+  }
+
+  getFailedFiles(): UppyResource[] {
+    return this.uppy.getFiles() as unknown as UppyResource[]
+  }
+
+  retryUpload(fileId) {
+    this.uppy.retryUpload(fileId)
   }
 
   uploadFiles(files: UppyResource[]) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -622,6 +622,7 @@ importers:
       '@uppy/core': ^3.0.2
       '@uppy/drop-target': ^2.0.0
       '@uppy/tus': ^3.0.1
+      '@uppy/utils': ^5.0.2
       '@uppy/xhr-upload': ^3.0.1
       axios: ^0.27.2
       easygettext: https://github.com/owncloud/easygettext/archive/refs/tags/v2.18.1-oc.tar.gz
@@ -674,6 +675,7 @@ importers:
       '@uppy/core': 3.0.2
       '@uppy/drop-target': 2.0.0_@uppy+core@3.0.2
       '@uppy/tus': 3.0.1_@uppy+core@3.0.2
+      '@uppy/utils': 5.0.2
       '@uppy/xhr-upload': 3.0.1_@uppy+core@3.0.2
       axios: 0.27.2
       easygettext: '@github.com/owncloud/easygettext/archive/refs/tags/v2.18.1-oc.tar.gz'

--- a/tests/unit/config/jest.config.js
+++ b/tests/unit/config/jest.config.js
@@ -24,7 +24,8 @@ module.exports = {
     '@uppy/core': '<rootDir>tests/unit/stubs/uppy',
     '@uppy/xhr-upload': '<rootDir>tests/unit/stubs/uppy',
     '@uppy/drop-target': '<rootDir>tests/unit/stubs/uppy',
-    '@uppy/tus': '<rootDir>tests/unit/stubs/uppy'
+    '@uppy/tus': '<rootDir>tests/unit/stubs/uppy',
+    '@uppy/utils': '<rootDir>tests/unit/stubs/uppy'
   },
   modulePathIgnorePatterns: ['packages/design-system/docs/utils/statusLabels.spec.js'],
   testEnvironment: 'jsdom',


### PR DESCRIPTION
## Description
When re-uploading a file that failed uploading before (or after closing the browser-tab during the upload), the upload is now being retried instead of being started from scratch again. This fixes some issues with the overlay and preserves the upload progress.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7944

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
