### PR TITLE
Omit 'page'-query in breadcrumb navigation

### DIFF
--- a/changelog/unreleased/bugfix-omit-page-query-in-breadcrumb-navigation
+++ b/changelog/unreleased/bugfix-omit-page-query-in-breadcrumb-navigation
@@ -1,0 +1,6 @@
+Bugfix: Omit "page"-query in breadcrumb navigation
+
+We've omitted the "page"-query when navigating via breadcrumb. This solves an issue were the file list would be empty after navigating via breadcrumb from a paginated folder.
+
+https://github.com/owncloud/web/pull/8061
+https://github.com/owncloud/web/issues/8060

--- a/packages/web-app-files/src/helpers/breadcrumbs.ts
+++ b/packages/web-app-files/src/helpers/breadcrumbs.ts
@@ -24,7 +24,7 @@ export const breadcrumbsFromPath = (
         text,
         to: {
           path: '/' + [...current].splice(0, current.length - resource.length + i + 1).join('/'),
-          query: omit(currentRoute.query, 'fileId') // TODO: we need the correct fileId in the query. until we have that we must omit it because otherwise we would correct the path to the one of the (wrong) fileId.
+          query: omit(currentRoute.query, 'fileId', 'page') // TODO: we need the correct fileId in the query. until we have that we must omit it because otherwise we would correct the path to the one of the (wrong) fileId.
         }
       } as BreadcrumbItem)
   )

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -232,7 +232,7 @@ export default defineComponent({
 
       let spaceBreadcrumbItem
       let { params, query } = createFileRouteOptions(space, { fileId: space.fileId })
-      query = { ...unref(route).query, ...query }
+      query = omit({ ...unref(route).query, ...query }, 'page')
       if (isPersonalSpaceResource(space)) {
         spaceBreadcrumbItem = {
           text: space.name,


### PR DESCRIPTION
## Description
We've omitted the "page"-query when navigating via breadcrumb. This solves an issue were the file list would be empty after navigating via breadcrumb from a paginated folder.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8060

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
