### PR TITLE
[tests-only][full-ci]Skip private link related tests on ocis

### DIFF
--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -33,19 +33,12 @@ Other free text and markdown formatting can be used elsewhere in the document if
 ### [when sharer renames the shared resource, sharee get the updated name](https://github.com/owncloud/ocis/issues/2256)
 -   [webUIRenameFiles/renameFiles.feature:226](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIRenameFiles/renameFiles.feature#L226)
 
-### [Scoped links](https://github.com/owncloud/web/issues/6844)
--   [webUIFilesCopy/copyPrivateLinks.feature:20](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesCopy/copyPrivateLinks.feature#L20)
--   [webUIFilesCopy/copyPrivateLinks.feature:21](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesCopy/copyPrivateLinks.feature#L21)
-
 ### [Cannot create users with special characters](https://github.com/owncloud/ocis/issues/1417)
 -   [webUISharingAutocompletion/shareAutocompletionSpecialChars.feature:37](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletionSpecialChars.feature#L37)
 -   [webUISharingAutocompletion/shareAutocompletionSpecialChars.feature:38](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletionSpecialChars.feature#L38)
 -   [webUISharingAutocompletion/shareAutocompletionSpecialChars.feature:39](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletionSpecialChars.feature#L39)
 -   [webUISharingAutocompletion/shareAutocompletionSpecialChars.feature:36](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAutocompletion/shareAutocompletionSpecialChars.feature#L36)
 
-### [webUI-Private-Links](https://github.com/owncloud/web/issues/6844)
--   [webUIPrivateLinks/accessingPrivateLinks.feature:9](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPrivateLinks/accessingPrivateLinks.feature#L9)
--   [webUIPrivateLinks/accessingPrivateLinks.feature:23](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIPrivateLinks/accessingPrivateLinks.feature#L23)
 
 ### [Share additional info](https://github.com/owncloud/ocis/issues/1253)
 -   [webUISharingInternalUsersShareWithPage/shareWithUsers.feature:138](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalUsersShareWithPage/shareWithUsers.feature#L138)

--- a/tests/acceptance/features/webUIFilesCopy/copyPrivateLinks.feature
+++ b/tests/acceptance/features/webUIFilesCopy/copyPrivateLinks.feature
@@ -1,4 +1,4 @@
-@ocis-web-issue-52
+@issue-6844
 Feature: copy path as a permanent link
   As a user
   I want to copy the permanent link of a resource

--- a/tests/acceptance/features/webUIFilesCopy/copyPrivateLinks.feature
+++ b/tests/acceptance/features/webUIFilesCopy/copyPrivateLinks.feature
@@ -1,4 +1,4 @@
-@issue-6844
+@notToImplementOnOCIS @issue-6844
 Feature: copy path as a permanent link
   As a user
   I want to copy the permanent link of a resource

--- a/tests/acceptance/features/webUIPrivateLinks/accessingPrivateLinks.feature
+++ b/tests/acceptance/features/webUIPrivateLinks/accessingPrivateLinks.feature
@@ -1,4 +1,4 @@
-@skipOnOCIS @issue-6844
+@notToImplementOnOCIS @issue-6844
 Feature: Access private link
   As a user I want to directly access item which I have received private link for
 

--- a/tests/acceptance/features/webUIPrivateLinks/accessingPrivateLinks.feature
+++ b/tests/acceptance/features/webUIPrivateLinks/accessingPrivateLinks.feature
@@ -1,3 +1,4 @@
+@skipOnOCIS @issue-6844
 Feature: Access private link
   As a user I want to directly access item which I have received private link for
 
@@ -5,14 +6,14 @@ Feature: Access private link
     Given user "Alice" has been created with default attributes and without skeleton files in the server
     And user "Alice" has uploaded file "lorem.txt" to "lorem.txt" in the server
 
-  @smokeTest @ocisSmokeTest
+  @smokeTest
   Scenario: Copy and access private link
     Given user "Alice" has logged in using the webUI
     When the user copies the private link of the file "lorem.txt" using the webUI
     And the user navigates to the copied private link using the webUI
     Then file "lorem.txt" should be listed on the webUI
 
-  @smokeTest @ocisSmokeTest
+  @smokeTest
   Scenario: Access private link before authorisation
     When an anonymous user tries to navigate to the private link created by user "Alice" for file "lorem.txt"
     Then the user should be redirected to the IdP login page


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR skips the tests related to `private-links`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- part of: https://github.com/owncloud/web/issues/7896

## Motivation and Context
If I understand issue https://github.com/owncloud/web/issues/6844 correctly then there won't be a separate `copy-private-link` button in ocis which is the case for oc10 right now. In the case of ocis 
> As a user I want to get a link to a resource as easily and quickly as possible. I don't want to decide whether I need a 'private' or a 'public' link in the first place. Still, I might want to decide (e.g., for security reasons) for whom the link is usable (link scope): for everybody (public) / only invited people (private).

So Private link tests might be obsolete in this case, thus they are skipped but in `oc10` there is a copy-private-link button

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
