### PR TITLE
Fix disappearing space members when adding links

### DIFF
--- a/changelog/unreleased/bugfix-space-member-disappearing
+++ b/changelog/unreleased/bugfix-space-member-disappearing
@@ -1,0 +1,6 @@
+Bugfix: Space member disappearing
+
+We've fixed a bug where adding links to a space would remove newly added members in the UI.
+
+https://github.com/owncloud/web/issues/8081
+https://github.com/owncloud/web/pull/8082

--- a/packages/web-app-files/src/store/actions.ts
+++ b/packages/web-app-files/src/store/actions.ts
@@ -12,7 +12,12 @@ import { ShareTypes } from 'web-client/src/helpers/share'
 import get from 'lodash-es/get'
 import { ClipboardActions } from '../helpers/clipboardActions'
 import { thumbnailService } from '../services'
-import { buildResource, Resource, SpaceResource } from 'web-client/src/helpers'
+import {
+  buildResource,
+  isProjectSpaceResource,
+  Resource,
+  SpaceResource
+} from 'web-client/src/helpers'
 import { WebDAV } from 'web-client/src/webdav'
 import { ClientService } from 'web-pkg/src/services'
 
@@ -192,7 +197,7 @@ export default {
   },
   updateCurrentFileShareTypes({ state, getters, commit }) {
     const highlighted = getters.highlightedFile
-    if (!highlighted) {
+    if (!highlighted || isProjectSpaceResource(highlighted)) {
       return
     }
     commit('UPDATE_RESOURCE_FIELD', {

--- a/packages/web-app-files/tests/unit/store/actions.spec.ts
+++ b/packages/web-app-files/tests/unit/store/actions.spec.ts
@@ -2,6 +2,8 @@ import actions from '../../../src/store/actions'
 import { spaceRoleManager, ShareTypes, Share } from 'web-client/src/helpers/share'
 import { mockDeep } from 'jest-mock-extended'
 import { OwnCloudSdk } from 'web-client/src/types'
+import { Resource } from 'web-client'
+import { SpaceResource } from 'web-client/src/helpers'
 
 jest.mock('../../../src/helpers/resources')
 jest.mock('../../../src/gettext')
@@ -96,6 +98,27 @@ describe('vuex store actions', () => {
       })
 
       expect(stateMock.commit).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('updateCurrentFileShareTypes', () => {
+    const stateMock = { currentFileOutgoingShares: [] }
+    const commitSpy = jest.fn()
+
+    it('updates the resource if given', () => {
+      const getters = { highlightedFile: mockDeep<Resource>() }
+      actions.updateCurrentFileShareTypes({ state: stateMock, getters, commit: commitSpy })
+      expect(commitSpy).toHaveBeenCalledTimes(1)
+    })
+    it('does not update the resource if not given', () => {
+      const getters = { highlightedFile: undefined }
+      actions.updateCurrentFileShareTypes({ state: stateMock, getters, commit: commitSpy })
+      expect(commitSpy).toHaveBeenCalledTimes(0)
+    })
+    it('does not update project space resources', () => {
+      const getters = { highlightedFile: mockDeep<SpaceResource>({ driveType: 'project' }) }
+      actions.updateCurrentFileShareTypes({ state: stateMock, getters, commit: commitSpy })
+      expect(commitSpy).toHaveBeenCalledTimes(0)
     })
   })
 })


### PR DESCRIPTION
## Description
We've fixed a bug where adding links to a space would remove newly added members in the UI.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8081

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
