### PR TITLE
[tests-only][full-ci]Bump ocis stable-2.0 commit id to web stable-6.0

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=b7482e54101771423592e23afbb8c9eafdceb9c5
-OCIS_BRANCH=master
+OCIS_COMMITID=883ed8a2b4eca34371ac6a2592f3393a35886cbb
+OCIS_BRANCH=stable-2.0


### PR DESCRIPTION
### Description
Bump latest `ocis stable-2.0` commit id to `web stable-6.0`

### Related issue: 
 https://github.com/owncloud/QA/issues/791