### PR TITLE
feat: support browsers that are 1 year old

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "vite:oc10": "OCIS=false vite"
   },
   "browserslist": [
-    "last 2 versions",
+    "last 1 year",
     "> .2%",
     "not dead",
     "not Explorer > 0",
@@ -69,6 +69,7 @@
     "autoprefixer": "10.4.13",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "29.3.1",
+    "browserslist-to-esbuild": "^1.2.0",
     "browserslist-useragent-regexp": "^3.0.2",
     "commander": "8.3.0",
     "core-js": "3.26.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,7 @@ importers:
       autoprefixer: 10.4.13
       babel-core: 7.0.0-bridge.0
       babel-jest: 29.3.1
+      browserslist-to-esbuild: ^1.2.0
       browserslist-useragent-regexp: ^3.0.2
       caf: '*'
       commander: 8.3.0
@@ -126,6 +127,7 @@ importers:
       autoprefixer: 10.4.13_postcss@8.4.19
       babel-core: 7.0.0-bridge.0_@babel+core@7.20.5
       babel-jest: 29.3.1_@babel+core@7.20.5
+      browserslist-to-esbuild: 1.2.0
       browserslist-useragent-regexp: 3.0.2
       commander: 8.3.0
       core-js: 3.26.1
@@ -8069,6 +8071,13 @@ packages:
     resolution: {integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==}
     dependencies:
       pako: 1.0.11
+    dev: true
+
+  /browserslist-to-esbuild/1.2.0:
+    resolution: {integrity: sha512-ftrrbI/VHBgEnmnSyhkqvQVMp6jAKybfs0qMIlm7SLBrQTGMsdCIP4q3BoKeLsZTBQllIQtY9kbxgRYV2WU47g==}
+    engines: {node: '>=12'}
+    dependencies:
+      browserslist: 4.21.4
     dev: true
 
   /browserslist-useragent-regexp/3.0.2:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ import { existsSync, readdirSync, readFileSync } from 'fs'
 // build config
 import packageJson from './package.json'
 import { getUserAgentRegExp } from 'browserslist-useragent-regexp'
+import browserslistToEsbuild from 'browserslist-to-esbuild'
 
 const buildConfig = {
   requirejs: {},
@@ -108,7 +109,8 @@ export default defineConfig(({ mode, command }) => {
               }
             }
           }
-        }
+        },
+        target: browserslistToEsbuild()
       },
       server: {
         host: 'host.docker.internal',


### PR DESCRIPTION
## Description
This PR tackles two things:
- we want to support more than the `last 2 versions`, because `last 2 versions` frequently let's e.g. firefox extended support releases (esr) run into the unsupported browser situation. Chrome is probably similar. We expect users to be on a recent-is browser, but `last 2 versions` is too harsh.
- our vite config was actually ignoring the `browserslist` config, as it only uses esbuild targets. Which is a different thing. Added a plugin to transform `browserslist` into `esbuild targets`. If we don't want to do that we need to move away from `browserslist`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

cc @mmattel as this is relevant for the docs.