### PR TITLE
[full-ci] [tests-only] Bump ocis stable commit id to latest

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=883ed8a2b4eca34371ac6a2592f3393a35886cbb
+OCIS_COMMITID=dcc65b09ea88356733e0da0571025f9b377b84f7
 OCIS_BRANCH=stable-2.0


### PR DESCRIPTION
Bump ocis stable-2.0 commit id to latest.
Part of https://github.com/owncloud/QA/issues/791