### PR TITLE
[full-ci] Allow 425 status-code in propfinds

### DIFF
--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -120,7 +120,7 @@ export default defineComponent({
         switch (response.status) {
           case 425:
             this.errorMessage = this.$gettext(
-              'The requested file is not yet available, please try again later.'
+              'This file is currently being processed and is not yet available for use. Please try again shortly.'
             )
             break
           default:

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -117,10 +117,19 @@ export default defineComponent({
       })
 
       if (response.status !== 200) {
-        this.errorMessage = response.message
+        switch (response.status) {
+          case 425:
+            this.errorMessage = this.$gettext(
+              'The requested file is not yet available, please try again later.'
+            )
+            break
+          default:
+            this.errorMessage = response.data?.message
+        }
+
         this.loading = false
         this.loadingError = true
-        console.error('Error fetching app information', response.status, this.errorMessage)
+        console.error('Error fetching app information', response.status, response.data.message)
         return
       }
 

--- a/packages/web-app-external/tests/unit/__snapshots__/app.spec.ts.snap
+++ b/packages/web-app-external/tests/unit/__snapshots__/app.spec.ts.snap
@@ -25,7 +25,7 @@ exports[`The app provider extension should be able to load an iFrame via post 1`
 exports[`The app provider extension should fail for unauthenticated users 1`] = `
 <main class="oc-height-1-1 oc-flex oc-flex-center oc-flex-middle">
   <h1 class="oc-invisible-sr">"exampleApp" app page</h1>
-  <errorscreen-stub message="Login Required"></errorscreen-stub>
+  <errorscreen-stub message="Error retrieving file information"></errorscreen-stub>
   <!---->
   <!---->
 </main>
@@ -43,7 +43,7 @@ exports[`The app provider extension should show a loading spinner while loading 
 exports[`The app provider extension should show a meaningful message if an error occurs during loading 1`] = `
 <main class="oc-height-1-1 oc-flex oc-flex-center oc-flex-middle">
   <h1 class="oc-invisible-sr">"exampleApp" app page</h1>
-  <errorscreen-stub message="We encountered an internal error"></errorscreen-stub>
+  <errorscreen-stub message="Error retrieving file information"></errorscreen-stub>
   <!---->
   <!---->
 </main>

--- a/packages/web-client/src/helpers/resource/functions.ts
+++ b/packages/web-client/src/helpers/resource/functions.ts
@@ -99,6 +99,7 @@ export function buildResource(resource): Resource {
     webDavPath: resource.name,
     type: isFolder ? 'folder' : resource.type,
     isFolder,
+    processing: resource.processing || false,
     mdate: resource.fileInfo[DavProperty.LastModifiedDate],
     size: isFolder
       ? resource.fileInfo[DavProperty.ContentSize]

--- a/packages/web-client/src/helpers/resource/types.ts
+++ b/packages/web-client/src/helpers/resource/types.ts
@@ -13,6 +13,7 @@ export interface Resource {
   downloadURL?: string
   type?: string
   status?: number
+  processing?: boolean
   spaceRoles?: {
     [k: string]: any[]
   }

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -25,7 +25,7 @@
     "luxon": "^2.4.0",
     "marked": "^4.0.12",
     "oidc-client-ts": "^2.1.0",
-    "owncloud-sdk": "~3.0.0-alpha.17",
+    "owncloud-sdk": "~3.1.0-alpha.1",
     "p-queue": "^6.6.2",
     "popper-max-size-modifier": "^0.2.0",
     "portal-vue": "^2.1.7",

--- a/packages/web-runtime/src/helpers/additionalTranslations.ts
+++ b/packages/web-runtime/src/helpers/additionalTranslations.ts
@@ -4,9 +4,6 @@ function $gettext(msg: string): string {
 }
 
 export const additionalTranslations = {
-  fileInProcessing: $gettext(
-    'This file is currently being processed and is not yet available for use. Please try again shortly.'
-  ),
   activities: $gettext('Activities'),
   noActivities: $gettext('No activities'),
   virusDetectedActivity: $gettext(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -619,7 +619,7 @@ importers:
       luxon: ^2.4.0
       marked: ^4.0.12
       oidc-client-ts: ^2.1.0
-      owncloud-sdk: ~3.0.0-alpha.17
+      owncloud-sdk: ~3.1.0-alpha.1
       p-queue: ^6.6.2
       popper-max-size-modifier: ^0.2.0
       portal-vue: ^2.1.7
@@ -673,7 +673,7 @@ importers:
       luxon: 2.4.0
       marked: 4.0.12
       oidc-client-ts: 2.1.0
-      owncloud-sdk: 3.0.0-alpha.17_qgpf6seimtkgc6dfu7oqfstxh4
+      owncloud-sdk: 3.1.0-alpha.1_qgpf6seimtkgc6dfu7oqfstxh4
       p-queue: 6.6.2
       popper-max-size-modifier: 0.2.0_@popperjs+core@2.11.5
       portal-vue: 2.1.7_vue@2.7.14
@@ -3160,7 +3160,7 @@ packages:
       '@babel/core': 7.20.5
       '@babel/helper-module-transforms': 7.20.2
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-simple-access': 7.19.4
+      '@babel/helper-simple-access': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -17539,8 +17539,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /owncloud-sdk/3.0.0-alpha.17_qgpf6seimtkgc6dfu7oqfstxh4:
-    resolution: {integrity: sha512-XO6XzyiMfAB/i4TcshuB6VGYzcsZUI/x+JBwv40Lj4p0bSU4eD1c2CPk66uj3t+13pcAqJqF9Mv9NcM0aEbj4w==}
+  /owncloud-sdk/3.1.0-alpha.1_qgpf6seimtkgc6dfu7oqfstxh4:
+    resolution: {integrity: sha512-iurt3QNIdWBxYCzx4j6Ihyy13vYfjY6UgU9qCrXFG9NiIpMlMLDFhwRLZdlVZlpeuAzCboi8hHmHooUpYFI6zQ==}
     peerDependencies:
       axios: ^0.27.2
       cross-fetch: ^3.0.6


### PR DESCRIPTION
## Description
Splitting out the propfind 425 status code handling from https://github.com/owncloud/web/pull/8069 so that async upload e2e tests get unblocked.

## Related Issue
- Relates to https://github.com/owncloud/ocis/issues/5184

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 


cc @individual-it 