### PR TITLE
[full-ci] Space group members

### DIFF
--- a/changelog/unreleased/enhancement-share-group-recipient
+++ b/changelog/unreleased/enhancement-share-group-recipient
@@ -2,5 +2,5 @@ Enhancement: Space group shares
 
 We've added the possibility to share a space with a group.
 
-https://github.com/owncloud/web/pull/8160
+https://github.com/owncloud/web/pull/8161
 https://github.com/owncloud/web/issues/8160

--- a/changelog/unreleased/enhancement-share-group-recipient
+++ b/changelog/unreleased/enhancement-share-group-recipient
@@ -1,0 +1,3 @@
+Enhancement: Group shares
+
+https://github.com/owncloud/web/pull/8160

--- a/changelog/unreleased/enhancement-share-group-recipient
+++ b/changelog/unreleased/enhancement-share-group-recipient
@@ -1,3 +1,6 @@
-Enhancement: Group shares
+Enhancement: Space group shares
+
+We've added the possibility to share a space with a group.
 
 https://github.com/owncloud/web/pull/8160
+https://github.com/owncloud/web/issues/8160

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -20,7 +20,7 @@
         <autocomplete-item :item="option" />
       </template>
       <template #no-options>
-        <translate> No users or groups found. </translate>
+        <span v-text="$gettext('No users or groups found.')" />
       </template>
       <template #selected-option-container="{ option, deselect }">
         <recipient-container

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -20,8 +20,7 @@
         <autocomplete-item :item="option" />
       </template>
       <template #no-options>
-        <span v-if="resourceIsSpace" v-text="$gettext(' No users found. ')" />
-        <span v-else v-text="$gettext(' No users or groups found. ')" />
+        <translate> No users or groups found. </translate>
       </template>
       <template #selected-option-container="{ option, deselect }">
         <recipient-container
@@ -210,10 +209,7 @@ export default defineComponent({
             }
           })
 
-        let groups = []
-        if (!this.resourceIsSpace) {
-          groups = recipients.exact.groups.concat(recipients.groups)
-        }
+        let groups = recipients.exact.groups.concat(recipients.groups)
 
         const remotes = recipients.exact.remotes.concat(recipients.remotes)
 

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -209,8 +209,7 @@ export default defineComponent({
             }
           })
 
-        let groups = recipients.exact.groups.concat(recipients.groups)
-
+        const groups = recipients.exact.groups.concat(recipients.groups)
         const remotes = recipients.exact.remotes.concat(recipients.remotes)
 
         this.autocompleteResults = users.concat(groups, remotes).filter((collaborator) => {

--- a/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
@@ -120,11 +120,7 @@ export default defineComponent({
       return this.currentUserIsManager
     },
     currentUserIsManager() {
-      const currentUserCollaborator = this.spaceMembers.find(
-        (collaborator) => collaborator.collaborator.name === this.user.id
-      )
-
-      return currentUserCollaborator?.role?.name === spaceRoleManager.name
+      return this.space.isManager(this.user)
     }
   },
   watch: {

--- a/packages/web-app-files/src/fileSideBars.ts
+++ b/packages/web-app-files/src/fileSideBars.ts
@@ -120,7 +120,7 @@ const panelGenerators: (({
       return [
         ...highlightedFile.spaceRoles[spaceRoleManager.name],
         ...highlightedFile.spaceRoles[spaceRoleEditor.name]
-      ].includes(user.uuid)
+      ].find((role) => role.id === user.uuid)
     }
   }),
   ({ capabilities, router, multipleSelection, rootFolder, highlightedFile }) => ({

--- a/packages/web-app-files/src/mixins/actions/delete.js
+++ b/packages/web-app-files/src/mixins/actions/delete.js
@@ -64,8 +64,8 @@ export default {
 
             if (
               isProjectSpaceResource(this.space) &&
-              !this.space.isEditor(this.user.uuid) &&
-              !this.space.isManager(this.user.uuid)
+              !this.space.isEditor(this.user) &&
+              !this.space.isManager(this.user)
             ) {
               return false
             }

--- a/packages/web-app-files/src/mixins/actions/emptyTrashBin.js
+++ b/packages/web-app-files/src/mixins/actions/emptyTrashBin.js
@@ -26,8 +26,8 @@ export default {
 
             if (
               isProjectSpaceResource(this.space) &&
-              !this.space.isEditor(this.user.uuid) &&
-              !this.space.isManager(this.user.uuid)
+              !this.space.isEditor(this.user) &&
+              !this.space.isManager(this.user)
             ) {
               return false
             }

--- a/packages/web-app-files/src/mixins/actions/restore.ts
+++ b/packages/web-app-files/src/mixins/actions/restore.ts
@@ -35,8 +35,8 @@ export default {
 
             if (
               isProjectSpaceResource(this.space) &&
-              !this.space.isEditor(this.user.uuid) &&
-              !this.space.isManager(this.user.uuid)
+              !this.space.isEditor(this.user) &&
+              !this.space.isManager(this.user)
             ) {
               return false
             }

--- a/packages/web-app-files/src/views/spaces/GenericTrash.vue
+++ b/packages/web-app-files/src/views/spaces/GenericTrash.vue
@@ -171,8 +171,8 @@ export default defineComponent({
     showActions() {
       return (
         !isProjectSpaceResource(this.space) ||
-        this.space.isEditor(this.user.uuid) ||
-        this.space.isManager(this.user.uuid)
+        this.space.isEditor(this.user) ||
+        this.space.isManager(this.user)
       )
     }
   },

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
@@ -64,12 +64,10 @@ describe('FileShares', () => {
   })
 
   describe('collaborators list', () => {
-    const collaborators = [
-      getCollaborator(),
-      getCollaborator(),
-      getCollaborator(),
-      getCollaborator()
-    ]
+    let collaborators
+    beforeEach(() => {
+      collaborators = [getCollaborator(), getCollaborator(), getCollaborator(), getCollaborator()]
+    })
 
     it('renders sharedWithLabel and sharee list', () => {
       const { wrapper } = getWrapper({ collaborators })
@@ -114,6 +112,29 @@ describe('FileShares', () => {
       expect(wrapper.vm.sharesListCollapsed).toBe(!showAllOnLoad)
       await wrapper.find('.toggle-shares-list-btn').trigger('click')
       expect(wrapper.vm.sharesListCollapsed).toBe(showAllOnLoad)
+    })
+    it('share should be modifiable if its personal space share', async () => {
+      const space = mockDeep<SpaceResource>({ driveType: 'personal' })
+      const { wrapper } = getWrapper({ space, mountType: shallowMount, collaborators })
+      expect(wrapper.vm.isShareModifiable(collaborators[0])).toBe(true)
+    })
+    it('share should not be modifiable if its not personal space share', async () => {
+      const space = mockDeep<SpaceResource>({ driveType: 'project' })
+      const { wrapper } = getWrapper({ space, mountType: shallowMount, collaborators })
+      expect(wrapper.vm.isShareModifiable(collaborators[0])).toBe(false)
+    })
+    it('share should not be modifiable if collaborator is indirect', async () => {
+      const space = mockDeep<SpaceResource>({ driveType: 'personal' })
+      const { wrapper } = getWrapper({ space, mountType: shallowMount, collaborators })
+      collaborators[0]['indirect'] = true
+      expect(wrapper.vm.isShareModifiable(collaborators[0])).toBe(false)
+    })
+    it('share should not be modifiable if user is not manager', async () => {
+      const space = mockDeep<SpaceResource>({ driveType: 'personal' }) as any
+      ;(space as any).isManager = jest.fn(() => false)
+      collaborators[0]['indirect'] = true
+      const { wrapper } = getWrapper({ space, mountType: shallowMount, collaborators })
+      expect(wrapper.vm.isShareModifiable(collaborators[0])).toBe(false)
     })
   })
 

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
@@ -122,8 +122,8 @@ describe('FileShares', () => {
       const user = { id: '1' }
       const space = mockDeep<SpaceResource>({ driveType: 'project' })
       const spaceMembers = [
-        { collaborator: { name: user.id, displayName: 'user' } },
-        { collaborator: { name: 2, displayName: 'user' } }
+        { collaborator: { name: user.id } },
+        { collaborator: { name: 2 } }
       ]
       const collaborator = getCollaborator()
       collaborator.collaborator = { ...collaborator.collaborator, name: user.id }

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
@@ -121,11 +121,13 @@ describe('FileShares', () => {
     it('loads space members if a space is given and the current user is member', () => {
       const user = { id: '1' }
       const space = mockDeep<SpaceResource>({ driveType: 'project' })
-      const spaceMembers = [{ collaborator: { name: user.id, displayName: 'user' } }, { collaborator: { name: 2, displayName: 'user' } }]
+      const spaceMembers = [
+        { collaborator: { name: user.id, displayName: 'user' } },
+        { collaborator: { name: 2, displayName: 'user' } }
+      ]
       const collaborator = getCollaborator()
       collaborator.collaborator = { ...collaborator.collaborator, name: user.id }
       const { wrapper } = getWrapper({ space, collaborators: [collaborator], user, spaceMembers })
-      console.log(wrapper.html())
       expect(wrapper.find('#files-collaborators-list').exists()).toBeTruthy()
       expect(wrapper.findAll('#files-collaborators-list li').length).toBe(1)
       expect(wrapper.html()).toMatchSnapshot()

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
@@ -121,12 +121,13 @@ describe('FileShares', () => {
     it('loads space members if a space is given and the current user is member', () => {
       const user = { id: '1' }
       const space = mockDeep<SpaceResource>({ driveType: 'project' })
-      const spaceMembers = [{ collaborator: { name: user.id } }, { collaborator: { name: '2' } }]
+      const spaceMembers = [{ collaborator: { name: user.id, displayName: 'user' } }, { collaborator: { name: 2, displayName: 'user' } }]
       const collaborator = getCollaborator()
       collaborator.collaborator = { ...collaborator.collaborator, name: user.id }
       const { wrapper } = getWrapper({ space, collaborators: [collaborator], user, spaceMembers })
-      expect(wrapper.find('#space-collaborators-list').exists()).toBeTruthy()
-      expect(wrapper.findAll('#space-collaborators-list li').length).toBe(spaceMembers.length)
+      console.log(wrapper.html())
+      expect(wrapper.find('#files-collaborators-list').exists()).toBeTruthy()
+      expect(wrapper.findAll('#files-collaborators-list li').length).toBe(1)
       expect(wrapper.html()).toMatchSnapshot()
     })
     it('does not load space members if a space is given but the current user not a member', () => {

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
@@ -121,10 +121,7 @@ describe('FileShares', () => {
     it('loads space members if a space is given and the current user is member', () => {
       const user = { id: '1' }
       const space = mockDeep<SpaceResource>({ driveType: 'project' })
-      const spaceMembers = [
-        { collaborator: { name: user.id } },
-        { collaborator: { name: 2 } }
-      ]
+      const spaceMembers = [{ collaborator: { name: user.id } }, { collaborator: { name: 2 } }]
       const collaborator = getCollaborator()
       collaborator.collaborator = { ...collaborator.collaborator, name: user.id }
       const { wrapper } = getWrapper({ space, collaborators: [collaborator], user, spaceMembers })

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
@@ -1,5 +1,5 @@
 import FileShares from 'web-app-files/src/components/SideBar/Shares/FileShares.vue'
-import { mockDeep } from 'jest-mock-extended'
+import { mock, mockDeep } from 'jest-mock-extended'
 import { Resource } from 'web-client'
 import { SpaceResource } from 'web-client/src/helpers'
 import { v4 as uuidV4 } from 'uuid'
@@ -42,22 +42,22 @@ const getCollaborator = () => ({
 describe('FileShares', () => {
   describe('invite collaborator form', () => {
     it('renders the form when the resource can be shared', () => {
-      const resource = mockDeep<Resource>({ isReceivedShare: () => false, canShare: () => true })
+      const resource = mock<Resource>({ isReceivedShare: () => false, canShare: () => true })
       const { wrapper } = getWrapper({ resource })
       expect(wrapper.find('invite-collaborator-form-stub').exists()).toBeTruthy()
     })
     it('does not render the form when the resource can not be shared', () => {
-      const resource = mockDeep<Resource>({ isReceivedShare: () => false, canShare: () => false })
+      const resource = mock<Resource>({ isReceivedShare: () => false, canShare: () => false })
       const { wrapper } = getWrapper({ resource })
       expect(wrapper.find('invite-collaborator-form-stub').exists()).toBeFalsy()
     })
     it('does render the form when the resource is a received share and re-sharing is enabled', () => {
-      const resource = mockDeep<Resource>({ isReceivedShare: () => true, canShare: () => true })
+      const resource = mock<Resource>({ isReceivedShare: () => true, canShare: () => true })
       const { wrapper } = getWrapper({ resource })
       expect(wrapper.find('invite-collaborator-form-stub').exists()).toBeTruthy()
     })
     it('does not render the form when the resource is a received share and re-sharing is disabled', () => {
-      const resource = mockDeep<Resource>({ isReceivedShare: () => true, canShare: () => true })
+      const resource = mock<Resource>({ isReceivedShare: () => true, canShare: () => true })
       const { wrapper } = getWrapper({ resource, hasReSharing: false })
       expect(wrapper.find('invite-collaborator-form-stub').exists()).toBeFalsy()
     })
@@ -114,23 +114,23 @@ describe('FileShares', () => {
       expect(wrapper.vm.sharesListCollapsed).toBe(showAllOnLoad)
     })
     it('share should be modifiable if its personal space share', async () => {
-      const space = mockDeep<SpaceResource>({ driveType: 'personal' })
+      const space = mock<SpaceResource>({ driveType: 'personal' })
       const { wrapper } = getWrapper({ space, mountType: shallowMount, collaborators })
       expect(wrapper.vm.isShareModifiable(collaborators[0])).toBe(true)
     })
     it('share should not be modifiable if its not personal space share', async () => {
-      const space = mockDeep<SpaceResource>({ driveType: 'project' })
+      const space = mock<SpaceResource>({ driveType: 'project' })
       const { wrapper } = getWrapper({ space, mountType: shallowMount, collaborators })
       expect(wrapper.vm.isShareModifiable(collaborators[0])).toBe(false)
     })
     it('share should not be modifiable if collaborator is indirect', async () => {
-      const space = mockDeep<SpaceResource>({ driveType: 'personal' })
+      const space = mock<SpaceResource>({ driveType: 'personal' })
       const { wrapper } = getWrapper({ space, mountType: shallowMount, collaborators })
       collaborators[0]['indirect'] = true
       expect(wrapper.vm.isShareModifiable(collaborators[0])).toBe(false)
     })
     it('share should not be modifiable if user is not manager', async () => {
-      const space = mockDeep<SpaceResource>({ driveType: 'personal' }) as any
+      const space = mock<SpaceResource>({ driveType: 'personal' }) as any
       ;(space as any).isManager = jest.fn(() => false)
       collaborators[0]['indirect'] = true
       const { wrapper } = getWrapper({ space, mountType: shallowMount, collaborators })
@@ -141,7 +141,7 @@ describe('FileShares', () => {
   describe('current space', () => {
     it('loads space members if a space is given and the current user is member', () => {
       const user = { id: '1' }
-      const space = mockDeep<SpaceResource>({ driveType: 'project' })
+      const space = mock<SpaceResource>({ driveType: 'project' })
       const spaceMembers = [{ collaborator: { name: user.id } }, { collaborator: { name: 2 } }]
       const collaborator = getCollaborator()
       collaborator.collaborator = { ...collaborator.collaborator, name: user.id }
@@ -152,7 +152,7 @@ describe('FileShares', () => {
     })
     it('does not load space members if a space is given but the current user not a member', () => {
       const user = { id: '1' }
-      const space = mockDeep<SpaceResource>({ driveType: 'project' })
+      const space = mock<SpaceResource>({ driveType: 'project' })
       const spaceMembers = [{ collaborator: { name: `${user}-2` } }]
       const collaborator = getCollaborator()
       collaborator.collaborator = { ...collaborator.collaborator, name: user.id }
@@ -165,7 +165,7 @@ describe('FileShares', () => {
     it('calls "deleteShare" when successful', async () => {
       const { wrapper } = getWrapper()
       const deleteShareSpy = jest.spyOn(wrapper.vm, 'deleteShare')
-      const share = mockDeep<Share>()
+      const share = mock<Share>()
       await wrapper.vm.$_ocCollaborators_deleteShare(share)
       expect(deleteShareSpy).toHaveBeenCalled()
     })
@@ -174,7 +174,7 @@ describe('FileShares', () => {
       const { wrapper } = getWrapper()
       jest.spyOn(wrapper.vm, 'deleteShare').mockRejectedValue(new Error())
       const showMessageSpy = jest.spyOn(wrapper.vm, 'showMessage')
-      const share = mockDeep<Share>()
+      const share = mock<Share>()
       await wrapper.vm.$_ocCollaborators_deleteShare(share)
       expect(showMessageSpy).toHaveBeenCalled()
     })
@@ -185,7 +185,7 @@ describe('FileShares', () => {
       })
       const deleteShareSpy = jest.spyOn(wrapper.vm, 'deleteShare')
       const removeFilesSpy = jest.spyOn(wrapper.vm, 'REMOVE_FILES')
-      const share = mockDeep<Share>()
+      const share = mock<Share>()
       await wrapper.vm.$_ocCollaborators_deleteShare(share)
       expect(deleteShareSpy).toHaveBeenCalled()
       expect(removeFilesSpy).toHaveBeenCalled()
@@ -195,9 +195,9 @@ describe('FileShares', () => {
 
 function getWrapper({
   mountType = shallowMount,
-  resource = mockDeep<Resource>({ isReceivedShare: () => false, canShare: () => true }),
+  resource = mock<Resource>({ isReceivedShare: () => false, canShare: () => true }),
   hasReSharing = true,
-  space = mockDeep<SpaceResource>(),
+  space = mock<SpaceResource>(),
   collaborators = [],
   sharesTree = {},
   spaceMembers = [],

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/SpaceMembers.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/SpaceMembers.spec.ts
@@ -6,7 +6,7 @@ import {
   spaceRoleEditor,
   Share
 } from 'web-client/src/helpers/share'
-import { mockDeep } from 'jest-mock-extended'
+import { mock } from 'jest-mock-extended'
 import { ProjectSpaceResource, SpaceResource, User } from 'web-client/src/helpers'
 import {
   createStore,
@@ -56,13 +56,13 @@ const memberMocks = {
 describe('SpaceMembers', () => {
   describe('invite collaborator form', () => {
     it('renders the form when the current user is a manager of the space', () => {
-      const space = mockDeep<ProjectSpaceResource>({ isManager: () => true })
+      const space = mock<ProjectSpaceResource>({ isManager: () => true })
       const wrapper = getWrapper({ space })
       expect(wrapper.find('invite-collaborator-form-stub').exists()).toBeTruthy()
       expect(wrapper.html()).toMatchSnapshot()
     })
     it('does not render the form when the current user is no manager of the space', () => {
-      const space = mockDeep<ProjectSpaceResource>({ isManager: () => false })
+      const space = mock<ProjectSpaceResource>({ isManager: () => false })
       const wrapper = getWrapper({ space })
       expect(wrapper.find('invite-collaborator-form-stub').exists()).toBeFalsy()
     })
@@ -70,13 +70,13 @@ describe('SpaceMembers', () => {
 
   describe('existing members', () => {
     it('can edit when current user is manager of the space', () => {
-      const space = mockDeep<ProjectSpaceResource>({ isManager: () => true })
+      const space = mock<ProjectSpaceResource>({ isManager: () => true })
       const wrapper = getWrapper({ space })
       expect(wrapper.findAll('collaborator-list-item-stub').at(1).props().modifiable).toEqual(true)
       expect(wrapper.html()).toMatchSnapshot()
     })
     it('can not edit when current user is not a manager of the space', () => {
-      const space = mockDeep<ProjectSpaceResource>({ isManager: () => false })
+      const space = mock<ProjectSpaceResource>({ isManager: () => false })
       const wrapper = getWrapper({ space })
       expect(wrapper.findAll('collaborator-list-item-stub').at(1).props().modifiable).toEqual(false)
     })
@@ -89,7 +89,7 @@ describe('SpaceMembers', () => {
         '$_ocCollaborators_deleteShare_trigger'
       )
 
-      const user = mockDeep<User>({ id: memberMocks.manager.collaborator.name })
+      const user = mock<User>({ id: memberMocks.manager.collaborator.name })
       const wrapper = getWrapper({ user })
       wrapper.find('collaborator-list-item-stub').vm.$emit('onDelete')
       await wrapper.vm.$nextTick()
@@ -98,7 +98,7 @@ describe('SpaceMembers', () => {
     it('calls "deleteSpaceMember" when successful', async () => {
       const wrapper = getWrapper()
       const deleteSpaceMemberSpy = jest.spyOn(wrapper.vm, 'deleteSpaceMember')
-      const share = mockDeep<Share>()
+      const share = mock<Share>()
       await wrapper.vm.$_ocCollaborators_deleteShare(share)
       expect(deleteSpaceMemberSpy).toHaveBeenCalled()
     })
@@ -107,19 +107,19 @@ describe('SpaceMembers', () => {
       const wrapper = getWrapper()
       jest.spyOn(wrapper.vm, 'deleteSpaceMember').mockRejectedValue(new Error())
       const showMessageSpy = jest.spyOn(wrapper.vm, 'showMessage')
-      const share = mockDeep<Share>()
+      const share = mock<Share>()
       await wrapper.vm.$_ocCollaborators_deleteShare(share)
       expect(showMessageSpy).toHaveBeenCalled()
     })
     it('redirects to the "files-spaces-projects"-page when the current user has been removed', async () => {
-      const user = mockDeep<User>({ id: memberMocks.manager.collaborator.name })
+      const user = mock<User>({ id: memberMocks.manager.collaborator.name })
       const wrapper = getWrapper({ user })
       jest.spyOn(wrapper.vm, 'deleteSpaceMember')
       await wrapper.vm.$_ocCollaborators_deleteShare(memberMocks.manager)
       expect(wrapper.vm.$router.push).toHaveBeenCalled()
     })
     it('refreshes the page when the current user has been removed on the "files-spaces-projects"-page', async () => {
-      const user = mockDeep<User>({ id: memberMocks.manager.collaborator.name })
+      const user = mock<User>({ id: memberMocks.manager.collaborator.name })
       const wrapper = getWrapper({ user, currentRouteName: 'files-spaces-projects' })
       jest.spyOn(wrapper.vm, 'deleteSpaceMember')
       await wrapper.vm.$_ocCollaborators_deleteShare(memberMocks.manager)
@@ -129,7 +129,7 @@ describe('SpaceMembers', () => {
 
   describe('filter', () => {
     it('toggles the filter on click', async () => {
-      const space = mockDeep<ProjectSpaceResource>({ isManager: () => true })
+      const space = mock<ProjectSpaceResource>({ isManager: () => true })
       const wrapper = getWrapper({ mountType: mount, space })
       expect(wrapper.vm.isFilterOpen).toBeFalsy()
       await wrapper.find('.open-filter-btn').trigger('click')
@@ -141,9 +141,9 @@ describe('SpaceMembers', () => {
 
 function getWrapper({
   mountType = shallowMount,
-  space = mockDeep<SpaceResource>(),
+  space = mock<SpaceResource>(),
   spaceMembers = [memberMocks.manager, memberMocks.editor, memberMocks.viewer],
-  user = mockDeep<User>(),
+  user = mock<User>(),
   currentRouteName = 'files-spaces-generic'
 } = {}) {
   const storeOptions = {

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/FileShares.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/FileShares.spec.ts.snap
@@ -32,16 +32,16 @@ exports[`FileShares collaborators list renders sharedWithLabel and sharee list 1
   </div>
   <ul aria-label="Share receivers" class="oc-list oc-list-divider oc-overflow-hidden oc-m-rm" id="files-collaborators-list">
     <li>
-      <collaborator-list-item-stub share="[object Object]"></collaborator-list-item-stub>
+      <collaborator-list-item-stub modifiable="true" share="[object Object]"></collaborator-list-item-stub>
     </li>
     <li>
-      <collaborator-list-item-stub share="[object Object]"></collaborator-list-item-stub>
+      <collaborator-list-item-stub modifiable="true" share="[object Object]"></collaborator-list-item-stub>
     </li>
     <li>
-      <collaborator-list-item-stub share="[object Object]"></collaborator-list-item-stub>
+      <collaborator-list-item-stub modifiable="true" share="[object Object]"></collaborator-list-item-stub>
     </li>
     <li>
-      <collaborator-list-item-stub share="[object Object]"></collaborator-list-item-stub>
+      <collaborator-list-item-stub modifiable="true" share="[object Object]"></collaborator-list-item-stub>
     </li>
   </ul>
   <div class="oc-flex oc-flex-center">
@@ -61,12 +61,21 @@ exports[`FileShares current space loads space members if a space is given and th
   <div class="avatars-wrapper oc-flex oc-flex-middle oc-flex-between">
     <h4 class="oc-text-bold oc-my-rm">Shared with</h4>
   </div>
-  <ul aria-label="Share receivers" class="oc-list oc-list-divider oc-overflow-hidden oc-m-rm" id="files-collaborators-list">
+  <ul aria-label="Share receivers" class="oc-list oc-list-divider oc-overflow-hidden oc-mb-l" id="files-collaborators-list">
     <li>
       <collaborator-list-item-stub share="[object Object]"></collaborator-list-item-stub>
     </li>
   </ul>
   <!---->
+  <h4 class="oc-text-bold oc-my-s">Space members</h4>
+  <ul aria-label="Space members" class="oc-list oc-list-divider oc-overflow-hidden oc-m-rm" id="space-collaborators-list">
+    <li>
+      <collaborator-list-item-stub share="[object Object]"></collaborator-list-item-stub>
+    </li>
+    <li>
+      <collaborator-list-item-stub share="[object Object]"></collaborator-list-item-stub>
+    </li>
+  </ul>
   <!---->
 </div>
 `;

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/FileShares.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/FileShares.spec.ts.snap
@@ -32,16 +32,16 @@ exports[`FileShares collaborators list renders sharedWithLabel and sharee list 1
   </div>
   <ul aria-label="Share receivers" class="oc-list oc-list-divider oc-overflow-hidden oc-m-rm" id="files-collaborators-list">
     <li>
-      <collaborator-list-item-stub modifiable="true" share="[object Object]"></collaborator-list-item-stub>
+      <collaborator-list-item-stub share="[object Object]"></collaborator-list-item-stub>
     </li>
     <li>
-      <collaborator-list-item-stub modifiable="true" share="[object Object]"></collaborator-list-item-stub>
+      <collaborator-list-item-stub share="[object Object]"></collaborator-list-item-stub>
     </li>
     <li>
-      <collaborator-list-item-stub modifiable="true" share="[object Object]"></collaborator-list-item-stub>
+      <collaborator-list-item-stub share="[object Object]"></collaborator-list-item-stub>
     </li>
     <li>
-      <collaborator-list-item-stub modifiable="true" share="[object Object]"></collaborator-list-item-stub>
+      <collaborator-list-item-stub share="[object Object]"></collaborator-list-item-stub>
     </li>
   </ul>
   <div class="oc-flex oc-flex-center">
@@ -61,21 +61,12 @@ exports[`FileShares current space loads space members if a space is given and th
   <div class="avatars-wrapper oc-flex oc-flex-middle oc-flex-between">
     <h4 class="oc-text-bold oc-my-rm">Shared with</h4>
   </div>
-  <ul aria-label="Share receivers" class="oc-list oc-list-divider oc-overflow-hidden oc-mb-l" id="files-collaborators-list">
+  <ul aria-label="Share receivers" class="oc-list oc-list-divider oc-overflow-hidden oc-m-rm" id="files-collaborators-list">
     <li>
       <collaborator-list-item-stub share="[object Object]"></collaborator-list-item-stub>
     </li>
   </ul>
   <!---->
-  <h4 class="oc-text-bold oc-my-s">Space members</h4>
-  <ul aria-label="Space members" class="oc-list oc-list-divider oc-overflow-hidden oc-m-rm" id="space-collaborators-list">
-    <li>
-      <collaborator-list-item-stub share="[object Object]"></collaborator-list-item-stub>
-    </li>
-    <li>
-      <collaborator-list-item-stub share="[object Object]"></collaborator-list-item-stub>
-    </li>
-  </ul>
   <!---->
 </div>
 `;

--- a/packages/web-client/src/graph.ts
+++ b/packages/web-client/src/graph.ts
@@ -46,6 +46,7 @@ export interface Graph {
   groups: {
     listGroups: (orderBy?: string) => AxiosPromise<CollectionOfGroup>
     createGroup: (group: Group) => AxiosPromise<Group>
+    getGroup: (groupId: string) => AxiosPromise<Group>
     editGroup: (groupId: string, group: Group) => AxiosPromise<void>
     deleteGroup: (groupId: string) => AxiosPromise<void>
     addMember: (groupId: string, userId: string, server: string) => AxiosPromise<void>
@@ -116,6 +117,7 @@ export const graph = (baseURI: string, axiosClient: AxiosInstance): Graph => {
     groups: {
       createGroup: (group: Group) => groupsApiFactory.createGroup(group),
       editGroup: (groupId: string, group: Group) => groupApiFactory.updateGroup(groupId, group),
+      getGroup: (groupId: string) => groupApiFactory.getGroup(groupId),
       deleteGroup: (groupId: string) => groupApiFactory.deleteGroup(groupId),
       listGroups: (orderBy?: any) =>
         groupsApiFactory.listGroups(

--- a/packages/web-client/src/helpers/resource/types.ts
+++ b/packages/web-client/src/helpers/resource/types.ts
@@ -1,5 +1,11 @@
 import { User } from '../user'
 
+export interface SpaceRole {
+  id: string
+  kind: 'user' | 'group'
+  isMember(u: User): boolean
+}
+
 // TODO: add more fields to the resource interface. Extend into different resource types: FileResource, FolderResource, ShareResource, IncomingShareResource, OutgoingShareResource, ...
 export interface Resource {
   id: number | string
@@ -16,7 +22,7 @@ export interface Resource {
   status?: number
   processing?: boolean
   spaceRoles?: {
-    [k: string]: any[]
+    [k: string]: SpaceRole[]
   }
   spaceQuota?: any
   spaceImageData?: any

--- a/packages/web-client/src/helpers/resource/types.ts
+++ b/packages/web-client/src/helpers/resource/types.ts
@@ -65,7 +65,6 @@ export interface Resource {
   isMounted?(): boolean
 
   getDomSelector?(): string
-
   matchingSpace?: any
 
   resourceOwner?: User

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -88,9 +88,10 @@ export function buildSpace(data): SpaceResource {
       for (const role of SpacePeopleShareRoles.list()) {
         if (permission.roles.includes(role.name)) {
           spaceRoles[role.name] = permission.grantedToIdentities.reduce((acc, info) => {
+            const kind = info.hasOwnProperty('group') ? 'group' : 'user'
             const spaceRole: SpaceRole = {
-              kind: 'user',
-              id: '',
+              kind,
+              id: info[kind].id,
               isMember(u?: any): boolean {
                 if (!u) {
                   return false
@@ -106,13 +107,6 @@ export function buildSpace(data): SpaceResource {
                 }
               }
             }
-
-            if (info.hasOwnProperty('group')) {
-              spaceRole.kind = 'group'
-            }
-
-            spaceRole.id = info[spaceRole.kind].id
-
             return [...acc, spaceRole]
           }, [])
         }

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -99,10 +99,8 @@ export function buildSpace(data): SpaceResource {
                 switch (this.kind) {
                   case 'user':
                     return this.id == u.uuid
-                    break
                   case 'group':
                     return u.groups.map((g) => g.id).includes(this.id)
-                    break
                   default:
                     return false
                 }
@@ -172,52 +170,34 @@ export function buildSpace(data): SpaceResource {
     spaceImageData,
     spaceReadmeData,
     canUpload: function ({ user }: { user?: User } = {}): boolean {
-      const allowedRoles = [
-        ...this.spaceRoles[spaceRoleManager.name],
-        ...this.spaceRoles[spaceRoleEditor.name]
-      ]
-      return user && allowedRoles.map((r) => r.isAllowed(user)).some(Boolean)
+      return this.isManager(user) || this.isEditor(user)
     },
     canDownload: function () {
       return true
     },
     canBeDeleted: function ({ user }: { user?: User } = {}) {
-      const allowedRoles = [...this.spaceRoles[spaceRoleManager.name]]
-      return this.disabled && user && allowedRoles.map((r) => r.isAllowed(user)).some(Boolean)
+      return this.disabled && this.isManager(user)
     },
     canRename: function ({ user }: { user?: User } = {}) {
-      const allowedRoles = [...this.spaceRoles[spaceRoleManager.name]]
-      return user && allowedRoles.map((r) => r.isAllowed(user)).some(Boolean)
+      return this.isManager(user)
     },
     canEditDescription: function ({ user }: { user?: User } = {}) {
-      const allowedRoles = [...this.spaceRoles[spaceRoleManager.name]]
-      return user && allowedRoles.map((r) => r.isAllowed(user)).some(Boolean)
+      return this.isManager(user)
     },
     canRestore: function ({ user }: { user?: User } = {}) {
-      const allowedRoles = [...this.spaceRoles[spaceRoleManager.name]]
-      return this.disabled && user && allowedRoles.map((r) => r.isAllowed(user)).some(Boolean)
+      return this.disabled && this.isManager(user)
     },
     canDisable: function ({ user }: { user?: User } = {}) {
-      const allowedRoles = [...this.spaceRoles[spaceRoleManager.name]]
-      return !this.disabled && user && allowedRoles.map((r) => r.isAllowed(user)).some(Boolean)
+      return !this.disabled && this.isManager(user)
     },
     canShare: function ({ user }: { user?: User } = {}) {
-      const allowedRoles = [...this.spaceRoles[spaceRoleManager.name]]
-      return user && allowedRoles.map((r) => r.isAllowed(user)).some(Boolean)
+      return this.isManager(user)
     },
     canEditImage: function ({ user }: { user?: User } = {}) {
-      const allowedRoles = [
-        ...this.spaceRoles[spaceRoleManager.name],
-        ...this.spaceRoles[spaceRoleEditor.name]
-      ]
-      return user && allowedRoles.map((r) => r.isAllowed(user)).some(Boolean)
+      return this.isManager(user) || this.isEditor(user)
     },
     canEditReadme: function ({ user }: { user?: User } = {}) {
-      const allowedRoles = [
-        ...this.spaceRoles[spaceRoleManager.name],
-        ...this.spaceRoles[spaceRoleEditor.name]
-      ]
-      return user && allowedRoles.map((r) => r.isAllowed(user)).some(Boolean)
+      return this.isManager(user) || this.isEditor(user)
     },
     canCreate: function () {
       return true
@@ -242,13 +222,13 @@ export function buildSpace(data): SpaceResource {
       return urlJoin(webDavTrashUrl, path)
     },
     isViewer(user: User): boolean {
-      return this.spaceRoles[spaceRoleViewer.name].map((r) => r.isAllowed(user)).some(Boolean)
+      return this.spaceRoles[spaceRoleViewer.name].map((r) => r.isMember(user)).some(Boolean)
     },
     isEditor(user: User): boolean {
-      return this.spaceRoles[spaceRoleEditor.name].map((r) => r.isAllowed(user)).some(Boolean)
+      return this.spaceRoles[spaceRoleEditor.name].map((r) => r.isMember(user)).some(Boolean)
     },
     isManager(user: User): boolean {
-      return this.spaceRoles[spaceRoleManager.name].map((r) => r.isAllowed(user)).some(Boolean)
+      return this.spaceRoles[spaceRoleManager.name].map((r) => r.isMember(user)).some(Boolean)
     },
     isMember(user: User): boolean {
       return this.isViewer(user) || this.isEditor(user) || this.isManager(user)

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -4,7 +4,8 @@ import {
   buildWebDavSpacesTrashPath,
   extractDomSelector,
   extractNodeId,
-  Resource
+  Resource,
+  SpaceRole
 } from '../resource'
 import { SpacePeopleShareRoles, spaceRoleEditor, spaceRoleManager, spaceRoleViewer } from '../share'
 import { PublicSpaceResource, ShareSpaceResource, SpaceResource, SHARE_JAIL_ID } from './types'
@@ -86,9 +87,36 @@ export function buildSpace(data): SpaceResource {
     for (const permission of data.root.permissions) {
       for (const role of SpacePeopleShareRoles.list()) {
         if (permission.roles.includes(role.name)) {
-          spaceRoles[role.name].push(
-            ...permission.grantedToIdentities.filter((el) => !!el.user).map((el) => el.user.id)
-          )
+          spaceRoles[role.name] = permission.grantedToIdentities.reduce((acc, info) => {
+            const spaceRole: SpaceRole = {
+              kind: 'user',
+              id: '',
+              isMember(u?: any): boolean {
+                if (!u) {
+                  return false
+                }
+
+                switch (this.kind) {
+                  case 'user':
+                    return this.id == u.uuid
+                    break
+                  case 'group':
+                    return u.groups.map((g) => g.id).includes(this.id)
+                    break
+                  default:
+                    return false
+                }
+              }
+            }
+
+            if (info.hasOwnProperty('group')) {
+              spaceRole.kind = 'group'
+            }
+
+            spaceRole.id = info[spaceRole.kind].id
+
+            return [...acc, spaceRole]
+          }, [])
         }
       }
     }
@@ -143,53 +171,53 @@ export function buildSpace(data): SpaceResource {
     spaceRoles,
     spaceImageData,
     spaceReadmeData,
-    canUpload: function ({ user }: { user?: User } = {}) {
+    canUpload: function ({ user }: { user?: User } = {}): boolean {
       const allowedRoles = [
         ...this.spaceRoles[spaceRoleManager.name],
         ...this.spaceRoles[spaceRoleEditor.name]
       ]
-      return user && allowedRoles.includes(user.uuid)
+      return user && allowedRoles.map((r) => r.isAllowed(user)).some(Boolean)
     },
     canDownload: function () {
       return true
     },
     canBeDeleted: function ({ user }: { user?: User } = {}) {
       const allowedRoles = [...this.spaceRoles[spaceRoleManager.name]]
-      return this.disabled && user && allowedRoles.includes(user.uuid)
+      return this.disabled && user && allowedRoles.map((r) => r.isAllowed(user)).some(Boolean)
     },
     canRename: function ({ user }: { user?: User } = {}) {
       const allowedRoles = [...this.spaceRoles[spaceRoleManager.name]]
-      return user && allowedRoles.includes(user.uuid)
+      return user && allowedRoles.map((r) => r.isAllowed(user)).some(Boolean)
     },
     canEditDescription: function ({ user }: { user?: User } = {}) {
       const allowedRoles = [...this.spaceRoles[spaceRoleManager.name]]
-      return user && allowedRoles.includes(user.uuid)
+      return user && allowedRoles.map((r) => r.isAllowed(user)).some(Boolean)
     },
     canRestore: function ({ user }: { user?: User } = {}) {
       const allowedRoles = [...this.spaceRoles[spaceRoleManager.name]]
-      return this.disabled && user && allowedRoles.includes(user.uuid)
+      return this.disabled && user && allowedRoles.map((r) => r.isAllowed(user)).some(Boolean)
     },
     canDisable: function ({ user }: { user?: User } = {}) {
       const allowedRoles = [...this.spaceRoles[spaceRoleManager.name]]
-      return !this.disabled && user && allowedRoles.includes(user.uuid)
+      return !this.disabled && user && allowedRoles.map((r) => r.isAllowed(user)).some(Boolean)
     },
     canShare: function ({ user }: { user?: User } = {}) {
       const allowedRoles = [...this.spaceRoles[spaceRoleManager.name]]
-      return user && allowedRoles.includes(user.uuid)
+      return user && allowedRoles.map((r) => r.isAllowed(user)).some(Boolean)
     },
     canEditImage: function ({ user }: { user?: User } = {}) {
       const allowedRoles = [
         ...this.spaceRoles[spaceRoleManager.name],
         ...this.spaceRoles[spaceRoleEditor.name]
       ]
-      return user && allowedRoles.includes(user.uuid)
+      return user && allowedRoles.map((r) => r.isAllowed(user)).some(Boolean)
     },
     canEditReadme: function ({ user }: { user?: User } = {}) {
       const allowedRoles = [
         ...this.spaceRoles[spaceRoleManager.name],
         ...this.spaceRoles[spaceRoleEditor.name]
       ]
-      return user && allowedRoles.includes(user.uuid)
+      return user && allowedRoles.map((r) => r.isAllowed(user)).some(Boolean)
     },
     canCreate: function () {
       return true
@@ -213,14 +241,17 @@ export function buildSpace(data): SpaceResource {
     getWebDavTrashUrl({ path }: { path: string }): string {
       return urlJoin(webDavTrashUrl, path)
     },
-    isViewer(uuid: string): boolean {
-      return this.spaceRoles[spaceRoleViewer.name].includes(uuid)
+    isViewer(user: User): boolean {
+      return this.spaceRoles[spaceRoleViewer.name].map((r) => r.isAllowed(user)).some(Boolean)
     },
-    isEditor(uuid: string): boolean {
-      return this.spaceRoles[spaceRoleEditor.name].includes(uuid)
+    isEditor(user: User): boolean {
+      return this.spaceRoles[spaceRoleEditor.name].map((r) => r.isAllowed(user)).some(Boolean)
     },
-    isManager(uuid: string): boolean {
-      return this.spaceRoles[spaceRoleManager.name].includes(uuid)
+    isManager(user: User): boolean {
+      return this.spaceRoles[spaceRoleManager.name].map((r) => r.isAllowed(user)).some(Boolean)
+    },
+    isMember(user: User): boolean {
+      return this.isViewer(user) || this.isEditor(user) || this.isManager(user)
     }
   }
   Object.defineProperty(s, 'nodeId', {

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -222,13 +222,13 @@ export function buildSpace(data): SpaceResource {
       return urlJoin(webDavTrashUrl, path)
     },
     isViewer(user: User): boolean {
-      return this.spaceRoles[spaceRoleViewer.name].map((r) => r.isMember(user)).some(Boolean)
+      return this.spaceRoles[spaceRoleViewer.name].map((r) => r.id === user).some(Boolean)
     },
     isEditor(user: User): boolean {
-      return this.spaceRoles[spaceRoleEditor.name].map((r) => r.isMember(user)).some(Boolean)
+      return this.spaceRoles[spaceRoleEditor.name].map((r) => r.id === user).some(Boolean)
     },
     isManager(user: User): boolean {
-      return this.spaceRoles[spaceRoleManager.name].map((r) => r.isMember(user)).some(Boolean)
+      return this.spaceRoles[spaceRoleManager.name].map((r) => r.id === user).some(Boolean)
     },
     isMember(user: User): boolean {
       return this.isViewer(user) || this.isEditor(user) || this.isManager(user)

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -222,13 +222,13 @@ export function buildSpace(data): SpaceResource {
       return urlJoin(webDavTrashUrl, path)
     },
     isViewer(user: User): boolean {
-      return this.spaceRoles[spaceRoleViewer.name].map((r) => r.id === user).some(Boolean)
+      return this.spaceRoles[spaceRoleViewer.name].map((r) => r.isMember(user)).some(Boolean)
     },
     isEditor(user: User): boolean {
-      return this.spaceRoles[spaceRoleEditor.name].map((r) => r.id === user).some(Boolean)
+      return this.spaceRoles[spaceRoleEditor.name].map((r) => r.isMember(user)).some(Boolean)
     },
     isManager(user: User): boolean {
-      return this.spaceRoles[spaceRoleManager.name].map((r) => r.id === user).some(Boolean)
+      return this.spaceRoles[spaceRoleManager.name].map((r) => r.isMember(user)).some(Boolean)
     },
     isMember(user: User): boolean {
       return this.isViewer(user) || this.isEditor(user) || this.isManager(user)

--- a/packages/web-client/src/helpers/space/types.ts
+++ b/packages/web-client/src/helpers/space/types.ts
@@ -7,6 +7,7 @@
 // because in the else block resource gets the type never. If this is changed in a later TypeScript version
 // or all types get different members, the underscored props can be removed.
 import { Resource } from '../resource'
+import { User } from '../user'
 
 export const SHARE_JAIL_ID = 'a0ca6a90-a365-4782-871e-d44447bbc668'
 
@@ -39,9 +40,9 @@ export const isPersonalSpaceResource = (resource: Resource): resource is Persona
 
 export interface ProjectSpaceResource extends SpaceResource {
   __projectSpaceResource?: any
-  isViewer(uuid: string): boolean
-  isEditor(uuid: string): boolean
-  isManager(uuid: string): boolean
+  isViewer(uuid: User): boolean
+  isEditor(uuid: User): boolean
+  isManager(uuid: User): boolean
 }
 export const isProjectSpaceResource = (resource: Resource): resource is ProjectSpaceResource => {
   return resource.driveType === 'project'

--- a/packages/web-client/tests/unit/helpers/space/functions.spec.ts
+++ b/packages/web-client/tests/unit/helpers/space/functions.spec.ts
@@ -15,7 +15,7 @@ describe('buildSpace', () => {
           permissions: [{ roles: data.role, grantedToIdentities: [{ user: { id: uuid } }] }]
         }
       }) as ProjectSpaceResource
-      expect(space.isViewer(uuid)).toBe(data.expectedResult)
+      expect(space.isViewer({uuid} as any)).toBe(data.expectedResult)
     })
   })
 
@@ -30,7 +30,7 @@ describe('buildSpace', () => {
           permissions: [{ roles: data.role, grantedToIdentities: [{ user: { id: uuid } }] }]
         }
       }) as ProjectSpaceResource
-      expect(space.isEditor(uuid)).toBe(data.expectedResult)
+      expect(space.isEditor({uuid} as any)).toBe(data.expectedResult)
     })
   })
 
@@ -45,7 +45,7 @@ describe('buildSpace', () => {
           permissions: [{ roles: data.role, grantedToIdentities: [{ user: { id: uuid } }] }]
         }
       }) as ProjectSpaceResource
-      expect(space.isManager(uuid)).toBe(data.expectedResult)
+      expect(space.isManager({uuid} as any)).toBe(data.expectedResult)
     })
   })
 })

--- a/packages/web-client/tests/unit/helpers/space/functions.spec.ts
+++ b/packages/web-client/tests/unit/helpers/space/functions.spec.ts
@@ -15,7 +15,7 @@ describe('buildSpace', () => {
           permissions: [{ roles: data.role, grantedToIdentities: [{ user: { id: uuid } }] }]
         }
       }) as ProjectSpaceResource
-      expect(space.isViewer({uuid} as any)).toBe(data.expectedResult)
+      expect(space.isViewer({ uuid } as any)).toBe(data.expectedResult)
     })
   })
 
@@ -30,7 +30,7 @@ describe('buildSpace', () => {
           permissions: [{ roles: data.role, grantedToIdentities: [{ user: { id: uuid } }] }]
         }
       }) as ProjectSpaceResource
-      expect(space.isEditor({uuid} as any)).toBe(data.expectedResult)
+      expect(space.isEditor({ uuid } as any)).toBe(data.expectedResult)
     })
   })
 
@@ -45,7 +45,7 @@ describe('buildSpace', () => {
           permissions: [{ roles: data.role, grantedToIdentities: [{ user: { id: uuid } }] }]
         }
       }) as ProjectSpaceResource
-      expect(space.isManager({uuid} as any)).toBe(data.expectedResult)
+      expect(space.isManager({ uuid } as any)).toBe(data.expectedResult)
     })
   })
 })

--- a/packages/web-client/tests/unit/helpers/space/functions.spec.ts
+++ b/packages/web-client/tests/unit/helpers/space/functions.spec.ts
@@ -1,5 +1,7 @@
 import { buildSpace, ProjectSpaceResource } from '../../../../src/helpers/space'
 import { spaceRoleEditor, spaceRoleManager, spaceRoleViewer } from '../../../../src/helpers/share'
+import { mock } from 'jest-mock-extended'
+import { User } from 'web-client/src'
 
 describe('buildSpace', () => {
   const uuid = '1'
@@ -15,7 +17,7 @@ describe('buildSpace', () => {
           permissions: [{ roles: data.role, grantedToIdentities: [{ user: { id: uuid } }] }]
         }
       }) as ProjectSpaceResource
-      expect(space.isViewer({ uuid } as any)).toBe(data.expectedResult)
+      expect(space.isViewer(mock<User>({ uuid }))).toBe(data.expectedResult)
     })
   })
 
@@ -30,7 +32,7 @@ describe('buildSpace', () => {
           permissions: [{ roles: data.role, grantedToIdentities: [{ user: { id: uuid } }] }]
         }
       }) as ProjectSpaceResource
-      expect(space.isEditor({ uuid } as any)).toBe(data.expectedResult)
+      expect(space.isEditor(mock<User>({ uuid }))).toBe(data.expectedResult)
     })
   })
 
@@ -45,7 +47,7 @@ describe('buildSpace', () => {
           permissions: [{ roles: data.role, grantedToIdentities: [{ user: { id: uuid } }] }]
         }
       }) as ProjectSpaceResource
-      expect(space.isManager({ uuid } as any)).toBe(data.expectedResult)
+      expect(space.isManager(mock<User>({ uuid }))).toBe(data.expectedResult)
     })
   })
 })

--- a/packages/web-runtime/src/store/spaces.ts
+++ b/packages/web-runtime/src/store/spaces.ts
@@ -1,4 +1,4 @@
-import { buildSpace, isProjectSpaceResource } from 'web-client/src/helpers'
+import { buildSpace, isProjectSpaceResource, SpaceResource } from 'web-client/src/helpers'
 import Vue, { Ref } from 'vue'
 import { set, has } from 'lodash-es'
 import { unref } from 'vue'
@@ -134,7 +134,10 @@ const actions = {
     context.commit('CLEAR_PROJECT_SPACES')
     context.commit('ADD_SPACES', spaces)
   },
-  loadSpaceMembers(context, { graphClient, space }: { graphClient: Ref<Graph>; space: any }) {
+  loadSpaceMembers(
+    context,
+    { graphClient, space }: { graphClient: Ref<Graph>; space: SpaceResource }
+  ) {
     context.commit('CLEAR_SPACE_MEMBERS')
     const promises = []
     const spaceShares = []
@@ -207,7 +210,6 @@ const actions = {
     const additionalParams = {
       shareWith: share.collaborator.name || share.collaborator.displayName
     } as any
-    console.log(additionalParams)
     await client.shares.deleteShare(share.id, additionalParams)
 
     if (reloadSpace) {

--- a/packages/web-runtime/src/store/spaces.ts
+++ b/packages/web-runtime/src/store/spaces.ts
@@ -107,7 +107,7 @@ const mutations = {
 }
 
 const actions = {
-  async loadSpaces(context, { graphClient }) {
+  async loadSpaces(context, { graphClient }: { graphClient: Graph }) {
     context.commit('SET_SPACES_LOADING', true)
     try {
       const graphResponse = await graphClient.drives.listMyDrives()
@@ -142,7 +142,6 @@ const actions = {
     for (const role of Object.keys(space.spaceRoles)) {
       for (const { kind, id } of space.spaceRoles[role]) {
         const client = unref(graphClient)
-
         let prom: Promise<AxiosResponse>
         switch (kind) {
           case 'user':


### PR DESCRIPTION
## Description
This pr allows to select groups int the space member sharing dialogue.
So far it was only possible to select users.

## Related Issue
- [x] Fixes https://github.com/owncloud/web/issues/8160
- [x] depends on https://github.com/owncloud/web/pull/8171
- [x] depends on https://github.com/owncloud/ocis/pull/5312
- [x] depends on https://github.com/owncloud/ocis/pull/5310
- [x] depends on https://github.com/owncloud/ocis/pull/5309
- [x] depends on https://github.com/owncloud/libre-graph-api/pull/74
- [x] depends on https://github.com/owncloud/libre-graph-api/pull/73
- [x] depends on https://github.com/cs3org/reva/pull/3575
- [x] depends on https://github.com/cs3org/reva/pull/3574

## Motivation and Context
be able to share resources to groups instead of user only.

## How Has This Been Tested?
- [x] e2e tests
- [x] unit tests
- [x] local environment

## Screenshots (if appropriate):

![Bildschirm­foto 2023-01-02 um 19 52 40](https://user-images.githubusercontent.com/49308105/210269693-2e8c6fe6-dd62-4f2e-a341-41787a049fa0.png)
![Bildschirm­foto 2023-01-02 um 19 52 32](https://user-images.githubusercontent.com/49308105/210269696-685441c8-c001-4241-8757-f060a39e28f5.png)
![Bildschirm­foto 2023-01-02 um 19 52 09](https://user-images.githubusercontent.com/49308105/210269700-dc217c58-69ae-4369-ac89-7b7c69479a56.png)
![Bildschirm­foto 2023-01-02 um 19 52 02](https://user-images.githubusercontent.com/49308105/210269703-5c604df8-271b-40d1-9fac-f0f9fcc99b77.png)
![Bildschirm­foto 2023-01-02 um 19 51 55](https://user-images.githubusercontent.com/49308105/210269705-d90deb46-175b-4453-81ef-a1680f41bbef.png)
![Bildschirm­foto 2023-01-02 um 19 51 38](https://user-images.githubusercontent.com/49308105/210269706-0edf6b1c-354d-4b8b-90b1-712ee5749152.png)
![Bildschirm­foto 2023-01-02 um 19 51 32](https://user-images.githubusercontent.com/49308105/210269710-074f443d-9249-4303-9463-7bd4364f0582.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] E2E tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Basic implementation
- [x] Changelog
- [ ] Add e2e tests (can be done in follow-up PR)
- [ ] Add more unit-tests (can be done in follow-up PR)
- [x] fix unit tests
