### PR TITLE
[tests-only][full-ci]Bump latest ocis-stable-2.0 commit-id on web-stable-6.0

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=dcc65b09ea88356733e0da0571025f9b377b84f7
+OCIS_COMMITID=b36c2e6dbffa6dc3f28f7f580300306fecab8edc
 OCIS_BRANCH=stable-2.0


### PR DESCRIPTION
### Description
Bump latest `ocis-stable-2.0` commit id to `web-stable-6.0`

### Part of:
https://github.com/owncloud/QA/issues/791