### PR TITLE
Fix search bar input appearance

### DIFF
--- a/changelog/unreleased/bugfix-search-bar-input-appearance
+++ b/changelog/unreleased/bugfix-search-bar-input-appearance
@@ -1,0 +1,6 @@
+Bugfix: Search bar input appearance
+
+The broken appearance of the search bar input field has been fixed.
+
+https://github.com/owncloud/web/issues/8158
+https://github.com/owncloud/web/pull/8203

--- a/packages/design-system/src/components/OcSearchBar/OcSearchBar.vue
+++ b/packages/design-system/src/components/OcSearchBar/OcSearchBar.vue
@@ -311,9 +311,9 @@ export default {
   }
 
   &-input {
-    border-radius: 25px;
-    border: 1px solid var(--oc-color-input-border);
-    color: var(--oc-color-input-text-muted);
+    border-radius: 25px !important;
+    border: 1px solid var(--oc-color-input-border) !important;
+    color: var(--oc-color-input-text-muted) !important;
 
     &:focus {
       background-color: var(--oc-color-input-bg);
@@ -328,7 +328,7 @@ export default {
   }
 
   &-input-icon {
-    padding: 0 var(--oc-space-xlarge);
+    padding: 0 var(--oc-space-xlarge) !important;
   }
 
   &-input-button {


### PR DESCRIPTION
## Description
The broken appearance of the search bar input field has been fixed.

**Note:** The priority of CSS rules seem to differ between `pnpm build` and `pnpm vite`. With `pnpm vite`, the CSS rules in ODS have a higher prio, which is correct. Somehow this changes with `pnpm build`. That might be worth debugging in the future, but for now, we are fine with simply adding `!important` (like we often do in the ODS).

![image](https://user-images.githubusercontent.com/50302941/211555790-6edc040c-7748-4731-b028-66238d315975.png)

## Issue
Fixes https://github.com/owncloud/web/issues/8158

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
