### PR TITLE
Vue 3: Fix 'Shift + click'-selection in files table

### DIFF
--- a/changelog/unreleased/bugfix-shift-click-selection
+++ b/changelog/unreleased/bugfix-shift-click-selection
@@ -1,0 +1,6 @@
+Bugfix: "Shift + click"-selection
+
+"Shift + click"-selection in the files table has been fixed.
+
+https://github.com/owncloud/web/pull/8207
+https://github.com/owncloud/web/issues/8206

--- a/changelog/unreleased/bugfix-shift-click-selection
+++ b/changelog/unreleased/bugfix-shift-click-selection
@@ -1,6 +1,0 @@
-Bugfix: "Shift + click"-selection
-
-"Shift + click"-selection in the files table has been fixed.
-
-https://github.com/owncloud/web/pull/8207
-https://github.com/owncloud/web/issues/8206

--- a/changelog/unreleased/change-update-vue
+++ b/changelog/unreleased/change-update-vue
@@ -1,7 +1,14 @@
-Change: Update Vue to v2.7.14
+Change: Update Vue to v3.2.45 (via compat mode)
 
-Vue has been updated to 2.7.14
+Vue has been updated to v3.2.45. It is currently running in the so-called "compat mode", which guarantees compatibility with Vue 2.7. More detailed information can be found in the referenced issues and PRs down below.
 
 BREAKING CHANGE for developers: The `vue/composition-api` plugin is not available anymore as the composition-api now comes with Vue.
 
+https://github.com/owncloud/web/issues/7948
+https://github.com/owncloud/web/issues/5269
+https://github.com/owncloud/web/pull/8128
 https://github.com/owncloud/web/pull/7877
+https://github.com/owncloud/web/pull/8207
+https://github.com/owncloud/web/pull/8201
+https://github.com/owncloud/web/pull/8202
+https://github.com/owncloud/web/pull/8198

--- a/packages/web-app-files/src/components/FilesList/KeyboardActions.vue
+++ b/packages/web-app-files/src/components/FilesList/KeyboardActions.vue
@@ -183,7 +183,7 @@ export default defineComponent({
 
     handleShiftClickAction(resource) {
       const parent = document.querySelectorAll(`[data-item-id='${resource.id}']`)[0]
-      const resourceNodes = Object.values(parent.parentNode.childNodes) as HTMLElement[]
+      const resourceNodes = Object.values(parent.parentNode.children)
       const latestNode = resourceNodes.find(
         (r) => r.getAttribute('data-item-id') === this.latestSelectedId
       )


### PR DESCRIPTION
## Description
"Shift + click"-selection in the files table has been fixed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8206

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
