### PR TITLE
restore original "space" icon from remixicon

### DIFF
--- a/packages/design-system/src/assets/icons/space.svg
+++ b/packages/design-system/src/assets/icons/space.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
     <g>
         <path fill="none" d="M0 0h24v24H0z"/>
-        <path d="M3 3h8v8H3V3zm0 10h8v8H3v-8zM13 3h8v8h-8V3zm0 10h8v8h-8v-8z"/>
+        <path d="M4 9v4h16V9h2v5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V9h2z"/>
     </g>
 </svg>


### PR DESCRIPTION
## Description
At some point we replaced the `space` icon from [remixicon.com](http://remixicon.com) with something custom. We don't seem to use that anymore (at least I couldn't find any occurrence), but use `layout-grid` instead. So this PR re-introduces the `space` remixicon (which represents a `blank/space` for a text editor user interface).
