### PR TITLE
Fix group avatar display in space members list

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=770fc74a14d2150c51c088e6966434faef8b5557
+OCIS_COMMITID=e1a4ac6b330079e3488152f4c638b1e32743224a
 OCIS_BRANCH=master

--- a/changelog/unreleased/enhancement-share-group-recipient
+++ b/changelog/unreleased/enhancement-share-group-recipient
@@ -5,3 +5,4 @@ We've added the possibility to share a space with a group.
 https://github.com/owncloud/web/pull/8161
 https://github.com/owncloud/web/issues/8160
 https://github.com/owncloud/web/pull/8185
+https://github.com/owncloud/web/pull/8248

--- a/changelog/unreleased/enhancement-update-sdk
+++ b/changelog/unreleased/enhancement-update-sdk
@@ -1,9 +1,12 @@
-Enhancement: Update SDK to v3.1.0-alpha.2
+Enhancement: Update SDK to v3.1.0-alpha.3
 
-We updated the ownCloud SDK to version v3.1.0-alpha.2. Please refer to the full changelog in the SDK release (linked) for more details. Summary:
+We updated the ownCloud SDK to version v3.1.0-alpha.3. Please refer to the full changelog in the SDK release (linked) for more details. Summary:
 
-* Bugfix - Allow removing expiration dates from space shares: [#1204](https://github.com/owncloud/owncloud-sdk/pull/1204)
-* Enhancement - Resource processing: [#1109](https://github.com/owncloud/owncloud-sdk/pull/1109)
+* Bugfix - Allow removing expiration dates from space shares: [owncloud/owncloud-sdk#1204](https://github.com/owncloud/owncloud-sdk/pull/1204)
+* Enhancement - Resource processing: [owncloud/owncloud-sdk#1109](https://github.com/owncloud/owncloud-sdk/pull/1109)
+* Enhancement - Share space with group: [owncloud/owncloud-sdk#1207](https://github.com/owncloud/owncloud-sdk/pull/1207)
+
 
 https://github.com/owncloud/web/pull/8320
-https://github.com/owncloud/owncloud-sdk/releases/tag/v3.1.0-alpha.2
+https://github.com/owncloud/web/pull/8248
+https://github.com/owncloud/owncloud-sdk/releases/tag/v3.1.0-alpha.3

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/AutocompleteItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/AutocompleteItem.vue
@@ -5,7 +5,7 @@
     :class="collaboratorClass"
   >
     <avatar-image
-      v-if="isUser || isSpace"
+      v-if="isUser || isSpaceUser"
       class="oc-mr-s"
       :width="36"
       :userid="item.value.shareWith"
@@ -21,7 +21,7 @@
     >
     </oc-icon>
     <oc-icon
-      v-else-if="isGroup"
+      v-else-if="isGroup || isSpaceGroup"
       key="avatar-group"
       class="oc-mr-s files-recipient-suggestion-avatar"
       name="group"
@@ -76,8 +76,8 @@ export default {
       return this.shareType === ShareTypes.user
     },
 
-    isSpace() {
-      return this.shareType === ShareTypes.space
+    isSpaceUser() {
+      return this.shareType === ShareTypes.spaceUser
     },
 
     isGuest() {
@@ -86,6 +86,10 @@ export default {
 
     isGroup() {
       return this.shareType === ShareTypes.group
+    },
+
+    isSpaceGroup() {
+      return this.shareType === ShareTypes.spaceGroup
     },
 
     collaboratorClass() {

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/RecipientContainer.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/RecipientContainer.vue
@@ -49,7 +49,7 @@ export default {
       formattedRecipient: {
         name: this.recipient.label,
         icon: this.getRecipientIcon(),
-        hasAvatar: [ShareTypes.user.value, ShareTypes.space.value].includes(
+        hasAvatar: [ShareTypes.user.value, ShareTypes.spaceUser.value].includes(
           this.recipient.value.shareType
         ),
         isLoadingAvatar: true

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
@@ -316,7 +316,7 @@ export default defineComponent({
     },
     showAvatar() {
       if (this.isSpace) {
-        return this.share.collaborator.name
+        return !!this.share.collaborator.name
       }
       return this.isUser
     }

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :data-testid="`collaborator-${isUser || isSpace ? 'user' : 'group'}-item-${
+    :data-testid="`collaborator-${isAnyUserShareType ? 'user' : 'group'}-item-${
       share.collaborator.name
     }`"
     class="files-collaborators-collaborator oc-py-xs"
@@ -9,7 +9,7 @@
       <div class="oc-width-2-3 oc-flex oc-flex-middle">
         <div>
           <avatar-image
-            v-if="showAvatar"
+            v-if="isAnyUserShareType"
             :userid="share.collaborator.name"
             :user-name="share.collaborator.displayName"
             :width="36"
@@ -40,7 +40,7 @@
                 :dom-selector="shareDomSelector"
                 :existing-permissions="share.customPermissions"
                 :existing-role="share.role"
-                :allow-share-permission="hasResharing || isSpace"
+                :allow-share-permission="hasResharing || isAnySpaceShareType"
                 class="files-collaborators-collaborator-role"
                 @option-change="shareRoleChanged"
               />
@@ -92,7 +92,7 @@
         <oc-info-drop
           ref="accessDetailsDrop"
           class="share-access-details-drop"
-          v-bind="isSpace ? accessDetailsPropsSpace : accessDetailsProps"
+          v-bind="isAnySpaceShareType ? accessDetailsPropsSpace : accessDetailsProps"
           mode="manual"
           :target="`#edit-drop-down-${editDropDownToggleId}`"
         />
@@ -165,12 +165,12 @@ export default defineComponent({
       return extractDomSelector(this.share.id)
     },
 
-    isUser() {
-      return this.shareType === ShareTypes.user
+    isAnyUserShareType() {
+      return [ShareTypes.user, ShareTypes.spaceUser].includes(this.shareType)
     },
 
-    isSpace() {
-      return this.shareType === ShareTypes.space
+    isAnySpaceShareType() {
+      return [ShareTypes.spaceUser, ShareTypes.spaceGroup].includes(this.shareType)
     },
 
     shareTypeText() {
@@ -313,12 +313,6 @@ export default defineComponent({
         title: this.$gettext('Access details'),
         list
       }
-    },
-    showAvatar() {
-      if (this.isSpace) {
-        return !!this.share.collaborator.name
-      }
-      return this.isUser
     }
   },
   methods: {
@@ -364,8 +358,10 @@ export default defineComponent({
     saveShareChanges({ role, permissions, expirationDate }) {
       const bitmask = role.hasCustomPermissions
         ? SharePermissions.permissionsToBitmask(permissions)
-        : SharePermissions.permissionsToBitmask(role.permissions(this.hasResharing || this.isSpace))
-      const changeMethod = this.isSpace ? this.changeSpaceMember : this.changeShare
+        : SharePermissions.permissionsToBitmask(
+            role.permissions(this.hasResharing || this.isAnySpaceShareType)
+          )
+      const changeMethod = this.isAnySpaceShareType ? this.changeSpaceMember : this.changeShare
       changeMethod({
         ...this.$language,
         client: this.$client,

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
@@ -9,7 +9,7 @@
       <div class="oc-width-2-3 oc-flex oc-flex-middle">
         <div>
           <avatar-image
-            v-if="isUser || isSpace"
+            v-if="showAvatar"
             :userid="share.collaborator.name"
             :user-name="share.collaborator.displayName"
             :width="36"
@@ -313,6 +313,12 @@ export default defineComponent({
         title: this.$gettext('Access details'),
         list
       }
+    },
+    showAvatar() {
+      if (this.isSpace) {
+        return this.share.collaborator.name
+      }
+      return this.isUser
     }
   },
   methods: {

--- a/packages/web-app-files/src/helpers/resources.ts
+++ b/packages/web-app-files/src/helpers/resources.ts
@@ -9,9 +9,7 @@ import {
   Share,
   ShareStatus,
   ShareTypes,
-  spaceRoleEditor,
-  spaceRoleManager,
-  spaceRoleViewer
+  buildSpaceShare
 } from 'web-client/src/helpers/share'
 import {
   buildWebDavSpacesPath,
@@ -236,42 +234,11 @@ export function buildShare(s, file, allowSharePermission): Share {
   if (parseInt(s.share_type) === ShareTypes.link.value) {
     return _buildLink(s)
   }
-  if (parseInt(s.share_type) === ShareTypes.space.value) {
+  if ([ShareTypes.spaceUser.value, ShareTypes.spaceGroup.value].includes(parseInt(s.share_type))) {
     return buildSpaceShare(s, file)
   }
 
   return buildCollaboratorShare(s, file, allowSharePermission)
-}
-
-export function buildSpaceShare(s, storageId): Share {
-  let permissions, role
-
-  switch (s.role) {
-    case spaceRoleManager.name:
-      permissions = spaceRoleManager.bitmask(true)
-      role = spaceRoleManager
-      break
-    case spaceRoleEditor.name:
-      permissions = spaceRoleEditor.bitmask(true)
-      role = spaceRoleEditor
-      break
-    case spaceRoleViewer.name:
-      permissions = spaceRoleViewer.bitmask(true)
-      role = spaceRoleViewer
-      break
-  }
-
-  return {
-    shareType: ShareTypes.space.value,
-    id: storageId,
-    collaborator: {
-      name: s.onPremisesSamAccountName,
-      displayName: s.displayName,
-      additionalInfo: null
-    },
-    permissions,
-    role
-  }
 }
 
 function _buildLink(link): Share {

--- a/packages/web-app-files/src/services/folder/loaderSharedWithOthers.ts
+++ b/packages/web-app-files/src/services/folder/loaderSharedWithOthers.ts
@@ -35,7 +35,9 @@ export class FolderLoaderSharedWithOthers implements FolderLoader {
       store.commit('Files/CLEAR_CURRENT_FILES_LIST')
 
       const shareTypes = ShareTypes.authenticated
-        .filter((type) => type.value !== ShareTypes.space.value)
+        .filter(
+          (type) => ![ShareTypes.spaceUser.value, ShareTypes.spaceGroup.value].includes(type.value)
+        )
         .map((share) => share.value)
         .join(',')
 

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/__snapshots__/RecipientContainer.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/__snapshots__/RecipientContainer.spec.ts.snap
@@ -67,3 +67,14 @@ exports[`InviteCollaborator RecipientContainer renders a recipient with a desele
   </button>
 </span>
 `;
+
+exports[`InviteCollaborator RecipientContainer renders a recipient with a deselect button different recipients for different shareTypes 6`] = `
+<span class="oc-recipient files-share-invite-recipient">
+  <oc-icon-stub accessiblelabel="User" class="oc-recipient-icon" color="" filltype="fill" name="user" size="small" type="span" variation="passive"></oc-icon-stub>
+  <p class="oc-recipient-name">Albert Einstein</p> <!-- @slot Append content (actions, additional info, etc.)  -->
+  <button aria-label="Deselect Albert Einstein" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw files-share-invite-recipient-btn-remove" type="button">
+    <!-- @slot Content of the button -->
+    <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="close" size="small" type="span" variation="passive"></oc-icon-stub>
+  </button>
+</span>
+`;

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/ListItem.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/ListItem.spec.ts
@@ -34,8 +34,8 @@ const selectors = {
 
 describe('Collaborator ListItem component', () => {
   describe('displays the correct image/icon according to the shareType', () => {
-    describe('user and space share type', () => {
-      it.each([ShareTypes.user.value, ShareTypes.space.value])(
+    describe('user and spaceUser share type', () => {
+      it.each([ShareTypes.user.value, ShareTypes.spaceUser.value])(
         'should display a users avatar',
         (shareType) => {
           const { wrapper } = createWrapper({ shareType })
@@ -54,7 +54,7 @@ describe('Collaborator ListItem component', () => {
     describe('non-user share types', () => {
       it.each(
         ShareTypes.all.filter(
-          (shareType) => ![ShareTypes.user, ShareTypes.space].includes(shareType)
+          (shareType) => ![ShareTypes.user, ShareTypes.spaceUser].includes(shareType)
         )
       )('should display an oc-avatar-item for any non-user share types', (shareType) => {
         const { wrapper } = createWrapper({ shareType: shareType.value })
@@ -64,7 +64,7 @@ describe('Collaborator ListItem component', () => {
       })
       it('should display an oc-avatar-item for space group shares', () => {
         const { wrapper } = createWrapper({
-          shareType: ShareTypes.space.value,
+          shareType: ShareTypes.spaceGroup.value,
           collaborator: { name: undefined, displayName: 'someGroup', additionalInfo: undefined }
         })
         expect(wrapper.find(selectors.userAvatarImage).exists()).toBeFalsy()
@@ -123,7 +123,7 @@ describe('Collaborator ListItem component', () => {
       expect(changeShareStub).toHaveBeenCalled()
     })
     it('calls "changeSpaceMember" for space resources', () => {
-      const { wrapper } = createWrapper({ shareType: ShareTypes.space.value })
+      const { wrapper } = createWrapper({ shareType: ShareTypes.spaceUser.value })
       const changeShareStub = jest.spyOn(wrapper.vm, 'changeSpaceMember')
       ;(wrapper.findComponent<any>('role-dropdown-stub').vm as any).$emit('optionChange', {
         role: peopleRoleViewerFile,

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/ListItem.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/ListItem.spec.ts
@@ -62,6 +62,14 @@ describe('Collaborator ListItem component', () => {
         expect(wrapper.find(selectors.notUserAvatar).exists()).toBeTruthy()
         expect(wrapper.find(selectors.notUserAvatar).attributes().name).toEqual(shareType.key)
       })
+      it('should display an oc-avatar-item for space group shares', () => {
+        const { wrapper } = createWrapper({
+          shareType: ShareTypes.space.value,
+          collaborator: { name: undefined, displayName: 'someGroup', additionalInfo: undefined }
+        })
+        expect(wrapper.find(selectors.userAvatarImage).exists()).toBeFalsy()
+        expect(wrapper.find(selectors.notUserAvatar).exists()).toBeTruthy()
+      })
     })
   })
   describe('share info', () => {

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/SpaceMembers.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/SpaceMembers.spec.ts
@@ -21,7 +21,7 @@ import {
 const memberMocks = {
   [spaceRoleManager.name]: {
     id: '1',
-    shareType: ShareTypes.space.value,
+    shareType: ShareTypes.spaceUser.value,
     collaborator: {
       name: 'alice',
       displayName: 'alice'
@@ -32,7 +32,7 @@ const memberMocks = {
   },
   [spaceRoleEditor.name]: {
     id: '2',
-    shareType: ShareTypes.space.value,
+    shareType: ShareTypes.spaceUser.value,
     collaborator: {
       onPremisesSamAccountName: 'Einstein',
       displayName: 'einstein'
@@ -43,7 +43,7 @@ const memberMocks = {
   },
   [spaceRoleViewer.name]: {
     id: '3',
-    shareType: ShareTypes.space.value,
+    shareType: ShareTypes.spaceUser.value,
     collaborator: {
       onPremisesSamAccountName: 'Marie',
       displayName: 'marie'

--- a/packages/web-app-files/tests/unit/store/mutations.spec.ts
+++ b/packages/web-app-files/tests/unit/store/mutations.spec.ts
@@ -105,7 +105,7 @@ describe('vuex store mutations', () => {
     it('removes an outgoing space share', () => {
       const shareToRemove = {
         id: 1,
-        shareType: ShareTypes.space.value,
+        shareType: ShareTypes.spaceUser.value,
         collaborator: { name: 'admin' }
       }
       const state = { currentFileOutgoingShares: [shareToRemove] }
@@ -127,7 +127,7 @@ describe('vuex store mutations', () => {
     it('updates an outgoing space share', () => {
       const share = {
         id: 1,
-        shareType: ShareTypes.space.value,
+        shareType: ShareTypes.spaceUser.value,
         permissions: 1,
         collaborator: { name: 'admin' }
       }

--- a/packages/web-client/src/helpers/share/space.ts
+++ b/packages/web-client/src/helpers/share/space.ts
@@ -20,8 +20,26 @@ export function buildSpaceShare(s, storageId): Share {
       break
   }
 
+  let shareType
+  if (Object.prototype.hasOwnProperty.call(s, 'share_type')) {
+    shareType = parseInt(s.share_type)
+  } else if (Object.prototype.hasOwnProperty.call(s, 'kind')) {
+    switch (s.kind) {
+      case 'user': {
+        shareType = ShareTypes.spaceUser.value
+        break
+      }
+      case 'group': {
+        shareType = ShareTypes.spaceGroup.value
+        break
+      }
+      default:
+        break
+    }
+  }
+
   return {
-    shareType: ShareTypes.space.value,
+    shareType,
     id: storageId,
     collaborator: {
       name: s.onPremisesSamAccountName,

--- a/packages/web-client/src/helpers/share/type.ts
+++ b/packages/web-client/src/helpers/share/type.ts
@@ -41,13 +41,29 @@ export abstract class ShareTypes {
   static readonly link = new ShareType('link', 3, $gettext('Link'), 'link')
   static readonly guest = new ShareType('guest', 4, $gettext('Guest'), 'global')
   static readonly remote = new ShareType('remote', 6, $gettext('Federated'), 'earth')
-  static readonly space = new ShareType('space', 7, $gettext('User'), 'user')
+  static readonly spaceUser = new ShareType('spaceUser', 7, $gettext('User'), 'user')
+  static readonly spaceGroup = new ShareType('spaceGroup', 8, $gettext('Group'), 'group')
 
-  static readonly individuals = [this.user, this.guest, this.remote, this.space]
-  static readonly collectives = [this.group]
+  static readonly individuals = [this.user, this.guest, this.remote, this.spaceUser]
+  static readonly collectives = [this.group, this.spaceGroup]
   static readonly unauthenticated = [this.link]
-  static readonly authenticated = [this.user, this.group, this.guest, this.remote, this.space]
-  static readonly all = [this.user, this.group, this.link, this.guest, this.remote, this.space]
+  static readonly authenticated = [
+    this.user,
+    this.group,
+    this.guest,
+    this.remote,
+    this.spaceUser,
+    this.spaceGroup
+  ]
+  static readonly all = [
+    this.user,
+    this.group,
+    this.link,
+    this.guest,
+    this.remote,
+    this.spaceUser,
+    this.spaceGroup
+  ]
 
   static isIndividual(type: ShareType): boolean {
     return this.individuals.includes(type)

--- a/packages/web-pkg/tests/unit/components/sidebar/Spaces/Details/SpaceDetails.spec.ts
+++ b/packages/web-pkg/tests/unit/components/sidebar/Spaces/Details/SpaceDetails.spec.ts
@@ -25,7 +25,7 @@ const spaceMock = {
 
 const spaceShare = {
   id: '1',
-  shareType: ShareTypes.space.value,
+  shareType: ShareTypes.spaceUser.value,
   collaborator: {
     onPremisesSamAccountName: 'Alice',
     displayName: 'alice'

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -25,7 +25,7 @@
     "luxon": "^2.4.0",
     "marked": "^4.0.12",
     "oidc-client-ts": "^2.1.0",
-    "owncloud-sdk": "~3.1.0-alpha.2",
+    "owncloud-sdk": "~3.1.0-alpha.3",
     "p-queue": "^6.6.2",
     "popper-max-size-modifier": "^0.2.0",
     "portal-vue": "3.0.0",

--- a/packages/web-runtime/src/store/spaces.ts
+++ b/packages/web-runtime/src/store/spaces.ts
@@ -161,7 +161,9 @@ const actions = {
         }
 
         prom.then((resolved) => {
-          spaceShares.push(buildSpaceShare({ ...resolved.data, role, expirationDate }, space.id))
+          spaceShares.push(
+            buildSpaceShare({ ...resolved.data, role, kind, expirationDate }, space.id)
+          )
         })
 
         promises.push(prom)
@@ -182,10 +184,11 @@ const actions = {
       role,
       storageId,
       displayName,
+      shareType,
       expirationDate
     }
   ) {
-    await client.shares.shareSpaceWithUser(path, shareWith, storageId, {
+    await client.shares.shareSpace(path, shareWith, shareType, storageId, {
       permissions,
       role: role.name,
       expirationDate
@@ -196,7 +199,8 @@ const actions = {
       role: role.name,
       onPremisesSamAccountName: shareWith,
       displayName,
-      expirationDate
+      expirationDate,
+      share_type: shareType
     }
     context.commit('UPSERT_SPACE_MEMBERS', buildSpaceShare(shareObj, storageId))
   },
@@ -204,9 +208,10 @@ const actions = {
     context,
     { client, graphClient, share, permissions, expirationDate, role }
   ) {
-    await client.shares.shareSpaceWithUser(
+    await client.shares.shareSpace(
       '',
       share.collaborator.name || share.collaborator.displayName,
+      share.shareType,
       share.id,
       {
         permissions,
@@ -222,7 +227,8 @@ const actions = {
         role: role.name,
         onPremisesSamAccountName: share.collaborator.name,
         displayName: share.collaborator.displayName,
-        expirationDate
+        expirationDate,
+        share_type: share.shareType
       },
       share.id
     )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -627,7 +627,7 @@ importers:
       luxon: ^2.4.0
       marked: ^4.0.12
       oidc-client-ts: ^2.1.0
-      owncloud-sdk: ~3.1.0-alpha.2
+      owncloud-sdk: ~3.1.0-alpha.3
       p-queue: ^6.6.2
       popper-max-size-modifier: ^0.2.0
       portal-vue: 3.0.0
@@ -674,7 +674,7 @@ importers:
       luxon: 2.4.0
       marked: 4.0.12
       oidc-client-ts: 2.1.0
-      owncloud-sdk: 3.1.0-alpha.2_qgpf6seimtkgc6dfu7oqfstxh4
+      owncloud-sdk: 3.1.0-alpha.3_qgpf6seimtkgc6dfu7oqfstxh4
       p-queue: 6.6.2
       popper-max-size-modifier: 0.2.0_@popperjs+core@2.11.5
       portal-vue: 3.0.0_vue@3.2.45
@@ -8178,7 +8178,7 @@ packages:
       minipass-pipeline: 1.2.4
       mkdirp: 1.0.4
       p-map: 4.0.0
-      promise-inflight: 1.0.1_bluebird@3.7.2
+      promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 8.0.1
       tar: 6.1.13
@@ -17271,8 +17271,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /owncloud-sdk/3.1.0-alpha.2_qgpf6seimtkgc6dfu7oqfstxh4:
-    resolution: {integrity: sha512-G3hHbGx9hD1XXuQpBqClgBkLCe3G6FyN7DuaU1e1K55CoB2bp4+8gPTDxT4cP1BOEx0BIEvwAkeyWfJ4OhyYvw==}
+  /owncloud-sdk/3.1.0-alpha.3_qgpf6seimtkgc6dfu7oqfstxh4:
+    resolution: {integrity: sha512-jouNHVHUJBuYs7A1ZPUNl+uSUulSYwTFzOjW4NhONl9xbDthKDeB+vWycUY9IdFRKroF8l1qo4xkXVO9mn7U/A==}
     peerDependencies:
       axios: ^0.27.2
       cross-fetch: ^3.0.6
@@ -18419,6 +18419,15 @@ packages:
   /progress/2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
+    dev: true
+
+  /promise-inflight/1.0.1:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
     dev: true
 
   /promise-inflight/1.0.1_bluebird@3.7.2:


### PR DESCRIPTION
## Description
The solution is not super straight-forwarded currently, unfortunately... We need to check for the presence of `collaborator.name` as space group shares don't have that property. We can't check for the share type because all user- and group-shares for spaces have the exact same share type.

Edit: we've introduced a `shareType 8` for groups as space members. With that it's pretty much straightforward now.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8243

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Open tasks
- [x] update sdk after https://github.com/owncloud/owncloud-sdk/pull/1207 has been merged and released