### PR TITLE
[full-ci] Vue 3: Remove `vuex-router-sync`

### DIFF
--- a/changelog/unreleased/change-update-vue
+++ b/changelog/unreleased/change-update-vue
@@ -15,3 +15,4 @@ https://github.com/owncloud/web/pull/8198
 https://github.com/owncloud/web/pull/8213
 https://github.com/owncloud/web/pull/8214
 https://github.com/owncloud/web/pull/8221
+https://github.com/owncloud/web/pull/8256

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -46,7 +46,6 @@
     "vue-router": "4.1.6",
     "vue-select": "4.0.0-beta.6",
     "vuex": "4.1.0",
-    "vuex-router-sync": "^5.0.0",
     "web-client": "npm:@ownclouders/web-client",
     "web-pkg": "npm:@ownclouders/web-pkg",
     "web-runtime": "workspace:*",

--- a/packages/web-runtime/src/App.vue
+++ b/packages/web-runtime/src/App.vue
@@ -71,7 +71,7 @@ export default defineComponent({
     }
   },
   computed: {
-    ...mapState(['route', 'user', 'modal', 'sidebar']),
+    ...mapState(['user', 'modal', 'sidebar']),
     ...mapGetters(['configuration', 'capabilities', 'getSettingsValue']),
     ...mapGetters('runtime/auth', ['isUserContextReady', 'isPublicLinkContextReady']),
     layout() {

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -6,7 +6,6 @@ import { Router } from 'vue-router'
 import Vue from 'vue'
 import { loadTheme } from '../helpers/theme'
 import OwnCloud from 'owncloud-sdk'
-import { sync as routerSync } from 'vuex-router-sync'
 import getTextPlugin from 'vue-gettext'
 import set from 'lodash-es/set'
 import { getBackendVersion, getWebVersion } from './versions'
@@ -360,8 +359,6 @@ export const announceDefaults = ({
       redirect: () => route
     })
   }
-
-  routerSync(store, router)
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -659,7 +659,6 @@ importers:
       vue-router: 4.1.6
       vue-select: 4.0.0-beta.6
       vuex: 4.1.0
-      vuex-router-sync: ^5.0.0
       web-client: npm:@ownclouders/web-client
       web-pkg: npm:@ownclouders/web-pkg
       web-runtime: workspace:*
@@ -708,7 +707,6 @@ importers:
       vue-router: 4.1.6_vue@3.2.45
       vue-select: 4.0.0-beta.6_vue@3.2.45
       vuex: 4.1.0_vue@3.2.45
-      vuex-router-sync: 5.0.0_mhkwdqbz43jpnlolybzfmh5sqi
       web-client: link:../web-client
       web-pkg: link:../web-pkg
       web-runtime: 'link:'
@@ -22493,16 +22491,6 @@ packages:
       '@vue/runtime-dom': 3.2.45
       '@vue/server-renderer': 3.2.45_vue@3.2.45
       '@vue/shared': 3.2.45
-
-  /vuex-router-sync/5.0.0_mhkwdqbz43jpnlolybzfmh5sqi:
-    resolution: {integrity: sha512-Mry2sO4kiAG64714X1CFpTA/shUH1DmkZ26DFDtwoM/yyx6OtMrc+MxrU+7vvbNLO9LSpgwkiJ8W+rlmRtsM+w==}
-    peerDependencies:
-      vue-router: ^3.0.0
-      vuex: ^3.0.0
-    dependencies:
-      vue-router: 4.1.6_vue@3.2.45
-      vuex: 4.1.0_vue@3.2.45
-    dev: false
 
   /vuex/4.1.0_vue@3.2.45:
     resolution: {integrity: sha512-hmV6UerDrPcgbSy9ORAtNXDr9M4wlNP4pEFKye4ujJF8oqgFFuxDCdOLS3eNoRTtq5O3hoBDh9Doj1bQMYHRbQ==}


### PR DESCRIPTION
## Description
Remove `vuex-router-sync` because 1. it does not support `vue-router` v4 (https://github.com/vuejs/vue-hackernews-2.0/commit/758961e73ac4089890079d4ce14996741cf9344b#r50475667) and 2. we don't use it anyways (?)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
