### PR TITLE
Vue 3: Use Teleport for the drag ghost item

### DIFF
--- a/changelog/unreleased/change-update-vue
+++ b/changelog/unreleased/change-update-vue
@@ -16,3 +16,4 @@ https://github.com/owncloud/web/pull/8213
 https://github.com/owncloud/web/pull/8214
 https://github.com/owncloud/web/pull/8221
 https://github.com/owncloud/web/pull/8256
+https://github.com/owncloud/web/pull/8258

--- a/packages/design-system/src/components/OcAvatar/OcAvatar.vue
+++ b/packages/design-system/src/components/OcAvatar/OcAvatar.vue
@@ -120,11 +120,6 @@ export default defineComponent({
       return ''
     }
   },
-  mounted() {
-    if (!this.isImage) {
-      this.$emit('avatar-initials', this.userName, this.userInitial)
-    }
-  },
   methods: {
     onImgError() {
       this.imgError = true

--- a/packages/design-system/src/components/OcList/OcList.vue
+++ b/packages/design-system/src/components/OcList/OcList.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul :ref="ref" class="oc-list oc-my-rm oc-mx-rm" :class="{ 'oc-list-raw': raw }">
+  <ul class="oc-list oc-my-rm oc-mx-rm" :class="{ 'oc-list-raw': raw }">
     <slot />
   </ul>
 </template>

--- a/packages/design-system/src/components/OcTable/OcTable.vue
+++ b/packages/design-system/src/components/OcTable/OcTable.vue
@@ -78,13 +78,13 @@
         </td>
       </tr>
     </tfoot>
+    <Teleport v-if="dragItem" to="body">
+      <oc-ghost-element
+        ref="ghostElement"
+        :preview-items="[dragItem, ...dragSelection]"
+      ></oc-ghost-element>
+    </Teleport>
   </table>
-  <Teleport v-if="dragItem" to="body">
-    <oc-ghost-element
-      ref="ghostElement"
-      :preview-items="[dragItem, ...dragSelection]"
-    ></oc-ghost-element>
-  </Teleport>
 </template>
 <script lang="ts">
 import OcThead from '../_OcTableHeader/_OcTableHeader.vue'

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -46,6 +46,7 @@ module.exports = {
       extends: ['plugin:vue/recommended', 'plugin:prettier-vue/recommended'],
       rules: {
         'vue/multi-word-component-names': 'warn',
+        'vue/no-multiple-template-root': 'off',
         'vue/no-v-text-v-html-on-component': 'warn'
       }
     },

--- a/packages/web-app-admin-settings/tests/unit/components/Spaces/__snapshots__/SpacesList.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/components/Spaces/__snapshots__/SpacesList.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`SpacesList should render all spaces in a table 1`] = `
     </div>
     <!--v-if-->
   </div>
-  <table class="oc-table oc-table-hover oc-table-sticky spaces-table">
+  <table class="oc-table oc-table-hover oc-table-sticky">
     <thead class="oc-thead">
       <tr class="oc-table-header-row" tabindex="-1">
         <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-select oc-pl-s" style="top: 0px;">
@@ -154,5 +154,6 @@ exports[`SpacesList should render all spaces in a table 1`] = `
       </tr>
     </tfoot>
   </table>
+  <!--v-if-->
 </div>
 `;

--- a/packages/web-app-admin-settings/tests/unit/components/Spaces/__snapshots__/SpacesList.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/components/Spaces/__snapshots__/SpacesList.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`SpacesList should render all spaces in a table 1`] = `
     </div>
     <!--v-if-->
   </div>
-  <table class="oc-table oc-table-hover oc-table-sticky">
+  <table class="oc-table oc-table-hover oc-table-sticky spaces-table">
     <thead class="oc-thead">
       <tr class="oc-table-header-row" tabindex="-1">
         <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-select oc-pl-s" style="top: 0px;">
@@ -153,7 +153,7 @@ exports[`SpacesList should render all spaces in a table 1`] = `
         </td>
       </tr>
     </tfoot>
+    <!--v-if-->
   </table>
-  <!--v-if-->
 </div>
 `;


### PR DESCRIPTION
## Description
This is needed in preparation for Vue 3 because `Vue.extend()` is not supported anymore.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/web/issues/7948

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

