### PR TITLE
[tests-only][full-ci]Extended download folders for kinder garden feature

### DIFF
--- a/tests/e2e/cucumber/features/journeys/kindergarten.oc10.feature
+++ b/tests/e2e/cucumber/features/journeys/kindergarten.oc10.feature
@@ -48,8 +48,8 @@ Feature: Kindergarten can use web to organize a day
       | meal plan |
     And "Brian" navigates to the personal space page
     And "Brian" downloads the following resources using the sidebar panel
-      | resource | from             |
-      | data.zip | Shares/meal plan |
+      | resource | from             | type |
+      | data.zip | Shares/meal plan | file |
     # Then what do we check for to be confident that the above things done by Brian have worked?
     # Then the downloaded zip should contain... ?
     When "Carol" logs in
@@ -60,31 +60,40 @@ Feature: Kindergarten can use web to organize a day
       | meal plan |
     And "Carol" navigates to the personal space page
     And "Carol" downloads the following resources using the sidebar panel
-      | resource      | from             |
-      | data.zip      | Shares/meal plan |
-      | lorem.txt     | Shares/meal plan |
-      | lorem-big.txt | Shares/meal plan |
+      | resource      | from             | type   |
+      | data.zip      | Shares/meal plan | file   |
+      | lorem.txt     | Shares/meal plan | file   |
+      | lorem-big.txt | Shares/meal plan | file   |
+      | meal plan     | Shares           | folder |
     # Then what do we check for to be confident that the above things done by Carol have worked?
     # Then the downloaded files should have content "abc..."
     And "Carol" logs out
     When "Brian" downloads the following resources using the sidebar panel
-      | resource      | from             |
-      | lorem.txt     | Shares/meal plan |
-      | lorem-big.txt | Shares/meal plan |
+      | resource      | from             | type   |
+      | lorem.txt     | Shares/meal plan | file   |
+      | lorem-big.txt | Shares/meal plan | file   |
+      | meal plan     | Shares           | folder |
     # Then what do we check for to be confident that the above things done by Brian have worked?
     # Then the downloaded files should have content "abc..."
     And "Brian" logs out
     And "Alice" downloads the following resources using the sidebar panel
-      | resource      | from                                 |
-      | parent.txt    | groups/Kindergarten Koalas/meal plan |
-      | lorem.txt     | groups/Kindergarten Koalas/meal plan |
-      | lorem-big.txt | groups/Kindergarten Koalas/meal plan |
-      | data.zip      | groups/Pre-Schools Pirates/meal plan |
-      | lorem.txt     | groups/Pre-Schools Pirates/meal plan |
-      | lorem-big.txt | groups/Pre-Schools Pirates/meal plan |
-      | data.zip      | groups/Teddy Bear Daycare/meal plan  |
-      | lorem.txt     | groups/Teddy Bear Daycare/meal plan  |
-      | lorem-big.txt | groups/Teddy Bear Daycare/meal plan  |
+      | resource            | from                                 | type   |
+      | parent.txt          | groups/Kindergarten Koalas/meal plan | file   |
+      | lorem.txt           | groups/Kindergarten Koalas/meal plan | file   |
+      | lorem-big.txt       | groups/Kindergarten Koalas/meal plan | file   |
+      | data.zip            | groups/Pre-Schools Pirates/meal plan | file   |
+      | lorem.txt           | groups/Pre-Schools Pirates/meal plan | file   |
+      | lorem-big.txt       | groups/Pre-Schools Pirates/meal plan | file   |
+      | data.zip            | groups/Teddy Bear Daycare/meal plan  | file   |
+      | lorem.txt           | groups/Teddy Bear Daycare/meal plan  | file   |
+      | lorem-big.txt       | groups/Teddy Bear Daycare/meal plan  | file   |
+      | meal plan           | groups/Kindergarten Koalas           | folder |
+      | meal plan           | groups/Pre-Schools Pirates           | folder |
+      | meal plan           | groups/Teddy Bear Daycare            | folder |
+      | Kindergarten Koalas | groups                               | folder |
+      | Pre-Schools Pirates | groups                               | folder |
+      | Teddy Bear Daycare  | groups                               | folder |
+      | groups              |                                      | folder |
     # Then what do we check for to be confident that the above things done by Alice have worked?
     # Then the downloaded files should have content "abc..."
     And "Alice" logs out

--- a/tests/e2e/cucumber/features/journeys/kindergarten.ocis.feature
+++ b/tests/e2e/cucumber/features/journeys/kindergarten.ocis.feature
@@ -46,8 +46,8 @@ Feature: Kindergarten can use web to organize a day
       | name      |
       | meal plan |
     And "Brian" downloads the following resources using the sidebar panel
-      | resource | from      |
-      | data.zip | meal plan |
+      | resource | from      | type |
+      | data.zip | meal plan | file |
     # Then what do we check for to be confident that the above things done by Brian have worked?
     # Then the downloaded zip should contain... ?
     When "Carol" logs in
@@ -57,31 +57,40 @@ Feature: Kindergarten can use web to organize a day
       | name      |
       | meal plan |
     And "Carol" downloads the following resources using the sidebar panel
-      | resource      | from      |
-      | data.zip      | meal plan |
-      | lorem.txt     | meal plan |
-      | lorem-big.txt | meal plan |
+      | resource      | from      | type   |
+      | data.zip      | meal plan | file   |
+      | lorem.txt     | meal plan | file   |
+      | lorem-big.txt | meal plan | file   |
+      | meal plan     |           | folder |
     # Then what do we check for to be confident that the above things done by Carol have worked?
     # Then the downloaded files should have content "abc..."
     And "Carol" logs out
     When "Brian" downloads the following resources using the sidebar panel
-      | resource      | from      |
-      | lorem.txt     | meal plan |
-      | lorem-big.txt | meal plan |
+      | resource      | from      | type   |
+      | lorem.txt     | meal plan | file   |
+      | lorem-big.txt | meal plan | file   |
+      | meal plan     |           | folder |
     # Then what do we check for to be confident that the above things done by Brian have worked?
     # Then the downloaded files should have content "abc..."
     And "Brian" logs out
     And "Alice" downloads the following resources using the sidebar panel
-      | resource      | from                                 |
-      | parent.txt    | groups/Kindergarten Koalas/meal plan |
-      | lorem.txt     | groups/Kindergarten Koalas/meal plan |
-      | lorem-big.txt | groups/Kindergarten Koalas/meal plan |
-      | data.zip      | groups/Pre-Schools Pirates/meal plan |
-      | lorem.txt     | groups/Pre-Schools Pirates/meal plan |
-      | lorem-big.txt | groups/Pre-Schools Pirates/meal plan |
-      | data.zip      | groups/Teddy Bear Daycare/meal plan  |
-      | lorem.txt     | groups/Teddy Bear Daycare/meal plan  |
-      | lorem-big.txt | groups/Teddy Bear Daycare/meal plan  |
+      | resource            | from                                 | type   |
+      | parent.txt          | groups/Kindergarten Koalas/meal plan | file   |
+      | lorem.txt           | groups/Kindergarten Koalas/meal plan | file   |
+      | lorem-big.txt       | groups/Kindergarten Koalas/meal plan | file   |
+      | data.zip            | groups/Pre-Schools Pirates/meal plan | file   |
+      | lorem.txt           | groups/Pre-Schools Pirates/meal plan | file   |
+      | lorem-big.txt       | groups/Pre-Schools Pirates/meal plan | file   |
+      | data.zip            | groups/Teddy Bear Daycare/meal plan  | file   |
+      | lorem.txt           | groups/Teddy Bear Daycare/meal plan  | file   |
+      | lorem-big.txt       | groups/Teddy Bear Daycare/meal plan  | file   |
+      | meal plan           | groups/Kindergarten Koalas           | folder |
+      | meal plan           | groups/Pre-Schools Pirates           | folder |
+      | meal plan           | groups/Teddy Bear Daycare            | folder |
+      | Kindergarten Koalas | groups                               | folder |
+      | Pre-Schools Pirates | groups                               | folder |
+      | Teddy Bear Daycare  | groups                               | folder |
+      | groups              |                                      | folder |
     # Then what do we check for to be confident that the above things done by Alice have worked?
     # Then the downloaded files should have content "abc..."
     And "Alice" logs out

--- a/tests/e2e/cucumber/features/smoke/link.feature
+++ b/tests/e2e/cucumber/features/smoke/link.feature
@@ -32,15 +32,15 @@ Feature: link
     #Then the public should not see the following files on the files-drop page
     #  | textfile.txt |
     When "Alice" downloads the following resources using the batch action
-      | resource     | from         |
-      | lorem.txt    | folderPublic |
-      | textfile.txt | folderPublic |
+      | resource     | from         | type |
+      | lorem.txt    | folderPublic | file |
+      | textfile.txt | folderPublic | file |
     And "Alice" edits the public link named "myPublicLink" of resource "folderPublic" changing role to "editor"
     And "Anonymous" refreshes the old link
     And "Anonymous" downloads the following public link resources using the sidebar panel
-      | resource     |
-      | lorem.txt    |
-      | textfile.txt |
+      | resource     | type |
+      | lorem.txt    | file |
+      | textfile.txt | file |
     And "Anonymous" uploads the following resources in public link page
       | resource      |
       | new-lorem.txt |

--- a/tests/e2e/cucumber/features/smoke/share.oc10.feature
+++ b/tests/e2e/cucumber/features/smoke/share.oc10.feature
@@ -56,8 +56,8 @@ Feature: share
       | PARENT/simple.pdf | folder_to_shared | replace |
     #Then "Alice" should see that the resource "folder_to_shared/simple.pdf" has 1 version
     And "Brian" downloads old version of the following resource
-      | resource   | to                      |
-      | simple.pdf | Shares/folder_to_shared |
+      | resource   | to                      | type |
+      | simple.pdf | Shares/folder_to_shared | file |
     When "Brian" restores following resources
       | resource   | to                      | version |
       | simple.pdf | Shares/folder_to_shared | 1       |
@@ -102,8 +102,8 @@ Feature: share
       | resource               | to       |
       | Shares/testavatar.jpeg | Personal |
     And "Brian" downloads the following resource using the sidebar panel
-      | resource        | from   |
-      | testavatar.jpeg | Shares |
+      | resource        | from   | type |
+      | testavatar.jpeg | Shares | file |
     And "Alice" updates following sharee role
       | resource                         | recipient | role   | resourceType |
       | folder_to_shared/testavatar.jpeg | Brian     | editor | file         |

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -4,6 +4,7 @@ import { World } from '../../environment'
 import { objects } from '../../../support'
 import { expect } from '@playwright/test'
 import { config } from '../../../config'
+import {ocs} from "web-client/src/ocs";
 
 When(
   '{string} creates the following resource(s)',
@@ -263,15 +264,21 @@ export const processDownload = async (
   pageObject: any,
   actionType: string
 ) => {
-  let downloads, files, parentFolder
+  let downloads,
+    files,
+    parentFolder,
+    downloadedResources = []
   const downloadInfo = stepTable.hashes().reduce((acc, stepRow) => {
-    const { resource, from } = stepRow
-
+    const { resource, from, type } = stepRow
+    const resourceInfo = {
+      name: resource,
+      type: type
+    }
     if (!acc[from]) {
       acc[from] = []
     }
 
-    acc[from].push(resource)
+    acc[from].push(resourceInfo)
 
     return acc
   }, {})
@@ -281,37 +288,41 @@ export const processDownload = async (
     parentFolder = folder !== 'undefined' ? folder : null
     downloads = await pageObject.download({
       folder: parentFolder,
-      names: files,
+      resources: files,
       via: actionType === 'batch action' ? 'BATCH_ACTION' : 'SIDEBAR_PANEL'
     })
+
+    downloads.forEach((download) => {
+      downloadedResources.push(download.suggestedFilename())
+    })
+
     if (actionType === 'sidebar panel') {
       expect(files.length).toBe(downloads.length)
-      downloads.forEach((download) => {
-        expect(files).toContain(download.suggestedFilename())
-      })
+      for (const resource of files) {
+        if (resource.type === 'file') {
+          expect(downloadedResources).toContain(resource.name)
+        } else {
+           // downloading folders in oc10 downloads with name of resource but in ocis it is downloaded as 'download.tar'
+            (config.ocis) ? expect(downloadedResources).toContain('download.tar') : expect(downloadedResources).toContain(`${resource.name}.zip`)
+        }
+      }
     }
   }
+
   if (actionType === 'batch action') {
-    if (files.length === 1) {
-      expect(files.length).toBe(downloads.length)
-      downloads.forEach((download) => {
-        expect(files[0]).toBe(download.suggestedFilename())
-      })
-    } else {
-      expect(downloads.length).toBe(1)
-      downloads.forEach((download) => {
-        const { name } = path.parse(download.suggestedFilename())
-        if (config.ocis) {
-          expect(name).toBe('download')
+    expect(downloads.length).toBe(1)
+    downloads.forEach((download) => {
+      const { name } = path.parse(download.suggestedFilename())
+      if (config.ocis) {
+        expect(name).toBe('download')
+      } else {
+        if (parentFolder) {
+          expect(name).toBe(parentFolder)
         } else {
-          if (parentFolder) {
-            expect(name).toBe(parentFolder)
-          } else {
-            expect(name).toBe('download')
-          }
+          expect(name).toBe('download')
         }
-      })
-    }
+      }
+    })
   }
 }
 

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -292,19 +292,21 @@ export const processDownload = async (
     })
 
     downloads.forEach((download) => {
-      downloadedResources.push(download.suggestedFilename())
+      const { name } = path.parse(download.suggestedFilename())
+      downloadedResources.push(name)
     })
 
     if (actionType === 'sidebar panel') {
       expect(files.length).toBe(downloads.length)
       for (const resource of files) {
+        const fileOrFolderName = path.parse(resource.name).name
         if (resource.type === 'file') {
-          expect(downloadedResources).toContain(resource.name)
+          expect(downloadedResources).toContain(fileOrFolderName)
         } else {
           // downloading folders in oc10 downloads with name of resource but in ocis it is downloaded as 'download.tar'
           config.ocis
-            ? expect(downloadedResources).toContain('download.tar')
-            : expect(downloadedResources).toContain(`${resource.name}.zip`)
+            ? expect(downloadedResources).toContain('download')
+            : expect(downloadedResources).toContain(fileOrFolderName)
         }
       }
     }

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -4,7 +4,6 @@ import { World } from '../../environment'
 import { objects } from '../../../support'
 import { expect } from '@playwright/test'
 import { config } from '../../../config'
-import {ocs} from "web-client/src/ocs";
 
 When(
   '{string} creates the following resource(s)',
@@ -302,8 +301,10 @@ export const processDownload = async (
         if (resource.type === 'file') {
           expect(downloadedResources).toContain(resource.name)
         } else {
-           // downloading folders in oc10 downloads with name of resource but in ocis it is downloaded as 'download.tar'
-            (config.ocis) ? expect(downloadedResources).toContain('download.tar') : expect(downloadedResources).toContain(`${resource.name}.zip`)
+          // downloading folders in oc10 downloads with name of resource but in ocis it is downloaded as 'download.tar'
+          config.ocis
+            ? expect(downloadedResources).toContain('download.tar')
+            : expect(downloadedResources).toContain(`${resource.name}.zip`)
         }
       }
     }

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -244,9 +244,14 @@ export const uploadResource = async (args: uploadResourceArgs): Promise<void> =>
 
 /**/
 
+interface resourceArgs {
+  name: string
+  type: string
+}
+
 export interface downloadResourcesArgs {
   page: Page
-  resources: [Object: any]
+  resources: resourceArgs[]
   folder?: string
   via: 'SIDEBAR_PANEL' | 'BATCH_ACTION'
 }
@@ -296,7 +301,7 @@ export const downloadResources = async (args: downloadResourcesArgs): Promise<Do
 
 export type selectResourcesArgs = {
   page: Page
-  resources: [Object: any]
+  resources: resourceArgs[]
   folder?: string
   select: boolean
 }

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -6,9 +6,11 @@ import path from 'path'
 import { File } from '../../../types'
 import { sidebar } from '../utils'
 
-const downloadButtonSideBar = '#oc-files-actions-sidebar .oc-files-actions-download-file-trigger'
-const downloadButtonBatchActionSingleFile = '.oc-files-actions-download-file-trigger'
-const downloadButtonBatchActionMultiple = '.oc-files-actions-download-archive-trigger'
+const downloadFileButtonSideBar =
+  '#oc-files-actions-sidebar .oc-files-actions-download-file-trigger'
+const downloadFolderButtonSidedBar =
+  '#oc-files-actions-sidebar .oc-files-actions-download-archive-trigger'
+const downloadButtonBatchAction = '.oc-files-actions-download-archive-trigger'
 const checkBox = `//*[@data-test-resource-name="%s"]//ancestor::tr//input`
 const checkBoxForTrashbin = `//*[@data-test-resource-path="%s"]//ancestor::tr//input`
 export const fileRow = '//ancestor::tr'
@@ -244,13 +246,13 @@ export const uploadResource = async (args: uploadResourceArgs): Promise<void> =>
 
 export interface downloadResourcesArgs {
   page: Page
-  names: string[]
+  resources: [Object: any]
   folder?: string
   via: 'SIDEBAR_PANEL' | 'BATCH_ACTION'
 }
 
 export const downloadResources = async (args: downloadResourcesArgs): Promise<Download[]> => {
-  const { page, names, folder, via } = args
+  const { page, resources, folder, via } = args
   const downloads = []
 
   switch (via) {
@@ -258,13 +260,14 @@ export const downloadResources = async (args: downloadResourcesArgs): Promise<Do
       if (folder) {
         await clickResource({ page, path: folder })
       }
-      for (const name of names) {
-        await sidebar.open({ page, resource: name })
+      for (const resource of resources) {
+        await sidebar.open({ page, resource: resource.name })
         await sidebar.openPanel({ page, name: 'actions' })
-
+        const downloadResourceSelector =
+          resource.type === 'file' ? downloadFileButtonSideBar : downloadFolderButtonSidedBar
         const [download] = await Promise.all([
           page.waitForEvent('download'),
-          page.locator(downloadButtonSideBar).click()
+          page.locator(downloadResourceSelector).click()
         ])
 
         await sidebar.close({ page })
@@ -275,14 +278,13 @@ export const downloadResources = async (args: downloadResourcesArgs): Promise<Do
     }
 
     case 'BATCH_ACTION': {
-      await selectOrDeselectResources({ page, names, folder, select: true })
-      let downloadSelector = downloadButtonBatchActionMultiple
-      if (names.length === 1) {
-        downloadSelector = downloadButtonBatchActionSingleFile
+      await selectOrDeselectResources({ page, resources, folder, select: true })
+      if (resources.length === 1) {
+        throw new Error('Single resource cannot be downloaded with batch action')
       }
       const [download] = await Promise.all([
         page.waitForEvent('download'),
-        page.locator(downloadSelector).click()
+        page.locator(downloadButtonBatchAction).click()
       ])
       downloads.push(download)
       break
@@ -294,24 +296,24 @@ export const downloadResources = async (args: downloadResourcesArgs): Promise<Do
 
 export type selectResourcesArgs = {
   page: Page
-  names: string[]
+  resources: [Object: any]
   folder?: string
   select: boolean
 }
 
 export const selectOrDeselectResources = async (args: selectResourcesArgs): Promise<void> => {
-  const { page, folder, names, select } = args
+  const { page, folder, resources, select } = args
   if (folder) {
     await clickResource({ page, path: folder })
   }
 
-  for (const resource of names) {
+  for (const resource of resources) {
     const exists = await resourceExists({
       page,
-      name: resource
+      name: resource.name
     })
     if (exists) {
-      const resourceCheckbox = page.locator(util.format(checkBox, resource))
+      const resourceCheckbox = page.locator(util.format(checkBox, resource.name))
 
       if (!(await resourceCheckbox.isChecked()) && select) {
         await resourceCheckbox.check()
@@ -319,7 +321,7 @@ export const selectOrDeselectResources = async (args: selectResourcesArgs): Prom
         await resourceCheckbox.uncheck()
       }
     } else {
-      throw new Error(`The resource ${resource} you are trying to select does not exist`)
+      throw new Error(`The resource ${resource.name} you are trying to select does not exist`)
     }
   }
 }


### PR DESCRIPTION
### Description
This PR refactors the download function to be able to download folders as well since previously the download function only downloads the files. This is done in order to extend the download folder feature to `kindergarten.feature`for `oCIS` and `oc10`.

### Related Issue
 https://github.com/owncloud/web/issues/8101