### PR TITLE
Fix sidebar data loading for users

### DIFF
--- a/changelog/unreleased/bugfix-loading-additional-user-data
+++ b/changelog/unreleased/bugfix-loading-additional-user-data
@@ -3,3 +3,4 @@ Bugfix: Loading additional user data
 Loading additional user data in the admin settings when opening the sidebar via select-toggle has been fixed.
 
 https://github.com/owncloud/web/pull/8276
+https://github.com/owncloud/web/issues/8275

--- a/changelog/unreleased/bugfix-loading-additional-user-data
+++ b/changelog/unreleased/bugfix-loading-additional-user-data
@@ -1,0 +1,5 @@
+Bugfix: Loading additional user data
+
+Loading additional user data in the admin settings when opening the sidebar via select-toggle has been fixed.
+
+https://github.com/owncloud/web/pull/8276

--- a/packages/web-app-admin-settings/src/components/AppTemplate.vue
+++ b/packages/web-app-admin-settings/src/components/AppTemplate.vue
@@ -27,7 +27,7 @@
         v-if="sideBarOpen"
         :active-panel="sideBarActivePanel"
         :available-panels="sideBarAvailablePanels"
-        :loading="false"
+        :loading="sideBarLoading"
         :open="sideBarOpen"
         :is-header-compact="isSideBarHeaderCompact"
         @selectPanel="selectPanel"
@@ -73,6 +73,11 @@ export default defineComponent({
     sideBarActivePanel: {
       required: true,
       type: String
+    },
+    sideBarLoading: {
+      required: false,
+      type: Boolean,
+      default: false
     },
     isSideBarHeaderCompact: {
       required: false,

--- a/packages/web-app-admin-settings/src/components/Groups/GroupsList.vue
+++ b/packages/web-app-admin-settings/src/components/Groups/GroupsList.vue
@@ -50,7 +50,7 @@
           v-oc-tooltip="$gettext('Details')"
           appearance="raw"
           class="oc-mr-xs quick-action-button oc-p-xs"
-          @click="$emit('showPanel', { group: item, panel: 'DetailsPanel' })"
+          @click="showDetails(item)"
         >
           <oc-icon name="information" fill-type="line" />
         </oc-button>
@@ -74,6 +74,8 @@
 import { defineComponent } from 'vue'
 import Fuse from 'fuse.js'
 import Mark from 'mark.js'
+import { eventBus } from 'web-pkg'
+import { SideBarEventTopics } from 'web-pkg/src/composables/sideBar'
 
 export default defineComponent({
   name: 'GroupsList',
@@ -90,6 +92,15 @@ export default defineComponent({
       type: Number,
       required: true
     }
+  },
+  setup(props, { emit }) {
+    const showDetails = (group) => {
+      emit('unSelectAllGroups')
+      emit('toggleSelectGroup', group)
+      eventBus.publish(SideBarEventTopics.open)
+    }
+
+    return { showDetails }
   },
   data() {
     return {

--- a/packages/web-app-admin-settings/src/components/Users/SideBar/DetailsPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Users/SideBar/DetailsPanel.vue
@@ -47,15 +47,16 @@ export default defineComponent({
     UserInfoBox
   },
   props: {
+    user: {
+      type: Object,
+      required: true
+    },
     users: {
       type: Array,
       required: true
     }
   },
   computed: {
-    user() {
-      return this.users.length === 1 ? this.users[0] : null
-    },
     noUsers() {
       return !this.users.length
     },

--- a/packages/web-app-admin-settings/src/components/Users/UsersList.vue
+++ b/packages/web-app-admin-settings/src/components/Users/UsersList.vue
@@ -51,21 +51,21 @@
           v-oc-tooltip="$gettext('Details')"
           appearance="raw"
           class="oc-mr-xs quick-action-button oc-p-xs"
-          @click="$emit('showPanel', { user: item, panel: 'DetailsPanel' })"
+          @click="showDetails(item)"
         >
           <oc-icon name="information" fill-type="line" /></oc-button
         ><oc-button
           v-oc-tooltip="$gettext('Group assignments')"
           appearance="raw"
           class="oc-mr-xs quick-action-button oc-p-xs"
-          @click="$emit('showPanel', { user: item, panel: 'GroupAssignmentsPanel' })"
+          @click="showGroupAssigmentPanel(item)"
         >
           <oc-icon name="group-2" fill-type="line" /></oc-button
         ><oc-button
           v-oc-tooltip="$gettext('Edit')"
           appearance="raw"
           class="oc-mr-xs quick-action-button oc-p-xs"
-          @click="$emit('showPanel', { user: item, panel: 'EditPanel' })"
+          @click="showEditPanel(item)"
         >
           <oc-icon name="pencil" fill-type="line" />
         </oc-button>
@@ -85,6 +85,8 @@ import { defineComponent } from 'vue'
 
 import Fuse from 'fuse.js'
 import Mark from 'mark.js'
+import { eventBus } from 'web-pkg'
+import { SideBarEventTopics } from 'web-pkg/src/composables/sideBar'
 
 export default defineComponent({
   name: 'UsersList',
@@ -101,6 +103,27 @@ export default defineComponent({
       type: Number,
       required: true
     }
+  },
+  setup(props, { emit }) {
+    const showDetails = (user) => {
+      emit('unSelectAllUsers')
+      emit('toggleSelectUser', user)
+      eventBus.publish(SideBarEventTopics.open)
+    }
+
+    const showEditPanel = (user) => {
+      emit('unSelectAllUsers')
+      emit('toggleSelectUser', user)
+      eventBus.publish(SideBarEventTopics.openWithPanel, 'EditPanel')
+    }
+
+    const showGroupAssigmentPanel = (user) => {
+      emit('unSelectAllUsers')
+      emit('toggleSelectUser', user)
+      eventBus.publish(SideBarEventTopics.openWithPanel, 'GroupAssignmentsPanel')
+    }
+
+    return { showDetails, showEditPanel, showGroupAssigmentPanel }
   },
   data() {
     return {

--- a/packages/web-app-admin-settings/src/views/Groups.vue
+++ b/packages/web-app-admin-settings/src/views/Groups.vue
@@ -53,7 +53,7 @@
             :header-position="listHeaderPosition"
             @toggleSelectGroup="toggleSelectGroup"
             @toggleSelectAllGroups="toggleSelectAllGroups"
-            @showPanel="showPanel"
+            @unSelectAllGroups="unselectAllGroups"
           />
         </div>
       </template>
@@ -212,11 +212,6 @@ export default defineComponent({
     },
     toggleDeleteGroupModal() {
       this.deleteGroupModalOpen = !this.deleteGroupModalOpen
-    },
-    showPanel({ group, panel }) {
-      this.selectedGroups = [group]
-      this.sideBarActivePanel = panel
-      this.sideBarOpen = true
     },
     async deleteGroups(groups) {
       const promises = groups.map((group) => this.graphClient.groups.deleteGroup(group.id))

--- a/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/DetailsPanel.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/DetailsPanel.spec.ts
@@ -4,18 +4,19 @@ import { defaultPlugins, shallowMount } from 'web-test-helpers'
 describe('DetailsPanel', () => {
   describe('computed method "user"', () => {
     it('should be set if only one user is given', () => {
-      const { wrapper } = getWrapper({ propsData: { users: [{ displayName: 'user' }] } })
+      const user = { displayName: 'user' }
+      const { wrapper } = getWrapper({ props: { user, users: [user] } })
       expect(wrapper.vm.user).toEqual({ displayName: 'user' })
     })
     it('should not be set if no users are given', () => {
       const { wrapper } = getWrapper({
-        propsData: { users: [] }
+        props: { user: null, users: [] }
       })
       expect(wrapper.vm.user).toEqual(null)
     })
     it('should not be set if multiple users are given', () => {
       const { wrapper } = getWrapper({
-        propsData: { users: [{ displayName: 'user1' }, { displayName: 'user2' }] }
+        props: { user: null, users: [{ displayName: 'user1' }, { displayName: 'user2' }] }
       })
       expect(wrapper.vm.user).toEqual(null)
     })
@@ -24,38 +25,40 @@ describe('DetailsPanel', () => {
   describe('computed method "noUsers"', () => {
     it('should be true if no users are given', () => {
       const { wrapper } = getWrapper({
-        propsData: { users: [] }
+        props: { user: null, users: [] }
       })
       expect(wrapper.vm.noUsers).toBeTruthy()
     })
     it('should be false if users are given', () => {
-      const { wrapper } = getWrapper({ propsData: { users: [{ displayName: 'user' }] } })
+      const user = { displayName: 'user' }
+      const { wrapper } = getWrapper({ props: { user, users: [user] } })
       expect(wrapper.vm.noUsers).toBeFalsy()
     })
   })
 
   describe('computed method "multipleUsers"', () => {
     it('should be false if no users are given', () => {
-      const { wrapper } = getWrapper({ propsData: { users: [] } })
+      const { wrapper } = getWrapper({ props: { user: null, users: [] } })
       expect(wrapper.vm.multipleUsers).toBeFalsy()
     })
     it('should be false if one user is given', () => {
-      const { wrapper } = getWrapper({ propsData: { users: [{ displayName: 'user' }] } })
+      const user = { displayName: 'user' }
+      const { wrapper } = getWrapper({ props: { user, users: [user] } })
       expect(wrapper.vm.multipleUsers).toBeFalsy()
     })
     it('should be true if multiple users are given', () => {
       const { wrapper } = getWrapper({
-        propsData: { users: [{ displayName: 'user1' }, { displayName: 'user2' }] }
+        props: { user: null, users: [{ displayName: 'user1' }, { displayName: 'user2' }] }
       })
       expect(wrapper.vm.multipleUsers).toBeTruthy()
     })
   })
 })
 
-function getWrapper({ propsData = {} } = {}) {
+function getWrapper({ props = {} } = {}) {
   return {
     wrapper: shallowMount(DetailsPanel, {
-      props: { ...propsData },
+      props: { ...props },
       global: {
         plugins: [...defaultPlugins()]
       }

--- a/packages/web-app-admin-settings/tests/unit/views/Users.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/views/Users.spec.ts
@@ -193,19 +193,22 @@ describe('Users view', () => {
 
   describe('computed method "sideBarAvailablePanels"', () => {
     it('should contain EditPanel when one user is selected', () => {
-      const { wrapper } = getMountedWrapper({ data: { selectedUsers: [{ id: '1' }] } })
+      const { wrapper } = getMountedWrapper()
+      wrapper.vm.selectedUsers = [{ id: '1' }]
       expect(
         wrapper.vm.sideBarAvailablePanels.find((panel) => panel.app === 'EditPanel').enabled
       ).toBeTruthy()
     })
     it('should contain DetailsPanel no user is selected', () => {
-      const { wrapper } = getMountedWrapper({ data: { selectedUsers: [] } })
+      const { wrapper } = getMountedWrapper()
+      wrapper.vm.selectedUsers = []
       expect(
         wrapper.vm.sideBarAvailablePanels.find((panel) => panel.app === 'DetailsPanel').enabled
       ).toBeTruthy()
     })
     it('should not contain EditPanel when multiple users are selected', () => {
-      const { wrapper } = getMountedWrapper({ data: { selectedUsers: [{ id: '1' }, { id: '2' }] } })
+      const { wrapper } = getMountedWrapper()
+      wrapper.vm.selectedUsers = [{ id: '1' }, { id: '2' }]
       expect(
         wrapper.vm.sideBarAvailablePanels.find((panel) => panel.app === 'EditPanel')
       ).toBeFalsy()
@@ -214,9 +217,8 @@ describe('Users view', () => {
 
   describe('computed method "allUsersSelected"', () => {
     it('should be true if every user is selected', async () => {
-      const { wrapper } = getMountedWrapper({
-        data: { selectedUsers: [{ id: '1' }] }
-      })
+      const { wrapper } = getMountedWrapper()
+      wrapper.vm.selectedUsers = [{ id: '1' }]
       await wrapper.vm.loadResourcesTask.last
       expect(wrapper.vm.allUsersSelected).toBeTruthy()
     })
@@ -225,17 +227,15 @@ describe('Users view', () => {
       graph.users.listUsers.mockImplementation(() =>
         mockAxiosResolve({ value: [{ id: '1' }, { id: '2' }] })
       )
-      const { wrapper } = getMountedWrapper({
-        graph,
-        data: { selectedUsers: [{ id: '1' }] }
-      })
+      const { wrapper } = getMountedWrapper({ graph })
+      wrapper.vm.selectedUsers = [{ id: '1' }]
       await wrapper.vm.loadResourcesTask.last
       expect(wrapper.vm.allUsersSelected).toBeFalsy()
     })
   })
 })
 
-function getMountedWrapper({ data = {}, graph = defaultGraphMock() } = {}) {
+function getMountedWrapper({ graph = defaultGraphMock() } = {}) {
   const mocks = {
     ...defaultComponentMocks()
   }
@@ -253,17 +253,6 @@ function getMountedWrapper({ data = {}, graph = defaultGraphMock() } = {}) {
   return {
     mocks,
     wrapper: shallowMount(Users, {
-      data: () => {
-        return {
-          selectedUsers: [
-            {
-              id: '1',
-              memberOf: []
-            }
-          ],
-          ...data
-        }
-      },
       global: {
         plugins: [...defaultPlugins(), store],
         mocks


### PR DESCRIPTION
## Description
This PR improves the loading of additional user data which is needed in the sidebar.

Before, this was handled by a custom `showPanel` event, that first loaded the additional data, then opened the sidebar. Problems here:

1. This event was only fired on action click, not on select (see https://github.com/owncloud/web/issues/8275).
2. We might have deeper component structures in the future. When some deep component (or a composable) wants to emit this event, we'd need to propagate the event all the way to the parent view component.
3. There is no loading-indicator for the user. This might be no issue here, but in general this is bad.

The new approach uses the `eventBus` which is coupled with the `useSidebar` composable. Opening/closing the sidebar and setting the active panels is all being handled by the composable. Furthermore, the additional data is being loaded when a user gets selected. This way, it works on select-toggle as well.

Also, the sidebar now uses the loading state properly to show a loading spinner during data loading.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8275

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
