### PR TITLE
Add support for multiple clients in `theme.json`

### DIFF
--- a/changelog/unreleased/enhancement-support-multiple-clients-in-theme-json
+++ b/changelog/unreleased/enhancement-support-multiple-clients-in-theme-json
@@ -1,0 +1,6 @@
+Enhancement: Add support for multiple clients in `theme.json`
+
+The `theme.json` file now supports multiple clients which are defined via the top-level property. Therefore both web themes have been moved down one level into the new property "web". The change is backwards compatible though, meaning it still works when the web themes are defined top-level in `theme.json`.
+
+https://github.com/owncloud/web/pull/8280
+https://github.com/owncloud/enterprise/issues/5502

--- a/docs/theming/_index.md
+++ b/docs/theming/_index.md
@@ -35,24 +35,26 @@ You can use the snippet below as a base for writing your own theme by replacing 
 
 ```json
 {
-  "default": {
-    "general": {
-      "name": "ownCloud",
-      "slogan": "ownCloud – A safe home for all your data"
+  "web": {
+    "default": {
+      "general": {
+        "name": "ownCloud",
+        "slogan": "ownCloud – A safe home for all your data"
+      },
+      "logo": {
+        "topbar": "https://externalurl.example.com/url/for/remote/theme/assets/logo.svg",
+        "favicon": "https://externalurl.example.com/url/for/remote/theme/assets/favicon.jpg",
+        "login": "relative/path/for/local/theme/logo.svg"
+      },
+      "loginPage": {
+        "autoRedirect": true,
+        "backgroundImg": "relative/path/for/local/theme/background.jpg"
+      },
+      "designTokens": {}
     },
-    "logo": {
-      "topbar": "https://externalurl.example.com/url/for/remote/theme/assets/logo.svg",
-      "favicon": "https://externalurl.example.com/url/for/remote/theme/assets/favicon.jpg",
-      "login": "relative/path/for/local/theme/logo.svg"
-    },
-    "loginPage": {
-      "autoRedirect": true,
-      "backgroundImg": "relative/path/for/local/theme/background.jpg"
-    },
-    "designTokens": {}
-  },
-  "alternative": {},
-  "dark": {}
+    "alternative": {},
+    "dark": {}
+  }
 }
 ```
 
@@ -81,14 +83,16 @@ In general, the theme loader looks for a `designTokens` key inside your theme co
 
 ```json
 {
-  "default": {
-    "general": {},
-    "designTokens": {
-      "breakpoints": {},
-      "colorPalette": {},
-      "fontSizes": {},
-      "sizes": {},
-      "spacing": {}
+  "web": {
+    "default": {
+      "general": {},
+      "designTokens": {
+        "breakpoints": {},
+        "colorPalette": {},
+        "fontSizes": {},
+        "sizes": {},
+        "spacing": {}
+      }
     }
   }
 }
@@ -232,88 +236,90 @@ An empty template for your custom theme is provided below, and you can use the i
 
 ```json
 {
-  "default": {
-    "general": {
-      "name": "",
-      "slogan": ""
-    },
-    "logo": {
-      "topbar": "",
-      "favicon": "",
-      "login": "",
-      "notFound": ""
-    },
-    "loginPage": {
-      "autoRedirect": true,
-      "backgroundImg": ""
-    },
-    "designTokens": {
-      "breakpoints": {
-        "xsmall-max": "",
-        "small-default": "",
-        "small-max": "",
-        "medium-default": "",
-        "medium-max": "",
-        "large-default": "",
-        "large-max": "",
-        "xlarge": ""
+  "web": {
+    "default": {
+      "general": {
+        "name": "",
+        "slogan": ""
       },
-      "colorPalette": {
-        "background-accentuate": "",
-        "background-default": "",
-        "background-highlight": "",
-        "background-muted": "",
-        "border": "",
-        "input-bg": "",
-        "input-border": "",
-        "input-text-default": "",
-        "input-text-muted": "",
-        "swatch-brand-default": "",
-        "swatch-brand-hover": "",
-        "swatch-danger-default": "",
-        "swatch-danger-hover": "",
-        "swatch-danger-muted": "",
-        "swatch-inverse-default": "",
-        "swatch-inverse-hover": "",
-        "swatch-inverse-muted": "",
-        "swatch-passive-default": "",
-        "swatch-passive-hover": "",
-        "swatch-passive-muted": "",
-        "swatch-primary-default": "",
-        "swatch-primary-hover": "",
-        "swatch-primary-muted": "",
-        "swatch-primary-gradient": "",
-        "swatch-success-default": "",
-        "swatch-success-hover": "",
-        "swatch-success-muted": "",
-        "swatch-warning-default": "",
-        "swatch-warning-hover": "",
-        "swatch-warning-muted": "",
-        "text-default": "",
-        "text-inverse": "",
-        "text-muted": ""
+      "logo": {
+        "topbar": "",
+        "favicon": "",
+        "login": "",
+        "notFound": ""
       },
-      "fontSizes": {
-        "default": "",
-        "large": "",
-        "medium": ""
+      "loginPage": {
+        "autoRedirect": true,
+        "backgroundImg": ""
       },
-      "sizes": {
-        "form-check-default": "",
-        "height-small": "",
-        "height-table-row": "",
-        "icon-default": "",
-        "max-height-logo": "",
-        "max-width-logo": "",
-        "width-medium": ""
-      },
-      "spacing": {
-        "xsmall": "",
-        "small": "",
-        "medium": "",
-        "large": "",
-        "xlarge": "",
-        "xxlarge": ""
+      "designTokens": {
+        "breakpoints": {
+          "xsmall-max": "",
+          "small-default": "",
+          "small-max": "",
+          "medium-default": "",
+          "medium-max": "",
+          "large-default": "",
+          "large-max": "",
+          "xlarge": ""
+        },
+        "colorPalette": {
+          "background-accentuate": "",
+          "background-default": "",
+          "background-highlight": "",
+          "background-muted": "",
+          "border": "",
+          "input-bg": "",
+          "input-border": "",
+          "input-text-default": "",
+          "input-text-muted": "",
+          "swatch-brand-default": "",
+          "swatch-brand-hover": "",
+          "swatch-danger-default": "",
+          "swatch-danger-hover": "",
+          "swatch-danger-muted": "",
+          "swatch-inverse-default": "",
+          "swatch-inverse-hover": "",
+          "swatch-inverse-muted": "",
+          "swatch-passive-default": "",
+          "swatch-passive-hover": "",
+          "swatch-passive-muted": "",
+          "swatch-primary-default": "",
+          "swatch-primary-hover": "",
+          "swatch-primary-muted": "",
+          "swatch-primary-gradient": "",
+          "swatch-success-default": "",
+          "swatch-success-hover": "",
+          "swatch-success-muted": "",
+          "swatch-warning-default": "",
+          "swatch-warning-hover": "",
+          "swatch-warning-muted": "",
+          "text-default": "",
+          "text-inverse": "",
+          "text-muted": ""
+        },
+        "fontSizes": {
+          "default": "",
+          "large": "",
+          "medium": ""
+        },
+        "sizes": {
+          "form-check-default": "",
+          "height-small": "",
+          "height-table-row": "",
+          "icon-default": "",
+          "max-height-logo": "",
+          "max-width-logo": "",
+          "width-medium": ""
+        },
+        "spacing": {
+          "xsmall": "",
+          "small": "",
+          "medium": "",
+          "large": "",
+          "xlarge": "",
+          "xxlarge": ""
+        }
       }
     }
   }

--- a/docs/theming/_index.md
+++ b/docs/theming/_index.md
@@ -35,6 +35,12 @@ You can use the snippet below as a base for writing your own theme by replacing 
 
 ```json
 {
+  "common": {
+    "name": "ownCloud",
+    "slogan": "ownCloud – A safe home for all your data",
+    "logo": "themes/owncloud/assets/logo.svg"
+  },
+  "ios": {},
   "web": {
     "default": {
       "general": {
@@ -83,6 +89,8 @@ In general, the theme loader looks for a `designTokens` key inside your theme co
 
 ```json
 {
+  "common": {},
+  "ios": {},
   "web": {
     "default": {
       "general": {},
@@ -236,6 +244,12 @@ An empty template for your custom theme is provided below, and you can use the i
 
 ```json
 {
+   "common": {
+    "name": "",
+    "slogan": "",
+    "logo": ""
+  },
+  "ios": {},
   "web": {
     "default": {
       "general": {

--- a/packages/web-runtime/src/helpers/theme.ts
+++ b/packages/web-runtime/src/helpers/theme.ts
@@ -3,7 +3,7 @@ import defaultTheme from '../../themes/owncloud/theme.json'
 import { v4 as uuidV4 } from 'uuid'
 
 export const loadTheme = async (location = '') => {
-  const defaults = { theme: defaultTheme }
+  const defaults = { theme: defaultTheme.web || defaultTheme }
 
   if (location.split('.').pop() !== 'json') {
     if (isEqual(process.env.NODE_ENV, 'development')) {
@@ -18,7 +18,7 @@ export const loadTheme = async (location = '') => {
       return defaults
     }
     const theme = await response.json()
-    return { theme }
+    return { theme: theme.web || theme }
   } catch (e) {
     console.error(
       `Failed to load theme '${location}' is not a valid json file, using default theme.`

--- a/packages/web-runtime/tests/unit/helpers/theme.spec.js
+++ b/packages/web-runtime/tests/unit/helpers/theme.spec.js
@@ -12,35 +12,35 @@ describe('theme loading and error reporting', () => {
 
   it('should load the default theme if location is empty', async () => {
     const { theme } = await loadTheme()
-    expect(theme).toMatchObject(defaultTheme)
+    expect(theme).toMatchObject(defaultTheme.web)
   })
 
   it('should load the default theme if location is not a json file extension', async () => {
     const { theme } = await loadTheme('some_location_without_json_file_ending.xml')
-    expect(theme).toMatchObject(defaultTheme)
+    expect(theme).toMatchObject(defaultTheme.web)
   })
 
   it('should load the default theme if location is not found', async () => {
     fetch.mockResponse(new Error(), { status: 404 })
     const { theme } = await loadTheme('http://www.owncloud.com/unknown.json')
-    expect(theme).toMatchObject(defaultTheme)
+    expect(theme).toMatchObject(defaultTheme.web)
   })
 
   it('should load the default theme if location is not a valid json file', async () => {
     const customTheme = merge({}, defaultTheme, { default: { logo: { login: 'custom.svg' } } })
     fetch.mockResponse(JSON.stringify(customTheme) + '-invalid')
     const { theme } = await loadTheme('http://www.owncloud.com/invalid.json')
-    expect(theme).toMatchObject(defaultTheme)
+    expect(theme).toMatchObject(defaultTheme.web)
   })
 
   it('should load the default theme if server errors', async () => {
     fetch.mockReject(new Error())
     const { theme } = await loadTheme('http://www.owncloud.com')
-    expect(theme).toMatchObject(defaultTheme)
+    expect(theme).toMatchObject(defaultTheme.web)
   })
 
   it('should load the custom theme if a custom location is given', async () => {
-    const customTheme = merge({}, defaultTheme, { default: { logo: { login: 'custom.svg' } } })
+    const customTheme = merge({}, defaultTheme.web, { default: { logo: { login: 'custom.svg' } } })
 
     fetch.mockResponse(JSON.stringify(customTheme))
 

--- a/packages/web-runtime/themes/owncloud/theme.json
+++ b/packages/web-runtime/themes/owncloud/theme.json
@@ -1,4 +1,10 @@
 {
+  "common": {
+      "name": "ownCloud",
+      "slogan": "ownCloud – A safe home for all your data",
+      "logo": "themes/owncloud/assets/logo.svg"
+  },
+  "ios": {},
   "web": {
     "default": {
       "general": {

--- a/packages/web-runtime/themes/owncloud/theme.json
+++ b/packages/web-runtime/themes/owncloud/theme.json
@@ -1,161 +1,163 @@
 {
-  "default": {
-    "general": {
-      "name": "ownCloud",
-      "slogan": "ownCloud – A safe home for all your data"
-    },
-    "logo": {
-      "topbar": "themes/owncloud/assets/logo.svg",
-      "favicon": "themes/owncloud/assets/favicon.jpg",
-      "login": "themes/owncloud/assets/logo.svg",
-      "notFound": "themes/owncloud/assets/cloud.svg"
-    },
-    "loginPage": {
-      "autoRedirect": true,
-      "backgroundImg": "themes/owncloud/assets/loginBackground.jpg"
-    },
-    "designTokens": {
-      "colorPalette": {
-        "background-accentuate": "rgba(255, 255, 5, 0.1)",
-        "background-default": "#ffffff",
-        "background-highlight": "#edf3fa",
-        "background-muted": "#f8f8f8",
-        "background-secondary": "#ffffff",
-        "background-hover": "rgb(236, 236, 236)",
-        "border": "#ecebee",
-        "input-bg": "#ffffff",
-        "input-border": "#ceddee",
-        "input-text-default": "#041e42",
-        "input-text-muted": "#4c5f79",
-        "swatch-brand-default": "#041e42",
-        "swatch-brand-hover": "#223959",
-        "swatch-danger-default": "#e00000",
-        "swatch-danger-hover": "#e96464",
-        "swatch-danger-muted": "#b50000",
-        "swatch-inverse-default": "#ffffff",
-        "swatch-inverse-hover": "#ffffff",
-        "swatch-inverse-muted": "#bfbfbf",
-        "swatch-passive-default": "#4c5f79",
-        "swatch-passive-hover": "#97a2b1",
-        "swatch-passive-muted": "#283e5d",
-        "swatch-primary-default": "#4a76ac",
-        "swatch-primary-hover": "#80a7d7",
-        "swatch-primary-muted": "#2c588e",
-        "swatch-primary-gradient": "#4e85c8",
-        "swatch-success-default": "#4f822f",
-        "swatch-success-hover": "#93e054",
-        "swatch-success-muted": "#53960a",
-        "swatch-warning-default": "#c6501b",
-        "swatch-warning-hover": "#fda94b",
-        "swatch-warning-muted": "#b35100",
-        "text-default": "#041e42",
-        "text-inverse": "#ffffff",
-        "text-muted": "#4c5f79",
-        "icon-folder": "#4d7eaf",
-        "icon-archive": "#fbbe54",
-        "icon-image": "#ee6b3b",
-        "icon-spreadsheet": "#15c286",
-        "icon-document": "#3b44a6",
-        "icon-video": "#045459",
-        "icon-audio": "#700460",
-        "icon-presentation": "#ee6b3b",
-        "icon-pdf": "#ec0d47"
+  "web": {
+    "default": {
+      "general": {
+        "name": "ownCloud",
+        "slogan": "ownCloud – A safe home for all your data"
+      },
+      "logo": {
+        "topbar": "themes/owncloud/assets/logo.svg",
+        "favicon": "themes/owncloud/assets/favicon.jpg",
+        "login": "themes/owncloud/assets/logo.svg",
+        "notFound": "themes/owncloud/assets/cloud.svg"
+      },
+      "loginPage": {
+        "autoRedirect": true,
+        "backgroundImg": "themes/owncloud/assets/loginBackground.jpg"
+      },
+      "designTokens": {
+        "colorPalette": {
+          "background-accentuate": "rgba(255, 255, 5, 0.1)",
+          "background-default": "#ffffff",
+          "background-highlight": "#edf3fa",
+          "background-muted": "#f8f8f8",
+          "background-secondary": "#ffffff",
+          "background-hover": "rgb(236, 236, 236)",
+          "border": "#ecebee",
+          "input-bg": "#ffffff",
+          "input-border": "#ceddee",
+          "input-text-default": "#041e42",
+          "input-text-muted": "#4c5f79",
+          "swatch-brand-default": "#041e42",
+          "swatch-brand-hover": "#223959",
+          "swatch-danger-default": "#e00000",
+          "swatch-danger-hover": "#e96464",
+          "swatch-danger-muted": "#b50000",
+          "swatch-inverse-default": "#ffffff",
+          "swatch-inverse-hover": "#ffffff",
+          "swatch-inverse-muted": "#bfbfbf",
+          "swatch-passive-default": "#4c5f79",
+          "swatch-passive-hover": "#97a2b1",
+          "swatch-passive-muted": "#283e5d",
+          "swatch-primary-default": "#4a76ac",
+          "swatch-primary-hover": "#80a7d7",
+          "swatch-primary-muted": "#2c588e",
+          "swatch-primary-gradient": "#4e85c8",
+          "swatch-success-default": "#4f822f",
+          "swatch-success-hover": "#93e054",
+          "swatch-success-muted": "#53960a",
+          "swatch-warning-default": "#c6501b",
+          "swatch-warning-hover": "#fda94b",
+          "swatch-warning-muted": "#b35100",
+          "text-default": "#041e42",
+          "text-inverse": "#ffffff",
+          "text-muted": "#4c5f79",
+          "icon-folder": "#4d7eaf",
+          "icon-archive": "#fbbe54",
+          "icon-image": "#ee6b3b",
+          "icon-spreadsheet": "#15c286",
+          "icon-document": "#3b44a6",
+          "icon-video": "#045459",
+          "icon-audio": "#700460",
+          "icon-presentation": "#ee6b3b",
+          "icon-pdf": "#ec0d47"
+        }
       }
-    }
-  },
-  "default-dark": {
-    "general": {
-      "name": "ownCloud",
-      "slogan": "ownCloud – A safe home for all your data"
     },
-    "logo": {
-      "topbar": "themes/owncloud/assets/logo.svg",
-      "favicon": "themes/owncloud/assets/favicon.jpg",
-      "login": "themes/owncloud/assets/logo.svg",
-      "notFound": "themes/owncloud/assets/cloud.svg"
-    },
-    "loginPage": {
-      "autoRedirect": true,
-      "backgroundImg": "themes/owncloud/assets/loginBackground.jpg"
-    },
-    "designTokens": {
-      "breakpoints": {
-        "xsmall-max": "",
-        "small-default": "",
-        "small-max": "",
-        "medium-default": "",
-        "medium-max": "",
-        "large-default": "",
-        "large-max": "",
-        "xlarge": ""
+    "default-dark": {
+      "general": {
+        "name": "ownCloud",
+        "slogan": "ownCloud – A safe home for all your data"
       },
-      "colorPalette": {
-        "background-accentuate": "#696969",
-        "background-default": "#292929",
-        "background-highlight": "#383838",
-        "background-muted": "#383838",
-        "background-secondary": "#4f4f4f",
-        "background-hover": "#383838",
-        "border": "#383838",
-        "input-bg": "#4f4f4f",
-        "input-border": "#4f4f4f",
-        "input-text-default": "#dadcdf",
-        "input-text-muted": "#bdbfc3",
-        "swatch-brand-default": "#212121",
-        "swatch-brand-hover": "#ffffff",
-        "swatch-danger-default": "#d11d1c",
-        "swatch-danger-hover": "",
-        "swatch-danger-muted": "",
-        "swatch-inverse-default": "",
-        "swatch-inverse-hover": "",
-        "swatch-inverse-muted": "#696969",
-        "swatch-passive-default": "#c2c2c2",
-        "swatch-passive-hover": "",
-        "swatch-passive-muted": "#bdbfc3",
-        "swatch-primary-default": "#73b0f2",
-        "swatch-primary-hover": "#7bafef",
-        "swatch-primary-muted": "",
-        "swatch-primary-gradient": "#4e85c8",
-        "swatch-success-default": "#04b253",
-        "swatch-success-hover": "",
-        "swatch-success-muted": "",
-        "swatch-warning-default": "",
-        "swatch-warning-hover": "",
-        "swatch-warning-muted": "",
-        "text-default": "#DADCDF",
-        "text-inverse": "#000000",
-        "text-muted": "#c2c2c2",
-        "icon-folder": "rgb(44, 101, 255)",
-        "icon-archive": "rgb(255, 207, 1)",
-        "icon-image": "rgb(255, 111, 0)",
-        "icon-spreadsheet": "rgb(0, 182, 87)",
-        "icon-document": "rgb(44, 101, 255)",
-        "icon-video": "rgb(0, 187, 219)",
-        "icon-audio": "rgb(208, 67, 236)",
-        "icon-presentation": "rgb(255, 64, 6)",
-        "icon-pdf": "rgb(225, 5, 14)"
+      "logo": {
+        "topbar": "themes/owncloud/assets/logo.svg",
+        "favicon": "themes/owncloud/assets/favicon.jpg",
+        "login": "themes/owncloud/assets/logo.svg",
+        "notFound": "themes/owncloud/assets/cloud.svg"
       },
-      "fontSizes": {
-        "default": "",
-        "large": "",
-        "medium": ""
+      "loginPage": {
+        "autoRedirect": true,
+        "backgroundImg": "themes/owncloud/assets/loginBackground.jpg"
       },
-      "sizes": {
-        "form-check-default": "",
-        "height-small": "",
-        "height-table-row": "",
-        "icon-default": "",
-        "max-height-logo": "",
-        "max-width-logo": "",
-        "width-medium": ""
-      },
-      "spacing": {
-        "xsmall": "",
-        "small": "",
-        "medium": "",
-        "large": "",
-        "xlarge": "",
-        "xxlarge": ""
+      "designTokens": {
+        "breakpoints": {
+          "xsmall-max": "",
+          "small-default": "",
+          "small-max": "",
+          "medium-default": "",
+          "medium-max": "",
+          "large-default": "",
+          "large-max": "",
+          "xlarge": ""
+        },
+        "colorPalette": {
+          "background-accentuate": "#696969",
+          "background-default": "#292929",
+          "background-highlight": "#383838",
+          "background-muted": "#383838",
+          "background-secondary": "#4f4f4f",
+          "background-hover": "#383838",
+          "border": "#383838",
+          "input-bg": "#4f4f4f",
+          "input-border": "#4f4f4f",
+          "input-text-default": "#dadcdf",
+          "input-text-muted": "#bdbfc3",
+          "swatch-brand-default": "#212121",
+          "swatch-brand-hover": "#ffffff",
+          "swatch-danger-default": "#d11d1c",
+          "swatch-danger-hover": "",
+          "swatch-danger-muted": "",
+          "swatch-inverse-default": "",
+          "swatch-inverse-hover": "",
+          "swatch-inverse-muted": "#696969",
+          "swatch-passive-default": "#c2c2c2",
+          "swatch-passive-hover": "",
+          "swatch-passive-muted": "#bdbfc3",
+          "swatch-primary-default": "#73b0f2",
+          "swatch-primary-hover": "#7bafef",
+          "swatch-primary-muted": "",
+          "swatch-primary-gradient": "#4e85c8",
+          "swatch-success-default": "#04b253",
+          "swatch-success-hover": "",
+          "swatch-success-muted": "",
+          "swatch-warning-default": "",
+          "swatch-warning-hover": "",
+          "swatch-warning-muted": "",
+          "text-default": "#DADCDF",
+          "text-inverse": "#000000",
+          "text-muted": "#c2c2c2",
+          "icon-folder": "rgb(44, 101, 255)",
+          "icon-archive": "rgb(255, 207, 1)",
+          "icon-image": "rgb(255, 111, 0)",
+          "icon-spreadsheet": "rgb(0, 182, 87)",
+          "icon-document": "rgb(44, 101, 255)",
+          "icon-video": "rgb(0, 187, 219)",
+          "icon-audio": "rgb(208, 67, 236)",
+          "icon-presentation": "rgb(255, 64, 6)",
+          "icon-pdf": "rgb(225, 5, 14)"
+        },
+        "fontSizes": {
+          "default": "",
+          "large": "",
+          "medium": ""
+        },
+        "sizes": {
+          "form-check-default": "",
+          "height-small": "",
+          "height-table-row": "",
+          "icon-default": "",
+          "max-height-logo": "",
+          "max-width-logo": "",
+          "width-medium": ""
+        },
+        "spacing": {
+          "xsmall": "",
+          "small": "",
+          "medium": "",
+          "large": "",
+          "xlarge": "",
+          "xxlarge": ""
+        }
       }
     }
   }


### PR DESCRIPTION
## Description
The `theme.json` file now supports multiple clients which are defined via the top-level property. Therefore both web themes have been moved down one level into the new property "web". The change is backwards compatible though, meaning it still works when the web themes are defined top-level in `theme.json`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- See https://github.com/owncloud/enterprise/issues/5502

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [x] Tests
