### PR TITLE
[tests-only][full-ci] Add share with custom permission e2e tests (stable-6)

### DIFF
--- a/tests/e2e/cucumber/features/smoke/reshare.feature
+++ b/tests/e2e/cucumber/features/smoke/reshare.feature
@@ -30,8 +30,8 @@ Feature: reshare
     And "Brian" opens the "files" app
     And "Brian" navigates to the shared with me page
     When "Brian" reshares the following resource
-      | resource         | recipient | type  | role   |
-      | folder_to_shared | sales     | group | viewer |
+      | resource         | recipient | type  | role   | resourceType |
+      | folder_to_shared | sales     | group | viewer | folder       |
 
     And "Carol" logs in
     And "Carol" opens the "files" app
@@ -40,8 +40,8 @@ Feature: reshare
       | name             |
       | folder_to_shared |
     And "Carol" reshares the following resource
-      | resource         | recipient | type | role   |
-      | folder_to_shared | Alice     | user | viewer |
+      | resource         | recipient | type | role   | resourceType |
+      | folder_to_shared | Alice     | user | viewer | folder       |
 
     And "Alice" logs in
     And "Alice" opens the "files" app
@@ -53,8 +53,8 @@ Feature: reshare
     And "Alice" logs out
 
     When "Brian" updates following sharee role
-      | resource         | recipient | type  | role                    |
-      | folder_to_shared | sales     | group | custom_permissions:read |
+      | resource         | recipient | type  | role                    | resourceType |
+      | folder_to_shared | sales     | group | custom_permissions:read | folder       |
     And "Brian" logs out
 
     And "Carol" navigates to the shared with me page

--- a/tests/e2e/cucumber/features/smoke/search.feature
+++ b/tests/e2e/cucumber/features/smoke/search.feature
@@ -21,9 +21,9 @@ Feature: Search
     When "Brian" logs in
     And "Brian" opens the "files" app
     And "Brian" shares the following resource using the sidebar panel
-      | resource             | recipient | type | role   |
-      | new_share_from_brian | Alice     | user | viewer |
-      | new-lorem-big.txt    | Alice     | user | viewer |
+      | resource             | recipient | type | role   | resourceType |
+      | new_share_from_brian | Alice     | user | viewer | folder       |
+      | new-lorem-big.txt    | Alice     | user | viewer | file         |
     And "Brian" logs out
 
     When "Alice" logs in

--- a/tests/e2e/cucumber/features/smoke/share.oc10.feature
+++ b/tests/e2e/cucumber/features/smoke/share.oc10.feature
@@ -9,36 +9,44 @@ Feature: share
       | id    |
       | Alice |
       | Brian |
-    When "Alice" logs in
+    And "Alice" logs in
     And "Alice" opens the "files" app
     And "Alice" navigates to the personal space page
     And "Alice" creates the following resources
-      | resource         | type   |
-      | folder_to_shared | folder |
+      | resource               | type   |
+      | folder_to_shared       | folder |
+      | folder_to_customShared | folder |
     And "Alice" uploads the following resource
-      | resource  | to               |
-      | lorem.txt | folder_to_shared |
+      | resource      | to                     |
+      | lorem.txt     | folder_to_shared       |
+      | lorem-big.txt | folder_to_customShared |
     #Then "Alice" should see the following resource
     #  | folder_to_shared/lorem.txt |
     When "Alice" shares the following resource using the sidebar panel
-      | resource         | recipient | type | role   |
-      | folder_to_shared | Brian     | user | editor |
+      | resource               | recipient | type | role                                  | resourceType |
+      | folder_to_shared       | Brian     | user | editor                                | folder       |
+      | folder_to_customShared | Brian     | user | custom_permissions:read,create,delete | folder       |
     And "Brian" logs in
     And "Brian" opens the "files" app
     And "Brian" navigates to the shared with me page
     And "Brian" accepts the following share
-      | name             |
-      | folder_to_shared |
+      | name                   |
+      | folder_to_shared       |
+      | folder_to_customShared |
     And "Brian" navigates to the personal space page
     And "Brian" renames the following resource
       | resource                          | as            |
       | Shares/folder_to_shared/lorem.txt | lorem_new.txt |
     And "Brian" uploads the following resource
-      | resource   | to                      |
-      | simple.pdf | Shares/folder_to_shared |
+      | resource        | to                            |
+      | simple.pdf      | Shares/folder_to_shared       |
+      | testavatar.jpeg | Shares/folder_to_customShared |
     And "Brian" copies the following resource using dropdown-menu
       | resource                | to       |
       | Shares/folder_to_shared | Personal |
+    When "Brian" deletes the following resources
+      | resource                                    |
+      | Shares/folder_to_customShared/lorem-big.txt |
     When "Alice" opens the "files" app
     #Then "Alice" should see the following resources
     #  | folder_to_shared/lorem_new.txt |
@@ -59,7 +67,7 @@ Feature: share
       | folder_to_shared/lorem_new.txt |
       | folder_to_shared               |
     And "Alice" logs out
-    And "Brian" opens the "files" app
+    #And "Brian" opens the "files" app
     #Then "Brian" should not see the following resource
     #  | Shares/folder_to_shared |
     And "Brian" logs out
@@ -77,15 +85,18 @@ Feature: share
     And "Alice" uploads the following resource
       | resource        | to               |
       | testavatar.jpeg | folder_to_shared |
+      | lorem.txt       |                  |
     And "Alice" shares the following resource using the quick action
-      | resource                         | recipient | type | role   |
-      | folder_to_shared/testavatar.jpeg | Brian     | user | viewer |
+      | resource                         | recipient | type | role                                 |
+      | folder_to_shared/testavatar.jpeg | Brian     | user | viewer                               |
+      | lorem.txt                        | Brian     | user | custom_permissions:read,update,share |
     And "Brian" logs in
     And "Brian" opens the "files" app
     And "Brian" navigates to the shared with me page
     And "Brian" accepts the following share
       | name            |
       | testavatar.jpeg |
+      | lorem.txt       |
     And "Brian" navigates to the personal space page
     And "Brian" copies the following resource using dropdown-menu
       | resource               | to       |
@@ -94,11 +105,14 @@ Feature: share
       | resource        | from   |
       | testavatar.jpeg | Shares |
     And "Alice" updates following sharee role
-      | resource                         | recipient | role   |
-      | folder_to_shared/testavatar.jpeg | Brian     | editor |
+      | resource                         | recipient | role   | resourceType |
+      | folder_to_shared/testavatar.jpeg | Brian     | editor | file         |
     And "Brian" renames the following resource
       | resource               | as                  |
       | Shares/testavatar.jpeg | testavatar_new.jpeg |
+    And "Brian" edits the following resources
+      | resource         | content     |
+      | Shares/lorem.txt | new content |
     And "Alice" removes following sharee
       | resource                         | recipient |
       | folder_to_shared/testavatar.jpeg | Brian     |

--- a/tests/e2e/cucumber/features/smoke/share.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/share.ocis.feature
@@ -19,10 +19,10 @@ Feature: share
       | lorem.txt     | folder_to_shared       |
       | lorem-big.txt | folder_to_customShared |
     When "Alice" shares the following resource using the sidebar panel
-      | resource               | recipient | type | role   |
-      | folder_to_shared       | Brian     | user | editor |
-      | shared_folder          | Brian     | user | editor |
-      | folder_to_customShared | Brian     | user | editor |
+      | resource               | recipient | type | role                                  | resourceType |
+      | folder_to_shared       | Brian     | user | editor                                | folder       |
+      | shared_folder          | Brian     | user | editor                                | folder       |
+      | folder_to_customShared | Brian     | user | custom_permissions:read,create,delete | folder       |
     And "Brian" logs in
     And "Brian" opens the "files" app
     And "Brian" navigates to the shared with me page
@@ -45,8 +45,12 @@ Feature: share
       | resource                   | as            |
       | folder_to_shared/lorem.txt | lorem_new.txt |
     And "Brian" uploads the following resource
-      | resource   | to               |
-      | simple.pdf | folder_to_shared |
+      | resource        | to                     |
+      | simple.pdf      | folder_to_shared       |
+      | testavatar.jpeg | folder_to_customShared |
+    And "Brian" deletes the following resources
+      | resource                             |
+      | folder_to_customShared/lorem-big.txt |
     And "Alice" opens the "files" app
     And "Alice" uploads the following resource
       | resource          | to               | option  |
@@ -86,12 +90,12 @@ Feature: share
       | testavatar.jpeg |
       | simple.pdf      |
     When "Alice" shares the following resource using the sidebar panel
-      | resource         | recipient | type | role   |
-      | shareToBrian.txt | Brian     | user | editor |
-      | shareToBrian.md  | Brian     | user | editor |
-      | testavatar.jpeg  | Brian     | user | viewer |
-      | simple.pdf       | Brian     | user | viewer |
-      | sharedFile.txt   | Brian     | user | editor |
+      | resource         | recipient | type | role                                 | resourceType |
+      | shareToBrian.txt | Brian     | user | editor                               | file         |
+      | shareToBrian.md  | Brian     | user | editor                               | file         |
+      | testavatar.jpeg  | Brian     | user | viewer                               | file         |
+      | simple.pdf       | Brian     | user | custom_permissions:read,update,share | file         |
+      | sharedFile.txt   | Brian     | user | editor                               | file         |
     And "Brian" logs in
     And "Brian" opens the "files" app
     And "Brian" navigates to the shared with me page

--- a/tests/e2e/cucumber/features/smoke/spaces/project.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/spaces/project.ocis.feature
@@ -56,8 +56,8 @@ Feature: spaces.personal
 
     # borrowed from share.feature
     When "Alice" shares the following resource using the sidebar panel
-      | resource         | recipient | type | role   |
-      | folder_to_shared | Brian     | user | editor |
+      | resource         | recipient | type | role   | resourceType |
+      | folder_to_shared | Brian     | user | editor | folder       |
 
     # team.2
     And "Alice" navigates to the projects space page

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -322,7 +322,7 @@ When(
     const resourceObject = new objects.applicationFiles.Resource({ page })
 
     for (const info of stepTable.hashes()) {
-      await resourceObject.editResourse({ name: info.resource, content: info.content })
+      await resourceObject.editResource({ name: info.resource, content: info.content })
     }
   }
 )

--- a/tests/e2e/cucumber/steps/ui/shares.ts
+++ b/tests/e2e/cucumber/steps/ui/shares.ts
@@ -5,7 +5,7 @@ import { objects } from '../../../support'
 
 const parseShareTable = function (stepTable: DataTable, usersEnvironment) {
   return stepTable.hashes().reduce((acc, stepRow) => {
-    const { resource, recipient, type, role } = stepRow
+    const { resource, recipient, type, role, resourceType } = stepRow
 
     if (!acc[resource]) {
       acc[resource] = []
@@ -17,7 +17,8 @@ const parseShareTable = function (stepTable: DataTable, usersEnvironment) {
           ? usersEnvironment.getGroup({ key: recipient })
           : usersEnvironment.getUser({ key: recipient }),
       role,
-      type
+      type,
+      resourceType
     })
 
     return acc

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -658,8 +658,17 @@ export interface editResourcesArgs {
 
 export const editResources = async (args: editResourcesArgs): Promise<void> => {
   const { page, name, content } = args
-  await page.locator(util.format(resourceNameSelector, name)).click()
-  await editTextDocument({ page, content: content, name })
+  const { dir: resourceDir } = path.parse(name)
+
+  const folderPaths = name.split('/')
+  const resourceName = folderPaths.pop()
+
+  if (resourceDir) {
+    await clickResource({ page, path: resourceDir })
+  }
+
+  await page.locator(util.format(resourceNameSelector, resourceName)).click()
+  await editTextDocument({ page, content: content, name: resourceName })
 }
 
 export interface openFileInViewerArgs {

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -161,7 +161,7 @@ export class Resource {
     await showHiddenResources(this.#page)
   }
 
-  async editResourse(args: Omit<editResourcesArgs, 'page'>): Promise<void> {
+  async editResource(args: Omit<editResourcesArgs, 'page'>): Promise<void> {
     await editResources({ ...args, page: this.#page })
   }
 


### PR DESCRIPTION
## Description
Added e2e tests to share files and folders with custom permissions

Ported from https://github.com/owncloud/web/pull/8193

## Related Issue
https://github.com/owncloud/web/pull/8193

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
