### PR TITLE
[tests-only][full-ci]Bump latest `master-ocis` commit to `web-master`

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=a2e26534ae2b037f325e77ed5ddd53d5c870ecb5
+OCIS_COMMITID=8aff14751bca33f1ba888e5d3410f602ecaeeb04
 OCIS_BRANCH=master


### PR DESCRIPTION
### Description
Bumps latest `ocis-master` commit-id to `web-master`

### Related issue
https://github.com/owncloud/QA/issues/795