### PR TITLE
[tests-only][full-ci]Bump `ocis-stable-2.0` commit to `web-stable-6.0`

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=176272d8ae7ba83198b8eafbee28358d127b471d
+OCIS_COMMITID=72de5431241fd0f3fceca300c52607679fa6550e
 OCIS_BRANCH=stable-2.0


### PR DESCRIPTION
### Description
Bumps latest `ocis-stable-2.0` commit-id to `web-stable-6.0`

### Related issue
https://github.com/owncloud/QA/issues/795