### PR TITLE
[full-ci] Move language selection to the account page and kill settings app

### DIFF
--- a/changelog/unreleased/enhancement-move-language-select-to-account-page
+++ b/changelog/unreleased/enhancement-move-language-select-to-account-page
@@ -1,0 +1,6 @@
+Enhancement: Move language selection to user account page
+
+The language selection has been moved from the settings app to the personal account page.
+The settings app has been removed from the default configs because we don't need it currently.
+
+https://github.com/owncloud/web/pull/8294

--- a/config/config.json.sample-ocis
+++ b/config/config.json.sample-ocis
@@ -18,12 +18,6 @@
     "external",
     "admin-settings"
   ],
-  "external_apps": [
-    {
-      "id": "settings",
-      "path": "https://localhost:9200/settings.js"
-    }
-  ],
   "options" : {
     "previewFileMimeTypes" : [
       "image/gif",

--- a/config/vite_oc10/config.json
+++ b/config/vite_oc10/config.json
@@ -8,6 +8,11 @@
     "authUrl": "http://host.docker.internal:8080/index.php/apps/oauth2/authorize",
     "logoutUrl": "http://host.docker.internal:8080/index.php/logout"
   },
+  "options": {
+    "accountEditLink": {
+      "href": "http://host.docker.internal:8080/index.php/settings/personal"
+    }
+  },
   "apps": [
     "files",
     "text-editor",

--- a/config/vite_ocis/config.json
+++ b/config/vite_ocis/config.json
@@ -23,10 +23,6 @@
       "config": {
         "mimeTypes": ["image/tiff","image/bmp","image/x-ms-bmp"]
       }
-    },
-    {
-      "id": "settings",
-      "path": "/settings.js"
     }
   ]
 }

--- a/dev/docker/oc10.web.config.json
+++ b/dev/docker/oc10.web.config.json
@@ -34,16 +34,6 @@
       },
       "icon": "swap-box",
       "url": "http://host.docker.internal:8080/index.php/apps/files"
-    },
-    {
-      "icon": "settings-4",
-      "menu": "user",
-      "target": "_self",
-      "title": {
-        "de": "Einstellungen",
-        "en": "Settings"
-      },
-      "url": "http://host.docker.internal:8080/index.php/settings/personal"
     }
   ]
 }

--- a/dev/docker/ocis.web.config.json
+++ b/dev/docker/ocis.web.config.json
@@ -41,10 +41,6 @@
       }
     },
     {
-      "id": "settings",
-      "path": "/settings.js"
-    },
-    {
       "id": "draw-io",
       "path": "web-app-draw-io",
       "config": {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,6 +48,8 @@ substring of a value of the authenticated user. Examples are `/Shares`, `/{{.Id}
 - `options.disablePreviews` Set this option to `true` to disable previews in all the different file listing views. The only list view that is not affected
   by this is the trash bin, as that doesn't allow showing previews at all.
 - `options.previewFileMimeTypes` Specifies which mimeTypes will be previewed in the ui. For example to only preview jpg and text files set this option to `["image/jpeg", "text/plain"]`.
+- `options.accountEditLink` This accepts an object with the following optional fields to have a link on the account page:
+  - `options.accountEditLink.href` Set a different target URL for the edit link. Make sure to prepend it with `http(s)://`.
 - `options.disableFeedbackLink` Set this option to `true` to disable the feedback link in the topbar. Keeping it enabled (value `false` or absence of the option)
   allows ownCloud to get feedback from your user base through a dedicated survey website.
 - `options.feedbackLink` This accepts an object with the following optional fields to customize the feedback link in the topbar:

--- a/packages/web-integration-oc10/lib/Controller/ConfigController.php
+++ b/packages/web-integration-oc10/lib/Controller/ConfigController.php
@@ -134,6 +134,9 @@ class ConfigController extends Controller {
      */
     private function addAccountEditLinkToConfig(array $config): array {
         $options = $config['options'] ?? [];
+        if (isset($options['accountEditLink'])) {
+            return $config;
+        }
         $serverUrl = $this->request->getServerProtocol() . '://' . $this->request->getServerHost();
         $options['accountEditLink'] = [
             'href' => $serverUrl . '/index.php/settings/personal'

--- a/packages/web-integration-oc10/lib/Controller/ConfigController.php
+++ b/packages/web-integration-oc10/lib/Controller/ConfigController.php
@@ -73,6 +73,7 @@ class ConfigController extends Controller {
             $configContent = \file_get_contents($configFile);
             $configAssoc = \json_decode($configContent, true);
             $extendedConfig = $this->addOC10AppsToConfig($configAssoc);
+            $extendedConfig = $this->addAccountEditLinkToConfig($extendedConfig);
             $response = new JSONResponse($extendedConfig);
 			$response->addHeader('Cache-Control', 'max-age=0, no-cache, no-store, must-revalidate');
 			$response->addHeader('Pragma', 'no-cache');
@@ -122,6 +123,22 @@ class ConfigController extends Controller {
         }
 
         $config['applications'] = $apps;
+        return $config;
+    }
+
+    /**
+     * Add an account edit link to the config.
+     *
+     * @param array $config
+     * @return array
+     */
+    private function addAccountEditLinkToConfig(array $config): array {
+        $options = $config['options'] ?? [];
+        $serverUrl = $this->request->getServerProtocol() . '://' . $this->request->getServerHost();
+        $options['accountEditLink'] = [
+            'href' => $serverUrl . '/index.php/settings/personal'
+        ];
+        $config['options'] = $options;
         return $config;
     }
 }

--- a/packages/web-runtime/src/pages/account.vue
+++ b/packages/web-runtime/src/pages/account.vue
@@ -94,15 +94,13 @@
 <script lang="ts">
 import { mapActions, mapGetters } from 'vuex'
 import EditPasswordModal from '../components/EditPasswordModal.vue'
-import { defineComponent, unref } from 'vue'
+import { computed, defineComponent, onMounted, unref } from 'vue'
 import { useAccessToken, useGraphClient, useStore } from 'web-pkg/src/composables'
 import { urlJoin } from 'web-client/src/utils'
 import { configurationManager } from 'web-pkg/src/configuration'
 import { useTask } from 'vue-concurrency'
 import axios from 'axios'
 import { v4 as uuidV4 } from 'uuid'
-import { onMounted } from 'vue-demi'
-import { computed } from 'vue'
 
 export default defineComponent({
   name: 'Personal',

--- a/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.ts.snap
+++ b/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.ts.snap
@@ -23,6 +23,12 @@ exports[`account page account information displays basic user information 1`] = 
       <span data-current-language="en" data-msgid="You are not part of any group">You are not part of any group</span>
     </dd>
   </div>
+  <div class="account-page-info-language oc-mb oc-width-1-2@s">
+    <dt class="oc-text-normal oc-text-muted" data-current-language="en" data-msgid="Language">Language</dt>
+    <dd>
+      <!--v-if-->
+    </dd>
+  </div>
 </dl>
 `;
 

--- a/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.ts.snap
+++ b/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.ts.snap
@@ -23,12 +23,7 @@ exports[`account page account information displays basic user information 1`] = 
       <span data-current-language="en" data-msgid="You are not part of any group">You are not part of any group</span>
     </dd>
   </div>
-  <div class="account-page-info-language oc-mb oc-width-1-2@s">
-    <dt class="oc-text-normal oc-text-muted" data-current-language="en" data-msgid="Language">Language</dt>
-    <dd>
-      <!--v-if-->
-    </dd>
-  </div>
+  <!--v-if-->
 </dl>
 `;
 
@@ -38,6 +33,4 @@ exports[`account page account information group membership displays group names 
 </dd>
 `;
 
-exports[`account page header section edit buttons edit route button should be displayed if running with ocis and has navItems 1`] = `<oc-button-stub to="some-route" type="router-link" variation="primary"></oc-button-stub>`;
-
-exports[`account page header section edit buttons edit url button should be displayed if not running with ocis 1`] = `<oc-button-stub href="/index.php/settings/personal" type="a" variation="primary"></oc-button-stub>`;
+exports[`account page header section edit url button should be displayed if defined via config 1`] = `<oc-button-stub href="/" target="_blank" type="a" variation="primary"></oc-button-stub>`;


### PR DESCRIPTION
## Description
The language selection has been moved from the settings app to the personal account page. The settings app has been removed from the default configs because we don't need it currently.

Fixes https://github.com/owncloud/web/issues/8290

Needs a follow-up PR in oCIS to adjust the configs there.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/50302941/214027130-864433d9-5f3e-469a-82c8-6db2c4234cdd.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
