### PR TITLE
[tests-only][full-ci]Remove duplicated steps in feature file for `share.ocis.feature`

### DIFF
--- a/tests/e2e/cucumber/features/smoke/share.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/share.ocis.feature
@@ -30,10 +30,6 @@ Feature: share
       | name                   |
       | folder_to_shared       |
       | folder_to_customShared |
-    Then "Brian" should not be able to open the folder "shared_folder"
-    When "Brian" accepts the following share from the context menu
-      | name          |
-      | shared_folder |
     And "Brian" declines the following share
       | name          |
       | shared_folder |


### PR DESCRIPTION
### Description
This PR removes the duplicated steps to accept or decline share in `share.ocis.feature` in master branch. This might have arrived during rebasing while backporting from `stable-6.0` to `master` 