### PR TITLE
Show selectable groups only

### DIFF
--- a/changelog/unreleased/enhancement-show-selectable-groups-only
+++ b/changelog/unreleased/enhancement-show-selectable-groups-only
@@ -1,0 +1,6 @@
+Enhancement: Show selectable groups only
+
+When managing user group assignments, we now show selectable groups only, meaning groups that have been selected already will not show up as available options.
+
+https://github.com/owncloud/web/pull/8306
+https://github.com/owncloud/web/issues/8305

--- a/packages/web-app-admin-settings/src/components/Users/SideBar/EditPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Users/SideBar/EditPanel.vue
@@ -54,7 +54,7 @@
         <group-select
           class="oc-mb-s"
           :selected-groups="editUser.memberOf"
-          :available-groups="groups"
+          :group-options="groupOptions"
           @selectedOptionChange="changeSelectedGroupOption"
         />
       </div>
@@ -70,7 +70,7 @@
   </div>
 </template>
 <script lang="ts">
-import { defineComponent, PropType, ref } from 'vue'
+import { computed, defineComponent, PropType, ref, unref } from 'vue'
 import * as EmailValidator from 'email-validator'
 import UserInfoBox from './UserInfoBox.vue'
 import CompareSaveDialog from 'web-pkg/src/components/sideBar/CompareSaveDialog.vue'
@@ -102,7 +102,7 @@ export default defineComponent({
       required: true
     }
   },
-  setup() {
+  setup(props) {
     const editUser: MaybeRef<User> = ref({})
     const formData = ref({
       displayName: {
@@ -114,7 +114,12 @@ export default defineComponent({
         valid: true
       }
     })
-    return { editUser, formData }
+    const groupOptions = computed(() => {
+      const { memberOf: selectedGroups } = unref(editUser)
+      return props.groups.filter((g) => !selectedGroups.some((s) => s.id === g.id))
+    })
+
+    return { editUser, formData, groupOptions }
   },
   computed: {
     invalidFormData() {

--- a/packages/web-app-admin-settings/src/components/Users/SideBar/EditPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Users/SideBar/EditPanel.vue
@@ -116,7 +116,9 @@ export default defineComponent({
     })
     const groupOptions = computed(() => {
       const { memberOf: selectedGroups } = unref(editUser)
-      return props.groups.filter((g) => !selectedGroups.some((s) => s.id === g.id))
+      return props.groups
+        .filter((g) => !selectedGroups.some((s) => s.id === g.id))
+        .sort((a, b) => a.displayName.localeCompare(b.displayName))
     })
 
     return { editUser, formData, groupOptions }

--- a/packages/web-app-admin-settings/src/components/Users/SideBar/GroupSelect.vue
+++ b/packages/web-app-admin-settings/src/components/Users/SideBar/GroupSelect.vue
@@ -4,7 +4,7 @@
       :model-value="selectedOption"
       class="oc-mb-s"
       multiple
-      :options="availableGroups"
+      :options="groupOptions"
       option-label="displayName"
       :label="$gettext('Groups')"
       :fix-message-line="true"
@@ -49,7 +49,7 @@ export default defineComponent({
       type: Array as PropType<Group[]>,
       required: true
     },
-    availableGroups: {
+    groupOptions: {
       type: Array as PropType<Group[]>,
       required: true
     }

--- a/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/EditPanel.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/EditPanel.spec.ts
@@ -3,7 +3,10 @@ import { defaultPlugins, shallowMount } from 'web-test-helpers'
 import { mock } from 'jest-mock-extended'
 import { Group } from 'web-client/src/generated'
 
-const availableGroupOptions = [mock<Group>({ id: '1' }), mock<Group>({ id: '2' })]
+const availableGroupOptions = [
+  mock<Group>({ id: '1', displayName: 'group1' }),
+  mock<Group>({ id: '2', displayName: 'group2' })
+]
 const selectors = {
   groupSelectStub: 'group-select-stub'
 }

--- a/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/EditPanel.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/EditPanel.spec.ts
@@ -1,10 +1,28 @@
 import EditPanel from '../../../../../src/components/Users/SideBar/EditPanel.vue'
 import { defaultPlugins, shallowMount } from 'web-test-helpers'
+import { mock } from 'jest-mock-extended'
+import { Group } from 'web-client/src/generated'
+
+const availableGroupOptions = [mock<Group>({ id: '1' }), mock<Group>({ id: '2' })]
+const selectors = {
+  groupSelectStub: 'group-select-stub'
+}
 
 describe('EditPanel', () => {
   it('renders all available inputs', () => {
     const { wrapper } = getWrapper()
     expect(wrapper.html()).toMatchSnapshot()
+  })
+  it('filters selected groups when passing the options to the GroupSelect component', () => {
+    const { wrapper } = getWrapper({ selectedGroups: [availableGroupOptions[0]] })
+    const selectedGroups = wrapper
+      .findComponent<any>(selectors.groupSelectStub)
+      .props('selectedGroups')
+    const groupOptions = wrapper.findComponent<any>(selectors.groupSelectStub).props('groupOptions')
+    expect(selectedGroups.length).toBe(1)
+    expect(selectedGroups[0].id).toEqual(availableGroupOptions[0].id)
+    expect(groupOptions.length).toBe(1)
+    expect(groupOptions[0].id).toEqual(availableGroupOptions[1].id)
   })
   describe('method "revertChanges"', () => {
     it('should revert changes on property editUser', () => {
@@ -69,7 +87,7 @@ describe('EditPanel', () => {
   })
 })
 
-function getWrapper() {
+function getWrapper({ selectedGroups = [] } = {}) {
   return {
     wrapper: shallowMount(EditPanel, {
       props: {
@@ -78,9 +96,11 @@ function getWrapper() {
           displayName: 'jan',
           mail: 'jan@owncloud.com',
           passwordProfile: { password: '' },
-          drive: { quota: {} }
+          drive: { quota: {} },
+          memberOf: selectedGroups
         },
-        roles: [{ id: '1', displayName: 'admin' }]
+        roles: [{ id: '1', displayName: 'admin' }],
+        groups: availableGroupOptions
       },
       global: {
         plugins: [...defaultPlugins()]

--- a/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/GroupSelect.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/GroupSelect.spec.ts
@@ -24,7 +24,7 @@ function getWrapper() {
     wrapper: shallowMount(GroupSelect, {
       props: {
         selectedGroups: [groupMock],
-        availableGroups: [groupMock]
+        groupOptions: [groupMock]
       },
       global: {
         plugins: [...defaultPlugins()]

--- a/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/__snapshots__/EditPanel.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/__snapshots__/EditPanel.spec.ts.snap
@@ -13,7 +13,7 @@ exports[`EditPanel renders all available inputs 1`] = `
         <div class="oc-text-input-message"></div>
       </div>
       <quota-select-stub class="oc-mb-s" maxquota="0" title="Personal quota" totalquota="0"></quota-select-stub>
-      <group-select-stub class="oc-mb-s"></group-select-stub>
+      <group-select-stub class="oc-mb-s" groupoptions="undefined,undefined" selectedgroups=""></group-select-stub>
     </div>
     <compare-save-dialog-stub class="edit-compare-save-dialog oc-mb-l" compareobject="[object Object]" confirmbuttondisabled="false" originalobject="[object Object]"></compare-save-dialog-stub>
   </form>


### PR DESCRIPTION
## Description
When managing user group assignments, we now show selectable groups only, meaning groups that have been selected already will not show up as available options.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8305

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
