### PR TITLE
[full-ci] Refactor sidebar resource usage in the files-app

### DIFF
--- a/packages/web-app-admin-settings/src/components/Spaces/SideBar/ActionsPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/SideBar/ActionsPanel.vue
@@ -3,7 +3,7 @@
     <quota-modal
       v-if="quotaModalIsOpen"
       :cancel="closeQuotaModal"
-      :space="selectedSpaces[0]"
+      :space="resources[0]"
       @space-quota-updated="spaceQuotaUpdated"
     />
     <oc-list id="oc-spaces-actions-sidebar" class-name="oc-mt-s">
@@ -11,7 +11,7 @@
         v-for="(action, index) in actions"
         :key="`action-${index}`"
         :action="action"
-        :items="selectedSpaces"
+        :items="resources"
         class="oc-py-xs"
       />
     </oc-list>
@@ -27,21 +27,20 @@ import Restore from 'web-pkg/src/mixins/spaces/restore'
 import EditDescription from 'web-pkg/src/mixins/spaces/editDescription'
 import EditQuota from 'web-pkg/src/mixins/spaces/editQuota'
 import QuotaModal from 'web-pkg/src/components/Spaces/QuotaModal.vue'
-import { computed, defineComponent, getCurrentInstance, PropType } from 'vue'
-import { SpaceResource } from 'web-client'
+import { computed, defineComponent, getCurrentInstance, inject, unref } from 'vue'
+import { Resource } from 'web-client'
 
 export default defineComponent({
   name: 'ActionsPanel',
   components: { ActionMenuItem, QuotaModal },
   mixins: [Rename, Delete, EditDescription, Disable, Restore, EditQuota],
-  props: {
-    selectedSpaces: {
-      type: Array as PropType<Array<SpaceResource>>,
-      required: true
-    }
-  },
-  setup(props) {
+  setup() {
     const instance = getCurrentInstance().proxy as any
+    const resource = inject<Resource>('resource')
+    const resources = computed(() => {
+      return [unref(resource)]
+    })
+
     const actions = computed(() => {
       return [
         ...instance.$_rename_items,
@@ -50,7 +49,7 @@ export default defineComponent({
         ...instance.$_restore_items,
         ...instance.$_delete_items,
         ...instance.$_disable_items
-      ].filter((item) => item.isEnabled({ resources: props.selectedSpaces }))
+      ].filter((item) => item.isEnabled({ resources: unref(resources) }))
     })
     const quotaModalIsOpen = computed(() => instance.$data.$_editQuota_modalOpen)
     const closeQuotaModal = () => {
@@ -59,7 +58,7 @@ export default defineComponent({
     const spaceQuotaUpdated = (quota) => {
       instance.$data.$_editQuota_selectedSpace.spaceQuota = quota
     }
-    return { actions, quotaModalIsOpen, closeQuotaModal, spaceQuotaUpdated }
+    return { actions, quotaModalIsOpen, closeQuotaModal, spaceQuotaUpdated, resources }
   }
 })
 </script>

--- a/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersPanel.vue
@@ -25,8 +25,8 @@
   </div>
 </template>
 <script lang="ts">
-import { computed, defineComponent, PropType, watch } from 'vue'
-import { SpaceResource } from 'web-client/src'
+import { computed, defineComponent, inject, watch } from 'vue'
+import { Resource } from 'web-client/src'
 import MembersRoleSection from './MembersRoleSection.vue'
 import { ref, unref } from 'vue-demi'
 import Fuse from 'fuse.js'
@@ -36,13 +36,8 @@ import { spaceRoleEditor, spaceRoleManager, spaceRoleViewer } from 'web-client/s
 export default defineComponent({
   name: 'MembersPanel',
   components: { MembersRoleSection },
-  props: {
-    spaceResource: {
-      type: Object as PropType<SpaceResource>,
-      required: true
-    }
-  },
-  setup(props) {
+  setup() {
+    const resource = inject<Resource>('resource')
     const filterTerm = ref('')
     const markInstance = ref(null)
     const membersListRef = ref(null)
@@ -63,15 +58,15 @@ export default defineComponent({
 
     const spaceMembers = computed(() => {
       return [
-        ...props.spaceResource.spaceRoles.manager.map((r) => ({
+        ...unref(resource).spaceRoles.manager.map((r) => ({
           ...r,
           roleType: spaceRoleManager.name
         })),
-        ...props.spaceResource.spaceRoles.editor.map((r) => ({
+        ...unref(resource).spaceRoles.editor.map((r) => ({
           ...r,
           roleType: spaceRoleEditor.name
         })),
-        ...props.spaceResource.spaceRoles.viewer.map((r) => ({
+        ...unref(resource).spaceRoles.viewer.map((r) => ({
           ...r,
           roleType: spaceRoleViewer.name
         }))
@@ -113,4 +108,3 @@ export default defineComponent({
   }
 })
 </script>
-

--- a/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersRoleSection.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersRoleSection.vue
@@ -39,4 +39,3 @@ export default defineComponent({
   }
 })
 </script>
-

--- a/packages/web-app-admin-settings/src/views/Spaces.vue
+++ b/packages/web-app-admin-settings/src/views/Spaces.vue
@@ -111,6 +111,11 @@ export default defineComponent({
     BatchActions
   },
   mixins: [Delete, Disable, Restore],
+  provide() {
+    return {
+      resource: computed(() => this.selectedSpaces[0])
+    }
+  },
   setup() {
     const instance = getCurrentInstance().proxy as any
     const store = useStore()
@@ -195,8 +200,8 @@ export default defineComponent({
           default: true,
           enabled: unref(selectedSpaces).length === 1,
           componentAttrs: {
-            spaceResource: unref(selectedSpaces)[0],
-            showSpaceImage: false
+            showSpaceImage: false,
+            showShareIndicators: false
           }
         },
         {
@@ -216,10 +221,7 @@ export default defineComponent({
           title: $gettext('Actions'),
           component: ActionsPanel,
           default: false,
-          enabled: unref(selectedSpaces).length === 1,
-          componentAttrs: {
-            selectedSpaces: unref(selectedSpaces)
-          }
+          enabled: unref(selectedSpaces).length === 1
         },
         {
           app: 'SpaceMembers',
@@ -227,10 +229,7 @@ export default defineComponent({
           title: $gettext('Members'),
           component: MembersPanel,
           default: false,
-          enabled: unref(selectedSpaces).length === 1,
-          componentAttrs: {
-            spaceResource: unref(selectedSpaces)[0]
-          }
+          enabled: unref(selectedSpaces).length === 1
         }
       ].filter((p) => p.enabled)
     })

--- a/packages/web-app-admin-settings/tests/unit/components/Spaces/SideBar/MembersPanel.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Spaces/SideBar/MembersPanel.spec.ts
@@ -45,11 +45,9 @@ describe('MembersPanel', () => {
 function getWrapper({ spaceResource = spaceMock } = {}) {
   return {
     wrapper: shallowMount(MembersPanel, {
-      props: {
-        spaceResource
-      },
       global: {
-        plugins: [...defaultPlugins()]
+        plugins: [...defaultPlugins()],
+        provide: { resource: spaceResource }
       }
     })
   }

--- a/packages/web-app-files/src/components/Search/List.vue
+++ b/packages/web-app-files/src/components/Search/List.vue
@@ -136,7 +136,7 @@ export default defineComponent({
   },
   computed: {
     ...mapGetters(['configuration']),
-    ...mapGetters('Files', ['highlightedFile', 'totalFilesCount', 'totalFilesSize']),
+    ...mapGetters('Files', ['totalFilesCount', 'totalFilesSize']),
     displayThumbnails() {
       return !this.configuration?.options?.disablePreviews
     },

--- a/packages/web-app-files/src/components/SideBar/Actions/FileActions.vue
+++ b/packages/web-app-files/src/components/SideBar/Actions/FileActions.vue
@@ -12,11 +12,9 @@
 </template>
 
 <script lang="ts">
-import { mapGetters } from 'vuex'
 import ActionMenuItem from 'web-pkg/src/components/ContextActions/ActionMenuItem.vue'
-
 import FileActions from '../../../mixins/fileActions'
-import { ComputedRef, defineComponent, inject } from 'vue'
+import { computed, defineComponent, getCurrentInstance, inject, unref } from 'vue'
 import { Resource } from 'web-client'
 
 export default defineComponent({
@@ -24,22 +22,23 @@ export default defineComponent({
   components: { ActionMenuItem },
   mixins: [FileActions],
   setup() {
-    return {
-      space: inject<ComputedRef<Resource>>('displayedSpace')
-    }
-  },
-  computed: {
-    ...mapGetters('Files', ['highlightedFile']),
-
-    resources() {
-      return [this.highlightedFile]
-    },
-
-    actions() {
-      return this.$_fileActions_getAllAvailableActions({
-        space: this.space,
-        resources: this.resources
+    const instance = getCurrentInstance().proxy as any
+    const resource = inject<Resource>('resource')
+    const space = inject<Resource>('space')
+    const resources = computed(() => {
+      return [unref(resource)]
+    })
+    const actions = computed(() => {
+      return instance.$_fileActions_getAllAvailableActions({
+        space: unref(space),
+        resources: unref(resources)
       })
+    })
+
+    return {
+      space,
+      resources,
+      actions
     }
   }
 })

--- a/packages/web-app-files/src/components/SideBar/Actions/SpaceActions.vue
+++ b/packages/web-app-files/src/components/SideBar/Actions/SpaceActions.vue
@@ -29,7 +29,6 @@
 </template>
 
 <script lang="ts">
-import { mapGetters } from 'vuex'
 import ActionMenuItem from 'web-pkg/src/components/ContextActions/ActionMenuItem.vue'
 import Rename from 'web-pkg/src/mixins/spaces/rename'
 import Delete from 'web-pkg/src/mixins/spaces/delete'
@@ -43,7 +42,7 @@ import EditQuota from 'web-pkg/src/mixins/spaces/editQuota'
 import QuotaModal from 'web-pkg/src/components/Spaces/QuotaModal.vue'
 import ReadmeContentModal from 'web-pkg/src/components/Spaces/ReadmeContentModal.vue'
 import { thumbnailService } from '../../../services'
-import { ComputedRef, defineComponent, inject } from 'vue'
+import { computed, ComputedRef, defineComponent, inject, unref } from 'vue'
 import { Resource } from 'web-client'
 
 export default defineComponent({
@@ -61,15 +60,17 @@ export default defineComponent({
     EditQuota
   ],
   setup() {
+    const resource = inject<Resource>('resource')
+    const resources = computed(() => {
+      return [unref(resource)]
+    })
+
     return {
-      space: inject<ComputedRef<Resource>>('displayedSpace')
+      space: inject<ComputedRef<Resource>>('space'),
+      resources
     }
   },
   computed: {
-    ...mapGetters('Files', ['highlightedFile']),
-    resources() {
-      return [this.highlightedFile]
-    },
     actions() {
       return [
         ...this.$_rename_items,

--- a/packages/web-app-files/src/components/SideBar/PrivateLinkItem.vue
+++ b/packages/web-app-files/src/components/SideBar/PrivateLinkItem.vue
@@ -31,8 +31,8 @@ export default defineComponent({
   setup() {
     const { $gettext } = useGettext()
     const store = useStore<any>()
-    const displayedItem = inject<Resource>('displayedItem')
-    const privateLink = computed(() => unref(displayedItem))
+    const resource = inject<Resource>('resource')
+    const privateLink = computed(() => unref(resource))
 
     const {
       copy,

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
@@ -36,7 +36,6 @@
           <div>
             <div v-if="canEditOrDelete" class="oc-flex oc-flex-nowrap oc-flex-middle">
               <role-dropdown
-                :resource="highlightedFile"
                 :dom-selector="shareDomSelector"
                 :existing-permissions="share.customPermissions"
                 :existing-role="share.role"
@@ -102,7 +101,7 @@
 </template>
 
 <script lang="ts">
-import { mapGetters, mapActions, mapState } from 'vuex'
+import { mapActions, mapState } from 'vuex'
 import { DateTime } from 'luxon'
 
 import EditDropdown from './EditDropdown.vue'
@@ -143,7 +142,6 @@ export default defineComponent({
     }
   },
   computed: {
-    ...mapGetters('Files', ['highlightedFile']),
     ...mapState(['user']),
 
     shareType() {

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
@@ -113,7 +113,7 @@ import {
   SpacePeopleShareRoles
 } from 'web-client/src/helpers/share'
 import * as uuid from 'uuid'
-import { ComputedRef, defineComponent, inject, PropType } from 'vue'
+import { defineComponent, inject, PropType } from 'vue'
 import {
   useCapabilityFilesSharingAllowCustomPermissions,
   useCapabilityFilesSharingCanDenyAccess,
@@ -125,10 +125,6 @@ export default defineComponent({
   name: 'RoleDropdown',
   components: { RoleItem },
   props: {
-    resource: {
-      type: Object,
-      required: true
-    },
     existingRole: {
       type: Object as PropType<ShareRole>,
       required: false,
@@ -153,7 +149,8 @@ export default defineComponent({
   setup() {
     const store = useStore()
     return {
-      incomingParentShare: inject<ComputedRef<Resource>>('incomingParentShare'),
+      resource: inject<Resource>('resource'),
+      incomingParentShare: inject<Resource>('incomingParentShare'),
       hasRoleDenyAccess: useCapabilityFilesSharingCanDenyAccess(store),
       hasRoleCustomPermissions: useCapabilityFilesSharingAllowCustomPermissions(store)
     }

--- a/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
@@ -182,9 +182,9 @@ import {
   linkRoleInternalFolder,
   LinkShareRoles
 } from 'web-client/src/helpers/share'
-import { defineComponent, PropType } from 'vue'
+import { defineComponent, inject } from 'vue'
 import { formatDateFromDateTime, formatRelativeDateFromDateTime } from 'web-pkg/src/helpers'
-import { SpaceResource } from 'web-client/src/helpers'
+import { Resource, SpaceResource } from 'web-client/src/helpers'
 import { createFileRouteOptions } from 'web-pkg/src/helpers/router'
 
 export default defineComponent({
@@ -218,18 +218,12 @@ export default defineComponent({
     link: {
       type: Object,
       required: true
-    },
-    file: {
-      type: Object,
-      required: true
-    },
-    space: {
-      type: Object as PropType<SpaceResource>,
-      required: false,
-      default: null
     }
   },
   emits: ['removePublicLink', 'updateLink'],
+  setup() {
+    return { space: inject<Resource>('space'), resource: inject<Resource>('resource') }
+  },
   data() {
     return {
       newExpiration: this.link.expiration
@@ -339,7 +333,7 @@ export default defineComponent({
 
     viaRouterParams() {
       const matchingSpace = (this.space ||
-        this.spaces.find((space) => space.id === this.file.storageId)) as SpaceResource
+        this.spaces.find((space) => space.id === this.resource.storageId)) as SpaceResource
       if (!matchingSpace) {
         return {}
       }

--- a/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
@@ -6,26 +6,15 @@
         v-if="showSpaceMembers"
         ref="peopleShares"
         class="oc-background-highlight oc-p-m oc-mb-s"
-        :space="space"
       />
-      <file-shares
-        v-else
-        ref="peopleShares"
-        class="oc-background-highlight oc-p-m oc-mb-s"
-        :space="space"
-      />
-      <file-links
-        v-if="showLinks"
-        ref="linkShares"
-        class="oc-background-highlight oc-p-m"
-        :space="space"
-      />
+      <file-shares v-else ref="peopleShares" class="oc-background-highlight oc-p-m oc-mb-s" />
+      <file-links v-if="showLinks" ref="linkShares" class="oc-background-highlight oc-p-m" />
     </template>
   </div>
 </template>
 
 <script lang="ts">
-import { computed, ComputedRef, defineComponent, inject, provide } from 'vue'
+import { computed, defineComponent, inject, provide } from 'vue'
 import FileLinks from './FileLinks.vue'
 import FileShares from './FileShares.vue'
 import SpaceMembers from './SpaceMembers.vue'
@@ -56,16 +45,15 @@ export default defineComponent({
       incomingParentShare,
       ...rest,
       sharesLoading,
-      space: inject<ComputedRef<Resource>>('displayedSpace'),
-      file: inject<ComputedRef<Resource>>('displayedItem'),
-      activePanel: inject<ComputedRef<String>>('activePanel')
+      resource: inject<Resource>('resource'),
+      activePanel: inject<String>('activePanel')
     }
   },
   watch: {
     sharesLoading: {
       handler: function (sharesLoading, old) {
         if (!sharesLoading) {
-          this.loadIncomingParentShare.perform(this.file)
+          this.loadIncomingParentShare.perform(this.resource)
         }
         // FIXME: !old can be removed as soon as https://github.com/owncloud/web/issues/7621 has been fixed
         if (this.loading || !this.activePanel || !old) {

--- a/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
@@ -67,9 +67,9 @@ import CollaboratorListItem from './Collaborators/ListItem.vue'
 import InviteCollaboratorForm from './Collaborators/InviteCollaborator/InviteCollaboratorForm.vue'
 import { spaceRoleManager } from 'web-client/src/helpers/share'
 import { createLocationSpaces, isLocationSpacesActive } from '../../../router'
-import { defineComponent, PropType } from 'vue'
+import { defineComponent, inject } from 'vue'
 import { shareSpaceAddMemberHelp } from '../../../helpers/contextualHelpers'
-import { SpaceResource } from 'web-client/src/helpers'
+import { Resource } from 'web-client/src/helpers'
 import { useGraphClient } from 'web-pkg/src/composables'
 import Fuse from 'fuse.js'
 import Mark from 'mark.js'
@@ -80,16 +80,10 @@ export default defineComponent({
     CollaboratorListItem,
     InviteCollaboratorForm
   },
-  props: {
-    space: {
-      type: Object as PropType<SpaceResource>,
-      required: false,
-      default: null
-    }
-  },
   setup() {
     return {
-      ...useGraphClient()
+      ...useGraphClient(),
+      resource: inject<Resource>('resource')
     }
   },
   data: () => {
@@ -120,7 +114,7 @@ export default defineComponent({
       return this.currentUserIsManager
     },
     currentUserIsManager() {
-      return this.space.isManager(this.user)
+      return this.resource.isManager(this.user)
     }
   },
   watch: {

--- a/packages/web-app-files/src/components/SideBar/TagsPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/TagsPanel.vue
@@ -73,8 +73,8 @@ export default defineComponent({
     const store = useStore()
     const { graphClient } = useGraphClient()
 
-    const displayedItem = inject<Resource>('displayedItem')
-    const resource = computed(() => unref(displayedItem))
+    const injectedResource = inject<Resource>('resource')
+    const resource = computed(() => unref(injectedResource))
     const selectedTags = ref([])
     const availableTags = ref([])
     const tagSelect = ref(null)
@@ -116,7 +116,6 @@ export default defineComponent({
           value: [...unref(selectedTags)]
         })
 
-        unref(resource).tags = [...unref(selectedTags)]
         eventBus.publish('sidebar.entity.saved')
       } catch (e) {
         console.error(e)
@@ -124,7 +123,7 @@ export default defineComponent({
     }
 
     watch(resource, () => {
-      if (unref(resource).canEditTags()) {
+      if (unref(resource)?.canEditTags()) {
         revertChanges()
       }
     })

--- a/packages/web-app-files/src/mixins/fileActions.ts
+++ b/packages/web-app-files/src/mixins/fileActions.ts
@@ -63,7 +63,7 @@ export default {
   ],
   computed: {
     ...mapState(['apps']),
-    ...mapGetters('Files', ['highlightedFile', 'currentFolder']),
+    ...mapGetters('Files', ['currentFolder']),
     ...mapGetters(['capabilities', 'configuration']),
 
     $_fileActions_systemActions() {

--- a/packages/web-app-files/src/store/mutations.ts
+++ b/packages/web-app-files/src/store/mutations.ts
@@ -255,7 +255,7 @@ function $_upsertResource(state, resource, allowInsert) {
   }
 
   if (found) {
-    files[index] = resource
+    Object.assign(files[index], resource)
   } else {
     files.push(resource)
   }

--- a/packages/web-app-files/src/views/Favorites.vue
+++ b/packages/web-app-files/src/views/Favorites.vue
@@ -134,7 +134,7 @@ export default defineComponent({
   computed: {
     ...mapState(['app']),
     ...mapState('Files', ['files']),
-    ...mapGetters('Files', ['highlightedFile', 'totalFilesCount', 'totalFilesSize']),
+    ...mapGetters('Files', ['totalFilesCount', 'totalFilesSize']),
     ...mapGetters(['user', 'configuration']),
 
     isEmpty() {

--- a/packages/web-app-files/src/views/shares/SharedViaLink.vue
+++ b/packages/web-app-files/src/views/shares/SharedViaLink.vue
@@ -129,7 +129,7 @@ export default defineComponent({
   computed: {
     ...mapState(['app']),
     ...mapState('Files', ['files']),
-    ...mapGetters('Files', ['highlightedFile', 'totalFilesCount']),
+    ...mapGetters('Files', ['totalFilesCount']),
     ...mapGetters(['configuration']),
 
     helpersEnabled() {

--- a/packages/web-app-files/src/views/shares/SharedWithOthers.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithOthers.vue
@@ -128,7 +128,7 @@ export default defineComponent({
   computed: {
     ...mapState(['app']),
     ...mapState('Files', ['files']),
-    ...mapGetters('Files', ['highlightedFile', 'totalFilesCount']),
+    ...mapGetters('Files', ['totalFilesCount']),
     ...mapGetters(['configuration', 'user']),
 
     isEmpty() {

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -344,12 +344,7 @@ export default defineComponent({
   computed: {
     ...mapState(['app']),
     ...mapState('Files', ['files']),
-    ...mapGetters('Files', [
-      'highlightedFile',
-      'currentFolder',
-      'totalFilesCount',
-      'totalFilesSize'
-    ]),
+    ...mapGetters('Files', ['currentFolder', 'totalFilesCount', 'totalFilesSize']),
     ...mapGetters(['user', 'configuration']),
 
     isEmpty() {

--- a/packages/web-app-files/src/views/spaces/GenericTrash.vue
+++ b/packages/web-app-files/src/views/spaces/GenericTrash.vue
@@ -159,7 +159,7 @@ export default defineComponent({
 
   computed: {
     ...mapState('Files', ['files']),
-    ...mapGetters('Files', ['highlightedFile', 'totalFilesCount']),
+    ...mapGetters('Files', ['totalFilesCount']),
     ...mapGetters(['user']),
 
     isEmpty() {

--- a/packages/web-app-files/tests/unit/components/Search/List.spec.ts
+++ b/packages/web-app-files/tests/unit/components/Search/List.spec.ts
@@ -123,7 +123,6 @@ describe('List component', () => {
 //           selectedIds: []
 //         },
 //         getters: {
-//           highlightedFile: () => activeFiles[0],
 //           activeFiles: () => activeFiles,
 //           selectedFiles: () => [],
 //           totalFilesCount: () => ({ files: activeFiles.length, folders: 0 }),

--- a/packages/web-app-files/tests/unit/components/SideBar/Actions/FileActions.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Actions/FileActions.spec.ts
@@ -1,6 +1,6 @@
 import FileActions from 'web-app-files/src/components/SideBar/Actions/FileActions.vue'
 import { getActions, fileActions } from 'web-app-files/tests/__fixtures__/fileActions'
-import { Resource, SpaceResource } from 'web-client/src/helpers'
+import { SpaceResource } from 'web-client/src/helpers'
 import { mock } from 'jest-mock-extended'
 import {
   createStore,
@@ -51,7 +51,6 @@ describe('FileActions', () => {
 function getWrapper(actions = []) {
   const storeOptions = { ...defaultStoreMockOptions }
   storeOptions.modules.Files.state.currentFolder = { path: '' }
-  storeOptions.modules.Files.getters.highlightedFile.mockImplementation(() => mock<Resource>())
   const store = createStore(storeOptions)
   return {
     wrapper: mount(Component, {

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.ts
@@ -184,7 +184,6 @@ function createWrapper(
     }
   }
 
-  storeOptions.modules.Files.getters.highlightedFile.mockImplementation(() => testResource)
   storeOptions.modules.Files.getters.versions.mockImplementation(() => ['2'])
   storeOptions.modules.Files.getters.sharesTree.mockImplementation((state) => state.sharesTree)
   storeOptions.modules.Files.state.sharesTree = {}
@@ -200,22 +199,11 @@ function createWrapper(
       global: {
         stubs: { 'router-link': true, 'oc-resource-icon': true },
         provide: {
-          displayedItem: testResource,
-          displayedSpace: mockDeep<SpaceResource>()
-        },
-        directives: {
-          OcTooltip: jest.fn()
+          resource: testResource,
+          space: mockDeep<SpaceResource>()
         },
         plugins: [...defaultPlugins(), store],
-        mocks: {
-          ...defaultComponentMocks(),
-          $route: {
-            meta: {
-              auth: !publicLinkContext
-            }
-          },
-          $router: jest.fn()
-        }
+        mocks: { ...defaultComponentMocks() }
       }
     })
   }

--- a/packages/web-app-files/tests/unit/components/SideBar/FileInfo.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/FileInfo.spec.ts
@@ -17,7 +17,6 @@ const selectors = {
 describe('FileInfo', () => {
   it('shows file info', () => {
     const { wrapper } = createWrapper()
-    // FIXME check for highlightedFile
     expect(wrapper.find(selectors.name).exists()).toBeTruthy()
   })
 })
@@ -31,17 +30,13 @@ function createWrapper() {
   })
   const storeOptions = { ...defaultStoreMockOptions }
   storeOptions.getters.capabilities.mockImplementation(() => ({ files: { privateLinks: true } }))
-  storeOptions.modules.Files.getters.highlightedFile.mockImplementation(() => file)
   const store = createStore(storeOptions)
   return {
     wrapper: shallowMount(FileInfo, {
       global: {
         plugins: [...defaultPlugins(), store],
-        directives: {
-          OcTooltip: jest.fn()
-        },
         provide: {
-          displayedItem: file
+          resource: file
         },
         mocks: {
           ...defaultComponentMocks({ currentRoute: mock<RouteLocation>({ path: '/files' }) })

--- a/packages/web-app-files/tests/unit/components/SideBar/PrivateLinkItem.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/PrivateLinkItem.spec.ts
@@ -46,7 +46,6 @@ describe('PrivateLinkItem', () => {
 function getWrapper() {
   const storeOptions = { ...defaultStoreMockOptions }
   storeOptions.getters.capabilities.mockImplementation(() => ({ files: { privateLinks: true } }))
-  storeOptions.modules.Files.getters.highlightedFile.mockImplementation(() => folder)
   const store = createStore(storeOptions)
   return {
     storeOptions,
@@ -54,7 +53,7 @@ function getWrapper() {
       global: {
         plugins: [...defaultPlugins(), store],
         provide: {
-          displayedItem: folder
+          resource: folder
         }
       }
     })

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.ts
@@ -54,9 +54,9 @@ describe('InviteCollaboratorForm', () => {
       expect(spyTriggerUpload).toHaveBeenCalledTimes(0)
     })
     it.each([
-      { storageId: undefined, highlightedFile: folderMock, addMethod: 'addShare' },
-      { storageId: undefined, highlightedFile: spaceMock, addMethod: 'addSpaceMember' },
-      { storageId: 1, highlightedFile: folderMock, addMethod: 'addShare' }
+      { storageId: undefined, resource: folderMock, addMethod: 'addShare' },
+      { storageId: undefined, resource: spaceMock, addMethod: 'addSpaceMember' },
+      { storageId: 1, resource: folderMock, addMethod: 'addShare' }
     ])('calls the "addShare" action', async (dataSet) => {
       const selectedCollaborators = [
         { shareWith: 'marie', value: { shareType: ShareTypes.user.value }, label: 'label' }
@@ -64,7 +64,7 @@ describe('InviteCollaboratorForm', () => {
       const { wrapper } = getWrapper({
         selectedCollaborators,
         storageId: dataSet.storageId,
-        highlightedFile: dataSet.highlightedFile as any
+        resource: dataSet.resource as any
       })
       const addShareSpy = jest.spyOn(wrapper.vm as any, dataSet.addMethod)
       await (wrapper.vm as any).share()
@@ -77,13 +77,12 @@ describe('InviteCollaboratorForm', () => {
 function getWrapper({
   selectedCollaborators = [],
   storageId = 'fake-storage-id',
-  highlightedFile = folderMock
+  resource = folderMock
 } = {}) {
   const storeOptions = defaultStoreMockOptions
   storeOptions.getters.capabilities.mockImplementation(() => ({
     files_sharing: { federation: { incoming: true, outgoing: true } }
   }))
-  storeOptions.modules.Files.getters.highlightedFile.mockImplementation(() => highlightedFile)
   const store = createStore(storeOptions)
   return {
     wrapper: shallowMount(InviteCollaboratorForm, {
@@ -94,6 +93,7 @@ function getWrapper({
       },
       global: {
         plugins: [...defaultPlugins(), store],
+        provide: { resource },
         mocks: defaultComponentMocks({
           currentRoute: mock<RouteLocation>({ params: { storageId } })
         })

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/ListItem.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/ListItem.spec.ts
@@ -186,10 +186,6 @@ function createWrapper({
     ...defaultStoreMockOptions,
     state: { user: { id: '1' } }
   }
-  storeOptions.modules.Files.getters.highlightedFile.mockImplementation(() => ({
-    type: 'folder',
-    isFolder: true
-  }))
   storeOptions.modules.Files.actions.changeShare = jest.fn()
   const store = createStore(storeOptions)
   return {

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/RoleDropdown.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/RoleDropdown.spec.ts
@@ -129,13 +129,6 @@ function getWrapper({
   return {
     wrapper: mountType(RoleDropdown, {
       props: {
-        resource: mock<Resource>({
-          name: resourceType === 'folder' ? 'testfolder' : 'testfile',
-          extension: resourceType === 'folder' ? '' : 'jpg',
-          type: resourceType,
-          isFolder: resourceType === 'folder',
-          canShare: () => canShare
-        }),
         existingRole,
         allowSharePermission: true
       },
@@ -143,6 +136,13 @@ function getWrapper({
         plugins: [...defaultPlugins(), store],
         renderStubDefaultSlot: true,
         provide: {
+          resource: mock<Resource>({
+            name: resourceType === 'folder' ? 'testfolder' : 'testfile',
+            extension: resourceType === 'folder' ? '' : 'jpg',
+            type: resourceType,
+            isFolder: resourceType === 'folder',
+            canShare: () => canShare
+          }),
           incomingParentShare
         }
       }

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/ListItem.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/ListItem.spec.ts.snap
@@ -14,7 +14,7 @@ exports[`Collaborator ListItem component share inheritance indicators show when 
         </div>
         <div>
           <div class="oc-flex oc-flex-nowrap oc-flex-middle">
-            <role-dropdown-stub allowsharepermission="true" class="files-collaborators-collaborator-role" domselector="asdf" existingpermissions="" existingrole="[object Object]" resource="[object Object]"></role-dropdown-stub>
+            <role-dropdown-stub allowsharepermission="true" class="files-collaborators-collaborator-role" domselector="asdf" existingpermissions="" existingrole="[object Object]"></role-dropdown-stub>
           </div>
         </div>
       </div>

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileLinks.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileLinks.spec.ts
@@ -90,21 +90,21 @@ describe('FileLinks', () => {
   })
   describe('when canCreatePublicLinks is set to false', () => {
     it('should show the "no reshare permissions" message', () => {
-      const highlightedFile = mockDeep<Resource>({
+      const resource = mockDeep<Resource>({
         path: '/lorem.txt',
         type: 'file',
         canShare: jest.fn(() => false),
         isFolder: false,
         isReceivedShare: jest.fn()
       })
-      const { wrapper } = getWrapper({ highlightedFile })
+      const { wrapper } = getWrapper({ resource })
       expect(wrapper.find(selectors.noResharePermissions).exists()).toBeTruthy()
     })
   })
 })
 
 function getWrapper({
-  highlightedFile = mockDeep<Resource>({ isFolder: false, canShare: () => true }),
+  resource = mockDeep<Resource>({ isFolder: false, canShare: () => true }),
   links = defaultLinksList,
   sharesTreeLoading = false
 } = {}) {
@@ -134,9 +134,6 @@ function getWrapper({
       })
     }
   }
-  defaultStoreMockOptions.modules.Files.getters.highlightedFile.mockImplementation(
-    () => highlightedFile
-  )
   defaultStoreMockOptions.modules.Files.getters.currentFileOutgoingLinks.mockImplementation(
     () => links
   )
@@ -152,7 +149,7 @@ function getWrapper({
         stubs: { OcButton: false },
         provide: {
           incomingParentShare: {},
-          displayedItem: mockDeep<Resource>()
+          resource
         }
       }
     })

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
@@ -96,7 +96,7 @@ describe('FileShares', () => {
     })
     it('lists indirect outgoing shares', () => {
       const parentPath = '/parent'
-      const resource = mock<Resource>({ path: `${parentPath}/child` })
+      const resource = mock<Resource>({ path: `${parentPath}/child`, canShare: () => true })
       const sharesTree = {
         [parentPath]: [
           mock<Share>({
@@ -106,7 +106,7 @@ describe('FileShares', () => {
           })
         ]
       }
-      const { wrapper } = getWrapper({ sharesTree, resource })
+      const { wrapper } = getWrapper({ sharesTree, resource, collaborators })
       expect(
         wrapper.findComponent<any>('collaborator-list-item-stub').props().sharedParentRoute
       ).toBeDefined()
@@ -228,20 +228,20 @@ function getWrapper({
   storeOptions.modules.runtime.modules.spaces.getters.spaceMembers.mockImplementation(
     () => spaceMembers
   )
-  storeOptions.modules.Files.getters.highlightedFile.mockImplementation(() => resource)
   storeOptions.modules.Files.getters.currentFileOutgoingCollaborators.mockImplementation(
     () => collaborators
   )
   const store = createStore(storeOptions)
   return {
     wrapper: mountType(FileShares, {
-      props: { space },
       global: {
         plugins: [...defaultPlugins(), store],
         mocks: defaultComponentMocks({
           currentRoute: mock<RouteLocation>({ name: currentRouteName })
         }),
         provide: {
+          resource,
+          space,
           incomingParentShare: {}
         },
         stubs: {

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Links/__snapshots__/DetailsAndEdit.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Links/__snapshots__/DetailsAndEdit.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DetailsAndEdit component if user can edit renders dropdown and edit button 1`] = `
-<div class="link-details oc-flex oc-flex-between oc-flex-middle oc-pl-s">
+<div class="link-details oc-flex oc-flex-between oc-flex-middle oc-pl-s" file="undefined">
   <div>
     <oc-button-stub appearance="raw" class="edit-public-link-role-dropdown-toggle oc-text-left" disabled="false" gapsize="none" id="edit-public-link-role-dropdown-toggle-undefined" justifycontent="center" size="medium" submit="button" type="button" variation="passive">
       <span class="link-current-role">Viewer</span>
@@ -99,7 +99,7 @@ exports[`DetailsAndEdit component if user can edit renders dropdown and edit but
 `;
 
 exports[`DetailsAndEdit component if user can not edit does not render dropdown or edit button 1`] = `
-<div class="link-details oc-flex oc-flex-between oc-flex-middle oc-pl-s">
+<div class="link-details oc-flex oc-flex-between oc-flex-middle oc-pl-s" file="undefined">
   <p class="oc-my-rm">
     <span class="link-current-role">Viewer</span>
   </p>

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/SpaceMembers.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/SpaceMembers.spec.ts
@@ -165,19 +165,16 @@ function getWrapper({
   storeOptions.modules.runtime.modules.spaces.getters.spaceMembers.mockImplementation(
     () => spaceMembers
   )
-  storeOptions.modules.Files.getters.highlightedFile.mockImplementation(() => space)
   const store = createStore(storeOptions)
   return mountType(SpaceMembers, {
-    props: {
-      space
-    },
     global: {
       plugins: [...defaultPlugins(), store],
       mocks: defaultComponentMocks({
         currentRoute: mock<RouteLocation>({ name: currentRouteName })
       }),
       provide: {
-        displayedItem: space
+        space,
+        resource: space
       },
       stubs: {
         OcButton: false,

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/FileShares.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/FileShares.spec.ts.snap
@@ -12,7 +12,7 @@ exports[`FileShares collaborators list correctly passes the shared parent route 
   </div>
   <ul aria-label="Share receivers" class="oc-list oc-list-divider oc-overflow-hidden oc-m-rm" id="files-collaborators-list">
     <li>
-      <collaborator-list-item-stub modifiable="false" share="[object Object]" sharedparentroute="[object Object]"></collaborator-list-item-stub>
+      <collaborator-list-item-stub modifiable="false" share="[object Object]"></collaborator-list-item-stub>
     </li>
   </ul>
   <!--v-if-->

--- a/packages/web-app-files/tests/unit/components/SideBar/SideBar.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/SideBar.spec.ts
@@ -4,7 +4,6 @@ import {
   createLocationSpaces,
   createLocationTrash
 } from '../../../../src/router'
-import InnerSideBar from 'web-pkg/src/components/sideBar/SideBar.vue'
 import SideBar from 'web-app-files/src/components/SideBar/SideBar.vue'
 import { Resource } from 'web-client/src/helpers'
 import { mock, mockDeep } from 'jest-mock-extended'
@@ -28,10 +27,52 @@ jest.mock('web-app-files/src/helpers/resources', () => {
 
 const selectors = {
   noSelectionInfoPanel: 'no-selection-stub',
+  fileInfoStub: 'file-info-stub',
+  spaceInfoStub: 'space-info-stub',
   tagsPanel: '#sidebar-panel-tags'
 }
 
 describe('SideBar', () => {
+  describe('file info header', () => {
+    it('should show when one resource selected', async () => {
+      const item = mock<Resource>({ path: '/someFolder' })
+      const { wrapper } = createWrapper({ item })
+      wrapper.vm.loadedResource = item
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find(selectors.fileInfoStub).exists()).toBeTruthy()
+    })
+    it('not show when no resource selected', () => {
+      const { wrapper } = createWrapper()
+      expect(wrapper.find(selectors.fileInfoStub).exists()).toBeFalsy()
+    })
+    it('should not show when selected resource is a project space', async () => {
+      const item = mock<Resource>({ path: '/someFolder', driveType: 'project' })
+      const { wrapper } = createWrapper({ item })
+      wrapper.vm.loadedResource = item
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find(selectors.fileInfoStub).exists()).toBeFalsy()
+    })
+  })
+  describe('space info header', () => {
+    it('should show when one project space resource selected', async () => {
+      const item = mock<Resource>({ path: '/someFolder', driveType: 'project' })
+      const { wrapper } = createWrapper({ item })
+      wrapper.vm.loadedResource = item
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find(selectors.spaceInfoStub).exists()).toBeTruthy()
+    })
+    it('not show when no resource selected', () => {
+      const { wrapper } = createWrapper()
+      expect(wrapper.find(selectors.spaceInfoStub).exists()).toBeFalsy()
+    })
+    it('should not show when selected resource is not a project space', async () => {
+      const item = mock<Resource>({ path: '/someFolder' })
+      const { wrapper } = createWrapper({ item })
+      wrapper.vm.loadedResource = item
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find(selectors.spaceInfoStub).exists()).toBeFalsy()
+    })
+  })
   describe('no selection info panel', () => {
     afterEach(() => {
       jest.clearAllMocks()
@@ -55,6 +96,7 @@ describe('SideBar', () => {
       ])('%s', async (name, { path, noSelectionExpected }) => {
         const item = mockDeep<Resource>({ path })
         const { wrapper } = createWrapper({ item })
+        wrapper.vm.loadedResource = item
         await wrapper.vm.$nextTick()
         expect(wrapper.find(selectors.noSelectionInfoPanel).exists()).toBe(noSelectionExpected)
       })
@@ -78,38 +120,49 @@ describe('SideBar', () => {
       ])('%s', async (name, { path, noSelectionExpected }) => {
         const item = mockDeep<Resource>({ path })
         const { wrapper } = createWrapper({ item })
+        wrapper.vm.loadedResource = item
         await wrapper.vm.$nextTick()
         expect(wrapper.find(selectors.noSelectionInfoPanel).exists()).toBe(noSelectionExpected)
       })
     })
   })
   describe('tags panel', () => {
-    it('shows when enabled via capabilities and possible on the resource', () => {
+    it('shows when enabled via capabilities and possible on the resource', async () => {
       const item = mockDeep<Resource>({ path: '/someFolder', canEditTags: () => true })
       const { wrapper } = createWrapper({ item })
+      wrapper.vm.loadedResource = item
+      await wrapper.vm.$nextTick()
       expect(wrapper.find(selectors.tagsPanel).exists()).toBe(true)
     })
-    it('does not show when disabled via capabilities', () => {
+    it('does not show when disabled via capabilities', async () => {
       const item = mockDeep<Resource>({ path: '/someFolder', canEditTags: () => true })
       const { wrapper } = createWrapper({ item, tagsEnabled: false })
+      wrapper.vm.loadedResource = item
+      await wrapper.vm.$nextTick()
       expect(wrapper.find(selectors.tagsPanel).exists()).toBe(false)
     })
-    it('does not show for root folders', () => {
+    it('does not show for root folders', async () => {
       const item = mockDeep<Resource>({ path: '/', canEditTags: () => true })
       const { wrapper } = createWrapper({ item })
+      wrapper.vm.loadedResource = item
+      await wrapper.vm.$nextTick()
       expect(wrapper.find(selectors.tagsPanel).exists()).toBe(false)
     })
-    it('does not show when not possible on the resource', () => {
+    it('does not show when not possible on the resource', async () => {
       const item = mockDeep<Resource>({ path: '/someFolder', canEditTags: () => false })
       const { wrapper } = createWrapper({ item })
+      wrapper.vm.loadedResource = item
+      await wrapper.vm.$nextTick()
       expect(wrapper.find(selectors.tagsPanel).exists()).toBe(false)
     })
     it.each([
       createLocationTrash('files-trash-generic'),
       createLocationPublic('files-public-link')
-    ])('does not show on trash and public routes', (currentRoute) => {
+    ])('does not show on trash and public routes', async (currentRoute) => {
       const item = mockDeep<Resource>({ path: '/someFolder', canEditTags: () => true })
       const { wrapper } = createWrapper({ item, currentRoute })
+      wrapper.vm.loadedResource = item
+      await wrapper.vm.$nextTick()
       expect(wrapper.find(selectors.tagsPanel).exists()).toBe(false)
     })
   })
@@ -151,10 +204,7 @@ function createWrapper({
         plugins: [...defaultPlugins(), store],
         renderStubDefaultSlot: true,
         stubs: {
-          SideBar: InnerSideBar
-        },
-        directives: {
-          'click-outside': jest.fn()
+          InnerSideBar: false
         },
         mocks: {
           ...defaultComponentMocks({ currentRoute: mock<RouteLocation>(currentRoute as any) })

--- a/packages/web-app-files/tests/unit/components/SideBar/TagsPanel.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/TagsPanel.spec.ts
@@ -121,7 +121,7 @@ describe('Tags Panel', () => {
   })
 })
 
-function createWrapper(testResource, graphMock = mockDeep<Graph>()) {
+function createWrapper(resource, graphMock = mockDeep<Graph>()) {
   jest.spyOn(clientService, 'graphAuthenticated').mockImplementation(() => graphMock)
   return {
     wrapper: mount(TagsPanel, {
@@ -129,9 +129,7 @@ function createWrapper(testResource, graphMock = mockDeep<Graph>()) {
         plugins: [...defaultPlugins(), createStore(defaultStoreMockOptions)],
         mocks: { ...defaultComponentMocks(), $clientService: clientService },
         stubs: defaultStubs,
-        provide: {
-          displayedItem: testResource
-        }
+        provide: { resource }
       }
     })
   }

--- a/packages/web-pkg/src/components/sideBar/Spaces/SpaceInfo.vue
+++ b/packages/web-pkg/src/components/sideBar/Spaces/SpaceInfo.vue
@@ -4,28 +4,27 @@
       <div class="oc-mr-s">
         <oc-icon
           name="layout-grid"
-          :size="spaceResource.description ? 'large' : 'medium'"
+          :size="resource.description ? 'large' : 'medium'"
           class="oc-display-block"
         />
       </div>
       <div>
-        <h3 data-testid="space-info-name" v-text="spaceResource.name" />
-        <span data-testid="space-info-subtitle" v-text="spaceResource.description" />
+        <h3 data-testid="space-info-name" v-text="resource.name" />
+        <span data-testid="space-info-subtitle" v-text="resource.description" />
       </div>
     </div>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from 'vue'
-import { SpaceResource } from 'web-client'
+import { defineComponent, inject } from 'vue'
+import { Resource } from 'web-client'
 
 export default defineComponent({
   name: 'SpaceInfo',
-  props: {
-    spaceResource: {
-      type: Object as PropType<SpaceResource>,
-      required: false
+  setup() {
+    return {
+      resource: inject<Resource>('resource')
     }
   }
 })

--- a/packages/web-pkg/src/composables/capability/useCapability.ts
+++ b/packages/web-pkg/src/composables/capability/useCapability.ts
@@ -53,6 +53,10 @@ export const useCapabilityFilesTusExtension = createCapabilityComposable<string>
   ''
 )
 export const useCapabilityFilesTags = createCapabilityComposable('files.tags', false)
+export const useCapabilityPrivateLinks = createCapabilityComposable<boolean>(
+  'files.privateLinks',
+  false
+)
 export const useCapabilityFilesSharingCanDenyAccess = createCapabilityComposable(
   'files_sharing.deny_access',
   false

--- a/packages/web-pkg/tests/unit/components/sidebar/Spaces/Details/SpaceDetails.spec.ts
+++ b/packages/web-pkg/tests/unit/components/sidebar/Spaces/Details/SpaceDetails.spec.ts
@@ -49,8 +49,11 @@ describe('Details SideBar Panel', () => {
     const { wrapper } = createWrapper({ props: { showSpaceImage: false } })
     expect(wrapper.find(selectors.spaceDefaultImage).exists()).toBeTruthy()
   })
-  it('does not render the space members count if spaceResource is given', () => {
-    const { wrapper } = createWrapper({ props: { spaceResource: spaceMock } })
+  it('does not render share indicators if "showShareIndicators" is false', () => {
+    const { wrapper } = createWrapper({
+      spaceResource: spaceMock,
+      props: { showShareIndicators: false }
+    })
     expect(wrapper.find(selectors.spaceMembers).exists()).toBeFalsy()
   })
 })
@@ -61,7 +64,6 @@ function createWrapper({ spaceResource = spaceMock, props = {} } = {}) {
   storeOptions.modules.runtime.modules.spaces.getters.spaceMembers.mockImplementation(() => [
     spaceShare
   ])
-  storeOptions.modules.Files.getters.highlightedFile.mockImplementation(() => spaceResource)
   storeOptions.modules.Files.getters.currentFileOutgoingCollaborators.mockImplementation(() => [
     spaceShare
   ])
@@ -71,12 +73,7 @@ function createWrapper({ spaceResource = spaceMock, props = {} } = {}) {
       props: { ...props },
       global: {
         plugins: [...defaultPlugins(), store],
-        directives: {
-          OcTooltip: jest.fn()
-        },
-        provide: {
-          displayedItem: spaceResource
-        }
+        provide: { resource: spaceResource }
       }
     })
   }

--- a/packages/web-pkg/tests/unit/components/sidebar/Spaces/SpaceInfo.spec.ts
+++ b/packages/web-pkg/tests/unit/components/sidebar/Spaces/SpaceInfo.spec.ts
@@ -28,9 +28,9 @@ describe('SpaceInfo', () => {
 function createWrapper(spaceResource) {
   return {
     wrapper: shallowMount(SpaceInfo, {
-      props: { spaceResource },
       global: {
-        plugins: [...defaultPlugins()]
+        plugins: [...defaultPlugins()],
+        provide: { resource: spaceResource }
       }
     })
   }


### PR DESCRIPTION
## Description

* `Sidebar.vue` now provides `resource` and `space`:
  * `resource` is the fully loaded resource which should be used by all panels and underlying components.
  * `space` is the space we're currently in.
* I reworked the resource loading a bit as well. It still feels complicated, but I don't know how to simplify it more.
  * Each panel that needs `resource` is now disabled until the `resource` is fully loaded, so we guarantee that prop is always available when needed.
  * The sidebar is in a loading state as long as `currentFolder` is not set (except when being in the root of a space)

We could move all this parts to `setup()`, but first I want to know if this approach makes sense. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
