### PR TITLE
fix: edit panel for users who never logged in

### DIFF
--- a/changelog/unreleased/bugfix-edit-user-empty-drive
+++ b/changelog/unreleased/bugfix-edit-user-empty-drive
@@ -1,0 +1,5 @@
+Bugfix: Editing users who never logged in
+
+We've fixed a bug where the Edit panel for users who never logged in failed to load (happened due to a recent backend change).
+
+https://github.com/owncloud/web/pull/8326

--- a/packages/web-app-admin-settings/src/components/Users/SideBar/EditPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Users/SideBar/EditPanel.vue
@@ -141,7 +141,7 @@ export default defineComponent({
         .includes(false)
     },
     showQuota() {
-      return this.editUser.drive
+      return this.editUser.drive?.quota
     },
     compareSaveDialogOriginalObject() {
       return cloneDeep({ ...this.user, passwordProfile: { password: '' } })


### PR DESCRIPTION
## Description
Made edit panel more resilient. As of today, the backend sends an empty drive object for users who never logged in.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
