### PR TITLE
fix: space member loading if a user or group was deleted

### DIFF
--- a/changelog/unreleased/bugfix-space-members-panel-deleted-members
+++ b/changelog/unreleased/bugfix-space-members-panel-deleted-members
@@ -1,0 +1,6 @@
+Bugfix: Show space members despite deleted entries
+
+The space members panel in the right sidebar was not showing any members anymore if one of the members was deleted. This has been fixed and now shows the remaining members.
+
+https://github.com/owncloud/web/issues/8148
+https://github.com/owncloud/web/pull/8336

--- a/packages/web-runtime/src/store/spaces.ts
+++ b/packages/web-runtime/src/store/spaces.ts
@@ -137,7 +137,7 @@ const actions = {
     context.commit('CLEAR_PROJECT_SPACES')
     context.commit('ADD_SPACES', spaces)
   },
-  loadSpaceMembers(
+  async loadSpaceMembers(
     context,
     { graphClient, space }: { graphClient: Ref<Graph>; space: SpaceResource }
   ) {
@@ -168,9 +168,8 @@ const actions = {
       }
     }
 
-    return Promise.all(promises).then(() => {
-      context.commit('SET_SPACE_MEMBERS', sortSpaceMembers(spaceShares))
-    })
+    await Promise.allSettled(promises)
+    context.commit('SET_SPACE_MEMBERS', sortSpaceMembers(spaceShares))
   },
   async addSpaceMember(
     context,


### PR DESCRIPTION
## Description
Loading space members died entirely when one of the members was deleted before. This has been fixed by ignoring the errors on the `getUser` request for deleted users or groups (still appears in the browser console).

## Related Issue
- Fixes https://github.com/owncloud/web/issues/8148

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
