### PR TITLE
fix: group shares by file_source instead of file_target

### DIFF
--- a/packages/web-app-files/src/helpers/resources.ts
+++ b/packages/web-app-files/src/helpers/resources.ts
@@ -64,7 +64,7 @@ export function aggregateResourceShares(
   }
   if (incomingShares) {
     shares = addSharedWithToShares(shares)
-    return orderBy(shares, ['file_target', 'permissions'], ['asc', 'desc']).map((share) => {
+    return orderBy(shares, ['file_source', 'permissions'], ['asc', 'desc']).map((share) => {
       const resource = buildSharedResource(
         share,
         incomingShares,


### PR DESCRIPTION
## Description
This PR has no user facing value, hence the absence of a changelog item.

Grouping shares bei `file_source` instead of `file_target` would've had a visible effect back when we still had public links and user/group-shares in the same "Shared with others" view. That would've grouped the public links and user/group-shares on the same resource together. But as we don't show them together anymore there is no visible effect.

Technically it's still the correct thing to do, so let's fix it and close one issue. 😁 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/6518

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
