### PR TITLE
Fix cancelling custom permissions

### DIFF
--- a/changelog/unreleased/bugfix-cancel-custom-permissions
+++ b/changelog/unreleased/bugfix-cancel-custom-permissions
@@ -1,0 +1,6 @@
+Bugfix: Cancel custom permissions
+
+We've fixed a bug where cancelling the custom permissions on a share would remove all permissions.
+
+https://github.com/owncloud/web/pull/8340
+https://github.com/owncloud/web/issues/8335

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/RoleDropdown.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/RoleDropdown.spec.ts.snap
@@ -1,28 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RoleDropdown for file shares custom permissions inherits the parents share's permissions: 17 1`] = `
+exports[`RoleDropdown renders a button with existing role if given for resource type file 1`] = `
 <span class="oc-flex oc-flex-middle">
-  <oc-button-stub appearance="raw" class="files-recipient-role-select-btn" gap-size="none" id="files-collaborators-role-button-new">
+  <oc-button-stub appearance="raw" class="files-recipient-role-select-btn" disabled="false" gapsize="none" id="files-collaborators-role-button-new" justifycontent="center" size="medium" submit="button" type="button" variation="passive">
     <span>Viewer</span>
-    <oc-icon-stub name="arrow-down-s"></oc-icon-stub>
+    <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="arrow-down-s" size="medium" type="span" variation="passive"></oc-icon-stub>
   </oc-button-stub>
-  <oc-drop-stub class="files-recipient-role-drop" closeonclick="true" dropid="oc-drop-13" isnested="false" mode="click" offset="0" paddingsize="small" position="bottom-start" toggle="#files-collaborators-role-button-new">
+  <oc-drop-stub class="files-recipient-role-drop" closeonclick="true" dropid="oc-drop-7" isnested="false" mode="click" offset="0" paddingsize="small" position="bottom-start" toggle="#files-collaborators-role-button-new">
     <oc-list-stub aria-label="Select role for the invitation" class="files-recipient-role-drop-list" raw="false">
       <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s oc-background-primary-gradient selected" id="files-recipient-role-drop-btn-viewer" justify-content="space-between" variation="inverse">
+        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s oc-background-primary-gradient selected" disabled="false" gapsize="medium" id="files-recipient-role-drop-btn-viewer" justifycontent="space-between" size="medium" submit="button" type="button" variation="inverse">
           <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="eye"></oc-icon-stub>
+            <oc-icon-stub accessiblelabel="" class="oc-pl-s oc-pr-m" color="" filltype="fill" name="eye" size="medium" type="span" variation="passive"></oc-icon-stub>
             <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
           </span>
           <span class="oc-flex">
-            <oc-icon-stub name="check"></oc-icon-stub>
+            <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="check" size="medium" type="span" variation="passive"></oc-icon-stub>
           </span>
         </oc-button-stub>
       </li>
       <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" id="files-recipient-role-drop-btn-editor" justify-content="space-between" variation="passive">
+        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" disabled="false" gapsize="medium" id="files-recipient-role-drop-btn-editor" justifycontent="space-between" size="medium" submit="button" type="button" variation="passive">
           <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="pencil"></oc-icon-stub>
+            <oc-icon-stub accessiblelabel="" class="oc-pl-s oc-pr-m" color="" filltype="fill" name="pencil" size="medium" type="span" variation="passive"></oc-icon-stub>
             <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
           </span>
           <span class="oc-flex">
@@ -31,9 +31,9 @@ exports[`RoleDropdown for file shares custom permissions inherits the parents sh
         </oc-button-stub>
       </li>
       <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" id="files-recipient-role-drop-btn-custom" justify-content="space-between" variation="passive">
+        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" disabled="false" gapsize="medium" id="files-recipient-role-drop-btn-custom" justifycontent="space-between" size="medium" submit="button" type="button" variation="passive">
           <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="settings-3"></oc-icon-stub>
+            <oc-icon-stub accessiblelabel="" class="oc-pl-s oc-pr-m" color="" filltype="fill" name="settings-3" size="medium" type="span" variation="passive"></oc-icon-stub>
             <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
           </span>
           <span class="oc-flex">
@@ -43,7 +43,7 @@ exports[`RoleDropdown for file shares custom permissions inherits the parents sh
       </li>
     </oc-list-stub>
   </oc-drop-stub>
-  <oc-drop-stub class="files-recipient-custom-permissions-drop" closeonclick="false" dropid="oc-drop-14" isnested="false" mode="manual" paddingsize="remove" position="bottom-start" target="#files-collaborators-role-button-new" toggle="">
+  <oc-drop-stub class="files-recipient-custom-permissions-drop" closeonclick="false" dropid="oc-drop-8" isnested="false" mode="manual" paddingsize="remove" position="bottom-start" target="#files-collaborators-role-button-new" toggle="">
     <h4 class="oc-text-bold oc-m-rm oc-px-m oc-pt-m oc-pb-s">Custom permissions</h4>
     <oc-list-stub raw="false">
       <li class="oc-my-s oc-px-m">
@@ -63,36 +63,36 @@ exports[`RoleDropdown for file shares custom permissions inherits the parents sh
       </li>
     </oc-list-stub>
     <div class="files-recipient-custom-permissions-drop-cancel-confirm-btns oc-px-m oc-py-s oc-mt-m oc-rounded-bottom">
-      <oc-button-stub size="small">Cancel</oc-button-stub>
-      <oc-button-stub appearance="filled" class="oc-ml-s" size="small" variation="primary">Apply</oc-button-stub>
+      <oc-button-stub appearance="outline" class="files-recipient-custom-permissions-drop-cancel" disabled="false" gapsize="medium" justifycontent="center" size="small" submit="button" type="button" variation="passive">Cancel</oc-button-stub>
+      <oc-button-stub appearance="filled" class="files-recipient-custom-permissions-drop-confirm oc-ml-s" disabled="false" gapsize="medium" justifycontent="center" size="small" submit="button" type="button" variation="primary">Apply</oc-button-stub>
     </div>
   </oc-drop-stub>
 </span>
 `;
 
-exports[`RoleDropdown for file shares custom permissions inherits the parents share's permissions: 23 1`] = `
+exports[`RoleDropdown renders a button with existing role if given for resource type folder 1`] = `
 <span class="oc-flex oc-flex-middle">
-  <oc-button-stub appearance="raw" class="files-recipient-role-select-btn" gap-size="none" id="files-collaborators-role-button-new">
+  <oc-button-stub appearance="raw" class="files-recipient-role-select-btn" disabled="false" gapsize="none" id="files-collaborators-role-button-new" justifycontent="center" size="medium" submit="button" type="button" variation="passive">
     <span>Viewer</span>
-    <oc-icon-stub name="arrow-down-s"></oc-icon-stub>
+    <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="arrow-down-s" size="medium" type="span" variation="passive"></oc-icon-stub>
   </oc-button-stub>
-  <oc-drop-stub class="files-recipient-role-drop" closeonclick="true" dropid="oc-drop-15" isnested="false" mode="click" offset="0" paddingsize="small" position="bottom-start" toggle="#files-collaborators-role-button-new">
+  <oc-drop-stub class="files-recipient-role-drop" closeonclick="true" dropid="oc-drop-5" isnested="false" mode="click" offset="0" paddingsize="small" position="bottom-start" toggle="#files-collaborators-role-button-new">
     <oc-list-stub aria-label="Select role for the invitation" class="files-recipient-role-drop-list" raw="false">
       <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s oc-background-primary-gradient selected" id="files-recipient-role-drop-btn-viewer" justify-content="space-between" variation="inverse">
+        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s oc-background-primary-gradient selected" disabled="false" gapsize="medium" id="files-recipient-role-drop-btn-viewer" justifycontent="space-between" size="medium" submit="button" type="button" variation="inverse">
           <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="eye"></oc-icon-stub>
+            <oc-icon-stub accessiblelabel="" class="oc-pl-s oc-pr-m" color="" filltype="fill" name="eye" size="medium" type="span" variation="passive"></oc-icon-stub>
             <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
           </span>
           <span class="oc-flex">
-            <oc-icon-stub name="check"></oc-icon-stub>
+            <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="check" size="medium" type="span" variation="passive"></oc-icon-stub>
           </span>
         </oc-button-stub>
       </li>
       <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" id="files-recipient-role-drop-btn-editor" justify-content="space-between" variation="passive">
+        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" disabled="false" gapsize="medium" id="files-recipient-role-drop-btn-editor" justifycontent="space-between" size="medium" submit="button" type="button" variation="passive">
           <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="pencil"></oc-icon-stub>
+            <oc-icon-stub accessiblelabel="" class="oc-pl-s oc-pr-m" color="" filltype="fill" name="pencil" size="medium" type="span" variation="passive"></oc-icon-stub>
             <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
           </span>
           <span class="oc-flex">
@@ -101,9 +101,9 @@ exports[`RoleDropdown for file shares custom permissions inherits the parents sh
         </oc-button-stub>
       </li>
       <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" id="files-recipient-role-drop-btn-custom" justify-content="space-between" variation="passive">
+        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" disabled="false" gapsize="medium" id="files-recipient-role-drop-btn-custom" justifycontent="space-between" size="medium" submit="button" type="button" variation="passive">
           <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="settings-3"></oc-icon-stub>
+            <oc-icon-stub accessiblelabel="" class="oc-pl-s oc-pr-m" color="" filltype="fill" name="settings-3" size="medium" type="span" variation="passive"></oc-icon-stub>
             <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
           </span>
           <span class="oc-flex">
@@ -113,7 +113,7 @@ exports[`RoleDropdown for file shares custom permissions inherits the parents sh
       </li>
     </oc-list-stub>
   </oc-drop-stub>
-  <oc-drop-stub class="files-recipient-custom-permissions-drop" closeonclick="false" dropid="oc-drop-16" isnested="false" mode="manual" paddingsize="remove" position="bottom-start" target="#files-collaborators-role-button-new" toggle="">
+  <oc-drop-stub class="files-recipient-custom-permissions-drop" closeonclick="false" dropid="oc-drop-6" isnested="false" mode="manual" paddingsize="remove" position="bottom-start" target="#files-collaborators-role-button-new" toggle="">
     <h4 class="oc-text-bold oc-m-rm oc-px-m oc-pt-m oc-pb-s">Custom permissions</h4>
     <oc-list-stub raw="false">
       <li class="oc-my-s oc-px-m">
@@ -133,316 +133,36 @@ exports[`RoleDropdown for file shares custom permissions inherits the parents sh
       </li>
     </oc-list-stub>
     <div class="files-recipient-custom-permissions-drop-cancel-confirm-btns oc-px-m oc-py-s oc-mt-m oc-rounded-bottom">
-      <oc-button-stub size="small">Cancel</oc-button-stub>
-      <oc-button-stub appearance="filled" class="oc-ml-s" size="small" variation="primary">Apply</oc-button-stub>
+      <oc-button-stub appearance="outline" class="files-recipient-custom-permissions-drop-cancel" disabled="false" gapsize="medium" justifycontent="center" size="small" submit="button" type="button" variation="passive">Cancel</oc-button-stub>
+      <oc-button-stub appearance="filled" class="files-recipient-custom-permissions-drop-confirm oc-ml-s" disabled="false" gapsize="medium" justifycontent="center" size="small" submit="button" type="button" variation="primary">Apply</oc-button-stub>
     </div>
   </oc-drop-stub>
 </span>
 `;
 
-exports[`RoleDropdown for file shares custom permissions inherits the parents share's permissions: 25 1`] = `
+exports[`RoleDropdown renders a button with invite text if no existing role given for resource type file 1`] = `
 <span class="oc-flex oc-flex-middle">
-  <oc-button-stub appearance="raw" class="files-recipient-role-select-btn" gap-size="none" id="files-collaborators-role-button-new">
-    <span>Viewer</span>
-    <oc-icon-stub name="arrow-down-s"></oc-icon-stub>
-  </oc-button-stub>
-  <oc-drop-stub class="files-recipient-role-drop" closeonclick="true" dropid="oc-drop-17" isnested="false" mode="click" offset="0" paddingsize="small" position="bottom-start" toggle="#files-collaborators-role-button-new">
-    <oc-list-stub aria-label="Select role for the invitation" class="files-recipient-role-drop-list" raw="false">
-      <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s oc-background-primary-gradient selected" id="files-recipient-role-drop-btn-viewer" justify-content="space-between" variation="inverse">
-          <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="eye"></oc-icon-stub>
-            <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
-          </span>
-          <span class="oc-flex">
-            <oc-icon-stub name="check"></oc-icon-stub>
-          </span>
-        </oc-button-stub>
-      </li>
-      <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" id="files-recipient-role-drop-btn-editor" justify-content="space-between" variation="passive">
-          <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="pencil"></oc-icon-stub>
-            <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
-          </span>
-          <span class="oc-flex">
-            <!--v-if-->
-          </span>
-        </oc-button-stub>
-      </li>
-      <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" id="files-recipient-role-drop-btn-custom" justify-content="space-between" variation="passive">
-          <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="settings-3"></oc-icon-stub>
-            <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
-          </span>
-          <span class="oc-flex">
-            <!--v-if-->
-          </span>
-        </oc-button-stub>
-      </li>
-    </oc-list-stub>
-  </oc-drop-stub>
-  <oc-drop-stub class="files-recipient-custom-permissions-drop" closeonclick="false" dropid="oc-drop-18" isnested="false" mode="manual" paddingsize="remove" position="bottom-start" target="#files-collaborators-role-button-new" toggle="">
-    <h4 class="oc-text-bold oc-m-rm oc-px-m oc-pt-m oc-pb-s">Custom permissions</h4>
-    <oc-list-stub raw="false">
-      <li class="oc-my-s oc-px-m">
-        <oc-checkbox-stub class="oc-mr-xs files-collaborators-permission-checkbox" disabled="true" hidelabel="false" id="files-collaborators-permission-read" label="Read" modelvalue="[object Object],[object Object]" option="[object Object]" outline="false" size="large"></oc-checkbox-stub>
-      </li>
-      <li class="oc-my-s oc-px-m">
-        <oc-checkbox-stub class="oc-mr-xs files-collaborators-permission-checkbox" disabled="false" hidelabel="false" id="files-collaborators-permission-update" label="Edit" modelvalue="[object Object],[object Object]" option="[object Object]" outline="false" size="large"></oc-checkbox-stub>
-      </li>
-      <li class="oc-my-s oc-px-m">
-        <oc-checkbox-stub class="oc-mr-xs files-collaborators-permission-checkbox" disabled="false" hidelabel="false" id="files-collaborators-permission-create" label="Create" modelvalue="[object Object],[object Object]" option="[object Object]" outline="false" size="large"></oc-checkbox-stub>
-      </li>
-      <li class="oc-my-s oc-px-m">
-        <oc-checkbox-stub class="oc-mr-xs files-collaborators-permission-checkbox" disabled="false" hidelabel="false" id="files-collaborators-permission-delete" label="Delete" modelvalue="[object Object],[object Object]" option="[object Object]" outline="false" size="large"></oc-checkbox-stub>
-      </li>
-      <li class="oc-my-s oc-px-m">
-        <oc-checkbox-stub class="oc-mr-xs files-collaborators-permission-checkbox" disabled="false" hidelabel="false" id="files-collaborators-permission-share" label="Share" modelvalue="[object Object],[object Object]" option="[object Object]" outline="false" size="large"></oc-checkbox-stub>
-      </li>
-    </oc-list-stub>
-    <div class="files-recipient-custom-permissions-drop-cancel-confirm-btns oc-px-m oc-py-s oc-mt-m oc-rounded-bottom">
-      <oc-button-stub size="small">Cancel</oc-button-stub>
-      <oc-button-stub appearance="filled" class="oc-ml-s" size="small" variation="primary">Apply</oc-button-stub>
-    </div>
-  </oc-drop-stub>
-</span>
-`;
-
-exports[`RoleDropdown for file shares when an existing role is present does not render a button if only one role is available 1`] = `
-<span class="oc-flex oc-flex-middle">
-  <oc-button-stub appearance="raw" class="files-recipient-role-select-btn" gap-size="none" id="files-collaborators-role-button-new">
-    <span>Viewer</span>
-    <oc-icon-stub name="arrow-down-s"></oc-icon-stub>
-  </oc-button-stub>
-  <oc-drop-stub class="files-recipient-role-drop" closeonclick="true" dropid="oc-drop-23" isnested="false" mode="click" offset="0" paddingsize="small" position="bottom-start" toggle="#files-collaborators-role-button-new">
-    <oc-list-stub aria-label="Select role for the invitation" class="files-recipient-role-drop-list" raw="false">
-      <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s oc-background-primary-gradient selected" id="files-recipient-role-drop-btn-viewer" justify-content="space-between" variation="inverse">
-          <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="eye"></oc-icon-stub>
-            <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
-          </span>
-          <span class="oc-flex">
-            <oc-icon-stub name="check"></oc-icon-stub>
-          </span>
-        </oc-button-stub>
-      </li>
-      <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" id="files-recipient-role-drop-btn-editor" justify-content="space-between" variation="passive">
-          <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="pencil"></oc-icon-stub>
-            <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
-          </span>
-          <span class="oc-flex">
-            <!--v-if-->
-          </span>
-        </oc-button-stub>
-      </li>
-      <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" id="files-recipient-role-drop-btn-custom" justify-content="space-between" variation="passive">
-          <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="settings-3"></oc-icon-stub>
-            <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
-          </span>
-          <span class="oc-flex">
-            <!--v-if-->
-          </span>
-        </oc-button-stub>
-      </li>
-    </oc-list-stub>
-  </oc-drop-stub>
-  <oc-drop-stub class="files-recipient-custom-permissions-drop" closeonclick="false" dropid="oc-drop-24" isnested="false" mode="manual" paddingsize="remove" position="bottom-start" target="#files-collaborators-role-button-new" toggle="">
-    <h4 class="oc-text-bold oc-m-rm oc-px-m oc-pt-m oc-pb-s">Custom permissions</h4>
-    <oc-list-stub raw="false">
-      <li class="oc-my-s oc-px-m">
-        <oc-checkbox-stub class="oc-mr-xs files-collaborators-permission-checkbox" disabled="true" hidelabel="false" id="files-collaborators-permission-read" label="Read" modelvalue="[object Object],[object Object]" option="[object Object]" outline="false" size="large"></oc-checkbox-stub>
-      </li>
-      <li class="oc-my-s oc-px-m">
-        <oc-checkbox-stub class="oc-mr-xs files-collaborators-permission-checkbox" disabled="false" hidelabel="false" id="files-collaborators-permission-update" label="Edit" modelvalue="[object Object],[object Object]" option="[object Object]" outline="false" size="large"></oc-checkbox-stub>
-      </li>
-      <li class="oc-my-s oc-px-m">
-        <oc-checkbox-stub class="oc-mr-xs files-collaborators-permission-checkbox" disabled="false" hidelabel="false" id="files-collaborators-permission-create" label="Create" modelvalue="[object Object],[object Object]" option="[object Object]" outline="false" size="large"></oc-checkbox-stub>
-      </li>
-      <li class="oc-my-s oc-px-m">
-        <oc-checkbox-stub class="oc-mr-xs files-collaborators-permission-checkbox" disabled="false" hidelabel="false" id="files-collaborators-permission-delete" label="Delete" modelvalue="[object Object],[object Object]" option="[object Object]" outline="false" size="large"></oc-checkbox-stub>
-      </li>
-      <li class="oc-my-s oc-px-m">
-        <oc-checkbox-stub class="oc-mr-xs files-collaborators-permission-checkbox" disabled="false" hidelabel="false" id="files-collaborators-permission-share" label="Share" modelvalue="[object Object],[object Object]" option="[object Object]" outline="false" size="large"></oc-checkbox-stub>
-      </li>
-    </oc-list-stub>
-    <div class="files-recipient-custom-permissions-drop-cancel-confirm-btns oc-px-m oc-py-s oc-mt-m oc-rounded-bottom">
-      <oc-button-stub size="small">Cancel</oc-button-stub>
-      <oc-button-stub appearance="filled" class="oc-ml-s" size="small" variation="primary">Apply</oc-button-stub>
-    </div>
-  </oc-drop-stub>
-</span>
-`;
-
-exports[`RoleDropdown for file shares when an existing role is present renders a button with existing role if given for resource type file 1`] = `
-<span class="oc-flex oc-flex-middle">
-  <oc-button-stub appearance="raw" class="files-recipient-role-select-btn" gap-size="none" id="files-collaborators-role-button-new">
-    <span>Viewer</span>
-    <oc-icon-stub name="arrow-down-s"></oc-icon-stub>
-  </oc-button-stub>
-  <oc-drop-stub class="files-recipient-role-drop" closeonclick="true" dropid="oc-drop-21" isnested="false" mode="click" offset="0" paddingsize="small" position="bottom-start" toggle="#files-collaborators-role-button-new">
-    <oc-list-stub aria-label="Select role for the invitation" class="files-recipient-role-drop-list" raw="false">
-      <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s oc-background-primary-gradient selected" id="files-recipient-role-drop-btn-viewer" justify-content="space-between" variation="inverse">
-          <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="eye"></oc-icon-stub>
-            <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
-          </span>
-          <span class="oc-flex">
-            <oc-icon-stub name="check"></oc-icon-stub>
-          </span>
-        </oc-button-stub>
-      </li>
-      <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" id="files-recipient-role-drop-btn-editor" justify-content="space-between" variation="passive">
-          <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="pencil"></oc-icon-stub>
-            <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
-          </span>
-          <span class="oc-flex">
-            <!--v-if-->
-          </span>
-        </oc-button-stub>
-      </li>
-      <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" id="files-recipient-role-drop-btn-custom" justify-content="space-between" variation="passive">
-          <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="settings-3"></oc-icon-stub>
-            <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
-          </span>
-          <span class="oc-flex">
-            <!--v-if-->
-          </span>
-        </oc-button-stub>
-      </li>
-    </oc-list-stub>
-  </oc-drop-stub>
-  <oc-drop-stub class="files-recipient-custom-permissions-drop" closeonclick="false" dropid="oc-drop-22" isnested="false" mode="manual" paddingsize="remove" position="bottom-start" target="#files-collaborators-role-button-new" toggle="">
-    <h4 class="oc-text-bold oc-m-rm oc-px-m oc-pt-m oc-pb-s">Custom permissions</h4>
-    <oc-list-stub raw="false">
-      <li class="oc-my-s oc-px-m">
-        <oc-checkbox-stub class="oc-mr-xs files-collaborators-permission-checkbox" disabled="true" hidelabel="false" id="files-collaborators-permission-read" label="Read" modelvalue="[object Object],[object Object]" option="[object Object]" outline="false" size="large"></oc-checkbox-stub>
-      </li>
-      <li class="oc-my-s oc-px-m">
-        <oc-checkbox-stub class="oc-mr-xs files-collaborators-permission-checkbox" disabled="false" hidelabel="false" id="files-collaborators-permission-update" label="Edit" modelvalue="[object Object],[object Object]" option="[object Object]" outline="false" size="large"></oc-checkbox-stub>
-      </li>
-      <li class="oc-my-s oc-px-m">
-        <oc-checkbox-stub class="oc-mr-xs files-collaborators-permission-checkbox" disabled="false" hidelabel="false" id="files-collaborators-permission-create" label="Create" modelvalue="[object Object],[object Object]" option="[object Object]" outline="false" size="large"></oc-checkbox-stub>
-      </li>
-      <li class="oc-my-s oc-px-m">
-        <oc-checkbox-stub class="oc-mr-xs files-collaborators-permission-checkbox" disabled="false" hidelabel="false" id="files-collaborators-permission-delete" label="Delete" modelvalue="[object Object],[object Object]" option="[object Object]" outline="false" size="large"></oc-checkbox-stub>
-      </li>
-      <li class="oc-my-s oc-px-m">
-        <oc-checkbox-stub class="oc-mr-xs files-collaborators-permission-checkbox" disabled="false" hidelabel="false" id="files-collaborators-permission-share" label="Share" modelvalue="[object Object],[object Object]" option="[object Object]" outline="false" size="large"></oc-checkbox-stub>
-      </li>
-    </oc-list-stub>
-    <div class="files-recipient-custom-permissions-drop-cancel-confirm-btns oc-px-m oc-py-s oc-mt-m oc-rounded-bottom">
-      <oc-button-stub size="small">Cancel</oc-button-stub>
-      <oc-button-stub appearance="filled" class="oc-ml-s" size="small" variation="primary">Apply</oc-button-stub>
-    </div>
-  </oc-drop-stub>
-</span>
-`;
-
-exports[`RoleDropdown for file shares when an existing role is present renders a button with existing role if given for resource type folder 1`] = `
-<span class="oc-flex oc-flex-middle">
-  <oc-button-stub appearance="raw" class="files-recipient-role-select-btn" gap-size="none" id="files-collaborators-role-button-new">
-    <span>Viewer</span>
-    <oc-icon-stub name="arrow-down-s"></oc-icon-stub>
-  </oc-button-stub>
-  <oc-drop-stub class="files-recipient-role-drop" closeonclick="true" dropid="oc-drop-19" isnested="false" mode="click" offset="0" paddingsize="small" position="bottom-start" toggle="#files-collaborators-role-button-new">
-    <oc-list-stub aria-label="Select role for the invitation" class="files-recipient-role-drop-list" raw="false">
-      <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s oc-background-primary-gradient selected" id="files-recipient-role-drop-btn-viewer" justify-content="space-between" variation="inverse">
-          <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="eye"></oc-icon-stub>
-            <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
-          </span>
-          <span class="oc-flex">
-            <oc-icon-stub name="check"></oc-icon-stub>
-          </span>
-        </oc-button-stub>
-      </li>
-      <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" id="files-recipient-role-drop-btn-editor" justify-content="space-between" variation="passive">
-          <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="pencil"></oc-icon-stub>
-            <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
-          </span>
-          <span class="oc-flex">
-            <!--v-if-->
-          </span>
-        </oc-button-stub>
-      </li>
-      <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" id="files-recipient-role-drop-btn-custom" justify-content="space-between" variation="passive">
-          <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="settings-3"></oc-icon-stub>
-            <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
-          </span>
-          <span class="oc-flex">
-            <!--v-if-->
-          </span>
-        </oc-button-stub>
-      </li>
-    </oc-list-stub>
-  </oc-drop-stub>
-  <oc-drop-stub class="files-recipient-custom-permissions-drop" closeonclick="false" dropid="oc-drop-20" isnested="false" mode="manual" paddingsize="remove" position="bottom-start" target="#files-collaborators-role-button-new" toggle="">
-    <h4 class="oc-text-bold oc-m-rm oc-px-m oc-pt-m oc-pb-s">Custom permissions</h4>
-    <oc-list-stub raw="false">
-      <li class="oc-my-s oc-px-m">
-        <oc-checkbox-stub class="oc-mr-xs files-collaborators-permission-checkbox" disabled="true" hidelabel="false" id="files-collaborators-permission-read" label="Read" modelvalue="[object Object],[object Object]" option="[object Object]" outline="false" size="large"></oc-checkbox-stub>
-      </li>
-      <li class="oc-my-s oc-px-m">
-        <oc-checkbox-stub class="oc-mr-xs files-collaborators-permission-checkbox" disabled="false" hidelabel="false" id="files-collaborators-permission-update" label="Edit" modelvalue="[object Object],[object Object]" option="[object Object]" outline="false" size="large"></oc-checkbox-stub>
-      </li>
-      <li class="oc-my-s oc-px-m">
-        <oc-checkbox-stub class="oc-mr-xs files-collaborators-permission-checkbox" disabled="false" hidelabel="false" id="files-collaborators-permission-create" label="Create" modelvalue="[object Object],[object Object]" option="[object Object]" outline="false" size="large"></oc-checkbox-stub>
-      </li>
-      <li class="oc-my-s oc-px-m">
-        <oc-checkbox-stub class="oc-mr-xs files-collaborators-permission-checkbox" disabled="false" hidelabel="false" id="files-collaborators-permission-delete" label="Delete" modelvalue="[object Object],[object Object]" option="[object Object]" outline="false" size="large"></oc-checkbox-stub>
-      </li>
-      <li class="oc-my-s oc-px-m">
-        <oc-checkbox-stub class="oc-mr-xs files-collaborators-permission-checkbox" disabled="false" hidelabel="false" id="files-collaborators-permission-share" label="Share" modelvalue="[object Object],[object Object]" option="[object Object]" outline="false" size="large"></oc-checkbox-stub>
-      </li>
-    </oc-list-stub>
-    <div class="files-recipient-custom-permissions-drop-cancel-confirm-btns oc-px-m oc-py-s oc-mt-m oc-rounded-bottom">
-      <oc-button-stub size="small">Cancel</oc-button-stub>
-      <oc-button-stub appearance="filled" class="oc-ml-s" size="small" variation="primary">Apply</oc-button-stub>
-    </div>
-  </oc-drop-stub>
-</span>
-`;
-
-exports[`RoleDropdown for file shares when no existing role is present renders a button with invite text if no existing role given for resource type file 1`] = `
-<span class="oc-flex oc-flex-middle">
-  <oc-button-stub appearance="raw" class="files-recipient-role-select-btn" gap-size="none" id="files-collaborators-role-button-new">
+  <oc-button-stub appearance="raw" class="files-recipient-role-select-btn" disabled="false" gapsize="none" id="files-collaborators-role-button-new" justifycontent="center" size="medium" submit="button" type="button" variation="passive">
     <span>Invite as viewer</span>
-    <oc-icon-stub name="arrow-down-s"></oc-icon-stub>
+    <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="arrow-down-s" size="medium" type="span" variation="passive"></oc-icon-stub>
   </oc-button-stub>
   <oc-drop-stub class="files-recipient-role-drop" closeonclick="true" dropid="oc-drop-3" isnested="false" mode="click" offset="0" paddingsize="small" position="bottom-start" toggle="#files-collaborators-role-button-new">
     <oc-list-stub aria-label="Select role for the invitation" class="files-recipient-role-drop-list" raw="false">
       <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s oc-background-primary-gradient selected" id="files-recipient-role-drop-btn-viewer" justify-content="space-between" variation="inverse">
+        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s oc-background-primary-gradient selected" disabled="false" gapsize="medium" id="files-recipient-role-drop-btn-viewer" justifycontent="space-between" size="medium" submit="button" type="button" variation="inverse">
           <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="eye"></oc-icon-stub>
+            <oc-icon-stub accessiblelabel="" class="oc-pl-s oc-pr-m" color="" filltype="fill" name="eye" size="medium" type="span" variation="passive"></oc-icon-stub>
             <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
           </span>
           <span class="oc-flex">
-            <oc-icon-stub name="check"></oc-icon-stub>
+            <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="check" size="medium" type="span" variation="passive"></oc-icon-stub>
           </span>
         </oc-button-stub>
       </li>
       <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" id="files-recipient-role-drop-btn-editor" justify-content="space-between" variation="passive">
+        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" disabled="false" gapsize="medium" id="files-recipient-role-drop-btn-editor" justifycontent="space-between" size="medium" submit="button" type="button" variation="passive">
           <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="pencil"></oc-icon-stub>
+            <oc-icon-stub accessiblelabel="" class="oc-pl-s oc-pr-m" color="" filltype="fill" name="pencil" size="medium" type="span" variation="passive"></oc-icon-stub>
             <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
           </span>
           <span class="oc-flex">
@@ -451,9 +171,9 @@ exports[`RoleDropdown for file shares when no existing role is present renders a
         </oc-button-stub>
       </li>
       <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" id="files-recipient-role-drop-btn-custom" justify-content="space-between" variation="passive">
+        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" disabled="false" gapsize="medium" id="files-recipient-role-drop-btn-custom" justifycontent="space-between" size="medium" submit="button" type="button" variation="passive">
           <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="settings-3"></oc-icon-stub>
+            <oc-icon-stub accessiblelabel="" class="oc-pl-s oc-pr-m" color="" filltype="fill" name="settings-3" size="medium" type="span" variation="passive"></oc-icon-stub>
             <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
           </span>
           <span class="oc-flex">
@@ -477,36 +197,36 @@ exports[`RoleDropdown for file shares when no existing role is present renders a
       </li>
     </oc-list-stub>
     <div class="files-recipient-custom-permissions-drop-cancel-confirm-btns oc-px-m oc-py-s oc-mt-m oc-rounded-bottom">
-      <oc-button-stub size="small">Cancel</oc-button-stub>
-      <oc-button-stub appearance="filled" class="oc-ml-s" size="small" variation="primary">Apply</oc-button-stub>
+      <oc-button-stub appearance="outline" class="files-recipient-custom-permissions-drop-cancel" disabled="false" gapsize="medium" justifycontent="center" size="small" submit="button" type="button" variation="passive">Cancel</oc-button-stub>
+      <oc-button-stub appearance="filled" class="files-recipient-custom-permissions-drop-confirm oc-ml-s" disabled="false" gapsize="medium" justifycontent="center" size="small" submit="button" type="button" variation="primary">Apply</oc-button-stub>
     </div>
   </oc-drop-stub>
 </span>
 `;
 
-exports[`RoleDropdown for file shares when no existing role is present renders a button with invite text if no existing role given for resource type folder 1`] = `
+exports[`RoleDropdown renders a button with invite text if no existing role given for resource type folder 1`] = `
 <span class="oc-flex oc-flex-middle">
-  <oc-button-stub appearance="raw" class="files-recipient-role-select-btn" gap-size="none" id="files-collaborators-role-button-new">
+  <oc-button-stub appearance="raw" class="files-recipient-role-select-btn" disabled="false" gapsize="none" id="files-collaborators-role-button-new" justifycontent="center" size="medium" submit="button" type="button" variation="passive">
     <span>Invite as viewer</span>
-    <oc-icon-stub name="arrow-down-s"></oc-icon-stub>
+    <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="arrow-down-s" size="medium" type="span" variation="passive"></oc-icon-stub>
   </oc-button-stub>
   <oc-drop-stub class="files-recipient-role-drop" closeonclick="true" dropid="oc-drop-1" isnested="false" mode="click" offset="0" paddingsize="small" position="bottom-start" toggle="#files-collaborators-role-button-new">
     <oc-list-stub aria-label="Select role for the invitation" class="files-recipient-role-drop-list" raw="false">
       <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s oc-background-primary-gradient selected" id="files-recipient-role-drop-btn-viewer" justify-content="space-between" variation="inverse">
+        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s oc-background-primary-gradient selected" disabled="false" gapsize="medium" id="files-recipient-role-drop-btn-viewer" justifycontent="space-between" size="medium" submit="button" type="button" variation="inverse">
           <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="eye"></oc-icon-stub>
+            <oc-icon-stub accessiblelabel="" class="oc-pl-s oc-pr-m" color="" filltype="fill" name="eye" size="medium" type="span" variation="passive"></oc-icon-stub>
             <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
           </span>
           <span class="oc-flex">
-            <oc-icon-stub name="check"></oc-icon-stub>
+            <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="check" size="medium" type="span" variation="passive"></oc-icon-stub>
           </span>
         </oc-button-stub>
       </li>
       <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" id="files-recipient-role-drop-btn-editor" justify-content="space-between" variation="passive">
+        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" disabled="false" gapsize="medium" id="files-recipient-role-drop-btn-editor" justifycontent="space-between" size="medium" submit="button" type="button" variation="passive">
           <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="pencil"></oc-icon-stub>
+            <oc-icon-stub accessiblelabel="" class="oc-pl-s oc-pr-m" color="" filltype="fill" name="pencil" size="medium" type="span" variation="passive"></oc-icon-stub>
             <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
           </span>
           <span class="oc-flex">
@@ -515,9 +235,9 @@ exports[`RoleDropdown for file shares when no existing role is present renders a
         </oc-button-stub>
       </li>
       <li>
-        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" id="files-recipient-role-drop-btn-custom" justify-content="space-between" variation="passive">
+        <oc-button-stub appearance="raw" class="files-recipient-role-drop-btn oc-p-s" disabled="false" gapsize="medium" id="files-recipient-role-drop-btn-custom" justifycontent="space-between" size="medium" submit="button" type="button" variation="passive">
           <span class="oc-flex oc-flex-middle">
-            <oc-icon-stub class="oc-pl-s oc-pr-m" name="settings-3"></oc-icon-stub>
+            <oc-icon-stub accessiblelabel="" class="oc-pl-s oc-pr-m" color="" filltype="fill" name="settings-3" size="medium" type="span" variation="passive"></oc-icon-stub>
             <role-item-stub allowsharepermission="true" role="[object Object]"></role-item-stub>
           </span>
           <span class="oc-flex">
@@ -547,8 +267,8 @@ exports[`RoleDropdown for file shares when no existing role is present renders a
       </li>
     </oc-list-stub>
     <div class="files-recipient-custom-permissions-drop-cancel-confirm-btns oc-px-m oc-py-s oc-mt-m oc-rounded-bottom">
-      <oc-button-stub size="small">Cancel</oc-button-stub>
-      <oc-button-stub appearance="filled" class="oc-ml-s" size="small" variation="primary">Apply</oc-button-stub>
+      <oc-button-stub appearance="outline" class="files-recipient-custom-permissions-drop-cancel" disabled="false" gapsize="medium" justifycontent="center" size="small" submit="button" type="button" variation="passive">Cancel</oc-button-stub>
+      <oc-button-stub appearance="filled" class="files-recipient-custom-permissions-drop-confirm oc-ml-s" disabled="false" gapsize="medium" justifycontent="center" size="small" submit="button" type="button" variation="primary">Apply</oc-button-stub>
     </div>
   </oc-drop-stub>
 </span>


### PR DESCRIPTION
## Description
We've fixed a bug where cancelling the custom permissions on a share would remove all permissions.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8335

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
