### PR TITLE
[tests-only][full-ci]Expand kinder garden feature to delete serveral `objects/resources` 

### DIFF
--- a/tests/e2e/cucumber/features/journeys/kindergarten.oc10.feature
+++ b/tests/e2e/cucumber/features/journeys/kindergarten.oc10.feature
@@ -94,6 +94,29 @@ Feature: Kindergarten can use web to organize a day
       | Pre-Schools Pirates | groups                               | folder |
       | Teddy Bear Daycare  | groups                               | folder |
       | groups              |                                      | folder |
+    And "Alice" deletes the following resources using the batch action
+      | resource            | from                                 |
+      | lorem.txt           | groups/Kindergarten Koalas/meal plan |
+      | lorem-big.txt       | groups/Kindergarten Koalas/meal plan |
+      | data.zip            | groups/Pre-Schools Pirates/meal plan |
+      | lorem.txt           | groups/Pre-Schools Pirates/meal plan |
+      | lorem-big.txt       | groups/Pre-Schools Pirates/meal plan |
+      | data.zip            | groups/Teddy Bear Daycare/meal plan  |
+      | lorem.txt           | groups/Teddy Bear Daycare/meal plan  |
+      | lorem-big.txt       | groups/Teddy Bear Daycare/meal plan  |
+    And "Alice" deletes the following resources using the sidebar panel
+      | resource            | from                                 |
+      | meal plan           | groups/Kindergarten Koalas           |
+      | meal plan           | groups/Pre-Schools Pirates           |
+      | meal plan           | groups/Teddy Bear Daycare            |
+    And "Alice" deletes the following resources using the batch action
+      | resource            | from                                 |
+      | Kindergarten Koalas | groups                               |
+      | Pre-Schools Pirates | groups                               |
+      | Teddy Bear Daycare  | groups                               |
+    And "Alice" deletes the following resources using the sidebar panel
+      | resource            | from                                 |
+      | groups              |                                      |
     # Then what do we check for to be confident that the above things done by Alice have worked?
     # Then the downloaded files should have content "abc..."
     And "Alice" logs out

--- a/tests/e2e/cucumber/features/journeys/kindergarten.oc10.feature
+++ b/tests/e2e/cucumber/features/journeys/kindergarten.oc10.feature
@@ -104,19 +104,9 @@ Feature: Kindergarten can use web to organize a day
       | data.zip            | groups/Teddy Bear Daycare/meal plan  |
       | lorem.txt           | groups/Teddy Bear Daycare/meal plan  |
       | lorem-big.txt       | groups/Teddy Bear Daycare/meal plan  |
-    And "Alice" deletes the following resources using the sidebar panel
-      | resource            | from                                 |
-      | meal plan           | groups/Kindergarten Koalas           |
-      | meal plan           | groups/Pre-Schools Pirates           |
-      | meal plan           | groups/Teddy Bear Daycare            |
-    And "Alice" deletes the following resources using the batch action
-      | resource            | from                                 |
       | Kindergarten Koalas | groups                               |
       | Pre-Schools Pirates | groups                               |
       | Teddy Bear Daycare  | groups                               |
-    And "Alice" deletes the following resources using the sidebar panel
-      | resource            | from                                 |
-      | groups              |                                      |
     # Then what do we check for to be confident that the above things done by Alice have worked?
     # Then the downloaded files should have content "abc..."
     And "Alice" logs out

--- a/tests/e2e/cucumber/features/journeys/kindergarten.ocis.feature
+++ b/tests/e2e/cucumber/features/journeys/kindergarten.ocis.feature
@@ -91,6 +91,29 @@ Feature: Kindergarten can use web to organize a day
       | Pre-Schools Pirates | groups                               | folder |
       | Teddy Bear Daycare  | groups                               | folder |
       | groups              |                                      | folder |
+    And "Alice" deletes the following resources using the batch action
+      | resource            | from                                 |
+      | lorem.txt           | groups/Kindergarten Koalas/meal plan |
+      | lorem-big.txt       | groups/Kindergarten Koalas/meal plan |
+      | data.zip            | groups/Pre-Schools Pirates/meal plan |
+      | lorem.txt           | groups/Pre-Schools Pirates/meal plan |
+      | lorem-big.txt       | groups/Pre-Schools Pirates/meal plan |
+      | data.zip            | groups/Teddy Bear Daycare/meal plan  |
+      | lorem.txt           | groups/Teddy Bear Daycare/meal plan  |
+      | lorem-big.txt       | groups/Teddy Bear Daycare/meal plan  |
+    And "Alice" deletes the following resources using the sidebar panel
+      | resource            | from                                 |
+      | meal plan           | groups/Kindergarten Koalas           |
+      | meal plan           | groups/Pre-Schools Pirates           |
+      | meal plan           | groups/Teddy Bear Daycare            |
+    And "Alice" deletes the following resources using the batch action
+      | resource            | from                                 |
+      | Kindergarten Koalas | groups                               |
+      | Pre-Schools Pirates | groups                               |
+      | Teddy Bear Daycare  | groups                               |
+    And "Alice" deletes the following resources using the sidebar panel
+      | resource            | from                                 |
+      | groups              |                                      |
     # Then what do we check for to be confident that the above things done by Alice have worked?
     # Then the downloaded files should have content "abc..."
     And "Alice" logs out

--- a/tests/e2e/cucumber/features/journeys/kindergarten.ocis.feature
+++ b/tests/e2e/cucumber/features/journeys/kindergarten.ocis.feature
@@ -101,19 +101,9 @@ Feature: Kindergarten can use web to organize a day
       | data.zip            | groups/Teddy Bear Daycare/meal plan  |
       | lorem.txt           | groups/Teddy Bear Daycare/meal plan  |
       | lorem-big.txt       | groups/Teddy Bear Daycare/meal plan  |
-    And "Alice" deletes the following resources using the sidebar panel
-      | resource            | from                                 |
-      | meal plan           | groups/Kindergarten Koalas           |
-      | meal plan           | groups/Pre-Schools Pirates           |
-      | meal plan           | groups/Teddy Bear Daycare            |
-    And "Alice" deletes the following resources using the batch action
-      | resource            | from                                 |
       | Kindergarten Koalas | groups                               |
       | Pre-Schools Pirates | groups                               |
       | Teddy Bear Daycare  | groups                               |
-    And "Alice" deletes the following resources using the sidebar panel
-      | resource            | from                                 |
-      | groups              |                                      |
     # Then what do we check for to be confident that the above things done by Alice have worked?
     # Then the downloaded files should have content "abc..."
     And "Alice" logs out

--- a/tests/e2e/cucumber/features/smoke/share.oc10.feature
+++ b/tests/e2e/cucumber/features/smoke/share.oc10.feature
@@ -44,9 +44,9 @@ Feature: share
     And "Brian" copies the following resource using dropdown-menu
       | resource                | to       |
       | Shares/folder_to_shared | Personal |
-    When "Brian" deletes the following resources
-      | resource                                    |
-      | Shares/folder_to_customShared/lorem-big.txt |
+    When "Brian" deletes the following resources using the sidebar panel
+      | resource      | from                          |
+      | lorem-big.txt | Shares/folder_to_customShared |
     When "Alice" opens the "files" app
     #Then "Alice" should see the following resources
     #  | folder_to_shared/lorem_new.txt |
@@ -62,10 +62,10 @@ Feature: share
       | resource   | to                      | version |
       | simple.pdf | Shares/folder_to_shared | 1       |
     #Then "Brian" should see that the version of resource "simple.pdf" has been restored
-    When "Alice" deletes the following resources
-      | resource                       |
-      | folder_to_shared/lorem_new.txt |
-      | folder_to_shared               |
+    When "Alice" deletes the following resources using the sidebar panel
+      | resource         | from             |
+      | lorem_new.txt    | folder_to_shared |
+      | folder_to_shared |                  |
     And "Alice" logs out
     #And "Brian" opens the "files" app
     #Then "Brian" should not see the following resource

--- a/tests/e2e/cucumber/features/smoke/share.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/share.ocis.feature
@@ -48,9 +48,9 @@ Feature: share
       | resource        | to                     |
       | simple.pdf      | folder_to_shared       |
       | testavatar.jpeg | folder_to_customShared |
-    And "Brian" deletes the following resources
-      | resource                             |
-      | folder_to_customShared/lorem-big.txt |
+    When "Brian" deletes the following resources using the sidebar panel
+      | resource      | from                   |
+      | lorem-big.txt | folder_to_customShared |
     And "Alice" opens the "files" app
     And "Alice" uploads the following resource
       | resource          | to               | option  |
@@ -64,10 +64,10 @@ Feature: share
     And "Alice" removes following sharee
       | resource               | recipient |
       | folder_to_customShared | Brian     |
-    And "Alice" deletes the following resources
-      | resource                       |
-      | folder_to_shared/lorem_new.txt |
-      | folder_to_shared               |
+    When "Alice" deletes the following resources using the sidebar panel
+      | resource         | from             |
+      | lorem_new.txt    | folder_to_shared |
+      | folder_to_shared |                  |
     And "Alice" logs out
     Then "Brian" should not be able to see the following shares
       | resource               | owner        |

--- a/tests/e2e/cucumber/features/smoke/spaces/participantManagement.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/spaces/participantManagement.ocis.feature
@@ -44,9 +44,9 @@ Feature: spaces participant management
     And "Anonymous" deletes the following resources from public link
       | resource  |
       | lorem.txt |
-    And "Brian" deletes the following resources
-      | resource            |
-      | parent/textfile.txt |
+    When "Brian" deletes the following resources using the sidebar panel
+      | resource     | from   |
+      | textfile.txt | parent |
     And "Anonymous" logs out
     When "Carol" navigates to the trashbin of the project space "team.1"
     Then "Carol" should not be able to delete following resources from the trashbin

--- a/tests/e2e/cucumber/features/smoke/spaces/participantManagement.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/spaces/participantManagement.ocis.feature
@@ -41,9 +41,9 @@ Feature: spaces participant management
     And "Anonymous" uploads the following resources in public link page
       | resource     |
       | textfile.txt |
-    And "Anonymous" deletes the following resources from public link
-      | resource  |
-      | lorem.txt |
+    And "Anonymous" deletes the following resources from public link using sidebar panel
+      | resource  | from |
+      | lorem.txt |      |
     When "Brian" deletes the following resources using the sidebar panel
       | resource     | from   |
       | textfile.txt | parent |

--- a/tests/e2e/cucumber/features/smoke/spaces/project.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/spaces/project.ocis.feature
@@ -110,10 +110,10 @@ Feature: spaces.personal
     When "Brian" restores following resources
       | resource   | to               | version |
       | simple.pdf | folder_to_shared | 1       |
-    When "Alice" deletes the following resources
-      | resource                       |
-      | folder_to_shared/lorem_new.txt |
-      | folder_to_shared               |
+    When "Alice" deletes the following resources using the sidebar panel
+      | resource         | from             |
+      | lorem_new.txt    | folder_to_shared |
+      | folder_to_shared |                  |
     And "Brian" logs out
 
     # alice is done

--- a/tests/e2e/cucumber/steps/ui/public.ts
+++ b/tests/e2e/cucumber/steps/ui/public.ts
@@ -4,7 +4,7 @@ import { kebabCase } from 'lodash'
 import { DateTime } from 'luxon'
 import { World } from '../../environment'
 import { objects } from '../../../support'
-import { processDownload } from './resources'
+import { processDelete, processDownload } from './resources'
 import { linkStore } from '../../../support/store'
 
 When(
@@ -128,12 +128,15 @@ Then(
 )
 
 When(
-  '{string} deletes the following resources from public link',
-  async function (this: World, stepUser: string, stepTable: DataTable): Promise<void> {
+  /^"([^"]*)" deletes the following resources from public link using (sidebar panel| batch action)$/,
+  async function (
+    this: World,
+    stepUser: string,
+    actionType: string,
+    stepTable: DataTable
+  ): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const pageObject = new objects.applicationFiles.page.Public({ page })
-    for (const info of stepTable.hashes()) {
-      await pageObject.delete({ resource: info.resource })
-    }
+    await processDelete(stepTable, pageObject, actionType)
   }
 )

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -280,7 +280,7 @@ export const processDelete = async (stepTable: DataTable, pageObject: any, actio
     parentFolder = folder !== 'undefined' ? folder : null
     await pageObject.delete({
       folder: parentFolder,
-      resources: files,
+      resourcesWithInfo: files,
       via: actionType === 'batch action' ? 'BATCH_ACTION' : 'SIDEBAR_PANEL'
     })
   }

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -144,18 +144,6 @@ When(
 )
 
 When(
-  '{string} deletes the following resource(s)',
-  async function (this: World, stepUser: string, stepTable: DataTable) {
-    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
-    const resourceObject = new objects.applicationFiles.Resource({ page })
-
-    for (const info of stepTable.hashes()) {
-      await resourceObject.delete({ resource: info.resource })
-    }
-  }
-)
-
-When(
   '{string} downloads old version of the following resource(s)',
   async function (this: World, stepUser: string, stepTable: DataTable): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -56,30 +56,9 @@ When(
     actionType: string,
     stepTable: DataTable
   ) {
-    let files, parentFolder
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const resourceObject = new objects.applicationFiles.Resource({ page })
-    const deleteInfo = stepTable.hashes().reduce((acc, stepRow) => {
-      const { resource, from } = stepRow
-      const resourceInfo = {
-        name: resource
-      }
-      if (!acc[from]) {
-        acc[from] = []
-      }
-      acc[from].push(resourceInfo)
-      return acc
-    }, {})
-
-    for (const folder of Object.keys(deleteInfo)) {
-      files = deleteInfo[folder]
-      parentFolder = folder !== 'undefined' ? folder : null
-      await resourceObject.deleteWithOption({
-        folder: parentFolder,
-        resources: files,
-        via: actionType === 'batch action' ? 'BATCH_ACTION' : 'SIDEBAR_PANEL'
-      })
-    }
+    await processDelete(stepTable, resourceObject, actionType)
   }
 )
 
@@ -281,6 +260,31 @@ When(
     await resourceObject.showHiddenFiles()
   }
 )
+
+export const processDelete = async (stepTable: DataTable, pageObject: any, actionType: string) => {
+  let files, parentFolder
+  const deleteInfo = stepTable.hashes().reduce((acc, stepRow) => {
+    const { resource, from } = stepRow
+    const resourceInfo = {
+      name: resource
+    }
+    if (!acc[from]) {
+      acc[from] = []
+    }
+    acc[from].push(resourceInfo)
+    return acc
+  }, {})
+
+  for (const folder of Object.keys(deleteInfo)) {
+    files = deleteInfo[folder]
+    parentFolder = folder !== 'undefined' ? folder : null
+    await pageObject.delete({
+      folder: parentFolder,
+      resources: files,
+      via: actionType === 'batch action' ? 'BATCH_ACTION' : 'SIDEBAR_PANEL'
+    })
+  }
+}
 
 export const processDownload = async (
   stepTable: DataTable,

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -48,6 +48,42 @@ When(
 )
 
 When(
+    /^"([^"]*)" deletes the following resource(s)? using the (sidebar panel|batch action)$/,
+    async function (
+        this: World,
+        stepUser: string,
+        _: string,
+        actionType: string,
+        stepTable: DataTable
+    ) {
+        let files, parentFolder
+        const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+        const resourceObject = new objects.applicationFiles.Resource({ page })
+        const deleteInfo = stepTable.hashes().reduce((acc, stepRow) => {
+            const { resource, from } = stepRow
+            const resourceInfo = {
+                name: resource
+            }
+            if (!acc[from]) {
+                acc[from] = []
+            }
+            acc[from].push(resourceInfo)
+            return acc
+        }, {})
+
+        for (const folder of Object.keys(deleteInfo)) {
+            files = deleteInfo[folder]
+            parentFolder = folder !== 'undefined' ? folder : null
+            await resourceObject.deleteWithOption({
+                folder: parentFolder,
+                resources: files,
+                via: actionType === 'batch action' ? 'BATCH_ACTION' : 'SIDEBAR_PANEL'
+            })
+        }
+    }
+)
+
+When(
   '{string} renames the following resource(s)',
   async function (this: World, stepUser: string, stepTable: DataTable) {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -48,39 +48,39 @@ When(
 )
 
 When(
-    /^"([^"]*)" deletes the following resource(s)? using the (sidebar panel|batch action)$/,
-    async function (
-        this: World,
-        stepUser: string,
-        _: string,
-        actionType: string,
-        stepTable: DataTable
-    ) {
-        let files, parentFolder
-        const { page } = this.actorsEnvironment.getActor({ key: stepUser })
-        const resourceObject = new objects.applicationFiles.Resource({ page })
-        const deleteInfo = stepTable.hashes().reduce((acc, stepRow) => {
-            const { resource, from } = stepRow
-            const resourceInfo = {
-                name: resource
-            }
-            if (!acc[from]) {
-                acc[from] = []
-            }
-            acc[from].push(resourceInfo)
-            return acc
-        }, {})
+  /^"([^"]*)" deletes the following resource(s)? using the (sidebar panel|batch action)$/,
+  async function (
+    this: World,
+    stepUser: string,
+    _: string,
+    actionType: string,
+    stepTable: DataTable
+  ) {
+    let files, parentFolder
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const resourceObject = new objects.applicationFiles.Resource({ page })
+    const deleteInfo = stepTable.hashes().reduce((acc, stepRow) => {
+      const { resource, from } = stepRow
+      const resourceInfo = {
+        name: resource
+      }
+      if (!acc[from]) {
+        acc[from] = []
+      }
+      acc[from].push(resourceInfo)
+      return acc
+    }, {})
 
-        for (const folder of Object.keys(deleteInfo)) {
-            files = deleteInfo[folder]
-            parentFolder = folder !== 'undefined' ? folder : null
-            await resourceObject.deleteWithOption({
-                folder: parentFolder,
-                resources: files,
-                via: actionType === 'batch action' ? 'BATCH_ACTION' : 'SIDEBAR_PANEL'
-            })
-        }
+    for (const folder of Object.keys(deleteInfo)) {
+      files = deleteInfo[folder]
+      parentFolder = folder !== 'undefined' ? folder : null
+      await resourceObject.deleteWithOption({
+        folder: parentFolder,
+        resources: files,
+        via: actionType === 'batch action' ? 'BATCH_ACTION' : 'SIDEBAR_PANEL'
+      })
     }
+  }
 )
 
 When(

--- a/tests/e2e/support/objects/app-files/page/public.ts
+++ b/tests/e2e/support/objects/app-files/page/public.ts
@@ -3,8 +3,8 @@ import { File } from '../../../types'
 import util from 'util'
 import path from 'path'
 import {
-  deleteResource,
-  deleteResourceArgs,
+  deleteResourceViaOption,
+  deleteResourceViaOptionArgs,
   downloadResources,
   downloadResourcesArgs,
   renameResource,
@@ -72,9 +72,9 @@ export class Public {
     await this.#page.locator('body').click()
   }
 
-  async delete(args: Omit<deleteResourceArgs, 'page'>): Promise<void> {
+  async delete(args: Omit<deleteResourceViaOptionArgs, 'page'>): Promise<void> {
     const startUrl = this.#page.url()
-    await deleteResource({ ...args, page: this.#page })
+    await deleteResourceViaOption({ ...args, page: this.#page })
     await this.#page.goto(startUrl)
   }
 }

--- a/tests/e2e/support/objects/app-files/page/public.ts
+++ b/tests/e2e/support/objects/app-files/page/public.ts
@@ -3,8 +3,8 @@ import { File } from '../../../types'
 import util from 'util'
 import path from 'path'
 import {
-  deleteResourceViaOption,
-  deleteResourceViaOptionArgs,
+  deleteResource,
+  deleteResourceArgs,
   downloadResources,
   downloadResourcesArgs,
   renameResource,
@@ -72,9 +72,9 @@ export class Public {
     await this.#page.locator('body').click()
   }
 
-  async delete(args: Omit<deleteResourceViaOptionArgs, 'page'>): Promise<void> {
+  async delete(args: Omit<deleteResourceArgs, 'page'>): Promise<void> {
     const startUrl = this.#page.url()
-    await deleteResourceViaOption({ ...args, page: this.#page })
+    await deleteResource({ ...args, page: this.#page })
     await this.#page.goto(startUrl)
   }
 }

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -487,16 +487,14 @@ export interface deleteResourceArgs {
   resource: string
 }
 
-export interface deleteResourceWithOptionArgs {
+export interface deleteResourceViaOptionArgs {
   page: Page
   resources: resourceArgs[]
   folder?: string
   via: 'SIDEBAR_PANEL' | 'BATCH_ACTION'
 }
 
-export const deleteResourceWithOption = async (
-  args: deleteResourceWithOptionArgs
-): Promise<void> => {
+export const deleteResourceViaOption = async (args: deleteResourceViaOptionArgs): Promise<void> => {
   const { page, resources, folder, via } = args
   switch (via) {
     case 'SIDEBAR_PANEL': {

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -487,31 +487,6 @@ export interface deleteResourceArgs {
   resource: string
 }
 
-export const deleteResource = async (args: deleteResourceArgs): Promise<void> => {
-  const { page, resource } = args
-  const folderPaths = resource.split('/')
-  const resourceName = folderPaths.pop()
-
-  if (folderPaths.length) {
-    await clickResource({ page, path: folderPaths.join('/') })
-  }
-
-  await sidebar.open({ page, resource: resourceName })
-  await sidebar.openPanel({ page, name: 'actions' })
-
-  await page.locator(deleteButtonSidebar).first().click()
-  await Promise.all([
-    page.waitForResponse(
-      (resp) =>
-        resp.url().includes(encodeURIComponent(resourceName)) &&
-        resp.status() === 204 &&
-        resp.request().method() === 'DELETE'
-    ),
-    page.locator(util.format(actionConfirmationButton, 'Delete')).click()
-  ])
-  await sidebar.close({ page })
-}
-
 export interface deleteResourceWithOptionArgs {
   page: Page
   resources: resourceArgs[]

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -5,7 +5,7 @@ import { resourceExists, waitForResources } from './utils'
 import path from 'path'
 import { File } from '../../../types'
 import { sidebar } from '../utils'
-import {config} from "../../../../config";
+import { config } from '../../../../config'
 
 const downloadFileButtonSideBar =
   '#oc-files-actions-sidebar .oc-files-actions-download-file-trigger'
@@ -512,7 +512,6 @@ export const deleteResource = async (args: deleteResourceArgs): Promise<void> =>
   await sidebar.close({ page })
 }
 
-
 export interface deleteResourceWithOptionArgs {
   page: Page
   resources: resourceArgs[]
@@ -521,7 +520,7 @@ export interface deleteResourceWithOptionArgs {
 }
 
 export const deleteResourceWithOption = async (
-    args: deleteResourceWithOptionArgs
+  args: deleteResourceWithOptionArgs
 ): Promise<void> => {
   const { page, resources, folder, via } = args
   switch (via) {
@@ -535,10 +534,10 @@ export const deleteResourceWithOption = async (
         await page.locator(deleteButtonSidebar).first().click()
         await Promise.all([
           page.waitForResponse(
-              (resp) =>
-                  resp.url().includes(encodeURIComponent(resource.name)) &&
-                  resp.status() === 204 &&
-                  resp.request().method() === 'DELETE'
+            (resp) =>
+              resp.url().includes(encodeURIComponent(resource.name)) &&
+              resp.status() === 204 &&
+              resp.request().method() === 'DELETE'
           ),
           page.locator(util.format(actionConfirmationButton, 'Delete')).click()
         ])
@@ -556,15 +555,15 @@ export const deleteResourceWithOption = async (
       await page.locator(deleteButtonBatchAction).click()
       const deletetedResources = []
       await Promise.all([
-          page.waitForResponse((resp) => {
+        page.waitForResponse((resp) => {
           if (resp.status() === 204 && resp.request().method() === 'DELETE') {
             deletetedResources.push(decodeURIComponent(resp.url().split('/').pop()))
           }
           // waiting for GET response after all the resource are deleted with batch action
           return (
-              resp.url().includes(config.ocis ? 'graph/v1.0/drives' : 'ocs/v1.php/cloud/users') &&
-              resp.status() === 200 &&
-              resp.request().method() === 'GET'
+            resp.url().includes(config.ocis ? 'graph/v1.0/drives' : 'ocs/v1.php/cloud/users') &&
+            resp.status() === 200 &&
+            resp.request().method() === 'GET'
           )
         }),
         page.locator(util.format(actionConfirmationButton, 'Delete')).click()
@@ -578,7 +577,6 @@ export const deleteResourceWithOption = async (
     }
   }
 }
-
 
 export interface downloadResourceVersionArgs {
   page: Page

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -481,27 +481,22 @@ export const restoreResourceVersion = async (args: restoreResourceVersionArgs) =
 }
 
 /**/
-
 export interface deleteResourceArgs {
   page: Page
-  resource: string
-}
-
-export interface deleteResourceViaOptionArgs {
-  page: Page
-  resources: resourceArgs[]
+  resource?: string
+  resourcesWithInfo?: resourceArgs[]
   folder?: string
-  via: 'SIDEBAR_PANEL' | 'BATCH_ACTION'
+  via?: 'SIDEBAR_PANEL' | 'BATCH_ACTION'
 }
 
-export const deleteResourceViaOption = async (args: deleteResourceViaOptionArgs): Promise<void> => {
-  const { page, resources, folder, via } = args
+export const deleteResource = async (args: deleteResourceArgs): Promise<void> => {
+  const { page, resourcesWithInfo, folder, via } = args
   switch (via) {
     case 'SIDEBAR_PANEL': {
       if (folder) {
         await clickResource({ page, path: folder })
       }
-      for (const resource of resources) {
+      for (const resource of resourcesWithInfo) {
         await sidebar.open({ page, resource: resource.name })
         await sidebar.openPanel({ page, name: 'actions' })
         await page.locator(deleteButtonSidebar).first().click()
@@ -520,9 +515,9 @@ export const deleteResourceViaOption = async (args: deleteResourceViaOptionArgs)
     }
 
     case 'BATCH_ACTION': {
-      await selectOrDeselectResources({ page, resources, folder, select: true })
+      await selectOrDeselectResources({ page, resources: resourcesWithInfo, folder, select: true })
       const deletetedResources = []
-      if (resources.length <= 1) {
+      if (resourcesWithInfo.length <= 1) {
         throw new Error('Single resource or objects cannot be deleted with batch action')
       }
 
@@ -542,8 +537,8 @@ export const deleteResourceViaOption = async (args: deleteResourceViaOptionArgs)
         page.locator(util.format(actionConfirmationButton, 'Delete')).click()
       ])
       // assertion that the resources actually got deleted
-      expect(resources.length).toBe(deletetedResources.length)
-      for (const resource of resources) {
+      expect(resourcesWithInfo.length).toBe(deletetedResources.length)
+      for (const resource of resourcesWithInfo) {
         expect(deletetedResources).toContain(resource.name)
       }
       break

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -5,12 +5,14 @@ import { resourceExists, waitForResources } from './utils'
 import path from 'path'
 import { File } from '../../../types'
 import { sidebar } from '../utils'
+import {config} from "../../../../config";
 
 const downloadFileButtonSideBar =
   '#oc-files-actions-sidebar .oc-files-actions-download-file-trigger'
 const downloadFolderButtonSidedBar =
   '#oc-files-actions-sidebar .oc-files-actions-download-archive-trigger'
 const downloadButtonBatchAction = '.oc-files-actions-download-archive-trigger'
+const deleteButtonBatchAction = '.oc-files-actions-delete-trigger'
 const checkBox = `//*[@data-test-resource-name="%s"]//ancestor::tr//input`
 const checkBoxForTrashbin = `//*[@data-test-resource-path="%s"]//ancestor::tr//input`
 export const fileRow = '//ancestor::tr'
@@ -509,6 +511,74 @@ export const deleteResource = async (args: deleteResourceArgs): Promise<void> =>
   ])
   await sidebar.close({ page })
 }
+
+
+export interface deleteResourceWithOptionArgs {
+  page: Page
+  resources: resourceArgs[]
+  folder?: string
+  via: 'SIDEBAR_PANEL' | 'BATCH_ACTION'
+}
+
+export const deleteResourceWithOption = async (
+    args: deleteResourceWithOptionArgs
+): Promise<void> => {
+  const { page, resources, folder, via } = args
+  switch (via) {
+    case 'SIDEBAR_PANEL': {
+      if (folder) {
+        await clickResource({ page, path: folder })
+      }
+      for (const resource of resources) {
+        await sidebar.open({ page, resource: resource.name })
+        await sidebar.openPanel({ page, name: 'actions' })
+        await page.locator(deleteButtonSidebar).first().click()
+        await Promise.all([
+          page.waitForResponse(
+              (resp) =>
+                  resp.url().includes(encodeURIComponent(resource.name)) &&
+                  resp.status() === 204 &&
+                  resp.request().method() === 'DELETE'
+          ),
+          page.locator(util.format(actionConfirmationButton, 'Delete')).click()
+        ])
+        await sidebar.close({ page })
+      }
+      break
+    }
+
+    case 'BATCH_ACTION': {
+      await selectOrDeselectResources({ page, resources, folder, select: true })
+      if (resources.length <= 1) {
+        throw new Error('Single resource or objects cannot be deleted with batch action')
+      }
+
+      await page.locator(deleteButtonBatchAction).click()
+      const deletetedResources = []
+      await Promise.all([
+          page.waitForResponse((resp) => {
+          if (resp.status() === 204 && resp.request().method() === 'DELETE') {
+            deletetedResources.push(decodeURIComponent(resp.url().split('/').pop()))
+          }
+          // waiting for GET response after all the resource are deleted with batch action
+          return (
+              resp.url().includes(config.ocis ? 'graph/v1.0/drives' : 'ocs/v1.php/cloud/users') &&
+              resp.status() === 200 &&
+              resp.request().method() === 'GET'
+          )
+        }),
+        page.locator(util.format(actionConfirmationButton, 'Delete')).click()
+      ])
+      // assertion that the resources actually got deleted
+      expect(resources.length).toBe(deletetedResources.length)
+      for (const resource of resources) {
+        expect(deletetedResources).toContain(resource.name)
+      }
+      break
+    }
+  }
+}
+
 
 export interface downloadResourceVersionArgs {
   page: Page

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -483,10 +483,9 @@ export const restoreResourceVersion = async (args: restoreResourceVersionArgs) =
 /**/
 export interface deleteResourceArgs {
   page: Page
-  resource?: string
-  resourcesWithInfo?: resourceArgs[]
+  resourcesWithInfo: resourceArgs[]
   folder?: string
-  via?: 'SIDEBAR_PANEL' | 'BATCH_ACTION'
+  via: 'SIDEBAR_PANEL' | 'BATCH_ACTION'
 }
 
 export const deleteResource = async (args: deleteResourceArgs): Promise<void> => {
@@ -587,7 +586,12 @@ export const emptyTrashBinResources = async (page): Promise<string> => {
   return message.trim().toLowerCase()
 }
 
-export const deleteResourceTrashbin = async (args: deleteResourceArgs): Promise<string> => {
+export interface deleteResourceTrashbinArgs {
+  page: Page
+  resource: string
+}
+
+export const deleteResourceTrashbin = async (args: deleteResourceTrashbinArgs): Promise<string> => {
   const { page, resource } = args
   const resourceCheckbox = page.locator(
     util.format(checkBoxForTrashbin, `/${resource.replace(/^\/+/, '')}`)
@@ -609,7 +613,7 @@ export const deleteResourceTrashbin = async (args: deleteResourceArgs): Promise<
 }
 
 export const getDeleteResourceButtonVisibility = async (
-  args: deleteResourceArgs
+  args: deleteResourceTrashbinArgs
 ): Promise<boolean> => {
   const { page, resource } = args
   const resourceCheckbox = page.locator(

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -548,12 +548,12 @@ export const deleteResourceWithOption = async (
 
     case 'BATCH_ACTION': {
       await selectOrDeselectResources({ page, resources, folder, select: true })
+      const deletetedResources = []
       if (resources.length <= 1) {
         throw new Error('Single resource or objects cannot be deleted with batch action')
       }
 
       await page.locator(deleteButtonBatchAction).click()
-      const deletetedResources = []
       await Promise.all([
         page.waitForResponse((resp) => {
           if (resp.status() === 204 && resp.request().method() === 'DELETE') {

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -31,7 +31,8 @@ import {
   openFileInViewer,
   openFileInViewerArgs,
   getDeleteResourceButtonVisibility,
-  getRestoreResourceButtonVisibility
+  getRestoreResourceButtonVisibility,
+  deleteResourceTrashbinArgs
 } from './actions'
 
 export class Resource {
@@ -121,14 +122,16 @@ export class Resource {
     return await emptyTrashBinResources(this.#page)
   }
 
-  async deleteTrashBin(args: Omit<deleteResourceArgs, 'page'>): Promise<string> {
+  async deleteTrashBin(args: Omit<deleteResourceTrashbinArgs, 'page'>): Promise<string> {
     const startUrl = this.#page.url()
     const message = await deleteResourceTrashbin({ ...args, page: this.#page })
     await this.#page.goto(startUrl)
     return message
   }
 
-  async isDeleteTrashBinButtonVisible(args: Omit<deleteResourceArgs, 'page'>): Promise<boolean> {
+  async isDeleteTrashBinButtonVisible(
+    args: Omit<deleteResourceTrashbinArgs, 'page'>
+  ): Promise<boolean> {
     return await getDeleteResourceButtonVisibility({ ...args, page: this.#page })
   }
 

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -31,8 +31,8 @@ import {
   openFileInViewerArgs,
   getDeleteResourceButtonVisibility,
   getRestoreResourceButtonVisibility,
-  deleteResourceWithOption,
-  deleteResourceWithOptionArgs
+  deleteResourceViaOption,
+  deleteResourceViaOptionArgs
 } from './actions'
 
 export class Resource {
@@ -93,9 +93,9 @@ export class Resource {
     }
   }
 
-  async deleteWithOption(args: Omit<deleteResourceWithOptionArgs, 'page'>): Promise<void> {
+  async deleteWithOption(args: Omit<deleteResourceViaOptionArgs, 'page'>): Promise<void> {
     const startUrl = this.#page.url()
-    await deleteResourceWithOption({ ...args, page: this.#page })
+    await deleteResourceViaOption({ ...args, page: this.#page })
     await this.#page.goto(startUrl)
   }
 

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -3,7 +3,6 @@ import { Download, Page } from 'playwright'
 import {
   createResources,
   createResourceArgs,
-  deleteResource,
   deleteResourceArgs,
   deleteResourceTrashbin,
   downloadResources,
@@ -92,12 +91,6 @@ export class Resource {
     if (!config.ocis) {
       await this.#page.reload()
     }
-  }
-
-  async delete(args: Omit<deleteResourceArgs, 'page'>): Promise<void> {
-    const startUrl = this.#page.url()
-    await deleteResource({ ...args, page: this.#page })
-    await this.#page.goto(startUrl)
   }
 
   async deleteWithOption(args: Omit<deleteResourceWithOptionArgs, 'page'>): Promise<void> {

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -31,7 +31,9 @@ import {
   openFileInViewer,
   openFileInViewerArgs,
   getDeleteResourceButtonVisibility,
-  getRestoreResourceButtonVisibility
+  getRestoreResourceButtonVisibility,
+  deleteResourceWithOption,
+  deleteResourceWithOptionArgs
 } from './actions'
 
 export class Resource {
@@ -95,6 +97,12 @@ export class Resource {
   async delete(args: Omit<deleteResourceArgs, 'page'>): Promise<void> {
     const startUrl = this.#page.url()
     await deleteResource({ ...args, page: this.#page })
+    await this.#page.goto(startUrl)
+  }
+
+  async deleteWithOption(args: Omit<deleteResourceWithOptionArgs, 'page'>): Promise<void> {
+    const startUrl = this.#page.url()
+    await deleteResourceWithOption({ ...args, page: this.#page })
     await this.#page.goto(startUrl)
   }
 

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -3,6 +3,7 @@ import { Download, Page } from 'playwright'
 import {
   createResources,
   createResourceArgs,
+  deleteResource,
   deleteResourceArgs,
   deleteResourceTrashbin,
   downloadResources,
@@ -30,9 +31,7 @@ import {
   openFileInViewer,
   openFileInViewerArgs,
   getDeleteResourceButtonVisibility,
-  getRestoreResourceButtonVisibility,
-  deleteResourceViaOption,
-  deleteResourceViaOptionArgs
+  getRestoreResourceButtonVisibility
 } from './actions'
 
 export class Resource {
@@ -93,9 +92,9 @@ export class Resource {
     }
   }
 
-  async delete(args: Omit<deleteResourceViaOptionArgs, 'page'>): Promise<void> {
+  async delete(args: Omit<deleteResourceArgs, 'page'>): Promise<void> {
     const startUrl = this.#page.url()
-    await deleteResourceViaOption({ ...args, page: this.#page })
+    await deleteResource({ ...args, page: this.#page })
     await this.#page.goto(startUrl)
   }
 

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -93,7 +93,7 @@ export class Resource {
     }
   }
 
-  async deleteWithOption(args: Omit<deleteResourceViaOptionArgs, 'page'>): Promise<void> {
+  async delete(args: Omit<deleteResourceViaOptionArgs, 'page'>): Promise<void> {
     const startUrl = this.#page.url()
     await deleteResourceViaOption({ ...args, page: this.#page })
     await this.#page.goto(startUrl)


### PR DESCRIPTION
### Description
- This PR expands the kinder garden feature for (`oCIS` and `oc10`) to delete serveral or individual resources.
- This PR also refactors the steps to delete resource to be able to delete the resource(objects) both by batch action and sidebar panel since it was previously only deleted with sidebar panel

### Related Issue
https://github.com/owncloud/web/issues/8101