### PR TITLE
[tests-only][full-ci] Add a e2e test for quick link

### DIFF
--- a/tests/e2e/cucumber/features/smoke/link.feature
+++ b/tests/e2e/cucumber/features/smoke/link.feature
@@ -53,3 +53,24 @@ Feature: link
     And "Anonymous" should not be able to open the old link "myPublicLink"
     And "Anonymous" logs out
     And "Alice" logs out
+
+
+  Scenario: Quick link
+    Given "Admin" creates following users
+      | id    |
+      | Alice |
+    When "Alice" logs in
+    And "Alice" opens the "files" app
+    And "Alice" creates the following resources
+      | resource     | type   |
+      | folderPublic | folder |
+    And "Alice" uploads the following resources
+      | resource  | to           |
+      | lorem.txt | folderPublic |
+    And "Alice" copies quick link of the resource "folderPublic" from the context menu
+    When "Anonymous" opens the public link "Quicklink"
+    And "Anonymous" downloads the following public link resources using the sidebar panel
+      | resource     | type |
+      | lorem.txt    | file |
+    And "Anonymous" logs out
+    And "Alice" logs out

--- a/tests/e2e/support/environment/actor/shared.ts
+++ b/tests/e2e/support/environment/actor/shared.ts
@@ -20,6 +20,7 @@ export interface ActorOptions extends ActorsOptions {
 export const buildBrowserContextOptions = (options: ActorOptions): BrowserContextOptions => {
   const contextOptions: BrowserContextOptions = {
     acceptDownloads: options.context.acceptDownloads,
+    permissions: ['clipboard-read', 'clipboard-write'],
     ignoreHTTPSErrors: true,
     locale: 'en-US'
   }

--- a/tests/e2e/support/objects/app-files/share/actions.ts
+++ b/tests/e2e/support/objects/app-files/share/actions.ts
@@ -187,10 +187,12 @@ export const hasPermissionToShare = async (
   return !(await page.isVisible(noPermissionToShareLabel))
 }
 
-export const copyQuickLink = async (args: copyLinkArgs): Promise<void> => {
+export const copyQuickLink = async (args: copyLinkArgs): Promise<string> => {
   const { page, resource, via } = args
   if (via === 'CONTEXT_MENU') {
     await clickActionInContextMenu({ page, resource }, 'create-quicklink')
+    const url = await page.evaluate(() => navigator.clipboard.readText())
     await waitForPopupNotPresent(page)
+    return url
   }
 }

--- a/tests/e2e/support/objects/app-files/share/index.ts
+++ b/tests/e2e/support/objects/app-files/share/index.ts
@@ -16,6 +16,7 @@ import {
 import { resourceIsNotOpenable, isAcceptedSharePresent } from './utils'
 import { copyLinkArgs } from '../link/actions'
 import { LinksEnvironment } from '../../../environment'
+import { linkStore } from '../../../store'
 
 export class Share {
   #page: Page
@@ -23,7 +24,6 @@ export class Share {
 
   constructor({ page }: { page: Page }) {
     this.#page = page
-    this.#linksEnvironment = new LinksEnvironment()
   }
 
   async create(args: Omit<createShareArgs, 'page'>): Promise<void> {
@@ -70,12 +70,15 @@ export class Share {
   }
 
   async copyQuickLink(args: Omit<copyLinkArgs, 'page'>): Promise<void> {
-    await copyQuickLink({ ...args, page: this.#page })
-    const quickLink = await this.#page.evaluate(() => navigator.clipboard.readText())
-    this.#linksEnvironment.createLink({
-      key: 'Quicklink',
-      link: { name: 'Quicklink', url: quickLink }
-    })
+    this.#linksEnvironment = new LinksEnvironment()
+    const url = await copyQuickLink({ ...args, page: this.#page })
+    const key = 'Quicklink'
+    if (!linkStore.has(key)) {
+      this.#linksEnvironment.createLink({
+        key: key,
+        link: { name: key, url: url }
+      })
+    }
   }
 
   async resourceIsNotOpenable(resource): Promise<boolean> {

--- a/tests/e2e/support/objects/app-files/share/index.ts
+++ b/tests/e2e/support/objects/app-files/share/index.ts
@@ -15,12 +15,15 @@ import {
 } from './actions'
 import { resourceIsNotOpenable, isAcceptedSharePresent } from './utils'
 import { copyLinkArgs } from '../link/actions'
+import { LinksEnvironment } from '../../../environment'
 
 export class Share {
   #page: Page
+  #linksEnvironment: LinksEnvironment
 
   constructor({ page }: { page: Page }) {
     this.#page = page
+    this.#linksEnvironment = new LinksEnvironment()
   }
 
   async create(args: Omit<createShareArgs, 'page'>): Promise<void> {
@@ -68,6 +71,11 @@ export class Share {
 
   async copyQuickLink(args: Omit<copyLinkArgs, 'page'>): Promise<void> {
     await copyQuickLink({ ...args, page: this.#page })
+    const quickLink = await this.#page.evaluate(() => navigator.clipboard.readText())
+    this.#linksEnvironment.createLink({
+      key: 'Quicklink',
+      link: { name: 'Quicklink', url: quickLink }
+    })
   }
 
   async resourceIsNotOpenable(resource): Promise<boolean> {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
With this PR
-  when a quicklink is created then the corresponding url value is added into links environment with name `Quicklink` by extracting it from the clipboard

## Related Issue
- https://github.com/owncloud/web/issues/8347

## Motivation and Context
We have a test step
```feature
And "Brian" copies quick link of the resource "shared_folder" from the context menu
```
In the current scenario, we cannot access the link copied from the quick link if we use it together with this step
```feature
 When "Anonymous" opens the public link "QuickLink"
``` 
and in my expectation, we should be able to do so. As we have the same button to create+copy the quick link, the first time the button is clicked the link gets created and copied, and from the second time onwards the link is copied. Thus if the key `Quicklink` already exists while creating the link we do not add it to the link store otherwise the link is stored in the link store also.

## How Has This Been Tested?
- Locally
- CI


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

