### PR TITLE
perf: slightly faster key up/down

### DIFF
--- a/changelog/unreleased/enhancement-key-up-down-performance
+++ b/changelog/unreleased/enhancement-key-up-down-performance
@@ -1,0 +1,5 @@
+Enhancement: Slight improvement of key up/down performance
+
+The render performance of the key up/down events in file lists has been improved slightly.
+
+https://github.com/owncloud/web/pull/8356

--- a/packages/web-app-admin-settings/src/components/General/AppearanceSection.vue
+++ b/packages/web-app-admin-settings/src/components/General/AppearanceSection.vue
@@ -51,10 +51,10 @@ import { useStore } from 'web-pkg'
 
 export default defineComponent({
   name: 'AppearanceSection',
-  mixins: [UploadLogo, ResetLogo],
   components: {
     ContextActionMenu
   },
+  mixins: [UploadLogo, ResetLogo],
   setup() {
     const store = useStore()
     const instance = getCurrentInstance().proxy as any

--- a/packages/web-app-files/tests/unit/components/FilesList/KeyboardActions.spec.ts
+++ b/packages/web-app-files/tests/unit/components/FilesList/KeyboardActions.spec.ts
@@ -70,14 +70,14 @@ describe('KeyboardActions', () => {
     })
   })
   describe('global shortcuts', () => {
-    beforeEach(() => {
-      document.body.innerHTML =
-        '<table>' +
-        '<tr class="oc-tbody-tr" data-item-id="0"><td></td></tr>' +
-        '<tr class="oc-tbody-tr" data-item-id="1"><td></td></tr>' +
-        '<tr class="oc-tbody-tr" data-item-id="2"><td></td></tr>' +
-        '</table>'
-    })
+    // beforeEach(() => {
+    //   document.body.innerHTML =
+    //     '<table>' +
+    //     '<tr class="oc-tbody-tr" data-item-id="0"><td></td></tr>' +
+    //     '<tr class="oc-tbody-tr" data-item-id="1"><td></td></tr>' +
+    //     '<tr class="oc-tbody-tr" data-item-id="2"><td></td></tr>' +
+    //     '</table>'
+    // })
 
     it('copy selected files', () => {
       const event = new KeyboardEvent('keyDown', {
@@ -123,7 +123,6 @@ describe('KeyboardActions', () => {
       const event = new KeyboardEvent('keyDown', { keyCode: keycode(key) })
       const { wrapper, storeOptions } = getWrapper()
       wrapper.vm.handleGlobalShortcuts(event)
-      expect(storeOptions.modules.Files.actions.resetFileSelection).toHaveBeenCalled()
       expect(storeOptions.modules.Files.mutations.ADD_FILE_SELECTION).toHaveBeenCalled()
     })
     it.each(['down', 'up'])('navigate via shift + up and down keys', (key) => {
@@ -178,7 +177,15 @@ const getWrapper = ({ props = {}, latestSelectedId = undefined } = {}) => {
   return {
     storeOptions,
     wrapper: mount(KeyboardActions, {
-      props: { paginatedResources: [], space: mock<SpaceResource>(), ...props },
+      props: {
+        paginatedResources: [
+          mock<Resource>({ id: 0 }),
+          mock<Resource>({ id: 1 }),
+          mock<Resource>({ id: 2 })
+        ],
+        space: mock<SpaceResource>(),
+        ...props
+      },
       global: {
         plugins: [...defaultPlugins(), store]
       }

--- a/packages/web-app-files/tests/unit/components/FilesList/KeyboardActions.spec.ts
+++ b/packages/web-app-files/tests/unit/components/FilesList/KeyboardActions.spec.ts
@@ -70,14 +70,6 @@ describe('KeyboardActions', () => {
     })
   })
   describe('global shortcuts', () => {
-    // beforeEach(() => {
-    //   document.body.innerHTML =
-    //     '<table>' +
-    //     '<tr class="oc-tbody-tr" data-item-id="0"><td></td></tr>' +
-    //     '<tr class="oc-tbody-tr" data-item-id="1"><td></td></tr>' +
-    //     '<tr class="oc-tbody-tr" data-item-id="2"><td></td></tr>' +
-    //     '</table>'
-    // })
 
     it('copy selected files', () => {
       const event = new KeyboardEvent('keyDown', {

--- a/packages/web-app-files/tests/unit/components/FilesList/KeyboardActions.spec.ts
+++ b/packages/web-app-files/tests/unit/components/FilesList/KeyboardActions.spec.ts
@@ -70,7 +70,6 @@ describe('KeyboardActions', () => {
     })
   })
   describe('global shortcuts', () => {
-
     it('copy selected files', () => {
       const event = new KeyboardEvent('keyDown', {
         keyCode: keycode('c'),

--- a/packages/web-pkg/src/components/ContextActions/ActionMenuItem.vue
+++ b/packages/web-pkg/src/components/ContextActions/ActionMenuItem.vue
@@ -7,8 +7,8 @@
       :class="[action.class, 'action-menu-item', 'oc-py-s', 'oc-px-m', 'oc-width-1-1']"
       data-testid="action-handler"
       size="small"
-      v-on="componentListeners"
       justify-content="left"
+      v-on="componentListeners"
     >
       <oc-img
         v-if="action.img"


### PR DESCRIPTION
## Description
Keyboard interaction with file listings needs a major rework (should be a composable instead of a component + is not compatible with the tiles view), so I didn't dig deeper. This PR is just a slight improvement of the render performance of the current implementation of up/down key uses, since it was a low hanging fruit.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
