### PR TITLE
vue-tsc preparation

### DIFF
--- a/packages/design-system/docs/components/status/ComponentsList.vue
+++ b/packages/design-system/docs/components/status/ComponentsList.vue
@@ -77,7 +77,7 @@ export default defineComponent({
   methods: {
     getComponents: function () {
       const components = []
-      const contexts = [require.context('@/components/', true, /\.vue$/)]
+      const contexts = [(require as any).context('@/components/', true, /\.vue$/)]
 
       contexts.forEach((context) => {
         context.keys().forEach((key) => components.push(context(key).default))

--- a/packages/design-system/docs/components/tokens/IconList.vue
+++ b/packages/design-system/docs/components/tokens/IconList.vue
@@ -71,9 +71,9 @@ import { defineComponent } from 'vue'
 
 import OcIcon from '../../../src/components/OcIcon/OcIcon.vue'
 import OcTable from '../../../src/components/OcTable/OcTable.vue'
-import OcSearchBar from '../../../src/components/OcSearchBar/OcSearchBar'
-import HighlightedText from './_HighlightedText'
-const req = require.context('../../../src/assets/icons/', true, /^\.\/.*\.svg$/)
+import OcSearchBar from '../../../src/components/OcSearchBar/OcSearchBar.vue'
+import HighlightedText from './_HighlightedText.vue'
+const req = (require as any).context('../../../src/assets/icons/', true, /^\.\/.*\.svg$/)
 
 /**
  * All known icons in the ownCloud Design System

--- a/packages/design-system/docs/components/tokens/_HighlightedText.vue
+++ b/packages/design-system/docs/components/tokens/_HighlightedText.vue
@@ -23,6 +23,8 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue'
+
 export default defineComponent({
   name: 'HighlightedText',
   props: {
@@ -33,7 +35,7 @@ export default defineComponent({
     fragmentTag: {
       type: String,
       default: 'span',
-      validator: function (value) {
+      validator: function (value: string) {
         return ['span', 'i', 'em', 'b', 'strong'].includes(value)
       }
     },

--- a/packages/design-system/src/components/OcBreadcrumb/OcBreadcrumb.vue
+++ b/packages/design-system/src/components/OcBreadcrumb/OcBreadcrumb.vue
@@ -52,7 +52,7 @@
         ref="mobileDropdown"
         tabindex="0"
         class="oc-breadcrumb-drop-label oc-flex oc-flex-middle oc-flex-between"
-        @keydown.enter="$refs.mobileDropdown.click()"
+        @keydown.enter="clickMobileDropdown"
       >
         <span
           v-if="currentFolder"
@@ -90,13 +90,14 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { defineComponent, PropType } from 'vue'
 
 import { AVAILABLE_SIZES } from '../../helpers/constants'
 
 import OcButton from '../OcButton/OcButton.vue'
 import OcDrop from '../OcDrop/OcDrop.vue'
 import OcIcon from '../OcIcon/OcIcon.vue'
+import { BreadcrumbItem } from 'web-app-files/src/helpers/breadcrumbs'
 
 /**
  * Displays a breadcrumb. Each item in the items property has the following elements:
@@ -120,7 +121,7 @@ export default defineComponent({
      * Array of breadcrumb items
      */
     items: {
-      type: Array,
+      type: Array as PropType<BreadcrumbItem[]>,
       required: true
     },
     /**
@@ -175,6 +176,9 @@ export default defineComponent({
   methods: {
     getAriaCurrent(index) {
       return this.items.length - 1 === index ? 'page' : null
+    },
+    clickMobileDropdown() {
+      this.$refs.mobileDropdown.click()
     }
   }
 })

--- a/packages/design-system/src/components/OcButton/OcButton.vue
+++ b/packages/design-system/src/components/OcButton/OcButton.vue
@@ -45,8 +45,8 @@ export default defineComponent({
     size: {
       type: String,
       default: 'medium',
-      validator: (value) => {
-        return value.match(/(small|medium|large)/)
+      validator: (value: string) => {
+        return ['small', 'medium', 'large'].includes(value)
       }
     },
     /**
@@ -63,8 +63,8 @@ export default defineComponent({
     target: {
       type: String,
       default: null,
-      validator: (value) => {
-        return value.match(/(_blank|_self|_parent|_top)/)
+      validator: (value: string) => {
+        return ['_blank', '_self', '_parent', '_top'].includes(value)
       }
     },
     /**
@@ -88,8 +88,8 @@ export default defineComponent({
     submit: {
       type: String,
       default: 'button',
-      validator: (value) => {
-        return value.match(/(null|button|submit|reset)/)
+      validator: (value: string) => {
+        return ['null', 'button', 'submit', 'reset'].includes(value)
       }
     },
     /**
@@ -100,8 +100,8 @@ export default defineComponent({
     variation: {
       type: String,
       default: 'passive',
-      validator: (value) => {
-        return value.match(/(passive|primary|success|danger|warning|inverse)/)
+      validator: (value: string) => {
+        return ['passive', 'primary', 'danger', 'success', 'warning', 'inverse'].includes(value)
       }
     },
     /**
@@ -112,8 +112,8 @@ export default defineComponent({
     appearance: {
       type: String,
       default: 'outline',
-      validator: (value) => {
-        return value.match(/(filled|outline|raw)/)
+      validator: (value: string) => {
+        return ['filled', 'outline', 'raw'].includes(value)
       }
     },
     /**
@@ -123,8 +123,15 @@ export default defineComponent({
     justifyContent: {
       type: String,
       default: 'center',
-      validator: (value) => {
-        return value.match(/(left|center|right|space-around|space-between|space-evenly)/)
+      validator: (value: string) => {
+        return [
+          'left',
+          'center',
+          'right',
+          'space-around',
+          'space-between',
+          'space-evenly'
+        ].includes(value)
       }
     },
     /**
@@ -134,8 +141,8 @@ export default defineComponent({
     gapSize: {
       type: String,
       default: 'medium',
-      validator: (value) => {
-        return value.match(/(none|xsmall|small|medium|large|xlarge)/)
+      validator: (value: string) => {
+        return ['none', 'xsmall', 'small', 'medium', 'large', 'xlarge'].includes(value)
       }
     }
   },

--- a/packages/design-system/src/components/OcCheckbox/OcCheckbox.vue
+++ b/packages/design-system/src/components/OcCheckbox/OcCheckbox.vue
@@ -88,7 +88,7 @@ export default defineComponent({
       type: String,
       required: false,
       default: 'medium',
-      validator: (size) => /(small|medium|large)/.test(size)
+      validator: (size: string) => ['small', 'medium', 'large'].includes(size)
     },
     /**
      * Show outline of checkbox

--- a/packages/design-system/src/components/OcGrid/OcGrid.vue
+++ b/packages/design-system/src/components/OcGrid/OcGrid.vue
@@ -21,8 +21,8 @@ export default defineComponent({
     gutter: {
       type: String,
       default: 'collapse',
-      validator: (value) => {
-        return value.match(/(small|medium|large|collapse)/)
+      validator: (value: string) => {
+        return ['small', 'medium', 'large', 'collapse'].includes(value)
       }
     },
     /**

--- a/packages/design-system/src/components/OcHiddenAnnouncer/OcHiddenAnnouncer.vue
+++ b/packages/design-system/src/components/OcHiddenAnnouncer/OcHiddenAnnouncer.vue
@@ -35,8 +35,8 @@ export default defineComponent({
       type: String,
       required: false,
       default: 'polite',
-      validator: (value) => {
-        return value.match(/(polite|assertive|off)/)
+      validator: (value: string) => {
+        return ['polite', 'assertive', 'off'].includes(value)
       }
     },
     /**

--- a/packages/design-system/src/components/OcIcon/OcIcon.vue
+++ b/packages/design-system/src/components/OcIcon/OcIcon.vue
@@ -101,8 +101,8 @@ export default defineComponent({
       type: String,
       required: false,
       default: 'fill',
-      validator: (value) => {
-        return value.match(/(fill|line|none)/)
+      validator: (value: string) => {
+        return ['fill', 'line', 'none'].includes(value)
       }
     },
     /**
@@ -139,8 +139,8 @@ export default defineComponent({
     variation: {
       type: String,
       default: 'passive',
-      validator: (value) => {
-        return value.match(/(passive|primary|danger|success|warning|inverse)/)
+      validator: (value: string) => {
+        return ['passive', 'primary', 'danger', 'success', 'warning', 'inverse'].includes(value)
       }
     },
     /**

--- a/packages/design-system/src/components/OcImage/OcImage.vue
+++ b/packages/design-system/src/components/OcImage/OcImage.vue
@@ -45,8 +45,8 @@ export default defineComponent({
       type: String,
       required: false,
       default: 'eager',
-      validator: (value) => {
-        return value.match(/(eager|lazy)/)
+      validator: (value: string) => {
+        return ['eager', 'lazy'].includes(value)
       }
     }
   },

--- a/packages/design-system/src/components/OcInfoDrop/OcInfoDrop.vue
+++ b/packages/design-system/src/components/OcInfoDrop/OcInfoDrop.vue
@@ -40,12 +40,17 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { defineComponent, PropType } from 'vue'
 
 import OcButton from '../OcButton/OcButton.vue'
 import OcIcon from '../OcIcon/OcIcon.vue'
 import OcDrop from '../OcDrop/OcDrop.vue'
 import uniqueId from '../../utils/uniqueId'
+
+export type ListElement = {
+  text: string
+  headline?: string
+}
 
 export default defineComponent({
   name: 'OcInfoDrop',
@@ -77,8 +82,8 @@ export default defineComponent({
       type: String,
       required: false,
       default: 'click',
-      validator: (value) => {
-        return value.match(/(click|hover|manual)/)
+      validator: (value: string) => {
+        return ['click', 'hover', 'manual'].includes(value)
       }
     },
     /**
@@ -109,7 +114,7 @@ export default defineComponent({
      * List element
      */
     list: {
-      type: Array,
+      type: Array as PropType<ListElement[]>,
       required: false,
       default: () => []
     },

--- a/packages/design-system/src/components/OcLogo/OcLogo.vue
+++ b/packages/design-system/src/components/OcLogo/OcLogo.vue
@@ -1,5 +1,5 @@
 <template>
-  <oc-img :ref="ref" class="oc-logo" :src="src" :alt="alt" />
+  <oc-img class="oc-logo" :src="src" :alt="alt" />
 </template>
 
 <script lang="ts">

--- a/packages/design-system/src/components/OcModal/OcModal.vue
+++ b/packages/design-system/src/components/OcModal/OcModal.vue
@@ -123,8 +123,8 @@ export default defineComponent({
       type: String,
       required: false,
       default: 'passive',
-      validator: (value) => {
-        return value.match(/(passive|primary|danger|success|warning)/)
+      validator: (value: string) => {
+        return ['passive', 'primary', 'danger', 'success', 'warning'].includes(value)
       }
     },
     /**
@@ -189,8 +189,8 @@ export default defineComponent({
       type: String,
       required: false,
       default: 'passive',
-      validator: (value) => {
-        return value.match(/(passive|primary|danger|success|warning)/)
+      validator: (value: string) => {
+        return ['passive', 'primary', 'danger', 'success', 'warning'].includes(value)
       }
     },
     /**
@@ -200,8 +200,8 @@ export default defineComponent({
       type: String,
       required: false,
       default: 'outline',
-      validator: (value) => {
-        return value.match(/(outline|filled|raw)/)
+      validator: (value: string) => {
+        return ['outline', 'filled', 'raw'].includes(value)
       }
     },
     /**
@@ -219,8 +219,8 @@ export default defineComponent({
       type: String,
       required: false,
       default: 'passive',
-      validator: (value) => {
-        return value.match(/(passive|primary|danger|success|warning)/)
+      validator: (value: string) => {
+        return ['passive', 'primary', 'danger', 'success', 'warning'].includes(value)
       }
     },
     /**
@@ -230,8 +230,8 @@ export default defineComponent({
       type: String,
       required: false,
       default: 'outline',
-      validator: (value) => {
-        return value.match(/(outline|filled|raw)/)
+      validator: (value: string) => {
+        return ['outline', 'filled', 'raw'].includes(value)
       }
     },
     /**
@@ -249,8 +249,8 @@ export default defineComponent({
       type: String,
       required: false,
       default: 'filled',
-      validator: (value) => {
-        return value.match(/(outline|filled|raw)/)
+      validator: (value: string) => {
+        return ['outline', 'filled', 'raw'].includes(value)
       }
     },
     /**

--- a/packages/design-system/src/components/OcNotificationMessage/OcNotificationMessage.vue
+++ b/packages/design-system/src/components/OcNotificationMessage/OcNotificationMessage.vue
@@ -44,8 +44,8 @@ export default defineComponent({
       type: String,
       required: false,
       default: 'passive',
-      validator: (value) => {
-        return value.match(/(passive|primary|success|warning|danger)/)
+      validator: (value: string) => {
+        return ['passive', 'primary', 'success', 'warning', 'danger'].includes(value)
       }
     },
     /**

--- a/packages/design-system/src/components/OcNotifications/OcNotifications.vue
+++ b/packages/design-system/src/components/OcNotifications/OcNotifications.vue
@@ -30,8 +30,8 @@ export default defineComponent({
       type: String,
       required: false,
       default: 'top-center',
-      validator: (value) => {
-        return value.match(/(default|top-left|top-center|top-right)/)
+      validator: (value: string) => {
+        return ['default', 'top-left', 'top-center', 'top-right'].includes(value)
       }
     }
   },

--- a/packages/design-system/src/components/OcPagination/OcPagination.vue
+++ b/packages/design-system/src/components/OcPagination/OcPagination.vue
@@ -62,15 +62,15 @@ export default defineComponent({
     },
     /**
      * Number of pages to be displayed. It is required to use an odd number.
-     * Pages will be equaly split into two parts around the current page and remaining pages will be displayed as ellipsis
+     * Pages will be equally split into two parts around the current page and remaining pages will be displayed as ellipsis
      */
     maxDisplayed: {
       type: Number,
       required: false,
       default: null,
-      validator: (value) => {
+      validator: (value: number) => {
         if (value % 2 === 0) {
-          // Since Vue doens't support custom validator error message, log the error manually
+          // Since Vue doesn't support custom validator error message, log the error manually
           console.error('maxDisplayed needs to be an odd number')
 
           return false

--- a/packages/design-system/src/components/OcProgress/OcProgress.vue
+++ b/packages/design-system/src/components/OcProgress/OcProgress.vue
@@ -50,8 +50,8 @@ export default defineComponent({
       type: String,
       required: false,
       default: 'default',
-      validator: (value) => {
-        return value.match(/(default|small)/)
+      validator: (value: string) => {
+        return ['default', 'small'].includes(value)
       }
     },
     /**
@@ -63,8 +63,8 @@ export default defineComponent({
       type: String,
       required: false,
       default: 'primary',
-      validator: (value) => {
-        return value.match(/(primary|passive|success|warning|danger)/)
+      validator: (value: string) => {
+        return ['primary', 'passive', 'success', 'warning', 'danger'].includes(value)
       }
     },
     /**

--- a/packages/design-system/src/components/OcRadio/OcRadio.vue
+++ b/packages/design-system/src/components/OcRadio/OcRadio.vue
@@ -91,7 +91,7 @@ export default defineComponent({
       type: String,
       required: false,
       default: 'medium',
-      validator: (size) => /(small|medium|large)/.test(size)
+      validator: (size: string) => ['small', 'medium', 'large'].includes(size)
     }
   },
   emits: ['update:modelValue'],

--- a/packages/design-system/src/components/OcRecipient/OcRecipient.vue
+++ b/packages/design-system/src/components/OcRecipient/OcRecipient.vue
@@ -33,11 +33,22 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { defineComponent, PropType } from 'vue'
 
 import OcAvatar from '../OcAvatar/OcAvatar.vue'
 import OcIcon from '../OcIcon/OcIcon.vue'
 import OcSpinner from '../OcSpinner/OcSpinner.vue'
+
+export type Recipient = {
+  name: string
+  icon?: {
+    name: string
+    label: string
+  }
+  isLoadingAvatar?: boolean
+  hasAvatar?: boolean
+  avatar?: string
+}
 
 export default defineComponent({
   name: 'OcRecipient',
@@ -51,9 +62,9 @@ export default defineComponent({
      * Recipient object containing name (required), icon and avatar
      */
     recipient: {
-      type: Object,
+      type: Object as PropType<Recipient>,
       required: true,
-      validator: (recipient) => {
+      validator: (recipient: Recipient) => {
         if (!Object.prototype.hasOwnProperty.call(recipient, 'name')) {
           throw new Error('Recipient name is not defined')
         }

--- a/packages/design-system/src/components/OcSearchBar/OcSearchBar.vue
+++ b/packages/design-system/src/components/OcSearchBar/OcSearchBar.vue
@@ -104,7 +104,7 @@ export default defineComponent({
      * The icon to be displayed
      */
     icon: {
-      type: [String, Boolean],
+      type: String,
       required: false,
       default: 'search'
     },
@@ -202,8 +202,8 @@ export default defineComponent({
       type: String,
       required: false,
       default: 'primary',
-      validator: (value) => {
-        return value.match(/(passive|primary|danger|success|warning|inverse)/)
+      validator: (value: string) => {
+        return ['passive', 'primary', 'danger', 'success', 'warning', 'inverse'].includes(value)
       }
     },
     /**

--- a/packages/design-system/src/components/OcSelect/OcSelect.vue
+++ b/packages/design-system/src/components/OcSelect/OcSelect.vue
@@ -71,7 +71,6 @@ export default defineComponent({
           threshold: 0.2,
           location: 0,
           distance: 100,
-          maxPatternLength: 32,
           minMatchCharLength: 1
         })
 

--- a/packages/design-system/src/components/OcSpinner/OcSpinner.vue
+++ b/packages/design-system/src/components/OcSpinner/OcSpinner.vue
@@ -39,8 +39,10 @@ export default defineComponent({
     size: {
       type: String,
       default: 'medium',
-      validator: (value) => {
-        return value.match(/(xsmall|small|medium|large|xlarge|xxlarge|xxxlarge)/)
+      validator: (value: string) => {
+        return ['xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge', 'xxxlarge'].includes(
+          value
+        )
       }
     }
   },

--- a/packages/design-system/src/components/OcStatusIndicators/OcStatusIndicators.vue
+++ b/packages/design-system/src/components/OcStatusIndicators/OcStatusIndicators.vue
@@ -44,10 +44,21 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { defineComponent, PropType } from 'vue'
 import OcIcon from '../OcIcon/OcIcon.vue'
 import OcButton from '../OcButton/OcButton.vue'
 import uniqueId from '../../utils/uniqueId'
+
+export type Indicator = {
+  id: string
+  icon: string
+  label: string
+  handler?: any
+  accessibleDescription?: string
+  visible?: boolean
+  target?: string
+  type?: string
+}
 
 /**
  * Status indicators which can be attatched to a resource
@@ -80,7 +91,7 @@ export default defineComponent({
      * accessibleDescription: A string to be used as a accessible description for the indicator. It renders an element only visible for screenreaders to provide additional context
      */
     indicators: {
-      type: Array,
+      type: Array as PropType<Indicator[]>,
       required: true
     },
     target: {

--- a/packages/design-system/src/components/OcSwitch/OcSwitch.vue
+++ b/packages/design-system/src/components/OcSwitch/OcSwitch.vue
@@ -5,7 +5,7 @@
       data-testid="oc-switch-btn"
       class="oc-switch-btn"
       role="switch"
-      :aria-checked="checked.toString()"
+      :aria-checked="checked"
       :aria-labelledby="labelId"
       @click="toggle"
     />

--- a/packages/design-system/src/components/OcTable/OcTable.vue
+++ b/packages/design-system/src/components/OcTable/OcTable.vue
@@ -96,7 +96,7 @@ import OcGhostElement from '../_OcGhostElement/_OcGhostElement.vue'
 import OcButton from '../OcButton/OcButton.vue'
 import SortMixin from '../../mixins/sort'
 import { getSizeClass } from '../../utils/sizeClasses'
-import { defineComponent, ref } from 'vue'
+import { defineComponent, PropType, ref } from 'vue'
 
 import {
   EVENT_THEAD_CLICKED,
@@ -106,6 +106,21 @@ import {
   EVENT_ITEM_DROPPED,
   EVENT_ITEM_DRAGGED
 } from '../../helpers/constants'
+
+export type FieldType = {
+  name: string
+  title: string
+  headerType: string
+  type: string
+  callback: any
+  alignH: string
+  alignV: string
+  width: string
+  wrap: string
+  thClass: string
+  tdClass: string
+  sortable: string
+}
 
 /**
  * A table component with dynamic layout and data.
@@ -170,7 +185,7 @@ export default defineComponent({
      * - **sortable**: defines if the column is sortable, can be `true` or `false`.
      */
     fields: {
-      type: Array,
+      type: Array as PropType<FieldType[]>,
       required: true
     },
     /**
@@ -225,7 +240,7 @@ export default defineComponent({
       type: String,
       required: false,
       default: 'small',
-      validator: (size) => /(xsmall|small|medium|large|xlarge)/.test(size)
+      validator: (size: string) => ['xsmall', 'small', 'medium', 'large', 'xlarge'].includes(size)
     },
     /**
      * Enable Drag & Drop events
@@ -413,18 +428,11 @@ export default defineComponent({
       return props
     },
     extractCellProps(field) {
-      const result = {}
-      if (Object.prototype.hasOwnProperty.call(field, 'alignH')) {
-        result.alignH = field.alignH
+      return {
+        ...(field?.alignH && { alignH: field.alignH }),
+        ...(field?.alignV && { alignV: field.alignV }),
+        ...(field?.width && { width: field.width })
       }
-      if (Object.prototype.hasOwnProperty.call(field, 'alignV')) {
-        result.alignV = field.alignV
-      }
-      if (Object.prototype.hasOwnProperty.call(field, 'width')) {
-        result.width = field.width
-      }
-
-      return result
     },
     isHighlighted(item) {
       if (!this.highlighted) {

--- a/packages/design-system/src/components/OcTag/OcTag.vue
+++ b/packages/design-system/src/components/OcTag/OcTag.vue
@@ -24,7 +24,7 @@ export default defineComponent({
       type: String,
       required: false,
       default: 'span',
-      validator: (type) => type.match(/(span|button|router-link|a)/)
+      validator: (type: string) => ['span', 'button', 'router-link', 'a'].includes(type)
     },
 
     /**
@@ -43,8 +43,8 @@ export default defineComponent({
     size: {
       type: String,
       default: 'medium',
-      validator: (value) => {
-        return value.match(/(small|medium|large)/)
+      validator: (value: string) => {
+        return ['small', 'medium', 'large'].includes(value)
       }
     },
 

--- a/packages/design-system/src/components/OcTextInput/OcTextInput.vue
+++ b/packages/design-system/src/components/OcTextInput/OcTextInput.vue
@@ -85,8 +85,8 @@ export default defineComponent({
     type: {
       type: String,
       default: 'text',
-      validator: (value) => {
-        return value.match(/(text|number|email|password)/)
+      validator: (value: string) => {
+        return ['text', 'number', 'email', 'password'].includes(value)
       }
     },
     /**

--- a/packages/design-system/src/components/_OcTableCell/_OcTableCell.vue
+++ b/packages/design-system/src/components/_OcTableCell/_OcTableCell.vue
@@ -15,27 +15,27 @@ export default defineComponent({
       type: String,
       default: 'td',
       required: false,
-      validator: (type) => /(td|th)/.test(type)
+      validator: (type: string) => ['td', 'th'].includes(type)
     },
     alignH: {
       type: String,
       default: 'left',
-      validator: (alignment) => /(left|center|right)/.test(alignment)
+      validator: (alignment: string) => ['left', 'center', 'right'].includes(alignment)
     },
     alignV: {
       type: String,
       default: 'middle',
-      validator: (alignment) => /(top|middle|bottom)/.test(alignment)
+      validator: (alignment: string) => ['top', 'middle', 'bottom'].includes(alignment)
     },
     width: {
       type: String,
       default: 'auto',
-      validator: (width) => /(auto|shrink|expand)/.test(width)
+      validator: (width: string) => ['auto', 'shrink', 'expand'].includes(width)
     },
     wrap: {
       type: String,
       default: null,
-      validator: (wrap) => (wrap ? /(break|nowrap|truncate)/.test(wrap) : true)
+      validator: (wrap: string) => ['break', 'nowrap', 'truncate'].includes(wrap) || !wrap
     }
   },
   emits: ['click'],

--- a/packages/design-system/src/components/_OcTableCellData/_OcTableCellData.vue
+++ b/packages/design-system/src/components/_OcTableCellData/_OcTableCellData.vue
@@ -23,22 +23,22 @@ export default defineComponent({
     alignH: {
       type: String,
       default: 'left',
-      validator: (alignment) => /(left|center|right)/.test(alignment)
+      validator: (alignment: string) => ['left', 'center', 'right'].includes(alignment)
     },
     alignV: {
       type: String,
       default: 'middle',
-      validator: (alignment) => /(top|middle|bottom)/.test(alignment)
+      validator: (alignment: string) => ['top', 'middle', 'bottom'].includes(alignment)
     },
     width: {
       type: String,
       default: 'auto',
-      validator: (width) => /(auto|shrink|expand)/.test(width)
+      validator: (width: string) => ['auto', 'shrink', 'expand'].includes(width)
     },
     wrap: {
       type: String,
       default: null,
-      validator: (wrap) => (wrap ? /(break|nowrap|truncate)/.test(wrap) : true)
+      validator: (wrap: string) => ['break', 'nowrap', 'truncate'].includes(wrap) || !wrap
     }
   }
 })

--- a/packages/design-system/src/components/_OcTableCellHead/_OcTableCellHead.vue
+++ b/packages/design-system/src/components/_OcTableCellHead/_OcTableCellHead.vue
@@ -24,22 +24,22 @@ export default defineComponent({
     alignH: {
       type: String,
       default: 'left',
-      validator: (alignment) => /(left|center|right)/.test(alignment)
+      validator: (alignment: string) => ['left', 'center', 'right'].includes(alignment)
     },
     alignV: {
       type: String,
       default: 'middle',
-      validator: (alignment) => /(top|middle|bottom)/.test(alignment)
+      validator: (alignment: string) => ['top', 'middle', 'bottom'].includes(alignment)
     },
     width: {
       type: String,
       default: 'auto',
-      validator: (width) => /(auto|shrink|expand)/.test(width)
+      validator: (width: string) => ['auto', 'shrink', 'expand'].includes(width)
     },
     wrap: {
       type: String,
       default: 'nowrap',
-      validator: (wrap) => /(break|nowrap|truncate)/.test(wrap)
+      validator: (wrap: string) => ['break', 'nowrap', 'truncate'].includes(wrap)
     }
   },
   emits: ['click']

--- a/packages/web-app-admin-settings/src/components/Groups/ContextActions.vue
+++ b/packages/web-app-admin-settings/src/components/Groups/ContextActions.vue
@@ -22,7 +22,7 @@ export default defineComponent({
     }
   },
   setup(props) {
-    const instance = getCurrentInstance().proxy
+    const instance = getCurrentInstance().proxy as any
 
     const filterParams = computed(() => ({ resources: props.items }))
     const menuItemsPrimaryActions = computed(() =>

--- a/packages/web-app-admin-settings/src/components/Groups/SideBar/EditPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Groups/SideBar/EditPanel.vue
@@ -57,7 +57,7 @@ export default defineComponent({
     },
     invalidFormData() {
       return Object.values(this.formData)
-        .map((v) => !!v.valid)
+        .map((v: any) => !!v.valid)
         .includes(false)
     }
   },
@@ -85,7 +85,7 @@ export default defineComponent({
     },
     revertChanges() {
       this.editGroup = { ...this.group }
-      Object.values(this.formData).forEach((formDataValue) => {
+      Object.values(this.formData).forEach((formDataValue: any) => {
         formDataValue.valid = true
         formDataValue.errorMessage = ''
       })

--- a/packages/web-app-admin-settings/src/components/Spaces/ContextActions.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/ContextActions.vue
@@ -34,7 +34,7 @@ export default defineComponent({
     }
   },
   setup(props) {
-    const instance = getCurrentInstance().proxy
+    const instance = getCurrentInstance().proxy as any
 
     const filterParams = computed(() => ({ resources: props.items }))
     const menuItemsPrimaryActions = computed(() =>

--- a/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersPanel.vue
@@ -25,10 +25,9 @@
   </div>
 </template>
 <script lang="ts">
-import { computed, defineComponent, inject, watch } from 'vue'
+import { computed, defineComponent, inject, ref, watch, unref } from 'vue'
 import { Resource } from 'web-client/src'
 import MembersRoleSection from './MembersRoleSection.vue'
-import { ref, unref } from 'vue-demi'
 import Fuse from 'fuse.js'
 import Mark from 'mark.js'
 import { spaceRoleEditor, spaceRoleManager, spaceRoleViewer } from 'web-client/src/helpers/share'

--- a/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersRoleSection.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersRoleSection.vue
@@ -27,7 +27,7 @@ export default defineComponent({
   name: 'MembersRoleSection',
   props: {
     members: {
-      type: Object as PropType<SpaceRole>,
+      type: Array as PropType<SpaceRole[]>,
       required: true
     }
   },

--- a/packages/web-app-admin-settings/src/components/Users/ContextActions.vue
+++ b/packages/web-app-admin-settings/src/components/Users/ContextActions.vue
@@ -23,7 +23,7 @@ export default defineComponent({
     }
   },
   setup(props) {
-    const instance = getCurrentInstance().proxy
+    const instance = getCurrentInstance().proxy as any
 
     const filterParams = computed(() => ({ resources: props.items }))
     const menuItemsPrimaryActions = computed(() =>

--- a/packages/web-app-admin-settings/src/components/Users/SideBar/EditPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Users/SideBar/EditPanel.vue
@@ -138,7 +138,7 @@ export default defineComponent({
     },
     invalidFormData() {
       return Object.values(this.formData)
-        .map((v) => !!v.valid)
+        .map((v: any) => !!v.valid)
         .includes(false)
     },
     showQuota() {
@@ -196,7 +196,7 @@ export default defineComponent({
     },
     revertChanges() {
       this.editUser = cloneDeep(this.user)
-      Object.values(this.formData).forEach((formDataValue) => {
+      Object.values(this.formData).forEach((formDataValue: any) => {
         formDataValue.valid = true
         formDataValue.errorMessage = ''
       })

--- a/packages/web-app-files/src/components/AppBar/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar/AppBar.vue
@@ -107,7 +107,7 @@ export default defineComponent({
   },
   data: function () {
     return {
-      resizeObserver: new ResizeObserver(this.onResize),
+      resizeObserver: new ResizeObserver(this.onResize as ResizeObserverCallback),
       limitedScreenSpace: false
     }
   },

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -130,13 +130,8 @@
         <oc-icon fill-type="line" name="clipboard" />
         <span v-translate>Paste here</span>
       </oc-button>
-      <oc-button
-        :disabled="uploadOrFileCreationBlocked"
-        class="clear-clipboard-btn"
-        @click="clearClipboardFiles"
-      >
+
         <oc-icon fill-type="line" name="close" />
-      </oc-button>
     </div>
   </div>
 </template>

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -130,8 +130,13 @@
         <oc-icon fill-type="line" name="clipboard" />
         <span v-translate>Paste here</span>
       </oc-button>
-
+      <oc-button
+        :disabled="uploadOrFileCreationBlocked"
+        class="clear-clipboard-btn"
+        @click="clearClipboardFiles"
+      >
         <oc-icon fill-type="line" name="close" />
+      </oc-button>
     </div>
   </div>
 </template>

--- a/packages/web-app-files/src/components/AppBar/SharesNavigation.vue
+++ b/packages/web-app-files/src/components/AppBar/SharesNavigation.vue
@@ -64,14 +64,17 @@ export default defineComponent({
       routes[route.name] = router.getRoutes().find((r) => r.name === route.name)
       return routes
     }, {})
-    const sharesWithMeActive = useActiveLocation(isLocationSharesActive, locationSharesWithMe.name)
+    const sharesWithMeActive = useActiveLocation(
+      isLocationSharesActive,
+      locationSharesWithMe.name as string
+    )
     const sharesWithOthersActive = useActiveLocation(
       isLocationSharesActive,
-      locationSharesWithOthers.name
+      locationSharesWithOthers.name as string
     )
     const sharesViaLinkActive = useActiveLocation(
       isLocationSharesActive,
-      locationSharesViaLink.name
+      locationSharesViaLink.name as string
     )
     const navItems = computed(() => [
       {

--- a/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
+++ b/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
@@ -105,7 +105,7 @@ import ContextActions from '../../components/FilesList/ContextActions.vue'
 import NoContentMessage from 'web-pkg/src/components/NoContentMessage.vue'
 import { useSelectedResources } from '../../composables/selection'
 import { SortDir } from '../../composables'
-import { Location } from 'vue-router'
+import { RouteLocationNamedRaw } from 'vue-router'
 import { buildShareSpaceResource } from 'web-client/src/helpers'
 import { configurationManager } from 'web-pkg/src/configuration'
 import { CreateTargetRouteOptions } from '../../helpers/folderLink'
@@ -191,7 +191,7 @@ export default defineComponent({
       path,
       fileId,
       resource
-    }: CreateTargetRouteOptions): Location => {
+    }: CreateTargetRouteOptions): RouteLocationNamedRaw => {
       if (unref(hasShareJail)) {
         const space = buildShareSpaceResource({
           shareId: resource.id,

--- a/packages/web-app-files/src/components/SideBar/Actions/FileActions.vue
+++ b/packages/web-app-files/src/components/SideBar/Actions/FileActions.vue
@@ -15,7 +15,7 @@
 import ActionMenuItem from 'web-pkg/src/components/ContextActions/ActionMenuItem.vue'
 import FileActions from '../../../mixins/fileActions'
 import { computed, defineComponent, getCurrentInstance, inject, unref } from 'vue'
-import { Resource } from 'web-client'
+import { Resource, SpaceResource } from 'web-client'
 
 export default defineComponent({
   name: 'FileActions',
@@ -24,7 +24,7 @@ export default defineComponent({
   setup() {
     const instance = getCurrentInstance().proxy as any
     const resource = inject<Resource>('resource')
-    const space = inject<Resource>('space')
+    const space = inject<SpaceResource>('space')
     const resources = computed(() => {
       return [unref(resource)]
     })

--- a/packages/web-app-files/src/components/SideBar/Actions/SpaceActions.vue
+++ b/packages/web-app-files/src/components/SideBar/Actions/SpaceActions.vue
@@ -43,7 +43,7 @@ import QuotaModal from 'web-pkg/src/components/Spaces/QuotaModal.vue'
 import ReadmeContentModal from 'web-pkg/src/components/Spaces/ReadmeContentModal.vue'
 import { thumbnailService } from '../../../services'
 import { computed, ComputedRef, defineComponent, inject, unref } from 'vue'
-import { Resource } from 'web-client'
+import { Resource, SpaceResource } from 'web-client'
 
 export default defineComponent({
   name: 'SpaceActions',
@@ -66,7 +66,7 @@ export default defineComponent({
     })
 
     return {
-      space: inject<ComputedRef<Resource>>('space'),
+      space: inject<ComputedRef<SpaceResource>>('space'),
       resources
     }
   },

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/EditDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/EditDropdown.vue
@@ -70,7 +70,7 @@ export default defineComponent({
       type: String,
       required: false,
       default: null,
-      validator: function (value) {
+      validator: function (value: string) {
         return ['user', 'group'].includes(value) || !value
       }
     },

--- a/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
@@ -51,7 +51,7 @@
                     class="oc-text-bold oc-display-block oc-width-1-1"
                     v-text="$gettext(roleOption.label)"
                   />
-                  <span class="oc-text-small">{{ $gettext(roleOption.description()) }}</span>
+                  <span class="oc-text-small">{{ $gettext(roleOption.description(false)) }}</span>
                 </span>
               </span>
               <span class="oc-flex">
@@ -180,9 +180,10 @@ import { createLocationSpaces } from '../../../../router'
 import {
   linkRoleInternalFile,
   linkRoleInternalFolder,
-  LinkShareRoles
+  LinkShareRoles,
+  ShareRole
 } from 'web-client/src/helpers/share'
-import { defineComponent, inject } from 'vue'
+import { defineComponent, inject, PropType } from 'vue'
 import { formatDateFromDateTime, formatRelativeDateFromDateTime } from 'web-pkg/src/helpers'
 import { Resource, SpaceResource } from 'web-client/src/helpers'
 import { createFileRouteOptions } from 'web-pkg/src/helpers/router'
@@ -191,7 +192,7 @@ export default defineComponent({
   name: 'DetailsAndEdit',
   props: {
     availableRoleOptions: {
-      type: Array,
+      type: Array as PropType<ShareRole[]>,
       required: true
     },
     canRename: {

--- a/packages/web-app-search/src/portals/SearchBar.vue
+++ b/packages/web-app-search/src/portals/SearchBar.vue
@@ -19,7 +19,7 @@
       @input="updateTerm"
       @clear="onClear"
       @click="showPreview"
-      @keyup.esc="$refs.optionsDrop.hide()"
+      @keyup.esc="hideOptionsDrop"
       @keyup.up="onKeyUpUp"
       @keyup.down="onKeyUpDown"
       @keyup.enter="onKeyUpEnter"
@@ -60,7 +60,7 @@
                   <router-link
                     class="more-results"
                     :to="getMoreResultsLinkForProvider(provider)"
-                    @click="$refs.optionsDrop.hide()"
+                    @click="hideOptionsDrop"
                   >
                     <span>{{ getMoreResultsDetailsTextForProvider(provider) }}</span>
                   </router-link>
@@ -80,7 +80,7 @@
                   class="preview-component"
                   :provider="provider"
                   :search-result="providerSearchResultValue"
-                  @click="$refs.optionsDrop.hide()"
+                  @click="hideOptionsDrop"
                 />
               </li>
             </oc-list>
@@ -113,7 +113,7 @@ export default defineComponent({
 
   data() {
     return {
-      resizeObserver: new ResizeObserver(this.onResize),
+      resizeObserver: new ResizeObserver(this.onResize as ResizeObserverCallback),
       showCancelButton: false,
       term: '',
       activeProvider: undefined,
@@ -349,7 +349,7 @@ export default defineComponent({
     },
     showSearchBar() {
       document.getElementById('files-global-search-bar').style.visibility = 'visible'
-      const inputElement = document.getElementsByClassName('oc-search-input')[0] // FIXME: add when TypeScript is enabled: as HTMLElement
+      const inputElement = document.getElementsByClassName('oc-search-input')[0] as HTMLElement
       inputElement.focus()
 
       this.showCancelButton = true
@@ -374,6 +374,9 @@ export default defineComponent({
           this.showCancelButton = false
         }
       }
+    },
+    hideOptionsDrop() {
+      this.$refs.optionsDrop.hide()
     }
   }
 })

--- a/packages/web-pkg/src/components/ContextActions/ContextActionMenu.vue
+++ b/packages/web-pkg/src/components/ContextActions/ContextActionMenu.vue
@@ -24,12 +24,17 @@ import { defineComponent, PropType } from 'vue'
 import ActionMenuItem from './ActionMenuItem.vue'
 import { SpaceResource } from 'web-client/src/helpers'
 
+type MenuSection = {
+  name: string
+  items: any[]
+}
+
 export default defineComponent({
   name: 'ContextActionMenu',
   components: { ActionMenuItem },
   props: {
     menuSections: {
-      type: Array,
+      type: Array as PropType<MenuSection[]>,
       required: true
     },
     // items can e.g. be currentFolder (breadcrumbs) or selectedResources (resourceTable)

--- a/packages/web-pkg/src/components/ItemFilter.vue
+++ b/packages/web-pkg/src/components/ItemFilter.vue
@@ -17,7 +17,7 @@
         />
         <div ref="itemFilterListRef">
           <oc-list class="item-filter-list">
-            <li v-for="item in displayedItems" :key="item.key" class="oc-my-xs">
+            <li v-for="(item, index) in displayedItems" :key="index" class="oc-my-xs">
               <component
                 :is="isSelectionAllowed(item) ? 'oc-button' : 'div'"
                 class="item-filter-list-item oc-flex oc-flex-left oc-flex-middle oc-width-1-1 oc-p-xs"

--- a/packages/web-pkg/src/components/QuotaSelect.vue
+++ b/packages/web-pkg/src/components/QuotaSelect.vue
@@ -135,8 +135,8 @@ export default {
           selectable: false
         }
       }
-      const value = parseFloat(option).toFixed(2) * Math.pow(10, 9)
-      const displayValue = parseFloat(option).toFixed(2).toString().replace('.00', '')
+      const value = parseFloat(option) * Math.pow(10, 9)
+      const displayValue = parseFloat(option).toFixed(2).replace('.00', '')
       if (this.maxQuota && value > this.maxQuota) {
         return {
           value,

--- a/packages/web-runtime/src/components/Avatar.vue
+++ b/packages/web-runtime/src/components/Avatar.vue
@@ -29,8 +29,8 @@ export default defineComponent({
     type: {
       type: String,
       default: 'div',
-      validator: (value) => {
-        return value.match(/(div|span)/)
+      validator: (value: string) => {
+        return ['div', 'span'].includes(value)
       }
     },
     userName: {

--- a/packages/web-runtime/src/components/Topbar/UserMenu.vue
+++ b/packages/web-runtime/src/components/Topbar/UserMenu.vue
@@ -77,7 +77,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { defineComponent, PropType } from 'vue'
 import { mapGetters, mapState } from 'vuex'
 import filesize from 'filesize'
 import isNil from 'lodash-es/isNil'
@@ -87,7 +87,7 @@ import { useCapabilitySpacesEnabled } from 'web-pkg/src/composables'
 export default defineComponent({
   props: {
     applicationsList: {
-      type: Array,
+      type: Array as PropType<any>,
       required: false,
       default: () => []
     }

--- a/packages/web-runtime/src/components/UploadInfo.vue
+++ b/packages/web-runtime/src/components/UploadInfo.vue
@@ -155,7 +155,7 @@ export default defineComponent({
   data: () => ({
     showInfo: false, // show the overlay?
     infoExpanded: false, // show the info including all uploads?
-    uploads: {}, // uploads that are being displayed via "infoExpanded"
+    uploads: {} as Record<any, any>, // uploads that are being displayed via "infoExpanded"
     errors: {}, // all failed files
     successful: [], // all successful files
     filesInProgressCount: 0, // files (not folders!) that are being processed currently

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,95 @@
 {
-  "extends": "@ownclouders/tsconfig",
   "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                         /* Enable incremental compilation */
+    "target": "esnext",
+    /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "commonjs",
+    /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "lib": [
+      "ESNext",
+      "es2020",
+      "dom"
+    ],
+    /* Specify library files to be included in the compilation. */
+    //"allowJs": true,
+    /* Allow javascript files to be compiled. */
+    // "checkJs": true,                             /* Report errors in .js files. */
+    // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
+    // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                           /* Generates corresponding '.map' file. */
+    // "outFile": "./",                             /* Concatenate and emit output to single file. */
+    // "outDir": "./",                              /* Redirect output structure to the directory. */
+    // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                           /* Enable project compilation */
+    // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
+    // "removeComments": true,                      /* Do not emit comments to output. */
+    // "noEmit": true,                              /* Do not emit outputs. */
+    // "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
+    "downlevelIteration": true,
+    /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    "isolatedModules": true, /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+    /* Strict Type-Checking Options */
+    "strict": false,
+    /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                       /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                    /* Enable strict null checks. */
+    // "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,                 /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,        /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                      /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                        /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                      /* Report errors on unused locals. */
+    // "noUnusedParameters": true,                  /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,                   /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
+    // "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
+    // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
+    /* Module Resolution Options */
+    "moduleResolution": "node",
+    /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                             /* List of folders to include type definitions from. */
+    // "types": [],                                 /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,
+    /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
+    /* Source Map Options */
+    // "sourceRoot": "",                            /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                               /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,                     /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                       /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+    /* Experimental Options */
+    "experimentalDecorators": true,
+    /* Enables experimental support for ES7 decorators. */
+    //"emitDecoratorMetadata": true,
+    /* Enables experimental support for emitting type metadata for decorators. */
+    /* Advanced Options */
+    "skipLibCheck": true,
+    /* Skip type checking of declaration files. */
+    "forceConsistentCasingInFileNames": true,
+    /* Disallow inconsistently-cased references to the same file. */
+    "resolveJsonModule": true,
     "baseUrl": "./",
     "paths": {
       "*": [
         "packages/*"
       ]
     }
+  },
+  "exclude": [
+    "node_modules"
+  ],
+  "vueCompilerOptions": {
+    "target": 3
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,95 +1,11 @@
 {
+  "extends": "@ownclouders/tsconfig",
   "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig.json to read more about this file */
-
-    /* Basic Options */
-    // "incremental": true,                         /* Enable incremental compilation */
-    "target": "esnext",
-    /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-    "module": "commonjs",
-    /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    "lib": [
-      "ESNext",
-      "es2020",
-      "dom"
-    ],
-    /* Specify library files to be included in the compilation. */
-    //"allowJs": true,
-    /* Allow javascript files to be compiled. */
-    // "checkJs": true,                             /* Report errors in .js files. */
-    // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
-    // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                           /* Generates corresponding '.map' file. */
-    // "outFile": "./",                             /* Concatenate and emit output to single file. */
-    // "outDir": "./",                              /* Redirect output structure to the directory. */
-    // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                           /* Enable project compilation */
-    // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
-    // "removeComments": true,                      /* Do not emit comments to output. */
-    // "noEmit": true,                              /* Do not emit outputs. */
-    // "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
-    "downlevelIteration": true,
-    /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    "isolatedModules": true, /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-    /* Strict Type-Checking Options */
-    "strict": false,
-    /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                       /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,                    /* Enable strict null checks. */
-    // "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
-    // "strictBindCallApply": true,                 /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
-    // "strictPropertyInitialization": true,        /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                      /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                        /* Parse in strict mode and emit "use strict" for each source file. */
-
-    /* Additional Checks */
-    // "noUnusedLocals": true,                      /* Report errors on unused locals. */
-    // "noUnusedParameters": true,                  /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,                   /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
-    // "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
-    // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
-    /* Module Resolution Options */
-    "moduleResolution": "node",
-    /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                             /* List of folders to include type definitions from. */
-    // "types": [],                                 /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,
-    /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
-    // "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
-    /* Source Map Options */
-    // "sourceRoot": "",                            /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                               /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,                     /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                       /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-    /* Experimental Options */
-    "experimentalDecorators": true,
-    /* Enables experimental support for ES7 decorators. */
-    //"emitDecoratorMetadata": true,
-    /* Enables experimental support for emitting type metadata for decorators. */
-    /* Advanced Options */
-    "skipLibCheck": true,
-    /* Skip type checking of declaration files. */
-    "forceConsistentCasingInFileNames": true,
-    /* Disallow inconsistently-cased references to the same file. */
-    "resolveJsonModule": true,
     "baseUrl": "./",
     "paths": {
       "*": [
         "packages/*"
       ]
     }
-  },
-  "exclude": [
-    "node_modules"
-  ],
-  "vueCompilerOptions": {
-    "target": 3
   }
 }


### PR DESCRIPTION
## Description
Fix a bunch of typescript type errors in `.vue` files.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
We want to replace `tsc` with `vue-tsc` so types in `.vue` files are also checked.
Currently it does not work, because our `tsconfig.json` uses `extends` and the references package somehow is not found by `vue-tsc`.
We temporarily replaced the `extends` with the actual config from our tsconfig package. This allowed us to fix errors already.

vue-tsc will be fixed and enabled in a followup.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
