### PR TITLE
Introduce ancestor meta data to store

### DIFF
--- a/packages/web-app-files/src/services/folder/loaderSpace.ts
+++ b/packages/web-app-files/src/services/folder/loaderSpace.ts
@@ -89,7 +89,7 @@ export class FolderLoaderSpace implements FolderLoader {
         }
 
         yield store.dispatch('Files/loadAncestorMetaData', {
-          path: currentFolder.path,
+          folder: currentFolder,
           space,
           client: webdav
         })

--- a/packages/web-app-files/src/services/folder/loaderSpace.ts
+++ b/packages/web-app-files/src/services/folder/loaderSpace.ts
@@ -88,6 +88,12 @@ export class FolderLoaderSpace implements FolderLoader {
           }
         }
 
+        yield store.dispatch('Files/loadAncestorMetaData', {
+          path: currentFolder.path,
+          space,
+          client: webdav
+        })
+
         store.commit('Files/LOAD_FILES', {
           currentFolder,
           files: resources

--- a/packages/web-app-files/src/store/actions.ts
+++ b/packages/web-app-files/src/store/actions.ts
@@ -542,12 +542,16 @@ export default {
           .listFiles(
             space,
             { path: parentPath },
-            { depth: 0, davProperties: [DavProperty.FileId, DavProperty.ShareTypes] }
+            {
+              depth: 0,
+              davProperties: [DavProperty.FileId, DavProperty.ShareTypes, DavProperty.FileParent]
+            }
           )
           .then(({ resource }) => {
             ancestorMetaData[parentPath] = {
               id: resource.fileId,
               shareTypes: resource.shareTypes,
+              parentFolderId: resource.parentFolderId,
               spaceId: space.id
             }
           })

--- a/packages/web-app-files/src/store/getters.ts
+++ b/packages/web-app-files/src/store/getters.ts
@@ -12,6 +12,9 @@ export default {
   currentFolder: (state) => {
     return state.currentFolder
   },
+  ancestorMetaData: (state) => {
+    return state.ancestorMetaData
+  },
   clipboardResources: (state) => {
     return state.clipboardResources
   },

--- a/packages/web-app-files/src/store/mutations.ts
+++ b/packages/web-app-files/src/store/mutations.ts
@@ -236,6 +236,10 @@ export default {
     state.areFileExtensionsShown = value
 
     window.localStorage.setItem('oc_fileExtensionsShown', value)
+  },
+
+  SET_ANCESTOR_META_DATA(state, value) {
+    state.ancestorMetaData = value
   }
 }
 

--- a/packages/web-app-files/src/store/state.ts
+++ b/packages/web-app-files/src/store/state.ts
@@ -8,6 +8,7 @@ export default {
   clipboardResources: [],
   clipboardAction: null,
   versions: [],
+  ancestorMetaData: {},
 
   /**
    * Outgoing shares and links from currently highlighted element


### PR DESCRIPTION
## Description
This PR introduces the `ancestorMetaData` state in the store. It holds information about all ancestor folders: `fileId`, `sharesTypes`, `space`, `parentFolderId`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
