### PR TITLE
Clarify `config.json` installation path

### DIFF
--- a/docs/backend-oc10.md
+++ b/docs/backend-oc10.md
@@ -52,7 +52,7 @@ Login as administrator in the ownCloud Server web interface and go to the "User 
 
 ### Setting up Web
 
-In the local Web checkout, copy the `config/config.json.sample-oc10` file to `config/config.json` and adjust it accordingly:
+In the ownCloud server directory, copy the `apps/web/config/config.json.sample-oc10` file to `config/config.json` and adjust it accordingly:
 
 - Set the "server" key to the URL of the ownCloud server including path. If the URL contains a path, please also add a **trailing slash** there.
 - Set the "clientId" key to the **client identifier** as copied from the "User Authentication" section before.


### PR DESCRIPTION
## Description
When installing ownCloud Web in ownCloud 10 as app, the supplied `config.json.sample-oc10` is in `/path/to/owncloud/apps/web/config/` The `config.json` needs to be installed inside `/path/to/owncloud/config/` and not `/path/to/owncloud/apps/web/config/`


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
