### PR TITLE
[tests-only][full-ci] Fix upload success check 

### DIFF
--- a/tests/acceptance/pageObjects/personalPage.js
+++ b/tests/acceptance/pageObjects/personalPage.js
@@ -243,7 +243,7 @@ module.exports = {
         .click('@dialogConfirmBtnSecondaryEnabled')
         .waitForElementNotPresent('@dialog')
         .waitForAjaxCallsToStartAndFinish()
-        .waitForElementVisible('@fileUploadStatus')
+        .waitForElementVisible('@uploadSuccess')
         .closeFileFolderUploadProgress()
       return this
     },
@@ -414,6 +414,9 @@ module.exports = {
     },
     dialogBoxInputTextInRed: {
       selector: '.oc-text-input-danger'
+    },
+    uploadSuccess: {
+      selector: '.upload-info-status .upload-info-success'
     }
   }
 }


### PR DESCRIPTION
## Description
This PR changes the selector to strictly check for successful upload message dialogue only.
Before used selector was used to check the general upload message dialogue box whether its success or fail.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8391

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
