### PR TITLE
[tests-only][full-ci] Confirm context save completion 

### DIFF
--- a/tests/acceptance/pageObjects/textEditorPage.js
+++ b/tests/acceptance/pageObjects/textEditorPage.js
@@ -50,7 +50,9 @@ module.exports = {
       return this.elements.previewPanel.selector
     },
     saveFileEdit: function () {
-      return this.waitForElementVisible('@saveButton').click('@saveButton')
+      return this.waitForElementVisible('@saveButton')
+        .click('@saveButton')
+        .waitForElementVisible('@saveButtonDisabled')
     },
     closeTextEditor: function () {
       return this.waitForElementVisible('@closeButton').click('@closeButton')
@@ -99,6 +101,9 @@ module.exports = {
     },
     previewPanel: {
       selector: '#text-editor-preview'
+    },
+    saveButtonDisabled: {
+      selector: '#text-editor-controls-save:disabled'
     }
   }
 }


### PR DESCRIPTION
## Description
Previously we didn't wait until save-action finished which caused the intermittent failure.
This PR waits for save-button to be disables after it saves the changes

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8329

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
