### PR TITLE
[tests-only][full-ci]Bump commit id for tests in stable-6.0

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=d3a1c36c214b8dd6100f91ace930aa03791e2fc5
+OCIS_COMMITID=9286df9a1cd15a618a2477551c9d58c7cde944ec
 OCIS_BRANCH=stable-2.0


### PR DESCRIPTION
This PR bumps the commit id of ocis stable branch for tests
part of: https://github.com/owncloud/QA/issues/797