### PR TITLE
Option to inject custom css and js files

### DIFF
--- a/changelog/unreleased/enhancement-inject-customizations
+++ b/changelog/unreleased/enhancement-inject-customizations
@@ -6,7 +6,7 @@ This function is currently still experimental and there is a possibility that th
 For the reasons mentioned, the functionality is not yet documented in the official documentation, but can be used as follows:
 
 * to inject custom css add the following property to your `config.json`, `"styles": [{ "href": "css/custom.css", }]`.
-* to inject custom scripts add the following property to your `config.json`, `"scripts": [{ "src": "css/custom.js", "async": true, }]`.
+* to inject custom scripts add the following property to your `config.json`, `"scripts": [{ "src": "js/custom.js", "async": true, }]`.
 
 https://github.com/owncloud/web/pull/8432
 https://github.com/owncloud/web/pull/7689

--- a/changelog/unreleased/enhancement-inject-customizations
+++ b/changelog/unreleased/enhancement-inject-customizations
@@ -1,0 +1,13 @@
+Enhancement: Inject customizations
+
+We have added the possibility to include own header scripts and styles.
+This function is currently still experimental and there is a possibility that the api will change.
+
+For the reasons mentioned, the functionality is not yet documented in the official documentation, but can be used as follows:
+
+* to inject custom css add the following property to your `config.json`, `"styles": [{ "href": "css/custom.css", }]`.
+* to inject custom scripts add the following property to your `config.json`, `"scripts": [{ "src": "css/custom.js", "async": true, }]`.
+
+https://github.com/owncloud/web/pull/8430
+https://github.com/owncloud/web/pull/7689
+https://github.com/owncloud/web/issues/4735

--- a/changelog/unreleased/enhancement-inject-customizations
+++ b/changelog/unreleased/enhancement-inject-customizations
@@ -8,6 +8,6 @@ For the reasons mentioned, the functionality is not yet documented in the offici
 * to inject custom css add the following property to your `config.json`, `"styles": [{ "href": "css/custom.css", }]`.
 * to inject custom scripts add the following property to your `config.json`, `"scripts": [{ "src": "css/custom.js", "async": true, }]`.
 
-https://github.com/owncloud/web/pull/8430
+https://github.com/owncloud/web/pull/8432
 https://github.com/owncloud/web/pull/7689
 https://github.com/owncloud/web/issues/4735

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -390,3 +390,52 @@ export const startSentry = (runtimeConfiguration: RuntimeConfiguration, app: App
     })
   }
 }
+
+/**
+ * announceCustomScripts injects custom header scripts.
+ *
+ * @param runtimeConfiguration
+ */
+export const announceCustomScripts = ({
+  runtimeConfiguration
+}: {
+  runtimeConfiguration?: RuntimeConfiguration
+}): void => {
+  const { scripts = [] } = runtimeConfiguration
+
+  scripts.forEach(({ src = '', async = false }) => {
+    if (!src) {
+      return
+    }
+
+    const script = document.createElement('script')
+    script.src = src
+    script.async = async
+    document.head.appendChild(script)
+  })
+}
+
+/**
+ * announceCustomStyles injects custom header styles.
+ *
+ * @param runtimeConfiguration
+ */
+export const announceCustomStyles = ({
+  runtimeConfiguration
+}: {
+  runtimeConfiguration?: RuntimeConfiguration
+}): void => {
+  const { styles = [] } = runtimeConfiguration
+
+  styles.forEach(({ href = '' }) => {
+    if (!href) {
+      return
+    }
+
+    const link = document.createElement('link')
+    link.href = href
+    link.type = 'text/css'
+    link.rel = 'stylesheet'
+    document.head.appendChild(link)
+  })
+}

--- a/packages/web-runtime/src/container/index.ts
+++ b/packages/web-runtime/src/container/index.ts
@@ -1,2 +1,0 @@
-export * from './bootstrap'
-export * from './store'

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -1,9 +1,7 @@
 import { DesignSystem as designSystem, pages, translations, supportedLanguages } from './defaults'
-
 import { router } from './router'
 import { configurationManager } from 'web-pkg/src/configuration'
 import { createHead } from '@vueuse/head'
-
 import {
   announceConfiguration,
   initializeApplications,
@@ -13,14 +11,16 @@ import {
   announceClientService,
   announceStore,
   announceTheme,
+  announceCustomStyles,
   announceTranslations,
   announceVersions,
-  applicationStore,
   announceUppyService,
   announceAuthService,
   announcePermissionManager,
-  startSentry
-} from './container'
+  startSentry,
+  announceCustomScripts
+} from './container/bootstrap'
+import { applicationStore } from './container/store'
 import {
   buildPublicSpaceResource,
   buildSpace,
@@ -63,6 +63,8 @@ export const bootstrapApp = async (configurationPath: string): Promise<void> => 
   announceUppyService({ app })
   await announceClient(runtimeConfiguration)
   await announceAuthService({ app, configurationManager, store, router })
+  announceCustomStyles({ runtimeConfiguration })
+  announceCustomScripts({ runtimeConfiguration })
   announceDefaults({ store, router })
 
   app.use(router)


### PR DESCRIPTION
Add option to include own header scripts and styles.
This function is currently still experimental and there is a possibility that the api will change.

For the reasons mentioned, the functionality is not yet documented in the official documentation, but can be used as follows:

* to inject custom css add the following property to your `config.json`, `"styles": [{ "href": "css/custom.css", }]`.
* to inject custom scripts add the following property to your `config.json`, `"scripts": [{ "src": "js/custom.js", "async": true, }]`.

The feature was requested in https://github.com/owncloud/web/issues/4735 and backported from the experimental branch.