### PR TITLE
[full-ci] Pass `globalProperties` to routes and navItems of apps

### DIFF
--- a/packages/web-app-admin-settings/src/index.ts
+++ b/packages/web-app-admin-settings/src/index.ts
@@ -15,14 +15,11 @@ const appInfo = {
   isFileEditor: false
 }
 
-// FIXME: a better way to access this is needed
-const permissionManager = () => (window as any).__$permissionManager
-
-const routes = [
+const routes = (permissionManager) => [
   {
     path: '/',
     redirect: () => {
-      if (permissionManager().hasSystemManagement()) {
+      if (permissionManager.hasSystemManagement()) {
         return { name: 'admin-settings-general' }
       }
       return { name: 'admin-settings-spaces' }
@@ -66,7 +63,7 @@ const routes = [
   }
 ]
 
-const navItems = [
+const navItems = (permissionManager) => [
   {
     name: $gettext('General'),
     icon: 'settings-4',
@@ -74,7 +71,7 @@ const navItems = [
       path: `/${appInfo.id}/general?`
     },
     enabled: () => {
-      return permissionManager().hasSystemManagement()
+      return permissionManager.hasSystemManagement()
     }
   },
   {
@@ -84,7 +81,7 @@ const navItems = [
       path: `/${appInfo.id}/users?`
     },
     enabled: () => {
-      return permissionManager().hasUserManagement()
+      return permissionManager.hasUserManagement()
     }
   },
   {
@@ -94,7 +91,7 @@ const navItems = [
       path: `/${appInfo.id}/groups?`
     },
     enabled: () => {
-      return permissionManager().hasUserManagement()
+      return permissionManager.hasUserManagement()
     }
   },
   {
@@ -104,7 +101,7 @@ const navItems = [
       path: `/${appInfo.id}/spaces?`
     },
     enabled: () => {
-      return permissionManager().hasSpaceManagement()
+      return permissionManager.hasSpaceManagement()
     }
   }
 ]

--- a/packages/web-app-admin-settings/src/index.ts
+++ b/packages/web-app-admin-settings/src/index.ts
@@ -15,11 +15,11 @@ const appInfo = {
   isFileEditor: false
 }
 
-const routes = (permissionManager) => [
+const routes = ({ $permissionManager }) => [
   {
     path: '/',
     redirect: () => {
-      if (permissionManager.hasSystemManagement()) {
+      if ($permissionManager.hasSystemManagement()) {
         return { name: 'admin-settings-general' }
       }
       return { name: 'admin-settings-spaces' }
@@ -63,7 +63,7 @@ const routes = (permissionManager) => [
   }
 ]
 
-const navItems = (permissionManager) => [
+const navItems = ({ $permissionManager }) => [
   {
     name: $gettext('General'),
     icon: 'settings-4',
@@ -71,7 +71,7 @@ const navItems = (permissionManager) => [
       path: `/${appInfo.id}/general?`
     },
     enabled: () => {
-      return permissionManager.hasSystemManagement()
+      return $permissionManager.hasSystemManagement()
     }
   },
   {
@@ -81,7 +81,7 @@ const navItems = (permissionManager) => [
       path: `/${appInfo.id}/users?`
     },
     enabled: () => {
-      return permissionManager.hasUserManagement()
+      return $permissionManager.hasUserManagement()
     }
   },
   {
@@ -91,7 +91,7 @@ const navItems = (permissionManager) => [
       path: `/${appInfo.id}/groups?`
     },
     enabled: () => {
-      return permissionManager.hasUserManagement()
+      return $permissionManager.hasUserManagement()
     }
   },
   {
@@ -101,7 +101,7 @@ const navItems = (permissionManager) => [
       path: `/${appInfo.id}/spaces?`
     },
     enabled: () => {
-      return permissionManager.hasSpaceManagement()
+      return $permissionManager.hasSpaceManagement()
     }
   }
 ]

--- a/packages/web-app-admin-settings/tests/unit/index.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/index.spec.ts
@@ -4,54 +4,68 @@ describe('admin settings index', () => {
   describe('navItems', () => {
     describe('general', () => {
       it.each([true, false])('should be enabled according to the permissions', (enabled) => {
-        ;(window as any).__$permissionManager = {
-          hasSystemManagement: () => enabled
-        }
-        expect(index.navItems.find((n) => n.name === 'General').enabled()).toBe(enabled)
+        const permissionManager = { hasSystemManagement: () => enabled }
+        expect(
+          index
+            .navItems(permissionManager)
+            .find((n) => n.name === 'General')
+            .enabled()
+        ).toBe(enabled)
       })
     })
     describe('user management', () => {
       it.each([true, false])('should be enabled according to the permissions', (enabled) => {
-        ;(window as any).__$permissionManager = {
-          hasUserManagement: () => enabled
-        }
-        expect(index.navItems.find((n) => n.name === 'Users').enabled()).toBe(enabled)
+        const permissionManager = { hasUserManagement: () => enabled }
+        expect(
+          index
+            .navItems(permissionManager)
+            .find((n) => n.name === 'Users')
+            .enabled()
+        ).toBe(enabled)
       })
     })
     describe('group management', () => {
       it.each([true, false])('should be enabled according to the permissions', (enabled) => {
-        ;(window as any).__$permissionManager = {
-          hasUserManagement: () => enabled
-        }
-        expect(index.navItems.find((n) => n.name === 'Groups').enabled()).toBe(enabled)
+        const permissionManager = { hasUserManagement: () => enabled }
+        expect(
+          index
+            .navItems(permissionManager)
+            .find((n) => n.name === 'Groups')
+            .enabled()
+        ).toBe(enabled)
       })
     })
     describe('space management', () => {
       it.each([true, false])('should be enabled according to the permissions', (enabled) => {
-        ;(window as any).__$permissionManager = {
-          hasSpaceManagement: () => enabled
-        }
-        expect(index.navItems.find((n) => n.name === 'Spaces').enabled()).toBe(enabled)
+        const permissionManager = { hasSpaceManagement: () => enabled }
+        expect(
+          index
+            .navItems(permissionManager)
+            .find((n) => n.name === 'Spaces')
+            .enabled()
+        ).toBe(enabled)
       })
     })
   })
   describe('routes', () => {
     describe('default-route "/"', () => {
       it('should redirect to general if permission given', () => {
-        ;(window as any).__$permissionManager = {
-          hasSystemManagement: () => true
-        }
-        expect(index.routes.find((n) => n.path === '/').redirect().name).toEqual(
-          'admin-settings-general'
-        )
+        const permissionManager = { hasSystemManagement: () => true }
+        expect(
+          index
+            .routes(permissionManager)
+            .find((n) => n.path === '/')
+            .redirect().name
+        ).toEqual('admin-settings-general')
       })
       it('should redirect to space management if no system management permission given', () => {
-        ;(window as any).__$permissionManager = {
-          hasSystemManagement: () => false
-        }
-        expect(index.routes.find((n) => n.path === '/').redirect().name).toEqual(
-          'admin-settings-spaces'
-        )
+        const permissionManager = { hasSystemManagement: () => false }
+        expect(
+          index
+            .routes(permissionManager)
+            .find((n) => n.path === '/')
+            .redirect().name
+        ).toEqual('admin-settings-spaces')
       })
     })
   })

--- a/packages/web-app-admin-settings/tests/unit/index.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/index.spec.ts
@@ -4,10 +4,10 @@ describe('admin settings index', () => {
   describe('navItems', () => {
     describe('general', () => {
       it.each([true, false])('should be enabled according to the permissions', (enabled) => {
-        const permissionManager = { hasSystemManagement: () => enabled }
+        const $permissionManager = { hasSystemManagement: () => enabled }
         expect(
           index
-            .navItems(permissionManager)
+            .navItems({ $permissionManager })
             .find((n) => n.name === 'General')
             .enabled()
         ).toBe(enabled)
@@ -15,10 +15,10 @@ describe('admin settings index', () => {
     })
     describe('user management', () => {
       it.each([true, false])('should be enabled according to the permissions', (enabled) => {
-        const permissionManager = { hasUserManagement: () => enabled }
+        const $permissionManager = { hasUserManagement: () => enabled }
         expect(
           index
-            .navItems(permissionManager)
+            .navItems({ $permissionManager })
             .find((n) => n.name === 'Users')
             .enabled()
         ).toBe(enabled)
@@ -26,10 +26,10 @@ describe('admin settings index', () => {
     })
     describe('group management', () => {
       it.each([true, false])('should be enabled according to the permissions', (enabled) => {
-        const permissionManager = { hasUserManagement: () => enabled }
+        const $permissionManager = { hasUserManagement: () => enabled }
         expect(
           index
-            .navItems(permissionManager)
+            .navItems({ $permissionManager })
             .find((n) => n.name === 'Groups')
             .enabled()
         ).toBe(enabled)
@@ -37,10 +37,10 @@ describe('admin settings index', () => {
     })
     describe('space management', () => {
       it.each([true, false])('should be enabled according to the permissions', (enabled) => {
-        const permissionManager = { hasSpaceManagement: () => enabled }
+        const $permissionManager = { hasSpaceManagement: () => enabled }
         expect(
           index
-            .navItems(permissionManager)
+            .navItems({ $permissionManager })
             .find((n) => n.name === 'Spaces')
             .enabled()
         ).toBe(enabled)
@@ -50,19 +50,19 @@ describe('admin settings index', () => {
   describe('routes', () => {
     describe('default-route "/"', () => {
       it('should redirect to general if permission given', () => {
-        const permissionManager = { hasSystemManagement: () => true }
+        const $permissionManager = { hasSystemManagement: () => true }
         expect(
           index
-            .routes(permissionManager)
+            .routes({ $permissionManager })
             .find((n) => n.path === '/')
             .redirect().name
         ).toEqual('admin-settings-general')
       })
       it('should redirect to space management if no system management permission given', () => {
-        const permissionManager = { hasSystemManagement: () => false }
+        const $permissionManager = { hasSystemManagement: () => false }
         expect(
           index
-            .routes(permissionManager)
+            .routes({ $permissionManager })
             .find((n) => n.path === '/')
             .redirect().name
         ).toEqual('admin-settings-spaces')

--- a/packages/web-runtime/src/container/application/classic.ts
+++ b/packages/web-runtime/src/container/application/classic.ts
@@ -23,9 +23,9 @@ class ClassicApplication extends NextApplication {
 
   initialize(): Promise<void> {
     const { routes, navItems, translations, quickActions, store } = this.applicationScript
-    const permissionManager = this.app.config.globalProperties.$permissionManager
-    const _routes = typeof routes === 'function' ? routes(permissionManager) : routes
-    const _navItems = typeof navItems === 'function' ? navItems(permissionManager) : navItems
+    const { globalProperties } = this.app.config
+    const _routes = typeof routes === 'function' ? routes(globalProperties) : routes
+    const _navItems = typeof navItems === 'function' ? navItems(globalProperties) : navItems
 
     routes && this.runtimeApi.announceRoutes(_routes)
     navItems && this.runtimeApi.announceNavigationItems(_navItems)

--- a/packages/web-runtime/src/container/application/index.ts
+++ b/packages/web-runtime/src/container/application/index.ts
@@ -14,7 +14,7 @@ import * as luxon from 'luxon' // eslint-disable-line
 import * as vueGettext from 'vue3-gettext' // eslint-disable-line
 
 import { urlJoin } from 'web-client/src/utils'
-import { ConfigurationManager } from 'web-pkg'
+import { ConfigurationManager, PermissionManager } from 'web-pkg'
 
 export { NextApplication } from './next'
 
@@ -57,7 +57,8 @@ export const buildApplication = async ({
   router,
   translations,
   supportedLanguages,
-  configurationManager
+  configurationManager,
+  permissionManager
 }: {
   applicationPath: string
   store: Store<unknown>
@@ -65,6 +66,7 @@ export const buildApplication = async ({
   translations: unknown
   supportedLanguages: { [key: string]: string }
   configurationManager: ConfigurationManager
+  permissionManager: PermissionManager
 }): Promise<NextApplication> => {
   if (applicationStore.has(applicationPath)) {
     throw new RuntimeError('application already announced', applicationPath)
@@ -115,7 +117,8 @@ export const buildApplication = async ({
         store,
         router,
         translations,
-        supportedLanguages
+        supportedLanguages,
+        permissionManager
       }).catch()
     }
   } catch (err) {

--- a/packages/web-runtime/src/container/application/index.ts
+++ b/packages/web-runtime/src/container/application/index.ts
@@ -14,7 +14,8 @@ import * as luxon from 'luxon' // eslint-disable-line
 import * as vueGettext from 'vue3-gettext' // eslint-disable-line
 
 import { urlJoin } from 'web-client/src/utils'
-import { ConfigurationManager, PermissionManager } from 'web-pkg'
+import { ConfigurationManager } from 'web-pkg'
+import { App } from 'vue'
 
 export { NextApplication } from './next'
 
@@ -52,21 +53,21 @@ const loadScriptRequireJS = <T>(moduleUri: string) => {
  * @param args
  */
 export const buildApplication = async ({
+  app,
   applicationPath,
   store,
   router,
   translations,
   supportedLanguages,
-  configurationManager,
-  permissionManager
+  configurationManager
 }: {
+  app: App
   applicationPath: string
   store: Store<unknown>
   router: Router
   translations: unknown
   supportedLanguages: { [key: string]: string }
   configurationManager: ConfigurationManager
-  permissionManager: PermissionManager
 }): Promise<NextApplication> => {
   if (applicationStore.has(applicationPath)) {
     throw new RuntimeError('application already announced', applicationPath)
@@ -113,12 +114,12 @@ export const buildApplication = async ({
       throw new RuntimeError('next applications not implemented yet, stay tuned')
     } else {
       application = await convertClassicApplication({
+        app,
         applicationScript,
         store,
         router,
         translations,
-        supportedLanguages,
-        permissionManager
+        supportedLanguages
       }).catch()
     }
   } catch (err) {

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -97,29 +97,29 @@ export const announceClient = async (runtimeConfiguration: RuntimeConfiguration)
  * - bulk build all applications
  * - bulk register all applications, no other application is guaranteed to be registered here, don't request one
  *
+ * @param app
  * @param runtimeConfiguration
  * @param store
  * @param router
  * @param translations
  * @param supportedLanguages
- * @param permissionManager
  */
 export const initializeApplications = async ({
+  app,
   runtimeConfiguration,
   configurationManager,
   store,
   router,
   translations,
-  supportedLanguages,
-  permissionManager
+  supportedLanguages
 }: {
+  app: App
   runtimeConfiguration: RuntimeConfiguration
   configurationManager: ConfigurationManager
   store: Store<unknown>
   router: Router
   translations: unknown
   supportedLanguages: { [key: string]: string }
-  permissionManager: PermissionManager
 }): Promise<NextApplication[]> => {
   const { apps: internalApplications = [], external_apps: externalApplications = [] } =
     rewriteDeprecatedAppNames(runtimeConfiguration)
@@ -132,13 +132,13 @@ export const initializeApplications = async ({
   const applicationResults = await Promise.allSettled(
     applicationPaths.map((applicationPath) =>
       buildApplication({
+        app,
         applicationPath,
         store,
         supportedLanguages,
         router,
         translations,
-        configurationManager,
-        permissionManager
+        configurationManager
       })
     )
   )

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -102,6 +102,7 @@ export const announceClient = async (runtimeConfiguration: RuntimeConfiguration)
  * @param router
  * @param translations
  * @param supportedLanguages
+ * @param permissionManager
  */
 export const initializeApplications = async ({
   runtimeConfiguration,
@@ -109,7 +110,8 @@ export const initializeApplications = async ({
   store,
   router,
   translations,
-  supportedLanguages
+  supportedLanguages,
+  permissionManager
 }: {
   runtimeConfiguration: RuntimeConfiguration
   configurationManager: ConfigurationManager
@@ -117,6 +119,7 @@ export const initializeApplications = async ({
   router: Router
   translations: unknown
   supportedLanguages: { [key: string]: string }
+  permissionManager: PermissionManager
 }): Promise<NextApplication[]> => {
   const { apps: internalApplications = [], external_apps: externalApplications = [] } =
     rewriteDeprecatedAppNames(runtimeConfiguration)
@@ -134,7 +137,8 @@ export const initializeApplications = async ({
         supportedLanguages,
         router,
         translations,
-        configurationManager
+        configurationManager,
+        permissionManager
       })
     )
   )

--- a/packages/web-runtime/src/container/types.ts
+++ b/packages/web-runtime/src/container/types.ts
@@ -65,8 +65,8 @@ export interface ApplicationTranslations {
 export interface ClassicApplicationScript {
   appInfo?: ApplicationInformation
   store?: Store<any>
-  routes?: RouteRecordRaw[]
-  navItems?: ApplicationNavigationItem[]
+  routes?: ((...args) => RouteRecordRaw[]) | RouteRecordRaw[]
+  navItems?: ((...args) => ApplicationNavigationItem[]) | ApplicationNavigationItem[]
   quickActions?: ApplicationQuickActions
   translations?: ApplicationTranslations
   initialize?: () => void

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -53,7 +53,8 @@ export const bootstrapApp = async (configurationPath: string): Promise<void> => 
     store,
     supportedLanguages,
     router,
-    translations
+    translations,
+    permissionManager: app.config.globalProperties.$permissionManager
   })
   const themePromise = announceTheme({ store, app, designSystem, runtimeConfiguration })
   await Promise.all([applicationsPromise, themePromise])

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -48,13 +48,13 @@ export const bootstrapApp = async (configurationPath: string): Promise<void> => 
   announcePermissionManager({ app, store })
 
   const applicationsPromise = await initializeApplications({
+    app,
     runtimeConfiguration,
     configurationManager,
     store,
     supportedLanguages,
     router,
-    translations,
-    permissionManager: app.config.globalProperties.$permissionManager
+    translations
   })
   const themePromise = announceTheme({ store, app, designSystem, runtimeConfiguration })
   await Promise.all([applicationsPromise, themePromise])

--- a/packages/web-runtime/tests/unit/container/bootstrap.spec.ts
+++ b/packages/web-runtime/tests/unit/container/bootstrap.spec.ts
@@ -31,6 +31,7 @@ describe('initialize applications', () => {
     jest.mocked(buildApplication).mockImplementation(buildApplicationMock)
 
     const applications = await initializeApplications({
+      app: createApp(defineComponent({})),
       configurationManager: mockDeep<ConfigurationManager>(),
       runtimeConfiguration: {
         apps: ['internalFishy', 'internalValid'],


### PR DESCRIPTION
## Description
This PR passes `globalProperties` to `routes` and `navItems`, which gives apps the possibility to use those when defining their routes and navigation items.

This is a pre-requisite for https://github.com/owncloud/web/pull/8431

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
