### PR TITLE
[full-ci] Show single (publicly) shared file in DetailsView

### DIFF
--- a/changelog/unreleased/enhancement-single-share-view
+++ b/changelog/unreleased/enhancement-single-share-view
@@ -1,0 +1,7 @@
+Enhancement: Open individually shared file in dedicated view
+
+We have added functionality to open a single, publicly shared file in a different view (instead of showing it in a table).
+
+https://github.com/owncloud/web/issues/8445
+https://github.com/owncloud/web/pull/8440
+https://github.com/owncloud/web/pull/8446

--- a/packages/web-app-files/src/components/FilesList/ResourceDetails.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceDetails.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="resource-details oc-flex oc-flex-column oc-flex-middle">
+    <div class="oc-width-1-3@l oc-width-1-2@m oc-width-3-4">
+      <file-info />
+      <file-details class="oc-mb" />
+      <file-actions />
+    </div>
+  </div>
+</template>
+  
+  <script lang="ts">
+import { computed, defineComponent, PropType } from 'vue'
+import { Resource, SpaceResource } from 'web-client/src/helpers'
+
+import FileActions from '../SideBar/Actions/FileActions.vue'
+import FileDetails from '../SideBar/Details/FileDetails.vue'
+import FileInfo from '../SideBar/FileInfo.vue'
+
+export default defineComponent({
+  components: {
+    FileActions,
+    FileDetails,
+    FileInfo
+  },
+  provide() {
+    return {
+      resource: computed(() => this.singleResource),
+      space: computed(() => this.space)
+    }
+  },
+  props: {
+    singleResource: {
+      type: Object as PropType<Resource>,
+      required: false,
+      default: null
+    },
+    space: {
+      type: Object as PropType<SpaceResource>,
+      required: false,
+      default: null
+    }
+  }
+})
+</script>

--- a/packages/web-app-files/src/components/SideBar/Actions/SpaceActions.vue
+++ b/packages/web-app-files/src/components/SideBar/Actions/SpaceActions.vue
@@ -33,9 +33,13 @@
 </template>
 
 <script lang="ts">
+import { computed, defineComponent, inject, ref, unref, VNodeRef } from 'vue'
+import { SpaceResource } from 'web-client'
 import ActionMenuItem from 'web-pkg/src/components/ContextActions/ActionMenuItem.vue'
-import { useSpaceActionsUploadImage } from '../../../composables/actions/spaces/useSpaceActionsUploadImage'
-
+import QuotaModal from 'web-pkg/src/components/Spaces/QuotaModal.vue'
+import ReadmeContentModal from 'web-pkg/src/components/Spaces/ReadmeContentModal.vue'
+import { useCapabilitySpacesMaxQuota, useStore, usePreviewService } from 'web-pkg/src/composables'
+import { SpaceAction } from 'web-pkg/src/composables/actions'
 import {
   useSpaceActionsDelete,
   useSpaceActionsDisable,
@@ -45,13 +49,7 @@ import {
   useSpaceActionsRename,
   useSpaceActionsRestore
 } from 'web-pkg/src/composables/actions/spaces'
-
-import QuotaModal from 'web-pkg/src/components/Spaces/QuotaModal.vue'
-import ReadmeContentModal from 'web-pkg/src/components/Spaces/ReadmeContentModal.vue'
-import { computed, defineComponent, inject, ref, unref, VNodeRef } from 'vue'
-import { SpaceResource } from 'web-client'
-import { useCapabilitySpacesMaxQuota, useStore, usePreviewService } from 'web-pkg/src/composables'
-import { SpaceAction } from 'web-pkg/src/composables/actions'
+import { useSpaceActionsUploadImage } from '../../../composables/actions/spaces/useSpaceActionsUploadImage'
 
 export default defineComponent({
   name: 'SpaceActions',

--- a/packages/web-app-files/src/components/SideBar/Shares/Links/CreateQuickLink.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Links/CreateQuickLink.vue
@@ -13,9 +13,9 @@
         />
       </div>
       <oc-button
+        v-oc-tooltip="$gettext('Create link')"
         class="oc-ml-s"
         size="small"
-        v-oc-tooltip="$gettext('Create link')"
         :aria-label="$gettext('Create link')"
         @click="createQuickLink"
       >

--- a/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
+++ b/tests/acceptance/expected-failures-with-oc10-server-oauth2-login.md
@@ -18,7 +18,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUISharingPublicManagement/shareByPublicLink.feature:24](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature#L24)
 
 ### [Uploading folders does not work in files-drop](https://github.com/owncloud/web/issues/2443)
--   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:245](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L245)
+-   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:268](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L268)
 
 ### [Writing to locked files/folders give only a generic error message](https://github.com/owncloud/web/issues/5741)
 -   [webUIWebdavLockProtection/upload.feature:32](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIWebdavLockProtection/upload.feature#L32)

--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -53,7 +53,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 - [webUISharingExpirationDate/shareWithExpirationDate.feature:21](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingExpirationDate/shareWithExpirationDate.feature#L21)
 
 ### [Listing shares via ocs API does not show path for parent folders](https://github.com/owncloud/ocis/issues/1231)
--   [webUISharingPublicManagement/shareByPublicLink.feature:127](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature#L127)
+-   [webUISharingPublicManagement/shareByPublicLink.feature:110](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature#L110)
 
 ### [Propfind response to trashbin endpoint is different in ocis](https://github.com/owncloud/product/issues/186)
 -   [webUIFilesSearch/search.feature:131](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L131)
@@ -84,7 +84,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUISharingPublicManagement/shareByPublicLink.feature:24](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature#L24)
 
 ### [Uploading folders does not work in files-drop](https://github.com/owncloud/web/issues/2443)
--   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:245](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L245)
+-   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:268](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L268)
 
 ### [Resources cannot be locked under ocis](https://github.com/owncloud/ocis/issues/1284)
 -   [webUIWebdavLockProtection/delete.feature:33](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIWebdavLockProtection/delete.feature#L33)

--- a/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
@@ -164,7 +164,7 @@ Feature: deleting files and folders
       |                 | &and#hash       |
     And user "Alice" has shared folder "simple-folder" with link with "read, update, create, delete" permissions in the server
     When the public uses the webUI to access the last public link created by user "Alice" in a new session
-    And the user deletes the following file using the webUI
+    And the user deletes the following single share using the webUI
       | name-parts      |
       | 'single'        |
       | "double" quotes |

--- a/tests/acceptance/features/webUIFilesCopy/copy.feature
+++ b/tests/acceptance/features/webUIFilesCopy/copy.feature
@@ -81,7 +81,7 @@ Feature: copy files and folders
     When the public uses the webUI to access the last public link created by user "Alice" in a new session
     And the user copies file "data.zip" into folder "simple-empty-folder" using the webUI
     Then breadcrumb for folder "simple-empty-folder" should be displayed on the webUI
-    And file "data.zip" should be listed on the webUI
+    And file "data.zip" should be listed on the webUI as single share
     And as "Alice" file "simple-folder/simple-empty-folder/data.zip" should exist in the server
     And as "Alice" file "simple-folder/data.zip" should exist in the server
 

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -89,7 +89,7 @@ Feature: move files
     And the public uses the webUI to access the last public link created by user "Alice" in a new session
     And the user moves file "data.zip" into folder "simple-empty-folder" using the webUI
     Then breadcrumb for folder "simple-empty-folder" should be displayed on the webUI
-    And file "data.zip" should be listed on the webUI
+    And file "data.zip" should be listed on the webUI as single share
     And as "Alice" file "simple-folder/simple-empty-folder/data.zip" should exist in the server
     But as "Alice" file "simple-folder/data.zip" should not exist in the server
 

--- a/tests/acceptance/features/webUIPreview/mediaPreview.feature
+++ b/tests/acceptance/features/webUIPreview/mediaPreview.feature
@@ -3,8 +3,8 @@ Feature: display image in preview app on the webUI
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files in the server
 
-@ocisSmokeTest
-Scenario Outline: preview of image files with preview app is possible
+  @ocisSmokeTest
+  Scenario Outline: preview of image files with preview app is possible
     Given user "Alice" has uploaded file "<image-file>" to "<image-file>" in the server
     And user "Alice" has logged in using the webUI
     When the user views the file "<image-file>" in the preview app using the webUI
@@ -28,7 +28,7 @@ Scenario Outline: preview of image files with preview app is possible
     And user "Alice" has created a public link with following settings in the server
       | path | simple-empty-folder |
     When the public uses the webUI to access the last public link created by user "Alice" in a new session
-    And the public views the file "test_video.mp4" in the preview app using the webUI
+    And the public views the single share file "test_video.mp4" in the preview app using the webUI
     Then the file "test_video.mp4" should be displayed in the preview app webUI
 
 
@@ -38,7 +38,7 @@ Scenario Outline: preview of image files with preview app is possible
     And user "Alice" has created a public link with following settings in the server
       | path | simple-empty-folder |
     When the public uses the webUI to access the last public link created by user "Alice" in a new session
-    And the public views the file "testavatar.jpg" in the preview app using the webUI
+    And the public views the single share file "testavatar.jpg" in the preview app using the webUI
     Then the file "testavatar.jpg" should be displayed in the preview app webUI
 
 

--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -188,11 +188,11 @@ Feature: rename files
     And user "Alice" has uploaded file "lorem.txt" to "simple-folder/lorem.txt" in the server
     And user "Alice" has shared folder "simple-folder" with link with "read, update, create, delete" permissions in the server
     When the public uses the webUI to access the last public link created by user "Alice" in a new session
-    And the user renames file "lorem.txt" to "a-renamed-file.txt" using the webUI
-    Then file "a-renamed-file.txt" should be listed on the webUI
+    And the user renames single share "lorem.txt" to "a-renamed-file.txt" using the webUI
+    Then file "a-renamed-file.txt" should be listed on the webUI as single share
     But file "lorem.txt" should not be listed on the webUI
     When the user reloads the current page of the webUI
-    Then file "a-renamed-file.txt" should be listed on the webUI
+    Then file "a-renamed-file.txt" should be listed on the webUI as single share
     But file "lorem.txt" should not be listed on the webUI
     And as "Alice" file "simple-folder/a-renamed-file.txt" should exist in the server
     And as "Alice" file "simple-folder/lorem.txt" should not exist in the server

--- a/tests/acceptance/features/webUISharingPublicBasic/publicLinkCreate.feature
+++ b/tests/acceptance/features/webUISharingPublicBasic/publicLinkCreate.feature
@@ -22,7 +22,7 @@ Feature: Create public link shares
       | name        | Link           |
     And a link named "Link" should be listed with role "Anyone with the link can view" in the public link list of resource "simple-folder" on the webUI
     When the public uses the webUI to access the last public link created by user "Alice" in a new session
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share
 
   @smokeTest @ocisSmokeTest @issue-ocis-reva-383
   Scenario: simple file sharing by public link
@@ -38,7 +38,7 @@ Feature: Create public link shares
       | name        | Link        |
     And a link named "Link" should be listed with role "Anyone with the link can view" in the public link list of resource "lorem.txt" on the webUI
     When the public uses the webUI to access the last public link created by user "Alice" in a new session
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share
 
   @skipOnOC10 @issue-ocis-reva-383
   # When this issue is fixed delete this scenario and use the one above
@@ -54,7 +54,7 @@ Feature: Create public link shares
       | permissions | read           |
       | path        | /simple-folder |
     When the public uses the webUI to access the last public link created by user "Alice" in a new session
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share
 
   @skipOnOC10 @issue-ocis-reva-383
   # When this issue is fixed delete this scenario and use the one above
@@ -69,7 +69,7 @@ Feature: Create public link shares
       | permissions | read        |
       | path        | /lorem.txt  |
     When the public uses the webUI to access the last public link created by user "Alice" in a new session
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share
 
   @issue-ocis-reva-389
   Scenario: user shares a public link with folder longer than 64 chars and shorter link name
@@ -79,7 +79,7 @@ Feature: Create public link shares
     And user "Alice" has logged in using the webUI
     When the user creates a new public link for folder "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog" using the webUI
     And the public uses the webUI to access the last public link created by user "Alice" in a new session
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share
 
 
   Scenario: share two files with same name but different paths by public link

--- a/tests/acceptance/features/webUISharingPublicBasic/publicLinkEdit.feature
+++ b/tests/acceptance/features/webUISharingPublicBasic/publicLinkEdit.feature
@@ -69,7 +69,7 @@ Feature: Edit public link shares
       | password    | pass123       |
     When the user renames the public link named "Public-link" of folder "simple-folder" to "simple-folder Share"
     And the public uses the webUI to access the last public link created by user "Alice" with password "pass123" in a new session
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share
 
 
   Scenario: user edits the password of an already existing public link
@@ -83,7 +83,7 @@ Feature: Edit public link shares
     And user "Alice" has logged in using the webUI
     When the user tries to edit the public link named "Public-link" of folder "simple-folder" changing the password to "qwertyui"
     And the public uses the webUI to access the last public link created by user "Alice" with password "qwertyui" in a new session
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share
 
   @issue-3830
   Scenario: user edits the password of an already existing public link and tries to access with old password
@@ -110,8 +110,8 @@ Feature: Edit public link shares
     And user "Alice" has logged in using the webUI
     When the user tries to edit the public link named "Public-link" of folder "simple-folder" changing the role to "Viewer"
     And the public uses the webUI to access the last public link created by user "Alice" in a new session
-    Then file "lorem.txt" should be listed on the webUI
-    And it should not be possible to delete file "lorem.txt" using the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share
+    And it should not be possible to delete file "lorem.txt" as single share using the webUI
 
   @issue-ocis-reva-292 @disablePreviews
   Scenario: user edits the permission of an already existing public link from read to read-write
@@ -128,7 +128,9 @@ Feature: Edit public link shares
     And the user deletes the following elements using the webUI
       | name                |
       | simple-empty-folder |
-      | lorem.txt           |
+    And the user deletes the following single share using the webUI
+      | name-parts |
+      | lorem.txt  |
     Then the deleted elements should not be listed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload
 
@@ -167,4 +169,4 @@ Feature: Edit public link shares
     And user "Alice" has logged in using the webUI
     When the user tries to edit the public link named "Public-link" of folder "lorem.txt" adding a password "pass123"
     And the public uses the webUI to access the last public link created by user "Alice" with password "pass123" in a new session
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share

--- a/tests/acceptance/features/webUISharingPublicBasic/publicLinkPublicActions.feature
+++ b/tests/acceptance/features/webUISharingPublicBasic/publicLinkPublicActions.feature
@@ -13,7 +13,7 @@ Feature: Access public link shares by public
     Given user "Alice" has created file "simple-folder/lorem.txt" in the server
     And user "Alice" has shared folder "simple-folder" with link with "read, update, create, delete" permissions and password "pass123" in the server
     When the public uses the webUI to access the last public link created by user "Alice" with password "pass123" in a new session
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share
 
 
   Scenario: public should not be able to access a public link with wrong password

--- a/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature
+++ b/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature
@@ -12,6 +12,26 @@ Feature: Share by public link with different roles
     Given user "Alice" has been created with default attributes and without skeleton files in the server
     And user "Alice" has created folder "simple-folder" in the server
 
+  Scenario Outline: simple sharing by public link with read-only role
+    Given user "Alice" has created file "simple-folder/lorem.txt" in the server
+    And user "Alice" has logged in using the webUI
+    When the user creates a new public link for folder "simple-folder" using the webUI
+    And the user sets the role of the most recently created public link of resource "simple-folder" to "<role>"
+    Then user "Alice" should have a share with these details in the server:
+      | field       | value          |
+      | share_type  | public_link    |
+      | uid_owner   | Alice          |
+      | permissions | <permissions>  |
+      | path        | /simple-folder |
+    # Once issue @issue-ocis-reva-383 is resolved uncomment lines below
+    #   | name        | Link           |
+    # And a link named "Link" should be listed with role "<role>" in the public link list of folder "simple-folder" on the webUI
+    When the public uses the webUI to access the last public link created by user "Alice" in a new session
+    Then file "lorem.txt" should be listed on the webUI as single share
+    Examples:
+      | role   | permissions |
+      | Viewer | read        |
+
   @smokeTest @ocisSmokeTest @issue-ocis-reva-383
   Scenario Outline: simple sharing by public link with different roles
     Given user "Alice" has created file "simple-folder/lorem.txt" in the server
@@ -27,7 +47,7 @@ Feature: Share by public link with different roles
       | name        | Link           |
     And a link named "Link" should be listed with role "<displayed-role>" in the public link list of folder "simple-folder" on the webUI
     When the public uses the webUI to access the last public link created by user "Alice" in a new session
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share
     Examples:
       | role        | displayed-role                  | permissions                  |
       | Viewer      | Anyone with the link can view   | read                         |
@@ -48,10 +68,9 @@ Feature: Share by public link with different roles
       | permissions | <permissions>  |
       | path        | /simple-folder |
     When the public uses the webUI to access the last public link created by user "Alice" in a new session
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share
     Examples:
       | role        | permissions                  |
-      | Viewer      | read                         |
       | Editor      | read, update, create, delete |
       | Contributor | read, create                 |
 
@@ -104,7 +123,9 @@ Feature: Share by public link with different roles
       | simple-empty-folder                   |
       | lorem.txt                             |
       | strängé filename (duplicate #2 &).txt |
-      | zzzz-must-be-last-file-in-folder.txt  |
+    And the user deletes the following single share using the webUI
+      | name                                 |
+      | zzzz-must-be-last-file-in-folder.txt |
     Then the deleted elements should not be listed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload
 
@@ -125,7 +146,9 @@ Feature: Share by public link with different roles
       | simple-empty-folder                   |
       | lorem.txt                             |
       | strängé filename (duplicate #2 &).txt |
-      | zzzz-must-be-last-file-in-folder.txt  |
+    And the user deletes the following single share using the webUI
+      | name                                 |
+      | zzzz-must-be-last-file-in-folder.txt |
     Then the deleted elements should not be listed on the webUI
 
   @issue-ocis-270
@@ -133,14 +156,14 @@ Feature: Share by public link with different roles
     Given user "Alice" has created file "simple-folder/lorem.txt" in the server
     And user "Alice" has shared folder "simple-folder" with link with "read" permissions in the server
     When the public uses the webUI to access the last public link created by user "Alice" in a new session
-    Then it should not be possible to delete file "lorem.txt" using the webUI
+    Then it should not be possible to delete file "lorem.txt" as single share using the webUI
 
 
   Scenario: creating a public link with "Editor" role makes it possible to upload a file
     Given user "Alice" has shared folder "simple-folder" with link with "read, update, create, delete" permissions in the server
     When the public uses the webUI to access the last public link created by user "Alice" in a new session
     And the user uploads file "new-lorem.txt" using the webUI
-    Then file "new-lorem.txt" should be listed on the webUI
+    Then file "new-lorem.txt" should be listed on the webUI as single share
     And as "Alice" file "simple-folder/new-lorem.txt" should exist in the server
 
 
@@ -150,7 +173,7 @@ Feature: Share by public link with different roles
     When the public uses the webUI to access the last public link created by user "Alice" with password "pass123" in a new session
     And the user opens folder "simple-empty-folder" using the webUI
     And the user uploads file "new-lorem.txt" using the webUI
-    Then file "new-lorem.txt" should be listed on the webUI
+    Then file "new-lorem.txt" should be listed on the webUI as single share
     And as "Alice" file "simple-folder/simple-empty-folder/new-lorem.txt" should exist in the server
 
 
@@ -160,7 +183,7 @@ Feature: Share by public link with different roles
     And the user uploads folder "PARENT" using the webUI
     Then folder "PARENT" should be listed on the webUI
     And folder "CHILD" should be listed in the folder "PARENT" on the webUI
-    And file "child.txt" should be listed in the folder "CHILD" on the webUI
+    And file "child.txt" should be listed in the folder "CHILD" on the webUI as single share
     And as "Alice" file "simple-folder/PARENT/CHILD/child.txt" should exist in the server
 
 
@@ -172,7 +195,7 @@ Feature: Share by public link with different roles
     And the user uploads folder "PARENT" using the webUI
     Then folder "PARENT" should be listed on the webUI
     And folder "CHILD" should be listed in the folder "PARENT" on the webUI
-    And file "child.txt" should be listed in the folder "CHILD" on the webUI
+    And file "child.txt" should be listed in the folder "CHILD" on the webUI as single share
     And as "Alice" file "simple-folder/simple-empty-folder/PARENT/CHILD/child.txt" should exist in the server
 
 
@@ -180,7 +203,7 @@ Feature: Share by public link with different roles
     Given user "Alice" has shared folder "simple-folder" with link with "read, update, create, delete" permissions and password "pass123" in the server
     When the public uses the webUI to access the last public link created by user "Alice" with password "pass123" in a new session
     And the user uploads file "new-lorem.txt" using the webUI
-    Then file "new-lorem.txt" should be listed on the webUI
+    Then file "new-lorem.txt" should be listed on the webUI as single share
     And as "Alice" file "simple-folder/new-lorem.txt" should exist in the server
 
 
@@ -190,7 +213,7 @@ Feature: Share by public link with different roles
     When the public uses the webUI to access the last public link created by user "Alice" in a new session
     And the user opens folder "simple-empty-folder" using the webUI
     And the user uploads file "new-lorem.txt" using the webUI
-    Then file "new-lorem.txt" should be listed on the webUI
+    Then file "new-lorem.txt" should be listed on the webUI as single share
     And as "Alice" file "simple-folder/simple-empty-folder/new-lorem.txt" should exist in the server
 
 
@@ -200,7 +223,7 @@ Feature: Share by public link with different roles
     And the user uploads folder "PARENT" using the webUI
     Then folder "PARENT" should be listed on the webUI
     And folder "CHILD" should be listed in the folder "PARENT" on the webUI
-    And file "child.txt" should be listed in the folder "CHILD" on the webUI
+    And file "child.txt" should be listed in the folder "CHILD" on the webUI as single share
     And as "Alice" file "simple-folder/PARENT/CHILD/child.txt" should exist in the server
 
 
@@ -212,7 +235,7 @@ Feature: Share by public link with different roles
     And the user uploads folder "PARENT" using the webUI
     Then folder "PARENT" should be listed on the webUI
     And folder "CHILD" should be listed in the folder "PARENT" on the webUI
-    And file "child.txt" should be listed in the folder "CHILD" on the webUI
+    And file "child.txt" should be listed in the folder "CHILD" on the webUI as single share
     And as "Alice" file "simple-folder/simple-empty-folder/PARENT/CHILD/child.txt" should exist in the server
 
   @issue-ocis-723
@@ -237,7 +260,7 @@ Feature: Share by public link with different roles
     And the public uploads file "'single'quotes.txt" in files-drop page
     And the public uploads file "new-lorem.txt" in files-drop page
     Then the following files should be listed on the files-drop page:
-      | new-lorem.txt      |
+      | new-lorem.txt |
     And as "Alice" the content of "simple-folder/'single'quotes.txt" in the server should be the same as the content of local file "'single'quotes.txt"
     And as "Alice" the content of "simple-folder/new-lorem.txt" in the server should be the same as the content of local file "new-lorem.txt"
 
@@ -266,7 +289,7 @@ Feature: Share by public link with different roles
     And the public uploads file "'single'quotes.txt" in files-drop page
     And the public uploads file "new-lorem.txt" in files-drop page
     Then the following files should be listed on the files-drop page:
-      | new-lorem.txt      |
+      | new-lorem.txt |
     And as "Alice" the content of "simple-folder/'single'quotes.txt" in the server should be the same as the content of local file "'single'quotes.txt"
     And as "Alice" the content of "simple-folder/new-lorem.txt" in the server should be the same as the content of local file "new-lorem.txt"
 

--- a/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature
@@ -77,25 +77,8 @@ Feature: Public link share management
     And user "Alice" has logged in using the webUI
     When the user copies the url of public link named "Public-link" of folder "simple-folder" using the webUI
     And the user navigates to the copied public link using the webUI
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share
 
-
-  Scenario: access details dialog of public share and check the tabs displayed
-    Given user "Alice" has created file "simple-folder/lorem.txt" in the server
-    And user "Alice" has logged in using the webUI
-    When the user creates a new public link for folder "simple-folder" using the webUI
-    And the user renames the most recently created public link of folder "simple-folder" to "link1"
-    And the user tries to edit the public link named "link1" of folder "simple-folder" changing the role to "Editor"
-    And the public uses the webUI to access the last public link created by user "Alice" in a new session
-    And the user opens the sidebar for file "lorem.txt" on the webUI
-    Then the following panels should be visible in the details dialog on the webUI
-      | name    |
-      | actions |
-    And the following panels should not be visible in the details dialog on the webUI
-      | name     |
-      | people   |
-      | links    |
-      | versions |
 
   @issue-2897
   Scenario: sharing details of indirect items inside a shared folder
@@ -148,7 +131,7 @@ Feature: Public link share management
       | name        | public link |
       | permissions | read        |
     When the public uses the webUI to access the last public link created by user "Alice" in a new session
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share
     And the create button should not be visible on the webUI
 
 

--- a/tests/acceptance/features/webUISharingPublicManagement/sharingPublicSession.feature
+++ b/tests/acceptance/features/webUISharingPublicManagement/sharingPublicSession.feature
@@ -12,9 +12,9 @@ Feature: Session storage for public link
     And user "Alice" has created file "simple-folder/lorem.txt" in the server
     And user "Alice" has shared folder "simple-folder" with link with "read" permissions and password "pass123" in the server
     When the public uses the webUI to access the last public link created by user "Alice" with password "pass123" in a new session
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share
     When the user reloads the current page of the webUI
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share
 
 
   Scenario: Public accesses the public link files page in a new session after visiting once (folder share)
@@ -22,14 +22,14 @@ Feature: Session storage for public link
     And user "Alice" has created file "simple-folder/lorem.txt" in the server
     And user "Alice" has shared folder "simple-folder" with link with "read" permissions and password "pass123" in the server
     When the public uses the webUI to access the last public link created by user "Alice" with password "pass123" in a new session
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share
 
 
   Scenario: Public accesses the public link files page in a new session after visiting once (file share)
     Given user "Alice" has created file "lorem.txt" in the server
     And user "Alice" has shared folder "lorem.txt" with link with "read" permissions and password "pass123" in the server
     When the public uses the webUI to access the last public link created by user "Alice" with password "pass123" in a new session
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share
 
 
   Scenario: Public link author changes the password when the public is in public link files page session (folder share)
@@ -37,21 +37,21 @@ Feature: Session storage for public link
     And user "Alice" has created file "simple-folder/lorem.txt" in the server
     And user "Alice" has shared folder "simple-folder" with link with "read" permissions and password "pass123" in the server
     When the public uses the webUI to access the last public link created by user "Alice" with password "pass123" in a new session
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share
     And user "Alice" changes the password of last public link  to "newpass" using the Sharing API in the server
     When the user reloads the current page of the webUI
     Then the password input for the public link should appear on the webUI
     When the user accesses the public link with password "newpass" using the webUI
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share
 
 
   Scenario: Public link author changes the password when the public is in public link files page session (file share)
     Given user "Alice" has created file "lorem.txt" in the server
     And user "Alice" has shared folder "lorem.txt" with link with "read" permissions and password "pass123" in the server
     When the public uses the webUI to access the last public link created by user "Alice" with password "pass123" in a new session
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share
     And user "Alice" changes the password of last public link  to "newpass" using the Sharing API in the server
     When the user reloads the current page of the webUI
     Then the password input for the public link should appear on the webUI
     When the user accesses the public link with password "newpass" using the webUI
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share

--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -138,7 +138,7 @@ Feature: File Upload
     Given user "Alice" has shared folder "simple-folder" with link with "read, update, create, delete" permissions and password "pass123" in the server
     When the public uses the webUI to access the last public link created by user "Alice" with password "pass123" in a new session
     And the user uploads overwriting file "lorem.txt" using the webUI
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share
     And as "Alice" the content of "simple-folder/lorem.txt" in the server should be the same as the content of local file "lorem.txt"
 
 

--- a/tests/acceptance/features/webUIWebdavLockProtection/delete.feature
+++ b/tests/acceptance/features/webUIWebdavLockProtection/delete.feature
@@ -21,13 +21,13 @@ Feature: Locks
       | path        | simple-folder                |
       | permissions | read, create, delete, update |
     When the public uses the webUI to access the last public link created by user "brand-new-user" in a new session
-    And the user tries to delete folder "lorem.txt" using the webUI
+    And the user tries to delete single share "lorem.txt" using the webUI
     Then notifications should be displayed on the webUI with the text
       """
       Failed to delete "lorem.txt" - the file is locked
       """
     When the user reloads the current page of the webUI
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share
     Examples:
       | lockscope |
       | exclusive |

--- a/tests/acceptance/features/webUIWebdavLockProtection/move.feature
+++ b/tests/acceptance/features/webUIWebdavLockProtection/move.feature
@@ -22,14 +22,14 @@ Feature: Locks
       | path        | simple-folder                |
       | permissions | read, create, delete, update |
     When the public uses the webUI to access the last public link created by user "brand-new-user" in a new session
-    And the user tries to rename file "lorem.txt" to "a-renamed-file.txt" using the webUI
+    And the user tries to rename single share "lorem.txt" to "a-renamed-file.txt" using the webUI
     Then notifications should be displayed on the webUI with the text
       """
       Failed to rename "lorem.txt" to "a-renamed-file.txt" - the file is locked
       """
     When the user closes rename dialog
     And the user reloads the current page of the webUI
-    Then file "lorem.txt" should be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI as single share
     And file "a-renamed-file.txt" should not be listed on the webUI
     Examples:
       | lockscope |

--- a/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/appSideBar.js
@@ -118,19 +118,6 @@ module.exports = {
       const panelElement = this.elements[panelName + 'Panel']
       return await this.waitForElementPresent(panelElement.locateStrategy, panelElement.selector)
     },
-    getVisibleAccordionItems: async function () {
-      const items = []
-      let elements
-      await this.api.elements('@panelSelectButtons', function (result) {
-        elements = result.value
-      })
-      for (const { ELEMENT } of elements) {
-        await this.api.elementIdText(ELEMENT, function (result) {
-          items.push(result.value.toLowerCase())
-        })
-      }
-      return items
-    },
     getActionsMenuItemsExceptDefaults: async function () {
       const defaultItems = ['add to favorites', 'copy', 'cut', 'rename', 'delete']
       const items = []

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -57,6 +57,14 @@ module.exports = {
       await fileActionsMenu.delete()
       return this
     },
+    deleteSingleShare: async function () {
+      await fileActionsMenu.delete()
+      return this
+    },
+    deleteSingleShare: async function (resource) {
+      await fileActionsMenu.delete()
+      return this
+    },
     /**
      * @param {string} resource
      * @param {string} elementType
@@ -86,6 +94,15 @@ module.exports = {
      */
     renameFile: async function (fromName, toName, expectToSucceed = true, elementType = 'any') {
       await this.openFileActionsMenu(fromName, elementType)
+      await fileActionsMenu.rename(toName, expectToSucceed)
+      return this
+    },
+    renameSingleShare: async function (
+      fromName,
+      toName,
+      expectToSucceed = true,
+      elementType = 'any'
+    ) {
       await fileActionsMenu.rename(toName, expectToSucceed)
       return this
     },
@@ -349,6 +366,10 @@ module.exports = {
         return this
       }
       await this.waitForElementPresent({ selector: '@anyAfterLoading', abortOnFailure })
+      return this
+    },
+    waitForFileVisibleAsSingleShare: async function (resource) {
+      await this.waitForElementPresent({ selector: '@sharedDetailResource' })
       return this
     },
     /**
@@ -707,9 +728,12 @@ module.exports = {
     filesListProgressBar: {
       selector: '#files-list-progress'
     },
+    sharedDetailResource: {
+      selector: '.resource-details .oc-resource-name'
+    },
     anyAfterLoading: {
       selector:
-        '//*[self::table[contains(@class, "files-table")] or self::div[contains(@class, "files-empty")] or self::div[contains(@class, "files-not-found")]]',
+        '//*[self::table[contains(@class, "files-table")] or self::div[contains(@class, "files-empty")] or self::div[contains(@class, "files-not-found")] or self::div[contains(@class, "resource-details")]]',
       locateStrategy: 'xpath'
     },
     shareButtonInFileRow: {

--- a/tests/acceptance/pageObjects/FilesPageElement/previewPage.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/previewPage.js
@@ -11,6 +11,10 @@ module.exports = {
 
       return this
     },
+    openPreviewFromDetailsView: async function (fileName) {
+      await filesActionsMenu.preview()
+      return this
+    },
     waitForPreviewLoaded: function (fileName) {
       const image = util.format(this.elements.mediaImage.selector, fileName)
       return this.useXpath().waitForElementVisible(image).useCss()

--- a/tests/acceptance/pageObjects/personalPage.js
+++ b/tests/acceptance/pageObjects/personalPage.js
@@ -226,6 +226,9 @@ module.exports = {
       )
       return canCreate
     },
+    checkForNonPresentDeleteButtonInSingleShareView: function () {
+      return this.waitForElementNotPresent('@deleteSelectedButton')
+    },
     deleteAllCheckedFiles: function () {
       return this.waitForElementVisible('@deleteSelectedButton')
         .click('@deleteSelectedButton')

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -172,8 +172,8 @@ When('the user deletes file/folder {string} using the webUI', function (element)
   return client.page.FilesPageElement.filesList().deleteFile(element)
 })
 
-When('the user tries to delete file/folder {string} using the webUI', function (element) {
-  return client.page.FilesPageElement.filesList().deleteFile(element)
+When('the user tries to delete single share {string} using the webUI', function (element) {
+  return client.page.FilesPageElement.filesList().deleteSingleShare(element)
 })
 
 Given('the user has deleted file/folder/resource {string} using the webUI', function (element) {
@@ -278,6 +278,13 @@ When(
   }
 )
 
+When(
+  'the user renames single share {string} to {string} using the webUI',
+  function (fromName, toName) {
+    return client.page.FilesPageElement.filesList().renameSingleShare(fromName, toName)
+  }
+)
+
 Given('the user has renamed file/folder {string} to {string}', function (fromName, toName) {
   return client.page.FilesPageElement.filesList().renameFile(fromName, toName)
 })
@@ -286,6 +293,13 @@ When(
   'the user tries to rename file/folder {string} to {string} using the webUI',
   function (fromName, toName) {
     return client.page.FilesPageElement.filesList().renameFile(fromName, toName, false)
+  }
+)
+
+When(
+  'the user tries to rename single share {string} to {string} using the webUI',
+  function (fromName, toName) {
+    return client.page.FilesPageElement.filesList().renameSingleShare(fromName, toName, false)
   }
 )
 
@@ -357,6 +371,10 @@ Then('file {string} should be listed on the webUI', (file) => {
 
 Then('folder {string} should be listed on the webUI', (folder) => {
   return client.page.FilesPageElement.filesList().waitForFileVisible(folder, 'folder')
+})
+
+Then('file/folder {string} should be listed on the webUI as single share', (resource) => {
+  return client.page.FilesPageElement.filesList().waitForFileVisibleAsSingleShare(resource)
 })
 
 Then('file/folder with path {string} should be listed on the webUI', function (path) {
@@ -885,36 +903,6 @@ Then('the {string} details panel should be visible', async function (panel) {
   assert.strictEqual(expanded, true, `'${panel}-panel' should be active, but is not`)
 })
 
-Then(
-  'the following panels should be visible in the details dialog on the webUI',
-  async function (table) {
-    const visibleItems = await client.page.FilesPageElement.appSideBar().getVisibleAccordionItems()
-    const expectedVisibleItems = table.rows()
-    const difference = _.difference(expectedVisibleItems.flat(), visibleItems)
-
-    assert.strictEqual(
-      difference.length,
-      0,
-      `'${difference}' panels were expected to be visible but not found. Available panels '${visibleItems}'`
-    )
-  }
-)
-
-Then(
-  'the following panels should not be visible in the details dialog on the webUI',
-  async function (table) {
-    const visibleItems = await client.page.FilesPageElement.appSideBar().getVisibleAccordionItems()
-    const expectedNotVisibleItems = table.rows()
-    const difference = _.difference(expectedNotVisibleItems.flat(), visibleItems)
-
-    assert.strictEqual(
-      expectedNotVisibleItems.length,
-      difference.length,
-      `'${expectedNotVisibleItems}' panels were not expected to be visible but found. Available panels '${visibleItems}'`
-    )
-  }
-)
-
 const assertElementsAreListed = async function (elements) {
   for (const element of elements) {
     const state = await client.page.FilesPageElement.filesList().isElementListed(element)
@@ -964,6 +952,14 @@ Then(
     await api.waitForFileVisible(file)
 
     return client
+  }
+)
+
+Then(
+  'file/folder {string} should be listed in the folder {string} on the webUI as single share',
+  async function (file, folder) {
+    await client.page.FilesPageElement.filesList().navigateToFolder(folder)
+    return client.page.FilesPageElement.filesList().waitForFileVisibleAsSingleShare(file)
   }
 )
 
@@ -1064,6 +1060,12 @@ Then(
     )
   }
 )
+Then(
+  'it should not be possible to delete file {string} as single share using the webUI',
+  function (resource) {
+    return client.page.personalPage().checkForNonPresentDeleteButtonInSingleShareView()
+  }
+)
 
 Then(
   'it should be possible to delete file/folder {string} using the webUI',
@@ -1121,6 +1123,13 @@ Then('the user deletes the following file using the webUI', function (table) {
     .map((data) => data['name-parts'])
     .join('')
   return client.page.FilesPageElement.filesList().deleteFile(name)
+})
+Then('the user deletes the following single share using the webUI', function (table) {
+  const name = table
+    .hashes()
+    .map((data) => data['name-parts'])
+    .join('')
+  return client.page.FilesPageElement.filesList().deleteSingleShare(name)
 })
 
 Then('the user should be redirected to the files-drop page', function () {

--- a/tests/acceptance/stepDefinitions/previewContext.js
+++ b/tests/acceptance/stepDefinitions/previewContext.js
@@ -20,6 +20,14 @@ When(
   }
 )
 
+When(
+  'the user/public views the single share file {string} in the preview app using the webUI',
+  async function (fileName) {
+    await previewPage.openPreviewFromDetailsView(fileName)
+    return previewPage.waitForPreviewLoaded(fileName)
+  }
+)
+
 When('the user navigates to the next media resource using the webUI', function () {
   return previewPage.nextMediaResource()
 })

--- a/tests/e2e/cucumber/features/smoke/link.feature
+++ b/tests/e2e/cucumber/features/smoke/link.feature
@@ -69,7 +69,7 @@ Feature: link
     And "Alice" opens the "files" app
     When "Alice" copies quick link of the resource "folderPublic" from the context menu
     And "Anonymous" opens the public link "Link"
-    And "Anonymous" downloads the following public link resources using the sidebar panel
+    And "Anonymous" downloads the following public link resources using the single share view
       | resource  | type |
       | lorem.txt | file |
     And "Anonymous" logs out

--- a/tests/e2e/cucumber/steps/ui/public.ts
+++ b/tests/e2e/cucumber/steps/ui/public.ts
@@ -68,7 +68,7 @@ When(
 )
 
 When(
-  /^"([^"]*)" downloads the following public link resource(s)? using the (sidebar panel|batch action)$/,
+  /^"([^"]*)" downloads the following public link resource(s)? using the (sidebar panel|batch action|single share view)$/,
   async function (
     this: World,
     stepUser: string,

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -5,6 +5,8 @@ import { objects } from '../../../support'
 import { expect } from '@playwright/test'
 import { config } from '../../../config'
 import { displayedResourceType } from '../../../support/objects/app-files/resource/actions'
+import { Public } from '../../../support/objects/app-files/page/public'
+import { Resource } from '../../../support/objects/app-files'
 
 When(
   '{string} creates the following resource(s)',
@@ -279,7 +281,11 @@ When(
   }
 )
 
-export const processDelete = async (stepTable: DataTable, pageObject: any, actionType: string) => {
+export const processDelete = async (
+  stepTable: DataTable,
+  pageObject: Public | Resource,
+  actionType: string
+) => {
   let files, parentFolder
   const deleteInfo = stepTable.hashes().reduce((acc, stepRow) => {
     const { resource, from } = stepRow
@@ -306,13 +312,11 @@ export const processDelete = async (stepTable: DataTable, pageObject: any, actio
 
 export const processDownload = async (
   stepTable: DataTable,
-  pageObject: any,
+  pageObject: Public | Resource,
   actionType: string
 ) => {
-  let downloads,
-    files,
-    parentFolder,
-    downloadedResources = []
+  let downloads, files, parentFolder
+  const downloadedResources = []
   const downloadInfo = stepTable.hashes().reduce((acc, stepRow) => {
     const { resource, from, type } = stepRow
     const resourceInfo = {
@@ -334,7 +338,12 @@ export const processDownload = async (
     downloads = await pageObject.download({
       folder: parentFolder,
       resources: files,
-      via: actionType === 'batch action' ? 'BATCH_ACTION' : 'SIDEBAR_PANEL'
+      via:
+        actionType === 'batch action'
+          ? 'BATCH_ACTION'
+          : actionType === 'sidebar panel'
+          ? 'SIDEBAR_PANEL'
+          : 'SINGLE_SHARE_VIEW'
     })
 
     downloads.forEach((download) => {

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -7,9 +7,11 @@ import { File, Space } from '../../../types'
 import { sidebar } from '../utils'
 import { config } from '../../../../config'
 
+const downloadFileButtonSingleShareView = '.oc-files-actions-download-file-trigger'
+const downloadFolderButtonSingleShareView = '.oc-files-actions-download-archive-trigger'
 const downloadFileButtonSideBar =
   '#oc-files-actions-sidebar .oc-files-actions-download-file-trigger'
-const downloadFolderButtonSidedBar =
+const downloadFolderButtonSideBar =
   '#oc-files-actions-sidebar .oc-files-actions-download-archive-trigger'
 const downloadButtonBatchAction = '.oc-files-actions-download-archive-trigger'
 const deleteButtonBatchAction = '.oc-files-actions-delete-trigger'
@@ -327,7 +329,7 @@ export interface downloadResourcesArgs {
   page: Page
   resources: resourceArgs[]
   folder?: string
-  via: 'SIDEBAR_PANEL' | 'BATCH_ACTION'
+  via: 'SIDEBAR_PANEL' | 'BATCH_ACTION' | 'SINGLE_SHARE_VIEW'
 }
 
 export const downloadResources = async (args: downloadResourcesArgs): Promise<Download[]> => {
@@ -343,7 +345,7 @@ export const downloadResources = async (args: downloadResourcesArgs): Promise<Do
         await sidebar.open({ page, resource: resource.name })
         await sidebar.openPanel({ page, name: 'actions' })
         const downloadResourceSelector =
-          resource.type === 'file' ? downloadFileButtonSideBar : downloadFolderButtonSidedBar
+          resource.type === 'file' ? downloadFileButtonSideBar : downloadFolderButtonSideBar
         const [download] = await Promise.all([
           page.waitForEvent('download'),
           page.locator(downloadResourceSelector).click()
@@ -366,6 +368,25 @@ export const downloadResources = async (args: downloadResourcesArgs): Promise<Do
         page.locator(downloadButtonBatchAction).click()
       ])
       downloads.push(download)
+      break
+    }
+
+    case 'SINGLE_SHARE_VIEW': {
+      if (folder) {
+        await clickResource({ page, path: folder })
+      }
+      for (const resource of resources) {
+        const downloadResourceSelector =
+          resource.type === 'file'
+            ? downloadFileButtonSingleShareView
+            : downloadFolderButtonSingleShareView
+        const [download] = await Promise.all([
+          page.waitForEvent('download'),
+          page.locator(downloadResourceSelector).click()
+        ])
+
+        downloads.push(download)
+      }
       break
     }
   }


### PR DESCRIPTION
## Description
Needs 
- ~[ ] extracting components from the `packages/web-app-files/src/components/Sidebar/` directory (we decided that this is not necessary for now)~
- [x] adding unit tests for the CERN/reva and the oCIS/oC10 resolving of "single shared file"
- [x] (perhaps) updating a lot of acceptance tests (since they 1. currently expect a table and ~2. IIRC there's also expected failures for this exact feature~ couldn't find any)

## Related Issue
- Supersedes #8440 
- Fixes #8445
