### PR TITLE
Prevent empty autosaveInterval in config editor-options

### DIFF
--- a/changelog/unreleased/change-configurable-extension-autosave
+++ b/changelog/unreleased/change-configurable-extension-autosave
@@ -6,3 +6,4 @@ Handling of the provided autosave needs to be taken care of by the extension its
 
 https://github.com/owncloud/web/pull/8455
 https://github.com/owncloud/web/pull/8457
+https://github.com/owncloud/web/pull/8474

--- a/packages/web-app-text-editor/src/App.vue
+++ b/packages/web-app-text-editor/src/App.vue
@@ -229,7 +229,7 @@ export default defineComponent({
           if (isDirty.value) {
             save().then((r) => autosavePopup())
           }
-        }, editorOptions.autosaveInterval * 1000)
+        }, (editorOptions.autosaveInterval || 120) * 1000)
       }
     })
 


### PR DESCRIPTION
## Description
Prevents undefined `autosaveInterval` (which leads to _a lot_ of autosaves) when admin only sets `"autosaveEnabled": true` and overwrites the store defaults