### PR TITLE
PDFViewer / CSP - frame-src object-src blob:

### DIFF
--- a/changelog/unreleased/bugfix-oc10-pdf-display
+++ b/changelog/unreleased/bugfix-oc10-pdf-display
@@ -1,0 +1,7 @@
+Bugfix:  PDF display issue - Update CSP object-src policy
+
+PDF display is associated with object-src / frame-src policy with blob values. 
+
+We allow those for only : 'self' blob:;
+
+https://github.com/owncloud/web/pull/8498

--- a/packages/web-integration-oc10/lib/Controller/FilesController.php
+++ b/packages/web-integration-oc10/lib/Controller/FilesController.php
@@ -124,16 +124,20 @@ class FilesController extends Controller {
 			$response->setContentSecurityPolicy($csp);
 		}
 		if (\strpos($path, "index.html") === 0) {
-            $csp = new ContentSecurityPolicy();
-            $csp->allowInlineScript(true);
-            $csp = $this->applyCSPOpenIDConnect($csp);
+			$csp = new ContentSecurityPolicy();
+			$csp->allowInlineScript(true);
+			$csp = $this->applyCSPOpenIDConnect($csp);
+			
+			// Required to support PDF Viewer
+			$csp->addAllowedFrameDomain('\'self\'');
+			$csp->addAllowedObjectDomain('\'self\' blob:');
 
-            // for now we set CSP rules manually, until we have sufficient requirements for a generic solution.
-            $csp = $this->applyCSPOnlyOffice($csp);
-            $csp = $this->applyCSPRichDocuments($csp);
+			// for now we set CSP rules manually, until we have sufficient requirements for a generic solution.
+			$csp = $this->applyCSPOnlyOffice($csp);
+			$csp = $this->applyCSPRichDocuments($csp);
 
-            $response->setContentSecurityPolicy($csp);
-        }
+			$response->setContentSecurityPolicy($csp);
+		}
 
 		return $response;
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Using Owncloud Web 6.0.0, it is not possible to display a PDF using PDF Viewer cause the CSP is too restrictive.

It returns : 
```
Content Security Policy: The page’s settings blocked the loading of a resource at blob:https://xyz.com/bb6b39b8-1d71-4960-bc4c-16ab79bc1044 (“default-src”).
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes [PDFViewer / Content Security Policy blocks 'blob:'](https://github.com/owncloud/core/issues/40639)
- Fixes https://github.com/owncloud/web/issues/7931
- Fixes https://github.com/owncloud/web/issues/8497

## Motivation and Context
PDF will be working on Firefox out of the box.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
Old owncloud server running, updated to 10.11; added new configuration to support OwnCloud Web new front-end.

## Screenshots (if appropriate):

Before : 
CSP configuration : 
![image](https://user-images.githubusercontent.com/85616869/218868731-66115eb7-0a72-4ef3-938c-4f61271966bb.png)

View :
![image](https://user-images.githubusercontent.com/85616869/218868452-ad322a68-0379-46f5-8829-0c3c68b725cf.png)

After, with updated CSP and visible PDF : 
![image](https://user-images.githubusercontent.com/85616869/218869549-baab4878-9c95-4169-95a5-f3afa5c4ee72.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
