### PR TITLE
[tests-only][full-ci]Bump commit id for tests

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=9e73b17a403a9283a281495bb3c35246c75c08e9
+OCIS_COMMITID=5ad8e283b669a7270e6925bf653a636610e022ed
 OCIS_BRANCH=master


### PR DESCRIPTION
This PR bumps `ocis` commit id for tests 
Part of: https://github.com/owncloud/QA/issues/799