### PR TITLE
[tests-only][full-ci]Bump commit id for tests in stable

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=fe490fd28c2fbfdbdfec5198cc1388cc283f17dd
+OCIS_COMMITID=625fee3aeef5f0b53bde36612894f11cc8b9d622
 OCIS_BRANCH=stable-2.0


### PR DESCRIPTION
This PR bumps `ocis` commit id for tests
Part of: https://github.com/owncloud/QA/issues/799