### PR TITLE
Add drag and drop functionality to resource tiles

### DIFF
--- a/changelog/unreleased/enhancement-resources-tiles-view
+++ b/changelog/unreleased/enhancement-resources-tiles-view
@@ -11,6 +11,7 @@ https://github.com/owncloud/web/pull/8404
 https://github.com/owncloud/web/pull/8410
 https://github.com/owncloud/web/pull/8460
 https://github.com/owncloud/web/pull/8483
+https://github.com/owncloud/web/pull/8505
 https://github.com/owncloud/web/issues/6378
 https://github.com/owncloud/web/issues/6379
 https://github.com/owncloud/web/issues/6380
@@ -18,3 +19,4 @@ https://github.com/owncloud/web/issues/8367
 https://github.com/owncloud/web/issues/8368
 https://github.com/owncloud/web/issues/8365
 https://github.com/owncloud/web/issues/8370
+https://github.com/owncloud/web/issues/8369

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -52,12 +52,14 @@
           :resizable="true"
           :target-route-callback="resourceTargetRouteCallback"
           :space="space"
+          :drag-drop="true"
           :sort-fields="sortFields"
           :sort-by="sortBy"
           :sort-dir="sortDir"
           :view-size="viewSize"
           @row-mounted="rowMounted"
           @file-click="$_fileActions_triggerDefaultAction"
+          @file-dropped="fileDropped"
           @sort="handleSort"
         >
           <template #contextMenuActions="{ resource }">

--- a/packages/web-app-files/tests/unit/components/FilesList/ResourceTiles.spec.ts
+++ b/packages/web-app-files/tests/unit/components/FilesList/ResourceTiles.spec.ts
@@ -1,6 +1,8 @@
 import { createStore, defaultPlugins, defaultStoreMockOptions, mount } from 'web-test-helpers'
 import ResourceTiles from 'web-app-files/src/components/FilesList/ResourceTiles.vue'
 import { sortFields } from 'web-app-files/src/helpers/ui/resourceTiles'
+import { Resource } from 'web-client'
+import { mock } from 'jest-mock-extended'
 
 const spacesResources = [
   {
@@ -67,6 +69,21 @@ describe('ResourceTiles component', () => {
       expect(wrapper.emitted('sort')[0][0]).toEqual({
         sortBy: sortFields[index].name,
         sortDir: sortFields[index].sortDir
+      })
+    })
+    describe('drag and drop', () => {
+      it('emits the "update:selectedIds"-event on drag start', async () => {
+        const { wrapper } = getWrapper()
+        wrapper.vm.dragItem = mock<Resource>()
+        await wrapper.vm.$nextTick()
+        ;(wrapper.vm.$refs.ghostElementRef as any).$el = { style: {} }
+        wrapper.vm.dragStart(mock<Resource>(), { dataTransfer: { setDragImage: jest.fn() } })
+        expect(wrapper.emitted('update:selectedIds')).toBeDefined()
+      })
+      it('emits the "fileDropped"-event on resource drop', () => {
+        const { wrapper } = getWrapper()
+        wrapper.vm.fileDropped(mock<Resource>(), { dataTransfer: {} })
+        expect(wrapper.emitted('fileDropped')).toBeDefined()
       })
     })
   })

--- a/packages/web-app-files/tests/unit/components/FilesList/__snapshots__/ResourceTiles.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/FilesList/__snapshots__/ResourceTiles.spec.ts.snap
@@ -4,6 +4,7 @@ exports[`ResourceTiles component renders a footer slot 1`] = `
 <div>
   <!--v-if-->
   <oc-list class="oc-tiles oc-flex"></oc-list>
+  <!--v-if-->
   <div class="oc-tiles-footer">Hello, ResourceTiles footer!</div>
 </div>
 `;
@@ -13,12 +14,13 @@ exports[`ResourceTiles component renders an array of spaces correctly 1`] = `
   <!--v-if-->
   <oc-list class="oc-tiles oc-flex">
     <li class="oc-tiles-item">
-      <oc-tile is-resource-selected="false" resource="[object Object]" resource-icon-size="xlarge" resource-route="[object Object]"></oc-tile>
+      <oc-tile draggable="false" is-resource-selected="false" resource="[object Object]" resource-icon-size="xlarge" resource-route="[object Object]"></oc-tile>
     </li>
     <li class="oc-tiles-item">
-      <oc-tile is-resource-selected="false" resource="[object Object]" resource-icon-size="xlarge" resource-route="[object Object]"></oc-tile>
+      <oc-tile draggable="false" is-resource-selected="false" resource="[object Object]" resource-icon-size="xlarge" resource-route="[object Object]"></oc-tile>
     </li>
   </oc-list>
+  <!--v-if-->
   <div class="oc-tiles-footer"></div>
 </div>
 `;

--- a/packages/web-app-files/tests/unit/views/spaces/__snapshots__/Projects.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/views/spaces/__snapshots__/Projects.spec.ts.snap
@@ -41,12 +41,13 @@ exports[`Projects view different files view states lists all available project s
           </div>
           <ul class="oc-list oc-my-rm oc-mx-rm oc-tiles oc-flex resizableTiles">
             <li class="oc-tiles-item">
-              <oc-tile-stub is-resource-selected="false" resource="[object Object]" resource-icon-size="xlarge" resource-route="[object Object]"></oc-tile-stub>
+              <oc-tile-stub draggable="false" is-resource-selected="false" resource="[object Object]" resource-icon-size="xlarge" resource-route="[object Object]"></oc-tile-stub>
             </li>
             <li class="oc-tiles-item">
-              <oc-tile-stub is-resource-selected="false" resource="[object Object]" resource-icon-size="xlarge" resource-route="[object Object]"></oc-tile-stub>
+              <oc-tile-stub draggable="false" is-resource-selected="false" resource="[object Object]" resource-icon-size="xlarge" resource-route="[object Object]"></oc-tile-stub>
             </li>
           </ul>
+          <!--v-if-->
           <div class="oc-tiles-footer"></div>
         </div>
       </div>


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8369

## Screenshots (if appropriate):
![Documents](https://user-images.githubusercontent.com/50302941/221176886-94d84242-b2d1-4ce0-bca8-8bceecfca474.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
