### PR TITLE
Re-enable space edit actions for space admins

### DIFF
--- a/changelog/unreleased/change-remove-permission-manager
+++ b/changelog/unreleased/change-remove-permission-manager
@@ -4,3 +4,4 @@ BREAKING CHANGE for developers: The `PermissionManager` has been removed. Permis
 
 https://github.com/owncloud/web/pull/8431
 https://github.com/owncloud/web/pull/8488
+https://github.com/owncloud/web/pull/8509

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -172,14 +172,14 @@ export function buildSpace(data): SpaceResource {
     canBeDeleted: function ({ user, ability }: { user?: User; ability?: any } = {}) {
       return this.disabled && (ability?.can('delete-all', 'Space') || this.isManager(user))
     },
-    canRename: function ({ user }: { user?: User } = {}) {
-      return this.isManager(user)
+    canRename: function ({ user, ability }: { user?: User; ability?: any } = {}) {
+      return ability?.can('update-all', 'Space') || this.isManager(user)
     },
-    canEditDescription: function ({ user }: { user?: User } = {}) {
-      return this.isManager(user)
+    canEditDescription: function ({ user, ability }: { user?: User; ability?: any } = {}) {
+      return ability?.can('update-all', 'Space') || this.isManager(user)
     },
-    canRestore: function ({ user }: { user?: User } = {}) {
-      return this.disabled && this.isManager(user)
+    canRestore: function ({ user, ability }: { user?: User; ability?: any } = {}) {
+      return this.disabled && (ability?.can('update-all', 'Space') || this.isManager(user))
     },
     canDisable: function ({ user, ability }: { user?: User; ability?: any } = {}) {
       return !this.disabled && (ability?.can('delete-all', 'Space') || this.isManager(user))

--- a/packages/web-pkg/src/mixins/spaces/editDescription.ts
+++ b/packages/web-pkg/src/mixins/spaces/editDescription.ts
@@ -22,7 +22,7 @@ export default {
               return false
             }
 
-            return resources[0].canEditDescription({ user: this.user })
+            return resources[0].canEditDescription({ user: this.user, ability: this.$ability })
           },
           componentType: 'button',
           class: 'oc-files-actions-edit-description-trigger'

--- a/packages/web-pkg/src/mixins/spaces/rename.ts
+++ b/packages/web-pkg/src/mixins/spaces/rename.ts
@@ -20,7 +20,7 @@ export default {
               return false
             }
 
-            return resources[0].canRename({ user: this.user })
+            return resources[0].canRename({ user: this.user, ability: this.$ability })
           },
           componentType: 'button',
           class: 'oc-files-actions-rename-trigger'

--- a/packages/web-pkg/src/mixins/spaces/restore.ts
+++ b/packages/web-pkg/src/mixins/spaces/restore.ts
@@ -41,7 +41,7 @@ export default {
     ...mapMutations('runtime/spaces', ['UPDATE_SPACE_FIELD']),
 
     filterResourcesToRestore(resources): SpaceResource[] {
-      return resources.filter((r) => r.canRestore({ user: this.user }))
+      return resources.filter((r) => r.canRestore({ user: this.user, ability: this.$ability }))
     },
     $_restore_trigger({ resources }) {
       const allowedResources = this.filterResourcesToRestore(resources)

--- a/packages/web-runtime/src/services/auth/abilities.ts
+++ b/packages/web-runtime/src/services/auth/abilities.ts
@@ -33,11 +33,11 @@ export const getAbilities = (
       { action: 'update-all', subject: 'Setting' }
     ],
     'create-space.all': [{ action: 'create-all', subject: 'Space' }],
-    'delete-all-spaces.all': [{ action: 'delete-all', subject: 'Space' }],
-    'list-all-spaces.all': [
-      { action: 'read-all', subject: 'Space' },
-      { action: 'delete-all', subject: 'Space' } // FIXME: Why is this needed? backend issue?
+    'Drive.ReadWriteEnabled.all': [
+      { action: 'delete-all', subject: 'Space' },
+      { action: 'update-all', subject: 'Space' }
     ],
+    'list-all-spaces.all': [{ action: 'read-all', subject: 'Space' }],
     'set-space-quota.all': [{ action: 'set-quota-all', subject: 'Space' }]
   }
 

--- a/packages/web-runtime/tests/unit/services/auth/abilities.spec.ts
+++ b/packages/web-runtime/tests/unit/services/auth/abilities.spec.ts
@@ -38,8 +38,8 @@ describe('getAbilities', () => {
   it.each([
     { permissions: [''], expectedActions: [] },
     { permissions: ['create-space.all'], expectedActions: ['create-all'] },
-    { permissions: ['delete-all-spaces.all'], expectedActions: ['delete-all'] },
-    { permissions: ['list-all-spaces.all'], expectedActions: ['read-all', 'delete-all'] },
+    { permissions: ['list-all-spaces.all'], expectedActions: ['read-all'] },
+    { permissions: ['Drive.ReadWriteEnabled.all'], expectedActions: ['delete-all', 'update-all'] },
     { permissions: ['set-space-quota.all'], expectedActions: ['set-quota-all'] }
   ])('gets correct abilities for subject "Space"', function (data) {
     const abilities = getAbilities(data.permissions)


### PR DESCRIPTION
## Description
Follow-up after https://github.com/owncloud/ocis/issues/5414 has been merged.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8506

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
