### PR TITLE
Improve FileDrop View

### DIFF
--- a/packages/design-system/src/components/OcButton/OcButton.vue
+++ b/packages/design-system/src/components/OcButton/OcButton.vue
@@ -209,8 +209,8 @@ export default defineComponent({
     background-color: transparent;
     border-style: none;
     color: $color;
-    font-size: var(--oc-font-size-medium);
-    font-weight: normal;
+    font-size: inherit;
+    font-weight: inherit;
     min-height: 0;
     padding: 0;
 

--- a/packages/design-system/src/styles/theme/_variables.scss
+++ b/packages/design-system/src/styles/theme/_variables.scss
@@ -28,5 +28,12 @@ $weights: (
   "black": $oc-font-weight-black
 );
 
+$breakpoints: (
+  "s": $oc-breakpoint-small-default,
+  "m": $oc-breakpoint-medium-default,
+  "l": $oc-breakpoint-large-default,
+  "xl": $oc-breakpoint-xlarge
+);
+
 $global-control-height: 15px;
 $global-border-width: 2px;

--- a/packages/design-system/src/styles/theme/oc-position.scss
+++ b/packages/design-system/src/styles/theme/oc-position.scss
@@ -1,3 +1,44 @@
+.oc-inset-0,
+.oc-inset-x-0 {
+  right:0;
+  left:0
+}
+
+.oc-inset-0,
+.oc-inset-y-0
+{
+  top:0;
+  bottom:0
+}
+
+.oc-top-0 {
+  top:0
+}
+
+.oc-right-0 {
+  right:0
+}
+
+.oc-bottom-0 {
+  bottom:0
+}
+
+.oc-left-0 {
+  left:0
+}
+
+@each $directionKey, $directionValues in $directions {
+  .oc-#{$directionKey} {
+    @each $sizeKey, $sizeValue in $sizes {
+      &-#{$sizeKey} {
+        @each $direction in $directionValues {
+          #{$direction}: $sizeValue !important;
+        }
+      }
+    }
+  }
+}
+
 [class*="oc-float-"] {
   max-width: 100%;
 }

--- a/packages/design-system/src/styles/theme/oc-spacing.scss
+++ b/packages/design-system/src/styles/theme/oc-spacing.scss
@@ -26,6 +26,34 @@ $directives: ("m": "margin", "p": "padding");
   }
 }
 
+// Add responsive spacing
+@each $breakpointKey, $breakpointValue in $breakpoints {
+  @media (min-width: $breakpointValue) {
+    @each $directiveKey, $directiveValue in $directives {
+      .oc-#{$directiveKey} {
+        @each $sizeKey, $sizeValue in $sizes {
+          &-#{$sizeKey}\@#{$breakpointKey} {
+            #{$directiveValue}: $sizeValue !important;
+          }
+        }
+
+        @each $directionKey, $directionValues in $directions {
+          &#{$directionKey} {
+            @each $direction in $directionValues {
+              @each $sizeKey, $sizeValue in $sizes {
+                &-#{$sizeKey}\@#{$breakpointKey} {
+                  #{$directiveValue}-#{$direction}: $sizeValue !important;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+// Add classes to remove spacing
 @each $directiveKey, $directiveValue in $directives {
   .oc-#{$directiveKey} {
     @each $directionKey, $directionValues in $directions {

--- a/packages/design-system/src/styles/theme/oc-spacing.scss
+++ b/packages/design-system/src/styles/theme/oc-spacing.scss
@@ -14,10 +14,6 @@ $directives: ("m": "margin", "p": "padding");
               #{$directiveValue}-#{$direction}: $sizeValue !important;
             }
           }
-
-          &-rm {
-            #{$directiveValue}-#{$direction}: 0 !important;
-          }
         }
       }
     }
@@ -25,6 +21,20 @@ $directives: ("m": "margin", "p": "padding");
     @each $sizeKey, $sizeValue in $sizes {
       &-#{$sizeKey} {
         #{$directiveValue}: $sizeValue !important;
+      }
+    }
+  }
+}
+
+@each $directiveKey, $directiveValue in $directives {
+  .oc-#{$directiveKey} {
+    @each $directionKey, $directionValues in $directions {
+      &#{$directionKey} {
+        @each $direction in $directionValues {
+          &-rm {
+            #{$directiveValue}-#{$direction}: 0 !important;
+          }
+        }
       }
     }
 

--- a/packages/design-system/src/styles/theme/oc-text.scss
+++ b/packages/design-system/src/styles/theme/oc-text.scss
@@ -9,6 +9,10 @@ p {
   color: var(--oc-color-text-default);
 }
 
+p {
+  line-height: 1.625;
+}
+
 html * {
   font-family: var(--oc-font-family);
 }

--- a/packages/design-system/src/tokens/ods/font.yaml
+++ b/packages/design-system/src/tokens/ods/font.yaml
@@ -17,22 +17,22 @@ font:
       value: 1.29rem
   weight:
     default:
-      value: '400'
+      value: 400 !important
     thin:
-      value: '100'
+      value: 100 !important
     extralight:
-      value: '200'
+      value: 200 !important
     light:
-      value: '300'
+      value: 300 !important
     normal:
-      value: '400'
+      value: 400 !important
     medium:
-      value: '500'
+      value: 500 !important
     semibold:
-      value: '600'
+      value: 600 !important
     bold:
-      value: '700'
+      value: 700 !important
     extrabold:
-      value: '800'
+      value: 800 !important
     black:
-      value: '900'
+      value: 900 !important

--- a/packages/web-app-files/src/components/AppBar/Upload/ResourceUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/Upload/ResourceUpload.vue
@@ -1,9 +1,12 @@
 <template>
   <div>
-    <oc-button :class="btnClass" justify-content="left" appearance="raw" @click="triggerUpload">
-      <oc-resource-icon :resource="{ extension: '', isFolder }" size="medium" />
-      <span :id="uploadLabelId">{{ buttonLabel }}</span>
-    </oc-button>
+    <div class="oc-text-xlarge">
+      <h1 class="oc-text-normal">
+        <oc-button :class="btnClass" justify-content="left" appearance="raw" @click="triggerUpload" class="oc-display-inline-block oc-text-bold oc-position-relative">
+          <span :id="uploadLabelId">{{ buttonLabel }}</span>
+        </oc-button>
+        <span v-text="$gettext('or drag it here')" /></h1>
+    </div>
     <input
       :id="inputId"
       ref="input"
@@ -84,9 +87,38 @@ export default defineComponent({
 })
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 .upload-input-target {
   position: absolute;
   left: -99999px;
 }
+
+button {
+  color: var(--oc-color-swatch-primary-default);
+  font-weight: 600;
+
+  &::after {
+    content: '';
+    position: absolute;
+    width: 100%;
+    transform: scaleX(0);
+    height: 2px;
+    bottom: -2px;
+    left: 0;
+    background-color: #0087ca;
+    transform-origin: bottom right;
+    transition: transform 0.25s ease-out;
+  }
+
+  &:hover {
+    color: var(--oc-color-swatch-primary-default);
+    text-decoration: none;
+
+    &::after {
+      transform: scaleX(1);
+      transform-origin: bottom left;
+    }
+  }
+}
+
 </style>

--- a/packages/web-app-files/src/components/AppBar/Upload/ResourceUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/Upload/ResourceUpload.vue
@@ -2,10 +2,17 @@
   <div>
     <div class="oc-text-xlarge">
       <h1 class="oc-text-normal">
-        <oc-button :class="btnClass" justify-content="left" appearance="raw" @click="triggerUpload" class="oc-display-inline-block oc-text-bold oc-position-relative">
+        <oc-button
+          :class="btnClass"
+          justify-content="left"
+          appearance="raw"
+          class="oc-display-inline-block oc-text-bold oc-position-relative"
+          @click="triggerUpload"
+        >
           <span :id="uploadLabelId">{{ buttonLabel }}</span>
         </oc-button>
-        <span v-text="$gettext('or drag it here')" /></h1>
+        <span v-text="$gettext('or drag it here')" />
+      </h1>
     </div>
     <input
       :id="inputId"
@@ -120,5 +127,4 @@ button {
     }
   }
 }
-
 </style>

--- a/packages/web-app-files/src/components/AppBar/Upload/ResourceUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/Upload/ResourceUpload.vue
@@ -1,19 +1,13 @@
 <template>
   <div>
-    <div class="oc-text-xlarge">
-      <h1 class="oc-text-normal">
-        <oc-button
-          :class="btnClass"
-          justify-content="left"
-          appearance="raw"
-          class="oc-display-inline-block oc-text-bold oc-position-relative"
-          @click="triggerUpload"
-        >
+    <slot :triggerUpload="triggerUpload" :uploadLabelId="uploadLabelId" >
+      <div>
+        <oc-button :class="btnClass" justify-content="left" appearance="raw" @click="triggerUpload">
+          <oc-resource-icon :resource="{ extension: '', isFolder }" size="medium" />
           <span :id="uploadLabelId">{{ buttonLabel }}</span>
         </oc-button>
-        <span v-text="$gettext('or drag it here')" />
-      </h1>
-    </div>
+      </div>
+    </slot>
     <input
       :id="inputId"
       ref="input"
@@ -104,27 +98,6 @@ button {
   color: var(--oc-color-swatch-primary-default);
   font-weight: 600;
 
-  &::after {
-    content: '';
-    position: absolute;
-    width: 100%;
-    transform: scaleX(0);
-    height: 2px;
-    bottom: -2px;
-    left: 0;
-    background-color: #0087ca;
-    transform-origin: bottom right;
-    transition: transform 0.25s ease-out;
-  }
 
-  &:hover {
-    color: var(--oc-color-swatch-primary-default);
-    text-decoration: none;
-
-    &::after {
-      transform: scaleX(1);
-      transform-origin: bottom left;
-    }
-  }
 }
 </style>

--- a/packages/web-app-files/src/views/FilesDrop.vue
+++ b/packages/web-app-files/src/views/FilesDrop.vue
@@ -217,7 +217,7 @@ export default defineComponent({
 })
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 #files-drop-container {
   position: relative;
   background: transparent;
@@ -301,11 +301,6 @@ export default defineComponent({
   0% {-webkit-transform: translateY(-30px); opacity: 0;}
   60% { opacity: 1;}
   100% {-webkit-transform: translateY(-10px); opacity: 0}
-}
-
-.snackbars #upload-info,  // hide upload info snackbar as it would be a duplicate
-#applications-menu {      // hide applications menu as there is no use in puplic link page
-  display: none;
 }
 
 </style>

--- a/packages/web-app-files/src/views/FilesDrop.vue
+++ b/packages/web-app-files/src/views/FilesDrop.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="oc-flex oc-flex-column oc-p-xl oc-pb-rm oc-flex-nowrap">
+  <div class="oc-flex oc-flex-column oc-p-xl oc-flex-nowrap">
     <div class="oc-flex oc-flex-column oc-height-1-1">
       <div
         id="files-drop-container"
@@ -66,29 +66,37 @@
             <p class="oc-m-rm" v-text="errorMessage" />
           </div>
 
-          <div class="explanation oc-flex oc-flex-center oc-mt-l">
-            <div class="oc-width-1-2@m oc-width-1-3@xl oc-pt-l">
+          <div class="explanation oc-flex oc-flex-center oc-flex-column oc-flex-center oc-flex-middle">
+            <div class="oc-width-1-2@m oc-width-1-3@xl">
               <h2 class="oc-text-center" v-text="$gettext('What is this?')" />
-              <p
+              <p class="oc-mb-rm"
                 v-text="
                   $gettext(
-                    'You can upload files here simply by drag `n drop or click on “Choose a file“ to open a file selection box.'
-                  )
-                "
-              />
-              <p
-                v-text="
-                  $gettext(
-                    'Since this an upload-only link you cannot see the contents existing within this resource. If you are not sure why you`re seeing this please contact the person who sent you the link or contact your local administrator.'
+                    'You can upload files here simply by drag `n drop or click on “Choose a file“ to open a file selection box. Since this an upload-only link you cannot see the contents existing within this resource.'
                   )
                 "
               />
             </div>
+
+            <div class="oc-text-center oc-pt-l oc-mt-l oc-width-1-2@m oc-width-1-3@xl">
+              <img v-if="configuration.currentTheme.logo.dark" :src="configuration.currentTheme.logo.dark" alt="ownCloud" class="oc-width-1-3@m" />
+              <img v-else-if="configuration.currentTheme.logo.default" :src="configuration.currentTheme.logo.default" alt="ownCloud" class="oc-width-1-3@m" />
+
+                <div class="oc-mt-m">
+                  <p
+                  v-text="
+                    $gettext(
+                      'This feature is brought to you by %{ company }.',
+                      { company: 'ownCloud' }
+                    )
+                  "
+                />
+                  <p class="" v-text="configuration.currentTheme.general.slogan + '.'" />
+                </div>
+                <a v-if="configuration.currentTheme.general.url" :href="configuration.currentTheme.general.url" target="_blank" v-text="$gettext('Learn more about ownCloud')" />
+              </div>
           </div>
         </div>
-      </div>
-      <div class="oc-text-center">
-        <p v-text="configuration.currentTheme.general.slogan" />
       </div>
     </div>
   </div>

--- a/packages/web-app-files/src/views/FilesDrop.vue
+++ b/packages/web-app-files/src/views/FilesDrop.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="oc-flex oc-flex-column oc-p-xl oc-flex-nowrap">
+  <div class="oc-flex oc-flex-column oc-p-m oc-p-xl@m oc-flex-nowrap">
     <div class="oc-flex oc-flex-column oc-height-1-1">
       <div
         id="files-drop-container"
@@ -79,21 +79,29 @@
             </div>
 
             <div class="oc-text-center oc-pt-l oc-mt-l oc-width-1-2@m oc-width-1-3@xl">
-              <img v-if="configuration.currentTheme.logo.dark" :src="configuration.currentTheme.logo.dark" alt="ownCloud" class="oc-width-1-3@m" />
-              <img v-else-if="configuration.currentTheme.logo.default" :src="configuration.currentTheme.logo.default" alt="ownCloud" class="oc-width-1-3@m" />
+              <img v-if="configuration.currentTheme.logo.dark" :src="configuration.currentTheme.logo.dark" alt="ownCloud" class="oc-width-1-2 oc-width-1-3@s oc-width-1-4@m" />
+              <img v-else-if="configuration.currentTheme.logo.default" :src="configuration.currentTheme.logo.default" alt="ownCloud" class="oc-width-1-2 oc-width-1-3@s oc-width-1-4@m" />
 
                 <div class="oc-mt-m">
                   <p
                   v-text="
                     $gettext(
                       'This feature is brought to you by %{ company }.',
-                      { company: 'ownCloud' }
+                      { company: configuration.currentTheme.general.name }
                     )
                   "
                 />
                   <p class="" v-text="configuration.currentTheme.general.slogan + '.'" />
                 </div>
-                <a v-if="configuration.currentTheme.general.url" :href="configuration.currentTheme.general.url" target="_blank" v-text="$gettext('Learn more about ownCloud')" />
+                <a
+                  v-if="configuration.currentTheme.general.url"
+                  :href="configuration.currentTheme.general.url"
+                  target="_blank"
+                  v-text="$gettext('Learn more about %{ company }',
+                  {
+                    company: configuration.currentTheme.general.name
+                  })"
+                />
               </div>
           </div>
         </div>

--- a/packages/web-app-files/src/views/FilesDrop.vue
+++ b/packages/web-app-files/src/views/FilesDrop.vue
@@ -1,8 +1,15 @@
 <template>
   <div class="oc-flex oc-flex-column oc-p-xl oc-pb-rm oc-flex-nowrap">
     <div class="oc-flex oc-flex-column oc-height-1-1">
-      <div id="files-drop-container" class="oc-flex oc-flex-column oc-flex-between oc-flex-center oc-width-expand oc-flex-nowrap oc-p-m" :class="{'dragarea-enabled': dragareaEnabled}">
-        <div v-if="dragareaEnabled" class="dragarea oc-position-absolute oc-inset-0 oc-background-highlight oc-flex oc-flex-center oc-flex-column oc-flex-middle oc-p-m" >
+      <div
+        id="files-drop-container"
+        class="oc-flex oc-flex-column oc-flex-between oc-flex-center oc-width-expand oc-flex-nowrap oc-p-m"
+        :class="{ 'dragarea-enabled': dragareaEnabled }"
+      >
+        <div
+          v-if="dragareaEnabled"
+          class="dragarea oc-position-absolute oc-inset-0 oc-background-highlight oc-flex oc-flex-center oc-flex-column oc-flex-middle oc-p-m"
+        >
           <div class="upload-icon oc-position-relative oc-mb-m oc-text-xlarge">
             <div class="box"></div>
             <div class="arrow oc-position-absolute oc-position-center"></div>
@@ -17,7 +24,11 @@
           </h2>
           <oc-spinner :aria-hidden="true" />
         </div>
-        <div v-else key="loaded-drop" class="oc-flex oc-flex-column oc-height-1-1 oc-flex-middle oc-flex-center">
+        <div
+          v-else
+          key="loaded-drop"
+          class="oc-flex oc-flex-column oc-height-1-1 oc-flex-middle oc-flex-center"
+        >
           <div class="oc-text-center oc-width-1-1 oc-flex oc-flex-middle oc-flex-column">
             <div v-text="title" />
             <resource-upload
@@ -25,7 +36,7 @@
               ref="fileUpload"
               class="oc-flex oc-flex-middle oc-flex-center oc-placeholder"
               :btn-label="$gettext('Choose a file')"
-              :btnClass="'oc-text-bold oc-button-l'"
+              :btn-class="'oc-text-bold oc-button-l'"
             />
             <div id="previews" hidden />
 
@@ -40,12 +51,24 @@
           </div>
 
           <div class="explanation oc-flex oc-flex-center oc-mt-l">
-              <div class="oc-width-1-2@m oc-width-1-3@xl oc-pt-l">
-                <h2 class="oc-text-center" v-text="$gettext('What is this?')" />
-                <p v-text="$gettext('You can upload files here simply by drag `n drop or click on “Choose a file“ to open a file selection box.')" />
-                <p v-text="$gettext('Since this an upload-only link you cannot see the contents existing within this resource. If you are not sure why you`re seeing this please contact the person who sent you the link or contact your local administrator.')" />
-              </div>
+            <div class="oc-width-1-2@m oc-width-1-3@xl oc-pt-l">
+              <h2 class="oc-text-center" v-text="$gettext('What is this?')" />
+              <p
+                v-text="
+                  $gettext(
+                    'You can upload files here simply by drag `n drop or click on “Choose a file“ to open a file selection box.'
+                  )
+                "
+              />
+              <p
+                v-text="
+                  $gettext(
+                    'Since this an upload-only link you cannot see the contents existing within this resource. If you are not sure why you`re seeing this please contact the person who sent you the link or contact your local administrator.'
+                  )
+                "
+              />
             </div>
+          </div>
         </div>
       </div>
       <div class="oc-text-center">
@@ -223,11 +246,11 @@ export default defineComponent({
   background: transparent;
   border: 3px dashed var(--oc-color-input-border);
   border-radius: 12px;
-  transition : border 500ms ease-out;
+  transition: border 500ms ease-out;
 
   &.dragarea-enabled {
     border: 3px dashed var(--oc-color-swatch-primary-muted);
-    transition : border 500ms ease-out;
+    transition: border 500ms ease-out;
   }
 
   .dragarea {
@@ -251,7 +274,7 @@ export default defineComponent({
 
       .arrow:before,
       .arrow:after {
-      content: '';
+        content: '';
         position: absolute;
         top: 0;
         right: -16px;
@@ -260,47 +283,78 @@ export default defineComponent({
         border-radius: 10px;
         display: block;
         background: var(--oc-color-text-default);
-        transform:rotate(-45deg);
-        -webkit-transform:rotate(-45deg);
+        transform: rotate(-45deg);
+        -webkit-transform: rotate(-45deg);
       }
 
-      .arrow:after{
+      .arrow:after {
         right: inherit;
         left: -15px;
-        transform:rotate(45deg);
-        -webkit-transform:rotate(45deg);
+        transform: rotate(45deg);
+        -webkit-transform: rotate(45deg);
       }
     }
   }
 
   .explanation {
-    &> div {
+    & > div {
       border-top: 1px solid var(--oc-color-input-border);
     }
   }
 }
 
 @-webkit-keyframes bounce {
-  0% {-webkit-transform: translateY(-30xp); opacity: 0;}
-  60% { opacity: 1;}
-  100% {-webkit-transform: translateY(-10px); opacity: 0}
+  0% {
+    -webkit-transform: translateY(-30xp);
+    opacity: 0;
+  }
+  60% {
+    opacity: 1;
+  }
+  100% {
+    -webkit-transform: translateY(-10px);
+    opacity: 0;
+  }
 }
 
 @-moz-keyframes bounce {
-  0% {-webkit-transform: translateY(-30px); opacity: 0;}
-  60% { opacity: 1;}
-  100% {-webkit-transform: translateY(-10px); opacity: 0}
+  0% {
+    -webkit-transform: translateY(-30px);
+    opacity: 0;
+  }
+  60% {
+    opacity: 1;
+  }
+  100% {
+    -webkit-transform: translateY(-10px);
+    opacity: 0;
+  }
 }
 
 @-o-keyframes bounce {
-  0% {-webkit-transform: translateY(-30px); opacity: 0;}
-  60% { opacity: 1;}
-  100% {-webkit-transform: translateY(-10px); opacity: 0}
+  0% {
+    -webkit-transform: translateY(-30px);
+    opacity: 0;
+  }
+  60% {
+    opacity: 1;
+  }
+  100% {
+    -webkit-transform: translateY(-10px);
+    opacity: 0;
+  }
 }
 @keyframes bounce {
-  0% {-webkit-transform: translateY(-30px); opacity: 0;}
-  60% { opacity: 1;}
-  100% {-webkit-transform: translateY(-10px); opacity: 0}
+  0% {
+    -webkit-transform: translateY(-30px);
+    opacity: 0;
+  }
+  60% {
+    opacity: 1;
+  }
+  100% {
+    -webkit-transform: translateY(-10px);
+    opacity: 0;
+  }
 }
-
 </style>

--- a/packages/web-app-files/src/views/FilesDrop.vue
+++ b/packages/web-app-files/src/views/FilesDrop.vue
@@ -40,7 +40,7 @@
             />
             <div id="previews" hidden />
 
-            <upload-info :info-expanded-prop="true" :standalone="false" />
+            <upload-info :info-expanded-initial="true" :standalone="false" />
           </div>
 
           <div v-if="errorMessage" class="oc-text-center">

--- a/packages/web-app-files/src/views/FilesDrop.vue
+++ b/packages/web-app-files/src/views/FilesDrop.vue
@@ -42,7 +42,7 @@
           <div class="explanation oc-flex oc-flex-center oc-mt-l">
               <div class="oc-width-1-2@m oc-width-1-3@xl oc-pt-l">
                 <h2 class="oc-text-center" v-text="$gettext('What is this?')" />
-                <p v-text="$gettext('You can upload files here simply by drag `n drop of click on “Choose a file“ to open a file selection box.')" />
+                <p v-text="$gettext('You can upload files here simply by drag `n drop or click on “Choose a file“ to open a file selection box.')" />
                 <p v-text="$gettext('Since this an upload-only link you cannot see the contents existing within this resource. If you are not sure why you`re seeing this please contact the person who sent you the link or contact your local administrator.')" />
               </div>
             </div>

--- a/packages/web-app-files/src/views/FilesDrop.vue
+++ b/packages/web-app-files/src/views/FilesDrop.vue
@@ -1,30 +1,34 @@
 <template>
-  <div id="files-drop-container" class="oc-height-1-1 oc-flex oc-flex-column oc-flex-between">
-    <div v-if="dragareaEnabled" class="dragarea" />
-    <h1 class="oc-invisible-sr">{{ pageTitle }}</h1>
-    <div class="oc-p oc-height-1-1">
-      <div v-if="loading" key="loading-drop" class="oc-flex oc-flex-column oc-flex-middle">
-        <h2 class="oc-login-card-title">
-          <span v-text="$gettext('Loading public link…')" />
-        </h2>
-        <oc-spinner :aria-hidden="true" />
-      </div>
-      <div v-else key="loaded-drop" class="oc-flex oc-flex-column oc-flex-middle oc-height-1-1">
-        <div class="oc-text-center oc-width-1-1 oc-width-xxlarge@m">
-          <h2 v-text="title" />
-          <resource-upload
-            id="files-drop-zone"
-            ref="fileUpload"
-            class="oc-flex oc-flex-middle oc-flex-center oc-placeholder"
-            :btn-label="$gettext('Drop files here to upload or click to select file')"
-          />
-          <div id="previews" hidden />
-        </div>
-        <div v-if="errorMessage" class="oc-text-center">
-          <h2>
-            <span v-text="$gettext('An error occurred while loading the public link')" />
+  <div>
+    <div id="files-drop-container" class="oc-flex oc-flex-column oc-flex-between oc-flex-center">
+      TESAT
+      <div v-if="dragareaEnabled" class="dragarea" />
+
+      <h1 class="oc-invisible-sr">{{ pageTitle }}</h1>
+      <div class="oc-p oc-height-1-1">
+        <div v-if="loading" key="loading-drop" class="oc-flex oc-flex-column oc-flex-middle">
+          <h2 class="oc-login-card-title">
+            <span v-text="$gettext('Loading public link…')" />
           </h2>
-          <p class="oc-m-rm" v-text="errorMessage" />
+          <oc-spinner :aria-hidden="true" />
+        </div>
+        <div v-else key="loaded-drop" class="oc-flex oc-flex-column oc-flex-middle oc-height-1-1">
+          <div class="oc-text-center oc-width-1-1 oc-width-xxlarge@m">
+            <h2 v-text="title" />
+            <resource-upload
+              id="files-drop-zone"
+              ref="fileUpload"
+              class="oc-flex oc-flex-middle oc-flex-center oc-placeholder"
+              :btn-label="$gettext('Drop files here to upload or click to select file')"
+            />
+            <div id="previews" hidden />
+          </div>
+          <div v-if="errorMessage" class="oc-text-center">
+            <h2>
+              <span v-text="$gettext('An error occurred while loading the public link')" />
+            </h2>
+            <p class="oc-m-rm" v-text="errorMessage" />
+          </div>
         </div>
       </div>
     </div>
@@ -197,8 +201,9 @@ export default defineComponent({
 #files-drop-container {
   position: relative;
   background: transparent;
-  border: 1px dashed var(--oc-color-input-border);
+  border: 3px dashed var(--oc-color-input-border);
   margin: var(--oc-space-xlarge);
+  border-radius: 12px;
 }
 .dragarea {
   background-color: rgba(60, 130, 225, 0.21);

--- a/packages/web-app-files/src/views/FilesDrop.vue
+++ b/packages/web-app-files/src/views/FilesDrop.vue
@@ -1,39 +1,56 @@
 <template>
-  <div>
-    <div id="files-drop-container" class="oc-flex oc-flex-column oc-flex-between oc-flex-center">
-      TESAT
-      <div v-if="dragareaEnabled" class="dragarea" />
+  <div class="oc-flex oc-flex-column oc-p-xl oc-pb-rm oc-flex-nowrap">
+    <div class="oc-flex oc-flex-column oc-height-1-1">
+      <div id="files-drop-container" class="oc-flex oc-flex-column oc-flex-between oc-flex-center oc-width-expand oc-flex-nowrap oc-p-m" :class="{'dragarea-enabled': dragareaEnabled}">
+        <div v-if="dragareaEnabled" class="dragarea oc-position-absolute oc-inset-0 oc-background-highlight oc-flex oc-flex-center oc-flex-column oc-flex-middle oc-p-m" >
+          <div class="upload-icon oc-position-relative oc-mb-m oc-text-xlarge">
+            <div class="box"></div>
+            <div class="arrow oc-position-absolute oc-position-center"></div>
+          </div>
+          <h1 class="oc-text-normal" v-text="$gettext('Drop files here to upload')"></h1>
+        </div>
 
-      <h1 class="oc-invisible-sr">{{ pageTitle }}</h1>
-      <div class="oc-p oc-height-1-1">
-        <div v-if="loading" key="loading-drop" class="oc-flex oc-flex-column oc-flex-middle">
+        <h1 class="oc-invisible-sr">{{ pageTitle }}</h1>
+        <div v-if="loading" key="loading-drop" class="oc-flex oc-flex-row oc-flex-middle">
           <h2 class="oc-login-card-title">
             <span v-text="$gettext('Loading public link…')" />
           </h2>
           <oc-spinner :aria-hidden="true" />
         </div>
-        <div v-else key="loaded-drop" class="oc-flex oc-flex-column oc-flex-middle oc-height-1-1">
-          <div class="oc-text-center oc-width-1-1 oc-width-xxlarge@m">
-            <h2 v-text="title" />
+        <div v-else key="loaded-drop" class="oc-flex oc-flex-column oc-height-1-1 oc-flex-middle oc-flex-center">
+          <div class="oc-text-center oc-width-1-1 oc-flex oc-flex-middle oc-flex-column">
+            <div v-text="title" />
             <resource-upload
               id="files-drop-zone"
               ref="fileUpload"
               class="oc-flex oc-flex-middle oc-flex-center oc-placeholder"
-              :btn-label="$gettext('Drop files here to upload or click to select file')"
+              :btn-label="$gettext('Choose a file')"
+              :btnClass="'oc-text-bold oc-button-l'"
             />
             <div id="previews" hidden />
+
+            <upload-info :infoExpanded="true" :standalone="false" />
           </div>
+
           <div v-if="errorMessage" class="oc-text-center">
             <h2>
               <span v-text="$gettext('An error occurred while loading the public link')" />
             </h2>
             <p class="oc-m-rm" v-text="errorMessage" />
           </div>
+
+          <div class="explanation oc-flex oc-flex-center oc-mt-l">
+              <div class="oc-width-1-2@m oc-width-1-3@xl oc-pt-l">
+                <h2 class="oc-text-center" v-text="$gettext('What is this?')" />
+                <p v-text="$gettext('You can upload files here simply by drag `n drop of click on “Choose a file“ to open a file selection box.')" />
+                <p v-text="$gettext('Since this an upload-only link you cannot see the contents existing within this resource. If you are not sure why you`re seeing this please contact the person who sent you the link or contact your local administrator.')" />
+              </div>
+            </div>
         </div>
       </div>
-    </div>
-    <div class="oc-text-center">
-      <p v-text="configuration.currentTheme.general.slogan" />
+      <div class="oc-text-center">
+        <p v-text="configuration.currentTheme.general.slogan" />
+      </div>
     </div>
   </div>
 </template>
@@ -59,14 +76,17 @@ import { linkRoleUploaderFolder } from 'web-client/src/helpers/share'
 import { useService } from 'web-pkg/src/composables/service'
 import { UppyService } from 'web-runtime/src/services/uppyService'
 import { useAuthService } from 'web-pkg/src/composables/authContext/useAuthService'
+import UploadInfo from 'web-runtime/src/components/UploadInfo.vue'
 
 export default defineComponent({
   components: {
-    ResourceUpload
+    ResourceUpload,
+    UploadInfo
   },
   setup() {
     const instance = getCurrentInstance().proxy as any
     const uppyService = useService<UppyService>('$uppyService')
+
     const store = useStore()
     const router = useRouter()
     const authService = useAuthService()
@@ -202,19 +222,90 @@ export default defineComponent({
   position: relative;
   background: transparent;
   border: 3px dashed var(--oc-color-input-border);
-  margin: var(--oc-space-xlarge);
   border-radius: 12px;
+  transition : border 500ms ease-out;
+
+  &.dragarea-enabled {
+    border: 3px dashed var(--oc-color-swatch-primary-muted);
+    transition : border 500ms ease-out;
+  }
+
+  .dragarea {
+    pointer-events: none;
+    z-index: 9;
+    border-radius: 12px;
+
+    .upload-icon {
+      width: 50px;
+      border: 3px solid var(--oc-color-text-default);
+      border-top: none;
+      height: 20px;
+      border-radius: 4px;
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
+
+      .arrow {
+        -webkit-animation: bounce 1.5s infinite;
+        animation: bounce 1.5s both infinite;
+      }
+
+      .arrow:before,
+      .arrow:after {
+      content: '';
+        position: absolute;
+        top: 0;
+        right: -16px;
+        width: 20px;
+        height: 5px;
+        border-radius: 10px;
+        display: block;
+        background: var(--oc-color-text-default);
+        transform:rotate(-45deg);
+        -webkit-transform:rotate(-45deg);
+      }
+
+      .arrow:after{
+        right: inherit;
+        left: -15px;
+        transform:rotate(45deg);
+        -webkit-transform:rotate(45deg);
+      }
+    }
+  }
+
+  .explanation {
+    &> div {
+      border-top: 1px solid var(--oc-color-input-border);
+    }
+  }
 }
-.dragarea {
-  background-color: rgba(60, 130, 225, 0.21);
-  pointer-events: none;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  position: absolute;
-  z-index: 9;
-  border-radius: 14px;
-  border: 2px dashed var(--oc-color-swatch-primary-muted);
+
+@-webkit-keyframes bounce {
+  0% {-webkit-transform: translateY(-30xp); opacity: 0;}
+  60% { opacity: 1;}
+  100% {-webkit-transform: translateY(-10px); opacity: 0}
 }
+
+@-moz-keyframes bounce {
+  0% {-webkit-transform: translateY(-30px); opacity: 0;}
+  60% { opacity: 1;}
+  100% {-webkit-transform: translateY(-10px); opacity: 0}
+}
+
+@-o-keyframes bounce {
+  0% {-webkit-transform: translateY(-30px); opacity: 0;}
+  60% { opacity: 1;}
+  100% {-webkit-transform: translateY(-10px); opacity: 0}
+}
+@keyframes bounce {
+  0% {-webkit-transform: translateY(-30px); opacity: 0;}
+  60% { opacity: 1;}
+  100% {-webkit-transform: translateY(-10px); opacity: 0}
+}
+
+.snackbars #upload-info,  // hide upload info snackbar as it would be a duplicate
+#applications-menu {      // hide applications menu as there is no use in puplic link page
+  display: none;
+}
+
 </style>

--- a/packages/web-app-files/src/views/FilesDrop.vue
+++ b/packages/web-app-files/src/views/FilesDrop.vue
@@ -35,12 +35,28 @@
               id="files-drop-zone"
               ref="fileUpload"
               class="oc-flex oc-flex-middle oc-flex-center oc-placeholder"
-              :btn-label="$gettext('Choose a file')"
-              :btn-class="'oc-text-bold oc-button-l'"
-            />
+            >
+              <template v-slot="{triggerUpload, uploadLabelId}">
+                <div class="oc-text-xlarge">
+                  <h1 class="oc-text-normal">
+                    <oc-button
+                      justify-content="left"
+                      appearance="raw"
+                      class="oc-font-semibold oc-button-l"
+                      variation="primary"
+                      @click="triggerUpload"
+                    >
+                      <span :id="uploadLabelId" v-text="$gettext('Choose a file')"></span>
+                    </oc-button>
+                    <span v-text="$gettext('or drag it here')" />
+                  </h1>
+                </div>
+              </template>
+            </resource-upload>
+
             <div id="previews" hidden />
 
-            <upload-info :info-expanded-initial="true" :standalone="false" />
+            <upload-info :info-expanded-initial="true" :headless="true" :show-expand-details-button="false" />
           </div>
 
           <div v-if="errorMessage" class="oc-text-center">
@@ -299,6 +315,13 @@ export default defineComponent({
   .explanation {
     & > div {
       border-top: 1px solid var(--oc-color-input-border);
+    }
+  }
+
+  button {
+    &:hover {
+      color: var(--oc-color-swatch-primary-default);
+      text-decoration: underline;
     }
   }
 }

--- a/packages/web-app-files/src/views/FilesDrop.vue
+++ b/packages/web-app-files/src/views/FilesDrop.vue
@@ -40,7 +40,7 @@
             />
             <div id="previews" hidden />
 
-            <upload-info :infoExpanded="true" :standalone="false" />
+            <upload-info :info-expanded-prop="true" :standalone="false" />
           </div>
 
           <div v-if="errorMessage" class="oc-text-center">

--- a/packages/web-runtime/src/components/UploadInfo.vue
+++ b/packages/web-runtime/src/components/UploadInfo.vue
@@ -1,8 +1,8 @@
 <template>
-  <div v-if="showInfo" id="upload-info" :class="{'oc-rounded oc-box-shadow-medium': standalone}">
+  <div v-if="showInfo" id="upload-info" :class="{ 'oc-rounded oc-box-shadow-medium': standalone }">
     <div
-      class="upload-info-title oc-flex oc-flex-between oc-flex-middle oc-px-m oc-py-s oc-rounded-top"
       v-if="standalone"
+      class="upload-info-title oc-flex oc-flex-between oc-flex-middle oc-px-m oc-py-s oc-rounded-top"
     >
       <p v-oc-tooltip="uploadDetails" class="oc-my-xs" v-text="uploadInfoTitle" />
       <oc-button
@@ -38,11 +38,11 @@
       </div>
       <div class="oc-flex">
         <oc-button
+          v-if="standalone"
           appearance="raw"
           class="oc-text-muted oc-text-small upload-info-toggle-details-btn"
           @click="toggleInfo"
           v-text="infoExpanded ? $gettext('Hide details') : $gettext('Show details')"
-          v-if="standalone"
         ></oc-button>
         <oc-button
           v-if="!runningUploads && Object.keys(errors).length"
@@ -152,14 +152,10 @@ import { formatFileSize } from 'web-pkg/src/helpers'
 import { UppyResource } from '../composables/upload'
 
 export default defineComponent({
-  setup() {
-    return {
-      hasShareJail: useCapabilityShareJailEnabled()
-    }
-  },
   props: {
     /*
      * show the info including all uploads?
+     * Prop only works intially, state gets copied ot local var infoExpanded
      */
     infoExpanded: {
       type: Boolean,
@@ -175,6 +171,11 @@ export default defineComponent({
       type: Boolean,
       default: true,
       required: false
+    }
+  },
+  setup() {
+    return {
+      hasShareJail: useCapabilityShareJailEnabled()
     }
   },
   data: () => ({

--- a/packages/web-runtime/src/components/UploadInfo.vue
+++ b/packages/web-runtime/src/components/UploadInfo.vue
@@ -157,7 +157,7 @@ export default defineComponent({
      * show the info including all uploads?
      * Prop only works intially, state gets copied ot local var infoExpanded
      */
-    infoExpanded: {
+    infoExpandedProp: {
       type: Boolean,
       default: false,
       required: false
@@ -180,6 +180,7 @@ export default defineComponent({
   },
   data: () => ({
     showInfo: false, // show the overlay?
+    infoExpanded: false, // show the info including all uploads?
     uploads: {} as Record<any, any>, // uploads that are being displayed via "infoExpanded"
     errors: {}, // all failed files
     successful: [], // all successful files
@@ -269,6 +270,8 @@ export default defineComponent({
     }
   },
   created() {
+    this.infoExpanded = this.infoExpandedProp
+
     this.$uppyService.subscribe('uploadStarted', () => {
       if (!this.remainingTime) {
         this.remainingTime = this.$gettext('Calculating estimated time...')

--- a/packages/web-runtime/src/components/UploadInfo.vue
+++ b/packages/web-runtime/src/components/UploadInfo.vue
@@ -1,7 +1,7 @@
 <template>
-  <div v-if="showInfo" id="upload-info" :class="{ 'oc-rounded oc-box-shadow-medium': standalone }">
+  <div v-if="showInfo" id="upload-info" :class="{ 'oc-rounded oc-box-shadow-medium': headless === false }">
     <div
-      v-if="standalone"
+      v-if="headless === false"
       class="upload-info-title oc-flex oc-flex-between oc-flex-middle oc-px-m oc-py-s oc-rounded-top"
     >
       <p v-oc-tooltip="uploadDetails" class="oc-my-xs" v-text="uploadInfoTitle" />
@@ -38,7 +38,7 @@
       </div>
       <div class="oc-flex">
         <oc-button
-          v-if="standalone"
+          v-if="showExpandDetailsButton"
           appearance="raw"
           class="oc-text-muted oc-text-small upload-info-toggle-details-btn"
           @click="toggleInfo"
@@ -157,17 +157,26 @@ export default defineComponent({
      * show the info including all uploads?
      * Prop only works intially, state gets copied ot local var infoExpanded
      */
-    infoExpandedInital: {
+    infoExpandedInitial: {
       type: Boolean,
       default: false,
       required: false
     },
 
     /**
-     * show it as standalone component?
+     * Render as headless component?
      * Renders the header and the close button
      */
-    standalone: {
+    headless: {
+      type: Boolean,
+      default: false,
+      required: false
+    },
+
+    /**
+     * Show the button to expand/hide upload details?
+     */
+     showExpandDetailsButton: {
       type: Boolean,
       default: true,
       required: false
@@ -270,7 +279,7 @@ export default defineComponent({
     }
   },
   created() {
-    this.infoExpanded = this.infoExpandedInital
+    this.infoExpanded = this.infoExpandedInitial
 
     this.$uppyService.subscribe('uploadStarted', () => {
       if (!this.remainingTime) {

--- a/packages/web-runtime/src/components/UploadInfo.vue
+++ b/packages/web-runtime/src/components/UploadInfo.vue
@@ -157,7 +157,7 @@ export default defineComponent({
      * show the info including all uploads?
      * Prop only works intially, state gets copied ot local var infoExpanded
      */
-    infoExpandedProp: {
+    infoExpandedInital: {
       type: Boolean,
       default: false,
       required: false
@@ -270,7 +270,7 @@ export default defineComponent({
     }
   },
   created() {
-    this.infoExpanded = this.infoExpandedProp
+    this.infoExpanded = this.infoExpandedInital
 
     this.$uppyService.subscribe('uploadStarted', () => {
       if (!this.remainingTime) {

--- a/packages/web-runtime/src/components/UploadInfo.vue
+++ b/packages/web-runtime/src/components/UploadInfo.vue
@@ -1,7 +1,8 @@
 <template>
-  <div v-if="showInfo" id="upload-info" class="oc-rounded oc-box-shadow-medium">
+  <div v-if="showInfo" id="upload-info" :class="{'oc-rounded oc-box-shadow-medium': standalone}">
     <div
       class="upload-info-title oc-flex oc-flex-between oc-flex-middle oc-px-m oc-py-s oc-rounded-top"
+      v-if="standalone"
     >
       <p v-oc-tooltip="uploadDetails" class="oc-my-xs" v-text="uploadInfoTitle" />
       <oc-button
@@ -41,6 +42,7 @@
           class="oc-text-muted oc-text-small upload-info-toggle-details-btn"
           @click="toggleInfo"
           v-text="infoExpanded ? $gettext('Hide details') : $gettext('Show details')"
+          v-if="standalone"
         ></oc-button>
         <oc-button
           v-if="!runningUploads && Object.keys(errors).length"
@@ -155,9 +157,28 @@ export default defineComponent({
       hasShareJail: useCapabilityShareJailEnabled()
     }
   },
+  props: {
+    /*
+     * show the info including all uploads?
+     */
+    infoExpanded: {
+      type: Boolean,
+      default: false,
+      required: false
+    },
+
+    /**
+     * show it as standalone component?
+     * Renders the header and the close button
+     */
+    standalone: {
+      type: Boolean,
+      default: true,
+      required: false
+    }
+  },
   data: () => ({
     showInfo: false, // show the overlay?
-    infoExpanded: false, // show the info including all uploads?
     uploads: {} as Record<any, any>, // uploads that are being displayed via "infoExpanded"
     errors: {}, // all failed files
     successful: [], // all successful files

--- a/packages/web-runtime/src/store/config.ts
+++ b/packages/web-runtime/src/store/config.ts
@@ -18,13 +18,15 @@ const state = {
   currentTheme: {
     general: {
       name: '',
-      slogan: ''
+      slogan: '',
+      url: ''
     },
     logo: {
       topbar: '',
       favicon: '',
       login: '',
-      notFound: ''
+      notFound: '',
+      dark: ''
     },
     loginPage: {
       autoRedirect: true,

--- a/packages/web-runtime/themes/owncloud/theme.json
+++ b/packages/web-runtime/themes/owncloud/theme.json
@@ -9,12 +9,14 @@
     "default": {
       "general": {
         "name": "ownCloud",
-        "slogan": "ownCloud – A safe home for all your data"
+        "slogan": "ownCloud – A safe home for all your data",
+        "url": "https://owncloud.com"
       },
       "logo": {
         "topbar": "themes/owncloud/assets/logo.svg",
         "favicon": "themes/owncloud/assets/favicon.jpg",
-        "login": "themes/owncloud/assets/logo.svg"
+        "login": "themes/owncloud/assets/logo.svg",
+        "dark": "themes/owncloud/assets/logo_dark.svg"
       },
       "loginPage": {
         "autoRedirect": true,


### PR DESCRIPTION
## Description
Improve Layout of FileDrop view

## Motivation and Context
The FileDrop View is an external endpoint, which gets presented to users possible not knowing what a FileDrop or even ownCloud is. The current layout does not provide any information about it and does not offer clear instructions what to do, where to click.
Also, current status of (german) translations are ... well ... 💩 

## Screenshots (if appropriate):

Before:
![grafik](https://user-images.githubusercontent.com/16665512/221886857-e822b881-2357-4c99-92b6-fec2c03d92e5.png)

After:
![grafik](https://user-images.githubusercontent.com/16665512/221885621-ebb3f962-e453-4ca4-a7c5-2b7951a65275.png)

Drag `n Drop state:
![grafik](https://user-images.githubusercontent.com/16665512/221891675-055d487d-4403-4bb7-bd4b-c62a09575c78.png)

After upload showing file infos:
![grafik](https://user-images.githubusercontent.com/16665512/221892188-9c4cf258-5838-42d3-98d5-ffe0b6490a44.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Clarify why code changes are not compiled 
- [ ] Add translation strings to transifex and back
