### PR TITLE
fix: move custom styles and scripts to config options

### DIFF
--- a/changelog/unreleased/enhancement-inject-customizations
+++ b/changelog/unreleased/enhancement-inject-customizations
@@ -5,9 +5,10 @@ This function is currently still experimental and there is a possibility that th
 
 For the reasons mentioned, the functionality is not yet documented in the official documentation, but can be used as follows:
 
-* to inject custom css add the following property to your `config.json`, `"styles": [{ "href": "css/custom.css", }]`.
-* to inject custom scripts add the following property to your `config.json`, `"scripts": [{ "src": "js/custom.js", "async": true, }]`.
+* to inject custom css add the following property to the `"options"` object in your `config.json`, `"styles": [{ "href": "css/custom.css", }]`.
+* to inject custom scripts add the following property to the `"options"` object in your `config.json`, `"scripts": [{ "src": "js/custom.js", "async": true, }]`.
 
+https://github.com/owncloud/web/issues/4735
 https://github.com/owncloud/web/pull/8432
 https://github.com/owncloud/web/pull/7689
-https://github.com/owncloud/web/issues/4735
+https://github.com/owncloud/web/pull/8512

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -386,7 +386,7 @@ export const announceCustomScripts = ({
 }: {
   runtimeConfiguration?: RuntimeConfiguration
 }): void => {
-  const { scripts = [] } = runtimeConfiguration
+  const { scripts = [] } = runtimeConfiguration?.options
 
   scripts.forEach(({ src = '', async = false }) => {
     if (!src) {
@@ -410,7 +410,7 @@ export const announceCustomStyles = ({
 }: {
   runtimeConfiguration?: RuntimeConfiguration
 }): void => {
-  const { styles = [] } = runtimeConfiguration
+  const { styles = [] } = runtimeConfiguration?.options
 
   styles.forEach(({ href = '' }) => {
     if (!href) {

--- a/packages/web-runtime/tests/unit/container/bootstrap.spec.ts
+++ b/packages/web-runtime/tests/unit/container/bootstrap.spec.ts
@@ -60,26 +60,28 @@ describe('announceCustomScripts', () => {
 
   it('injects basic scripts', () => {
     announceCustomScripts({
-      runtimeConfiguration: { scripts: [{ src: 'foo.js' }, { src: 'bar.js' }] }
+      runtimeConfiguration: { options: { scripts: [{ src: 'foo.js' }, { src: 'bar.js' }] } }
     })
     const elements = document.getElementsByTagName('script')
     expect(elements.length).toBe(2)
   })
 
   it('skips the injection if no src option is provided', () => {
-    announceCustomScripts({ runtimeConfiguration: { scripts: [{}, {}, {}, {}, {}] } })
+    announceCustomScripts({ runtimeConfiguration: { options: { scripts: [{}, {}, {}, {}, {}] } } })
     const elements = document.getElementsByTagName('script')
     expect(elements.length).toBeFalsy()
   })
 
   it('loads scripts synchronous by default', () => {
-    announceCustomScripts({ runtimeConfiguration: { scripts: [{ src: 'foo.js' }] } })
+    announceCustomScripts({ runtimeConfiguration: { options: { scripts: [{ src: 'foo.js' }] } } })
     const element = document.querySelector<HTMLScriptElement>('[src="foo.js"]')
     expect(element.async).toBeFalsy()
   })
 
   it('injects scripts async if the corresponding configurations option is set', () => {
-    announceCustomScripts({ runtimeConfiguration: { scripts: [{ src: 'foo.js', async: true }] } })
+    announceCustomScripts({
+      runtimeConfiguration: { options: { scripts: [{ src: 'foo.js', async: true }] } }
+    })
     const element = document.querySelector<HTMLScriptElement>('[src="foo.js"]')
     expect(element.async).toBeTruthy()
   })
@@ -92,7 +94,7 @@ describe('announceCustomStyles', () => {
 
   it('injects basic styles', () => {
     const styles = [{ href: 'foo.css' }, { href: 'bar.css' }]
-    announceCustomStyles({ runtimeConfiguration: { styles } })
+    announceCustomStyles({ runtimeConfiguration: { options: { styles } } })
 
     styles.forEach(({ href }) => {
       const element = document.querySelector<HTMLLinkElement>(`[href="${href}"]`)
@@ -103,7 +105,7 @@ describe('announceCustomStyles', () => {
   })
 
   it('skips the injection if no href option is provided', () => {
-    announceCustomStyles({ runtimeConfiguration: { styles: [{}, {}] } })
+    announceCustomStyles({ runtimeConfiguration: { options: { styles: [{}, {}] } } })
     const elements = document.getElementsByTagName('link')
     expect(elements.length).toBeFalsy()
   })


### PR DESCRIPTION
oCIS parses the config.json file and ignores keys that are not known in the backend struct. Hence moving styles and scripts to "options" because that already is accepted as a (potentially nested) map in the config struct.

The other option would've been to define the `scripts` and `styles` entries in the backend struct. Not much of a difference effort wise, but I don't want to impose the bad design of the config.json on the backend code. 😅 

This is a followup of https://github.com/owncloud/web/pull/8432