### PR TITLE
Change behaviour of user filters to `OR`

### DIFF
--- a/changelog/unreleased/enhancement-user-group-filter
+++ b/changelog/unreleased/enhancement-user-group-filter
@@ -5,3 +5,4 @@ Users in the users list can now be filtered by their group assignments.
 https://github.com/owncloud/web/issues/8377
 https://github.com/owncloud/web/pull/8378
 https://github.com/owncloud/web/pull/8495
+https://github.com/owncloud/web/pull/8525

--- a/changelog/unreleased/enhancement-user-role-filter
+++ b/changelog/unreleased/enhancement-user-role-filter
@@ -4,3 +4,4 @@ Users in the users list can now be filtered by their role assignments.
 
 https://github.com/owncloud/web/pull/8492
 https://github.com/owncloud/web/pull/8495
+https://github.com/owncloud/web/pull/8525

--- a/packages/web-app-admin-settings/src/views/Users.vue
+++ b/packages/web-app-admin-settings/src/views/Users.vue
@@ -220,11 +220,12 @@ export default defineComponent({
     const loadUsersTask = useTask(function* (signal) {
       const filter = Object.values(filters)
         .reduce((acc, f) => {
-          acc.push(
-            unref(f.ids)
-              .map((id) => format(f.query, id))
-              .join(' and ')
-          )
+          const str = unref(f.ids)
+            .map((id) => format(f.query, id))
+            .join(' or ')
+          if (str) {
+            acc.push(`(${str})`)
+          }
           return acc
         }, [])
         .filter(Boolean)

--- a/packages/web-app-admin-settings/tests/unit/views/Users.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/views/Users.spec.ts
@@ -350,7 +350,7 @@ describe('Users view', () => {
         expect(graphMock.users.listUsers).toHaveBeenNthCalledWith(
           2,
           'displayName',
-          "memberOf/any(m:m/id eq '1')"
+          "(memberOf/any(m:m/id eq '1'))"
         )
       })
       it('does filter initially if group ids are given via query param', async () => {
@@ -364,7 +364,7 @@ describe('Users view', () => {
         await wrapper.vm.loadResourcesTask.last
         expect(graphMock.users.listUsers).toHaveBeenCalledWith(
           'displayName',
-          "memberOf/any(m:m/id eq '1') and memberOf/any(m:m/id eq '2')"
+          "(memberOf/any(m:m/id eq '1') or memberOf/any(m:m/id eq '2'))"
         )
       })
     })
@@ -383,7 +383,7 @@ describe('Users view', () => {
         expect(graphMock.users.listUsers).toHaveBeenNthCalledWith(
           2,
           'displayName',
-          "appRoleAssignments/any(m:m/appRoleId eq '1')"
+          "(appRoleAssignments/any(m:m/appRoleId eq '1'))"
         )
       })
       it('does filter initially if role ids are given via query param', async () => {
@@ -397,7 +397,7 @@ describe('Users view', () => {
         await wrapper.vm.loadResourcesTask.last
         expect(graphMock.users.listUsers).toHaveBeenCalledWith(
           'displayName',
-          "appRoleAssignments/any(m:m/appRoleId eq '1') and appRoleAssignments/any(m:m/appRoleId eq '2')"
+          "(appRoleAssignments/any(m:m/appRoleId eq '1') or appRoleAssignments/any(m:m/appRoleId eq '2'))"
         )
       })
     })


### PR DESCRIPTION
## Description
Change user filter for groups and roles to have an `OR` behaviour. So if you select both groups `physics-lovers` and `physics-haters`, it will result in users that are in either of those groups. Combining different filters like groups and roles still concatenates via `AND`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8469

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
