### PR TITLE
Revert "fix: move custom styles and scripts to config options"

### DIFF
--- a/changelog/unreleased/enhancement-inject-customizations
+++ b/changelog/unreleased/enhancement-inject-customizations
@@ -5,10 +5,9 @@ This function is currently still experimental and there is a possibility that th
 
 For the reasons mentioned, the functionality is not yet documented in the official documentation, but can be used as follows:
 
-* to inject custom css add the following property to the `"options"` object in your `config.json`, `"styles": [{ "href": "css/custom.css", }]`.
-* to inject custom scripts add the following property to the `"options"` object in your `config.json`, `"scripts": [{ "src": "js/custom.js", "async": true, }]`.
+* to inject custom css add the following property to your `config.json`, `"styles": [{ "href": "css/custom.css", }]`.
+* to inject custom scripts add the following property to your `config.json`, `"scripts": [{ "src": "js/custom.js", "async": true, }]`.
 
-https://github.com/owncloud/web/issues/4735
 https://github.com/owncloud/web/pull/8432
 https://github.com/owncloud/web/pull/7689
-https://github.com/owncloud/web/pull/8512
+https://github.com/owncloud/web/issues/4735

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -386,7 +386,7 @@ export const announceCustomScripts = ({
 }: {
   runtimeConfiguration?: RuntimeConfiguration
 }): void => {
-  const { scripts = [] } = runtimeConfiguration?.options
+  const { scripts = [] } = runtimeConfiguration
 
   scripts.forEach(({ src = '', async = false }) => {
     if (!src) {
@@ -410,7 +410,7 @@ export const announceCustomStyles = ({
 }: {
   runtimeConfiguration?: RuntimeConfiguration
 }): void => {
-  const { styles = [] } = runtimeConfiguration?.options
+  const { styles = [] } = runtimeConfiguration
 
   styles.forEach(({ href = '' }) => {
     if (!href) {

--- a/packages/web-runtime/tests/unit/container/bootstrap.spec.ts
+++ b/packages/web-runtime/tests/unit/container/bootstrap.spec.ts
@@ -60,28 +60,26 @@ describe('announceCustomScripts', () => {
 
   it('injects basic scripts', () => {
     announceCustomScripts({
-      runtimeConfiguration: { options: { scripts: [{ src: 'foo.js' }, { src: 'bar.js' }] } }
+      runtimeConfiguration: { scripts: [{ src: 'foo.js' }, { src: 'bar.js' }] }
     })
     const elements = document.getElementsByTagName('script')
     expect(elements.length).toBe(2)
   })
 
   it('skips the injection if no src option is provided', () => {
-    announceCustomScripts({ runtimeConfiguration: { options: { scripts: [{}, {}, {}, {}, {}] } } })
+    announceCustomScripts({ runtimeConfiguration: { scripts: [{}, {}, {}, {}, {}] } })
     const elements = document.getElementsByTagName('script')
     expect(elements.length).toBeFalsy()
   })
 
   it('loads scripts synchronous by default', () => {
-    announceCustomScripts({ runtimeConfiguration: { options: { scripts: [{ src: 'foo.js' }] } } })
+    announceCustomScripts({ runtimeConfiguration: { scripts: [{ src: 'foo.js' }] } })
     const element = document.querySelector<HTMLScriptElement>('[src="foo.js"]')
     expect(element.async).toBeFalsy()
   })
 
   it('injects scripts async if the corresponding configurations option is set', () => {
-    announceCustomScripts({
-      runtimeConfiguration: { options: { scripts: [{ src: 'foo.js', async: true }] } }
-    })
+    announceCustomScripts({ runtimeConfiguration: { scripts: [{ src: 'foo.js', async: true }] } })
     const element = document.querySelector<HTMLScriptElement>('[src="foo.js"]')
     expect(element.async).toBeTruthy()
   })
@@ -94,7 +92,7 @@ describe('announceCustomStyles', () => {
 
   it('injects basic styles', () => {
     const styles = [{ href: 'foo.css' }, { href: 'bar.css' }]
-    announceCustomStyles({ runtimeConfiguration: { options: { styles } } })
+    announceCustomStyles({ runtimeConfiguration: { styles } })
 
     styles.forEach(({ href }) => {
       const element = document.querySelector<HTMLLinkElement>(`[href="${href}"]`)
@@ -105,7 +103,7 @@ describe('announceCustomStyles', () => {
   })
 
   it('skips the injection if no href option is provided', () => {
-    announceCustomStyles({ runtimeConfiguration: { options: { styles: [{}, {}] } } })
+    announceCustomStyles({ runtimeConfiguration: { styles: [{}, {}] } })
     const elements = document.getElementsByTagName('link')
     expect(elements.length).toBeFalsy()
   })


### PR DESCRIPTION
Reverts owncloud/web#8512

Turned out that there are some de-serialization issues with maps in slices in the backend side struct. So we'll go the other way and add the `styles` and `scripts` to the config struct.