### PR TITLE
[tests-only][full-ci] Refactor e2e test for quick link

### DIFF
--- a/tests/e2e/support/environment/actor/shared.ts
+++ b/tests/e2e/support/environment/actor/shared.ts
@@ -20,7 +20,7 @@ export interface ActorOptions extends ActorsOptions {
 export const buildBrowserContextOptions = (options: ActorOptions): BrowserContextOptions => {
   const contextOptions: BrowserContextOptions = {
     acceptDownloads: options.context.acceptDownloads,
-    permissions: ['clipboard-read'],
+    permissions: ['clipboard-read', 'clipboard-write'],
     ignoreHTTPSErrors: true,
     locale: 'en-US'
   }

--- a/tests/e2e/support/objects/app-files/share/actions.ts
+++ b/tests/e2e/support/objects/app-files/share/actions.ts
@@ -206,7 +206,11 @@ export const copyQuickLink = async (args: copyLinkArgs): Promise<string> => {
   if (config.backendUrl.startsWith('https')) {
     url = await page.evaluate(() => navigator.clipboard.readText())
   } else {
-    url = await page.locator(util.format(publicLinkInputField, linkName)).textContent()
+    const quickLinkUrlLocator = util.format(publicLinkInputField, linkName)
+    if (!(await page.locator(quickLinkUrlLocator).isVisible())) {
+      await openSharingPanel(page, resource)
+    }
+    url = await page.locator(quickLinkUrlLocator).textContent()
   }
 
   await waitForPopupNotPresent(page)


### PR DESCRIPTION
## Description
enable clipboard both `read` and `write` permissions, and open sharing dialog if not open after creating quicklink (testing against oC10 server)

Same as in https://github.com/owncloud/web/pull/8530/files

## Related Issue

## Motivation and Context

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
