### PR TITLE
Fix additional user data loading

### DIFF
--- a/changelog/unreleased/enhancement-admin-change-spaces-quota-batch-action
+++ b/changelog/unreleased/enhancement-admin-change-spaces-quota-batch-action
@@ -5,4 +5,5 @@ We've added the batch edit quota functionality to the admin panel for users pers
 https://github.com/owncloud/web/pull/8387
 https://github.com/owncloud/web/pull/8430
 https://github.com/owncloud/web/pull/8438
+https://github.com/owncloud/web/pull/8555
 https://github.com/owncloud/web/issues/8417

--- a/packages/web-app-admin-settings/src/components/Users/UsersList.vue
+++ b/packages/web-app-admin-settings/src/components/Users/UsersList.vue
@@ -149,23 +149,31 @@ export default defineComponent({
     }
 
     const showDetails = (user) => {
-      selectUser(user)
+      if (!isUserSelected(user)) {
+        selectUser(user)
+      }
       eventBus.publish(SideBarEventTopics.open)
     }
 
     const showEditPanel = (user) => {
-      selectUser(user)
+      if (!isUserSelected(user)) {
+        selectUser(user)
+      }
       eventBus.publish(SideBarEventTopics.openWithPanel, 'EditPanel')
     }
 
     const showGroupAssigmentPanel = (user) => {
-      selectUser(user)
+      if (!isUserSelected(user)) {
+        selectUser(user)
+      }
       eventBus.publish(SideBarEventTopics.openWithPanel, 'GroupAssignmentsPanel')
     }
 
     const rowClicked = (data) => {
       const user = data[0]
-      selectUser(user)
+      if (!isUserSelected(user)) {
+        selectUser(user)
+      }
     }
     const showContextMenuOnBtnClick = (data, user) => {
       const { dropdown, event } = data

--- a/packages/web-app-admin-settings/src/views/Users.vue
+++ b/packages/web-app-admin-settings/src/views/Users.vue
@@ -284,14 +284,6 @@ export default defineComponent({
         console.debug('Failed to load additional user data', failedRequests)
       }
 
-      if (unref(selectedUsers).length === 1) {
-        loadedUser.value = unref(selectedUsers)[0]
-        sideBarLoading.value = false
-        return
-      }
-
-      loadedUser.value = null
-      sideBarLoading.value = false
       selectedPersonalDrives.value.splice(0, unref(selectedPersonalDrives).length)
       unref(selectedUsers).forEach((user) => {
         const drive = toRaw(user.drive)
@@ -305,6 +297,9 @@ export default defineComponent({
         } as SpaceResource
         selectedPersonalDrives.value.push(spaceResource)
       })
+
+      loadedUser.value = unref(selectedUsers).length === 1 ? unref(selectedUsers)[0] : null
+      sideBarLoading.value = false
     })
 
     const calculateListHeaderPosition = () => {


### PR DESCRIPTION
## Description
* Fix additional user loading when one user is selected
* Prevent sidebar loading state from being mutated twice

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8544
- Potentially fixes https://github.com/owncloud/web/issues/8548

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
