### PR TITLE
fix: order of view modes

### DIFF
--- a/packages/web-app-files/src/views/Favorites.vue
+++ b/packages/web-app-files/src/views/Favorites.vue
@@ -126,8 +126,8 @@ export default defineComponent({
     }
 
     const viewModes = computed(() => [
-      ViewModeConstants.default,
       ViewModeConstants.condensedTable,
+      ViewModeConstants.default,
       ViewModeConstants.tilesView
     ])
 

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -232,8 +232,8 @@ export default defineComponent({
     let loadResourcesEventToken
 
     const viewModes = computed(() => [
-      ViewModeConstants.default,
       ViewModeConstants.condensedTable,
+      ViewModeConstants.default,
       ViewModeConstants.tilesView
     ])
 


### PR DESCRIPTION
## Description
Change order of view modes to `condensed`, `default`, `tiles`. This is the order @tbsbdr and I agreed on - and I think we had that at some point. Somehow got lost in a refactoring. Or my mind is playing games with me and it was always `default`, `condensed`, `tiles`. 🤔 

<img width="152" alt="Screenshot 2023-03-14 at 00 26 06" src="https://user-images.githubusercontent.com/3532843/224854328-ef6078a5-90d8-43df-bbc9-cf8954dce2ea.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
