### PR TITLE
[test-only] Fix notification test-flaky

### DIFF
--- a/tests/e2e/support/objects/runtime/application.ts
+++ b/tests/e2e/support/objects/runtime/application.ts
@@ -26,6 +26,12 @@ export class Application {
   }
 
   async getNotificationMessages(): Promise<string[]> {
+    await this.#page.waitForResponse(
+      (resp) =>
+        resp.url().endsWith('notifications?format=json') &&
+        resp.status() === 200 &&
+        resp.request().method() === 'GET'
+    )
     const dropIsOpen = await this.#page.locator(notificationsDrop).isVisible()
     if (!dropIsOpen) {
       await this.#page.locator(notificationsBell).click()


### PR DESCRIPTION
notification test often fails in CI: 

test tries to see notification but doesn't find it and fails. 
I was looking the trace results and could not find the request
`GET https://host.docker.internal:9200/ocs/v2.php/apps/notifications/api/v1/notifications?format=json`

`npx playwright show-trace https://cache.owloud.com/public/owncloud/web/33631/tracing/user-should-be-able-to-read-and-dismiss-notifications-brian-2023-3-14-02-42-02.zip`

I added a wait for a response before the test gets a notification