### PR TITLE
add OcAlert component

### DIFF
--- a/packages/design-system/changelog/unreleased/enhancement-add-OcAlert
+++ b/packages/design-system/changelog/unreleased/enhancement-add-OcAlert
@@ -3,4 +3,4 @@ Enhancement: Add `OcAlert` component
 The component can to be used to display messages as information, success, warning or danger.
 It can also be equipped with an icon, a custom icon and a close button.
 
-https://github.com/owncloud/web/pull/8554/
+https://github.com/owncloud/web/pull/8613

--- a/packages/design-system/changelog/unreleased/enhancement-add-OcAlert
+++ b/packages/design-system/changelog/unreleased/enhancement-add-OcAlert
@@ -1,0 +1,6 @@
+Enhancement: Add `OcAlert` component
+
+The component can to be used to display messages as information, success, warning or danger.
+It can also be equipped with an icon, a custom icon and a close button.
+
+https://github.com/owncloud/web/pull/8554/

--- a/packages/design-system/src/components/OcAlert/OcAlert.spec.ts
+++ b/packages/design-system/src/components/OcAlert/OcAlert.spec.ts
@@ -1,0 +1,198 @@
+import { mount } from 'web-test-helpers'
+import OcAlert from './OcAlert.vue'
+
+describe('OcAlert', () => {
+  const selectors = {
+    closeButton: '.oc-alert-close-button',
+    icon: '.oc-alert-icon'
+  }
+  describe('prop value', () => {
+    describe('when alert is closeable', () => {
+      it('should render close button and remove alert when close button is clicked', async () => {
+        const wrapper = getWrapper({
+          closeable: true
+        })
+
+        const alertCloseButton = wrapper.find(selectors.closeButton)
+        expect(alertCloseButton.exists()).toBeTruthy()
+        await alertCloseButton.trigger('click')
+
+        expect(wrapper.find('.oc-alert').exists()).toBe(false)
+      })
+    })
+
+    describe('when alert is not closeable', () => {
+      it('should not render close button', () => {
+        const wrapper = getWrapper({
+          closeable: false
+        })
+
+        const alertCloseButton = wrapper.find(selectors.closeButton)
+        expect(alertCloseButton.exists()).toBeFalsy()
+      })
+    })
+
+    describe('when closeable is not set', () => {
+      it('should not render close button', () => {
+        const wrapper = getWrapper({
+          closeable: undefined
+        })
+
+        const alertCloseButton = wrapper.find(selectors.closeButton)
+        expect(alertCloseButton.exists()).toBeFalsy()
+      })
+    })
+
+    // Test icons
+    describe('custom icon is set', () => {
+      it('should render the given icon', () => {
+        const wrapper = getWrapper({
+          customIcon: 'test-tube'
+        })
+
+        const icon = wrapper.find(selectors.icon)
+        expect(icon.exists()).toBeTruthy()
+      })
+    })
+
+    describe('hasIcon is set', () => {
+      it('should render the icon', () => {
+        const wrapper = getWrapper({
+          hasIcon: true
+        })
+
+        const icon = wrapper.find(selectors.icon)
+        expect(icon.exists()).toBeTruthy()
+      })
+    })
+
+    describe('hasIcon is false', () => {
+      it('should not render the icon', () => {
+        const wrapper = getWrapper({
+          hasIcon: false
+        })
+
+        const icon = wrapper.find(selectors.icon)
+        expect(icon.exists()).toBe(false)
+      })
+    })
+
+    describe('hasIcon not set', () => {
+      it('should not render the icon', () => {
+        const wrapper = getWrapper({
+          hasIcon: undefined
+        })
+
+        const icon = wrapper.find(selectors.icon)
+        expect(icon.exists()).toBe(false)
+      })
+    })
+
+    // Test colors
+    describe('when type is set to "info"', () => {
+      it('should render the component as info alert', () => {
+        const wrapper = getWrapper({
+          variant: 'info'
+        })
+
+        const alert = wrapper.find('.oc-alert.oc-alert-info')
+        expect(alert.exists()).toBeTruthy()
+
+        // How to test for css class style settings?
+
+        // const backgroundColor = styles.getPropertyValue('background-color')
+        // const color = styles.getPropertyValue('color')
+        // const borderColor = styles.getPropertyValue('border-color')
+
+        // expect(backgroundColor).toBe('var(--oc-color-background-highlight)')
+        // expect(color).toBe('var(--oc-color-swatch-primary-default)')
+        // expect(borderColor).toBe('var(--oc-color-swatch-primary-default)')
+
+        // const icon = wrapper.find(selectors.icon)
+        // const svg = icon.find('svg')
+        // expect(svg.attributes('style')).toContain('fill: var(--oc-color-swatch-primary-default)')
+      })
+    })
+
+    describe('when type is set to "success"', () => {
+      it('should render the component as success alert', () => {
+        const wrapper = getWrapper({
+          variant: 'success'
+        })
+
+        const alert = wrapper.find('.oc-alert.oc-alert-success')
+        expect(alert.exists()).toBeTruthy()
+
+        // expect(wrapper.attributes('style')).toContain(
+        //   'background-color: var(--oc-color-swatch-success-background)'
+        // )
+        // expect(wrapper.attributes('style')).toContain(
+        //   'color: var(--oc-color-swatch-success-default)'
+        // )
+        // expect(wrapper.attributes('style')).toContain(
+        //   'border-color: var(--oc-color-swatch-success-default)'
+        // )
+
+        // const icon = wrapper.find(selectors.icon)
+        // const svg = icon.find('svg')
+        // expect(svg.attributes('style')).toContain('fill: var(--oc-color-swatch-success-default)')
+      })
+    })
+
+    describe('when type is set to "warning"', () => {
+      it('should render the component as warning alert', () => {
+        const wrapper = getWrapper({
+          variant: 'warning'
+        })
+
+        const alert = wrapper.find('.oc-alert.oc-alert-warning')
+        expect(alert.exists()).toBeTruthy()
+
+        // expect(wrapper.attributes('style')).toContain(
+        //   'background-color: var(--oc-color-swatch-warning-background)'
+        // )
+        // expect(wrapper.attributes('style')).toContain(
+        //   'color: var(--oc-color-swatch-warning-default)'
+        // )
+        // expect(wrapper.attributes('style')).toContain(
+        //   'border-color: var(--oc-color-swatch-warning-default)'
+        // )
+
+        // const icon = wrapper.find(selectors.icon)
+        // const svg = icon.find('svg')
+        // expect(svg.attributes('style')).toContain('fill: var(--oc-color-swatch-warning-default)')
+      })
+    })
+
+    describe('when type is set to "danger"', () => {
+      it('should render the component as danger alert', () => {
+        const wrapper = getWrapper({
+          variant: 'danger'
+        })
+
+        const alert = wrapper.find('.oc-alert.oc-alert-danger')
+        expect(alert.exists()).toBeTruthy()
+
+        // expect(wrapper.attributes('style')).toContain(
+        //   'background-color: var(--oc-color-swatch-danger-background)'
+        // )
+        // expect(wrapper.attributes('style')).toContain(
+        //   'color: var(--oc-color-swatch-danger-default)'
+        // )
+        // expect(wrapper.attributes('style')).toContain(
+        //   'border-color: var(--oc-color-swatch-danger-default)'
+        // )
+
+        // const icon = wrapper.find(selectors.icon)
+        // const svg = icon.find('svg')
+        // expect(svg.attributes('style')).toContain('fill: var(--oc-color-swatch-danger-default)')
+      })
+    })
+  })
+})
+
+function getWrapper(props) {
+  return mount(OcAlert, {
+    props
+  })
+}

--- a/packages/design-system/src/components/OcAlert/OcAlert.vue
+++ b/packages/design-system/src/components/OcAlert/OcAlert.vue
@@ -1,0 +1,241 @@
+<template>
+  <div
+    v-if="!closed"
+    class="oc-alert oc-position-relative"
+    :class="[
+      alertStyle,
+      closeable ? 'oc-alert-closeable' : '',
+      renderIcon ? 'oc-alert-has-icon' : ''
+    ]"
+    :aria-label="ariaLabel"
+  >
+    <oc-icon v-if="renderIcon" :name="icon" class="oc-alert-icon" :accessible-label="ariaLabel" />
+    <oc-button
+      v-if="closeable"
+      size="small"
+      type="button"
+      appearance="raw"
+      class="oc-alert-close-button"
+      @click="close"
+    >
+      <oc-icon name="close" accessible-label="Close" />
+    </oc-button>
+    <slot />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+/**
+ * Alert is component to display a message to the user in various colors.
+ */
+export default defineComponent({
+  name: 'OcAlert',
+  status: 'ready',
+  release: '2.0.0',
+  components: {},
+  props: {
+    /**
+     * Style of the alert:
+     * - info: light blue background, blue color, renders as oc-alert-info; use for informational messages
+     * - success: light green background, green color, renders as oc-alert-success, use for success messages
+     * - warning: light yellow background, yellow color, renders as oc-alert-warning, use for warning messages
+     * - danger: light red background, red color, renders as oc-alert-danger, use for error messages
+     */
+    variant: {
+      type: String,
+      default: 'info',
+      validator(value: string) {
+        // The value must match one of these strings
+        return ['info', 'success', 'warning', 'danger'].includes(value)
+      }
+    },
+    /**
+     * Whether the alert can be closed or not
+     */
+    closeable: {
+      type: Boolean,
+      default: false
+    },
+
+    /**
+     * Whether the alert has an icon or not. Icon is determined by the style prop.
+     */
+    hasIcon: {
+      type: Boolean,
+      default: false
+    },
+
+    /**
+     * Custom Icon, if default icons are not suitable; if set icon gets rendered
+     * regardless of hasIcon prop
+     */
+    customIcon: {
+      type: String,
+      default: ''
+    },
+
+    ariaLabel: {
+      type: String,
+      default: 'Alert'
+    }
+  },
+  data() {
+    return {
+      closed: false
+    }
+  },
+  computed: {
+    alertStyle() {
+      switch (this.variant) {
+        case 'success':
+          return 'oc-alert-success'
+        case 'warning':
+          return 'oc-alert-warning'
+        case 'danger':
+          return 'oc-alert-danger'
+        case 'info':
+        default:
+          return 'oc-alert-info'
+      }
+    },
+    icon() {
+      if (this.customIcon) {
+        return this.customIcon
+      }
+
+      switch (this.variant) {
+        case 'success':
+          return 'checkbox-circle'
+        case 'warning':
+          return 'error-warning'
+        case 'danger':
+          return 'close-circle'
+        case 'info':
+        default:
+          return 'information'
+      }
+    },
+
+    /**
+     * Whether the alert has an icon or not. Icon is determined by the style prop.
+     * If a custom Icon is used, it will always be rendered.
+     */
+    renderIcon() {
+      if (this.customIcon) {
+        return true
+      }
+
+      return this.hasIcon
+    }
+  },
+  methods: {
+    close() {
+      this.closed = true
+    }
+  }
+})
+</script>
+
+<style lang="scss">
+.oc-alert {
+  padding: var(--oc-space-small) var(--oc-space-medium);
+  margin: var(--oc-space-medium) 0;
+  border-radius: 6px;
+  border-width: 1px;
+  border-style: solid;
+
+  &.oc-alert- {
+    &info {
+      background-color: var(--oc-color-background-highlight);
+      color: var(--oc-color-swatch-primary-default);
+      border-color: var(--oc-color-swatch-primary-default);
+
+      svg,
+      .oc-alert-close-button svg {
+        fill: var(--oc-color-swatch-primary-default);
+      }
+    }
+
+    &success {
+      background-color: var(--oc-color-swatch-success-background);
+      color: var(--oc-color-swatch-success-default);
+      border-color: var(--oc-color-swatch-success-default);
+
+      svg,
+      .oc-alert-close-button svg {
+        fill: var(--oc-color-swatch-success-default);
+      }
+    }
+
+    &warning {
+      background-color: var(--oc-color-swatch-warning-background);
+      color: var(--oc-color-swatch-warning-default);
+      border-color: var(--oc-color-swatch-warning-default);
+
+      svg,
+      .oc-alert-close-button svg {
+        fill: var(--oc-color-swatch-warning-default);
+      }
+    }
+
+    &danger {
+      background-color: var(--oc-color-swatch-danger-background);
+      color: var(--oc-color-swatch-danger-default);
+      border-color: var(--oc-color-swatch-danger-default);
+
+      svg,
+      .oc-alert-close-button svg {
+        fill: var(--oc-color-swatch-danger-default);
+      }
+    }
+
+    &has-icon {
+      display: flex;
+      align-items: center;
+      padding-left: var(--oc-space-large);
+
+      .oc-alert-icon svg {
+        position: absolute;
+        left: var(--oc-space-small);
+        top: var(--oc-space-small);
+      }
+    }
+
+    &closeable {
+      padding-right: var(--oc-space-large);
+    }
+  }
+
+  .oc-alert-close-button {
+    position: absolute;
+    right: var(--oc-space-small);
+    top: var(--oc-space-small);
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+  }
+}
+</style>
+
+<docs>
+```js
+  <oc-alert :closeable="true" :hasIcon="true">
+    I'm just an info message. I can be closed and have the default info icon.
+  </oc-alert>
+  <oc-alert :variant="'success'" :closeable="true" :hasIcon="true">
+    Yay! Success! I can be closed and have the default success icon.
+  </oc-alert>
+  <oc-alert :variant="'warning'" :closeable="true">
+    Hm there seems to be something wrong. I can be closed and have no icon.
+  </oc-alert>
+  <oc-alert :variant="'danger'" :hasIcon="true">
+    WHAAA. PANIC! I can't be closed and have the default danger icon.
+  </oc-alert>
+  <oc-alert :variant="'danger'" customIcon="cloud-off" :closeable="true" :hasIcon="true">
+    WHAAA. PANIC! With a custom Icon
+  </oc-alert>
+```
+</docs>

--- a/packages/design-system/src/components/OcAlert/OcAlert.vue
+++ b/packages/design-system/src/components/OcAlert/OcAlert.vue
@@ -48,7 +48,7 @@ export default defineComponent({
     variant: {
       type: String,
       default: 'info',
-      validator(value) {
+      validator(value: string) {
         return ['info', 'success', 'warning', 'danger'].includes(value)
       }
     },

--- a/packages/design-system/src/components/OcAlert/OcAlert.vue
+++ b/packages/design-system/src/components/OcAlert/OcAlert.vue
@@ -1,9 +1,9 @@
 <template>
   <div
-    v-if="!closed"
+    v-show="!closed"
     class="oc-alert oc-position-relative"
     :class="[
-      alertStyle,
+      alertStyles[variant],
       closeable ? 'oc-alert-closeable' : '',
       renderIcon ? 'oc-alert-has-icon' : ''
     ]"
@@ -45,24 +45,13 @@ export default defineComponent({
   release: '2.0.0',
   components: {},
   props: {
-    /**
-     * Style of the alert:
-     * - info: light blue background, blue color, renders as oc-alert-info; use for informational messages
-     * - success: light green background, green color, renders as oc-alert-success, use for success messages
-     * - warning: light yellow background, yellow color, renders as oc-alert-warning, use for warning messages
-     * - danger: light red background, red color, renders as oc-alert-danger, use for error messages
-     */
     variant: {
       type: String,
       default: 'info',
-      validator(value: string) {
-        // The value must match one of these strings
+      validator(value) {
         return ['info', 'success', 'warning', 'danger'].includes(value)
       }
     },
-    /**
-     * Whether the alert can be closed or not
-     */
     closeable: {
       type: Boolean,
       default: false
@@ -75,16 +64,10 @@ export default defineComponent({
       type: Boolean,
       default: false
     },
-
-    /**
-     * Custom Icon, if default icons are not suitable; if set icon gets rendered
-     * regardless of hasIcon prop
-     */
     customIcon: {
       type: String,
       default: ''
     },
-
     ariaLabel: {
       type: String,
       default: 'Alert'
@@ -96,46 +79,29 @@ export default defineComponent({
     }
   },
   computed: {
-    alertStyle() {
-      switch (this.variant) {
-        case 'success':
-          return 'oc-alert-success'
-        case 'warning':
-          return 'oc-alert-warning'
-        case 'danger':
-          return 'oc-alert-danger'
-        case 'info':
-        default:
-          return 'oc-alert-info'
+    alertStyles() {
+      return {
+        info: 'oc-alert-info',
+        success: 'oc-alert-success',
+        warning: 'oc-alert-warning',
+        danger: 'oc-alert-danger'
       }
     },
     icon() {
       if (this.customIcon) {
         return this.customIcon
       }
-
-      switch (this.variant) {
-        case 'success':
-          return 'checkbox-circle'
-        case 'warning':
-          return 'error-warning'
-        case 'danger':
-          return 'close-circle'
-        case 'info':
-        default:
-          return 'information'
-      }
+      return {
+        info: 'information',
+        success: 'checkbox-circle',
+        warning: 'error-warning',
+        danger: 'close-circle'
+      }[this.variant]
     },
-
-    /**
-     * Whether the alert has an icon or not. Icon is determined by the style prop.
-     * If a custom Icon is used, it will always be rendered.
-     */
     renderIcon() {
       if (this.customIcon) {
         return true
       }
-
       return this.hasIcon
     }
   },

--- a/packages/design-system/src/components/OcAlert/OcAlert.vue
+++ b/packages/design-system/src/components/OcAlert/OcAlert.vue
@@ -1,10 +1,10 @@
 <template>
   <div
-    v-show="!closed"
+    v-show="!dismissed"
     class="oc-alert oc-position-relative"
     :class="[
       alertStyles[variant],
-      closeable ? 'oc-alert-closeable' : '',
+      dismissable ? 'oc-alert-dismissable' : '',
       renderIcon ? 'oc-alert-has-icon' : ''
     ]"
     :aria-label="ariaLabel"
@@ -17,12 +17,12 @@
         :accessible-label="ariaLabel"
       />
       <oc-button
-        v-if="closeable"
+        v-if="dismissable"
         size="small"
         type="button"
         appearance="raw"
         class="oc-alert-close-button"
-        @click="close"
+        @click="dismiss"
       >
         <oc-icon name="close" accessible-label="Close" />
       </oc-button>
@@ -52,7 +52,7 @@ export default defineComponent({
         return ['info', 'success', 'warning', 'danger'].includes(value)
       }
     },
-    closeable: {
+    dismissable: {
       type: Boolean,
       default: false
     },
@@ -62,8 +62,12 @@ export default defineComponent({
      */
     hasIcon: {
       type: Boolean,
-      default: false
+      default: true
     },
+
+    /**
+     * Pass custom icon name to use instead of the default one.
+     */
     customIcon: {
       type: String,
       default: ''
@@ -73,9 +77,10 @@ export default defineComponent({
       default: 'Alert'
     }
   },
+  emits: ['dismissed'],
   data() {
     return {
-      closed: false
+      dismissed: false
     }
   },
   computed: {
@@ -106,8 +111,9 @@ export default defineComponent({
     }
   },
   methods: {
-    close() {
-      this.closed = true
+    dismiss() {
+      this.dismissed = true
+      this.$emit('dismissed')
     }
   }
 })
@@ -115,7 +121,7 @@ export default defineComponent({
 
 <style lang="scss">
 .oc-alert {
-  padding: var(--oc-space-small) var(--oc-space-medium);
+  padding: var(--oc-space-small) var(--oc-space-medium) var(--oc-space-small) var(--oc-space-small);
   margin: var(--oc-space-medium) 0;
   border-radius: 6px;
   border-width: 1px;
@@ -184,7 +190,7 @@ export default defineComponent({
       }
     }
 
-    &closeable > .oc-alert-title {
+    &dismissable > .oc-alert-title {
       padding-right: var(--oc-space-large);
     }
   }
@@ -203,25 +209,25 @@ export default defineComponent({
 
 <docs>
 ```js
-  <oc-alert :closeable="true" :hasIcon="true">
+  <oc-alert :dismissable="true" :hasIcon="true">
     I'm just an info message. I can be closed and have the default info icon.
   </oc-alert>
-  <oc-alert :closeable="true" :hasIcon="true">
+  <oc-alert :dismissable="true" :hasIcon="true">
     I'm just an info message. I can be closed and have the default info icon.
     <template #message>
       <p>And I have a custom message, which can be multiline or multipart. It acts as alert body - contents are passed via named slot</p>
     </template>
   </oc-alert>
-  <oc-alert :variant="'success'" :closeable="true" :hasIcon="true">
+  <oc-alert :variant="'success'" :dismissable="true" :hasIcon="true">
     Yay! Success! I can be closed and have the default success icon.
   </oc-alert>
-  <oc-alert :variant="'warning'" :closeable="true">
+  <oc-alert :variant="'warning'" :dismissable="true">
     Hm there seems to be something wrong. I can be closed and have no icon.
   </oc-alert>
   <oc-alert :variant="'danger'" :hasIcon="true">
     WHAAA. PANIC! I can't be closed and have the default danger icon.
   </oc-alert>
-  <oc-alert :variant="'danger'" customIcon="cloud-off" :closeable="true" :hasIcon="true">
+  <oc-alert :variant="'danger'" customIcon="cloud-off" :dismissable="true" :hasIcon="true">
     WHAAA. PANIC! With a custom Icon
   </oc-alert>
 ```

--- a/packages/design-system/src/components/OcAlert/OcAlert.vue
+++ b/packages/design-system/src/components/OcAlert/OcAlert.vue
@@ -42,7 +42,7 @@ import { defineComponent } from 'vue'
 export default defineComponent({
   name: 'OcAlert',
   status: 'ready',
-  release: '2.0.0',
+  release: '2.0.1',
   components: {},
   props: {
     variant: {

--- a/packages/design-system/src/components/OcAlert/OcAlert.vue
+++ b/packages/design-system/src/components/OcAlert/OcAlert.vue
@@ -9,24 +9,33 @@
     ]"
     :aria-label="ariaLabel"
   >
-    <oc-icon v-if="renderIcon" :name="icon" class="oc-alert-icon" :accessible-label="ariaLabel" />
-    <oc-button
-      v-if="closeable"
-      size="small"
-      type="button"
-      appearance="raw"
-      class="oc-alert-close-button"
-      @click="close"
-    >
-      <oc-icon name="close" accessible-label="Close" />
-    </oc-button>
-    <slot />
+    <div class="oc-alert-title">
+      <oc-icon
+        v-if="renderIcon"
+        :name="icon"
+        class="oc-alert-icon oc-mr-s"
+        :accessible-label="ariaLabel"
+      />
+      <oc-button
+        v-if="closeable"
+        size="small"
+        type="button"
+        appearance="raw"
+        class="oc-alert-close-button"
+        @click="close"
+      >
+        <oc-icon name="close" accessible-label="Close" />
+      </oc-button>
+      <slot />
+    </div>
+    <div class="oc-alert-message oc-mt-s oc-pt-s">
+      <slot name="message" />
+    </div>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue'
-
 /**
  * Alert is component to display a message to the user in various colors.
  */
@@ -60,7 +69,7 @@ export default defineComponent({
     },
 
     /**
-     * Whether the alert has an icon or not. Icon is determined by the style prop.
+     * Whether the alert has an icon or not. Icon is determined by the `variant` prop.
      */
     hasIcon: {
       type: Boolean,
@@ -146,6 +155,17 @@ export default defineComponent({
   border-width: 1px;
   border-style: solid;
 
+  .oc-alert-message {
+    display: block;
+    border-top: 1px solid var(--oc-color-swatch-primary-default);
+    font-size: 1rem;
+    line-height: 1.75;
+
+    &:empty {
+      display: none;
+    }
+  }
+
   &.oc-alert- {
     &info {
       background-color: var(--oc-color-background-highlight);
@@ -192,18 +212,13 @@ export default defineComponent({
     }
 
     &has-icon {
-      display: flex;
-      align-items: center;
-      padding-left: var(--oc-space-large);
-
-      .oc-alert-icon svg {
-        position: absolute;
-        left: var(--oc-space-small);
-        top: var(--oc-space-small);
+      .oc-alert-title {
+        display: flex;
+        align-items: center;
       }
     }
 
-    &closeable {
+    &closeable > .oc-alert-title {
       padding-right: var(--oc-space-large);
     }
   }
@@ -224,6 +239,12 @@ export default defineComponent({
 ```js
   <oc-alert :closeable="true" :hasIcon="true">
     I'm just an info message. I can be closed and have the default info icon.
+  </oc-alert>
+  <oc-alert :closeable="true" :hasIcon="true">
+    I'm just an info message. I can be closed and have the default info icon.
+    <template #message>
+      <p>And I have a custom message, which can be multiline or multipart. It acts as alert body - contents are passed via named slot</p>
+    </template>
   </oc-alert>
   <oc-alert :variant="'success'" :closeable="true" :hasIcon="true">
     Yay! Success! I can be closed and have the default success icon.

--- a/packages/design-system/src/components/OcNotificationMessage/OcNotificationMessage.vue
+++ b/packages/design-system/src/components/OcNotificationMessage/OcNotificationMessage.vue
@@ -5,6 +5,7 @@
     :has-icon="true"
     :role="role"
     :aria-live="ariaLive"
+    :variant="status"
   >
     {{ title }}
     <template #message>
@@ -14,7 +15,6 @@
 </template>
 <script lang="ts">
 import { defineComponent } from 'vue'
-import OcIcon from '../OcIcon/OcIcon.vue'
 
 /**
  * Notifications are used to inform users about errors, warnings and as confirmations for their actions.
@@ -23,9 +23,6 @@ export default defineComponent({
   name: 'OcNotificationMessage',
   status: 'ready',
   release: '1.0.0',
-  components: {
-    OcIcon
-  },
   props: {
     /**
      * Notification messages are sub components of the oc-notifications component.
@@ -36,9 +33,9 @@ export default defineComponent({
     status: {
       type: String,
       required: false,
-      default: 'passive',
+      default: 'info',
       validator: (value: string) => {
-        return ['passive', 'primary', 'success', 'warning', 'danger'].includes(value)
+        return ['info', 'success', 'warning', 'danger'].includes(value)
       }
     },
     /**
@@ -89,8 +86,8 @@ export default defineComponent({
      * Notification will be destroyed if timeout is set
      */
     setTimeout(() => {
-      // this.close()
-    }, this.timeout * 5000000000000)
+      this.close()
+    }, this.timeout * 1000)
   },
   methods: {
     close() {

--- a/packages/design-system/src/components/OcNotificationMessage/OcNotificationMessage.vue
+++ b/packages/design-system/src/components/OcNotificationMessage/OcNotificationMessage.vue
@@ -103,15 +103,9 @@ export default defineComponent({
 
 <style lang="scss">
 .oc-notification-message {
-  background-color: var(--oc-color-background-default) !important;
-  cursor: pointer;
   margin-top: var(--oc-space-small);
   position: relative;
   word-break: break-word;
-
-  &-title {
-    font-size: 1.15rem;
-  }
 }
 </style>
 

--- a/packages/design-system/src/components/OcNotificationMessage/OcNotificationMessage.vue
+++ b/packages/design-system/src/components/OcNotificationMessage/OcNotificationMessage.vue
@@ -1,23 +1,16 @@
 <template>
-  <div
-    class="oc-fade-in oc-flex oc-flex-wrap oc-notification-message oc-box-shadow-medium oc-rounded oc-p-m"
-    :class="classes"
+  <oc-alert
+    class="oc-fade-in oc-box-shadow-medium"
+    :closeable="true"
+    :has-icon="true"
+    :role="role"
+    :aria-live="ariaLive"
   >
-    <div class="oc-flex oc-flex-wrap oc-flex-middle oc-flex-1" :role="role" :aria-live="ariaLive">
-      <div class="oc-flex oc-flex-middle">
-        <oc-icon :variation="iconVariation" name="information" fill-type="line" class="oc-mr-s" />
-        <div class="oc-notification-message-title">
-          {{ title }}
-        </div>
-      </div>
-      <div
-        v-if="message"
-        class="oc-text-muted oc-width-1-1 oc-notification-message-content oc-mt-s oc-pl-s oc-ml-l"
-      >
-        {{ message }}
-      </div>
-    </div>
-  </div>
+    {{ title }}
+    <template #message>
+      {{ message }}
+    </template>
+  </oc-alert>
 </template>
 <script lang="ts">
 import { defineComponent } from 'vue'
@@ -96,8 +89,8 @@ export default defineComponent({
      * Notification will be destroyed if timeout is set
      */
     setTimeout(() => {
-      this.close()
-    }, this.timeout * 1000)
+      // this.close()
+    }, this.timeout * 5000000000000)
   },
   methods: {
     close() {

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -1,3 +1,4 @@
+export { default as OcAlert } from './OcAlert/OcAlert.vue'
 export { default as OcAvatar } from './OcAvatar/OcAvatar.vue'
 export { default as OcAvatarCount } from './OcAvatarCount/OcAvatarCount.vue'
 export { default as OcAvatarFederated } from './OcAvatarFederated/OcAvatarFederated.vue'

--- a/packages/web-app-admin-settings/src/views/Groups.vue
+++ b/packages/web-app-admin-settings/src/views/Groups.vue
@@ -221,7 +221,8 @@ export default defineComponent({
         const response = await client.groups.createGroup(group)
         this.toggleCreateGroupModal()
         this.showMessage({
-          title: this.$gettext('Group was created successfully')
+          title: this.$gettext('Group was created successfully'),
+          status: 'success'
         })
         this.groups.push({ ...response?.data, members: [] })
       } catch (error) {
@@ -240,7 +241,8 @@ export default defineComponent({
         Object.assign(group, editGroup)
 
         this.showMessage({
-          title: this.$gettext('Group was edited successfully')
+          title: this.$gettext('Group was edited successfully'),
+          status: 'success'
         })
       } catch (error) {
         console.error(error)

--- a/packages/web-app-admin-settings/src/views/Users.vue
+++ b/packages/web-app-admin-settings/src/views/Users.vue
@@ -446,7 +446,8 @@ export default defineComponent({
           }
         }
         await store.dispatch('showMessage', {
-          title: $gettext('Users were added to groups successfully')
+          title: $gettext('Users were added to groups successfully'),
+          status: 'success'
         })
         addToGroupsModalIsOpen.value = false
       } catch (e) {
@@ -490,7 +491,8 @@ export default defineComponent({
           }
         }
         await store.dispatch('showMessage', {
-          title: $gettext('Users were removed from groups successfully')
+          title: $gettext('Users were removed from groups successfully'),
+          status: 'success'
         })
         removeFromGroupsModalIsOpen.value = false
       } catch (e) {
@@ -619,7 +621,8 @@ export default defineComponent({
 
         this.toggleCreateUserModal()
         this.showMessage({
-          title: this.$gettext('User was created successfully')
+          title: this.$gettext('User was created successfully'),
+          status: 'success'
         })
       } catch (error) {
         console.error(error)

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -474,7 +474,8 @@ export default defineComponent({
             {
               folderName
             }
-          )
+          ),
+          status: 'success'
         })
       } catch (error) {
         console.error(error)
@@ -550,7 +551,8 @@ export default defineComponent({
         this.showMessage({
           title: this.$gettextInterpolate(this.$gettext('"%{fileName}" was created successfully'), {
             fileName
-          })
+          }),
+          status: 'success'
         })
       } catch (error) {
         console.error(error)
@@ -596,7 +598,8 @@ export default defineComponent({
         this.showMessage({
           title: this.$gettextInterpolate(this.$gettext('"%{fileName}" was created successfully'), {
             fileName
-          })
+          }),
+          status: 'success'
         })
       } catch (error) {
         console.error(error)

--- a/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
@@ -465,7 +465,8 @@ export default defineComponent({
       })
 
       this.showMessage({
-        title: this.$gettext('Link was created successfully')
+        title: this.$gettext('Link was created successfully'),
+        status: 'success'
       })
     },
 
@@ -486,7 +487,8 @@ export default defineComponent({
         })
 
       this.showMessage({
-        title: this.$gettext('Link was updated successfully')
+        title: this.$gettext('Link was updated successfully'),
+        status: 'success'
       })
     },
 
@@ -524,7 +526,8 @@ export default defineComponent({
       try {
         await this.removeLink({ client, share, path, loadIndicators })
         this.showMessage({
-          title: this.$gettext('Link was deleted successfully')
+          title: this.$gettext('Link was deleted successfully'),
+          status: 'success'
         })
 
         if (lastLinkId && isLocationSharesActive(this.$router, 'files-shares-via-link')) {

--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -311,7 +311,8 @@ export default defineComponent({
 
         this.hideModal()
         this.showMessage({
-          title: this.$gettext('Share was removed successfully')
+          title: this.$gettext('Share was removed successfully'),
+          status: 'success'
         })
         if (lastShareId && isLocationSharesActive(this.$router, 'files-shares-with-others')) {
           this.REMOVE_FILES([{ id: lastShareId }])

--- a/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
@@ -200,7 +200,8 @@ export default defineComponent({
           reloadSpace: !currentUserRemoved
         })
         this.showMessage({
-          title: this.$gettext('Share was removed successfully')
+          title: this.$gettext('Share was removed successfully'),
+          status: 'success'
         })
 
         if (currentUserRemoved) {

--- a/packages/web-app-files/src/quickActions.ts
+++ b/packages/web-app-files/src/quickActions.ts
@@ -32,7 +32,7 @@ export function showQuickLinkPasswordModal({ $gettext, store }, onConfirm) {
       if (!password || password.trim() === '') {
         store.dispatch('showMessage', {
           title: $gettext('Password cannot be empty'),
-          status: 'danger'
+          status: 'warning'
         })
       } else {
         await store.dispatch('hideModal')

--- a/packages/web-pkg/src/components/Spaces/QuotaModal.vue
+++ b/packages/web-pkg/src/components/Spaces/QuotaModal.vue
@@ -169,7 +169,10 @@ export default defineComponent({
       const errors = results.filter((r) => r.status === 'rejected')
       if (errors.length) {
         errors.forEach(console.error)
-        await store.dispatch('showMessage', { title: getErrorMessage(errors.length), status: 'danger' })
+        await store.dispatch('showMessage', {
+          title: getErrorMessage(errors.length),
+          status: 'danger'
+        })
       }
     }
 

--- a/packages/web-pkg/src/components/Spaces/QuotaModal.vue
+++ b/packages/web-pkg/src/components/Spaces/QuotaModal.vue
@@ -169,7 +169,7 @@ export default defineComponent({
       const errors = results.filter((r) => r.status === 'rejected')
       if (errors.length) {
         errors.forEach(console.error)
-        await store.dispatch('showMessage', { title: getErrorMessage(errors.length) })
+        await store.dispatch('showMessage', { title: getErrorMessage(errors.length), status: 'danger' })
       }
     }
 

--- a/packages/web-pkg/src/components/Spaces/ReadmeContentModal.vue
+++ b/packages/web-pkg/src/components/Spaces/ReadmeContentModal.vue
@@ -83,7 +83,8 @@ export default defineComponent({
             value: { ...this.space.spaceReadmeData, ...{ etag: readmeMetaData.ETag } }
           })
           this.showMessage({
-            title: this.$gettext('Space description was edited successfully')
+            title: this.$gettext('Space description was edited successfully'),
+            status: 'success'
           })
         })
         .catch((error) => {

--- a/packages/web-runtime/src/components/MessageBar.vue
+++ b/packages/web-runtime/src/components/MessageBar.vue
@@ -6,8 +6,9 @@
       :title="item.title"
       :message="item.desc"
       :status="item.status"
-      @close="deleteMessage(item)"
     />
+      :dismissable="true"
+      @dismissed="deleteMessage(item)"
   </oc-notifications>
 </template>
 

--- a/packages/web-runtime/src/components/MessageBar.vue
+++ b/packages/web-runtime/src/components/MessageBar.vue
@@ -2,8 +2,8 @@
   <oc-notifications :position="notificationPosition">
     <oc-alert
       v-for="item in $_ocMessages_limited"
-      class="oc-fade-in oc-box-shadow-medium oc-my-s"
       :key="item.id"
+      class="oc-fade-in oc-box-shadow-medium oc-my-s"
       :variant="item.status"
       :dismissable="true"
       @dismissed="deleteMessage(item)"

--- a/packages/web-runtime/src/components/MessageBar.vue
+++ b/packages/web-runtime/src/components/MessageBar.vue
@@ -1,14 +1,18 @@
 <template>
   <oc-notifications :position="notificationPosition">
-    <oc-notification-message
+    <oc-alert
       v-for="item in $_ocMessages_limited"
+      class="oc-fade-in oc-box-shadow-medium oc-my-s"
       :key="item.id"
-      :title="item.title"
-      :message="item.desc"
-      :status="item.status"
-    />
+      :variant="item.status"
       :dismissable="true"
       @dismissed="deleteMessage(item)"
+    >
+      {{ item.title }}
+      <template #message>
+        {{ item.desc }}
+      </template>
+    </oc-alert>
   </oc-notifications>
 </template>
 

--- a/packages/web-runtime/src/pages/account.vue
+++ b/packages/web-runtime/src/pages/account.vue
@@ -265,7 +265,8 @@ export default defineComponent({
         .then(() => {
           this.closeEditPasswordModal()
           this.showMessage({
-            title: this.$gettext('Password was changed successfully')
+            title: this.$gettext('Password was changed successfully'),
+            status: 'success'
           })
         })
         .catch((error) => {


### PR DESCRIPTION
Continuing this topic from https://github.com/owncloud/web/pull/8554

I was missing an alert component, which nearly every css framework offers. So I built it.

Edit: I found some changelogs, where an ocAlert component got removed. What's up with that?

## Description
![grafik](https://user-images.githubusercontent.com/16665512/225278433-8cbe5a98-16e1-4b5d-812a-8506ec995f52.png)

![grafik](https://user-images.githubusercontent.com/16665512/225278493-dabd550d-7f86-47e2-b6e7-7d21f946b08a.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
