### PR TITLE
fix: don't run into early return in password enforcement check

### DIFF
--- a/changelog/unreleased/bugfix-password-enforced-check
+++ b/changelog/unreleased/bugfix-password-enforced-check
@@ -1,0 +1,6 @@
+Bugfix: password enforced check for public links
+
+We've fixed a bug where we ignored the selected role in the password enforcement check. The web ui was sending the request to update a link instead of showing a modal with a password input prompt.
+
+https://github.com/owncloud/web/issues/8587
+https://github.com/owncloud/web/pull/8623

--- a/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
@@ -348,19 +348,16 @@ export default defineComponent({
       const canCreate = currentRole.hasPermission(SharePermissions.create)
       const canDelete = currentRole.hasPermission(SharePermissions.delete)
 
-      if (this.passwordEnforced.read_only === true) {
-        return canRead && !canUpdate && !canCreate && !canDelete
-      }
-      if (this.passwordEnforced.upload_only === true) {
-        return !canRead && !canUpdate && canCreate && !canDelete
-      }
-      if (this.passwordEnforced.read_write === true) {
-        return canRead && !canUpdate && canCreate && !canDelete
-      }
-      if (this.passwordEnforced.read_write_delete === true) {
-        return canRead && canUpdate && canCreate && canDelete
-      }
-      return false
+      const isReadOnly = canRead && !canUpdate && !canCreate && !canDelete
+      const isUploadOnly = !canRead && !canUpdate && canCreate && !canDelete
+      const isReadWrite = canRead && !canUpdate && canCreate && !canDelete
+      const isReadWriteDelete = canRead && canUpdate && canCreate && canDelete
+      return (
+        (this.passwordEnforced.read_only === true && isReadOnly) ||
+        (this.passwordEnforced.upload_only === true && isUploadOnly) ||
+        (this.passwordEnforced.read_write === true && isReadWrite) ||
+        (this.passwordEnforced.read_write_delete === true && isReadWriteDelete)
+      )
     },
 
     addNewLink() {


### PR DESCRIPTION
## Description
The `isPasswordEnforcedFor` check in public link creation / editing was basically ignoring the permission bits of the selected role and always did an early return on the first password enforcement capability that was `true`. Fixed by not returning early anymore. 😆 

## Related Issue
- Fixes https://github.com/owncloud/web/issues/8587

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
