### PR TITLE
[tests-only]Fix flaky login e2e test

### DIFF
--- a/tests/e2e/cucumber/features/smoke/admin-settings/general.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/admin-settings/general.ocis.feature
@@ -6,5 +6,6 @@ Feature: general management
     And "Admin" navigates to the general management page
     Then "Admin" should be able to upload a logo from the local file "filesForUpload/testavatar.png"
     And "Admin" navigates to the general management page
-    Then "Admin" should be able to reset the logo
-  
+    And "Admin" should be able to reset the logo
+    And "Admin" logs out
+

--- a/tests/e2e/cucumber/features/smoke/admin-settings/users.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/admin-settings/users.ocis.feature
@@ -102,6 +102,7 @@ Feature: spaces management
       | username    | anna             |
       | displayname | Anna Murphy      |
       | email       | anna@example.org |
+    And "anna" logs out
 
 
   Scenario: assign user to groups
@@ -126,3 +127,4 @@ Feature: spaces management
     Then "Alice" should have self info:
       | key    | value                                   |
       | groups | finance department, security department |
+    And "Alice" logs out

--- a/tests/e2e/cucumber/features/smoke/notifications.oc10.feature
+++ b/tests/e2e/cucumber/features/smoke/notifications.oc10.feature
@@ -27,3 +27,4 @@ Feature: Notifications
     And "Brian" marks all notifications as read
     Then "Brian" should see no notifications
     And "Alice" logs out
+    And "Brian" logs out


### PR DESCRIPTION
Fixes: https://github.com/owncloud/web/issues/8626
This PR adds log-out steps for each login. Some tests were using the session of the previous steps, for instance, Admin , as this user is not recreated, it's possible that the other steps were using the same session for the admin user in different scenarios and we get the login failure which eventually passes in retry.
