### PR TITLE
[test-only] change notification test after fixing #5865

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=cefdb457a10b04e53f8a5fdb18171a4cc39c4dbf
+OCIS_COMMITID=48be9ccf3ef7cb3952ec30c6782d002086e3bbbd
 OCIS_BRANCH=master

--- a/tests/e2e/cucumber/features/smoke/notifications.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/notifications.ocis.feature
@@ -8,61 +8,71 @@ Feature: Notifications
       | id    |
       | Alice |
       | Brian |
+      | Carol |
     And "Admin" assigns following roles to the users using API
       | id    | role        |
       | Alice | Space Admin |
 
   Scenario: User should be able to read and dismiss notifications
-    Given "Alice" creates the following folder in personal space using API
+    Given "Admin" creates following groups using API
+      | id    |
+      | sales |
+    And "Admin" adds user to the group using API
+      | user  | group |
+      | Alice | sales |
+      | Brian | sales |
+    And "Alice" creates the following folder in personal space using API
       | name             |
       | folder_to_shared |
+      | share_to_group   |
     And "Alice" creates the following project space using API
       | name | id     |
       | team | team.1 |
     And "Alice" logs in
     And "Alice" opens the "files" app
-    And "Alice" shares the following resource using the sidebar panel
-      | resource         | recipient | type | role   | resourceType |
-      | folder_to_shared | Brian     | user | editor | folder       |
+    When "Alice" shares the following resource using the sidebar panel
+      | resource         | recipient | type  | role   | resourceType |
+      | folder_to_shared | Brian     | user  | editor | folder       |
+      | share_to_group   | sales     | group | editor | folder       |
+    And "Brian" logs in
+    Then "Brian" should see the following notifications
+      | message                                       |
+      | Alice Hansen shared folder_to_shared with you |
+      | Alice Hansen shared share_to_group with you   |
+    And "Brian" marks all notifications as read
+    When "Alice" removes following sharee
+      | resource         | recipient |
+      | folder_to_shared | Brian     |
     And "Alice" navigates to the projects space page
     And "Alice" navigates to the project space "team.1"
     And "Alice" adds following users to the project space
       | user  | role   | kind |
       | Brian | editor | user |
-    When "Brian" logs in
-    Then "Brian" should see the following notifications
-      | message                                       |
-      | Alice Hansen shared folder_to_shared with you |
-      | Alice Hansen added you to Space team          |
-    And "Brian" marks all notifications as read
-    Then "Brian" should see no notifications
-    When "Alice" opens the "files" app
-    And "Alice" removes following sharee
-      | resource         | recipient |
-      | folder_to_shared | Brian     |
-    And "Alice" navigates to the projects space page
-    And "Alice" navigates to the project space "team.1"
-    And "Alice" removes access to following users from the project space
-      | user  | role   | kind |
-      | Brian | editor | user |
-    When "Brian" reloads the page
-    Then "Brian" should see the following notifications
+      | Carol | editor | user |
+    Then "Alice" should see no notifications
+    And "Brian" should see the following notifications
       | message                                         |
       | Alice Hansen unshared folder_to_shared with you |
-      | Alice Hansen removed you from Space team        |
+      | Alice Hansen added you to Space team            |
     And "Brian" marks all notifications as read
-    Then "Brian" should see no notifications
-    And "Brian" logs out
+    When "Alice" removes access to following users from the project space
+      | user  | role   | kind |
+      | Carol | editor | user |
+    And "Carol" logs in
+    Then "Carol" should see the following notifications
+      | message                                  |
+      | Alice Hansen added you to Space team     |
+      | Alice Hansen removed you from Space team | 
+    And "Carol" logs out
     When "Alice" opens the "admin-settings" app
     And "Alice" navigates to the project spaces management page
     And "Alice" disables the space "team.1" using the context-menu
-    And "Alice" reloads the page
-    Then "Alice" should see the following notifications
+    Then "Brian" should see the following notifications
       | message                          |
       | Alice Hansen disabled Space team |
-    And "Alice" deletes the space "team.1" using the context-menu
-    And "Alice" reloads the page
-    Then "Alice" should see the following notifications
+    When "Alice" deletes the space "team.1" using the context-menu
+    Then "Brian" should see the following notifications
       | message                         |
       | Alice Hansen deleted Space team |
+    And "Brian" logs out
     And "Alice" logs out


### PR DESCRIPTION
related [#5865](https://github.com/owncloud/ocis/issues/5865)

- user should not get notification about own action

@kobergj I ran a notification test agains your branch `kobergj:NoNotificationForOwnActions `and found that the user does not receive notifications about disabling and deleting space. Could you please check this