### PR TITLE
[tests-only][full-ci]Add test to check the list of members in a space in the admin settings via sidebar panel

### DIFF
--- a/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersPanel.vue
@@ -5,20 +5,20 @@
       class="oc-text-truncate oc-mr-s oc-mt-m"
       :label="$gettext('Filter members')"
     />
-    <div ref="membersListRef">
+    <div ref="membersListRef" data-testid="space-members">
       <div v-if="!filteredSpaceMembers.length">
         <h3 class="oc-text-bold oc-text-medium" v-text="$gettext('No members found')" />
       </div>
-      <div v-if="filteredSpaceManagers.length" class="oc-mb-m">
+      <div v-if="filteredSpaceManagers.length" class="oc-mb-m" data-testid="space-members-role-manager">
         <h3 class="oc-text-bold oc-text-medium" v-text="$gettext('Managers')" />
         <members-role-section :members="filteredSpaceManagers" />
       </div>
-      <div v-if="filteredSpaceEditors.length" class="oc-mb-m">
+      <div v-if="filteredSpaceEditors.length" class="oc-mb-m" data-testid="space-members-role-editor">
         <h3 class="oc-text-bold oc-text-medium" v-text="$gettext('Editors')" />
         <members-role-section :members="filteredSpaceEditors" />
       </div>
-      <div v-if="filteredSpaceViewers.length" class="oc-mb-m">
-        <h3 class="oc-text-bold oc-text-medium" v-text="$gettext('Viewers')" />
+      <div v-if="filteredSpaceViewers.length" class="oc-mb-m" data-testid="space-members-role-viewers">
+        <h3 class="oc-text-bold oc-text-medium"  v-text="$gettext('Viewers')" />
         <members-role-section :members="filteredSpaceViewers" />
       </div>
     </div>

--- a/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersPanel.vue
@@ -9,16 +9,28 @@
       <div v-if="!filteredSpaceMembers.length">
         <h3 class="oc-text-bold oc-text-medium" v-text="$gettext('No members found')" />
       </div>
-      <div v-if="filteredSpaceManagers.length" class="oc-mb-m" data-testid="space-members-role-manager">
+      <div
+        v-if="filteredSpaceManagers.length"
+        class="oc-mb-m"
+        data-testid="space-members-role-managers"
+      >
         <h3 class="oc-text-bold oc-text-medium" v-text="$gettext('Managers')" />
         <members-role-section :members="filteredSpaceManagers" />
       </div>
-      <div v-if="filteredSpaceEditors.length" class="oc-mb-m" data-testid="space-members-role-editor">
+      <div
+        v-if="filteredSpaceEditors.length"
+        class="oc-mb-m"
+        data-testid="space-members-role-editors"
+      >
         <h3 class="oc-text-bold oc-text-medium" v-text="$gettext('Editors')" />
         <members-role-section :members="filteredSpaceEditors" />
       </div>
-      <div v-if="filteredSpaceViewers.length" class="oc-mb-m" data-testid="space-members-role-viewers">
-        <h3 class="oc-text-bold oc-text-medium"  v-text="$gettext('Viewers')" />
+      <div
+        v-if="filteredSpaceViewers.length"
+        class="oc-mb-m"
+        data-testid="space-members-role-viewers"
+      >
+        <h3 class="oc-text-bold oc-text-medium" v-text="$gettext('Viewers')" />
         <members-role-section :members="filteredSpaceViewers" />
       </div>
     </div>

--- a/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersRoleSection.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersRoleSection.vue
@@ -1,6 +1,6 @@
 <template>
   <ul class="oc-list">
-    <li v-for="(member, index) in members" :key="index" class="oc-flex oc-flex-middle oc-mb-s">
+    <li v-for="(member, index) in members" :key="index" class="oc-flex oc-flex-middle oc-mb-s" data-testid="space-members-list">
       <oc-avatar
         v-if="member.kind === 'user'"
         :user-name="member.displayName"

--- a/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersRoleSection.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersRoleSection.vue
@@ -1,6 +1,11 @@
 <template>
   <ul class="oc-list">
-    <li v-for="(member, index) in members" :key="index" class="oc-flex oc-flex-middle oc-mb-s" data-testid="space-members-list">
+    <li
+      v-for="(member, index) in members"
+      :key="index"
+      class="oc-flex oc-flex-middle oc-mb-s"
+      data-testid="space-members-list"
+    >
       <oc-avatar
         v-if="member.kind === 'user'"
         :user-name="member.displayName"

--- a/tests/e2e/cucumber/features/smoke/admin-settings/spaces.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/admin-settings/spaces.ocis.feature
@@ -111,7 +111,7 @@ Feature: spaces management
       | Carol   | viewer | space     |
       | Marie   | viewer | space     |
       | Richard | viewer | space     |
-    When "Alice" logs in
+    And "Alice" logs in
     And "Alice" opens the "admin-settings" app
     And "Alice" navigates to the project spaces management page
     When "Alice" lists the members of project space "team.a" using a sidebar panel

--- a/tests/e2e/cucumber/features/smoke/admin-settings/spaces.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/admin-settings/spaces.ocis.feature
@@ -92,7 +92,7 @@ Feature: spaces management
 
 
   Scenario: list members via sidebar
-    Given "Admin" creates following users
+    Given "Admin" creates following users using API
       | id      |
       | Alice   |
       | Brian   |
@@ -105,7 +105,7 @@ Feature: spaces management
     And "Alice" creates the following project spaces using API
       | name   | id     |
       | team A | team.a |
-    And "Alice" adds following members to the space "team A" using API
+    And "Alice" adds the following members to the space "team A" using API
       | user    | role   | shareType |
       | Brian   | editor | space     |
       | Carol   | viewer | space     |

--- a/tests/e2e/cucumber/features/smoke/admin-settings/spaces.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/admin-settings/spaces.ocis.feature
@@ -89,3 +89,36 @@ Feature: spaces management
       | team.c |
       | team.d |
     And "Alice" logs out
+
+
+  Scenario: list members via sidebar
+    Given "Admin" creates following users
+      | id      |
+      | Alice   |
+      | Brian   |
+      | Carol   |
+      | Marie   |
+      | Richard |
+    And "Admin" assigns following roles to the users using API
+      | id    | role        |
+      | Alice | Space Admin |
+    And "Alice" creates the following project spaces using API
+      | name   | id     |
+      | team A | team.a |
+    And "Alice" adds following members to the space "team A" using API
+      | user    | role   | shareType |
+      | Brian   | editor | space     |
+      | Carol   | viewer | space     |
+      | Marie   | viewer | space     |
+      | Richard | viewer | space     |
+    When "Alice" logs in
+    And "Alice" opens the "admin-settings" app
+    And "Alice" navigates to the project spaces management page
+    When "Alice" lists the members of project space "team.a" using a sidebar panel
+    Then "Alice" should see the following users in the sidebar panel of spaces admin settings
+      | user    | role    |
+      | Alice   | manager |
+      | Brian   | editor  |
+      | Carol   | viewer  |
+      | Marie   | viewer  |
+      | Richard | viewer  |

--- a/tests/e2e/cucumber/steps/api.ts
+++ b/tests/e2e/cucumber/steps/api.ts
@@ -4,7 +4,6 @@ import { config } from '../../config'
 import { api } from '../../support'
 import fs from 'fs'
 
-
 Given(
   '{string} creates following user(s) using API',
   async function (this: World, stepUser: string, stepTable: DataTable): Promise<void> {
@@ -221,16 +220,22 @@ Given(
 )
 
 Given(
-    '{string} adds following member(s) to the space {string} using API',
-    async function (
-        this: World,
-        stepUser: string,
-        space: string,
-        stepTable: DataTable
-    ): Promise<void> {
-        const user = this.usersEnvironment.getUser({ key: stepUser })
-        for (const info of stepTable.hashes()) {
-            await api.dav.addMembersToTheProjectSpace({user,spaceName:space,shareWith:info.user,shareType:info.shareType,role:info.role})
-        }
+  '{string} adds following member(s) to the space {string} using API',
+  async function (
+    this: World,
+    stepUser: string,
+    space: string,
+    stepTable: DataTable
+  ): Promise<void> {
+    const user = this.usersEnvironment.getUser({ key: stepUser })
+    for (const info of stepTable.hashes()) {
+      await api.dav.addMembersToTheProjectSpace({
+        user,
+        spaceName: space,
+        shareWith: info.user,
+        shareType: info.shareType,
+        role: info.role
+      })
     }
+  }
 )

--- a/tests/e2e/cucumber/steps/api.ts
+++ b/tests/e2e/cucumber/steps/api.ts
@@ -220,7 +220,7 @@ Given(
 )
 
 Given(
-  '{string} adds following member(s) to the space {string} using API',
+  '{string} adds the following member(s) to the space {string} using API',
   async function (
     this: World,
     stepUser: string,

--- a/tests/e2e/cucumber/steps/api.ts
+++ b/tests/e2e/cucumber/steps/api.ts
@@ -4,6 +4,7 @@ import { config } from '../../config'
 import { api } from '../../support'
 import fs from 'fs'
 
+
 Given(
   '{string} creates following user(s) using API',
   async function (this: World, stepUser: string, stepTable: DataTable): Promise<void> {
@@ -217,4 +218,19 @@ Given(
       })
     }
   }
+)
+
+Given(
+    '{string} adds following member(s) to the space {string} using API',
+    async function (
+        this: World,
+        stepUser: string,
+        space: string,
+        stepTable: DataTable
+    ): Promise<void> {
+        const user = this.usersEnvironment.getUser({ key: stepUser })
+        for (const info of stepTable.hashes()) {
+            await api.dav.addMembersToTheProjectSpace({user,spaceName:space,shareWith:info.user,shareType:info.shareType,role:info.role})
+        }
+    }
 )

--- a/tests/e2e/cucumber/steps/ui/adminSettings.ts
+++ b/tests/e2e/cucumber/steps/ui/adminSettings.ts
@@ -542,6 +542,6 @@ Then(
           default:
             throw new Error(`'${info.role}' role not implemented`)
         }
-      }
     }
+  }
 )

--- a/tests/e2e/cucumber/steps/ui/adminSettings.ts
+++ b/tests/e2e/cucumber/steps/ui/adminSettings.ts
@@ -509,4 +509,39 @@ Then('{string} should see the edit panel', async function (this: World, stepUser
   const { page } = this.actorsEnvironment.getActor({ key: stepUser })
   const usersObject = new objects.applicationAdminSettings.Users({ page })
   await usersObject.waitForEditPanelToBeVisible()
-})
+}
+)
+
+When(
+  '{string} lists the members of project space {string} using a sidebar panel',
+  async function (this: World, stepUser: string, key: string): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const spacesObject = new objects.applicationAdminSettings.Spaces({ page })
+    await spacesObject.openPanel({ key })
+    await spacesObject.openActionSideBarPanel({ action: 'SpaceMembers' })
+  }
+)
+
+Then(
+    '{string} should see the following users in the sidebar panel of spaces admin settings',
+    async function (this:World, stepUser: string,stepTable: DataTable): Promise<void>{
+      const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+      const spacesObject = new objects.applicationAdminSettings.Spaces({ page })
+      let expected = null
+      for(const info of stepTable.hashes()){
+        switch (info.role){
+          case 'manager':
+            expected = await spacesObject.listMembers({filter:'managers'})
+            break
+          case 'editor':
+            expected = await spacesObject.listMembers({filter:'editor'})
+            break
+          case 'viewer':
+            expected = await spacesObject.listMembers({filter:'viewer'})
+            break
+          default:
+            throw new Error(`'${info.role}' role not implemented`)
+        }
+      }
+    }
+)

--- a/tests/e2e/cucumber/steps/ui/adminSettings.ts
+++ b/tests/e2e/cucumber/steps/ui/adminSettings.ts
@@ -509,8 +509,7 @@ Then('{string} should see the edit panel', async function (this: World, stepUser
   const { page } = this.actorsEnvironment.getActor({ key: stepUser })
   const usersObject = new objects.applicationAdminSettings.Users({ page })
   await usersObject.waitForEditPanelToBeVisible()
-}
-)
+})
 
 When(
   '{string} lists the members of project space {string} using a sidebar panel',
@@ -523,25 +522,25 @@ When(
 )
 
 Then(
-    '{string} should see the following users in the sidebar panel of spaces admin settings',
-    async function (this:World, stepUser: string,stepTable: DataTable): Promise<void>{
-      const { page } = this.actorsEnvironment.getActor({ key: stepUser })
-      const spacesObject = new objects.applicationAdminSettings.Spaces({ page })
-      let expected = null
-      for(const info of stepTable.hashes()){
-        switch (info.role){
-          case 'manager':
-            expected = await spacesObject.listMembers({filter:'managers'})
-            break
-          case 'editor':
-            expected = await spacesObject.listMembers({filter:'editor'})
-            break
-          case 'viewer':
-            expected = await spacesObject.listMembers({filter:'viewer'})
-            break
-          default:
-            throw new Error(`'${info.role}' role not implemented`)
-        }
+  '{string} should see the following users in the sidebar panel of spaces admin settings',
+  async function (this: World, stepUser: string, stepTable: DataTable): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const spacesObject = new objects.applicationAdminSettings.Spaces({ page })
+    let expected = null
+    for (const info of stepTable.hashes()) {
+      switch (info.role) {
+        case 'manager':
+          expected = await spacesObject.listMembers({ filter: 'managers' })
+          break
+        case 'editor':
+          expected = await spacesObject.listMembers({ filter: 'editor' })
+          break
+        case 'viewer':
+          expected = await spacesObject.listMembers({ filter: 'viewer' })
+          break
+        default:
+          throw new Error(`'${info.role}' role not implemented`)
+      }
     }
   }
 )

--- a/tests/e2e/support/api/davSpaces/index.ts
+++ b/tests/e2e/support/api/davSpaces/index.ts
@@ -3,5 +3,6 @@ export {
   createFolderInsideSpaceBySpaceName,
   createFolderInsidePersonalSpace,
   getIdOfFileInsideSpace,
-  uploadFileInsideSpaceBySpaceName
+  uploadFileInsideSpaceBySpaceName,
+  addMembersToTheProjectSpace
 } from './spaces'

--- a/tests/e2e/support/api/davSpaces/spaces.ts
+++ b/tests/e2e/support/api/davSpaces/spaces.ts
@@ -6,7 +6,7 @@ import { config } from '../../../config'
 import { Response } from 'node-fetch'
 import convert from 'xml-js'
 import _ from 'lodash/object'
-import {createShare} from "../share";
+import { createShare } from '../share'
 
 export const folderExists = async ({
   user,
@@ -204,23 +204,19 @@ export const getIdOfFileInsideSpace = async ({
 }
 
 export const addMembersToTheProjectSpace = async ({
-user,
- spaceName,
- shareWith,
- shareType,
-    role
-
-}:{
+  user,
+  spaceName,
+  shareWith,
+  shareType,
+  role
+}: {
   user: User
   spaceName: string
   shareWith: string
   shareType: string
   role: string
-
-}):Promise<void> => {
+}): Promise<void> => {
   const space_ref = await getSpaceIdBySpaceName({ user, spaceType: 'project', spaceName })
   const path = '/' + spaceName
-  await createShare({user,path,shareWith,shareType,role,name:null,space_ref})
+  await createShare({ user, path, shareWith, shareType, role, name: null, space_ref })
 }
-
-

--- a/tests/e2e/support/api/davSpaces/spaces.ts
+++ b/tests/e2e/support/api/davSpaces/spaces.ts
@@ -6,6 +6,7 @@ import { config } from '../../../config'
 import { Response } from 'node-fetch'
 import convert from 'xml-js'
 import _ from 'lodash/object'
+import {createShare} from "../share";
 
 export const folderExists = async ({
   user,
@@ -201,3 +202,25 @@ export const getIdOfFileInsideSpace = async ({
   // extract file id form the response
   return _.get(fileDataResponse, '[0][d:prop][oc:fileid]')._text
 }
+
+export const addMembersToTheProjectSpace = async ({
+user,
+ spaceName,
+ shareWith,
+ shareType,
+    role
+
+}:{
+  user: User
+  spaceName: string
+  shareWith: string
+  shareType: string
+  role: string
+
+}):Promise<void> => {
+  const space_ref = await getSpaceIdBySpaceName({ user, spaceType: 'project', spaceName })
+  const path = '/' + spaceName
+  await createShare({user,path,shareWith,shareType,role,name:null,space_ref})
+}
+
+

--- a/tests/e2e/support/api/davSpaces/spaces.ts
+++ b/tests/e2e/support/api/davSpaces/spaces.ts
@@ -217,6 +217,5 @@ export const addMembersToTheProjectSpace = async ({
   role: string
 }): Promise<void> => {
   const space_ref = await getSpaceIdBySpaceName({ user, spaceType: 'project', spaceName })
-  const path = '/' + spaceName
-  await createShare({ user, path, shareWith, shareType, role, name: null, space_ref })
+  await createShare({ user, path: null, shareWith, shareType, role, name: null, space_ref })
 }

--- a/tests/e2e/support/api/share/index.ts
+++ b/tests/e2e/support/api/share/index.ts
@@ -1,2 +1,1 @@
-export { createShare } from './share'
-export { acceptShare } from './share'
+export { createShare, acceptShare } from './share'

--- a/tests/e2e/support/api/share/share.ts
+++ b/tests/e2e/support/api/share/share.ts
@@ -25,7 +25,7 @@ export const createShare = async ({
   shareType,
   role,
   name,
-                                    space_ref,
+  space_ref
 }: {
   user: User
   path: string
@@ -41,7 +41,7 @@ export const createShare = async ({
   body.append('shareType', shareTypes[shareType])
   body.append('role', role)
   body.append('name', name)
-  if(space_ref){
+  if (space_ref) {
     body.append('space_ref', space_ref)
   }
   const response = await request({

--- a/tests/e2e/support/api/share/share.ts
+++ b/tests/e2e/support/api/share/share.ts
@@ -9,11 +9,13 @@ export const shareTypes: Readonly<{
   group: string
   public: string
   federated: string
+  space: string
 }> = {
   user: '0',
   group: '1',
   public: '3',
-  federated: '6'
+  federated: '6',
+  space: '7'
 }
 
 export const createShare = async ({
@@ -22,7 +24,8 @@ export const createShare = async ({
   shareWith,
   shareType,
   role,
-  name
+  name,
+                                    space_ref,
 }: {
   user: User
   path: string
@@ -30,6 +33,7 @@ export const createShare = async ({
   shareWith?: string
   role?: string
   name?: string
+  space_ref?: string
 }): Promise<void> => {
   const body = new URLSearchParams()
   body.append('path', path)
@@ -37,7 +41,9 @@ export const createShare = async ({
   body.append('shareType', shareTypes[shareType])
   body.append('role', role)
   body.append('name', name)
-
+  if(space_ref){
+    body.append('space_ref', space_ref)
+  }
   const response = await request({
     method: 'POST',
     path: join('ocs', 'v2.php', 'apps', 'files_sharing', 'api', 'v1', 'shares'),

--- a/tests/e2e/support/api/share/share.ts
+++ b/tests/e2e/support/api/share/share.ts
@@ -28,7 +28,7 @@ export const createShare = async ({
   space_ref
 }: {
   user: User
-  path: string
+  path?: string
   shareType: string
   shareWith?: string
   role?: string

--- a/tests/e2e/support/objects/app-admin-settings/spaces/actions.ts
+++ b/tests/e2e/support/objects/app-admin-settings/spaces/actions.ts
@@ -1,5 +1,6 @@
 import { Page } from 'playwright'
 import util from 'util'
+import { locatorUtils } from '../../../utils'
 
 const spaceTrSelector = 'tr'
 const actionConfirmButton = '.oc-modal-body-actions-confirm'
@@ -12,6 +13,14 @@ const modalConfirmBtn = `.oc-modal-body-actions-confirm`
 const quotaValueDropDown = `.vs__dropdown-option :text-is("%s")`
 const selectedQuotaValueField = '.vs__dropdown-toggle'
 const spacesQuotaSearchField = '.oc-modal .vs__search'
+const appSidebarDiv = '#app-sidebar'
+const toggleSidebarButton = '#files-toggle-sidebar'
+const sideBarActive = '.sidebar-panel.is-active-default-panel'
+const sideBarCloseButton = '.sidebar-panel .header__close:visible'
+const sideBarBackButton = '.sidebar-panel .header__back:visible'
+const sideBarActionButtons = `#sidebar-panel-%s-select`
+const siderBarActionPanel = `#sidebar-panel-%s`
+const spaceMembers = '[data-testid="space-members"]'
 
 export const getDisplayedSpaces = async (page): Promise<string[]> => {
   const spaces = []
@@ -220,4 +229,46 @@ const waitForSpaceResponse = async (args: {
     ),
     page.locator(confirmButton).click()
   ])
+}
+
+export const openSpaceAdminSidebarPanel = async (args:{
+page: Page
+  id: string
+}):Promise<void> => {
+  const { page, id} = args
+  if (await page.locator(appSidebarDiv).count()) {
+    await page.locator(sideBarCloseButton).click()
+  }
+  await selectSpace({page,id})
+  await page.click(toggleSidebarButton)
+}
+
+export const openSpaceAdminActionSidebarPanel = async (args:{
+  page: Page
+  action: string
+}):Promise<void> => {
+  const { page, action} = args
+  const currentPanel = await page.locator(sideBarActive)
+  const backButton = await currentPanel.locator(sideBarBackButton)
+  if (await backButton.count()) {
+    await backButton.click()
+    await locatorUtils.waitForEvent(currentPanel, 'transitionend')
+  }
+  const panelSelector = await page.locator(util.format(sideBarActionButtons,'SpaceMembers'))
+  const nextPanel = page.locator(util.format(siderBarActionPanel,'SpaceMembers'))
+  await panelSelector.click()
+  await locatorUtils.waitForEvent(nextPanel, 'transitionend')
+}
+
+export const listSpaceMambers = async (args:{
+  page:Page
+  filter:string
+}):Promise<void> => {
+  const {page} = args
+  await page.waitForSelector(spaceMembers)
+  const test = await page.getByTestId('space-members-role').allInnerTexts()
+  const test2 = await page.getByTestId('space-members-list').allInnerTexts()
+  console.log(test)
+  console.log(test2)
+
 }

--- a/tests/e2e/support/objects/app-admin-settings/spaces/actions.ts
+++ b/tests/e2e/support/objects/app-admin-settings/spaces/actions.ts
@@ -256,8 +256,8 @@ export const openSpaceAdminActionSidebarPanel = async (args: {
     await backButton.click()
     await locatorUtils.waitForEvent(currentPanel, 'transitionend')
   }
-  const panelSelector = await page.locator(util.format(sideBarActionButtons, 'SpaceMembers'))
-  const nextPanel = page.locator(util.format(siderBarActionPanel, 'SpaceMembers'))
+  const panelSelector = await page.locator(util.format(sideBarActionButtons, action))
+  const nextPanel = page.locator(util.format(siderBarActionPanel, action))
   await panelSelector.click()
   await locatorUtils.waitForEvent(nextPanel, 'transitionend')
 }
@@ -268,8 +268,7 @@ export const listSpaceMembers = async (args: {
 }): Promise<Array<string>> => {
   const { page, filter } = args
   await page.waitForSelector(spaceMembersDiv)
-  let users = null
-  let name = null
+  let users = []
   const names = []
   switch (filter) {
     case 'managers':
@@ -284,7 +283,7 @@ export const listSpaceMembers = async (args: {
   }
   for (const user of users) {
     // the value comes in "['initials firstName secondName lastName',..]" format so only get the first name
-    [, name] = user.split(' ')
+    const [, name] = user.split(' ')
     names.push(name)
   }
   return names

--- a/tests/e2e/support/objects/app-admin-settings/spaces/index.ts
+++ b/tests/e2e/support/objects/app-admin-settings/spaces/index.ts
@@ -7,7 +7,7 @@ import {
   renameSpace,
   changeSpaceSubtitle,
   selectSpace,
-  enableSpace
+  enableSpace, openSpaceAdminSidebarPanel, openSpaceAdminActionSidebarPanel, listSpaceMambers
 } from './actions'
 import { SpacesEnvironment } from '../../../environment'
 import { Space } from '../../../types'
@@ -70,5 +70,18 @@ export class Spaces {
   async changeSubtitle({ key, value }: { key: string; value: string }): Promise<void> {
     const { id } = this.#spacesEnvironment.getSpace({ key })
     await changeSpaceSubtitle({ id, page: this.#page, value })
+  }
+
+  async openPanel({key}:{key:string}): Promise<void>{
+    const { id } = this.#spacesEnvironment.getSpace({key})
+    await openSpaceAdminSidebarPanel({page: this.#page,id})
+  }
+
+  async openActionSideBarPanel({action}:{action:string}): Promise<void>{
+    await openSpaceAdminActionSidebarPanel({page:this.#page,action})
+  }
+
+  async listMembers({filter}:{filter:string}):Promise<void>{
+    await listSpaceMambers({page:this.#page, filter})
   }
 }

--- a/tests/e2e/support/objects/app-admin-settings/spaces/index.ts
+++ b/tests/e2e/support/objects/app-admin-settings/spaces/index.ts
@@ -7,7 +7,10 @@ import {
   renameSpace,
   changeSpaceSubtitle,
   selectSpace,
-  enableSpace, openSpaceAdminSidebarPanel, openSpaceAdminActionSidebarPanel, listSpaceMambers
+  enableSpace,
+  openSpaceAdminSidebarPanel,
+  openSpaceAdminActionSidebarPanel,
+  listSpaceMembers
 } from './actions'
 import { SpacesEnvironment } from '../../../environment'
 import { Space } from '../../../types'
@@ -72,16 +75,16 @@ export class Spaces {
     await changeSpaceSubtitle({ id, page: this.#page, value })
   }
 
-  async openPanel({key}:{key:string}): Promise<void>{
-    const { id } = this.#spacesEnvironment.getSpace({key})
-    await openSpaceAdminSidebarPanel({page: this.#page,id})
+  async openPanel({ key }: { key: string }): Promise<void> {
+    const { id } = this.#spacesEnvironment.getSpace({ key })
+    await openSpaceAdminSidebarPanel({ page: this.#page, id })
   }
 
-  async openActionSideBarPanel({action}:{action:string}): Promise<void>{
-    await openSpaceAdminActionSidebarPanel({page:this.#page,action})
+  async openActionSideBarPanel({ action }: { action: string }): Promise<void> {
+    await openSpaceAdminActionSidebarPanel({ page: this.#page, action })
   }
 
-  async listMembers({filter}:{filter:string}):Promise<void>{
-    await listSpaceMambers({page:this.#page, filter})
+  async listMembers({ filter }: { filter: string }): Promise<Array<string>> {
+    return listSpaceMembers({ page: this.#page, filter })
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR does the following
- Adds a scenario to check the list of members in the space
- Adds API step to add member in a space
- Changes the vue component to add some `data-testid` needed for tests

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of: https://github.com/owncloud/web/issues/8601

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Local
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
