### PR TITLE
Downgrade TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "ts-jest": "29.0.5",
     "ts-node": "10.9.1",
     "tslib": "2.5.0",
-    "typescript": "5.0.2",
+    "typescript": "4.9.5",
     "url-search-params-polyfill": "8.1.1",
     "vite": "4.0.4",
     "vite-plugin-environment": "^1.1.3",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -102,7 +102,7 @@
     "stylelint-config-standard": "^26.0.0",
     "tinycolor2": "^1.4.2",
     "tippy.js": "^6.3.7",
-    "typescript": "^5.0.0",
+    "typescript": "4.9.5",
     "url-loader": "^4.1.1",
     "v-calendar": "github:dschmidt/v-calendar#3ce6e3b8afd5491cb53ee811281d5fa8a45b044d",
     "vue": "3.2.47",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -16,9 +16,9 @@
   },
   "dependencies": {
     "@babel/eslint-parser": "^7.19.1",
-    "@typescript-eslint/eslint-plugin": "^5.39.0",
-    "@typescript-eslint/parser": "^5.39.0",
-    "eslint-config-prettier": "^8.5.0",
+    "@typescript-eslint/eslint-plugin": "^5.56.0",
+    "@typescript-eslint/parser": "^5.56.0",
+    "eslint-config-prettier": "^8.8.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jest": "^27.1.1",
@@ -28,7 +28,7 @@
     "eslint-plugin-unused-imports": "^2.0.0",
     "eslint-plugin-vue": "^9.6.0",
     "eslint-plugin-vuejs-accessibility": "^1.2.0",
-    "typescript": "^5.0.0"
+    "typescript": "4.9.5"
   },
   "peerDependencies": {
     "eslint": "^8.25.0"

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -18,7 +18,7 @@
     "@uppy/xhr-upload": "^3.0.1",
     "@vueuse/head": "1.1.23",
     "axios": "^0.27.2",
-    "easygettext": "https://github.com/owncloud/easygettext/archive/refs/tags/v2.18.1-oc.tar.gz",
+    "easygettext": "https://github.com/owncloud/easygettext/archive/refs/tags/v2.18.2-oc.tar.gz",
     "filesize": "^9.0.11",
     "focus-trap": "^7.2.0",
     "focus-trap-vue": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,7 +87,7 @@ importers:
       ts-jest: 29.0.5
       ts-node: 10.9.1
       tslib: 2.5.0
-      typescript: 5.0.2
+      typescript: 4.9.5
       url-search-params-polyfill: 8.1.1
       uuid: '*'
       vite: 4.0.4
@@ -137,7 +137,7 @@ importers:
       '@types/node-fetch': 2.6.2
       '@vitejs/plugin-vue': 4.0.0_vite@4.0.4+vue@3.2.47
       '@vue/test-utils': 2.3.1_vue@3.2.47
-      '@vue/vue3-jest': 29.2.3_32lqfenomsc3abepab4t3psgtm
+      '@vue/vue3-jest': 29.2.3_3ct2qspsll5oznyljmocvlpxry
       autoprefixer: 10.4.13_postcss@8.4.20
       babel-core: 7.0.0-bridge.0_@babel+core@7.20.12
       babel-jest: 29.3.1_@babel+core@7.20.12
@@ -156,7 +156,7 @@ importers:
       jest-environment-jsdom: 29.5.0
       jest-fetch-mock: 3.0.3
       jest-mock-axios: 4.6.2_ts-node@10.9.1
-      jest-mock-extended: 3.0.1_44ttdtjaknnkcgzh5px4h2qxl4
+      jest-mock-extended: 3.0.1_doipufordlnvh5g4adbwayvyvy
       jest-serializer-vue-tjw: 3.19.0_n3ezndisi6xx2kbxcsk5pv4dxy
       join-path: 1.1.1
       jsdom: 20.0.3
@@ -172,14 +172,14 @@ importers:
       requirejs: 2.3.6
       rollup-plugin-node-polyfills: 0.2.1
       rollup-plugin-visualizer: 5.9.0_rollup@3.14.0
-      ts-jest: 29.0.5_oiqch47h7k6spjal2ttwsnwsdm
-      ts-node: 10.9.1_b2u7dz2qqrl5aoicdb73uu2awe
+      ts-jest: 29.0.5_ytzn2be2wlngdyaxw5jrml6jvi
+      ts-node: 10.9.1_iedef3djpnfxdpbmfr4x6l3blq
       tslib: 2.5.0
-      typescript: 5.0.2
+      typescript: 4.9.5
       url-search-params-polyfill: 8.1.1
       vite: 4.0.4_@types+node@16.18.11
       vite-plugin-environment: 1.1.3_vite@4.0.4
-      vue-tsc: 1.3.4_typescript@5.0.2
+      vue-tsc: 1.3.4_typescript@4.9.5
       vue3-gettext: 2.3.4_a2ihsjreowava2sm4iorpgwkom
       wait-for-expect: 3.0.2
 
@@ -252,7 +252,7 @@ importers:
       stylelint-config-standard: ^26.0.0
       tinycolor2: ^1.4.2
       tippy.js: ^6.3.7
-      typescript: ^5.0.0
+      typescript: 4.9.5
       url-loader: ^4.1.1
       v-calendar: github:dschmidt/v-calendar#3ce6e3b8afd5491cb53ee811281d5fa8a45b044d
       vue: 3.2.47
@@ -335,7 +335,7 @@ importers:
       stylelint-config-standard: 26.0.0_stylelint@14.16.0
       tinycolor2: 1.4.2
       tippy.js: 6.3.7
-      typescript: 5.0.2
+      typescript: 4.9.5
       url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
       v-calendar: github.com/dschmidt/v-calendar/3ce6e3b8afd5491cb53ee811281d5fa8a45b044d_vue@3.2.47
       vue: 3.2.47
@@ -357,10 +357,10 @@ importers:
   packages/eslint-config:
     specifiers:
       '@babel/eslint-parser': ^7.19.1
-      '@typescript-eslint/eslint-plugin': ^5.39.0
-      '@typescript-eslint/parser': ^5.39.0
+      '@typescript-eslint/eslint-plugin': ^5.56.0
+      '@typescript-eslint/parser': ^5.56.0
       eslint: ^8.25.0
-      eslint-config-prettier: ^8.5.0
+      eslint-config-prettier: ^8.8.0
       eslint-config-standard: ^17.0.0
       eslint-plugin-import: ^2.26.0
       eslint-plugin-jest: ^27.1.1
@@ -370,23 +370,23 @@ importers:
       eslint-plugin-unused-imports: ^2.0.0
       eslint-plugin-vue: ^9.6.0
       eslint-plugin-vuejs-accessibility: ^1.2.0
-      typescript: ^5.0.0
+      typescript: 4.9.5
     dependencies:
       '@babel/eslint-parser': 7.19.1_omyp52tqvdzxozh6s55zhzw5w4
-      '@typescript-eslint/eslint-plugin': 5.39.0_6wiyttdjmhjpssagtvxtrkkpra
-      '@typescript-eslint/parser': 5.39.0_kykkfgtuomzgyhxd4xxwxcydwe
+      '@typescript-eslint/eslint-plugin': 5.56.0_rpapdhxtx74uxdjbku4mlaih5a
+      '@typescript-eslint/parser': 5.56.0_mx6jhvnay66odhn2yt7eqo2wou
       eslint: 8.25.0
-      eslint-config-prettier: 8.5.0_eslint@8.25.0
+      eslint-config-prettier: 8.8.0_eslint@8.25.0
       eslint-config-standard: 17.0.0_a432y4gghichzqs5hexeiieuzm
-      eslint-plugin-import: 2.26.0_dzvnzej2un7roooznz6ef2if2q
-      eslint-plugin-jest: 27.1.1_hkge35widolnwjodmm6vh6gaau
+      eslint-plugin-import: 2.26.0_nrmemtbccfexnzqti5ajbh4zje
+      eslint-plugin-jest: 27.1.1_dx4g5dh3kehlsydvljq6ykvwpy
       eslint-plugin-node: 11.1.0_eslint@8.25.0
       eslint-plugin-prettier-vue: 4.2.0
       eslint-plugin-promise: 6.0.1_eslint@8.25.0
-      eslint-plugin-unused-imports: 2.0.0_fd4zt552xrtdl27rs5sr76joou
+      eslint-plugin-unused-imports: 2.0.0_nhjeqhichv7xdxjeodsqjgdadu
       eslint-plugin-vue: 9.6.0_eslint@8.25.0
       eslint-plugin-vuejs-accessibility: 1.2.0_eslint@8.25.0
-      typescript: 5.0.2
+      typescript: 4.9.5
 
   packages/extension-sdk:
     specifiers:
@@ -2278,7 +2278,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.5
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
   /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.19.6:
@@ -2296,7 +2296,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
   /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.17.5:
@@ -4814,6 +4814,21 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@eslint-community/eslint-utils/4.3.0_eslint@8.25.0:
+    resolution: {integrity: sha512-v3oplH6FYCULtFuCeqyuTd9D2WKO937Dxdq+GmHOLL72TTRriLxz2VLlNfkZRsvj6PKnOPAtuT6dwrs/pA5DvA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+    dependencies:
+      eslint: 8.25.0
+      eslint-visitor-keys: 3.3.0
+    dev: false
+
+  /@eslint-community/regexpp/4.4.0:
+    resolution: {integrity: sha512-A9983Q0LnDGdLPjxyXQ00sbV+K+O+ko2Dr+CZigbHWtX9pNfxlaBkMR8X1CztI73zuEyEBXTVjx7CE+/VSwDiQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+    dev: false
+
   /@eslint/eslintrc/1.3.3:
     resolution: {integrity: sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -5932,7 +5947,6 @@ packages:
 
   /@types/semver/7.3.13:
     resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
-    dev: true
 
   /@types/source-list-map/0.1.2:
     resolution: {integrity: sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==}
@@ -6027,8 +6041,8 @@ packages:
     dev: true
     optional: true
 
-  /@typescript-eslint/eslint-plugin/5.39.0_6wiyttdjmhjpssagtvxtrkkpra:
-    resolution: {integrity: sha512-xVfKOkBm5iWMNGKQ2fwX5GVgBuHmZBO1tCRwXmY5oAIsPscfwm2UADDuNB8ZVYCtpQvJK4xpjrK7jEhcJ0zY9A==}
+  /@typescript-eslint/eslint-plugin/5.56.0_rpapdhxtx74uxdjbku4mlaih5a:
+    resolution: {integrity: sha512-ZNW37Ccl3oMZkzxrYDUX4o7cnuPgU+YrcaYXzsRtLB16I1FR5SHMqga3zGsaSliZADCWo2v8qHWqAYIj8nWCCg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
@@ -6038,23 +6052,25 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.39.0_kykkfgtuomzgyhxd4xxwxcydwe
-      '@typescript-eslint/scope-manager': 5.39.0
-      '@typescript-eslint/type-utils': 5.39.0_kykkfgtuomzgyhxd4xxwxcydwe
-      '@typescript-eslint/utils': 5.39.0_kykkfgtuomzgyhxd4xxwxcydwe
+      '@eslint-community/regexpp': 4.4.0
+      '@typescript-eslint/parser': 5.56.0_mx6jhvnay66odhn2yt7eqo2wou
+      '@typescript-eslint/scope-manager': 5.56.0
+      '@typescript-eslint/type-utils': 5.56.0_mx6jhvnay66odhn2yt7eqo2wou
+      '@typescript-eslint/utils': 5.56.0_mx6jhvnay66odhn2yt7eqo2wou
       debug: 4.3.4
       eslint: 8.25.0
-      ignore: 5.2.0
-      regexpp: 3.2.0
+      grapheme-splitter: 1.0.4
+      ignore: 5.2.1
+      natural-compare-lite: 1.4.0
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@5.0.2
-      typescript: 5.0.2
+      tsutils: 3.21.0_typescript@4.9.5
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser/5.39.0_kykkfgtuomzgyhxd4xxwxcydwe:
-    resolution: {integrity: sha512-PhxLjrZnHShe431sBAGHaNe6BDdxAASDySgsBCGxcBecVCi8NQWxQZMcizNA4g0pN51bBAn/FUfkWG3SDVcGlA==}
+  /@typescript-eslint/parser/5.56.0_mx6jhvnay66odhn2yt7eqo2wou:
+    resolution: {integrity: sha512-sn1OZmBxUsgxMmR8a8U5QM/Wl+tyqlH//jTqCg8daTAmhAk26L2PFhcqPLlYBhYUJMZJK276qLXlHN3a83o2cg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -6063,12 +6079,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 5.39.0
-      '@typescript-eslint/types': 5.39.0
-      '@typescript-eslint/typescript-estree': 5.39.0_typescript@5.0.2
+      '@typescript-eslint/scope-manager': 5.56.0
+      '@typescript-eslint/types': 5.56.0
+      '@typescript-eslint/typescript-estree': 5.56.0_typescript@4.9.5
       debug: 4.3.4
       eslint: 8.25.0
-      typescript: 5.0.2
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -6081,8 +6097,16 @@ packages:
       '@typescript-eslint/visitor-keys': 5.39.0
     dev: false
 
-  /@typescript-eslint/type-utils/5.39.0_kykkfgtuomzgyhxd4xxwxcydwe:
-    resolution: {integrity: sha512-KJHJkOothljQWzR3t/GunL0TPKY+fGJtnpl+pX+sJ0YiKTz3q2Zr87SGTmFqsCMFrLt5E0+o+S6eQY0FAXj9uA==}
+  /@typescript-eslint/scope-manager/5.56.0:
+    resolution: {integrity: sha512-jGYKyt+iBakD0SA5Ww8vFqGpoV2asSjwt60Gl6YcO8ksQ8s2HlUEyHBMSa38bdLopYqGf7EYQMUIGdT/Luw+sw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.56.0
+      '@typescript-eslint/visitor-keys': 5.56.0
+    dev: false
+
+  /@typescript-eslint/type-utils/5.56.0_mx6jhvnay66odhn2yt7eqo2wou:
+    resolution: {integrity: sha512-8WxgOgJjWRy6m4xg9KoSHPzBNZeQbGlQOH7l2QEhQID/+YseaFxg5J/DLwWSsi9Axj4e/cCiKx7PVzOq38tY4A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '*'
@@ -6091,12 +6115,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.39.0_typescript@5.0.2
-      '@typescript-eslint/utils': 5.39.0_kykkfgtuomzgyhxd4xxwxcydwe
+      '@typescript-eslint/typescript-estree': 5.56.0_typescript@4.9.5
+      '@typescript-eslint/utils': 5.56.0_mx6jhvnay66odhn2yt7eqo2wou
       debug: 4.3.4
       eslint: 8.25.0
-      tsutils: 3.21.0_typescript@5.0.2
-      typescript: 5.0.2
+      tsutils: 3.21.0_typescript@4.9.5
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -6106,7 +6130,12 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /@typescript-eslint/typescript-estree/5.39.0_typescript@5.0.2:
+  /@typescript-eslint/types/5.56.0:
+    resolution: {integrity: sha512-JyAzbTJcIyhuUhogmiu+t79AkdnqgPUEsxMTMc/dCZczGMJQh1MK2wgrju++yMN6AWroVAy2jxyPcPr3SWCq5w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: false
+
+  /@typescript-eslint/typescript-estree/5.39.0_typescript@4.9.5:
     resolution: {integrity: sha512-qLFQP0f398sdnogJoLtd43pUgB18Q50QSA+BTE5h3sUxySzbWDpTSdgt4UyxNSozY/oDK2ta6HVAzvGgq8JYnA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6121,13 +6150,34 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@5.0.2
-      typescript: 5.0.2
+      tsutils: 3.21.0_typescript@4.9.5
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/utils/5.39.0_kykkfgtuomzgyhxd4xxwxcydwe:
+  /@typescript-eslint/typescript-estree/5.56.0_typescript@4.9.5:
+    resolution: {integrity: sha512-41CH/GncsLXOJi0jb74SnC7jVPWeVJ0pxQj8bOjH1h2O26jXN3YHKDT1ejkVz5YeTEQPeLCCRY0U2r68tfNOcg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.56.0
+      '@typescript-eslint/visitor-keys': 5.56.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.8
+      tsutils: 3.21.0_typescript@4.9.5
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@typescript-eslint/utils/5.39.0_mx6jhvnay66odhn2yt7eqo2wou:
     resolution: {integrity: sha512-+DnY5jkpOpgj+EBtYPyHRjXampJfC0yUZZzfzLuUWVZvCuKqSdJVC8UhdWipIw7VKNTfwfAPiOWzYkAwuIhiAg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6136,10 +6186,30 @@ packages:
       '@types/json-schema': 7.0.9
       '@typescript-eslint/scope-manager': 5.39.0
       '@typescript-eslint/types': 5.39.0
-      '@typescript-eslint/typescript-estree': 5.39.0_typescript@5.0.2
+      '@typescript-eslint/typescript-estree': 5.39.0_typescript@4.9.5
       eslint: 8.25.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.25.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: false
+
+  /@typescript-eslint/utils/5.56.0_mx6jhvnay66odhn2yt7eqo2wou:
+    resolution: {integrity: sha512-XhZDVdLnUJNtbzaJeDSCIYaM+Tgr59gZGbFuELgF7m0IY03PlciidS7UQNKLE0+WpUTn1GlycEr6Ivb/afjbhA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.3.0_eslint@8.25.0
+      '@types/json-schema': 7.0.9
+      '@types/semver': 7.3.13
+      '@typescript-eslint/scope-manager': 5.56.0
+      '@typescript-eslint/types': 5.56.0
+      '@typescript-eslint/typescript-estree': 5.56.0_typescript@4.9.5
+      eslint: 8.25.0
+      eslint-scope: 5.1.1
+      semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -6150,6 +6220,14 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.39.0
+      eslint-visitor-keys: 3.3.0
+    dev: false
+
+  /@typescript-eslint/visitor-keys/5.56.0:
+    resolution: {integrity: sha512-1mFdED7u5bZpX6Xxf5N9U2c18sb+8EvU3tyOIj6LQZ5OOvnmj8BVeNNP603OFPm5KkS1a7IvCIcwrdHXaEMG/Q==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.56.0
       eslint-visitor-keys: 3.3.0
     dev: false
 
@@ -6550,7 +6628,7 @@ packages:
       '@vue/server-renderer': 3.2.47_vue@3.2.47
     dev: true
 
-  /@vue/vue3-jest/29.2.3_32lqfenomsc3abepab4t3psgtm:
+  /@vue/vue3-jest/29.2.3_3ct2qspsll5oznyljmocvlpxry:
     resolution: {integrity: sha512-wbit0rGgy9ARUBtc5dZ6PGCrxazCPs5pZ6ycB0qYMoEPmkRj8lIVUfJmTz03ryIAeVQOcTKnEWdcqgrTErl3vg==}
     engines: {node: '>10'}
     peerDependencies:
@@ -6572,7 +6650,7 @@ packages:
       jest: 29.5.0_35bb52e3ngsl3trrvg3csiponq
       source-map: 0.5.6
       tsconfig: 7.0.0
-      typescript: 5.0.2
+      typescript: 4.9.5
       vue: 3.2.47
     transitivePeerDependencies:
       - supports-color
@@ -10724,8 +10802,8 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-prettier/8.5.0_eslint@8.25.0:
-    resolution: {integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==}
+  /eslint-config-prettier/8.8.0_eslint@8.25.0:
+    resolution: {integrity: sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
@@ -10742,7 +10820,7 @@ packages:
       eslint-plugin-promise: ^6.0.0
     dependencies:
       eslint: 8.25.0
-      eslint-plugin-import: 2.26.0_dzvnzej2un7roooznz6ef2if2q
+      eslint-plugin-import: 2.26.0_nrmemtbccfexnzqti5ajbh4zje
       eslint-plugin-n: 15.3.0_eslint@8.25.0
       eslint-plugin-promise: 6.0.1_eslint@8.25.0
     dev: false
@@ -10756,7 +10834,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-module-utils/2.7.3_zgjfcdlr3zhegzdqses2t5vk6u:
+  /eslint-module-utils/2.7.3_7tkqywrydjbibzbrmc2verxdma:
     resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -10774,7 +10852,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.39.0_kykkfgtuomzgyhxd4xxwxcydwe
+      '@typescript-eslint/parser': 5.56.0_mx6jhvnay66odhn2yt7eqo2wou
       debug: 3.2.7
       eslint-import-resolver-node: 0.3.6
       find-up: 2.1.0
@@ -10804,7 +10882,7 @@ packages:
       regexpp: 3.2.0
     dev: false
 
-  /eslint-plugin-import/2.26.0_dzvnzej2un7roooznz6ef2if2q:
+  /eslint-plugin-import/2.26.0_nrmemtbccfexnzqti5ajbh4zje:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -10814,14 +10892,14 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.39.0_kykkfgtuomzgyhxd4xxwxcydwe
+      '@typescript-eslint/parser': 5.56.0_mx6jhvnay66odhn2yt7eqo2wou
       array-includes: 3.1.4
       array.prototype.flat: 1.2.5
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 8.25.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3_zgjfcdlr3zhegzdqses2t5vk6u
+      eslint-module-utils: 2.7.3_7tkqywrydjbibzbrmc2verxdma
       has: 1.0.3
       is-core-module: 2.8.1
       is-glob: 4.0.3
@@ -10835,7 +10913,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-plugin-jest/27.1.1_hkge35widolnwjodmm6vh6gaau:
+  /eslint-plugin-jest/27.1.1_dx4g5dh3kehlsydvljq6ykvwpy:
     resolution: {integrity: sha512-vuSuXGKHHi/UAffIM46QKm4g0tQP+6n52nRxUpMq6x6x9rhnv5WM7ktSu3h9cTnXE4b0Y0ODQTgRlCm9rdRLvg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -10848,8 +10926,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.39.0_6wiyttdjmhjpssagtvxtrkkpra
-      '@typescript-eslint/utils': 5.39.0_kykkfgtuomzgyhxd4xxwxcydwe
+      '@typescript-eslint/eslint-plugin': 5.56.0_rpapdhxtx74uxdjbku4mlaih5a
+      '@typescript-eslint/utils': 5.39.0_mx6jhvnay66odhn2yt7eqo2wou
       eslint: 8.25.0
     transitivePeerDependencies:
       - supports-color
@@ -10907,7 +10985,7 @@ packages:
       eslint: 8.25.0
     dev: false
 
-  /eslint-plugin-unused-imports/2.0.0_fd4zt552xrtdl27rs5sr76joou:
+  /eslint-plugin-unused-imports/2.0.0_nhjeqhichv7xdxjeodsqjgdadu:
     resolution: {integrity: sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -10917,7 +10995,7 @@ packages:
       '@typescript-eslint/eslint-plugin':
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.39.0_6wiyttdjmhjpssagtvxtrkkpra
+      '@typescript-eslint/eslint-plugin': 5.56.0_rpapdhxtx74uxdjbku4mlaih5a
       eslint: 8.25.0
       eslint-rule-composer: 0.3.0
     dev: false
@@ -12022,7 +12100,7 @@ packages:
       glob: 7.2.0
       parse5: 6.0.1
       pofile: 1.0.11
-      typescript: 4.9.4
+      typescript: 4.9.5
 
   /git-repo-info/2.1.1:
     resolution: {integrity: sha512-8aCohiDo4jwjOwma4FmYFd3i97urZulL8XL24nIPxuE+GZnfsAyy/g2Shqx6OjUiFKUXZM+Yy+KHnOmmA3FVcg==}
@@ -13442,7 +13520,7 @@ packages:
       pretty-format: 27.5.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_b2u7dz2qqrl5aoicdb73uu2awe
+      ts-node: 10.9.1_iedef3djpnfxdpbmfr4x6l3blq
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -13523,7 +13601,7 @@ packages:
       pretty-format: 29.5.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_b2u7dz2qqrl5aoicdb73uu2awe
+      ts-node: 10.9.1_iedef3djpnfxdpbmfr4x6l3blq
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13917,15 +13995,15 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jest-mock-extended/3.0.1_44ttdtjaknnkcgzh5px4h2qxl4:
+  /jest-mock-extended/3.0.1_doipufordlnvh5g4adbwayvyvy:
     resolution: {integrity: sha512-RF4Ow8pXvbRuEcCTj56oYHmig5311BSFvbEGxPNYL51wGKGu93MvVQgx0UpFmjqyBXIcElkZo2Rke88kR1iSKQ==}
     peerDependencies:
       jest: ^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0
       typescript: ^3.0.0 || ^4.0.0
     dependencies:
       jest: 29.5.0_35bb52e3ngsl3trrvg3csiponq
-      ts-essentials: 7.0.3_typescript@5.0.2
-      typescript: 5.0.2
+      ts-essentials: 7.0.3_typescript@4.9.5
+      typescript: 4.9.5
     dev: true
 
   /jest-mock/27.5.1:
@@ -15886,6 +15964,10 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /natural-compare-lite/1.4.0:
+    resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
+    dev: false
 
   /natural-compare/1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -20316,15 +20398,15 @@ packages:
     engines: {node: '>=6.10'}
     dev: true
 
-  /ts-essentials/7.0.3_typescript@5.0.2:
+  /ts-essentials/7.0.3_typescript@4.9.5:
     resolution: {integrity: sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==}
     peerDependencies:
       typescript: '>=3.7.0'
     dependencies:
-      typescript: 5.0.2
+      typescript: 4.9.5
     dev: true
 
-  /ts-jest/29.0.5_oiqch47h7k6spjal2ttwsnwsdm:
+  /ts-jest/29.0.5_ytzn2be2wlngdyaxw5jrml6jvi:
     resolution: {integrity: sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -20355,7 +20437,7 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.3.8
-      typescript: 5.0.2
+      typescript: 4.9.5
       yargs-parser: 21.1.1
     dev: true
 
@@ -20363,7 +20445,7 @@ packages:
     resolution: {integrity: sha512-vDWbsl26LIcPGmDpoVzjEP6+hvHZkBkLW7JpvwbCv/5IYPJlsbzCVXY3wsCeAxAUeTclNOUZxnLdGh3VBD/J6w==}
     dev: true
 
-  /ts-node/10.9.1_b2u7dz2qqrl5aoicdb73uu2awe:
+  /ts-node/10.9.1_iedef3djpnfxdpbmfr4x6l3blq:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -20389,7 +20471,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.0.2
+      typescript: 4.9.5
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
@@ -20426,14 +20508,14 @@ packages:
   /tslib/2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
 
-  /tsutils/3.21.0_typescript@5.0.2:
+  /tsutils/3.21.0_typescript@4.9.5:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.0.2
+      typescript: 4.9.5
     dev: false
 
   /tty-browserify/0.0.0:
@@ -20536,14 +20618,9 @@ packages:
     hasBin: true
     dev: true
 
-  /typescript/4.9.4:
-    resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==}
+  /typescript/4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
-    hasBin: true
-
-  /typescript/5.0.2:
-    resolution: {integrity: sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==}
-    engines: {node: '>=12.20'}
     hasBin: true
 
   /typical/4.0.0:
@@ -21383,7 +21460,7 @@ packages:
     resolution: {integrity: sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==}
     dev: true
 
-  /vue-tsc/1.3.4_typescript@5.0.2:
+  /vue-tsc/1.3.4_typescript@4.9.5:
     resolution: {integrity: sha512-EF+AyuisIChY4UO2WQTG/tia/qx92IGWmh2NFara8r/iaX/ADCRtmBKAxQ8pgrfcy6BmiXdaIuGUur5m4ftNcQ==}
     hasBin: true
     peerDependencies:
@@ -21391,7 +21468,7 @@ packages:
     dependencies:
       '@volar/vue-language-core': 1.3.4
       '@volar/vue-typescript': 1.3.4
-      typescript: 5.0.2
+      typescript: 4.9.5
     dev: true
 
   /vue/3.2.47:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -638,7 +638,7 @@ importers:
       '@uppy/xhr-upload': ^3.0.1
       '@vueuse/head': 1.1.23
       axios: ^0.27.2
-      easygettext: https://github.com/owncloud/easygettext/archive/refs/tags/v2.18.1-oc.tar.gz
+      easygettext: https://github.com/owncloud/easygettext/archive/refs/tags/v2.18.2-oc.tar.gz
       filesize: ^9.0.11
       focus-trap: ^7.2.0
       focus-trap-vue: ^4.0.1
@@ -686,7 +686,7 @@ importers:
       '@uppy/xhr-upload': 3.0.1_@uppy+core@3.0.5
       '@vueuse/head': 1.1.23_vue@3.2.47
       axios: 0.27.2
-      easygettext: '@github.com/owncloud/easygettext/archive/refs/tags/v2.18.1-oc.tar.gz'
+      easygettext: '@github.com/owncloud/easygettext/archive/refs/tags/v2.18.2-oc.tar.gz_typescript@4.9.5'
       filesize: 9.0.11
       focus-trap: 7.2.0
       focus-trap-vue: 4.0.1_sc5smigrnndzyzpmn4n4e4xcs4
@@ -22190,14 +22190,16 @@ packages:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
     dev: true
 
-  '@github.com/owncloud/easygettext/archive/refs/tags/v2.18.1-oc.tar.gz':
-    resolution: {tarball: https://github.com/owncloud/easygettext/archive/refs/tags/v2.18.1-oc.tar.gz}
+  '@github.com/owncloud/easygettext/archive/refs/tags/v2.18.2-oc.tar.gz_typescript@4.9.5':
+    resolution: {tarball: https://github.com/owncloud/easygettext/archive/refs/tags/v2.18.2-oc.tar.gz}
+    id: '@github.com/owncloud/easygettext/archive/refs/tags/v2.18.2-oc.tar.gz'
     name: easygettext
     version: 2.16.0
     engines: {node: '>=8'}
     hasBin: true
     dependencies:
       '@babel/core': 7.20.12
+      '@typescript-eslint/typescript-estree': 5.56.0_typescript@4.9.5
       acorn: 7.4.1
       acorn-stage3: 4.0.0_acorn@7.4.1
       acorn-walk: 8.2.0
@@ -22211,6 +22213,7 @@ packages:
       pug: 3.0.2
     transitivePeerDependencies:
       - supports-color
+      - typescript
     dev: false
 
   github.com/dschmidt/v-calendar/3ce6e3b8afd5491cb53ee811281d5fa8a45b044d_vue@3.2.47:


### PR DESCRIPTION
## Description
This downgrades TypeScript to 4.9.5 until `ts-jest` supports TypeScript 5.

Moreover, this updates a bunch of dependencies to work with TypeScript 5 so we are ready when `ts-jest` is ready.
This also avoids warning about TypeScript 4.9.5 not being supported.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
