### PR TITLE
[tests-only][full-ci] Added e2e tests for filtering users list by role

### DIFF
--- a/tests/e2e/cucumber/features/smoke/admin-settings/users.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/admin-settings/users.ocis.feature
@@ -136,9 +136,22 @@ Feature: users management
       | Alice |
       | Brian |
       | Carol |
+      | Marie |
     And "Admin" logs in
     And "Admin" opens the "admin-settings" app
     And "Admin" navigates to the users management page
+    And "Admin" changes role to "Space Admin" for user "Marie" using the sidebar panel
+    When "Admin" sets the following filter
+      | filter | values     |
+      | roles  | User,Admin |
+    Then "Admin" should see the following users
+      | user  |
+      | Alice |
+      | Brian |
+      | Carol |
+    And "Admin" should not see the following users
+      | user  |
+      | Marie |
     When "Admin" deletes the following users using the batch actions
       | id    |
       | Alice |


### PR DESCRIPTION
## Description
Added e2e test for filtering users list by user role

## Related Issue
Part of https://github.com/owncloud/web/issues/8601

## How Has This Been Tested?
- test environment: local

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
