### PR TITLE
[tests-only][full-ci] Check multiple response

### DIFF
--- a/tests/e2e/cucumber/features/smoke/admin-settings/spaces.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/admin-settings/spaces.ocis.feature
@@ -82,12 +82,12 @@ Feature: spaces management
       | team.b |
       | team.c |
       | team.d |
-    # Then "Alice" should not see the following spaces
-    #   | id     |
-    #   | team.a |
-    #   | team.b |
-    #   | team.c |
-    #   | team.d |
+    Then "Alice" should not see the following spaces
+      | id     |
+      | team.a |
+      | team.b |
+      | team.c |
+      | team.d |
     And "Alice" logs out
 
 

--- a/tests/e2e/cucumber/steps/ui/adminSettings.ts
+++ b/tests/e2e/cucumber/steps/ui/adminSettings.ts
@@ -45,13 +45,13 @@ When(
 
     switch (action) {
       case 'disables':
-        await spacesObject.disable({ key, context: 'context-menu' })
+        await spacesObject.disable({ spaces: [key], context: 'context-menu' })
         break
       case 'deletes':
-        await spacesObject.delete({ key, context: 'context-menu' })
+        await spacesObject.delete({ spaces: [key], context: 'context-menu' })
         break
       case 'enables':
-        await spacesObject.enable({ key, context: 'context-menu' })
+        await spacesObject.enable({ spaces: [key], context: 'context-menu' })
         break
       default:
         throw new Error(`${action} not implemented`)
@@ -80,7 +80,7 @@ When(
         await spacesObject.changeSubtitle({ key, value })
         break
       case 'quota':
-        await spacesObject.changeQuota({ key, value, context: 'context-menu' })
+        await spacesObject.changeQuota({ spaces: [key], value, context: 'context-menu' })
         break
       default:
         throw new Error(`'${action}' not implemented`)
@@ -98,11 +98,13 @@ When(
   ): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const spacesObject = new objects.applicationAdminSettings.Spaces({ page })
+    const spaces = []
     for (const info of stepTable.hashes()) {
+      spaces.push(info.id)
       await spacesObject.select({ key: info.id })
     }
     await spacesObject.changeQuota({
-      key: stepTable.hashes()[0].id,
+      spaces,
       value,
       context: 'batch-actions'
     })
@@ -119,18 +121,20 @@ When(
   ): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const spacesObject = new objects.applicationAdminSettings.Spaces({ page })
+    const spaces = []
     for (const info of stepTable.hashes()) {
+      spaces.push(info.id)
       await spacesObject.select({ key: info.id })
     }
     switch (action) {
       case 'disables':
-        await spacesObject.disable({ key: stepTable.hashes()[0].id, context: 'batch-actions' })
+        await spacesObject.disable({ spaces, context: 'batch-actions' })
         break
       case 'deletes':
-        await spacesObject.delete({ key: stepTable.hashes()[0].id, context: 'batch-actions' })
+        await spacesObject.delete({ spaces, context: 'batch-actions' })
         break
       case 'enables':
-        await spacesObject.enable({ key: stepTable.hashes()[0].id, context: 'batch-actions' })
+        await spacesObject.enable({ spaces, context: 'batch-actions' })
         break
       default:
         throw new Error(`'${action}' not implemented`)

--- a/tests/e2e/support/objects/app-admin-settings/spaces/actions.ts
+++ b/tests/e2e/support/objects/app-admin-settings/spaces/actions.ts
@@ -204,7 +204,7 @@ const confirmAction = async (args: {
 
   const checkResponses = []
   for (const id of spaceIds) {
-    checkResponses.push(() =>
+    checkResponses.push(
       page.waitForResponse(
         (resp) =>
           resp.url().endsWith(encodeURIComponent(id)) &&

--- a/tests/e2e/support/objects/app-admin-settings/spaces/actions.ts
+++ b/tests/e2e/support/objects/app-admin-settings/spaces/actions.ts
@@ -2,7 +2,8 @@ import { Page } from 'playwright'
 import util from 'util'
 import { locatorUtils } from '../../../utils'
 
-const spaceTrSelector = 'tr'
+const spaceTrSelector = '.spaces-table tbody > tr'
+const spacesEmptySelector = '#admin-settings-spaces-empty'
 const actionConfirmButton = '.oc-modal-body-actions-confirm'
 const spaceIdSelector = `[data-item-id="%s"] .spaces-table-btn-action-dropdown`
 const spaceCheckboxSelector = `[data-item-id="%s"]:not(.oc-table-highlighted) input[type=checkbox]`
@@ -26,7 +27,15 @@ const spaceMemberList =
 
 export const getDisplayedSpaces = async (page): Promise<string[]> => {
   const spaces = []
-  const result = page.locator(spaceTrSelector)
+  try {
+    // check if the list is empty
+    // early return if there are no spaces
+    await page.waitForSelector(spacesEmptySelector, { timeout: 500 })
+    return spaces
+  } catch (e) {
+    console.log('[INFO] Spaces list is not empty')
+  }
+  const result = await page.locator(spaceTrSelector)
 
   const count = await result.count()
   for (let i = 0; i < count; i++) {

--- a/tests/e2e/support/objects/app-admin-settings/spaces/actions.ts
+++ b/tests/e2e/support/objects/app-admin-settings/spaces/actions.ts
@@ -3,9 +3,8 @@ import util from 'util'
 import { locatorUtils } from '../../../utils'
 
 const spaceTrSelector = '.spaces-table tbody > tr'
-const spacesEmptySelector = '#admin-settings-spaces-empty'
 const actionConfirmButton = '.oc-modal-body-actions-confirm'
-const spaceIdSelector = `[data-item-id="%s"] .spaces-table-btn-action-dropdown`
+const contextMenuSelector = `[data-item-id="%s"] .spaces-table-btn-action-dropdown`
 const spaceCheckboxSelector = `[data-item-id="%s"]:not(.oc-table-highlighted) input[type=checkbox]`
 const contextMenuActionButton = `.oc-files-actions-%s-trigger`
 const inputFieldSelector =
@@ -27,14 +26,6 @@ const spaceMemberList =
 
 export const getDisplayedSpaces = async (page): Promise<string[]> => {
   const spaces = []
-  try {
-    // check if the list is empty
-    // early return if there are no spaces
-    await page.waitForSelector(spacesEmptySelector, { timeout: 500 })
-    return spaces
-  } catch (e) {
-    console.log('[INFO] Spaces list is not empty')
-  }
   const result = await page.locator(spaceTrSelector)
 
   const count = await result.count()
@@ -45,17 +36,16 @@ export const getDisplayedSpaces = async (page): Promise<string[]> => {
   return spaces
 }
 
-const clickOnContextMenuActionButton = async (args: {
+const performAction = async (args: {
   page: Page
-  id: string
   action: string
-  isBatchActions: boolean
+  context: string
+  id?: string
 }): Promise<void> => {
-  const { page, id, action, isBatchActions } = args
-  let context = '.batch-actions'
-  if (!isBatchActions) {
-    context = '.context-menu'
-    await page.locator(util.format(spaceIdSelector, id)).click()
+  const { page, action, context, id } = args
+
+  if (id && context === 'context-menu') {
+    await page.locator(util.format(contextMenuSelector, id)).click()
   }
 
   let contextMenuActionButtonSelector = null
@@ -82,83 +72,75 @@ const clickOnContextMenuActionButton = async (args: {
       throw new Error(`${action} not implemented`)
   }
   await page.waitForSelector(contextMenuActionButtonSelector)
-  await page.locator(context).locator(contextMenuActionButtonSelector).click()
+  await page.locator(`.${context}`).locator(contextMenuActionButtonSelector).click()
 }
 
 export const changeSpaceQuota = async (args: {
   page: Page
-  id: string
+  spaceIds: string[]
   value: string
   context: string
 }): Promise<void> => {
-  const { page, value, id, context } = args
-  const action = 'edit-quota'
-  const isBatchActions = context === 'batch-actions'
-  await clickOnContextMenuActionButton({ page, id, action, isBatchActions })
+  const { page, value, spaceIds, context } = args
+  await performAction({ page, action: 'edit-quota', context, id: spaceIds[0] })
+
   const searchLocator = await page.locator(spacesQuotaSearchField)
   await searchLocator.fill(value)
   await page.waitForSelector(selectedQuotaValueField)
   await page.locator(util.format(quotaValueDropDown, `${value} GB`)).click()
-  await waitForSpaceResponse({
+  await confirmAction({
     page,
     method: 'PATCH',
     statusCode: 200,
-    isBatchActions,
-    id,
+    spaceIds,
     actionConfirm: true
   })
 }
 
 export const disableSpace = async (args: {
   page: Page
-  id: string
+  spaceIds: string[]
   context: string
 }): Promise<void> => {
-  const { page, id, context } = args
-  const isBatchActions = context === 'batch-actions'
-  await clickOnContextMenuActionButton({ page, id, action: 'disable', isBatchActions })
-  await waitForSpaceResponse({
+  const { page, spaceIds, context } = args
+  await performAction({ page, action: 'disable', context, id: spaceIds[0] })
+  await confirmAction({
     page,
     method: 'DELETE',
     statusCode: 204,
-    isBatchActions,
-    id,
+    spaceIds,
     actionConfirm: false
   })
 }
 
 export const enableSpace = async (args: {
   page: Page
-  id: string
+  spaceIds: string[]
   context: string
 }): Promise<void> => {
-  const { page, id, context } = args
-  const isBatchActions = context === 'batch-actions'
-  await clickOnContextMenuActionButton({ page, id, action: 'restore', isBatchActions })
-  await waitForSpaceResponse({
+  const { page, spaceIds, context } = args
+  await performAction({ page, action: 'restore', context, id: spaceIds[0] })
+  await confirmAction({
     page,
     method: 'PATCH',
     statusCode: 200,
-    isBatchActions,
-    id,
+    spaceIds,
     actionConfirm: false
   })
 }
 
 export const deleteSpace = async (args: {
   page: Page
-  id: string
+  spaceIds: string[]
   context: string
 }): Promise<void> => {
-  const { page, id, context } = args
-  const isBatchActions = context === 'batch-actions'
-  await clickOnContextMenuActionButton({ page, id, action: 'delete', isBatchActions })
-  await waitForSpaceResponse({
+  const { page, spaceIds, context } = args
+  await performAction({ page, action: 'delete', context, id: spaceIds[0] })
+  await confirmAction({
     page,
     method: 'DELETE',
     statusCode: 204,
-    isBatchActions,
-    id,
+    spaceIds,
     actionConfirm: false
   })
 }
@@ -179,16 +161,13 @@ export const renameSpace = async (args: {
   value: string
 }): Promise<void> => {
   const { page, id, value } = args
-  const action = 'rename'
-  const isBatchActions = false
-  await clickOnContextMenuActionButton({ page, id, action, isBatchActions })
+  await performAction({ page, action: 'rename', context: 'context-menu', id })
   await page.locator(inputFieldSelector).fill(value)
-  await waitForSpaceResponse({
+  await confirmAction({
     page,
     method: 'PATCH',
     statusCode: 200,
-    isBatchActions,
-    id,
+    spaceIds: [id],
     actionConfirm: true
   })
 }
@@ -199,47 +178,44 @@ export const changeSpaceSubtitle = async (args: {
   value: string
 }): Promise<void> => {
   const { page, id, value } = args
-  const isBatchActions = false
-  await clickOnContextMenuActionButton({
-    page,
-    id,
-    action: 'edit-description',
-    isBatchActions
-  })
+  await performAction({ page, action: 'edit-description', context: 'context-menu', id })
   await page.locator(inputFieldSelector).fill(value)
-  await waitForSpaceResponse({
+  await confirmAction({
     page,
     method: 'PATCH',
     statusCode: 200,
-    isBatchActions,
-    id,
+    spaceIds: [id],
     actionConfirm: true
   })
 }
 
-const waitForSpaceResponse = async (args: {
+const confirmAction = async (args: {
   page: Page
   method: string
   statusCode: number
-  isBatchActions: boolean
-  id: string
+  spaceIds: string[]
   actionConfirm: boolean
 }): Promise<void> => {
-  const { page, method, statusCode, isBatchActions, id, actionConfirm } = args
+  const { page, method, statusCode, spaceIds, actionConfirm } = args
   let confirmButton = modalConfirmBtn
   if (actionConfirm) {
     confirmButton = actionConfirmButton
   }
+
+  const checkResponses = []
+  for (const id of spaceIds) {
+    checkResponses.push(() =>
+      page.waitForResponse(
+        (resp) =>
+          resp.url().endsWith(encodeURIComponent(id)) &&
+          resp.status() === statusCode &&
+          resp.request().method() === method
+      )
+    )
+  }
+
   await page.waitForSelector(confirmButton)
-  await Promise.all([
-    page.waitForResponse(
-      (resp) =>
-        (isBatchActions || resp.url().endsWith(encodeURIComponent(id))) &&
-        resp.status() === statusCode &&
-        resp.request().method() === method
-    ),
-    page.locator(confirmButton).click()
-  ])
+  await Promise.all([...checkResponses, page.locator(confirmButton).click()])
 }
 
 export const openSpaceAdminSidebarPanel = async (args: {

--- a/tests/e2e/support/objects/app-admin-settings/spaces/index.ts
+++ b/tests/e2e/support/objects/app-admin-settings/spaces/index.ts
@@ -43,7 +43,7 @@ export class Spaces {
   }): Promise<void> {
     const spaceIds = []
     for (const space of spaces) {
-      spaceIds.push(this.#spacesEnvironment.getSpace({ key: space }))
+      spaceIds.push(this.#spacesEnvironment.getSpace({ key: space }).id)
     }
     await changeSpaceQuota({ spaceIds, value, page: this.#page, context })
   }
@@ -51,7 +51,7 @@ export class Spaces {
   async disable({ spaces, context }: { spaces: string[]; context: string }): Promise<void> {
     const spaceIds = []
     for (const space of spaces) {
-      spaceIds.push(this.#spacesEnvironment.getSpace({ key: space }))
+      spaceIds.push(this.#spacesEnvironment.getSpace({ key: space }).id)
     }
     await disableSpace({ spaceIds, page: this.#page, context })
   }
@@ -59,7 +59,7 @@ export class Spaces {
   async enable({ spaces, context }: { spaces: string[]; context: string }): Promise<void> {
     const spaceIds = []
     for (const space of spaces) {
-      spaceIds.push(this.#spacesEnvironment.getSpace({ key: space }))
+      spaceIds.push(this.#spacesEnvironment.getSpace({ key: space }).id)
     }
     await enableSpace({ spaceIds, page: this.#page, context })
   }
@@ -67,7 +67,7 @@ export class Spaces {
   async delete({ spaces, context }: { spaces: string[]; context: string }): Promise<void> {
     const spaceIds = []
     for (const space of spaces) {
-      spaceIds.push(this.#spacesEnvironment.getSpace({ key: space }))
+      spaceIds.push(this.#spacesEnvironment.getSpace({ key: space }).id)
     }
     await deleteSpace({ spaceIds, page: this.#page, context })
   }

--- a/tests/e2e/support/objects/app-admin-settings/spaces/index.ts
+++ b/tests/e2e/support/objects/app-admin-settings/spaces/index.ts
@@ -33,31 +33,43 @@ export class Spaces {
   }
 
   async changeQuota({
-    key,
+    spaces,
     value,
     context
   }: {
-    key: string
+    spaces: string[]
     value: string
     context: string
   }): Promise<void> {
-    const { id } = this.#spacesEnvironment.getSpace({ key })
-    await changeSpaceQuota({ id, value, page: this.#page, context })
+    const spaceIds = []
+    for (const space of spaces) {
+      spaceIds.push(this.#spacesEnvironment.getSpace({ key: space }))
+    }
+    await changeSpaceQuota({ spaceIds, value, page: this.#page, context })
   }
 
-  async disable({ key, context }: { key: string; context: string }): Promise<void> {
-    const { id } = this.#spacesEnvironment.getSpace({ key })
-    await disableSpace({ id, page: this.#page, context })
+  async disable({ spaces, context }: { spaces: string[]; context: string }): Promise<void> {
+    const spaceIds = []
+    for (const space of spaces) {
+      spaceIds.push(this.#spacesEnvironment.getSpace({ key: space }))
+    }
+    await disableSpace({ spaceIds, page: this.#page, context })
   }
 
-  async enable({ key, context }: { key: string; context: string }): Promise<void> {
-    const { id } = this.#spacesEnvironment.getSpace({ key })
-    await enableSpace({ id, page: this.#page, context })
+  async enable({ spaces, context }: { spaces: string[]; context: string }): Promise<void> {
+    const spaceIds = []
+    for (const space of spaces) {
+      spaceIds.push(this.#spacesEnvironment.getSpace({ key: space }))
+    }
+    await enableSpace({ spaceIds, page: this.#page, context })
   }
 
-  async delete({ key, context }: { key: string; context: string }): Promise<void> {
-    const { id } = this.#spacesEnvironment.getSpace({ key })
-    await deleteSpace({ id, page: this.#page, context })
+  async delete({ spaces, context }: { spaces: string[]; context: string }): Promise<void> {
+    const spaceIds = []
+    for (const space of spaces) {
+      spaceIds.push(this.#spacesEnvironment.getSpace({ key: space }))
+    }
+    await deleteSpace({ spaceIds, page: this.#page, context })
   }
 
   async select({ key }: { key: string }): Promise<void> {


### PR DESCRIPTION
Implemented differently. 
we check each response while deleting spaces

## Description
Sometimes the selector `spaceTrSelector` can resolve to some elements in the spaces list even though the view would change to an `empty` view later. This behavior causes the tests to be flaky (see https://github.com/owncloud/web/issues/8648#issuecomment-1480853116) 

I have added a check for empty view before trying to get the spaces list and early return if the empty view is present.

![Screenshot from 2023-03-23 15-39-40](https://user-images.githubusercontent.com/52366632/227167186-f006c58c-db91-41f1-bc5f-9b6301611128.png)

## Related Issue
Part of https://github.com/owncloud/web/issues/8648

## Motivation and Context

## How Has This Been Tested?
- test environment: local

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
