### PR TITLE
Bugfix: Broken re-login after logout fails

### DIFF
--- a/changelog/unreleased/bugfix-oidc-logout-query-param-replication
+++ b/changelog/unreleased/bugfix-oidc-logout-query-param-replication
@@ -1,0 +1,6 @@
+Bugfix: Broken re-login after logout
+
+After a user logged out, it was no longer possible to login without reloading the ocis root domain,
+this has now been fixed and only allowed query-params are taken into account.
+
+https://github.com/owncloud/web/pull/8694

--- a/packages/web-runtime/src/router/helpers.ts
+++ b/packages/web-runtime/src/router/helpers.ts
@@ -1,5 +1,6 @@
 import { base, router } from './index'
 import { RouteLocation, RouteParams, Router, RouteRecordNormalized } from 'vue-router'
+import pick from 'lodash-es/pick'
 import {
   AuthContext,
   authContextValues,
@@ -10,7 +11,18 @@ import {
 export const buildUrl = (pathname) => {
   const isHistoryMode = !!base
   const baseUrl = new URL(window.location.href.split('#')[0])
-  baseUrl.search = window.location.search
+
+  // searchParams defines a set of search parameters which should be part of new url.
+  // The resulting querystring only contains the properties listed here.
+  const searchParams = new URLSearchParams(
+    pick(Object.fromEntries(new URLSearchParams(window.location.search).entries()), [
+      // needed for private links
+      'details'
+    ])
+  ).toString()
+
+  baseUrl.search = searchParams
+
   if (isHistoryMode) {
     // in history mode we can't determine the base path, it must be provided by the document
     baseUrl.pathname = new URL(base.href).pathname

--- a/packages/web-runtime/tests/unit/router/index.spec.ts
+++ b/packages/web-runtime/tests/unit/router/index.spec.ts
@@ -15,6 +15,9 @@ describe('buildUrl', () => {
     ${'https://localhost:9200/files/list/all'}                                        | ${'/foo'}                    | ${'/login/foo'} | ${'https://localhost:9200/foo/login/foo'}
     ${'https://localhost:9200/files/list/all'}                                        | ${'/'}                       | ${'/bar.html'}  | ${'https://localhost:9200/bar.html'}
     ${'https://localhost:9200/files/list/all'}                                        | ${'/foo'}                    | ${'/bar.html'}  | ${'https://localhost:9200/foo/bar.html'}
+    ${'https://localhost:9200/files/list/all?details=91953740'}                       | ${'/foo'}                    | ${'/bar.html'}  | ${'https://localhost:9200/foo/bar.html?details=91953740'}
+    ${'https://localhost:9200/files/list/all?details=91953740&unknown=87987987'}      | ${'/foo'}                    | ${'/bar.html'}  | ${'https://localhost:9200/foo/bar.html?details=91953740'}
+    ${'https://localhost:9200/files/list/all?unknown=87987987'}                       | ${'/foo'}                    | ${'/bar.html'}  | ${'https://localhost:9200/foo/bar.html'}
   `('$path -> $expected', async ({ location, base, path, expected }) => {
     delete window.location
     window.location = new URL(location) as any

--- a/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
+++ b/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
@@ -1,0 +1,27 @@
+import { AuthService } from 'web-runtime/src/services/auth/authService'
+
+describe('AuthService', () => {
+  describe('signInCallback', () => {
+    it.each([
+      [{ details: 'details' }, { details: 'details' }],
+      [{ details: 'details', unknown: 'unknown' }, { details: 'details' }],
+      [{ unknown: 'unknown' }, {}]
+    ])('forwards only whitelisted query parameters: %s = %s', async (query, expected: any) => {
+      const authService = new AuthService()
+      const replace = jest.fn()
+
+      jest.replaceProperty(authService as any, 'userManager', {
+        signinRedirectCallback: jest.fn(),
+        getAndClearPostLoginRedirectUrl: jest.fn()
+      })
+
+      jest.replaceProperty(authService as any, 'router', {
+        currentRoute: { query },
+        replace
+      })
+      await authService.signInCallback()
+
+      expect(replace.mock.calls[0][0].query).toEqual(expected)
+    })
+  })
+})


### PR DESCRIPTION
## Description
After a user logged out, it was no longer possible to re-login without reloading the ocis root domain,
this has now been fixed and only whitelisted query-params are taken into account in the logout url-replace.

## How Has This Been Tested?
- unit test
- manual testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] ~~New feature (non-breaking change which adds functionality)~~
- [ ] ~~Breaking change (fix or feature that would cause existing functionality to change)~~
- [ ] ~~Technical debt~~
- [X] Tests

## Checklist:
- [X] Code changes
- [X] Unit tests added
- [ ] ~~Acceptance tests added~~
- [ ] ~~Documentation ticket raised~~