### PR TITLE
[full-ci][tests-only] Added wait for responses after batch actions

### DIFF
--- a/tests/e2e/cucumber/features/smoke/admin-settings/users.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/admin-settings/users.ocis.feature
@@ -68,7 +68,7 @@ Feature: users management
       | Alice |
       | Brian |
       | Carol |
-    And "Admin" removes the following users from the groups "sales department,finance department" using the batch actions
+    And "Admin" removes the following users from the groups "sales,finance" using the batch actions
       | user  |
       | Alice |
       | Brian |

--- a/tests/e2e/cucumber/features/smoke/admin-settings/users.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/admin-settings/users.ocis.feature
@@ -55,7 +55,7 @@ Feature: users management
     When "Admin" logs in
     And "Admin" opens the "admin-settings" app
     And "Admin" navigates to the users management page
-    And "Admin" adds the following users to the groups "sales department,finance department" using the batch actions
+    And "Admin" adds the following users to the groups "sales,finance" using the batch actions
       | user  |
       | Alice |
       | Brian |

--- a/tests/e2e/cucumber/steps/ui/adminSettings.ts
+++ b/tests/e2e/cucumber/steps/ui/adminSettings.ts
@@ -217,10 +217,12 @@ When(
   ): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const usersObject = new objects.applicationAdminSettings.Users({ page })
+    const users = []
     for (const info of stepTable.hashes()) {
+      users.push(info.id)
       await usersObject.selectUser({ key: info.id })
     }
-    await usersObject.changeQuotaUsingBatchAction({ value })
+    await usersObject.changeQuotaUsingBatchAction({ value, users })
   }
 )
 

--- a/tests/e2e/cucumber/steps/ui/adminSettings.ts
+++ b/tests/e2e/cucumber/steps/ui/adminSettings.ts
@@ -289,7 +289,7 @@ When(
         await usersObject.addToGroupsBatchAtion({ users, groups: groups.split(',') })
         break
       case 'removes':
-        await usersObject.removeFromGroupsBatchAtion({ groups: groups.split(',') })
+        await usersObject.removeFromGroupsBatchAtion({ users, groups: groups.split(',') })
         break
       default:
         throw new Error(`'${action}' not implemented`)

--- a/tests/e2e/cucumber/steps/ui/adminSettings.ts
+++ b/tests/e2e/cucumber/steps/ui/adminSettings.ts
@@ -42,16 +42,16 @@ When(
   async function (this: World, stepUser: string, action: string, key: string): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const spacesObject = new objects.applicationAdminSettings.Spaces({ page })
-
+    const spaceId = spacesObject.getUUID({ key })
     switch (action) {
       case 'disables':
-        await spacesObject.disable({ spaces: [key], context: 'context-menu' })
+        await spacesObject.disable({ spaceIds: [spaceId], context: 'context-menu' })
         break
       case 'deletes':
-        await spacesObject.delete({ spaces: [key], context: 'context-menu' })
+        await spacesObject.delete({ spaceIds: [spaceId], context: 'context-menu' })
         break
       case 'enables':
-        await spacesObject.enable({ spaces: [key], context: 'context-menu' })
+        await spacesObject.enable({ spaceIds: [spaceId], context: 'context-menu' })
         break
       default:
         throw new Error(`${action} not implemented`)
@@ -71,7 +71,7 @@ When(
   ): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const spacesObject = new objects.applicationAdminSettings.Spaces({ page })
-
+    const spaceId = spacesObject.getUUID({ key })
     switch (action) {
       case 'name':
         await spacesObject.rename({ key, value })
@@ -80,7 +80,7 @@ When(
         await spacesObject.changeSubtitle({ key, value })
         break
       case 'quota':
-        await spacesObject.changeQuota({ spaces: [key], value, context: 'context-menu' })
+        await spacesObject.changeQuota({ spaceIds: [spaceId], value, context: 'context-menu' })
         break
       default:
         throw new Error(`'${action}' not implemented`)
@@ -98,13 +98,13 @@ When(
   ): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const spacesObject = new objects.applicationAdminSettings.Spaces({ page })
-    const spaces = []
-    for (const info of stepTable.hashes()) {
-      spaces.push(info.id)
-      await spacesObject.select({ key: info.id })
+    const spaceIds = []
+    for (const { id: space } of stepTable.hashes()) {
+      spaceIds.push(spacesObject.getUUID({ key: space }))
+      await spacesObject.select({ key: space })
     }
     await spacesObject.changeQuota({
-      spaces,
+      spaceIds,
       value,
       context: 'batch-actions'
     })
@@ -121,20 +121,20 @@ When(
   ): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const spacesObject = new objects.applicationAdminSettings.Spaces({ page })
-    const spaces = []
-    for (const info of stepTable.hashes()) {
-      spaces.push(info.id)
-      await spacesObject.select({ key: info.id })
+    const spaceIds = []
+    for (const { id: space } of stepTable.hashes()) {
+      spaceIds.push(spacesObject.getUUID({ key: space }))
+      await spacesObject.select({ key: space })
     }
     switch (action) {
       case 'disables':
-        await spacesObject.disable({ spaces, context: 'batch-actions' })
+        await spacesObject.disable({ spaceIds, context: 'batch-actions' })
         break
       case 'deletes':
-        await spacesObject.delete({ spaces, context: 'batch-actions' })
+        await spacesObject.delete({ spaceIds, context: 'batch-actions' })
         break
       case 'enables':
-        await spacesObject.enable({ spaces, context: 'batch-actions' })
+        await spacesObject.enable({ spaceIds, context: 'batch-actions' })
         break
       default:
         throw new Error(`'${action}' not implemented`)
@@ -217,12 +217,12 @@ When(
   ): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const usersObject = new objects.applicationAdminSettings.Users({ page })
-    const users = []
-    for (const info of stepTable.hashes()) {
-      users.push(info.id)
-      await usersObject.selectUser({ key: info.id })
+    const userIds = []
+    for (const { id: user } of stepTable.hashes()) {
+      userIds.push(usersObject.getUUID({ key: user }))
+      await usersObject.selectUser({ key: user })
     }
-    await usersObject.changeQuotaUsingBatchAction({ value, users })
+    await usersObject.changeQuotaUsingBatchAction({ value, userIds })
   }
 )
 
@@ -277,19 +277,19 @@ When(
   ): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const usersObject = new objects.applicationAdminSettings.Users({ page })
-    const users = []
+    const userIds = []
 
     for (const { user } of stepTable.hashes()) {
-      users.push(user)
+      userIds.push(usersObject.getUUID({ key: user }))
       await usersObject.select({ key: user })
     }
 
     switch (action) {
       case 'adds':
-        await usersObject.addToGroupsBatchAtion({ users, groups: groups.split(',') })
+        await usersObject.addToGroupsBatchAtion({ userIds, groups: groups.split(',') })
         break
       case 'removes':
-        await usersObject.removeFromGroupsBatchAtion({ users, groups: groups.split(',') })
+        await usersObject.removeFromGroupsBatchAtion({ userIds, groups: groups.split(',') })
         break
       default:
         throw new Error(`'${action}' not implemented`)
@@ -378,14 +378,14 @@ When(
   ): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const usersObject = new objects.applicationAdminSettings.Users({ page })
-    const users = []
+    const userIds = []
     switch (actionType) {
       case 'batch actions':
-        for (const user of stepTable.hashes()) {
-          users.push(user.id)
-          await usersObject.selectUser({ key: user.id })
+        for (const { id: user } of stepTable.hashes()) {
+          userIds.push(usersObject.getUUID({ key: user }))
+          await usersObject.selectUser({ key: user })
         }
-        await usersObject.deleteUserUsingBatchAction({ users })
+        await usersObject.deleteUserUsingBatchAction({ userIds })
         break
       case 'context menu':
         for (const { user } of stepTable.hashes()) {
@@ -486,15 +486,15 @@ When(
   ): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const groupsObject = new objects.applicationAdminSettings.Groups({ page })
-    const groups = []
+    const groupIds = []
 
     switch (actionType) {
       case 'batch actions':
         for (const { group } of stepTable.hashes()) {
-          groups.push(group)
+          groupIds.push(groupsObject.getUUID({ key: group }))
           await groupsObject.selectGroup({ key: group })
         }
-        await groupsObject.deleteGroupUsingBatchAction({ groups })
+        await groupsObject.deleteGroupUsingBatchAction({ groupIds })
         break
       case 'context menu':
         for (const { group } of stepTable.hashes()) {

--- a/tests/e2e/cucumber/steps/ui/adminSettings.ts
+++ b/tests/e2e/cucumber/steps/ui/adminSettings.ts
@@ -481,13 +481,15 @@ When(
   ): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const groupsObject = new objects.applicationAdminSettings.Groups({ page })
+    const groups = []
 
     switch (actionType) {
       case 'batch actions':
         for (const { group } of stepTable.hashes()) {
+          groups.push(group)
           await groupsObject.selectGroup({ key: group })
         }
-        await groupsObject.deleteGroupUsingBatchAction()
+        await groupsObject.deleteGroupUsingBatchAction({ groups })
         break
       case 'context menu':
         for (const { group } of stepTable.hashes()) {

--- a/tests/e2e/cucumber/steps/ui/adminSettings.ts
+++ b/tests/e2e/cucumber/steps/ui/adminSettings.ts
@@ -277,14 +277,16 @@ When(
   ): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const usersObject = new objects.applicationAdminSettings.Users({ page })
+    const users = []
 
     for (const { user } of stepTable.hashes()) {
+      users.push(user)
       await usersObject.select({ key: user })
     }
 
     switch (action) {
       case 'adds':
-        await usersObject.addToGroupsBatchAtion({ groups: groups.split(',') })
+        await usersObject.addToGroupsBatchAtion({ users, groups: groups.split(',') })
         break
       case 'removes':
         await usersObject.removeFromGroupsBatchAtion({ groups: groups.split(',') })

--- a/tests/e2e/cucumber/steps/ui/adminSettings.ts
+++ b/tests/e2e/cucumber/steps/ui/adminSettings.ts
@@ -376,13 +376,14 @@ When(
   ): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const usersObject = new objects.applicationAdminSettings.Users({ page })
-
+    const users = []
     switch (actionType) {
       case 'batch actions':
         for (const user of stepTable.hashes()) {
+          users.push(user.id)
           await usersObject.selectUser({ key: user.id })
         }
-        await usersObject.deleteUserUsingBatchAction()
+        await usersObject.deleteUserUsingBatchAction({ users })
         break
       case 'context menu':
         for (const { user } of stepTable.hashes()) {

--- a/tests/e2e/support/objects/app-admin-settings/groups/actions.ts
+++ b/tests/e2e/support/objects/app-admin-settings/groups/actions.ts
@@ -68,17 +68,24 @@ export const deleteGroupUsingContextMenu = async (args: {
   ])
 }
 
-export const deleteGrouprUsingBatchAction = async (args: { page: Page }): Promise<void> => {
-  const { page } = args
+export const deleteGrouprUsingBatchAction = async (args: {
+  page: Page
+  groupIds: string[]
+}): Promise<void> => {
+  const { page, groupIds } = args
   await page.locator(deleteBtnBatchAction).click()
 
-  await Promise.all([
-    page.waitForResponse(
-      (resp) =>
-        resp.url().includes('groups') &&
-        resp.status() === 204 &&
-        resp.request().method() === 'DELETE'
-    ),
-    await page.locator(actionConfirmButton).click()
-  ])
+  const checkResponses = []
+  for (const id of groupIds) {
+    checkResponses.push(
+      page.waitForResponse(
+        (resp) =>
+          resp.url().endsWith(encodeURIComponent(id)) &&
+          resp.status() === 204 &&
+          resp.request().method() === 'DELETE'
+      )
+    )
+  }
+
+  await Promise.all([...checkResponses, page.locator(actionConfirmButton).click()])
 }

--- a/tests/e2e/support/objects/app-admin-settings/groups/index.ts
+++ b/tests/e2e/support/objects/app-admin-settings/groups/index.ts
@@ -29,8 +29,12 @@ export class Groups {
     const { uuid } = this.#usersEnvironment.getGroup({ key })
     await selectGroup({ uuid, page: this.#page })
   }
-  async deleteGroupUsingBatchAction(): Promise<void> {
-    await deleteGrouprUsingBatchAction({ page: this.#page })
+  async deleteGroupUsingBatchAction({ groups }: { groups: string[] }): Promise<void> {
+    const groupIds = []
+    for (const group of groups) {
+      groupIds.push(this.#usersEnvironment.getGroup({ key: group }).uuid)
+    }
+    await deleteGrouprUsingBatchAction({ page: this.#page, groupIds })
   }
   async deleteGroupUsingContextMenu({ key }: { key: string }): Promise<void> {
     const { uuid } = this.#usersEnvironment.getGroup({ key })

--- a/tests/e2e/support/objects/app-admin-settings/groups/index.ts
+++ b/tests/e2e/support/objects/app-admin-settings/groups/index.ts
@@ -29,11 +29,7 @@ export class Groups {
     const { uuid } = this.#usersEnvironment.getGroup({ key })
     await selectGroup({ uuid, page: this.#page })
   }
-  async deleteGroupUsingBatchAction({ groups }: { groups: string[] }): Promise<void> {
-    const groupIds = []
-    for (const group of groups) {
-      groupIds.push(this.#usersEnvironment.getGroup({ key: group }).uuid)
-    }
+  async deleteGroupUsingBatchAction({ groupIds }: { groupIds: string[] }): Promise<void> {
     await deleteGrouprUsingBatchAction({ page: this.#page, groupIds })
   }
   async deleteGroupUsingContextMenu({ key }: { key: string }): Promise<void> {

--- a/tests/e2e/support/objects/app-admin-settings/groups/index.ts
+++ b/tests/e2e/support/objects/app-admin-settings/groups/index.ts
@@ -16,8 +16,7 @@ export class Groups {
     this.#page = page
   }
   getUUID({ key }: { key: string }) {
-    const { uuid } = this.#usersEnvironment.getGroup({ key })
-    return uuid
+    return this.#usersEnvironment.getGroup({ key }).uuid
   }
   async createGroup({ key }: { key: string }): Promise<string> {
     return await createGroup({ page: this.#page, key: key })
@@ -26,14 +25,12 @@ export class Groups {
     return getDisplayedGroups({ page: this.#page })
   }
   async selectGroup({ key }: { key: string }): Promise<void> {
-    const { uuid } = this.#usersEnvironment.getGroup({ key })
-    await selectGroup({ uuid, page: this.#page })
+    await selectGroup({ page: this.#page, uuid: this.getUUID({ key }) })
   }
   async deleteGroupUsingBatchAction({ groupIds }: { groupIds: string[] }): Promise<void> {
     await deleteGrouprUsingBatchAction({ page: this.#page, groupIds })
   }
   async deleteGroupUsingContextMenu({ key }: { key: string }): Promise<void> {
-    const { uuid } = this.#usersEnvironment.getGroup({ key })
-    await deleteGroupUsingContextMenu({ page: this.#page, uuid })
+    await deleteGroupUsingContextMenu({ page: this.#page, uuid: this.getUUID({ key }) })
   }
 }

--- a/tests/e2e/support/objects/app-admin-settings/groups/index.ts
+++ b/tests/e2e/support/objects/app-admin-settings/groups/index.ts
@@ -15,7 +15,7 @@ export class Groups {
     this.#usersEnvironment = new UsersEnvironment()
     this.#page = page
   }
-  getUUID({ key }: { key: string }) {
+  getUUID({ key }: { key: string }): string {
     return this.#usersEnvironment.getGroup({ key }).uuid
   }
   async createGroup({ key }: { key: string }): Promise<string> {

--- a/tests/e2e/support/objects/app-admin-settings/spaces/index.ts
+++ b/tests/e2e/support/objects/app-admin-settings/spaces/index.ts
@@ -25,7 +25,7 @@ export class Spaces {
   }
 
   getUUID({ key }: { key: string }) {
-    return this.#spacesEnvironment.getSpace({ key }).id
+    return this.getSpace({ key }).id
   }
 
   getDisplayedSpaces(): Promise<string[]> {
@@ -61,23 +61,19 @@ export class Spaces {
   }
 
   async select({ key }: { key: string }): Promise<void> {
-    const { id } = this.#spacesEnvironment.getSpace({ key })
-    await selectSpace({ id, page: this.#page })
+    await selectSpace({ page: this.#page, id: this.getUUID({ key }) })
   }
 
   async rename({ key, value }: { key: string; value: string }): Promise<void> {
-    const { id } = this.#spacesEnvironment.getSpace({ key })
-    await renameSpace({ id, page: this.#page, value })
+    await renameSpace({ page: this.#page, id: this.getUUID({ key }), value })
   }
 
   async changeSubtitle({ key, value }: { key: string; value: string }): Promise<void> {
-    const { id } = this.#spacesEnvironment.getSpace({ key })
-    await changeSpaceSubtitle({ id, page: this.#page, value })
+    await changeSpaceSubtitle({ page: this.#page, id: this.getUUID({ key }), value })
   }
 
   async openPanel({ key }: { key: string }): Promise<void> {
-    const { id } = this.#spacesEnvironment.getSpace({ key })
-    await openSpaceAdminSidebarPanel({ page: this.#page, id })
+    await openSpaceAdminSidebarPanel({ page: this.#page, id: this.getUUID({ key }) })
   }
 
   async openActionSideBarPanel({ action }: { action: string }): Promise<void> {

--- a/tests/e2e/support/objects/app-admin-settings/spaces/index.ts
+++ b/tests/e2e/support/objects/app-admin-settings/spaces/index.ts
@@ -24,51 +24,39 @@ export class Spaces {
     this.#page = page
   }
 
+  getUUID({ key }: { key: string }) {
+    return this.#spacesEnvironment.getSpace({ key }).id
+  }
+
   getDisplayedSpaces(): Promise<string[]> {
     return getDisplayedSpaces(this.#page)
   }
 
-  async getSpace({ key }: { key: string }): Promise<Space> {
+  getSpace({ key }: { key: string }): Space {
     return this.#spacesEnvironment.getSpace({ key })
   }
 
   async changeQuota({
-    spaces,
+    spaceIds,
     value,
     context
   }: {
-    spaces: string[]
+    spaceIds: string[]
     value: string
     context: string
   }): Promise<void> {
-    const spaceIds = []
-    for (const space of spaces) {
-      spaceIds.push(this.#spacesEnvironment.getSpace({ key: space }).id)
-    }
     await changeSpaceQuota({ spaceIds, value, page: this.#page, context })
   }
 
-  async disable({ spaces, context }: { spaces: string[]; context: string }): Promise<void> {
-    const spaceIds = []
-    for (const space of spaces) {
-      spaceIds.push(this.#spacesEnvironment.getSpace({ key: space }).id)
-    }
+  async disable({ spaceIds, context }: { spaceIds: string[]; context: string }): Promise<void> {
     await disableSpace({ spaceIds, page: this.#page, context })
   }
 
-  async enable({ spaces, context }: { spaces: string[]; context: string }): Promise<void> {
-    const spaceIds = []
-    for (const space of spaces) {
-      spaceIds.push(this.#spacesEnvironment.getSpace({ key: space }).id)
-    }
+  async enable({ spaceIds, context }: { spaceIds: string[]; context: string }): Promise<void> {
     await enableSpace({ spaceIds, page: this.#page, context })
   }
 
-  async delete({ spaces, context }: { spaces: string[]; context: string }): Promise<void> {
-    const spaceIds = []
-    for (const space of spaces) {
-      spaceIds.push(this.#spacesEnvironment.getSpace({ key: space }).id)
-    }
+  async delete({ spaceIds, context }: { spaceIds: string[]; context: string }): Promise<void> {
     await deleteSpace({ spaceIds, page: this.#page, context })
   }
 
@@ -96,7 +84,7 @@ export class Spaces {
     await openSpaceAdminActionSidebarPanel({ page: this.#page, action })
   }
 
-  async listMembers({ filter }: { filter: string }): Promise<Array<string>> {
+  listMembers({ filter }: { filter: string }): Promise<Array<string>> {
     return listSpaceMembers({ page: this.#page, filter })
   }
 }

--- a/tests/e2e/support/objects/app-admin-settings/spaces/index.ts
+++ b/tests/e2e/support/objects/app-admin-settings/spaces/index.ts
@@ -24,7 +24,7 @@ export class Spaces {
     this.#page = page
   }
 
-  getUUID({ key }: { key: string }) {
+  getUUID({ key }: { key: string }): string {
     return this.getSpace({ key }).id
   }
 

--- a/tests/e2e/support/objects/app-admin-settings/users/actions.ts
+++ b/tests/e2e/support/objects/app-admin-settings/users/actions.ts
@@ -158,12 +158,11 @@ export const addSelectedUsersToGroups = async (args: {
   groups: string[]
 }): Promise<void> => {
   const { page, userIds, groups } = args
-  const usersEnvironment = new UsersEnvironment()
   const groupIds = []
 
   await page.locator(addToGroupsBatchAction).click()
   for (const group of groups) {
-    groupIds.push(usersEnvironment.getGroup({ key: group }).uuid)
+    groupIds.push(getGroupId(group))
     await page.locator(groupsModalInput).click()
     await page.locator(groupsModalInput).fill(group)
     await page.keyboard.press('Enter')
@@ -198,12 +197,11 @@ export const removeSelectedUsersFromGroups = async (args: {
   groups: string[]
 }): Promise<void> => {
   const { page, userIds, groups } = args
-  const usersEnvironment = new UsersEnvironment()
   const groupIds = []
 
   await page.locator(removeFromGroupsBatchAction).click()
   for (const group of groups) {
-    groupIds.push(usersEnvironment.getGroup({ key: group }).uuid)
+    groupIds.push(getGroupId(group))
     await page.locator(groupsModalInput).click()
     await page.locator(groupsModalInput).fill(group)
     await page.keyboard.press('Enter')
@@ -215,7 +213,11 @@ export const removeSelectedUsersFromGroups = async (args: {
       checkResponses.push(
         page.waitForResponse(
           (resp) =>
-            resp.url().endsWith(`groups/${groupId}/members/${encodeURIComponent(userId)}/$ref`) &&
+            resp
+              .url()
+              .endsWith(
+                `groups/${encodeURIComponent(groupId)}/members/${encodeURIComponent(userId)}/$ref`
+              ) &&
             resp.status() === 204 &&
             resp.request().method() === 'DELETE'
         )
@@ -275,10 +277,9 @@ export const addUserToGroups = async (args: {
   groups: string[]
 }): Promise<void> => {
   const { page, userId, groups } = args
-  const usersEnvironment = new UsersEnvironment()
   const groupIds = []
   for (const group of groups) {
-    groupIds.push(usersEnvironment.getGroup({ key: group }).uuid)
+    groupIds.push(getGroupId(group))
     await page.locator(groupsInput).fill(group)
     await page.keyboard.press('Enter')
   }
@@ -310,10 +311,9 @@ export const removeUserFromGroups = async (args: {
   groups: string[]
 }): Promise<void> => {
   const { page, userId, groups } = args
-  const usersEnvironment = new UsersEnvironment()
   const groupIds = []
   for (const group of groups) {
-    groupIds.push(usersEnvironment.getGroup({ key: group }).uuid)
+    groupIds.push(getGroupId(group))
     await page.getByTitle(group).click()
   }
 
@@ -322,7 +322,11 @@ export const removeUserFromGroups = async (args: {
     checkResponses.push(
       page.waitForResponse(
         (resp) =>
-          resp.url().endsWith(`groups/${groupId}/members/${encodeURIComponent(userId)}/$ref`) &&
+          resp
+            .url()
+            .endsWith(
+              `groups/${encodeURIComponent(groupId)}/members/${encodeURIComponent(userId)}/$ref`
+            ) &&
           resp.status() === 204 &&
           resp.request().method() === 'DELETE'
       )
@@ -399,4 +403,9 @@ export const deleteUserUsingBatchAction = async (args: {
 export const waitForEditPanelToBeVisible = async (args: { page: Page }): Promise<void> => {
   const { page } = args
   await page.waitForSelector(editPanel)
+}
+
+const getGroupId = (group: string): string => {
+  const usersEnvironment = new UsersEnvironment()
+  return usersEnvironment.getGroup({ key: group }).uuid
 }

--- a/tests/e2e/support/objects/app-admin-settings/users/actions.ts
+++ b/tests/e2e/support/objects/app-admin-settings/users/actions.ts
@@ -313,19 +313,26 @@ export const deleteUserUsingContextMenu = async (args: {
   ])
 }
 
-export const deleteUserUsingBatchAction = async (args: { page: Page }): Promise<void> => {
-  const { page } = args
+export const deleteUserUsingBatchAction = async (args: {
+  page: Page
+  userIds: string[]
+}): Promise<void> => {
+  const { page, userIds } = args
   await page.locator(deleteActionBtn).click()
 
-  await Promise.all([
-    page.waitForResponse(
-      (resp) =>
-        resp.url().includes('users') &&
-        resp.status() === 204 &&
-        resp.request().method() === 'DELETE'
-    ),
-    await page.locator(actionConfirmButton).click()
-  ])
+  const checkResponses = []
+  for (const id of userIds) {
+    checkResponses.push(
+      page.waitForResponse(
+        (resp) =>
+          resp.url().endsWith(encodeURIComponent(id)) &&
+          resp.status() === 204 &&
+          resp.request().method() === 'DELETE'
+      )
+    )
+  }
+
+  await Promise.all([...checkResponses, await page.locator(actionConfirmButton).click()])
 }
 
 export const waitForEditPanelToBeVisible = async (args: { page: Page }): Promise<void> => {

--- a/tests/e2e/support/objects/app-admin-settings/users/index.ts
+++ b/tests/e2e/support/objects/app-admin-settings/users/index.ts
@@ -93,8 +93,15 @@ export class Users {
     const userIds = this.getUserIds(users)
     await addSelectedUsersToGroups({ page: this.#page, userIds, groups })
   }
-  async removeFromGroupsBatchAtion({ groups }: { groups: string[] }): Promise<void> {
-    await removeSelectedUsersFromGroups({ page: this.#page, groups })
+  async removeFromGroupsBatchAtion({
+    users,
+    groups
+  }: {
+    users: string[]
+    groups: string[]
+  }): Promise<void> {
+    const userIds = this.getUserIds(users)
+    await removeSelectedUsersFromGroups({ page: this.#page, userIds, groups })
   }
   async filter({ filter, values }: { filter: string; values: string[] }): Promise<void> {
     await filterUsers({ page: this.#page, filter, values })

--- a/tests/e2e/support/objects/app-admin-settings/users/index.ts
+++ b/tests/e2e/support/objects/app-admin-settings/users/index.ts
@@ -31,14 +31,6 @@ export class Users {
     return uuid
   }
 
-  getUserIds(users: string[]): string[] {
-    const userIds = []
-    for (const user of users) {
-      userIds.push(this.getUUID({ key: user }))
-    }
-    return userIds
-  }
-
   async allowLogin({ key, action }: { key: string; action: string }): Promise<void> {
     const { uuid } = this.#usersEnvironment.getUser({ key })
     await openEditPanel({ page: this.#page, uuid, action })
@@ -68,12 +60,11 @@ export class Users {
   }
   async changeQuotaUsingBatchAction({
     value,
-    users
+    userIds
   }: {
     value: string
-    users: string[]
+    userIds: string[]
   }): Promise<void> {
-    const userIds = this.getUserIds(users)
     await changeQuotaUsingBatchAction({ page: this.#page, value, userIds })
   }
   getDisplayedUsers(): Promise<string[]> {
@@ -84,23 +75,21 @@ export class Users {
     await selectUser({ uuid, page: this.#page })
   }
   async addToGroupsBatchAtion({
-    users,
+    userIds,
     groups
   }: {
-    users: string[]
+    userIds: string[]
     groups: string[]
   }): Promise<void> {
-    const userIds = this.getUserIds(users)
     await addSelectedUsersToGroups({ page: this.#page, userIds, groups })
   }
   async removeFromGroupsBatchAtion({
-    users,
+    userIds,
     groups
   }: {
-    users: string[]
+    userIds: string[]
     groups: string[]
   }): Promise<void> {
-    const userIds = this.getUserIds(users)
     await removeSelectedUsersFromGroups({ page: this.#page, userIds, groups })
   }
   async filter({ filter, values }: { filter: string; values: string[] }): Promise<void> {
@@ -151,8 +140,7 @@ export class Users {
     const { uuid } = this.#usersEnvironment.getUser({ key })
     await deleteUserUsingContextMenu({ page: this.#page, uuid })
   }
-  async deleteUserUsingBatchAction({ users }: { users: string[] }): Promise<void> {
-    const userIds = this.getUserIds(users)
+  async deleteUserUsingBatchAction({ userIds }: { userIds: string[] }): Promise<void> {
     await deleteUserUsingBatchAction({ page: this.#page, userIds })
   }
   async createUser({

--- a/tests/e2e/support/objects/app-admin-settings/users/index.ts
+++ b/tests/e2e/support/objects/app-admin-settings/users/index.ts
@@ -83,8 +83,15 @@ export class Users {
     const { uuid } = this.#usersEnvironment.getUser({ key })
     await selectUser({ uuid, page: this.#page })
   }
-  async addToGroupsBatchAtion({ groups }: { groups: string[] }): Promise<void> {
-    await addSelectedUsersToGroups({ page: this.#page, groups })
+  async addToGroupsBatchAtion({
+    users,
+    groups
+  }: {
+    users: string[]
+    groups: string[]
+  }): Promise<void> {
+    const userIds = this.getUserIds(users)
+    await addSelectedUsersToGroups({ page: this.#page, userIds, groups })
   }
   async removeFromGroupsBatchAtion({ groups }: { groups: string[] }): Promise<void> {
     await removeSelectedUsersFromGroups({ page: this.#page, groups })

--- a/tests/e2e/support/objects/app-admin-settings/users/index.ts
+++ b/tests/e2e/support/objects/app-admin-settings/users/index.ts
@@ -57,8 +57,18 @@ export class Users {
     const { uuid } = this.#usersEnvironment.getUser({ key })
     await selectUser({ uuid, page: this.#page })
   }
-  async changeQuotaUsingBatchAction({ value }: { value: string }): Promise<void> {
-    await changeQuotaUsingBatchAction({ value, page: this.#page })
+  async changeQuotaUsingBatchAction({
+    value,
+    users
+  }: {
+    value: string
+    users: string[]
+  }): Promise<void> {
+    const userIds = []
+    for (const user of users) {
+      userIds.push(this.#usersEnvironment.getUser({ key: user }).uuid)
+    }
+    await changeQuotaUsingBatchAction({ page: this.#page, value, userIds })
   }
   getDisplayedUsers(): Promise<string[]> {
     return getDisplayedUsers({ page: this.#page })

--- a/tests/e2e/support/objects/app-admin-settings/users/index.ts
+++ b/tests/e2e/support/objects/app-admin-settings/users/index.ts
@@ -131,7 +131,7 @@ export class Users {
   }): Promise<void> {
     const { uuid } = this.#usersEnvironment.getUser({ key })
     await openEditPanel({ page: this.#page, uuid, action })
-    await removeUserFromGroups({ page: this.#page, uuid, groups })
+    await removeUserFromGroups({ page: this.#page, userId: uuid, groups })
   }
   async deleteUserUsingContextMenu({ key }: { key: string }): Promise<void> {
     const { uuid } = this.#usersEnvironment.getUser({ key })

--- a/tests/e2e/support/objects/app-admin-settings/users/index.ts
+++ b/tests/e2e/support/objects/app-admin-settings/users/index.ts
@@ -30,6 +30,15 @@ export class Users {
     const { uuid } = this.#usersEnvironment.getUser({ key })
     return uuid
   }
+
+  getUserIds(users: string[]): string[] {
+    const userIds = []
+    for (const user of users) {
+      userIds.push(this.getUUID({ key: user }))
+    }
+    return userIds
+  }
+
   async allowLogin({ key, action }: { key: string; action: string }): Promise<void> {
     const { uuid } = this.#usersEnvironment.getUser({ key })
     await openEditPanel({ page: this.#page, uuid, action })
@@ -64,10 +73,7 @@ export class Users {
     value: string
     users: string[]
   }): Promise<void> {
-    const userIds = []
-    for (const user of users) {
-      userIds.push(this.#usersEnvironment.getUser({ key: user }).uuid)
-    }
+    const userIds = this.getUserIds(users)
     await changeQuotaUsingBatchAction({ page: this.#page, value, userIds })
   }
   getDisplayedUsers(): Promise<string[]> {
@@ -131,8 +137,9 @@ export class Users {
     const { uuid } = this.#usersEnvironment.getUser({ key })
     await deleteUserUsingContextMenu({ page: this.#page, uuid })
   }
-  async deleteUserUsingBatchAction(): Promise<void> {
-    await deleteUserUsingBatchAction({ page: this.#page })
+  async deleteUserUsingBatchAction({ users }: { users: string[] }): Promise<void> {
+    const userIds = this.getUserIds(users)
+    await deleteUserUsingBatchAction({ page: this.#page, userIds })
   }
   async createUser({
     name,

--- a/tests/e2e/support/objects/app-admin-settings/users/index.ts
+++ b/tests/e2e/support/objects/app-admin-settings/users/index.ts
@@ -27,17 +27,16 @@ export class Users {
     this.#page = page
   }
   getUUID({ key }: { key: string }) {
-    const { uuid } = this.#usersEnvironment.getUser({ key })
-    return uuid
+    return this.#usersEnvironment.getUser({ key }).uuid
   }
 
   async allowLogin({ key, action }: { key: string; action: string }): Promise<void> {
-    const { uuid } = this.#usersEnvironment.getUser({ key })
+    const uuid = this.getUUID({ key })
     await openEditPanel({ page: this.#page, uuid, action })
     await changeAccountEnabled({ uuid, value: true, page: this.#page })
   }
   async forbidLogin({ key, action }: { key: string; action: string }): Promise<void> {
-    const { uuid } = this.#usersEnvironment.getUser({ key })
+    const uuid = this.getUUID({ key })
     await openEditPanel({ page: this.#page, uuid, action })
     await changeAccountEnabled({ uuid, value: false, page: this.#page })
   }
@@ -50,13 +49,12 @@ export class Users {
     value: string
     action: string
   }): Promise<void> {
-    const { uuid } = this.#usersEnvironment.getUser({ key })
+    const uuid = this.getUUID({ key })
     await openEditPanel({ page: this.#page, uuid, action })
     await changeQuota({ uuid, value, page: this.#page })
   }
   async selectUser({ key }: { key: string }): Promise<void> {
-    const { uuid } = this.#usersEnvironment.getUser({ key })
-    await selectUser({ uuid, page: this.#page })
+    await selectUser({ page: this.#page, uuid: this.getUUID({ key }) })
   }
   async changeQuotaUsingBatchAction({
     value,
@@ -71,8 +69,7 @@ export class Users {
     return getDisplayedUsers({ page: this.#page })
   }
   async select({ key }: { key: string }): Promise<void> {
-    const { uuid } = this.#usersEnvironment.getUser({ key })
-    await selectUser({ uuid, page: this.#page })
+    await selectUser({ page: this.#page, uuid: this.getUUID({ key }) })
   }
   async addToGroupsBatchAtion({
     userIds,
@@ -106,7 +103,7 @@ export class Users {
     value: string
     action: string
   }): Promise<void> {
-    const { uuid } = this.#usersEnvironment.getUser({ key })
+    const uuid = this.getUUID({ key })
     await openEditPanel({ page: this.#page, uuid, action })
     await changeUser({ uuid, attribute: attribute, value: value, page: this.#page })
   }
@@ -119,7 +116,7 @@ export class Users {
     groups: string[]
     action: string
   }): Promise<void> {
-    const { uuid } = this.#usersEnvironment.getUser({ key })
+    const uuid = this.getUUID({ key })
     await openEditPanel({ page: this.#page, uuid, action })
     await addUserToGroups({ page: this.#page, userId: uuid, groups })
   }
@@ -132,13 +129,12 @@ export class Users {
     groups: string[]
     action: string
   }): Promise<void> {
-    const { uuid } = this.#usersEnvironment.getUser({ key })
+    const uuid = this.getUUID({ key })
     await openEditPanel({ page: this.#page, uuid, action })
     await removeUserFromGroups({ page: this.#page, userId: uuid, groups })
   }
   async deleteUserUsingContextMenu({ key }: { key: string }): Promise<void> {
-    const { uuid } = this.#usersEnvironment.getUser({ key })
-    await deleteUserUsingContextMenu({ page: this.#page, uuid })
+    await deleteUserUsingContextMenu({ page: this.#page, uuid: this.getUUID({ key }) })
   }
   async deleteUserUsingBatchAction({ userIds }: { userIds: string[] }): Promise<void> {
     await deleteUserUsingBatchAction({ page: this.#page, userIds })
@@ -158,8 +154,7 @@ export class Users {
   }
 
   async openEditPanel({ key, action }: { key: string; action: string }): Promise<void> {
-    const { uuid } = this.#usersEnvironment.getUser({ key })
-    await openEditPanel({ page: this.#page, uuid, action })
+    await openEditPanel({ page: this.#page, uuid: this.getUUID({ key }), action })
   }
 
   async waitForEditPanelToBeVisible(): Promise<void> {

--- a/tests/e2e/support/objects/app-admin-settings/users/index.ts
+++ b/tests/e2e/support/objects/app-admin-settings/users/index.ts
@@ -26,7 +26,7 @@ export class Users {
     this.#usersEnvironment = new UsersEnvironment()
     this.#page = page
   }
-  getUUID({ key }: { key: string }) {
+  getUUID({ key }: { key: string }): string {
     return this.#usersEnvironment.getUser({ key }).uuid
   }
 

--- a/tests/e2e/support/objects/app-admin-settings/users/index.ts
+++ b/tests/e2e/support/objects/app-admin-settings/users/index.ts
@@ -118,7 +118,7 @@ export class Users {
   }): Promise<void> {
     const { uuid } = this.#usersEnvironment.getUser({ key })
     await openEditPanel({ page: this.#page, uuid, action })
-    await addUserToGroups({ page: this.#page, groups })
+    await addUserToGroups({ page: this.#page, userId: uuid, groups })
   }
   async removeFromGroups({
     key,


### PR DESCRIPTION
## Description
Added wait for the desired list of responses for these batch actions from admin settings:
- delete groups
- delete users
- change users' quota
- add a user to groups
- remove a user from groups
- add users to groups
- remove users from groups

## Related Issue
part of https://github.com/owncloud/web/issues/8648

## Motivation and Context

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
