### PR TITLE
followup: context helper filter

### DIFF
--- a/changelog/unreleased/enhancement-context-helper-read-more-configurable
+++ b/changelog/unreleased/enhancement-context-helper-read-more-configurable
@@ -3,4 +3,5 @@ Enhancement: Context helper read more link configurable
 We've added a configuration variable to disable the read more link in the contextual helper.
 
 https://github.com/owncloud/web/pull/8713
+https://github.com/owncloud/web/pull/8719
 https://github.com/owncloud/web/issues/8570

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -68,7 +68,7 @@ hovers the row with his mouse. Defaults to `false`.
 - `options.upload.xhr.timeout` Specifies the timeout for XHR uploads in milliseconds.
 - `options.editor.autosaveEnabled` Specifies if the autosave for the editor apps is enabled.
 - `options.editor.autosaveInterval` Specifies the time interval for the autosave of editor apps in seconds.
-- `options.editor.contextHelpersReadMore` Specifies whether the "Read more" link should be displayed or not.
+- `options.contextHelpersReadMore` Specifies whether the "Read more" link should be displayed or not.
 
 ### Sentry
 

--- a/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
@@ -253,10 +253,10 @@ export default defineComponent({
     },
 
     viaLinkHelp() {
-      return shareViaLinkHelp(this.configurationManager)
+      return shareViaLinkHelp({ configurationManager: this.configurationManager })
     },
     indirectLinkHelp() {
-      return shareViaIndirectLinkHelp(this.configurationManager)
+      return shareViaIndirectLinkHelp({ configurationManager: this.configurationManager })
     },
 
     canCreateLinks() {

--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -151,15 +151,17 @@ export default defineComponent({
       const cernFeatures = !!this.configuration?.options?.cernFeatures
 
       if (cernFeatures) {
-        const mergedHelp = shareInviteCollaboratorHelp(this.configurationManager)
-        mergedHelp.list = [
-          ...shareInviteCollaboratorHelpCern.list,
-          ...shareInviteCollaboratorHelp(this.configurationManager).list
-        ]
+        const options = {
+          configurationManager: this.configurationManager
+        }
+        const mergedHelp = shareInviteCollaboratorHelp(options)
+        mergedHelp.list = [...shareInviteCollaboratorHelpCern(options).list, ...mergedHelp.list]
         return mergedHelp
       }
 
-      return shareInviteCollaboratorHelp(this.configurationManager)
+      return shareInviteCollaboratorHelp({
+        configurationManager: this.configurationManager
+      })
     },
     helpersEnabled() {
       return this.configuration?.options?.contextHelpers

--- a/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
@@ -108,7 +108,9 @@ export default defineComponent({
       return this.configuration?.options?.contextHelpers
     },
     spaceAddMemberHelp() {
-      return shareSpaceAddMemberHelp(this.configurationManager)
+      return shareSpaceAddMemberHelp({
+        configurationManager: this.configurationManager
+      })
     },
     hasCollaborators() {
       return this.spaceMembers.length > 0

--- a/packages/web-app-files/src/helpers/contextualHelpers.ts
+++ b/packages/web-app-files/src/helpers/contextualHelpers.ts
@@ -9,7 +9,6 @@ export const empty = {
   list: ['', '', '']
 }
 export const shareInviteCollaboratorHelp = (configurationManager: ConfigurationManager) => {
-  console.log(configurationManager.options)
   return {
     title: $gettext('Invite specific people'),
     text: $gettext('Enter a name or group to share this item.'),

--- a/packages/web-app-files/src/helpers/contextualHelpers.ts
+++ b/packages/web-app-files/src/helpers/contextualHelpers.ts
@@ -1,130 +1,161 @@
 import { ConfigurationManager } from 'web-pkg'
+import { omit } from 'lodash-es'
 
 // just a dummy function to trick gettext tools
 function $gettext(msg) {
   return msg
 }
-export const empty = {
-  text: '',
-  list: ['', '', '']
+
+export interface ContextualHelperDataListItem {
+  text: string
+  headline?: boolean
 }
-export const shareInviteCollaboratorHelp = (configurationManager: ConfigurationManager) => {
-  return {
-    title: $gettext('Invite specific people'),
-    text: $gettext('Enter a name or group to share this item.'),
-    list: [
-      { text: $gettext('Subfolders'), headline: true },
-      {
-        text: $gettext(
-          'If you share a folder, all of its contents and subfolders will be shared as well.'
-        )
-      },
-      { text: $gettext('Notification'), headline: true },
-      {
-        text: $gettext('Invited people will be notified via email or in-app notification.')
-      },
-      { text: $gettext('Incognito'), headline: true },
-      {
-        text: $gettext('Invited people can not see who else has access..')
-      },
-      { text: $gettext('“via folder”'), headline: true },
-      {
-        text: $gettext(
-          'The “via folder” is shown next to a share, if access has already been given via a parent folder. Click on the “via folder” to edit the share on its parent folder.'
-        )
-      }
-    ],
-    readMoreLink:
-      configurationManager.options.contextHelpersReadMore === false
-        ? ''
-        : 'https://doc.owncloud.com/webui/next/owncloud_web/web_for_users.html#sharing'
-  }
+export interface ContextualHelperData {
+  title: string
+  text?: string
+  list?: ContextualHelperDataListItem[]
+  readMoreLink?: string
 }
 
-export const shareInviteCollaboratorHelpCern = {
-  list: [
-    { text: $gettext('Search for service or secondary Account'), headline: true },
-    {
-      text: $gettext(
-        'To search for service or secondary accounts prefix the username with "a:" (like "a:doe") and for guest accounts prefix the username with "l:" (like "l:doe").'
-      )
-    }
-  ]
+export interface ContextualHelperOptions {
+  configurationManager: ConfigurationManager
 }
-export const shareSpaceAddMemberHelp = (configurationManager: ConfigurationManager) => ({
-  title: $gettext('Add members to this Space'),
-  text: $gettext('Enter a name to add people or groups as members to this Space.'),
-  list: [
-    { text: $gettext('What members can do'), headline: true },
+
+export const shareInviteCollaboratorHelp = (options: ContextualHelperOptions) =>
+  filterContextHelper(
     {
-      text: $gettext(
-        'Members can see who else has access to this space and can access all files in this space. Read or write permissions can be set by the member’s role such as “Viewer” or “Editor”.'
-      )
+      title: $gettext('Invite specific people'),
+      text: $gettext('Enter a name or group to share this item.'),
+      list: [
+        { text: $gettext('Subfolders'), headline: true },
+        {
+          text: $gettext(
+            'If you share a folder, all of its contents and subfolders will be shared as well.'
+          )
+        },
+        { text: $gettext('Notification'), headline: true },
+        {
+          text: $gettext('Invited people will be notified via email or in-app notification.')
+        },
+        { text: $gettext('Incognito'), headline: true },
+        {
+          text: $gettext('Invited people can not see who else has access..')
+        },
+        { text: $gettext('“via folder”'), headline: true },
+        {
+          text: $gettext(
+            'The “via folder” is shown next to a share, if access has already been given via a parent folder. Click on the “via folder” to edit the share on its parent folder.'
+          )
+        }
+      ],
+      readMoreLink: 'https://doc.owncloud.com/webui/next/owncloud_web/web_for_users.html#sharing'
     },
-    { text: $gettext('What Space managers can do'), headline: true },
+    options
+  )
+
+export const shareInviteCollaboratorHelpCern = (options: ContextualHelperOptions) =>
+  filterContextHelper(
     {
-      text: $gettext(
-        'Members with the Manager role can edit all properties and content of a Space, such as adding or removing members, sharing subfolders with non-members, or creating links to share.'
-      )
-    }
-  ],
-  readMoreLink:
-    configurationManager.options.contextHelpersReadMore === false
-      ? ''
-      : 'https://doc.owncloud.com/webui/next/owncloud_web/web_for_users.html#sharing'
-})
-export const shareViaLinkHelp = (configurationManager: ConfigurationManager) => ({
-  title: $gettext('Choose how access is granted'),
-  list: [
-    {
-      text: $gettext('Only invited people can access'),
-      headline: true
+      title: '',
+      list: [
+        { text: $gettext('Search for service or secondary Account'), headline: true },
+        {
+          text: $gettext(
+            'To search for service or secondary accounts prefix the username with "a:" (like "a:doe") and for guest accounts prefix the username with "l:" (like "l:doe").'
+          )
+        }
+      ]
     },
+    options
+  )
+
+export const shareSpaceAddMemberHelp = (options: ContextualHelperOptions) =>
+  filterContextHelper(
     {
-      text: $gettext(
-        'Account and login is required. Only people from the list "Invited people" can access.'
-      )
+      title: $gettext('Add members to this Space'),
+      text: $gettext('Enter a name to add people or groups as members to this Space.'),
+      list: [
+        { text: $gettext('What members can do'), headline: true },
+        {
+          text: $gettext(
+            'Members can see who else has access to this space and can access all files in this space. Read or write permissions can be set by the member’s role such as “Viewer” or “Editor”.'
+          )
+        },
+        { text: $gettext('What Space managers can do'), headline: true },
+        {
+          text: $gettext(
+            'Members with the Manager role can edit all properties and content of a Space, such as adding or removing members, sharing subfolders with non-members, or creating links to share.'
+          )
+        }
+      ],
+      readMoreLink: 'https://doc.owncloud.com/webui/next/owncloud_web/web_for_users.html#sharing'
     },
+    options
+  )
+export const shareViaLinkHelp = (options: ContextualHelperOptions) =>
+  filterContextHelper(
     {
-      text: $gettext('Everyone with the link'),
-      headline: true
+      title: $gettext('Choose how access is granted'),
+      list: [
+        {
+          text: $gettext('Only invited people can access'),
+          headline: true
+        },
+        {
+          text: $gettext(
+            'Account and login is required. Only people from the list "Invited people" can access.'
+          )
+        },
+        {
+          text: $gettext('Everyone with the link'),
+          headline: true
+        },
+        {
+          text: $gettext(
+            'No login required. Everyone with the link can access. If you share this link with people from the list "Invited people", they need to login so that their individual assigned permissions can take effect. If they are not logged-in, the permissions of the link take effect.'
+          )
+        },
+        {
+          text: $gettext('Quicklink'),
+          headline: true
+        },
+        {
+          text: $gettext(
+            'The quicklink is the default link that is copied when you select "Get link” from the context menu.'
+          )
+        }
+      ],
+      readMoreLink: 'https://doc.owncloud.com/webui/next/owncloud_web/web_for_users.html#sharing'
     },
+    options
+  )
+export const shareViaIndirectLinkHelp = (options: ContextualHelperOptions) =>
+  filterContextHelper(
     {
-      text: $gettext(
-        'No login required. Everyone with the link can access. If you share this link with people from the list "Invited people", they need to login so that their individual assigned permissions can take effect. If they are not logged-in, the permissions of the link take effect.'
-      )
+      title: $gettext('What are indirect links?'),
+      text: $gettext('Indirect links are links giving access by a parent folder.'),
+      list: [
+        {
+          text: $gettext('How to edit indirect links'),
+          headline: true
+        },
+        {
+          text: $gettext(
+            'Indirect links can only be edited in their parent folder. Click on the folder icon below the link to navgate to the parent folder.'
+          )
+        }
+      ],
+      readMoreLink: 'https://doc.owncloud.com/webui/next/owncloud_web/web_for_users.html#sharing'
     },
-    {
-      text: $gettext('Quicklink'),
-      headline: true
-    },
-    {
-      text: $gettext(
-        'The quicklink is the default link that is copied when you select "Get link” from the context menu.'
-      )
-    }
-  ],
-  readMoreLink:
-    configurationManager.options.contextHelpersReadMore === false
-      ? ''
-      : 'https://doc.owncloud.com/webui/next/owncloud_web/web_for_users.html#sharing'
-})
-export const shareViaIndirectLinkHelp = (configurationManager: ConfigurationManager) => ({
-  title: $gettext('What are indirect links?'),
-  text: $gettext('Indirect links are links giving access by a parent folder.'),
-  list: [
-    {
-      text: $gettext('How to edit indirect links'),
-      headline: true
-    },
-    {
-      text: $gettext(
-        'Indirect links can only be edited in their parent folder. Click on the folder icon below the link to navgate to the parent folder.'
-      )
-    }
-  ],
-  readMoreLink:
-    configurationManager.options.contextHelpersReadMore === false
-      ? ''
-      : 'https://doc.owncloud.com/webui/next/owncloud_web/web_for_users.html#sharing'
-})
+    options
+  )
+
+const filterContextHelper = (
+  data: ContextualHelperData,
+  options?: ContextualHelperOptions
+): ContextualHelperData => {
+  if (options.configurationManager.options.contextHelpersReadMore === false) {
+    return omit(data, 'readMoreLink')
+  }
+  return data
+}


### PR DESCRIPTION
## Description
As a followup to https://github.com/owncloud/web/pull/8713 I have:
- removed a `console.log` statement
- fixed the config option name in the docs
- switched from duplicated check in each context helper to a generic filtering approach
- made the options for the context helpers a single options object (I prefer that most of the time, because you can extend that much easier in the future)
- introduced types for the context helpers

## Related Issue
- Fixes https://github.com/owncloud/web/issues/8570 ... again? :trollface: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
