### PR TITLE
[full-ci] Introduce read-only options to OcSelect

### DIFF
--- a/packages/design-system/changelog/unreleased/enhancement-read-only-select-options
+++ b/packages/design-system/changelog/unreleased/enhancement-read-only-select-options
@@ -1,0 +1,6 @@
+Enhancement: Read-only select options
+
+The `OcSelect` component now supports read-only select options which can't be removed if selected.
+
+https://github.com/owncloud/web/issues/8729
+https://github.com/owncloud/web/pull/8727

--- a/packages/design-system/src/components/OcSelect/OcSelect.spec.ts
+++ b/packages/design-system/src/components/OcSelect/OcSelect.spec.ts
@@ -1,0 +1,94 @@
+import { defaultPlugins, mount } from 'web-test-helpers'
+import OcSelect from './OcSelect.vue'
+
+const selectors = {
+  ocSelect: '.oc-select',
+  selectedOptions: '.vs__selected-options .vs__selected',
+  deselectBtn: '.vs__selected-options .vs__deselect',
+  deselectLockIcon: '.vs__deselect-lock',
+  clearBtn: '.vs__clear',
+  searchInput: '.vs__search',
+  ocSpinner: '.oc-spinner',
+  warningMessage: '.oc-text-input-warning',
+  errorMessage: '.oc-text-input-danger',
+  descriptionMessage: '.oc-text-input-description'
+}
+
+describe('OcSelect', () => {
+  it('passes the options to the vue-select component', () => {
+    const options = [{ label: 'label1' }, { label: 'label2' }]
+    const wrapper = getWrapper({ options })
+    expect(wrapper.findComponent<any>(selectors.ocSelect).props('options')).toEqual(options)
+  })
+  it('shows ocSpinner component when loading', () => {
+    const wrapper = getWrapper({ loading: true })
+    expect(wrapper.find(selectors.ocSpinner).exists()).toBeTruthy()
+  })
+  it('triggers the "search:input"-event on search input', async () => {
+    const wrapper = getWrapper()
+    await wrapper.find(selectors.searchInput).trigger('input')
+    expect(wrapper.emitted('search:input')).toBeDefined()
+  })
+  describe('clear button', () => {
+    it('is hidden by default', () => {
+      const options = [{ label: 'label1' }, { label: 'label2' }]
+      const wrapper = getWrapper({ options, modelValue: options[0] })
+      expect(wrapper.find(selectors.clearBtn).attributes('style')).toEqual('display: none;')
+    })
+    it('is visible if "clearable" is set to true', () => {
+      const options = [{ label: 'label1' }, { label: 'label2' }]
+      const wrapper = getWrapper({ options, modelValue: options[0], clearable: true })
+      expect(wrapper.find(selectors.clearBtn).attributes('style')).toBeUndefined()
+    })
+  })
+  describe('selected option', () => {
+    it('displays', () => {
+      const options = [{ label: 'label1' }, { label: 'label2' }]
+      const wrapper = getWrapper({ options, modelValue: options[0] })
+      expect(wrapper.findAll(selectors.selectedOptions).length).toBe(1)
+      expect(wrapper.findAll(selectors.selectedOptions).at(0).text()).toEqual(options[0].label)
+    })
+    it('displays with a custom label property', () => {
+      const options = [{ customLabel: 'label1' }, { customLabel: 'label2' }]
+      const wrapper = getWrapper({ options, modelValue: options[0], optionLabel: 'customLabel' })
+      expect(wrapper.findAll(selectors.selectedOptions).at(0).text()).toEqual(
+        options[0].customLabel
+      )
+    })
+    it('can be cleared if multi-select is allowed', () => {
+      const options = [{ label: 'label1' }, { label: 'label2' }]
+      const wrapper = getWrapper({ options, modelValue: options[0], multiple: true })
+      expect(wrapper.find(selectors.deselectBtn).exists()).toBeTruthy()
+      expect(wrapper.find(selectors.deselectLockIcon).exists()).toBeFalsy()
+    })
+    it('can not be cleared if readonly', () => {
+      const options = [{ label: 'label1', readonly: true }, { label: 'label2' }]
+      const wrapper = getWrapper({ options, modelValue: options[0], multiple: true })
+      expect(wrapper.find(selectors.deselectBtn).exists()).toBeFalsy()
+      expect(wrapper.find(selectors.deselectLockIcon).exists()).toBeTruthy()
+    })
+  })
+  describe('message', () => {
+    it('displays a warning message', () => {
+      const wrapper = getWrapper({ warningMessage: 'foo' })
+      expect(wrapper.find(selectors.warningMessage).exists()).toBeTruthy()
+    })
+    it('displays an error message', () => {
+      const wrapper = getWrapper({ errorMessage: 'foo' })
+      expect(wrapper.find(selectors.errorMessage).exists()).toBeTruthy()
+    })
+    it('displays a description message', () => {
+      const wrapper = getWrapper({ descriptionMessage: 'foo' })
+      expect(wrapper.find(selectors.descriptionMessage).exists()).toBeTruthy()
+    })
+  })
+})
+
+function getWrapper(props = {}) {
+  return mount(OcSelect, {
+    props,
+    global: {
+      plugins: [...defaultPlugins()]
+    }
+  })
+}

--- a/packages/web-app-admin-settings/src/components/Users/GroupSelect.vue
+++ b/packages/web-app-admin-settings/src/components/Users/GroupSelect.vue
@@ -3,7 +3,7 @@
     <oc-select
       :model-value="selectedOption"
       class="oc-mb-s"
-      multiple
+      :multiple="true"
       :options="groupOptions"
       option-label="displayName"
       :label="$gettext('Groups')"

--- a/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/__snapshots__/EditPanel.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/__snapshots__/EditPanel.spec.ts.snap
@@ -10,11 +10,11 @@ exports[`EditPanel renders all available inputs 1`] = `
       <oc-text-input-stub class="oc-mb-s" clearbuttonaccessiblelabel="" clearbuttonenabled="false" disabled="false" errormessage="" fixmessageline="true" id="email-input" label="Email" modelvalue="jan@owncloud.com" type="email"></oc-text-input-stub>
       <oc-text-input-stub class="oc-mb-s" clearbuttonaccessiblelabel="" clearbuttonenabled="false" disabled="false" fixmessageline="true" id="password-input" label="Password" modelvalue="" placeholder="●●●●●●●●" type="password"></oc-text-input-stub>
       <div class="oc-mb-s">
-        <oc-select-stub clearable="false" disabled="false" filter="[Function]" fixmessageline="false" id="role-input" label="Role" loading="false" model-value="[object Object]" optionlabel="displayName" options="[object Object]" searchable="true"></oc-select-stub>
+        <oc-select-stub clearable="false" disabled="false" filter="[Function]" fixmessageline="false" id="role-input" label="Role" loading="false" model-value="[object Object]" multiple="false" optionlabel="displayName" options="[object Object]" searchable="true"></oc-select-stub>
         <div class="oc-text-input-message"></div>
       </div>
       <div class="oc-mb-s">
-        <oc-select-stub clearable="false" disabled="false" filter="[Function]" fixmessageline="false" id="login-input" label="Login" loading="false" model-value="[object Object]" options="[object Object],[object Object]" searchable="true"></oc-select-stub>
+        <oc-select-stub clearable="false" disabled="false" filter="[Function]" fixmessageline="false" id="login-input" label="Login" loading="false" model-value="[object Object]" multiple="false" optionlabel="label" options="[object Object],[object Object]" searchable="true"></oc-select-stub>
         <div class="oc-text-input-message"></div>
       </div>
       <quota-select-stub class="oc-mb-s" descriptionmessage="" disabled="false" fixmessageline="true" id="quota-select-form" maxquota="0" title="Personal quota" totalquota="0"></quota-select-stub>

--- a/packages/web-app-admin-settings/tests/unit/components/Users/__snapshots__/GroupSelect.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/__snapshots__/GroupSelect.spec.ts.snap
@@ -2,6 +2,6 @@
 
 exports[`GroupSelect renders the select input 1`] = `
 <div id="user-group-select-form">
-  <oc-select-stub class="oc-mb-s" clearable="false" disabled="false" filter="[Function]" fixmessageline="true" id="oc-select-1" label="Groups" loading="false" model-value="undefined" multiple="" optionlabel="displayName" options="undefined" searchable="true"></oc-select-stub>
+  <oc-select-stub class="oc-mb-s" clearable="false" disabled="false" filter="[Function]" fixmessageline="true" id="oc-select-1" label="Groups" loading="false" model-value="undefined" multiple="true" optionlabel="displayName" options="undefined" searchable="true"></oc-select-stub>
 </div>
 `;

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -60,7 +60,7 @@ const tagTableCell =
 const tagInFilesTable = '//*[contains(@class, "oc-tag")]//span[text()="%s"]//ancestor::a'
 const tagInDetailsPanel = '//*[@data-testid="tags"]/td//span[text()="%s"]'
 const tagInInputForm =
-  '//span[contains(@class, "vs__selected")]//span[text()="%s"]//ancestor::span/button[contains(@class, "vs__deselect")]'
+  '//span[contains(@class, "vs__selected")]//span[text()="%s"]//ancestor::span//button[contains(@class, "vs__deselect")]'
 const tagFormInput = '#tags-form input'
 const compareDialogConfirmBtn = '.compare-save-dialog-confirm-btn'
 const resourcesAsTiles = '#files-view .oc-tiles'


### PR DESCRIPTION
## Description
This is required for the user-group-assignment select because a user can have read-only groups that must not be removed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Needed for https://github.com/owncloud/web/issues/8729

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/50302941/228189293-94a3c3a9-7e08-4d96-935f-a52a3b218bd5.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
