### PR TITLE
feat: add oidc client config for filepicker development

### DIFF
--- a/dev/docker/ocis.idp.config.yaml
+++ b/dev/docker/ocis.idp.config.yaml
@@ -15,3 +15,13 @@ clients:
     - https://host.docker.internal:9100
     - https://host.docker.internal:9200
     - https://host.docker.internal:9201
+- id: filepicker
+  name: ownCloud file picker
+  application_type: ""
+  trusted: true
+  secret: ""
+  redirect_uris:
+    - https://host.docker.internal:8080/
+    - https://host.docker.internal:8080/oidc-callback.html
+  origins:
+    - https://host.docker.internal:8080


### PR DESCRIPTION
adding client config for developing the `file-picker` (see github.com/owncloud/file-picker) with our dockerized ocis dev environment.