### PR TITLE
Reduce input height in modals

### DIFF
--- a/packages/design-system/changelog/unreleased/enhancement-beautify-modals
+++ b/packages/design-system/changelog/unreleased/enhancement-beautify-modals
@@ -3,3 +3,5 @@ Enhancement: Beautify modals
 We've changed the look of modals slightly.
 
 https://github.com/owncloud/web/pull/8608
+https://github.com/owncloud/web/pull/8744
+https://github.com/owncloud/web/issues/8742

--- a/packages/design-system/src/components/OcModal/OcModal.vue
+++ b/packages/design-system/src/components/OcModal/OcModal.vue
@@ -513,6 +513,10 @@ export default defineComponent({
       margin-bottom: var(--oc-space-medium);
     }
 
+    .oc-input {
+      line-height: normal;
+    }
+
     &-input {
       /* FIXME: this is ugly, but required so that the bottom padding doesn't look off when reserving vertical space for error messages below the input. */
       margin-bottom: -20px;


### PR DESCRIPTION
## Description
... to match the other input forms.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8742

## Screenshots:

Before:

<img width="462" alt="image" src="https://user-images.githubusercontent.com/50302941/228593007-1394ad1a-dc8e-40b0-a04a-39e8fdaab175.png">

After:

<img width="458" alt="image" src="https://user-images.githubusercontent.com/50302941/228593131-433563c5-c47a-45b5-bfa1-16c3ccf34b50.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
