### PR TITLE
Add cucumber autocomplete extension + config

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,7 @@
     "EditorConfig.EditorConfig",
     "Orta.vscode-jest",
     "Vue.volar",
-    "Vue.vscode-typescript-vue-plugin"
+    "Vue.vscode-typescript-vue-plugin",
+    "alexkrechik.cucumberautocomplete"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,12 @@
   },
   "jest.jestCommandLine": "pnpm test:unit",
   "npm.packageManager": "pnpm",
-  "typescript.format.enable": false
+  "typescript.format.enable": false,
+  "editor.quickSuggestions": {
+    "strings": true
+  },
+  "cucumberautocomplete.steps": [
+    "tests/e2e/cucumber/steps/**/*.ts"
+  ],
+  "cucumberautocomplete.strictGherkinCompletion": true
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
1. To test install the recommended `alexkrechik.cucumberautocomplete`.
2. Go to any cucumber file e.g. `tests/e2e/cucumber/features/smoke/internalLink.ocis.feature`
3. Done, you now have syntax highlighting and autocompletion (also detects missing step definitions)

<img width="1680" alt="Bildschirmfoto 2023-03-30 um 15 41 11" src="https://user-images.githubusercontent.com/786551/228855345-7f702df8-b52e-4312-97d1-c566cfaca37e.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [x] Vscode configuration

