### PR TITLE
fix: set variation to brand for preview controls

### DIFF
--- a/changelog/unreleased/bugfix-preview-controls-colors
+++ b/changelog/unreleased/bugfix-preview-controls-colors
@@ -1,0 +1,5 @@
+Bugfix: Preview controls colors
+
+We've fixed a bug where the controls of the "preview" app were appearing black-on-grey in the dark theme.
+
+https://github.com/owncloud/web/pull/8758

--- a/packages/web-app-preview/src/App.vue
+++ b/packages/web-app-preview/src/App.vue
@@ -78,10 +78,11 @@
           v-oc-tooltip="previousDescription"
           class="preview-controls-previous"
           appearance="raw-inverse"
+          variation="brand"
           :aria-label="previousDescription"
           @click="prev"
         >
-          <oc-icon size="large" name="arrow-drop-left" />
+          <oc-icon size="large" name="arrow-drop-left" variation="inherit" />
         </oc-button>
         <p v-if="!isFolderLoading" class="oc-m-rm preview-controls-action-count">
           <span aria-hidden="true" v-text="ariaHiddenFileCount" />
@@ -91,10 +92,11 @@
           v-oc-tooltip="nextDescription"
           class="preview-controls-next"
           appearance="raw-inverse"
+          variation="brand"
           :aria-label="nextDescription"
           @click="next"
         >
-          <oc-icon size="large" name="arrow-drop-right" />
+          <oc-icon size="large" name="arrow-drop-right" variation="inherit" />
         </oc-button>
         <div class="oc-flex">
           <oc-button
@@ -103,6 +105,7 @@
             "
             class="preview-controls-fullscreen"
             appearance="raw-inverse"
+            variation="brand"
             :aria-label="
               isFullScreenModeActivated ? exitFullScreenDescription : enterFullScreenDescription
             "
@@ -111,6 +114,7 @@
             <oc-icon
               fill-type="line"
               :name="isFullScreenModeActivated ? 'fullscreen-exit' : 'fullscreen'"
+              variation="inherit"
             />
           </oc-button>
         </div>
@@ -120,15 +124,17 @@
               v-oc-tooltip="imageShrinkDescription"
               class="preview-controls-image-shrink"
               appearance="raw-inverse"
+              variation="brand"
               :aria-label="imageShrinkDescription"
               @click="imageShrink"
             >
-              <oc-icon fill-type="line" name="checkbox-indeterminate" />
+              <oc-icon fill-type="line" name="checkbox-indeterminate" variation="inherit" />
             </oc-button>
             <oc-button
               v-oc-tooltip="imageOriginalSizeDescription"
               class="preview-controls-image-original-size oc-ml-s oc-mr-s"
               appearance="raw-inverse"
+              variation="brand"
               :aria-label="imageOriginalSizeDescription"
               @click="currentImageZoom = 1"
             >
@@ -138,10 +144,11 @@
               v-oc-tooltip="imageZoomDescription"
               class="preview-controls-image-zoom"
               appearance="raw-inverse"
+              variation="brand"
               :aria-label="imageZoomDescription"
               @click="imageZoom"
             >
-              <oc-icon fill-type="line" name="add-box" />
+              <oc-icon fill-type="line" name="add-box" variation="inherit" />
             </oc-button>
           </div>
           <div class="oc-ml-m">
@@ -149,19 +156,21 @@
               v-oc-tooltip="imageRotateLeftDescription"
               class="preview-controls-rotate-left"
               appearance="raw-inverse"
+              variation="brand"
               :aria-label="imageRotateLeftDescription"
               @click="imageRotateLeft"
             >
-              <oc-icon fill-type="line" name="anticlockwise" />
+              <oc-icon fill-type="line" name="anticlockwise" variation="inherit" />
             </oc-button>
             <oc-button
               v-oc-tooltip="imageRotateRightDescription"
               class="preview-rotate-right"
               appearance="raw-inverse"
+              variation="brand"
               :aria-label="imageRotateRightDescription"
               @click="imageRotateRight"
             >
-              <oc-icon fill-type="line" name="clockwise" />
+              <oc-icon fill-type="line" name="clockwise" variation="inherit" />
             </oc-button>
           </div>
         </div>
@@ -635,7 +644,7 @@ export default defineComponent({
 }
 
 .preview-controls-action-count {
-  color: var(--oc-color-swatch-passive-contrast);
+  color: var(--oc-color-swatch-brand-contrast);
 }
 
 .preview-controls-image-original-size {


### PR DESCRIPTION
## Description
Controls in the preview app were using the default `passive` variation for buttons but the `brand` color swatch for the background. With our new `contrast` colors in color swatches this lead to `black on grey` in the dark theme.
Fixed by using the proper `brand` variation for the buttons => `brand` style background and `brand` variation for buttons = good contrast again.

## Screenshots (if appropriate):

### before (buggy)
<img width="1123" alt="Screenshot 2023-03-30 at 17 03 04" src="https://user-images.githubusercontent.com/3532843/228879750-5f2551f6-7d4e-4a86-ad22-a386a2dd78ec.png">

### after (fixed)
<img width="1120" alt="Screenshot 2023-03-30 at 16 58 10" src="https://user-images.githubusercontent.com/3532843/228879802-bd0c7e89-f216-471a-83e5-2d7f7b075978.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
