### PR TITLE
fix: oidc token renewal

### DIFF
--- a/changelog/unreleased/bugfix-token-renewal-hash-mode
+++ b/changelog/unreleased/bugfix-token-renewal-hash-mode
@@ -1,0 +1,6 @@
+Bugfix: Token renewal in vue router hash mode
+
+We've fixed a bug where the silent token renewal (= in iframe) with the vue router hash mode had a URL format that could not be parsed by the oidc-client-ts lib.
+
+https://github.com/owncloud/web/issues/8420
+https://github.com/owncloud/web/pull/8762 

--- a/changelog/unreleased/enhancement-unauthenticated-bootstrap
+++ b/changelog/unreleased/enhancement-unauthenticated-bootstrap
@@ -1,0 +1,5 @@
+Enhancement: Stop bootstrapping application earlier in anonymous contexts
+
+We've optimized the silent token refresh to make less application bootstrapping requests.
+
+https://github.com/owncloud/web/pull/8762

--- a/dev/docker/ocis.idp.config.yaml
+++ b/dev/docker/ocis.idp.config.yaml
@@ -5,14 +5,11 @@ clients:
   insecure: yes
   trusted: yes
   redirect_uris:
-    - https://host.docker.internal:9100/
-    - https://host.docker.internal:9200/
-    - https://host.docker.internal:9201/
-    - https://host.docker.internal:9100/oidc-callback.html
     - https://host.docker.internal:9200/oidc-callback.html
     - https://host.docker.internal:9201/oidc-callback.html
+    - https://host.docker.internal:9200/oidc-silent-redirect.html
+    - https://host.docker.internal:9201/oidc-silent-redirect.html
   origins:
-    - https://host.docker.internal:9100
     - https://host.docker.internal:9200
     - https://host.docker.internal:9201
 - id: filepicker
@@ -21,7 +18,7 @@ clients:
   trusted: true
   secret: ""
   redirect_uris:
-    - https://host.docker.internal:8080/
     - https://host.docker.internal:8080/oidc-callback.html
+    - https://host.docker.internal:8080/oidc-silent-redirect.html
   origins:
     - https://host.docker.internal:8080

--- a/dev/docker/ocis.idp.config.yaml
+++ b/dev/docker/ocis.idp.config.yaml
@@ -5,9 +5,11 @@ clients:
   insecure: yes
   trusted: yes
   redirect_uris:
+    - https://host.docker.internal:9200/
     - https://host.docker.internal:9200/oidc-callback.html
-    - https://host.docker.internal:9201/oidc-callback.html
     - https://host.docker.internal:9200/oidc-silent-redirect.html
+    - https://host.docker.internal:9201/
+    - https://host.docker.internal:9201/oidc-callback.html
     - https://host.docker.internal:9201/oidc-silent-redirect.html
   origins:
     - https://host.docker.internal:9200
@@ -18,6 +20,7 @@ clients:
   trusted: true
   secret: ""
   redirect_uris:
+    - https://host.docker.internal:8080/
     - https://host.docker.internal:8080/oidc-callback.html
     - https://host.docker.internal:8080/oidc-silent-redirect.html
   origins:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,6 @@ services:
 
       # IDP
       IDP_LDAP_BIND_PASSWORD: "${IDP_LDAP_BIND_PASSWORD:-some-ldap-idp-password}"
-      IDP_ACCESS_TOKEN_EXPIRATION: 1000000
 
       # STORAGE
       STORAGE_HOME_DRIVER: ${STORAGE_HOME_DRIVER:-ocis}

--- a/packages/web-runtime/src/router/setupAuthGuard.ts
+++ b/packages/web-runtime/src/router/setupAuthGuard.ts
@@ -16,7 +16,7 @@ export const setupAuthGuard = (router: Router) => {
     // vue-router currently (4.1.6) does not cancel navigations when a new one is triggered
     // we need to guard this case to be able to show the access denied page
     // and not be redirected to the login page
-    if (authService.hasAuthErrorOccured) {
+    if (authService.hasAuthErrorOccurred) {
       return to.name === 'accessDenied' || { name: 'accessDenied' }
     }
 
@@ -44,7 +44,7 @@ export const setupAuthGuard = (router: Router) => {
     if (to.name !== 'accessDenied') {
       return
     }
-    authService.hasAuthErrorOccured = false
+    authService.hasAuthErrorOccurred = false
   })
 }
 

--- a/packages/web-runtime/src/services/auth/userManager.ts
+++ b/packages/web-runtime/src/services/auth/userManager.ts
@@ -35,6 +35,8 @@ export class UserManager extends OidcUserManager {
   private ability: Ability
   private language: Language
 
+  public areEventHandlersRegistered: boolean
+
   constructor(options: UserManagerOptions) {
     const storePrefix = 'oc_oAuth.'
     const userStore = new WebStorageStateStore({


### PR DESCRIPTION
## Description
this PR fixes multiple oidc related things:

- Our dockerized dev environment was missing the redirect uris for silent token renewal `/oidc-silent-redirect.html`. The silent renewal landed in a (silent :trollface: ) access_denied.
- silent token renewal had a url format that the oidc-client-lib could not parse when in vue router hash mode
- we now stop the application bootstrap early in the silent redirect callback page. This mitigates an ocis bug in the authentication middleware. Will post an ocis issue as well later on. 

As a result you should not get redirected to the access denied page anymore. That was happening on token renewals before. 

## Issues
Fixes https://github.com/owncloud/web/issues/8420