### PR TITLE
Multiline wrapping for long breadcrumb

### DIFF
--- a/changelog/unreleased/bugfix-multiline-breadcrumb
+++ b/changelog/unreleased/bugfix-multiline-breadcrumb
@@ -1,0 +1,6 @@
+Bugfix: Layout with long breadcrumb
+
+The breadcrumb component with total length longer than the app area was breaking the layout and has been fixed
+
+https://github.com/owncloud/web/issues/6731
+https://github.com/owncloud/web/pull/8765

--- a/packages/design-system/src/components/OcBreadcrumb/OcBreadcrumb.vue
+++ b/packages/design-system/src/components/OcBreadcrumb/OcBreadcrumb.vue
@@ -195,6 +195,7 @@ export default defineComponent({
 
     list-style: none;
     align-items: baseline;
+    flex-wrap: wrap;
 
     #oc-breadcrumb-contextmenu-trigger > span {
       vertical-align: middle;


### PR DESCRIPTION
## Description
Fix for bug with the long breadcrumb that was breaking the layout

## Related Issue
https://github.com/owncloud/web/issues/6731

## Motivation and Context
- The table options and the sidebar were partly out of the visible area because of the long breadcrumb

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

