### PR TITLE
Add support for read-only groups

### DIFF
--- a/changelog/unreleased/enhancement-add-support-for-read-only-groups
+++ b/changelog/unreleased/enhancement-add-support-for-read-only-groups
@@ -1,0 +1,6 @@
+Enhancement: Add support for read-only groups
+
+Read-only groups are now supported. Such groups can't be edited or assigned to/removed from users. They are indicated via a lock icon in the group list and all affected inputs.
+
+https://github.com/owncloud/web/pull/8766
+https://github.com/owncloud/web/issues/8729

--- a/packages/web-app-admin-settings/src/components/Users/GroupSelect.vue
+++ b/packages/web-app-admin-settings/src/components/Users/GroupSelect.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="user-group-select-form">
     <oc-select
-      :model-value="selectedOption"
+      :model-value="selectedOptions"
       class="oc-mb-s"
       :multiple="true"
       :options="groupOptions"
@@ -38,8 +38,7 @@
   </div>
 </template>
 <script lang="ts">
-import { defineComponent, PropType, ref, unref, watch } from 'vue'
-import { computed } from 'vue'
+import { computed, defineComponent, PropType, ref, unref, watch } from 'vue'
 import { Group } from 'web-client/src/generated'
 
 export default defineComponent({
@@ -56,18 +55,27 @@ export default defineComponent({
   },
   emits: ['selectedOptionChange'],
   setup(props, { emit }) {
-    const selectedOption = ref(props.selectedGroups)
+    const selectedOptions = ref()
     const onUpdate = (event) => {
-      selectedOption.value = event
-      emit('selectedOptionChange', unref(selectedOption))
+      selectedOptions.value = event
+      emit('selectedOptionChange', unref(selectedOptions))
     }
 
     const currentGroups = computed(() => props.selectedGroups)
-    watch(currentGroups, () => {
-      selectedOption.value = props.selectedGroups
-    })
+    watch(
+      currentGroups,
+      () => {
+        selectedOptions.value = props.selectedGroups
+          .map((g) => ({
+            ...g,
+            readonly: g.groupTypes?.includes('ReadOnly')
+          }))
+          .sort((a: any, b: any) => b.readonly - a.readonly)
+      },
+      { immediate: true }
+    )
 
-    return { selectedOption, onUpdate }
+    return { selectedOptions, onUpdate }
   }
 })
 </script>

--- a/packages/web-app-admin-settings/src/components/Users/GroupsModal.vue
+++ b/packages/web-app-admin-settings/src/components/Users/GroupsModal.vue
@@ -8,7 +8,7 @@
     @confirm="$emit('confirm', { users, groups: selectedOptions })"
   >
     <template #content>
-      <GroupSelect
+      <group-select
         :selected-groups="selectedOptions"
         :group-options="groups"
         @selected-option-change="changeSelectedGroupOption"

--- a/packages/web-app-admin-settings/src/components/Users/SideBar/EditPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Users/SideBar/EditPanel.vue
@@ -164,7 +164,9 @@ export default defineComponent({
     })
     const groupOptions = computed(() => {
       const { memberOf: selectedGroups } = unref(editUser)
-      return props.groups.filter((g) => !selectedGroups.some((s) => s.id === g.id))
+      return props.groups.filter(
+        (g) => !selectedGroups.some((s) => s.id === g.id) && !g.groupTypes?.includes('ReadOnly')
+      )
     })
 
     const isLoginInputDisabled = computed(() => currentUser.uuid === (props.user as User).id)

--- a/packages/web-app-admin-settings/src/composables/actions/groups/useGroupActionsDelete.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/groups/useGroupActionsDelete.ts
@@ -86,7 +86,7 @@ export const useGroupActionsDelete = ({ store }: { store?: Store<any> }) => {
       },
       handler,
       isEnabled: ({ resources }) => {
-        return !!resources.length
+        return !!resources.length && !resources.some((r) => r.groupTypes?.includes('ReadOnly'))
       },
       componentType: 'button',
       class: 'oc-groups-actions-delete-trigger'

--- a/packages/web-app-admin-settings/src/composables/actions/groups/useGroupActionsEdit.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/groups/useGroupActionsEdit.ts
@@ -14,7 +14,7 @@ export const useGroupActionsEdit = () => {
       label: () => $gettext('Edit'),
       handler: () => eventBus.publish(SideBarEventTopics.openWithPanel, 'EditPanel'),
       isEnabled: ({ resources }) => {
-        return resources.length > 0
+        return resources.length === 1 && !resources[0].groupTypes?.includes('ReadOnly')
       },
       componentType: 'button',
       class: 'oc-groups-actions-edit-trigger'

--- a/packages/web-app-admin-settings/src/views/Groups.vue
+++ b/packages/web-app-admin-settings/src/views/Groups.vue
@@ -185,7 +185,9 @@ export default defineComponent({
           title: this.$gettext('Edit group'),
           component: EditPanel,
           default: false,
-          enabled: this.selectedGroups.length === 1,
+          enabled:
+            this.selectedGroups.length === 1 &&
+            !this.selectedGroups[0].groupTypes?.includes('ReadOnly'),
           componentAttrs: {
             group: this.selectedGroups.length === 1 ? this.selectedGroups[0] : null,
             onConfirm: this.editGroup

--- a/packages/web-app-admin-settings/src/views/Users.vue
+++ b/packages/web-app-admin-settings/src/views/Users.vue
@@ -111,7 +111,7 @@
     <groups-modal
       v-if="addToGroupsModalIsOpen"
       :title="addToGroupsModalTitle"
-      :groups="groups"
+      :groups="writableGroups"
       :users="selectedUsers"
       @cancel="() => (addToGroupsModalIsOpen = false)"
       @confirm="addUsersToGroups"
@@ -119,7 +119,7 @@
     <groups-modal
       v-if="removeFromGroupsModalIsOpen"
       :title="removeFromGroupsModalTitle"
-      :groups="groups"
+      :groups="writableGroups"
       :users="selectedUsers"
       @cancel="() => (removeFromGroupsModalIsOpen = false)"
       @confirm="removeUsersFromGroups"
@@ -180,7 +180,7 @@ import {
   useUserActionsAddToGroups
 } from '../composables/actions/users'
 import { configurationManager } from 'web-pkg'
-import { Drive } from 'web-client/src/generated'
+import { Drive, Group } from 'web-client/src/generated'
 
 export default defineComponent({
   name: 'UsersView',
@@ -505,6 +505,10 @@ export default defineComponent({
       }
     }
 
+    const writableGroups = computed<Group[]>(() => {
+      return unref(groups).filter((g) => !g.groupTypes?.includes('ReadOnly'))
+    })
+
     return {
       ...useSideBar(),
       maxQuota: useCapabilitySpacesMaxQuota(),
@@ -533,7 +537,8 @@ export default defineComponent({
       spaceQuotaUpdated,
       selectedPersonalDrives,
       addUsersToGroups,
-      removeUsersFromGroups
+      removeUsersFromGroups,
+      writableGroups
     }
   },
   computed: {

--- a/packages/web-app-admin-settings/tests/unit/components/Users/GroupSelect.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/GroupSelect.spec.ts
@@ -3,28 +3,33 @@ import { defaultPlugins, shallowMount } from 'web-test-helpers'
 import { mock } from 'jest-mock-extended'
 import { Group } from 'web-client/src/generated'
 
-const groupMock = mock<Group>({ id: '1' })
+const groupMock = mock<Group>({ id: '1', groupTypes: [] })
 
 describe('GroupSelect', () => {
   it('renders the select input', () => {
     const { wrapper } = getWrapper()
     expect(wrapper.html()).toMatchSnapshot()
   })
+  it('correctly maps the read-only state', () => {
+    const groupMock = mock<Group>({ id: '1', groupTypes: ['ReadOnly'] })
+    const { wrapper } = getWrapper(groupMock)
+    expect(wrapper.vm.selectedOptions[0].readonly).toBeTruthy()
+  })
   it('emits "selectedOptionChange" on update', () => {
-    const group = mock<Group>({ id: '2' })
+    const group = mock<Group>({ id: '2', groupTypes: [] })
     const { wrapper } = getWrapper()
     wrapper.vm.onUpdate(group)
     expect(wrapper.emitted().selectedOptionChange).toBeTruthy()
-    expect(wrapper.vm.selectedOption).toEqual(group)
+    expect(wrapper.vm.selectedOptions).toEqual(group)
   })
 })
 
-function getWrapper() {
+function getWrapper(group = groupMock) {
   return {
     wrapper: shallowMount(GroupSelect, {
       props: {
-        selectedGroups: [groupMock],
-        groupOptions: [groupMock]
+        selectedGroups: [group],
+        groupOptions: [group]
       },
       global: {
         plugins: [...defaultPlugins()]

--- a/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/EditPanel.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/EditPanel.spec.ts
@@ -12,8 +12,8 @@ import { Group } from 'web-client/src/generated'
 import { AxiosResponse } from 'axios'
 
 const availableGroupOptions = [
-  mock<Group>({ id: '1', displayName: 'group1' }),
-  mock<Group>({ id: '2', displayName: 'group2' })
+  mock<Group>({ id: '1', displayName: 'group1', groupTypes: [] }),
+  mock<Group>({ id: '2', displayName: 'group2', groupTypes: [] })
 ]
 const selectors = {
   groupSelectStub: 'group-select-stub'
@@ -132,9 +132,24 @@ describe('EditPanel', () => {
       expect(wrapper.vm.invalidFormData).toBeTruthy()
     })
   })
+
+  describe('group select', () => {
+    it('takes all available groups', () => {
+      const { wrapper } = getWrapper()
+      expect(wrapper.findComponent<any>('group-select-stub').props('groupOptions').length).toBe(
+        availableGroupOptions.length
+      )
+    })
+    it('filters out read-only groups', () => {
+      const { wrapper } = getWrapper({
+        groups: [mock<Group>({ id: '1', displayName: 'group1', groupTypes: ['ReadOnly'] })]
+      })
+      expect(wrapper.findComponent<any>('group-select-stub').props('groupOptions').length).toBe(0)
+    })
+  })
 })
 
-function getWrapper({ selectedGroups = [] } = {}) {
+function getWrapper({ selectedGroups = [], groups = availableGroupOptions } = {}) {
   const mocks = defaultComponentMocks()
   const storeOptions = defaultStoreMockOptions
   const store = createStore(storeOptions)
@@ -151,7 +166,7 @@ function getWrapper({ selectedGroups = [] } = {}) {
           memberOf: selectedGroups
         },
         roles: [{ id: '1', displayName: 'admin' }],
-        groups: availableGroupOptions
+        groups
       },
       global: {
         mocks,

--- a/packages/web-app-admin-settings/tests/unit/components/Users/__snapshots__/GroupSelect.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/__snapshots__/GroupSelect.spec.ts.snap
@@ -2,6 +2,6 @@
 
 exports[`GroupSelect renders the select input 1`] = `
 <div id="user-group-select-form">
-  <oc-select-stub class="oc-mb-s" clearable="false" disabled="false" filter="[Function]" fixmessageline="true" id="oc-select-1" label="Groups" loading="false" model-value="undefined" multiple="true" optionlabel="displayName" options="undefined" searchable="true"></oc-select-stub>
+  <oc-select-stub class="oc-mb-s" clearable="false" disabled="false" filter="[Function]" fixmessageline="true" id="oc-select-1" label="Groups" loading="false" model-value="[object Object]" multiple="true" optionlabel="displayName" options="undefined" searchable="true"></oc-select-stub>
 </div>
 `;

--- a/packages/web-app-admin-settings/tests/unit/views/Groups.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/views/Groups.spec.ts
@@ -14,7 +14,7 @@ const selectors = { batchActionsStub: 'batch-actions-stub' }
 const getClientServiceMock = () => {
   const clientService = mockDeep<ClientService>()
   clientService.graphAuthenticated.groups.listGroups.mockImplementation(() =>
-    mockAxiosResolve({ value: [{ id: '1', name: 'users' }] })
+    mockAxiosResolve({ value: [{ id: '1', name: 'users', groupTypes: [] }] })
   )
   return clientService
 }
@@ -85,25 +85,36 @@ describe('Groups view', () => {
   })
 
   describe('computed method "sideBarAvailablePanels"', () => {
-    it('should contain EditPanel when one group is selected', () => {
-      const { wrapper } = getWrapper()
-      wrapper.vm.selectedGroups = [{ id: '1' }]
-      expect(
-        wrapper.vm.sideBarAvailablePanels.find((panel) => panel.app === 'EditPanel').enabled
-      ).toBeTruthy()
+    describe('EditPanel', () => {
+      it('should be available when one group is selected', () => {
+        const { wrapper } = getWrapper()
+        wrapper.vm.selectedGroups = [{ id: '1' }]
+        expect(
+          wrapper.vm.sideBarAvailablePanels.find((panel) => panel.app === 'EditPanel')
+        ).toBeTruthy()
+      })
+      it('should not be available when multiple groups are selected', () => {
+        const { wrapper } = getWrapper()
+        wrapper.vm.selectedGroups = [{ id: '1' }, { id: '2' }]
+        expect(
+          wrapper.vm.sideBarAvailablePanels.find((panel) => panel.app === 'EditPanel')
+        ).toBeFalsy()
+      })
+      it('should not be available when one read-only group is selected', () => {
+        const { wrapper } = getWrapper()
+        wrapper.vm.selectedGroups = [{ id: '1', groupTypes: ['ReadOnly'] }]
+        expect(
+          wrapper.vm.sideBarAvailablePanels.find((panel) => panel.app === 'EditPanel')
+        ).toBeFalsy()
+      })
     })
-    it('should contain DetailsPanel when no group is selected', () => {
-      const { wrapper } = getWrapper()
-      expect(
-        wrapper.vm.sideBarAvailablePanels.find((panel) => panel.app === 'DetailsPanel').enabled
-      ).toBeTruthy()
-    })
-    it('should not contain EditPanel multiple groups are selected', () => {
-      const { wrapper } = getWrapper()
-      wrapper.vm.selectedGroups = [{ id: '1' }, { id: '2' }]
-      expect(
-        wrapper.vm.sideBarAvailablePanels.find((panel) => panel.app === 'EditPanel')
-      ).toBeFalsy()
+    describe('DetailsPanel', () => {
+      it('should contain DetailsPanel when no group is selected', () => {
+        const { wrapper } = getWrapper()
+        expect(
+          wrapper.vm.sideBarAvailablePanels.find((panel) => panel.app === 'DetailsPanel')
+        ).toBeTruthy()
+      })
     })
   })
 


### PR DESCRIPTION
## Description
Adds support for read-only groups. Such groups can't be edited or assigned to/removed from users. They are indicated via a lock icon in the group list and all affected inputs.

Needs latest oCIS master! You can test it by following the instructions given in https://github.com/owncloud/ocis/pull/5974.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8729

## Screenshots:

<img width="375" alt="image" src="https://user-images.githubusercontent.com/50302941/229460568-f9fb0543-03e7-4983-9c28-a15ff8302b16.png">

<img width="270" alt="image" src="https://user-images.githubusercontent.com/50302941/229460453-b23c1a81-f16f-4982-babc-08a7bd2b21bf.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## To-Do's:

- [x] Lock icon in group list?
- [x] Graph update for `groupTypes` property? -> is available after https://github.com/owncloud/web/pull/8741 has been merged
- [x] Fix unit tests
- [x] Disable group editing after https://github.com/owncloud/web/pull/8715 has been merged
- [x] Add unit tests
