### PR TITLE
Add option to set max length of a breadcrumb item

### DIFF
--- a/changelog/unreleased/enhancement-max-length-breadcrumb-item
+++ b/changelog/unreleased/enhancement-max-length-breadcrumb-item
@@ -1,0 +1,5 @@
+Enhancement: Option for the max length of a breadcrumb item
+
+We've added a configuration option `options.breadcrumbItemMaxLength` to set the max length of a breadcrumb items with exeption of the last item.
+
+https://github.com/owncloud/web/pull/8769

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -71,6 +71,7 @@ hovers the row with his mouse. Defaults to `false`.
 - `options.editor.autosaveEnabled` Specifies if the autosave for the editor apps is enabled.
 - `options.editor.autosaveInterval` Specifies the time interval for the autosave of editor apps in seconds.
 - `options.contextHelpersReadMore` Specifies whether the "Read more" link should be displayed or not.
+- `options.breadcrumbItemMaxLength` Specifies the maximum length in letters for the breadcrumb item. If set to 0, no maximum length will be set.
 
 ### Sentry
 

--- a/packages/design-system/src/components/OcBreadcrumb/OcBreadcrumb.vue
+++ b/packages/design-system/src/components/OcBreadcrumb/OcBreadcrumb.vue
@@ -7,7 +7,10 @@
         class="oc-breadcrumb-list-item oc-flex oc-flex-middle"
       >
         <router-link v-if="item.to" :aria-current="getAriaCurrent(index)" :to="item.to">
-          <span>{{ item.text }}</span>
+          <span v-if="shortenItemShown(item.text)" v-oc-tooltip="item.text">{{
+            getItemText(item.text)
+          }}</span>
+          <span v-else>{{ item.text }}</span>
         </router-link>
         <oc-icon
           v-if="item.to"
@@ -24,6 +27,13 @@
         >
           <span>{{ item.text }}</span>
         </oc-button>
+        <span
+          v-else-if="shortenItemShown(item.text)"
+          v-oc-tooltip="item.text"
+          :aria-current="getAriaCurrent(index)"
+          tabindex="-1"
+          v-text="getItemText(item.text)"
+        />
         <span v-else :aria-current="getAriaCurrent(index)" tabindex="-1" v-text="item.text" />
         <template v-if="showContextActions && index === items.length - 1">
           <oc-button
@@ -138,6 +148,15 @@ export default defineComponent({
     showContextActions: {
       type: Boolean,
       default: false
+    },
+    /**
+     * Defines the maximal length of a breadcrumb item. By longer item adds '...'. Defaults to 0 (no maximal length).
+     */
+    itemMaxLength: {
+      type: Number,
+      required: false,
+      default: 0,
+      validator: (value: number) => Number.isInteger(value) && value >= 0
     }
   },
   setup(props) {
@@ -161,7 +180,22 @@ export default defineComponent({
       return props.items.length - 1 === index ? 'page' : null
     }
 
-    return { currentFolder, parentFolderTo, contextMenuLabel, getAriaCurrent }
+    const getItemText = (itemText) => {
+      return `${itemText.slice(0, props.itemMaxLength - 1)}...`
+    }
+
+    const shortenItemShown = (itemText) => {
+      return props.itemMaxLength && itemText.length - props.itemMaxLength > 3
+    }
+
+    return {
+      currentFolder,
+      parentFolderTo,
+      contextMenuLabel,
+      getAriaCurrent,
+      getItemText,
+      shortenItemShown
+    }
   }
 })
 </script>

--- a/packages/web-app-files/src/components/AppBar/AppBar.vue
+++ b/packages/web-app-files/src/components/AppBar/AppBar.vue
@@ -18,6 +18,7 @@
           context-menu-padding="small"
           :show-context-actions="showContextActions"
           :items="breadcrumbs"
+          :itemMaxLength="breadcrumbItemMaxLength"
         >
           <template #contextMenu>
             <context-actions
@@ -182,10 +183,13 @@ export default defineComponent({
       return props.breadcrumbs.length <= 1
     })
 
+    const breadcrumbItemMaxLength = store.getters.configuration?.options?.breadcrumbItemMaxLength
+
     return {
       batchActions,
       showBreadcrumb,
-      showMobileNav
+      showMobileNav,
+      breadcrumbItemMaxLength
     }
   },
   data: function () {

--- a/packages/web-runtime/src/store/config.ts
+++ b/packages/web-runtime/src/store/config.ts
@@ -58,7 +58,8 @@ const state = {
     runningOnEos: false,
     cernFeatures: false,
     sharingRecipientsPerPage: 200,
-    contextHelpersReadMore: true
+    contextHelpersReadMore: true,
+    breadcrumbItemMaxLength: 0
   }
 }
 


### PR DESCRIPTION
## Description
Adds config option `breadcrumbItemMaxLength` for max length of a breadcrumb item (desktop version)

- With the option set to > 0 the item text gets cut to max length + "..."
- Shorten items get a tooltip with the full item text

## Related Issue
https://github.com/owncloud/web/issues/6731

## Motivation and Context
UI improvement

## Screenshots (if appropriate):

Long items without pr
![before](https://user-images.githubusercontent.com/7430156/229463261-692bb126-d390-427a-9692-34433282f4f7.png)

Long items with pr
![after](https://user-images.githubusercontent.com/7430156/229463281-094dbf77-92cd-4d10-8100-2ef3853d8293.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Should the last item always be fully visible?
- [ ] Should max length be also used for mobile version (drop)? But it doesn't have the same problem as a multiline list
- [ ] Now added only to breadcrumb in `AppBar.vue `. Where else it makes sense to add?
