### PR TITLE
[full-ci] [tests-only] Cleanup users/groups/spaces created by test scenario after execution of tests

### DIFF
--- a/tests/e2e/cucumber/environment/index.ts
+++ b/tests/e2e/cucumber/environment/index.ts
@@ -15,7 +15,7 @@ import { api, environment } from '../../support'
 import { World } from './world'
 import { state } from './shared'
 import { Browser, chromium, firefox, webkit } from 'playwright'
-import {spaceStore, linkStore, userStore, groupStore} from '../../support/store'
+import { spaceStore, linkStore, userStore, groupStore } from '../../support/store'
 
 export { World }
 
@@ -107,8 +107,8 @@ After(async function (this: World, { result }: ITestCaseHookParameter) {
     await this.actorsEnvironment.close()
   }
 
-  await userStore.forEach((user) =>{
-    if (user.id !== 'admin'){
+  await userStore.forEach((user) => {
+    if (user.id !== 'admin') {
       api.graph.deleteUser({
         user: this.usersEnvironment.getUser({ key: user.id }),
         admin: this.usersEnvironment.getUser({ key: 'admin' })
@@ -116,10 +116,22 @@ After(async function (this: World, { result }: ITestCaseHookParameter) {
     }
   })
 
-  await groupStore.forEach( (group) =>{
+  await groupStore.forEach((group) => {
     api.graph.deleteGroup({
       group: this.usersEnvironment.getGroup({ key: group.id }),
       admin: this.usersEnvironment.getUser({ key: 'admin' })
+    })
+  })
+
+  await spaceStore.forEach((space) => {
+    api.graph.disableSpace({
+      user: this.usersEnvironment.getUser({ key: 'admin' }),
+      space: space
+    })
+
+    api.graph.deleteSpace({
+      user: this.usersEnvironment.getUser({ key: 'admin' }),
+      space: space
     })
   })
 

--- a/tests/e2e/cucumber/environment/index.ts
+++ b/tests/e2e/cucumber/environment/index.ts
@@ -15,7 +15,7 @@ import { api, environment } from '../../support'
 import { World } from './world'
 import { state } from './shared'
 import { Browser, chromium, firefox, webkit } from 'playwright'
-import { spaceStore, linkStore } from '../../support/store'
+import {spaceStore, linkStore, userStore, groupStore} from '../../support/store'
 
 export { World }
 
@@ -106,6 +106,23 @@ After(async function (this: World, { result }: ITestCaseHookParameter) {
   if (result.status !== Status.PASSED) {
     await this.actorsEnvironment.close()
   }
+
+  await userStore.forEach((user) =>{
+    if (user.id !== 'admin'){
+      api.graph.deleteUser({
+        user: this.usersEnvironment.getUser({ key: user.id }),
+        admin: this.usersEnvironment.getUser({ key: 'admin' })
+      })
+    }
+  })
+
+  await groupStore.forEach( (group) =>{
+    api.graph.deleteGroup({
+      group: this.usersEnvironment.getGroup({ key: group.id }),
+      admin: this.usersEnvironment.getUser({ key: 'admin' })
+    })
+  })
+
   spaceStore.clear()
   linkStore.clear()
 })

--- a/tests/e2e/cucumber/features/smoke/admin-settings/spaces.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/admin-settings/spaces.ocis.feature
@@ -93,12 +93,12 @@ Feature: spaces management
 
   Scenario: list members via sidebar
     Given "Admin" creates following users using API
-      | id      |
-      | Alice   |
-      | Brian   |
-      | Carol   |
-      | Marie   |
-      | Richard |
+      | id       |
+      | Alice    |
+      | Brian    |
+      | Carol    |
+      | Gehendra |
+      | Bishal   |
     And "Admin" assigns following roles to the users using API
       | id    | role        |
       | Alice | Space Admin |
@@ -106,53 +106,20 @@ Feature: spaces management
       | name   | id     |
       | team A | team.a |
     And "Alice" adds the following members to the space "team A" using API
-      | user    | role   | shareType |
-      | Brian   | editor | space     |
-      | Carol   | viewer | space     |
-      | Marie   | viewer | space     |
-      | Richard | viewer | space     |
+      | user     | role   | shareType |
+      | Brian    | editor | space     |
+      | Carol    | viewer | space     |
+      | Gehendra | viewer | space     |
+      | Bishal   | viewer | space     |
     And "Alice" logs in
     And "Alice" opens the "admin-settings" app
     And "Alice" navigates to the project spaces management page
     When "Alice" lists the members of project space "team.a" using a sidebar panel
     Then "Alice" should see the following users in the sidebar panel of spaces admin settings
-      | user    | role    |
-      | Alice   | manager |
-      | Brian   | editor  |
-      | Carol   | viewer  |
-      | Marie   | viewer  |
-      | Richard | viewer  |
+      | user     | role    |
+      | Alice    | manager |
+      | Brian    | editor  |
+      | Carol    | viewer  |
+      | Gehendra | viewer  |
+      | Bishal   | viewer  |
     And "Alice" logs out
-
-  Scenario: clear user at after hook
-    Given "Admin" creates following users using API
-      | id |
-      | Alice |
-      | Brian |
-    And "Admin" assigns following roles to the users using API
-      | id | role |
-      | Alice | Space Admin |
-    And "Alice" creates the following project spaces using API
-      | name | id |
-      | team A | team.a |
-    When "Admin" logs in
-    And "Admin" opens the "admin-settings" app
-#    And "Admin" navigates to the users management page
-#    And "Admin" creates the following user
-#      | name | displayname | email | password |
-#      | max | Max Testing | maxtesting@owncloud.com | 12345678 |
-    And "Admin" navigates to the groups management page
-#    When "Admin" creates the following groups
-#      | id |
-#      | sales |
-#      | security |
-    And "Admin" creates following groups using API
-      | id       |
-      | security |
-#    When "Alice" logs in
-#    And "Alice" opens the "files" app
-#    And "Alice" navigates to the projects space page
-#    And "Alice" creates the following project spaces
-#      | name | id |
-#      | team | team.1 |
-#      | team2 | team.2 |

--- a/tests/e2e/cucumber/features/smoke/admin-settings/spaces.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/admin-settings/spaces.ocis.feature
@@ -123,3 +123,36 @@ Feature: spaces management
       | Marie   | viewer  |
       | Richard | viewer  |
     And "Alice" logs out
+
+  Scenario: clear user at after hook
+    Given "Admin" creates following users using API
+      | id |
+      | Alice |
+      | Brian |
+    And "Admin" assigns following roles to the users using API
+      | id | role |
+      | Alice | Space Admin |
+    And "Alice" creates the following project spaces using API
+      | name | id |
+      | team A | team.a |
+    When "Admin" logs in
+    And "Admin" opens the "admin-settings" app
+#    And "Admin" navigates to the users management page
+#    And "Admin" creates the following user
+#      | name | displayname | email | password |
+#      | max | Max Testing | maxtesting@owncloud.com | 12345678 |
+    And "Admin" navigates to the groups management page
+#    When "Admin" creates the following groups
+#      | id |
+#      | sales |
+#      | security |
+    And "Admin" creates following groups using API
+      | id       |
+      | security |
+#    When "Alice" logs in
+#    And "Alice" opens the "files" app
+#    And "Alice" navigates to the projects space page
+#    And "Alice" creates the following project spaces
+#      | name | id |
+#      | team | team.1 |
+#      | team2 | team.2 |

--- a/tests/e2e/cucumber/features/smoke/admin-settings/users.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/admin-settings/users.ocis.feature
@@ -132,15 +132,15 @@ Feature: users management
 
   Scenario: delete user
     Given "Admin" creates following users using API
-      | id    |
-      | Alice |
-      | Brian |
-      | Carol |
-      | Marie |
+      | id       |
+      | Alice    |
+      | Brian    |
+      | Carol    |
+      | Gehendra |
     And "Admin" logs in
     And "Admin" opens the "admin-settings" app
     And "Admin" navigates to the users management page
-    And "Admin" changes role to "Space Admin" for user "Marie" using the sidebar panel
+    And "Admin" changes role to "Space Admin" for user "Gehendra" using the sidebar panel
     When "Admin" sets the following filter
       | filter | values     |
       | roles  | User,Admin |
@@ -150,8 +150,8 @@ Feature: users management
       | Brian |
       | Carol |
     And "Admin" should not see the following users
-      | user  |
-      | Marie |
+      | user     |
+      | Gehendra |
     When "Admin" deletes the following users using the batch actions
       | id    |
       | Alice |

--- a/tests/e2e/cucumber/features/smoke/spaces/participantManagement.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/spaces/participantManagement.ocis.feature
@@ -2,20 +2,20 @@ Feature: spaces participant management
 
   Scenario: participant management
     Given "Admin" creates following users using API
-      | id      |
-      | Alice   |
-      | Brian   |
-      | Carol   |
-      | Marie   |
-      | Richard |
+      | id       |
+      | Alice    |
+      | Brian    |
+      | Carol    |
+      | Gehendra |
+      | Bishal   |
     And "Admin" creates following group using API
       | id       |
       | sales    |
       | security |
     And "Admin" adds user to the group using API
-      | user    | group    |
-      | Marie   | sales    |
-      | Richard | security |
+      | user     | group    |
+      | Gehendra | sales    |
+      | Bishal   | security |
     And "Admin" assigns following roles to the users using API
       | id    | role        |
       | Alice | Space Admin |
@@ -41,21 +41,21 @@ Feature: spaces participant management
     And "Brian" uploads the following resources
       | resource  | to     |
       | lorem.txt | parent |
-    When "Marie" logs in
-    And "Marie" navigates to the projects space page
-    And "Marie" navigates to the project space "team.1"
-    Then "Marie" should see folder "parent" but should not be able to edit
-    And "Marie" logs out
-    When "Richard" logs in
-    And "Richard" navigates to the projects space page
-    And "Richard" navigates to the project space "team.1"
-    And "Richard" creates the following resources
+    When "Gehendra" logs in
+    And "Gehendra" navigates to the projects space page
+    And "Gehendra" navigates to the project space "team.1"
+    Then "Gehendra" should see folder "parent" but should not be able to edit
+    And "Gehendra" logs out
+    When "Bishal" logs in
+    And "Bishal" navigates to the projects space page
+    And "Bishal" navigates to the project space "team.1"
+    And "Bishal" creates the following resources
       | resource | type   |
-      | richard  | folder |
-    And "Richard" uploads the following resources
-      | resource  | to      |
-      | lorem.txt | richard |
-    And "Richard" logs out
+      | bishal   | folder |
+    And "Bishal" uploads the following resources
+      | resource  | to     |
+      | lorem.txt | bishal |
+    And "Bishal" logs out
     When "Carol" logs in
     And "Carol" navigates to the projects space page
     And "Carol" navigates to the project space "team.1"

--- a/tests/e2e/cucumber/features/smoke/spaces/publicLink.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/spaces/publicLink.ocis.feature
@@ -2,11 +2,11 @@ Feature: spaces public link
 
   Scenario: public link for space
     Given "Admin" creates following users using API
-      | id    |
-      | Alice |
-      | Brian |
-      | Carol |
-      | Marie |
+      | id       |
+      | Alice    |
+      | Brian    |
+      | Carol    |
+      | Gehendra |
     And "Admin" assigns following roles to the users using API
       | id    | role        |
       | Alice | Space Admin |
@@ -24,10 +24,10 @@ Feature: spaces public link
     And "Alice" creates a public link for the resource "spaceFolder" using the sidebar panel
     And "Alice" renames the most recently created public link of resource "spaceFolder" to "folderLink"
     And "Alice" adds following users to the project space
-      | user  | role    | kind |
-      | Brian | editor  | user |
-      | Carol | viewer  | user |
-      | Marie | manager | user |
+      | user     | role    | kind |
+      | Brian    | editor  | user |
+      | Carol    | viewer  | user |
+      | Gehendra | manager | user |
     And "Alice" logs out
     When "Brian" logs in
     And "Brian" navigates to the projects space page
@@ -35,12 +35,12 @@ Feature: spaces public link
     Then public link named "spaceLink" should be visible to "Brian"
     But "Brian" should not be able to edit the public link named "spaceLink"
     And "Brian" logs out
-    When "Marie" logs in
-    And "Marie" navigates to the projects space page
-    And "Marie" navigates to the project space "team.1"
-    And "Marie" edits the public link named "spaceLink" of the space changing role to "editor"
-    And "Marie" edits the public link named "folderLink" of resource "spaceFolder" changing role to "editor"
-    And "Marie" logs out
+    When "Gehendra" logs in
+    And "Gehendra" navigates to the projects space page
+    And "Gehendra" navigates to the project space "team.1"
+    And "Gehendra" edits the public link named "spaceLink" of the space changing role to "editor"
+    And "Gehendra" edits the public link named "folderLink" of resource "spaceFolder" changing role to "editor"
+    And "Gehendra" logs out
     When "Carol" logs in
     And "Carol" navigates to the projects space page
     And "Carol" navigates to the project space "team.1"

--- a/tests/e2e/cucumber/steps/api.ts
+++ b/tests/e2e/cucumber/steps/api.ts
@@ -12,10 +12,8 @@ Given(
     for (const info of stepTable.hashes()) {
       const user = this.usersEnvironment.getUser({ key: info.id })
       if (config.ocis) {
-        await api.graph.deleteUser({ user, admin })
         await api.graph.createUser({ user, admin })
       } else {
-        await api.user.deleteUser({ user, admin })
         await api.user.createUser({ user, admin })
       }
     }
@@ -69,10 +67,8 @@ Given(
     for (const info of stepTable.hashes()) {
       const group = this.usersEnvironment.getGroup({ key: info.id })
       if (config.ocis) {
-        await api.graph.deleteGroup({ group, admin })
         await api.graph.createGroup({ group, admin })
       } else {
-        await api.user.deleteGroup({ group, admin })
         await api.user.createGroup({ group, admin })
       }
     }

--- a/tests/e2e/cucumber/steps/ui/adminSettings.ts
+++ b/tests/e2e/cucumber/steps/ui/adminSettings.ts
@@ -413,13 +413,6 @@ When(
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const groupsObject = new objects.applicationAdminSettings.Groups({ page })
 
-    for (const info of stepTable.hashes()) {
-      const group = this.usersEnvironment.getGroup({ key: info.id })
-      await api.graph.deleteGroup({
-        group: group,
-        admin: this.usersEnvironment.getUser({ key: stepUser })
-      })
-    }
     await page.reload()
     for (const info of stepTable.hashes()) {
       const group = this.usersEnvironment.getGroup({ key: info.id })
@@ -483,10 +476,6 @@ When(
     const usersObject = new objects.applicationAdminSettings.Users({ page })
     for (const info of stepTable.hashes()) {
       const user = this.usersEnvironment.getUser({ key: info.name })
-      await api.graph.deleteUser({
-        user: user,
-        admin: this.usersEnvironment.getUser({ key: stepUser })
-      })
       await usersObject.createUser({
         name: info.name,
         displayname: info.displayname,

--- a/tests/e2e/support/api/graph/index.ts
+++ b/tests/e2e/support/api/graph/index.ts
@@ -7,4 +7,10 @@ export {
   addUserToGroup,
   assignRole
 } from './userManagement'
-export { getPersonalSpaceId, createSpace, getSpaceIdBySpaceName } from './spaces'
+export {
+  getPersonalSpaceId,
+  createSpace,
+  getSpaceIdBySpaceName,
+  disableSpace,
+  deleteSpace
+} from './spaces'

--- a/tests/e2e/support/api/graph/spaces.ts
+++ b/tests/e2e/support/api/graph/spaces.ts
@@ -131,3 +131,26 @@ export const updateSpaceSpecialSection = async ({
     `Failed while creating special section "${type}" inside project space`
   )
 }
+
+export const disableSpace = async ({
+  user,
+  space
+}: {
+  user: User
+  space: Space
+}): Promise<void> => {
+  await request({
+    method: 'DELETE',
+    path: join('graph', 'v1.0', 'drives', space.id),
+    user: user
+  })
+}
+
+export const deleteSpace = async ({ user, space }: { user: User; space: Space }): Promise<void> => {
+  await request({
+    method: 'DELETE',
+    path: join('graph', 'v1.0', 'drives', space.id),
+    user: user,
+    header: { Purge: 'T' }
+  })
+}

--- a/tests/e2e/support/api/http.ts
+++ b/tests/e2e/support/api/http.ts
@@ -9,25 +9,32 @@ export const request = async ({
   path,
   body,
   user,
-  formatJson = true
+  formatJson = true,
+  header = null
 }: {
   method: 'POST' | 'DELETE' | 'PUT' | 'GET' | 'MKCOL' | 'PROPFIND' | 'PATCH'
   path: string
   body?: BodyInit
   user?: User
   formatJson?: boolean
+  header?: object
 }): Promise<Response> => {
   const format = config.ocis || !formatJson ? '' : 'format=json'
+
+  let basicHeader = {
+    'OCS-APIREQUEST': true as any,
+    ...(user && {
+      Authorization: 'Basic ' + Buffer.from(user.id + ':' + user.password).toString('base64')
+    })
+  }
+  if (header) {
+    basicHeader = Object.assign(basicHeader, header)
+  }
 
   return await fetch(join(config.backendUrl, path + (path.includes('?') ? '&' : '?') + format), {
     method,
     body,
-    headers: {
-      'OCS-APIREQUEST': true as any,
-      ...(user && {
-        Authorization: 'Basic ' + Buffer.from(user.id + ':' + user.password).toString('base64')
-      })
-    }
+    headers: basicHeader
   })
 }
 

--- a/tests/e2e/support/store/user.ts
+++ b/tests/e2e/support/store/user.ts
@@ -38,21 +38,21 @@ export const userStore = new Map<string, User>([
     }
   ],
   [
-    'marie',
+    'rina',
     {
-      id: 'marie',
-      displayName: 'Marie Skłodowska Curie',
+      id: 'rina',
+      displayName: 'Rina kumari Shrestha',
       password: '1234',
-      email: 'marie@example.org'
+      email: 'rina@example.org'
     }
   ],
   [
-    'richard',
+    'anu',
     {
-      id: 'richard',
-      displayName: 'Richard Phillips Feynman',
+      id: 'anu',
+      displayName: 'Anu Singh Feynman',
       password: '1234',
-      email: 'richard@example.org'
+      email: 'anu@example.org'
     }
   ],
   [

--- a/tests/e2e/support/store/user.ts
+++ b/tests/e2e/support/store/user.ts
@@ -38,21 +38,21 @@ export const userStore = new Map<string, User>([
     }
   ],
   [
-    'rina',
+    'gehendra',
     {
-      id: 'rina',
-      displayName: 'Rina kumari Shrestha',
+      id: 'gehendra',
+      displayName: 'Gehendra Sumsher',
       password: '1234',
-      email: 'rina@example.org'
+      email: 'gehendra@example.org'
     }
   ],
   [
-    'anu',
+    'bishal',
     {
-      id: 'anu',
-      displayName: 'Anu Singh Feynman',
+      id: 'bishal',
+      displayName: 'Bishal Nath Upreti',
       password: '1234',
-      email: 'anu@example.org'
+      email: 'bishal@example.org'
     }
   ],
   [


### PR DESCRIPTION
## Description
This issue clean-up the user, group and space after the test scenario run. 
User Marie and Richard are demo users and we use them as test users in the web e2e test. while cleaning up locally , Marie and Richard will be deleted. To avoid that new user has been introduced in place of Marie and Richard

## Related Issue
- https://github.com/owncloud/web/issues/8662

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
