### PR TITLE
[tests-only] Fix flaky 'create-space-from-resource'-e2e test

### DIFF
--- a/tests/e2e/cucumber/features/smoke/createSpaceFromSelection.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/createSpaceFromSelection.ocis.feature
@@ -1,58 +1,57 @@
 Feature: create Space shortcut
-#
-#  FIXME: skipped because of oCIS pipeline, un-skip and check if https://github.com/owncloud/web/pull/8781 solves the issue
-#  Scenario: create Space from folder
-#    Given "Admin" creates following users using API
-#      | id    |
-#      | Alice |
-#    And "Admin" assigns following roles to the users using API
-#      | id    | role        |
-#      | Alice | Space Admin |
-#    And "Alice" creates the following folder in personal space using API
-#      | name             |
-#      | spaceFolder      |
-#      | spaceFolder/test |
-#    When "Alice" logs in
-#    And "Alice" navigates to the personal space page
-#    And "Alice" uploads the following resources
-#      | resource          | to           |
-#      | data.zip          | spaceFolder  |
-#      | lorem.txt         | spaceFolder  |
-#    And "Alice" navigates to the personal space page
-#    And "Alice" creates space "folderSpace" from folder "spaceFolder" using the context menu
-#    And "Alice" navigates to the projects space page
-#    And "Alice" navigates to the project space "folderSpace"
-#    Then following resources should be displayed in the files list for user "Alice"
-#      | resource  |
-#      | data.zip  |
-#      | lorem.txt |
-#    And "Alice" logs out
-#
-#  Scenario: create space from resources
-#    Given "Admin" creates following users using API
-#      | id    |
-#      | Alice |
-#    And "Admin" assigns following roles to the users using API
-#      | id    | role        |
-#      | Alice | Space Admin |
-#    And "Alice" creates the following folder in personal space using API
-#      | name             |
-#      | resourceFolder   |
-#    When "Alice" logs in
-#    And "Alice" navigates to the personal space page
-#    And "Alice" uploads the following resources
-#      | resource          | to             |
-#      | data.zip          | resourceFolder |
-#      | lorem.txt         |                |
-#    And "Alice" navigates to the personal space page
-#    And "Alice" creates space "resourceSpace" from resources using the context menu
-#      | resource                |
-#      | resourceFolder          |
-#      | lorem.txt               |
-#    And "Alice" navigates to the projects space page
-#    And "Alice" navigates to the project space "resourceSpace"
-#    Then following resources should be displayed in the files list for user "Alice"
-#      | resource        |
-#      | resourceFolder  |
-#      | lorem.txt       |
-#    And "Alice" logs out
+
+  Scenario: create Space from folder
+    Given "Admin" creates following users using API
+      | id    |
+      | Alice |
+    And "Admin" assigns following roles to the users using API
+      | id    | role        |
+      | Alice | Space Admin |
+    And "Alice" creates the following folder in personal space using API
+      | name             |
+      | spaceFolder      |
+      | spaceFolder/test |
+    When "Alice" logs in
+    And "Alice" navigates to the personal space page
+    And "Alice" uploads the following resources
+      | resource          | to           |
+      | data.zip          | spaceFolder  |
+      | lorem.txt         | spaceFolder  |
+    And "Alice" navigates to the personal space page
+    And "Alice" creates space "folderSpace" from folder "spaceFolder" using the context menu
+    And "Alice" navigates to the projects space page
+    And "Alice" navigates to the project space "folderSpace"
+    Then following resources should be displayed in the files list for user "Alice"
+      | resource  |
+      | data.zip  |
+      | lorem.txt |
+    And "Alice" logs out
+
+  Scenario: create space from resources
+    Given "Admin" creates following users using API
+      | id    |
+      | Alice |
+    And "Admin" assigns following roles to the users using API
+      | id    | role        |
+      | Alice | Space Admin |
+    And "Alice" creates the following folder in personal space using API
+      | name             |
+      | resourceFolder   |
+    When "Alice" logs in
+    And "Alice" navigates to the personal space page
+    And "Alice" uploads the following resources
+      | resource          | to             |
+      | data.zip          | resourceFolder |
+      | lorem.txt         |                |
+    And "Alice" navigates to the personal space page
+    And "Alice" creates space "resourceSpace" from resources using the context menu
+      | resource                |
+      | resourceFolder          |
+      | lorem.txt               |
+    And "Alice" navigates to the projects space page
+    And "Alice" navigates to the project space "resourceSpace"
+    Then following resources should be displayed in the files list for user "Alice"
+      | resource        |
+      | resourceFolder  |
+      | lorem.txt       |
+    And "Alice" logs out

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -110,13 +110,18 @@ export const createSpaceFromFolder = async ({
   spaceName: string
 }): Promise<Space> => {
   await page.locator(util.format(resourceNameSelector, folderName)).click({ button: 'right' })
-  await page.locator(createSpaceFromResourceAction).first().click()
-  await page.locator(resourceNameInput).first().fill(spaceName)
-  await page.locator(util.format(actionConfirmationButton, 'Create')).click()
-  const response = await page.waitForResponse(
-    (resp) =>
-      resp.status() === 201 && resp.request().method() === 'POST' && resp.url().endsWith('/drives')
-  )
+  await page.locator(createSpaceFromResourceAction).click()
+  await page.locator(resourceNameInput).fill(spaceName)
+  const [response] = await Promise.all([
+    page.waitForResponse(
+      (resp) =>
+        resp.status() === 201 &&
+        resp.request().method() === 'POST' &&
+        resp.url().endsWith('/drives')
+    ),
+    page.locator(util.format(actionConfirmationButton, 'Create')).click()
+  ])
+
   await page.waitForSelector(notificationMessage)
   return (await response.json()) as Space
 }
@@ -137,13 +142,17 @@ export const createSpaceFromSelection = async ({
   })
   await page.locator(util.format(resourceNameSelector, resources[0])).click({ button: 'right' })
 
-  await page.locator(createSpaceFromResourceAction).first().click()
-  await page.locator(resourceNameInput).first().fill(spaceName)
-  await page.locator(util.format(actionConfirmationButton, 'Create')).click()
-  const response = await page.waitForResponse(
-    (resp) =>
-      resp.status() === 201 && resp.request().method() === 'POST' && resp.url().endsWith('/drives')
-  )
+  await page.locator(createSpaceFromResourceAction).click()
+  await page.locator(resourceNameInput).fill(spaceName)
+  const [response] = await Promise.all([
+    page.waitForResponse(
+      (resp) =>
+        resp.status() === 201 &&
+        resp.request().method() === 'POST' &&
+        resp.url().endsWith('/drives')
+    ),
+    page.locator(util.format(actionConfirmationButton, 'Create')).click()
+  ])
   await page.waitForSelector(notificationMessage)
   return (await response.json()) as Space
 }

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -13,6 +13,7 @@ const downloadFolderButtonSidedBar =
   '#oc-files-actions-sidebar .oc-files-actions-download-archive-trigger'
 const downloadButtonBatchAction = '.oc-files-actions-download-archive-trigger'
 const deleteButtonBatchAction = '.oc-files-actions-delete-trigger'
+const createSpaceFromResourceAction = '.oc-files-actions-create-space-from-resource-trigger'
 const checkBox = `//*[@data-test-resource-name="%s"]//ancestor::tr//input`
 const checkBoxForTrashbin = `//*[@data-test-resource-path="%s"]//ancestor::tr//input`
 export const fileRow =
@@ -43,6 +44,7 @@ const versionRevertButton = '//*[@data-testid="file-versions-revert-button"]'
 const actionButton = '//*[contains(@data-testid, "action-handler")]/span[text()="%s"]'
 const emptyTrashBinButton = '.oc-files-actions-empty-trash-bin-trigger'
 const notificationMessageDialog = '.oc-notification-message-title'
+const notificationMessage = '.oc-notification-message'
 const permanentDeleteButton = '.oc-files-actions-delete-permanent-trigger'
 const restoreResourceButton = '.oc-files-actions-restore-trigger'
 const globalSearchInput = '.oc-search-input'
@@ -108,15 +110,14 @@ export const createSpaceFromFolder = async ({
   spaceName: string
 }): Promise<Space> => {
   await page.locator(util.format(resourceNameSelector, folderName)).click({ button: 'right' })
-  await page.locator('text=Create Space from selection').first().click()
-  await page.locator('.oc-text-input').first().fill(spaceName)
+  await page.locator(createSpaceFromResourceAction).first().click()
+  await page.locator(resourceNameInput).first().fill(spaceName)
   await page.locator(util.format(actionConfirmationButton, 'Create')).click()
   const response = await page.waitForResponse(
     (resp) =>
       resp.status() === 201 && resp.request().method() === 'POST' && resp.url().endsWith('/drives')
   )
-  await page.waitForSelector('#oc-loading-indicator')
-  await page.waitForSelector('#oc-loading-indicator', { state: 'detached' })
+  await page.waitForSelector(notificationMessage)
   return (await response.json()) as Space
 }
 
@@ -136,15 +137,14 @@ export const createSpaceFromSelection = async ({
   })
   await page.locator(util.format(resourceNameSelector, resources[0])).click({ button: 'right' })
 
-  await page.locator('text=Create Space from selection').first().click()
-  await page.locator('.oc-text-input').first().fill(spaceName)
+  await page.locator(createSpaceFromResourceAction).first().click()
+  await page.locator(resourceNameInput).first().fill(spaceName)
   await page.locator(util.format(actionConfirmationButton, 'Create')).click()
   const response = await page.waitForResponse(
     (resp) =>
       resp.status() === 201 && resp.request().method() === 'POST' && resp.url().endsWith('/drives')
   )
-  await page.waitForSelector('#oc-loading-indicator')
-  await page.waitForSelector('#oc-loading-indicator', { state: 'detached' })
+  await page.waitForSelector(notificationMessage)
   return (await response.json()) as Space
 }
 


### PR DESCRIPTION
## Description
Fixes flaky e2e tests that were introduced with https://github.com/owncloud/web/pull/8730.

I'd prefer to wait for requests here, but there can be `n` requests, and we don't know `n` inside the test step.

Potentially fixes the broken pipeline in https://drone.owncloud.com/owncloud/ocis/21162/68/10.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
