### PR TITLE
fix: query param handling in AuthService.signInCallback

### DIFF
--- a/changelog/unreleased/bugfix-open-external-apps
+++ b/changelog/unreleased/bugfix-open-external-apps
@@ -1,6 +1,8 @@
 Bugfix: Open files in external app
 
-We've fixed a bug that caused office documents not to be opened in app provider editors anymore.
+We've fixed bugs that caused office documents not to be opened in app provider editors anymore.
 
-https://github.com/owncloud/web/pull/8705
 https://github.com/owncloud/web/issues/8695
+https://github.com/owncloud/web/pull/8705
+https://github.com/owncloud/web/issues/8773
+https://github.com/owncloud/web/pull/8782

--- a/packages/web-runtime/src/router/helpers.ts
+++ b/packages/web-runtime/src/router/helpers.ts
@@ -1,6 +1,5 @@
 import { base, router } from './index'
 import { RouteLocation, RouteParams, Router, RouteRecordNormalized } from 'vue-router'
-import pick from 'lodash-es/pick'
 import {
   AuthContext,
   authContextValues,
@@ -11,17 +10,7 @@ import {
 export const buildUrl = (pathname) => {
   const isHistoryMode = !!base
   const baseUrl = new URL(window.location.href.split('#')[0])
-
-  // searchParams defines a set of search parameters which should be part of new url.
-  // The resulting querystring only contains the properties listed here.
-  const searchParams = new URLSearchParams(
-    pick(Object.fromEntries(new URLSearchParams(window.location.search).entries()), [
-      // needed for private links
-      'details'
-    ])
-  ).toString()
-
-  baseUrl.search = searchParams
+  baseUrl.search = ''
 
   if (isHistoryMode) {
     // in history mode we can't determine the base path, it must be provided by the document

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -13,7 +13,6 @@ import {
 import { unref } from 'vue'
 import { Ability } from 'web-pkg/src/utils'
 import { Language } from 'vue3-gettext'
-import pick from 'lodash-es/pick'
 
 export class AuthService {
   private clientService: ClientService
@@ -176,23 +175,12 @@ export class AuthService {
    * Sign in callback gets called from the IDP after initial login.
    */
   public async signInCallback() {
-    const currentQuery = unref(this.router.currentRoute).query
-
     try {
       await this.userManager.signinRedirectCallback(this.buildSignInCallbackUrl())
-
-      const redirectUrl = this.userManager.getAndClearPostLoginRedirectUrl()
-
-      // transportQuery defines a set of query parameters which should be part of router route replace.
-      // The resulting object only contains the properties listed here.
-      const transportQuery = pick(currentQuery, [
-        // needed for private links
-        'details'
-      ])
-
+      const redirectRoute = this.router.resolve(this.userManager.getAndClearPostLoginRedirectUrl())
       return this.router.replace({
-        path: redirectUrl,
-        query: transportQuery
+        path: redirectRoute.path,
+        ...(redirectRoute.query && { query: redirectRoute.query })
       })
     } catch (e) {
       console.warn('error during authentication:', e)

--- a/packages/web-runtime/tests/unit/router/index.spec.ts
+++ b/packages/web-runtime/tests/unit/router/index.spec.ts
@@ -15,9 +15,6 @@ describe('buildUrl', () => {
     ${'https://localhost:9200/files/list/all'}                                        | ${'/foo'}                    | ${'/login/foo'} | ${'https://localhost:9200/foo/login/foo'}
     ${'https://localhost:9200/files/list/all'}                                        | ${'/'}                       | ${'/bar.html'}  | ${'https://localhost:9200/bar.html'}
     ${'https://localhost:9200/files/list/all'}                                        | ${'/foo'}                    | ${'/bar.html'}  | ${'https://localhost:9200/foo/bar.html'}
-    ${'https://localhost:9200/files/list/all?details=91953740'}                       | ${'/foo'}                    | ${'/bar.html'}  | ${'https://localhost:9200/foo/bar.html?details=91953740'}
-    ${'https://localhost:9200/files/list/all?details=91953740&unknown=87987987'}      | ${'/foo'}                    | ${'/bar.html'}  | ${'https://localhost:9200/foo/bar.html?details=91953740'}
-    ${'https://localhost:9200/files/list/all?unknown=87987987'}                       | ${'/foo'}                    | ${'/bar.html'}  | ${'https://localhost:9200/foo/bar.html'}
   `('$path -> $expected', async ({ location, base, path, expected }) => {
     delete window.location
     window.location = new URL(location) as any

--- a/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
+++ b/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
@@ -1,27 +1,41 @@
 import { AuthService } from 'web-runtime/src/services/auth/authService'
+import { createRouter } from 'web-test-helpers/src'
 
 describe('AuthService', () => {
   describe('signInCallback', () => {
     it.each([
-      [{ details: 'details' }, { details: 'details' }],
-      [{ details: 'details', unknown: 'unknown' }, { details: 'details' }],
-      [{ unknown: 'unknown' }, {}]
-    ])('forwards only whitelisted query parameters: %s = %s', async (query, expected: any) => {
-      const authService = new AuthService()
-      const replace = jest.fn()
+      ['/', '/', {}],
+      ['/?details=sharing', '/', { details: 'sharing' }],
+      [
+        '/external?contextRouteName=files-spaces-personal&fileId=0f897576',
+        '/external',
+        {
+          contextRouteName: 'files-spaces-personal',
+          fileId: '0f897576'
+        }
+      ]
+    ])(
+      'parses query params and passes them explicitly to router.replace: %s => %s %s',
+      async (url, path, query: any) => {
+        const authService = new AuthService()
 
-      jest.replaceProperty(authService as any, 'userManager', {
-        signinRedirectCallback: jest.fn(),
-        getAndClearPostLoginRedirectUrl: jest.fn()
-      })
+        jest.replaceProperty(authService as any, 'userManager', {
+          signinRedirectCallback: jest.fn(),
+          getAndClearPostLoginRedirectUrl: () => url
+        })
 
-      jest.replaceProperty(authService as any, 'router', {
-        currentRoute: { query },
-        replace
-      })
-      await authService.signInCallback()
+        const router = createRouter()
+        const replaceSpy = jest.spyOn(router, 'replace')
 
-      expect(replace.mock.calls[0][0].query).toEqual(expected)
-    })
+        authService.initialize(null, null, null, router, null, null)
+
+        await authService.signInCallback()
+
+        expect(replaceSpy).toHaveBeenCalledWith({
+          path,
+          query
+        })
+      }
+    )
   })
 })


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Fix query param handling in AuthService.signInCallback, needed at least for the `details` parameter of private links and parameters passed to the external app (fileId, ...).
 
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #8773 

## Motivation and Context
`vue-router` does not correctly parse query params  when pushing/replacing a url with query params.
We can parse them with router.resolve and pass them separately.
This makes the `details` handling in `resolvePrivateLink.vue` work and also fixes the params getting lost when redirecting into the external app after sign in.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
