### PR TITLE
Fix batch context actions in admin settings

### DIFF
--- a/changelog/unreleased/bugfix-admin-settings-batch-context-actions
+++ b/changelog/unreleased/bugfix-admin-settings-batch-context-actions
@@ -1,0 +1,6 @@
+Bugfix: Batch context actions in admin settings
+
+Several issues when triggering batch actions via the context menu for users/groups/spaces in the admin-settings have been fixed. Some actions were showing wrongly ("edit"), some actions were resetting the current selection ("show details").
+
+https://github.com/owncloud/web/issues/8549
+https://github.com/owncloud/web/pull/8785

--- a/packages/web-app-admin-settings/src/components/Groups/GroupsList.vue
+++ b/packages/web-app-admin-settings/src/components/Groups/GroupsList.vue
@@ -149,7 +149,9 @@ export default defineComponent({
     }
     const rowClicked = (data) => {
       const group = data[0]
-      selectGroup(group)
+      if (!isGroupSelected(group)) {
+        selectGroup(group)
+      }
     }
     const showContextMenuOnBtnClick = (data, group) => {
       const { dropdown, event } = data

--- a/packages/web-app-admin-settings/src/components/Spaces/SpacesList.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/SpacesList.vue
@@ -366,7 +366,9 @@ export default defineComponent({
 
     const fileClicked = (data) => {
       const space = data[0]
-      selectSpace(space)
+      if (!isSpaceSelected(space)) {
+        selectSpace(space)
+      }
     }
 
     const showContextMenuOnBtnClick = (data, space) => {

--- a/packages/web-app-admin-settings/src/composables/actions/groups/useGroupActionsDelete.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/groups/useGroupActionsDelete.ts
@@ -94,6 +94,8 @@ export const useGroupActionsDelete = ({ store }: { store?: Store<any> }) => {
   ])
 
   return {
-    actions
+    actions,
+    // HACK: exported for unit tests:
+    deleteGroups
   }
 }

--- a/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsDelete.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsDelete.ts
@@ -89,6 +89,8 @@ export const useUserActionsDelete = ({ store }: { store?: Store<any> }) => {
   ])
 
   return {
-    actions
+    actions,
+    // HACK: exported for unit tests:
+    deleteUsers
   }
 }

--- a/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsEdit.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsEdit.ts
@@ -14,7 +14,7 @@ export const useUserActionsEdit = () => {
       label: () => $gettext('Edit'),
       handler: () => eventBus.publish(SideBarEventTopics.openWithPanel, 'EditPanel'),
       isEnabled: ({ resources }) => {
-        return resources.length > 0
+        return resources.length === 1
       },
       componentType: 'button',
       class: 'oc-users-actions-edit-trigger'

--- a/packages/web-app-admin-settings/tests/unit/components/Groups/ContextActions.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Groups/ContextActions.spec.ts
@@ -48,7 +48,8 @@ describe('ContextActions', () => {
     it('render enabled actions', () => {
       const enabledComposables = [useGroupActionsDelete, useGroupActionsEdit]
       jest.mocked(useGroupActionsDelete).mockImplementation(() => ({
-        actions: computed(() => [mock<Action>({ isEnabled: () => true })])
+        actions: computed(() => [mock<Action>({ isEnabled: () => true })]),
+        deleteGroups: null
       }))
       jest.mocked(useGroupActionsEdit).mockImplementation(() => ({
         actions: computed(() => [mock<Action>({ isEnabled: () => true })])

--- a/packages/web-app-admin-settings/tests/unit/composables/actions/general/useGeneralActionsResetLogo.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/composables/actions/general/useGeneralActionsResetLogo.spec.ts
@@ -1,4 +1,4 @@
-import { useGeneralActionsResetLogo } from '../../../../src/composables/actions/general/useGeneralActionsResetLogo'
+import { useGeneralActionsResetLogo } from '../../../../../src/composables/actions/general/useGeneralActionsResetLogo'
 import { mock } from 'jest-mock-extended'
 import { unref } from 'vue'
 import {
@@ -15,8 +15,8 @@ jest.useFakeTimers()
 
 describe('resetLogo', () => {
   describe('handler', () => {
-    it('should show message on request success', async () => {
-      const { wrapper } = getWrapper({
+    it('should show message on request success', () => {
+      getWrapper({
         setup: async ({ actions }, { storeOptions, clientService, router }) => {
           clientService.httpAuthenticated.delete.mockResolvedValue(() => mockAxiosResolve())
           await unref(actions)[0].handler()
@@ -27,9 +27,9 @@ describe('resetLogo', () => {
       })
     })
 
-    it('should show message on request error', async () => {
+    it('should show message on request error', () => {
       jest.spyOn(console, 'error').mockImplementation(() => undefined)
-      const { wrapper } = getWrapper({
+      getWrapper({
         setup: async ({ actions }, { storeOptions, clientService, router }) => {
           clientService.httpAuthenticated.delete.mockRejectedValue(() => mockAxiosReject())
           await unref(actions)[0].handler()

--- a/packages/web-app-admin-settings/tests/unit/composables/actions/general/useGeneralActionsUploadLogo.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/composables/actions/general/useGeneralActionsUploadLogo.spec.ts
@@ -1,4 +1,4 @@
-import { useGeneralActionsUploadLogo } from '../../../../src/composables/actions/general/useGeneralActionsUploadLogo'
+import { useGeneralActionsUploadLogo } from '../../../../../src/composables/actions/general/useGeneralActionsUploadLogo'
 import { mock } from 'jest-mock-extended'
 import { VNodeRef } from 'vue'
 import {
@@ -15,8 +15,8 @@ jest.useFakeTimers()
 
 describe('uploadImage', () => {
   describe('method "uploadImage"', () => {
-    it('should show message on request success', async () => {
-      const { wrapper } = getWrapper({
+    it('should show message on request success', () => {
+      getWrapper({
         setup: async ({ uploadImage }, { storeOptions, clientService, router }) => {
           clientService.httpAuthenticated.post.mockResolvedValue(() => mockAxiosResolve())
           await uploadImage({
@@ -31,9 +31,9 @@ describe('uploadImage', () => {
       })
     })
 
-    it('should show message on request error', async () => {
+    it('should show message on request error', () => {
       jest.spyOn(console, 'error').mockImplementation(() => undefined)
-      const { wrapper } = getWrapper({
+      getWrapper({
         setup: async ({ uploadImage }, { storeOptions, clientService, router }) => {
           clientService.httpAuthenticated.post.mockRejectedValue(() => mockAxiosReject())
           await uploadImage({
@@ -48,10 +48,10 @@ describe('uploadImage', () => {
       })
     })
 
-    it('should show message on invalid mimeType', async () => {
+    it('should show message on invalid mimeType', () => {
       jest.spyOn(console, 'error').mockImplementation(() => undefined)
-      const { wrapper } = getWrapper({
-        setup: async ({ uploadImage }, { storeOptions, clientService, router }) => {
+      getWrapper({
+        setup: async ({ uploadImage }, { storeOptions, clientService }) => {
           await uploadImage({
             currentTarget: {
               files: [{ name: 'text.txt', type: 'text/plain' }]

--- a/packages/web-app-admin-settings/tests/unit/composables/actions/groups/useGroupActionsDelete.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/composables/actions/groups/useGroupActionsDelete.spec.ts
@@ -1,0 +1,94 @@
+import { useGroupActionsDelete } from '../../../../../src/composables/actions/groups/useGroupActionsDelete'
+import { mock } from 'jest-mock-extended'
+import { unref } from 'vue'
+import { Group } from 'web-client/src/generated'
+import { eventBus } from 'web-pkg/src'
+import {
+  createStore,
+  defaultComponentMocks,
+  defaultStoreMockOptions,
+  getComposableWrapper
+} from 'web-test-helpers'
+
+describe('useGroupActionsDelete', () => {
+  describe('method "isEnabled"', () => {
+    it.each([
+      { resources: [], isEnabled: false },
+      { resources: [mock<Group>({ groupTypes: [] })], isEnabled: true },
+      {
+        resources: [mock<Group>({ groupTypes: [] }), mock<Group>({ groupTypes: [] })],
+        isEnabled: true
+      }
+    ])('should only return true if 1 or more groups are selected', ({ resources, isEnabled }) => {
+      getWrapper({
+        setup: ({ actions }) => {
+          expect(unref(actions)[0].isEnabled({ resources })).toEqual(isEnabled)
+        }
+      })
+    })
+    it('should return false for read-only groups', () => {
+      getWrapper({
+        setup: ({ actions }) => {
+          const resources = [mock<Group>({ groupTypes: ['ReadOnly'] })]
+          expect(unref(actions)[0].isEnabled({ resources })).toBeFalsy()
+        }
+      })
+    })
+  })
+  describe('method "deleteGroups"', () => {
+    it('should successfully delete all given gropups and reload the groups list', () => {
+      const eventSpy = jest.spyOn(eventBus, 'publish')
+      getWrapper({
+        setup: async ({ deleteGroups }, { storeOptions, clientService }) => {
+          const group = mock<Group>({ id: '1' })
+          await deleteGroups([group])
+          expect(clientService.graphAuthenticated.groups.deleteGroup).toHaveBeenCalledWith(group.id)
+          expect(storeOptions.actions.hideModal).toHaveBeenCalled()
+          expect(eventSpy).toHaveBeenCalledWith('app.admin-settings.list.load')
+        }
+      })
+    })
+    it('should handle errors and not reload the groups list in such case', () => {
+      jest.spyOn(console, 'error').mockImplementation(() => undefined)
+      const eventSpy = jest.spyOn(eventBus, 'publish')
+      getWrapper({
+        setup: async ({ deleteGroups }, { storeOptions, clientService }) => {
+          clientService.graphAuthenticated.groups.deleteGroup.mockRejectedValue({})
+          const group = mock<Group>({ id: '1' })
+          await deleteGroups([group])
+          expect(clientService.graphAuthenticated.groups.deleteGroup).toHaveBeenCalledWith(group.id)
+          expect(storeOptions.actions.hideModal).toHaveBeenCalled()
+          expect(eventSpy).not.toHaveBeenCalledWith('app.admin-settings.list.load')
+        }
+      })
+    })
+  })
+})
+
+function getWrapper({
+  setup
+}: {
+  setup: (
+    instance: ReturnType<typeof useGroupActionsDelete>,
+    {
+      storeOptions,
+      clientService
+    }: {
+      storeOptions: typeof defaultStoreMockOptions
+      clientService: ReturnType<typeof defaultComponentMocks>['$clientService']
+    }
+  ) => void
+}) {
+  const storeOptions = defaultStoreMockOptions
+  const store = createStore(storeOptions)
+  const mocks = defaultComponentMocks()
+  return {
+    wrapper: getComposableWrapper(
+      () => {
+        const instance = useGroupActionsDelete({ store })
+        setup(instance, { storeOptions, clientService: mocks.$clientService })
+      },
+      { store, mocks }
+    )
+  }
+}

--- a/packages/web-app-admin-settings/tests/unit/composables/actions/groups/useGroupActionsEdit.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/composables/actions/groups/useGroupActionsEdit.spec.ts
@@ -1,0 +1,45 @@
+import { useGroupActionsEdit } from '../../../../../src/composables/actions/groups/useGroupActionsEdit'
+import { mock } from 'jest-mock-extended'
+import { unref } from 'vue'
+import { Group } from 'web-client/src/generated'
+import { getComposableWrapper } from 'web-test-helpers'
+
+describe('useGroupActionsEdit', () => {
+  describe('method "isEnabled"', () => {
+    it.each([
+      { resources: [mock<Group>({ groupTypes: [] })], isEnabled: true },
+      { resources: [], isEnabled: false },
+      {
+        resources: [mock<Group>({ groupTypes: [] }), mock<Group>({ groupTypes: [] })],
+        isEnabled: false
+      }
+    ])('should only return true for one group', ({ resources, isEnabled }) => {
+      getWrapper({
+        setup: ({ actions }) => {
+          expect(unref(actions)[0].isEnabled({ resources })).toEqual(isEnabled)
+        }
+      })
+    })
+    it('should return false for read-only groups', () => {
+      getWrapper({
+        setup: ({ actions }) => {
+          const resources = [mock<Group>({ groupTypes: ['ReadOnly'] })]
+          expect(unref(actions)[0].isEnabled({ resources })).toBeFalsy()
+        }
+      })
+    })
+  })
+})
+
+function getWrapper({
+  setup
+}: {
+  setup: (instance: ReturnType<typeof useGroupActionsEdit>) => void
+}) {
+  return {
+    wrapper: getComposableWrapper(() => {
+      const instance = useGroupActionsEdit()
+      setup(instance)
+    })
+  }
+}

--- a/packages/web-app-admin-settings/tests/unit/composables/actions/users/useUserActionsDelete.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/composables/actions/users/useUserActionsDelete.spec.ts
@@ -1,0 +1,83 @@
+import { useUserActionsDelete } from '../../../../../src/composables/actions/users/useUserActionsDelete'
+import { mock } from 'jest-mock-extended'
+import { unref } from 'vue'
+import { User } from 'web-client/src/generated'
+import { eventBus } from 'web-pkg/src'
+import {
+  createStore,
+  defaultComponentMocks,
+  defaultStoreMockOptions,
+  getComposableWrapper
+} from 'web-test-helpers'
+
+describe('useUserActionsDelete', () => {
+  describe('method "isEnabled"', () => {
+    it.each([
+      { resources: [], isEnabled: false },
+      { resources: [mock<User>()], isEnabled: true },
+      { resources: [mock<User>(), mock<User>()], isEnabled: true }
+    ])('should only return true if 1 or more users are selected', ({ resources, isEnabled }) => {
+      getWrapper({
+        setup: ({ actions }) => {
+          expect(unref(actions)[0].isEnabled({ resources })).toEqual(isEnabled)
+        }
+      })
+    })
+  })
+  describe('method "deleteUsers"', () => {
+    it('should successfully delete all given users and reload the users list', () => {
+      const eventSpy = jest.spyOn(eventBus, 'publish')
+      getWrapper({
+        setup: async ({ deleteUsers }, { storeOptions, clientService }) => {
+          const user = mock<User>({ id: '1' })
+          await deleteUsers([user])
+          expect(clientService.graphAuthenticated.users.deleteUser).toHaveBeenCalledWith(user.id)
+          expect(storeOptions.actions.hideModal).toHaveBeenCalled()
+          expect(eventSpy).toHaveBeenCalledWith('app.admin-settings.list.load')
+        }
+      })
+    })
+    it('should handle errors and not reload the users list in such case', () => {
+      jest.spyOn(console, 'error').mockImplementation(() => undefined)
+      const eventSpy = jest.spyOn(eventBus, 'publish')
+      getWrapper({
+        setup: async ({ deleteUsers }, { storeOptions, clientService }) => {
+          clientService.graphAuthenticated.users.deleteUser.mockRejectedValue({})
+          const user = mock<User>({ id: '1' })
+          await deleteUsers([user])
+          expect(clientService.graphAuthenticated.users.deleteUser).toHaveBeenCalledWith(user.id)
+          expect(storeOptions.actions.hideModal).toHaveBeenCalled()
+          expect(eventSpy).not.toHaveBeenCalledWith('app.admin-settings.list.load')
+        }
+      })
+    })
+  })
+})
+
+function getWrapper({
+  setup
+}: {
+  setup: (
+    instance: ReturnType<typeof useUserActionsDelete>,
+    {
+      storeOptions,
+      clientService
+    }: {
+      storeOptions: typeof defaultStoreMockOptions
+      clientService: ReturnType<typeof defaultComponentMocks>['$clientService']
+    }
+  ) => void
+}) {
+  const storeOptions = defaultStoreMockOptions
+  const store = createStore(storeOptions)
+  const mocks = defaultComponentMocks()
+  return {
+    wrapper: getComposableWrapper(
+      () => {
+        const instance = useUserActionsDelete({ store })
+        setup(instance, { storeOptions, clientService: mocks.$clientService })
+      },
+      { store, mocks }
+    )
+  }
+}

--- a/packages/web-app-admin-settings/tests/unit/composables/actions/users/useUserActionsEdit.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/composables/actions/users/useUserActionsEdit.spec.ts
@@ -1,0 +1,34 @@
+import { useUserActionsEdit } from '../../../../../src/composables/actions/users/useUserActionsEdit'
+import { mock } from 'jest-mock-extended'
+import { unref } from 'vue'
+import { User } from 'web-client/src/generated'
+import { getComposableWrapper } from 'web-test-helpers'
+
+describe('useUserActionsEdit', () => {
+  describe('method "isEnabled"', () => {
+    it.each([
+      { resources: [mock<User>()], isEnabled: true },
+      { resources: [], isEnabled: false },
+      { resources: [mock<User>(), mock<User>()], isEnabled: false }
+    ])('should only return true for one user', ({ resources, isEnabled }) => {
+      getWrapper({
+        setup: ({ actions }) => {
+          expect(unref(actions)[0].isEnabled({ resources })).toEqual(isEnabled)
+        }
+      })
+    })
+  })
+})
+
+function getWrapper({
+  setup
+}: {
+  setup: (instance: ReturnType<typeof useUserActionsEdit>) => void
+}) {
+  return {
+    wrapper: getComposableWrapper(() => {
+      const instance = useUserActionsEdit()
+      setup(instance)
+    })
+  }
+}


### PR DESCRIPTION
## Description
Fixes several issues that appeared when selecting multiple users/groups/spaces in the admin-settings and then triggering batch actions via the context menu. Some actions were showing wrongly ("edit"), some actions were resetting the current selection ("show details").

Also adds proper unit tests for the group and user action composables.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8549

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
