### PR TITLE
feat: add font family to theming

### DIFF
--- a/changelog/unreleased/enhancement-font-family-theming
+++ b/changelog/unreleased/enhancement-font-family-theming
@@ -1,0 +1,6 @@
+Enhancement: Font family in theming
+
+We've added support for modifying the font family via theming.
+Please note that the chosen font needs to be made available as `font-face` via additional CSS.
+
+https://github.com/owncloud/web/pull/8797

--- a/docs/theming/_index.md
+++ b/docs/theming/_index.md
@@ -97,6 +97,7 @@ In general, the theme loader looks for a `designTokens` key inside your theme co
       "designTokens": {
         "breakpoints": {},
         "colorPalette": {},
+        "fontFamily": "",
         "fontSizes": {},
         "sizes": {},
         "spacing": {}
@@ -204,6 +205,18 @@ Font size variables get prepended with `--oc-font-size-`, so e.g. *"default"* cr
   }
 }
 ```
+
+### Font family
+
+You can change the font family according to your needs. The font family gets written into the `--oc-font-family` CSS variable.
+
+```json
+{
+  "fontFamily": ""
+}
+```
+
+Please note that you also need to make the font available as a `font-face` via CSS.
 
 ### Sizes
 
@@ -330,6 +343,7 @@ An empty template for your custom theme is provided below, and you can use the i
           "large": "",
           "medium": ""
         },
+        "fontFamily": "",
         "sizes": {
           "form-check-default": "",
           "height-small": "",

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -6,11 +6,15 @@ import * as directives from './directives'
 
 const initializeCustomProps = (tokens = [], prefix) => {
   for (const param in tokens) {
-    ;(document.querySelector(':root') as HTMLElement).style.setProperty(
-      '--oc-' + prefix + param,
-      tokens[param]
-    )
+    initializeCustomProp(prefix + param, tokens[param])
   }
+}
+
+const initializeCustomProp = (key: string, value: string | undefined) => {
+  if (value === undefined) {
+    return
+  }
+  ;(document.querySelector(':root') as HTMLElement).style.setProperty('--oc-' + key, value)
 }
 
 export default {
@@ -21,6 +25,7 @@ export default {
     initializeCustomProps(themeOptions?.fontSizes, 'font-size-')
     initializeCustomProps(themeOptions?.sizes, 'size-')
     initializeCustomProps(themeOptions?.spacing, 'space-')
+    initializeCustomProp('font-family', themeOptions?.fontFamily)
 
     Object.values(components).forEach((c) => app.component(c.name, c))
     Object.values(directives).forEach((d) => app.directive(d.name, d))


### PR DESCRIPTION
## Description
Adds a `fontFamily` token to the `designTokens` in theming and makes sure that it gets applied to the already existing css variable.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
