### PR TITLE
Implement batch action for editing the login state of users

### DIFF
--- a/changelog/unreleased/enhancement-user-settings-login-field
+++ b/changelog/unreleased/enhancement-user-settings-login-field
@@ -4,5 +4,7 @@ We've introduced the new login field in the user settings,
 where the admin can allow or disallow the login for the respective user.
 
 https://github.com/owncloud/web/pull/8433
+https://github.com/owncloud/web/pull/8799
 https://github.com/owncloud/web/issues/8484
 https://github.com/owncloud/web/issues/8467
+https://github.com/owncloud/web/issues/8798

--- a/packages/web-app-admin-settings/src/components/Users/LoginModal.vue
+++ b/packages/web-app-admin-settings/src/components/Users/LoginModal.vue
@@ -1,6 +1,6 @@
 <template>
   <oc-modal
-    :title="$gettext('Edit Login')"
+    :title="modalTitle"
     :button-cancel-text="$gettext('Cancel')"
     :button-confirm-text="$gettext('Confirm')"
     :button-confirm-disabled="!selectedOption"
@@ -10,11 +10,11 @@
     <template #content>
       <oc-select
         :model-value="selectedOption"
-        :label="$gettext('Set login status for selected users')"
+        :label="$gettext('Login status')"
         :options="options"
         :placeholder="$gettext('Select...')"
         :warning-message="
-          currentUserSelected ? $gettext('Your own login state will remain unchanged.') : ''
+          currentUserSelected ? $gettext('Your own login status will remain unchanged.') : ''
         "
         @update:model-value="changeSelectedOption"
       />
@@ -44,7 +44,7 @@ export default defineComponent({
   emits: ['confirm', 'cancel'],
   setup(props) {
     const store = useStore()
-    const { $gettext } = useGettext()
+    const { $gettext, $ngettext } = useGettext()
 
     const selectedOption = ref()
 
@@ -61,6 +61,18 @@ export default defineComponent({
       return props.users.some((u) => u.id === store.getters.user.uuid)
     })
 
+    const modalTitle = computed(() => {
+      return $ngettext(
+        'Edit login for "%{user}"',
+        'Edit login for %{userCount} users',
+        props.users.length,
+        {
+          user: props.users[0].displayName,
+          userCount: props.users.length.toString()
+        }
+      )
+    })
+
     onMounted(() => {
       if (props.users.every((u) => u.accountEnabled !== false)) {
         selectedOption.value = unref(options).find(({ value }) => !!value)
@@ -73,7 +85,8 @@ export default defineComponent({
       selectedOption,
       options,
       changeSelectedOption,
-      currentUserSelected
+      currentUserSelected,
+      modalTitle
     }
   }
 })

--- a/packages/web-app-admin-settings/src/components/Users/LoginModal.vue
+++ b/packages/web-app-admin-settings/src/components/Users/LoginModal.vue
@@ -1,0 +1,80 @@
+<template>
+  <oc-modal
+    :title="$gettext('Edit Login')"
+    :button-cancel-text="$gettext('Cancel')"
+    :button-confirm-text="$gettext('Confirm')"
+    :button-confirm-disabled="!selectedOption"
+    @cancel="$emit('cancel')"
+    @confirm="$emit('confirm', { users, value: selectedOption.value })"
+  >
+    <template #content>
+      <oc-select
+        :model-value="selectedOption"
+        :label="$gettext('Set login status for selected users')"
+        :options="options"
+        :placeholder="$gettext('Select...')"
+        :warning-message="
+          currentUserSelected ? $gettext('Your own login state will remain unchanged.') : ''
+        "
+        @update:model-value="changeSelectedOption"
+      />
+    </template>
+  </oc-modal>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, onMounted, PropType, ref, unref } from 'vue'
+import { useGettext } from 'vue3-gettext'
+import { User } from 'web-client/src/generated'
+import { useStore } from 'web-pkg/src'
+
+type LoginOption = {
+  label: string
+  value: boolean
+}
+
+export default defineComponent({
+  name: 'LoginModal',
+  props: {
+    users: {
+      type: Array as PropType<User[]>,
+      required: true
+    }
+  },
+  emits: ['confirm', 'cancel'],
+  setup(props) {
+    const store = useStore()
+    const { $gettext } = useGettext()
+
+    const selectedOption = ref()
+
+    const options = computed<LoginOption[]>(() => {
+      return [
+        { label: $gettext('Allowed'), value: true },
+        { label: $gettext('Forbidden'), value: false }
+      ]
+    })
+    const changeSelectedOption = (option: LoginOption) => {
+      selectedOption.value = option
+    }
+    const currentUserSelected = computed(() => {
+      return props.users.some((u) => u.id === store.getters.user.uuid)
+    })
+
+    onMounted(() => {
+      if (props.users.every((u) => u.accountEnabled !== false)) {
+        selectedOption.value = unref(options).find(({ value }) => !!value)
+      } else if (props.users.every((u) => u.accountEnabled === false)) {
+        selectedOption.value = unref(options).find(({ value }) => !value)
+      }
+    })
+
+    return {
+      selectedOption,
+      options,
+      changeSelectedOption,
+      currentUserSelected
+    }
+  }
+})
+</script>

--- a/packages/web-app-admin-settings/src/composables/actions/users/index.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/users/index.ts
@@ -1,4 +1,5 @@
 export * from './useUserActionsAddToGroups'
 export * from './useUserActionsDelete'
 export * from './useUserActionsEdit'
+export * from './useUserActionsEditLogin'
 export * from './useUserActionsRemoveFromGroups'

--- a/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsEditLogin.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsEditLogin.ts
@@ -12,7 +12,7 @@ export const useUserActionsEditLogin = () => {
       icon: 'login-circle',
       componentType: 'button',
       class: 'oc-users-actions-edit-login-trigger',
-      label: () => $gettext('Edit Login'),
+      label: () => $gettext('Edit login'),
       isEnabled: ({ resources }) => resources.length > 0,
       handler() {
         eventBus.publish('app.admin-settings.users.actions.edit-login')

--- a/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsEditLogin.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsEditLogin.ts
@@ -1,0 +1,26 @@
+import { eventBus } from 'web-pkg/src/services/eventBus'
+import { computed } from 'vue'
+import { useGettext } from 'vue3-gettext'
+import { UserAction } from 'web-pkg/src/composables/actions'
+
+export const useUserActionsEditLogin = () => {
+  const { $gettext } = useGettext()
+
+  const actions = computed((): UserAction[] => [
+    {
+      name: 'edit-login',
+      icon: 'login-circle',
+      componentType: 'button',
+      class: 'oc-users-actions-edit-login-trigger',
+      label: () => $gettext('Edit Login'),
+      isEnabled: ({ resources }) => resources.length > 0,
+      handler() {
+        eventBus.publish('app.admin-settings.users.actions.edit-login')
+      }
+    }
+  ])
+
+  return {
+    actions
+  }
+}

--- a/packages/web-app-admin-settings/tests/unit/components/Users/LoginModal.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/LoginModal.spec.ts
@@ -1,0 +1,38 @@
+import LoginModal from '../../../../src/components/Users/LoginModal.vue'
+import {
+  createStore,
+  defaultPlugins,
+  defaultStoreMockOptions,
+  shallowMount
+} from 'web-test-helpers'
+import { mock } from 'jest-mock-extended'
+import { User } from 'web-client/src/generated'
+
+describe('LoginModal', () => {
+  it('renders the input including two options', () => {
+    const { wrapper } = getWrapper()
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+  it('shows a warning when the current user is being selected', () => {
+    const { wrapper } = getWrapper([mock<User>({ id: '1' })])
+    expect(wrapper.findComponent<any>('oc-select-stub').props('warningMessage')).toBeDefined()
+  })
+})
+
+function getWrapper(users = [mock<User>()]) {
+  const storeOptions = defaultStoreMockOptions
+  storeOptions.getters.user.mockReturnValue({ uuid: '1' })
+  const store = createStore(storeOptions)
+  return {
+    wrapper: shallowMount(LoginModal, {
+      props: {
+        users
+      },
+      global: {
+        renderStubDefaultSlot: true,
+        plugins: [...defaultPlugins(), store],
+        stubs: { OcModal: false }
+      }
+    })
+  }
+}

--- a/packages/web-app-admin-settings/tests/unit/components/Users/__snapshots__/LoginModal.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/__snapshots__/LoginModal.spec.ts.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LoginModal renders the input including two options 1`] = `
+<div aria-labelledby="oc-modal-title" class="oc-modal-background">
+  <focus-trap-stub active="true" allowoutsideclick="true" clickoutsidedeactivates="false" delayinitialfocus="true" escapedeactivates="true" initialfocus="[Function]" preventscroll="false" returnfocusondeactivate="true" setreturnfocus="false">
+    <div aria-modal="true" class="oc-modal oc-modal-passive" role="dialog" tabindex="0">
+      <div class="oc-modal-title">
+        <!--v-if-->
+        <h2 id="oc-modal-title">Edit Login</h2>
+      </div>
+      <div class="oc-modal-body">
+        <div class="oc-modal-body-message">
+          <oc-select-stub clearable="false" disabled="false" filter="[Function]" fixmessageline="false" id="oc-select-1" label="Set login status for selected users" loading="false" multiple="false" optionlabel="label" options="[object Object],[object Object]" placeholder="Select..." searchable="true" warningmessage=""></oc-select-stub>
+        </div>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div class="oc-modal-body-actions oc-flex oc-flex-right">
+        <oc-button-stub appearance="outline" class="oc-modal-body-actions-cancel" disabled="false" gapsize="medium" justifycontent="center" size="medium" submit="button" type="button" variation="passive">Cancel</oc-button-stub>
+        <!--v-if-->
+        <oc-button-stub appearance="filled" class="oc-modal-body-actions-confirm oc-ml-s" disabled="true" gapsize="medium" justifycontent="center" size="medium" submit="button" type="button" variation="primary">Confirm</oc-button-stub>
+      </div>
+    </div>
+  </focus-trap-stub>
+</div>
+`;

--- a/packages/web-app-admin-settings/tests/unit/components/Users/__snapshots__/LoginModal.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/__snapshots__/LoginModal.spec.ts.snap
@@ -6,11 +6,13 @@ exports[`LoginModal renders the input including two options 1`] = `
     <div aria-modal="true" class="oc-modal oc-modal-passive" role="dialog" tabindex="0">
       <div class="oc-modal-title">
         <!--v-if-->
-        <h2 id="oc-modal-title">Edit Login</h2>
+        <h2 id="oc-modal-title">Edit login for "function () {
+          return fn.apply(this, arguments);
+          }"</h2>
       </div>
       <div class="oc-modal-body">
         <div class="oc-modal-body-message">
-          <oc-select-stub clearable="false" disabled="false" filter="[Function]" fixmessageline="false" id="oc-select-1" label="Set login status for selected users" loading="false" multiple="false" optionlabel="label" options="[object Object],[object Object]" placeholder="Select..." searchable="true" warningmessage=""></oc-select-stub>
+          <oc-select-stub clearable="false" disabled="false" filter="[Function]" fixmessageline="false" id="oc-select-1" label="Login status" loading="false" multiple="false" optionlabel="label" options="[object Object],[object Object]" placeholder="Select..." searchable="true" warningmessage=""></oc-select-stub>
         </div>
         <!--v-if-->
         <!--v-if-->

--- a/packages/web-app-admin-settings/tests/unit/composables/actions/users/useUserActionsEditLogin.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/composables/actions/users/useUserActionsEditLogin.spec.ts
@@ -1,0 +1,46 @@
+import { useUserActionsEditLogin } from '../../../../../src/composables/actions/users/useUserActionsEditLogin'
+import { mock } from 'jest-mock-extended'
+import { unref } from 'vue'
+import { User } from 'web-client/src/generated'
+import { eventBus } from 'web-pkg/src'
+import { getComposableWrapper } from 'web-test-helpers'
+
+describe('useUserActionsEditLogin', () => {
+  describe('method "isEnabled"', () => {
+    it.each([
+      { resources: [], isEnabled: false },
+      { resources: [mock<User>()], isEnabled: true },
+      { resources: [mock<User>(), mock<User>()], isEnabled: true }
+    ])('requires at least one user to be enabled', ({ resources, isEnabled }) => {
+      getWrapper({
+        setup: ({ actions }) => {
+          expect(unref(actions)[0].isEnabled({ resources })).toEqual(isEnabled)
+        }
+      })
+    })
+  })
+  describe('method "handler"', () => {
+    it('emits an event', () => {
+      getWrapper({
+        setup: ({ actions }) => {
+          const eventSpy = jest.spyOn(eventBus, 'publish')
+          unref(actions)[0].handler()
+          expect(eventSpy).toHaveBeenCalledWith('app.admin-settings.users.actions.edit-login')
+        }
+      })
+    })
+  })
+})
+
+function getWrapper({
+  setup
+}: {
+  setup: (instance: ReturnType<typeof useUserActionsEditLogin>) => void
+}) {
+  return {
+    wrapper: getComposableWrapper(() => {
+      const instance = useUserActionsEditLogin()
+      setup(instance)
+    })
+  }
+}


### PR DESCRIPTION
## Description
Adds a batch action to the users list in the admin settings which allows the admin to batch-edit the login state of users.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8798

## Screenshots
<img width="468" alt="image" src="https://user-images.githubusercontent.com/50302941/231478298-f65a83b2-d414-4baf-b888-da382d243771.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

