### PR TITLE
chore: change filepicker idp ports

### DIFF
--- a/dev/docker/ocis.idp.config.yaml
+++ b/dev/docker/ocis.idp.config.yaml
@@ -20,8 +20,8 @@ clients:
   trusted: true
   secret: ""
   redirect_uris:
-    - https://host.docker.internal:8080/
-    - https://host.docker.internal:8080/oidc-callback.html
-    - https://host.docker.internal:8080/oidc-silent-redirect.html
+    - https://host.docker.internal:3000/
+    - https://host.docker.internal:3000/oidc-callback.html
+    - https://host.docker.internal:3000/oidc-silent-redirect.html
   origins:
-    - https://host.docker.internal:8080
+    - https://host.docker.internal:3000


### PR DESCRIPTION
the filepicker dev setup will use port 3000 when https://github.com/owncloud/file-picker/pull/198 is merged. Changing idp config in our dev setup here to align with that.