### PR TITLE
Prevent share recipient container from exceeding its height

### DIFF
--- a/changelog/unreleased/bugfix-share-recipient-container-exceed
+++ b/changelog/unreleased/bugfix-share-recipient-container-exceed
@@ -1,0 +1,6 @@
+Bugfix: Share recipient container exceed
+
+The share recipient container now shows a vertical scroll bar when the users would exceed the container height.
+
+https://github.com/owncloud/web/pull/8814
+https://github.com/owncloud/web/issues/8811

--- a/packages/design-system/src/components/OcSelect/OcSelect.vue
+++ b/packages/design-system/src/components/OcSelect/OcSelect.vue
@@ -332,7 +332,6 @@ export default defineComponent({
       margin: 0;
       max-width: 100%;
       outline: none;
-      overflow: visible;
       padding: 2px;
       transition-duration: 0.2s;
       transition-timing-function: ease-in-out;


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8811

## Screenshots
<img width="382" alt="image" src="https://user-images.githubusercontent.com/50302941/231983281-7f666ea8-dc03-445c-a2f3-4f523e5b2940.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
