### PR TITLE
Fix user quota reactivity

### DIFF
--- a/packages/web-app-admin-settings/src/components/Spaces/ContextActions.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/ContextActions.vue
@@ -6,7 +6,6 @@
       :cancel="closeQuotaModal"
       :spaces="items"
       :max-quota="maxQuota"
-      @space-quota-updated="spaceQuotaUpdated"
     />
   </div>
 </template>
@@ -46,8 +45,7 @@ export default defineComponent({
     const {
       actions: editQuotaActions,
       modalOpen: quotaModalIsOpen,
-      closeModal: closeQuotaModal,
-      spaceQuotaUpdated
+      closeModal: closeQuotaModal
     } = useSpaceActionsEditQuota({ store })
     const { actions: editDescriptionActions } = useSpaceActionsEditDescription({ store })
     const { actions: renameActions } = useSpaceActionsRename({ store })
@@ -99,8 +97,7 @@ export default defineComponent({
       maxQuota: useCapabilitySpacesMaxQuota(),
       menuSections,
       quotaModalIsOpen,
-      closeQuotaModal,
-      spaceQuotaUpdated
+      closeQuotaModal
     }
   }
 })

--- a/packages/web-app-admin-settings/src/components/Spaces/SideBar/ActionsPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/SideBar/ActionsPanel.vue
@@ -5,7 +5,6 @@
       :cancel="closeQuotaModal"
       :spaces="resources"
       :max-quota="maxQuota"
-      @space-quota-updated="spaceQuotaUpdated"
     />
     <oc-list id="oc-spaces-actions-sidebar" class-name="oc-mt-s">
       <action-menu-item
@@ -54,8 +53,7 @@ export default defineComponent({
     const {
       actions: editQuotaActions,
       modalOpen: quotaModalIsOpen,
-      closeModal: closeQuotaModal,
-      spaceQuotaUpdated
+      closeModal: closeQuotaModal
     } = useSpaceActionsEditQuota({ store })
     const { actions: renameActions } = useSpaceActionsRename({ store })
     const { actions: restoreActions } = useSpaceActionsRestore({ store })
@@ -77,7 +75,6 @@ export default defineComponent({
       maxQuota: useCapabilitySpacesMaxQuota(),
       quotaModalIsOpen,
       closeQuotaModal,
-      spaceQuotaUpdated,
       resources
     }
   }

--- a/packages/web-app-admin-settings/src/components/Users/ContextActions.vue
+++ b/packages/web-app-admin-settings/src/components/Users/ContextActions.vue
@@ -9,7 +9,6 @@
       :warning-message="quotaModalWarningMessage"
       :warning-message-contextual-helper-data="quotaWarningMessageContextualHelperData"
       resource-type="user"
-      @space-quota-updated="spaceQuotaUpdated"
     />
   </div>
 </template>
@@ -43,7 +42,7 @@ export default defineComponent({
     const selectedPersonalDrives = ref([])
     watch(
       () => props.items,
-      async () => {
+      () => {
         selectedPersonalDrives.value.splice(0, unref(selectedPersonalDrives).length)
         props.items.forEach((user) => {
           const drive = toRaw(user.drive)
@@ -87,8 +86,7 @@ export default defineComponent({
     const {
       actions: editQuotaActions,
       modalOpen: quotaModalIsOpen,
-      closeModal: closeQuotaModal,
-      spaceQuotaUpdated
+      closeModal: closeQuotaModal
     } = useSpaceActionsEditQuota({ store })
     const { actions: userEditActions } = useUserActionsEdit()
     const { actions: userDeleteActions } = useUserActionsDelete({ store })
@@ -138,7 +136,6 @@ export default defineComponent({
       menuSections,
       quotaModalIsOpen,
       closeQuotaModal,
-      spaceQuotaUpdated,
       selectedPersonalDrives,
       quotaModalWarningMessage,
       quotaWarningMessageContextualHelperData

--- a/packages/web-app-admin-settings/src/views/Spaces.vue
+++ b/packages/web-app-admin-settings/src/views/Spaces.vue
@@ -41,7 +41,6 @@
           :cancel="closeQuotaModal"
           :spaces="selectedSpaces"
           :max-quota="maxQuota"
-          @space-quota-updated="spaceQuotaUpdated"
         />
         <no-content-message
           v-if="!spaces.length"
@@ -196,8 +195,7 @@ export default defineComponent({
     const {
       actions: editQuotaActions,
       modalOpen: quotaModalIsOpen,
-      closeModal: closeQuotaModal,
-      spaceQuotaUpdated
+      closeModal: closeQuotaModal
     } = useSpaceActionsEditQuota({ store })
     const { actions: restoreActions } = useSpaceActionsRestore({ store })
 
@@ -308,8 +306,7 @@ export default defineComponent({
       toggleSelectSpace,
       unselectAllSpaces,
       quotaModalIsOpen,
-      closeQuotaModal,
-      spaceQuotaUpdated
+      closeQuotaModal
     }
   }
 })

--- a/packages/web-app-admin-settings/src/views/Users.vue
+++ b/packages/web-app-admin-settings/src/views/Users.vue
@@ -460,7 +460,7 @@ export default defineComponent({
           editLoginModalIsOpen.value = true
         }
       )
-      editLoginActionEventToken = eventBus.subscribe(
+      editQuotaActionEventToken = eventBus.subscribe(
         'app.admin-settings.users.user.quota.updated',
         updateSpaceQuota
       )

--- a/packages/web-app-admin-settings/tests/unit/composables/actions/groups/useGroupActionsDelete.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/composables/actions/groups/useGroupActionsDelete.spec.ts
@@ -48,7 +48,7 @@ describe('useGroupActionsDelete', () => {
         }
       })
     })
-    it('should handle errors and not reload the groups list in such case', () => {
+    it('should handle errors', () => {
       jest.spyOn(console, 'error').mockImplementation(() => undefined)
       const eventSpy = jest.spyOn(eventBus, 'publish')
       getWrapper({
@@ -58,7 +58,7 @@ describe('useGroupActionsDelete', () => {
           await deleteGroups([group])
           expect(clientService.graphAuthenticated.groups.deleteGroup).toHaveBeenCalledWith(group.id)
           expect(storeOptions.actions.hideModal).toHaveBeenCalled()
-          expect(eventSpy).not.toHaveBeenCalledWith('app.admin-settings.list.load')
+          expect(eventSpy).toHaveBeenCalledWith('app.admin-settings.list.load')
         }
       })
     })

--- a/packages/web-app-admin-settings/tests/unit/composables/actions/users/useUserActionsDelete.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/composables/actions/users/useUserActionsDelete.spec.ts
@@ -37,7 +37,7 @@ describe('useUserActionsDelete', () => {
         }
       })
     })
-    it('should handle errors and not reload the users list in such case', () => {
+    it('should handle errors', () => {
       jest.spyOn(console, 'error').mockImplementation(() => undefined)
       const eventSpy = jest.spyOn(eventBus, 'publish')
       getWrapper({
@@ -47,7 +47,7 @@ describe('useUserActionsDelete', () => {
           await deleteUsers([user])
           expect(clientService.graphAuthenticated.users.deleteUser).toHaveBeenCalledWith(user.id)
           expect(storeOptions.actions.hideModal).toHaveBeenCalled()
-          expect(eventSpy).not.toHaveBeenCalledWith('app.admin-settings.list.load')
+          expect(eventSpy).toHaveBeenCalledWith('app.admin-settings.list.load')
         }
       })
     })

--- a/packages/web-app-files/src/components/Spaces/SpaceContextActions.vue
+++ b/packages/web-app-files/src/components/Spaces/SpaceContextActions.vue
@@ -4,7 +4,7 @@
     <quota-modal
       v-if="quotaModalIsOpen"
       :cancel="closeQuotaModal"
-      :spaces="quotaModalSelectedSpaces"
+      :spaces="_actionOptions.resources"
       :max-quota="maxQuota"
     />
     <readme-content-modal
@@ -78,11 +78,8 @@ export default defineComponent({
     const {
       actions: editQuotaActions,
       modalOpen: quotaModalIsOpen,
-      closeModal: closeQuotaModal,
-      selectedSpace: quotaModalSelectedSpace,
-      spaceQuotaUpdated
+      closeModal: closeQuotaModal
     } = useSpaceActionsEditQuota({ store })
-    const quotaModalSelectedSpaces = computed(() => [unref(quotaModalSelectedSpace)])
     const { actions: editDescriptionActions } = useSpaceActionsEditDescription({ store })
     const {
       actions: editReadmeContentActions,
@@ -181,8 +178,7 @@ export default defineComponent({
       closeReadmeContentModal,
 
       quotaModalIsOpen,
-      closeQuotaModal,
-      quotaModalSelectedSpaces
+      closeQuotaModal
     }
   }
 })

--- a/packages/web-pkg/src/components/Spaces/QuotaModal.vue
+++ b/packages/web-pkg/src/components/Spaces/QuotaModal.vue
@@ -73,7 +73,6 @@ export default defineComponent({
       }
     }
   },
-  emits: ['spaceQuotaUpdated'],
   setup(props) {
     const store = useStore()
     const { $gettext, $ngettext } = useGettext()
@@ -159,9 +158,14 @@ export default defineComponent({
           { quota: { total: unref(selectedOption) } } as Drive,
           {}
         )
-        props.cancel()
         if (unref(router.currentRoute).name === 'admin-settings-spaces') {
           eventBus.publish('app.admin-settings.spaces.space.quota.updated', {
+            spaceId: space.id,
+            quota: driveData.quota
+          })
+        }
+        if (unref(router.currentRoute).name === 'admin-settings-users') {
+          eventBus.publish('app.admin-settings.users.user.quota.updated', {
             spaceId: space.id,
             quota: driveData.quota
           })
@@ -180,13 +184,15 @@ export default defineComponent({
       const results = await Promise.allSettled<Array<unknown>>(requests)
       const succeeded = results.filter((r) => r.status === 'fulfilled')
       if (succeeded.length) {
-        return store.dispatch('showMessage', { title: getSuccessMessage(succeeded.length) })
+        store.dispatch('showMessage', { title: getSuccessMessage(succeeded.length) })
       }
       const errors = results.filter((r) => r.status === 'rejected')
       if (errors.length) {
         errors.forEach(console.error)
-        await store.dispatch('showMessage', { title: getErrorMessage(errors.length) })
+        store.dispatch('showMessage', { title: getErrorMessage(errors.length) })
       }
+
+      props.cancel()
     }
 
     onMounted(() => {

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditQuota.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditQuota.ts
@@ -1,9 +1,8 @@
 import { Store } from 'vuex'
 import { useStore } from '../../store'
-import { computed, ref, Ref } from 'vue'
-import { SpaceAction, SpaceActionOptions } from '../types'
+import { computed, ref } from 'vue'
+import { SpaceAction } from '../types'
 import { useGettext } from 'vue3-gettext'
-import { SpaceResource } from 'web-client/src'
 import { User } from 'web-client/src/generated'
 import { useAbility } from '../../ability'
 
@@ -13,18 +12,12 @@ export const useSpaceActionsEditQuota = ({ store }: { store?: Store<any> } = {})
   const ability = useAbility()
 
   const modalOpen = ref(false)
-  const selectedSpace = ref(null) as Ref<SpaceResource>
-
-  const spaceQuotaUpdated = (quota) => {
-    selectedSpace.value.spaceQuota = quota
-  }
 
   const closeModal = () => {
     modalOpen.value = false
   }
 
-  const handler = ({ resources }: SpaceActionOptions) => {
-    selectedSpace.value = resources[0]
+  const handler = () => {
     modalOpen.value = true
   }
 
@@ -61,8 +54,6 @@ export const useSpaceActionsEditQuota = ({ store }: { store?: Store<any> } = {})
   return {
     modalOpen,
     closeModal,
-    spaceQuotaUpdated,
-    selectedSpace,
     actions
   }
 }


### PR DESCRIPTION
## Description
Fixes user quota reactivity in right sidebar and implements proper messaging on user- and group-batch-delete.

I had to refactor `useSpaceActionsEditQuota.ts` a bit and removed `selectedSpace` and the method which updates it. This was built to deal with one given space, but now that the quota can be edited via batch it doesn't make sense anymore.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8815
- Fixes https://github.com/owncloud/web/issues/8690

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
