### PR TITLE
Remove drop target in read-only folders

### DIFF
--- a/changelog/unreleased/bugfix-remove-drop-target-in-read-only-folders
+++ b/changelog/unreleased/bugfix-remove-drop-target-in-read-only-folders
@@ -1,0 +1,6 @@
+Bugfix: Remove drop target in read-only folders
+
+The drop target in read-only folders has been removed.
+
+https://github.com/owncloud/web/pull/8825
+https://github.com/owncloud/web/issues/8277

--- a/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.ts
+++ b/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.ts
@@ -238,6 +238,17 @@ describe('CreateAndUpload component', () => {
       expect(storeOptions.actions.showMessage).toHaveBeenCalled()
     })
   })
+  describe('drop target', () => {
+    it('is being initialized when user can upload', () => {
+      const { mocks } = getWrapper()
+      expect(mocks.$uppyService.useDropTarget).toHaveBeenCalled()
+    })
+    it('is not being initialized when user can not upload', () => {
+      const currentFolder = mockDeep<Resource>({ canUpload: () => false })
+      const { mocks } = getWrapper({ currentFolder })
+      expect(mocks.$uppyService.useDropTarget).not.toHaveBeenCalled()
+    })
+  })
 })
 
 function getWrapper({


### PR DESCRIPTION
## Description
Removes the drop target in read-only folders

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8277

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
