### PR TITLE
Fix context menu position when opened via keyboard

### DIFF
--- a/changelog/unreleased/bugfix-context-menu-keyboard
+++ b/changelog/unreleased/bugfix-context-menu-keyboard
@@ -1,0 +1,6 @@
+Bugfix: Opening context menu via keyboard
+
+The position of the context menu when opened via keyboard has been fixed.
+
+https://github.com/owncloud/web/pull/8827
+https://github.com/owncloud/web/issues/8232

--- a/packages/web-pkg/src/helpers/contextMenuDropdown.ts
+++ b/packages/web-pkg/src/helpers/contextMenuDropdown.ts
@@ -1,11 +1,16 @@
 export const displayPositionedDropdown = (dropdown, event, contextMenuButton) => {
   const contextMenuButtonPos = contextMenuButton.$el.getBoundingClientRect()
+  const isKeyboardEvent = event.clientY === 0
+  const yValue = isKeyboardEvent
+    ? event.srcElement?.getBoundingClientRect().top || 0
+    : event.clientY
+
   dropdown.setProps({
     getReferenceClientRect: () => ({
       width: 0,
       height: 0,
-      top: event.clientY,
-      bottom: event.clientY,
+      top: yValue,
+      bottom: yValue,
       /**
        * If event type is 'contextmenu' the trigger was a right click on the table row,
        * so we render the dropdown at the position of the mouse pointer.


### PR DESCRIPTION

## Description
Fixes context menu position when opened via keyboard.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8232

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
