### PR TITLE
Improve views in admin-settings when having limited horizontal screen estate

### DIFF
--- a/packages/web-app-admin-settings/src/components/AppTemplate.vue
+++ b/packages/web-app-admin-settings/src/components/AppTemplate.vue
@@ -1,5 +1,5 @@
 <template>
-  <main class="oc-flex oc-height-1-1 app-content oc-width-1-1">
+  <main class="oc-flex oc-flex-wrap oc-height-1-1 app-content oc-width-1-1">
     <app-loading-spinner v-if="loading" />
     <template v-else>
       <div id="admin-settings-wrapper" class="oc-width-expand">

--- a/packages/web-app-admin-settings/src/components/AppTemplate.vue
+++ b/packages/web-app-admin-settings/src/components/AppTemplate.vue
@@ -1,9 +1,9 @@
 <template>
-  <main ref="appBarRef" class="oc-flex oc-height-1-1 app-content oc-width-1-1">
+  <main class="oc-flex oc-height-1-1 app-content oc-width-1-1">
     <app-loading-spinner v-if="loading" />
     <template v-else>
       <div id="admin-settings-wrapper" class="oc-width-expand">
-        <div id="admin-settings-app-bar" ref="appBar" class="oc-app-bar oc-py-s">
+        <div id="admin-settings-app-bar" ref="appBarRef" class="oc-app-bar oc-py-s">
           <div class="admin-settings-app-bar-controls oc-flex oc-flex-between oc-flex-middle">
             <oc-breadcrumb
               v-if="!isMobileWidth"
@@ -61,7 +61,17 @@
 import AppLoadingSpinner from 'web-pkg/src/components/AppLoadingSpinner.vue'
 import SideBar from 'web-pkg/src/components/sideBar/SideBar.vue'
 import BatchActions from 'web-pkg/src/components/BatchActions.vue'
-import { defineComponent, inject, onBeforeUnmount, onMounted, PropType, Ref, ref, unref } from 'vue'
+import {
+  defineComponent,
+  inject,
+  onBeforeUnmount,
+  PropType,
+  Ref,
+  ref,
+  unref,
+  VNodeRef,
+  watch
+} from 'vue'
 import { eventBus, useAppDefaults } from 'web-pkg'
 import { SideBarEventTopics } from 'web-pkg/src/composables/sideBar'
 import { Panel } from 'web-pkg/src/components/sideBar'
@@ -125,14 +135,14 @@ export default defineComponent({
     }
   },
   setup(props) {
-    const appBarRef = ref()
+    const appBarRef = ref<VNodeRef>()
     const limitedScreenSpace = ref(false)
     const onResize = () => {
       limitedScreenSpace.value = props.sideBarOpen
-        ? window.innerWidth <= 1400
-        : window.innerWidth <= 1000
+        ? window.innerWidth <= 1600
+        : window.innerWidth <= 1200
     }
-    const resizeObserver = new ResizeObserver(onResize as ResizeObserverCallback)
+    const resizeObserver = new ResizeObserver(onResize)
 
     const closeSideBar = () => {
       eventBus.publish(SideBarEventTopics.close)
@@ -144,11 +154,20 @@ export default defineComponent({
       eventBus.publish(SideBarEventTopics.setActivePanel, panel)
     }
 
-    onMounted(() => {
-      resizeObserver.observe(unref(appBarRef))
-    })
+    watch(
+      appBarRef,
+      (ref) => {
+        if (ref) {
+          resizeObserver.observe(unref(appBarRef) as unknown as HTMLElement)
+        }
+      },
+      { immediate: true }
+    )
+
     onBeforeUnmount(() => {
-      resizeObserver.unobserve(unref(appBarRef))
+      if (unref(appBarRef)) {
+        resizeObserver.unobserve(unref(appBarRef) as unknown as HTMLElement)
+      }
     })
 
     return {

--- a/packages/web-app-admin-settings/src/components/Users/UsersList.vue
+++ b/packages/web-app-admin-settings/src/components/Users/UsersList.vue
@@ -376,7 +376,9 @@ export default defineComponent({
   }
 
   .oc-table-header-cell-role,
-  .oc-table-data-cell-role {
+  .oc-table-data-cell-role,
+  .oc-table-header-cell-accountEnabled,
+  .oc-table-data-cell-accountEnabled {
     display: none;
 
     @media only screen and (min-width: 1200px) {
@@ -395,7 +397,9 @@ export default defineComponent({
 
   &-squashed {
     .oc-table-header-cell-role,
-    .oc-table-data-cell-role {
+    .oc-table-data-cell-role,
+    .oc-table-header-cell-accountEnabled,
+    .oc-table-data-cell-accountEnabled {
       display: none;
 
       @media only screen and (min-width: 1600px) {

--- a/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Spaces.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Spaces.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Spaces view loading states should render spaces list after loading has been finished 1`] = `
 <div>
-  <main class="oc-flex oc-height-1-1 app-content oc-width-1-1">
+  <main class="oc-flex oc-flex-wrap oc-height-1-1 app-content oc-width-1-1">
     <div class="oc-width-expand" id="admin-settings-wrapper">
       <div class="oc-app-bar oc-py-s" id="admin-settings-app-bar">
         <div class="admin-settings-app-bar-controls oc-flex oc-flex-between oc-flex-middle">


### PR DESCRIPTION
## Description
* [Fix batch labels not hiding when sidebar is being opened](https://github.com/owncloud/web/commit/b5fdf65655c108e93e0b7c7cfba6ee226e364078)
* [Improve user list on smaller screens](https://github.com/owncloud/web/commit/ef258385bac6191f98e145f545c89e8f4c99fe3c)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8844
- Fixes https://github.com/owncloud/web/issues/8831

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
