### PR TITLE
Hide upload hint in empty read-only folders

### DIFF
--- a/changelog/unreleased/bugfix-hide-upload-hint-in-read-only-folders
+++ b/changelog/unreleased/bugfix-hide-upload-hint-in-read-only-folders
@@ -1,0 +1,6 @@
+Bugfix: Hide upload hint in empty read-only folders
+
+Empty read-only folders now don't show the upload hint to the user.
+
+https://github.com/owncloud/web/issues/8834
+https://github.com/owncloud/web/pull/8846

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -36,12 +36,10 @@
 
         <no-content-message v-if="isEmpty" id="files-space-empty" class="files-empty" icon="folder">
           <template #message>
-            <span v-translate>No resources found</span>
+            <span v-text="$gettext('No resources found')" />
           </template>
           <template #callToAction>
-            <span v-translate>
-              Drag files and folders here or use the "New" or "Upload" buttons to add files
-            </span>
+            <span v-if="canUpload" class="file-empty-upload-hint" v-text="uploadHint" />
           </template>
         </no-content-message>
         <resource-tiles
@@ -218,6 +216,10 @@ export default defineComponent({
     const store = useStore()
     const { $gettext, $ngettext, interpolate: $gettextInterpolate } = useGettext()
     let loadResourcesEventToken
+
+    const canUpload = computed(() => {
+      return store.getters['Files/currentFolder']?.canUpload({ user: store.getters.user })
+    })
 
     const viewModes = computed(() => [
       ViewModeConstants.condensedTable,
@@ -401,12 +403,16 @@ export default defineComponent({
     return {
       ...useFileActions(),
       ...resourcesViewDefaults,
+      canUpload,
       breadcrumbs,
       hasSpaceHeader,
       resourceTargetRouteCallback,
       performLoaderTask,
       ViewModeConstants,
-      viewModes
+      viewModes,
+      uploadHint: $gettext(
+        'Drag files and folders here or use the "New" or "Upload" buttons to add files'
+      )
     }
   },
 

--- a/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
@@ -117,6 +117,20 @@ describe('GenericSpace view', () => {
       expect(mocks.refreshFileListHeaderPosition).toHaveBeenCalledTimes(2)
     })
   })
+  describe('empty folder upload hint', () => {
+    it('renders if the user can upload to the current folder', () => {
+      const { wrapper } = getMountedWrapper({
+        currentFolder: mock<Resource>({ canUpload: () => true })
+      })
+      expect(wrapper.find('.file-empty-upload-hint').exists()).toBeTruthy()
+    })
+    it('does not render if the user can not upload to the current folder', () => {
+      const { wrapper } = getMountedWrapper({
+        currentFolder: mock<Resource>({ canUpload: () => false })
+      })
+      expect(wrapper.find('.file-empty-upload-hint').exists()).toBeFalsy()
+    })
+  })
 })
 
 function getMountedWrapper({
@@ -124,7 +138,8 @@ function getMountedWrapper({
   props = {},
   files = [],
   loading = false,
-  currentRoute = { name: 'files-spaces-generic', path: '/' }
+  currentRoute = { name: 'files-spaces-generic', path: '/' },
+  currentFolder = mock<Resource>()
 } = {}) {
   const resourcesViewDetailsMock = useResourcesViewDefaultsMock({
     paginatedResources: ref(files),
@@ -136,6 +151,7 @@ function getMountedWrapper({
     ...(mocks && mocks)
   }
   const storeOptions = { ...defaultStoreMockOptions }
+  storeOptions.modules.Files.getters.currentFolder.mockReturnValue(currentFolder)
   const propsData = {
     space: { id: 1, getDriveAliasAndItem: jest.fn(), name: 'Personal space' },
     item: '/',


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8834

## Screenshots
<img width="340" alt="image" src="https://user-images.githubusercontent.com/50302941/232730170-6903d690-1c55-4e77-9da4-ee4c1cc65189.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
