### PR TITLE
Restructure account page - GDPR export

### DIFF
--- a/changelog/unreleased/enhancement-restructure-gdpr-export-view
+++ b/changelog/unreleased/enhancement-restructure-gdpr-export-view
@@ -1,5 +1,6 @@
-Enhancement: Re-Structure GDPR-Export
+Enhancement: Re-Structure GDPR-Export view
 
 We re-structured the GDPR export to have it own section and provide some
 additional info.
 
+https://github.com/owncloud/web/pull/8851

--- a/changelog/unreleased/enhancement-restrucxture-gdpr-export
+++ b/changelog/unreleased/enhancement-restrucxture-gdpr-export
@@ -1,0 +1,5 @@
+Enhancement: Re-Structure GDPR-Export
+
+We re-structured the GDPR export to have it own section and provide some
+additional info.
+

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
@@ -1,5 +1,5 @@
 <template>
-  <span v-if="selectedRole" class="oc-flex oc-flex-middle">
+  <div v-if="selectedRole" class="oc-flex oc-flex-middle">
     <span v-if="availableRoles.length === 1">
       <span v-if="!existingRole" v-text="inviteLabel" />
       <span v-else>{{ $gettext(selectedRole.label) }}</span>
@@ -103,7 +103,7 @@
         />
       </div>
     </oc-drop>
-  </span>
+  </div>
 </template>
 
 <script lang="ts">

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/RoleDropdown.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/RoleDropdown.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RoleDropdown renders a button with existing role if given for resource type file 1`] = `
-<span class="oc-flex oc-flex-middle">
+<div class="oc-flex oc-flex-middle">
   <oc-button-stub appearance="raw" class="files-recipient-role-select-btn" disabled="false" gapsize="none" id="files-collaborators-role-button-new" justifycontent="center" size="medium" submit="button" type="button" variation="passive">
     <span>Viewer</span>
     <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="arrow-down-s" size="medium" type="span" variation="passive"></oc-icon-stub>
@@ -67,11 +67,11 @@ exports[`RoleDropdown renders a button with existing role if given for resource 
       <oc-button-stub appearance="filled" class="files-recipient-custom-permissions-drop-confirm oc-ml-s" disabled="false" gapsize="medium" justifycontent="center" size="small" submit="button" type="button" variation="primary">Apply</oc-button-stub>
     </div>
   </oc-drop-stub>
-</span>
+</div>
 `;
 
 exports[`RoleDropdown renders a button with existing role if given for resource type folder 1`] = `
-<span class="oc-flex oc-flex-middle">
+<div class="oc-flex oc-flex-middle">
   <oc-button-stub appearance="raw" class="files-recipient-role-select-btn" disabled="false" gapsize="none" id="files-collaborators-role-button-new" justifycontent="center" size="medium" submit="button" type="button" variation="passive">
     <span>Viewer</span>
     <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="arrow-down-s" size="medium" type="span" variation="passive"></oc-icon-stub>
@@ -137,11 +137,11 @@ exports[`RoleDropdown renders a button with existing role if given for resource 
       <oc-button-stub appearance="filled" class="files-recipient-custom-permissions-drop-confirm oc-ml-s" disabled="false" gapsize="medium" justifycontent="center" size="small" submit="button" type="button" variation="primary">Apply</oc-button-stub>
     </div>
   </oc-drop-stub>
-</span>
+</div>
 `;
 
 exports[`RoleDropdown renders a button with invite text if no existing role given for resource type file 1`] = `
-<span class="oc-flex oc-flex-middle">
+<div class="oc-flex oc-flex-middle">
   <oc-button-stub appearance="raw" class="files-recipient-role-select-btn" disabled="false" gapsize="none" id="files-collaborators-role-button-new" justifycontent="center" size="medium" submit="button" type="button" variation="passive">
     <span>Invite as viewer</span>
     <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="arrow-down-s" size="medium" type="span" variation="passive"></oc-icon-stub>
@@ -201,11 +201,11 @@ exports[`RoleDropdown renders a button with invite text if no existing role give
       <oc-button-stub appearance="filled" class="files-recipient-custom-permissions-drop-confirm oc-ml-s" disabled="false" gapsize="medium" justifycontent="center" size="small" submit="button" type="button" variation="primary">Apply</oc-button-stub>
     </div>
   </oc-drop-stub>
-</span>
+</div>
 `;
 
 exports[`RoleDropdown renders a button with invite text if no existing role given for resource type folder 1`] = `
-<span class="oc-flex oc-flex-middle">
+<div class="oc-flex oc-flex-middle">
   <oc-button-stub appearance="raw" class="files-recipient-role-select-btn" disabled="false" gapsize="none" id="files-collaborators-role-button-new" justifycontent="center" size="medium" submit="button" type="button" variation="passive">
     <span>Invite as viewer</span>
     <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="arrow-down-s" size="medium" type="span" variation="passive"></oc-icon-stub>
@@ -271,5 +271,5 @@ exports[`RoleDropdown renders a button with invite text if no existing role give
       <oc-button-stub appearance="filled" class="files-recipient-custom-permissions-drop-confirm oc-ml-s" disabled="false" gapsize="medium" justifycontent="center" size="small" submit="button" type="button" variation="primary">Apply</oc-button-stub>
     </div>
   </oc-drop-stub>
-</span>
+</div>
 `;

--- a/packages/web-runtime/src/components/Account/GdprExport.vue
+++ b/packages/web-runtime/src/components/Account/GdprExport.vue
@@ -1,31 +1,38 @@
 <template>
-  <span v-if="loading">
-    <oc-spinner />
-  </span>
-  <span v-else-if="exportInProgress" class="oc-flex oc-flex-middle" data-testid="export-in-process">
-    <oc-icon name="time" fill-type="line" size="small" class="oc-mr-s" />
-    <span v-text="$gettext('Export is being processed. This can take up to 24 hours.')" />
-  </span>
-  <div v-else>
-    <oc-button
-      appearance="raw"
-      variation="primary"
-      data-testid="request-export-btn"
-      @click="requestExport"
+  <div>
+    <p v-text="$gettext('Request a personal data export according to GDPR §20.')" />
+    <span v-if="loading">
+      <oc-spinner />
+    </span>
+    <span
+      v-else-if="exportInProgress"
+      class="oc-flex oc-flex-middle"
+      data-testid="export-in-process"
     >
-      <span v-text="$gettext('Request new export')" />
-    </oc-button>
-    <div v-if="exportFile" class="oc-flex oc-flex-middle">
+      <oc-icon name="time" fill-type="line" size="small" class="oc-mr-s" />
+      <span v-text="$gettext('Export is being processed. This can take up to 24 hours.')" />
+    </span>
+    <div v-else>
       <oc-button
-        appearance="raw"
+        :appearance="exportFile ? 'outline' : 'filled'"
         variation="primary"
-        data-testid="download-export-btn"
-        @click="downloadExport"
+        data-testid="request-export-btn"
+        @click="requestExport"
       >
-        <oc-icon name="download" fill-type="line" size="small" />
-        <span v-text="$gettext('Download export')" />
+        <span v-text="$gettext('Request new export')" />
       </oc-button>
-      <span class="oc-ml-s" v-text="`(${exportDate})`" />
+      <div v-if="exportFile" class="oc-mt-m">
+        <oc-button
+          :appearance="exportFile ? 'filled' : 'outline'"
+          variation="primary"
+          data-testid="download-export-btn"
+          @click="downloadExport"
+        >
+          <oc-icon name="download" fill-type="line" size="small" />
+          <span v-text="$gettext('Download latest export')" />
+          <span class="oc-ml-xs" v-text="`(${exportDate})`" />
+        </oc-button>
+      </div>
     </div>
   </div>
 </template>

--- a/packages/web-runtime/src/components/Account/GdprExport.vue
+++ b/packages/web-runtime/src/components/Account/GdprExport.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <p v-text="$gettext('Request a personal data export according to GDPR §20.')" />
+    <p v-text="$gettext('Request a personal data export according to §20 GDPR.')" />
     <span v-if="loading">
       <oc-spinner />
     </span>

--- a/packages/web-runtime/src/pages/account.vue
+++ b/packages/web-runtime/src/pages/account.vue
@@ -95,6 +95,7 @@
         </dd>
       </div>
       <div v-if="showGdprExport" class="account-page-gdpr-export oc-mb oc-width-1-2@s">
+        <h2 class="oc-text-bold oc-mb" v-text="$gettext('GDPR')" />
         <dt class="oc-text-normal oc-text-muted" v-text="$gettext('GDPR export')" />
         <dd data-testid="gdpr-export">
           <gdpr-export />


### PR DESCRIPTION
## Description
Re-Structure the account page. Gives the GDPR export an own section - it felt misplaced under "Account information".
Also, the request and download buttons look as buttons now and a line of information regarding §20 GDPR is added.

## Screenshots (if appropriate):
### Before
<img width="1081" alt="grafik" src="https://user-images.githubusercontent.com/16665512/232767068-03107604-b42e-47a7-b3ba-710b69dcc6cb.png">


### After
<img width="1081" alt="grafik" src="https://user-images.githubusercontent.com/16665512/232766964-1224e9db-b6a7-4e77-84ac-c145e48a9f35.png">


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
