### PR TITLE
Enhance bulk edit login

### DIFF
--- a/packages/web-app-admin-settings/src/components/Users/LoginModal.vue
+++ b/packages/web-app-admin-settings/src/components/Users/LoginModal.vue
@@ -10,7 +10,7 @@
     <template #content>
       <oc-select
         :model-value="selectedOption"
-        :label="$gettext('Login status')"
+        :label="$gettext('Login')"
         :options="options"
         :placeholder="$gettext('Select...')"
         :warning-message="

--- a/packages/web-app-admin-settings/src/components/Users/LoginModal.vue
+++ b/packages/web-app-admin-settings/src/components/Users/LoginModal.vue
@@ -8,6 +8,7 @@
     @confirm="$emit('confirm', { users, value: selectedOption.value })"
   >
     <template #content>
+      <p v-text="$gettext('Specify for the selected users whether they can log in.')" />
       <oc-select
         :model-value="selectedOption"
         :label="$gettext('Login')"

--- a/packages/web-app-admin-settings/tests/unit/components/Users/__snapshots__/LoginModal.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/__snapshots__/LoginModal.spec.ts.snap
@@ -12,7 +12,8 @@ exports[`LoginModal renders the input including two options 1`] = `
       </div>
       <div class="oc-modal-body">
         <div class="oc-modal-body-message">
-          <oc-select-stub clearable="false" disabled="false" filter="[Function]" fixmessageline="false" id="oc-select-1" label="Login status" loading="false" multiple="false" optionlabel="label" options="[object Object],[object Object]" placeholder="Select..." searchable="true" warningmessage=""></oc-select-stub>
+          <p>Specify for the selected users whether they can log in.</p>
+          <oc-select-stub clearable="false" disabled="false" filter="[Function]" fixmessageline="false" id="oc-select-1" label="Login" loading="false" multiple="false" optionlabel="label" options="[object Object],[object Object]" placeholder="Select..." searchable="true" warningmessage=""></oc-select-stub>
         </div>
         <!--v-if-->
         <!--v-if-->


### PR DESCRIPTION
Follow-up for https://github.com/owncloud/web/pull/8799

## Description
Re-use the select box label from the right sidebar sidebar ("Login") instead of introducing a new one ("Login status") which saves an additional translation and stays consistent with editing a single user in the right sidebar.

Also, add an informational text line in the modal to explain what happens here.

## Screenshots (if appropriate):
### Before
<img width="516" alt="grafik" src="https://user-images.githubusercontent.com/16665512/232786572-6029f5f1-4875-4c8b-bb79-5fea616a7861.png">

### After
<img width="520" alt="grafik" src="https://user-images.githubusercontent.com/16665512/232786398-edb865c7-a309-47e3-8b9c-9fd33d507195.png">

