### PR TITLE
Provide light and dark logos in common section

### DIFF
--- a/packages/web-runtime/themes/owncloud/theme.json
+++ b/packages/web-runtime/themes/owncloud/theme.json
@@ -1,8 +1,18 @@
 {
   "common": {
+    "general": {
       "name": "ownCloud",
-      "slogan": "ownCloud – A safe home for all your data",
-      "logo": "themes/owncloud/assets/logo.svg"
+      "slogan": "ownCloud – A safe home for all your data"
+    },
+    "logo-dark": {
+      "generic": "themes/owncloud/assets/logo_dark.svg"
+    },
+    "logo-light": {
+      "generic": "themes/owncloud/assets/logo.svg"
+    },
+    "logo": {
+      "generic": "themes/owncloud/assets/logo.svg"
+    }
   },
   "ios": {},
   "web": {


### PR DESCRIPTION
Follow-up of #8787. Required for https://github.com/owncloud/client/issues/10519. Feedback welcome!
