### PR TITLE
Fix client service requests with new access token

### DIFF
--- a/packages/web-app-files/src/components/SideBar/SideBar.vue
+++ b/packages/web-app-files/src/components/SideBar/SideBar.vue
@@ -81,9 +81,7 @@ export default defineComponent({
     const store = useStore()
     const router = useRouter()
     const { $gettext } = useGettext()
-    const { owncloudSdk } = useClientService()
     const clientService = useClientService()
-    const { webdav } = useClientService()
 
     const loadedResource = ref()
     const loading = ref(false)
@@ -228,7 +226,7 @@ export default defineComponent({
 
       // shared resources look different, hence we need to fetch the actual resource here
       try {
-        const shareResource = await (unref(webdav) as WebDAV).getFileInfo(props.space, {
+        const shareResource = await (clientService.webdav as WebDAV).getFileInfo(props.space, {
           path: unref(highlightedFile).path
         })
         shareResource.share = unref(highlightedFile).share
@@ -242,7 +240,7 @@ export default defineComponent({
 
     const loadShares = () => {
       store.dispatch('Files/loadShares', {
-        client: owncloudSdk,
+        client: clientService.owncloudSdk,
         path: unref(highlightedFile).path,
         storageId: unref(highlightedFile).fileId,
         // cache must not be used on flat file lists that gather resources form various locations

--- a/packages/web-app-files/src/composables/actions/files/useFileActionsAcceptShare.ts
+++ b/packages/web-app-files/src/composables/actions/files/useFileActionsAcceptShare.ts
@@ -23,7 +23,7 @@ export const useFileActionsAcceptShare = ({ store }: { store?: Store<any> } = {}
 
   const hasResharing = useCapabilityFilesSharingResharing()
   const hasShareJail = useCapabilityShareJailEnabled()
-  const { owncloudSdk } = useClientService()
+  const clientService = useClientService()
   const loadingService = useLoadingService()
 
   const handler = async ({ resources }: FileActionOptions) => {
@@ -39,7 +39,7 @@ export const useFileActionsAcceptShare = ({ store }: { store?: Store<any> } = {}
               ShareStatus.accepted,
               unref(hasResharing),
               unref(hasShareJail),
-              owncloudSdk
+              clientService.owncloudSdk
             )
             if (share) {
               store.commit('Files/UPDATE_RESOURCE', share)

--- a/packages/web-app-files/src/composables/actions/files/useFileActionsCreateSpaceFromResource.ts
+++ b/packages/web-app-files/src/composables/actions/files/useFileActionsCreateSpaceFromResource.ts
@@ -15,11 +15,12 @@ export const useFileActionsCreateSpaceFromResource = ({ store }: { store?: Store
   const loadingService = useLoadingService()
   const { createSpace } = useCreateSpace()
   const { checkSpaceNameModalInput } = useSpaceHelpers()
-  const { webdav } = useClientService()
+  const clientService = useClientService()
   const router = useRouter()
   const hasCreatePermission = computed(() => can('create-all', 'Space'))
 
   const confirmAction = async ({ spaceName, resources, space }) => {
+    const { webdav } = clientService
     store.dispatch('hideModal')
     const queue = new PQueue({ concurrency: 4 })
     const copyOps = []

--- a/packages/web-app-files/src/composables/actions/files/useFileActionsDeclineShare.ts
+++ b/packages/web-app-files/src/composables/actions/files/useFileActionsDeclineShare.ts
@@ -26,7 +26,7 @@ export const useFileActionsDeclineShare = ({ store }: { store?: Store<any> } = {
 
   const hasResharing = useCapabilityFilesSharingResharing()
   const hasShareJail = useCapabilityShareJailEnabled()
-  const { owncloudSdk } = useClientService()
+  const clientService = useClientService()
   const loadingService = useLoadingService()
 
   const handler = async ({ resources }: FileActionOptions) => {
@@ -42,7 +42,7 @@ export const useFileActionsDeclineShare = ({ store }: { store?: Store<any> } = {
               ShareStatus.declined,
               unref(hasResharing),
               unref(hasShareJail),
-              owncloudSdk
+              clientService.owncloudSdk
             )
             if (share) {
               store.commit('Files/UPDATE_RESOURCE', share)

--- a/packages/web-app-files/src/composables/actions/files/useFileActionsEmptyTrashBin.ts
+++ b/packages/web-app-files/src/composables/actions/files/useFileActionsEmptyTrashBin.ts
@@ -19,7 +19,7 @@ export const useFileActionsEmptyTrashBin = ({ store }: { store?: Store<any> } = 
   store = store || useStore()
   const router = useRouter()
   const { $gettext, $pgettext } = useGettext()
-  const { owncloudSdk } = useClientService()
+  const clientService = useClientService()
   const loadingService = useLoadingService()
   const hasShareJail = useCapabilityShareJailEnabled()
   const hasPermanentDeletion = useCapabilityFilesPermanentDeletion()
@@ -29,7 +29,7 @@ export const useFileActionsEmptyTrashBin = ({ store }: { store?: Store<any> } = 
       ? buildWebDavSpacesTrashPath(space.id)
       : buildWebDavFilesTrashPath(store.getters.user.id)
 
-    return owncloudSdk.fileTrash
+    return clientService.owncloudSdk.fileTrash
       .clearTrashBin(path)
       .then(() => {
         store.dispatch('showMessage', {

--- a/packages/web-app-files/src/composables/actions/files/useFileActionsFavorite.ts
+++ b/packages/web-app-files/src/composables/actions/files/useFileActionsFavorite.ts
@@ -16,13 +16,13 @@ export const useFileActionsFavorite = ({ store }: { store?: Store<any> } = {}) =
   store = store || useStore()
   const router = useRouter()
   const { $gettext, interpolate: $gettextInterpolate } = useGettext()
-  const { owncloudSdk: client } = useClientService()
+  const clientService = useClientService()
   const hasFavorites = useCapabilityFilesFavorites()
   const isFilesAppActive = useIsFilesAppActive()
   const handler = ({ resources }: FileActionOptions) => {
     store
       .dispatch('Files/markFavorite', {
-        client,
+        client: clientService.owncloudSdk,
         file: resources[0]
       })
       .catch(() => {

--- a/packages/web-app-files/src/composables/spaces/useCreateSpace.ts
+++ b/packages/web-app-files/src/composables/spaces/useCreateSpace.ts
@@ -4,11 +4,12 @@ import { useGettext } from 'vue3-gettext'
 import { useConfigurationManager, useClientService } from 'web-pkg/src/composables'
 
 export const useCreateSpace = () => {
-  const { graphAuthenticated, webdav } = useClientService()
+  const clientService = useClientService()
   const { $gettext } = useGettext()
   const configurationManager = useConfigurationManager()
 
   const createSpace = async (name: string) => {
+    const { graphAuthenticated, webdav } = clientService
     const { data: createdSpace } = await graphAuthenticated.drives.createDrive({ name }, {})
     const spaceResource = buildSpace({
       ...createdSpace,

--- a/packages/web-app-files/src/views/FilesDrop.vue
+++ b/packages/web-app-files/src/views/FilesDrop.vue
@@ -66,7 +66,7 @@ export default defineComponent({
     const store = useStore()
     const router = useRouter()
     const authService = useAuthService()
-    const { owncloudSdk } = useClientService()
+    const clientService = useClientService()
     const publicToken = usePublicLinkToken({ store })
     const publicLinkPassword = usePublicLinkPassword({ store })
 
@@ -88,7 +88,7 @@ export default defineComponent({
 
     const resolvePublicLink = () => {
       loading.value = true
-      owncloudSdk.publicFiles
+      clientService.owncloudSdk.publicFiles
         .list(unref(publicToken), unref(publicLinkPassword), DavProperties.PublicLink, '0')
         .then((files) => {
           // Redirect to files list if the link doesn't have role "uploader"

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsSetReadme.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsSetReadme.ts
@@ -8,10 +8,11 @@ export const useFileActionsSetReadme = ({ store }: { store?: Store<any> } = {}) 
   store = store || useStore()
   const router = useRouter()
   const { $gettext } = useGettext()
-  const { owncloudSdk } = useClientService()
+  const clientService = useClientService()
 
   const handler = async ({ space, resources }: FileActionOptions) => {
     try {
+      const { owncloudSdk } = clientService
       const fileContent = await owncloudSdk.files.getFileContents(resources[0].webDavPath)
       const fileMetaData = await owncloudSdk.files.putFileContents(
         `/spaces/${space.id}/.space/readme.md`,

--- a/packages/web-pkg/src/composables/appDefaults/useAppFileHandling.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppFileHandling.ts
@@ -31,15 +31,17 @@ export function useAppFileHandling({
   clientService: { webdav }
 }: AppFileHandlingOptions): AppFileHandlingResult {
   const isUrlSigningSupported = useCapabilityCoreSupportUrlSigning()
-  const {
-    webdav: { getFileUrl, revokeUrl }
-  } = useClientService()
+  const clientService = useClientService()
 
   const getUrlForResource = (space: SpaceResource, resource: Resource, options?: any) => {
-    return getFileUrl(space, resource, {
+    return clientService.webdav.getFileUrl(space, resource, {
       isUrlSigningEnabled: unref(isUrlSigningSupported),
       ...options
     })
+  }
+
+  const revokeUrl = (url: string) => {
+    return clientService.webdav.revokeUrl(url)
   }
 
   // TODO: support query parameters, possibly needs porting away from owncloud-sdk

--- a/packages/web-pkg/src/composables/download/useDownloadFile.ts
+++ b/packages/web-pkg/src/composables/download/useDownloadFile.ts
@@ -11,10 +11,11 @@ export const useDownloadFile = () => {
   const store = useStore()
   const isPublicLinkContext = usePublicLinkContext({ store })
   const isUrlSigningEnabled = useCapabilityCoreSupportUrlSigning()
-  const { owncloudSdk: client } = useClientService()
+  const clientService = useClientService()
   const { $gettext } = useGettext()
 
   const downloadFile = async (file, version = null) => {
+    const { owncloudSdk: client } = clientService
     const isUserContext = store.getters['runtime/auth/isUserContextReady']
 
     // construct the url and headers

--- a/packages/web-runtime/src/components/Account/GdprExport.vue
+++ b/packages/web-runtime/src/components/Account/GdprExport.vue
@@ -48,7 +48,7 @@ export default defineComponent({
   setup() {
     const store = useStore()
     const { $gettext, current: currentLanguage } = useGettext()
-    const { webdav, graphAuthenticated } = useClientService()
+    const clientService = useClientService()
     const { downloadFile } = useDownloadFile()
 
     const loading = ref(true)
@@ -62,7 +62,7 @@ export default defineComponent({
 
     const loadExportTask = useTask(function* () {
       try {
-        const resource = yield webdav.getFileInfo(unref(personalSpace), {
+        const resource = yield clientService.webdav.getFileInfo(unref(personalSpace), {
           path: `/${GDPR_EXPORT_FILE_NAME}`
         })
 
@@ -93,7 +93,7 @@ export default defineComponent({
 
     const requestExport = async () => {
       try {
-        await graphAuthenticated.users.exportPersonalData(store.getters.user.uuid, {
+        await clientService.graphAuthenticated.users.exportPersonalData(store.getters.user.uuid, {
           storageLocation: `/${GDPR_EXPORT_FILE_NAME}`
         })
         await loadExportTask.perform()

--- a/packages/web-runtime/src/components/Topbar/Notifications.vue
+++ b/packages/web-runtime/src/components/Topbar/Notifications.vue
@@ -112,7 +112,7 @@ export default {
   },
   setup() {
     const store = useStore()
-    const { owncloudSdk } = useClientService()
+    const clientService = useClientService()
     const { current: currentLanguage } = useGettext()
     const route = useRoute()
 
@@ -195,7 +195,7 @@ export default {
     const fetchNotificationsTask = useTask(function* (signal) {
       loading.value = true
       try {
-        const response = yield owncloudSdk.requests.ocs({
+        const response = yield clientService.owncloudSdk.requests.ocs({
           service: 'apps/notifications',
           action: 'api/v1/notifications'
         })
@@ -222,7 +222,7 @@ export default {
     const deleteNotifications = async (ids: string[]) => {
       loading.value = true
       try {
-        const { status } = await owncloudSdk.requests.ocs({
+        const { status } = await clientService.owncloudSdk.requests.ocs({
           service: 'apps/notifications',
           action: `api/v1/notifications`,
           method: 'DELETE',
@@ -233,7 +233,7 @@ export default {
           const promises = []
           for (const id of ids) {
             promises.push(
-              owncloudSdk.requests.ocs({
+              clientService.owncloudSdk.requests.ocs({
                 service: 'apps/notifications',
                 action: `api/v1/notifications/${id}`,
                 method: 'DELETE'
@@ -252,7 +252,7 @@ export default {
 
     const executeAction = async (app, link, type, notificationId) => {
       try {
-        const response = await owncloudSdk.requests.ocs({
+        const response = await clientService.owncloudSdk.requests.ocs({
           service: 'apps/' + app,
           action: link.slice(link.lastIndexOf('api')),
           method: type


### PR DESCRIPTION
## Description
We have to be careful not to destruct the `useClientService` composable in `setup`. The reactivity needed for getting the access token will get lost by doing this.

This is a regression from https://github.com/owncloud/web/pull/8621.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8861

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
