### PR TITLE
[tests-only][full-ci] Refactor user store for e2e tests

### DIFF
--- a/tests/e2e/cucumber/features/smoke/admin-settings/users.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/admin-settings/users.ocis.feature
@@ -91,10 +91,10 @@ Feature: users management
     And "Admin" opens the "admin-settings" app
     And "Admin" navigates to the users management page
     When "Admin" changes userName to "anna" for user "Alice" using the sidebar panel
-    And "Admin" changes displayName to "Anna Murphy" for user "Alice" using the sidebar panel
-    And "Admin" changes email to "anna@example.org" for user "Alice" using the sidebar panel
-    And "Admin" changes password to "password" for user "Alice" using the sidebar panel
-    And "Admin" changes role to "Space Admin" for user "Alice" using the sidebar panel
+    And "Admin" changes displayName to "Anna Murphy" for user "anna" using the sidebar panel
+    And "Admin" changes email to "anna@example.org" for user "anna" using the sidebar panel
+    And "Admin" changes password to "password" for user "anna" using the sidebar panel
+    And "Admin" changes role to "Space Admin" for user "anna" using the sidebar panel
     And "Admin" logs out
     When "anna" logs in
     Then "anna" should have self info:

--- a/tests/e2e/cucumber/steps/ui/public.ts
+++ b/tests/e2e/cucumber/steps/ui/public.ts
@@ -15,18 +15,6 @@ When(
       user = this.usersEnvironment.getUser({ key: stepUser })
     } catch (e) {}
 
-    if (!user) {
-      user = this.usersEnvironment.createUser({
-        key: stepUser,
-        user: {
-          id: stepUser,
-          displayName: stepUser,
-          password: '',
-          email: ''
-        }
-      })
-    }
-
     let actor
     try {
       actor = this.actorsEnvironment.getActor(user)

--- a/tests/e2e/support/api/graph/userManagement.ts
+++ b/tests/e2e/support/api/graph/userManagement.ts
@@ -4,6 +4,7 @@ import join from 'join-path'
 import { config } from '../../../config'
 import { getApplicationEntity } from './utils'
 import { userRoleStore } from '../../store'
+import { UsersEnvironment } from '../../environment'
 
 export const me = async ({ user }: { user: User }): Promise<Me> => {
   const response = await request({
@@ -32,9 +33,8 @@ export const createUser = async ({ user, admin }: { user: User; admin: User }): 
 
   checkResponseStatus(response, 'Failed while creating user')
 
-  const responseData = await response.json()
-  user.uuid = responseData.id
-
+  const usersEnvironment = new UsersEnvironment()
+  usersEnvironment.storeCreatedUser({ user: { ...user, uuid: (await response.json()).id } })
   return user
 }
 
@@ -44,7 +44,10 @@ export const deleteUser = async ({ user, admin }: { user: User; admin: User }): 
     path: join('graph', 'v1.0', 'users', user.id),
     user: admin
   })
-
+  try {
+    const usersEnvironment = new UsersEnvironment()
+    usersEnvironment.removeCreatedUser({ key: user.id })
+  } catch (e) {}
   return user
 }
 

--- a/tests/e2e/support/environment/userManagement.ts
+++ b/tests/e2e/support/environment/userManagement.ts
@@ -1,27 +1,67 @@
 import { Group, User } from '../types'
 import { dummyUserStore, dummyGroupStore } from '../store'
+import { createdUserStore } from '../store/user'
 
 export class UsersEnvironment {
   getUser({ key }: { key: string }): User {
-    const uniqueKey = key.toLowerCase()
+    const userKey = key.toLowerCase()
 
-    if (!dummyUserStore.has(uniqueKey)) {
-      throw new Error(`user with key '${uniqueKey}' not found`)
+    if (!dummyUserStore.has(userKey)) {
+      throw new Error(`user with key '${userKey}' not found`)
     }
 
-    return dummyUserStore.get(uniqueKey)
+    return dummyUserStore.get(userKey)
   }
 
   createUser({ key, user }: { key: string; user: User }): User {
-    const uniqueKey = key.toLowerCase()
+    const userKey = key.toLowerCase()
 
-    if (dummyUserStore.has(uniqueKey)) {
-      throw new Error(`user with key '${uniqueKey}' already exists`)
+    if (dummyUserStore.has(userKey)) {
+      throw new Error(`user with key '${userKey}' already exists`)
     }
 
-    dummyUserStore.set(uniqueKey, user)
+    dummyUserStore.set(userKey, user)
 
     return user
+  }
+
+  storeCreatedUser({ user }: { user: User }): User {
+    if (createdUserStore.has(user.id)) {
+      throw new Error(`user '${user.id}' already exists`)
+    }
+    createdUserStore.set(user.id, user)
+
+    return user
+  }
+
+  getCreatedUser({ key }: { key: string }): User {
+    const userKey = key.toLowerCase()
+    if (!createdUserStore.has(userKey)) {
+      throw new Error(`user with key '${userKey}' not found`)
+    }
+
+    return createdUserStore.get(userKey)
+  }
+
+  updateCreatedUser({ key, user }: { key: string; user: User }): User {
+    const userKey = key.toLowerCase()
+    if (!createdUserStore.has(userKey)) {
+      throw new Error(`user '${userKey}' not found`)
+    }
+    createdUserStore.delete(userKey)
+    createdUserStore.set(user.id, user)
+
+    return user
+  }
+
+  removeCreatedUser({ key }: { key: string }): boolean {
+    const userKey = key.toLowerCase()
+
+    if (!createdUserStore.has(userKey)) {
+      throw new Error(`user '${userKey}' not found`)
+    }
+
+    return createdUserStore.delete(userKey)
   }
 
   getGroup({ key }: { key: string }): Group {

--- a/tests/e2e/support/objects/app-admin-settings/users/actions.ts
+++ b/tests/e2e/support/objects/app-admin-settings/users/actions.ts
@@ -35,13 +35,23 @@ const displayNameInput = '#create-user-input-display-name'
 const emailInput = '#create-user-input-email'
 const passwordInput = '#create-user-input-password'
 
+export interface UserInterface {
+  displayName: string
+  givenName: string
+  id: string
+  mail: string
+  onPremisesSamAccountName: string
+  surname: string
+  userType: string
+}
+
 export const createUser = async (args: {
   page: Page
   name: string
   displayname: string
   email: string
   password: string
-}): Promise<void> => {
+}): Promise<UserInterface> => {
   const { page, name, displayname, email, password } = args
   await page.locator(createUserButton).click()
   await page.locator(userNameInput).fill(name)
@@ -49,13 +59,15 @@ export const createUser = async (args: {
   await page.locator(emailInput).fill(email)
   await page.locator(passwordInput).fill(password)
 
-  await Promise.all([
+  const [response] = await Promise.all([
     page.waitForResponse(
       (resp) =>
         resp.url().endsWith('users') && resp.status() === 200 && resp.request().method() === 'POST'
     ),
-    await page.locator(actionConfirmButton).click()
+    page.locator(actionConfirmButton).click()
   ])
+
+  return await response.json()
 }
 export const changeAccountEnabled = async (args: {
   page: Page


### PR DESCRIPTION
## Description
This PR removes **dummyUser** variable used from methods other than user creation time.
Now user gets user data from `dummyUser` and creates a user and stores the created data in `createdUser`
In the next PR I will implement the logic for the group store

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/web/issues/8819
Follow-up PR of 
- https://github.com/owncloud/web/pull/8848

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
