### PR TITLE
[tests-only][full-ci]Skip the expiry date related e2e test

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1191,7 +1191,7 @@ def e2eTests(ctx):
                      "image": OC_CI_NODEJS,
                      "environment": environment,
                      "commands": [
-                         "sleep 10 && pnpm test:e2e:cucumber tests/e2e/cucumber/**/*[!.%s].feature" % ("oc10" if server == "oCIS" else "ocis"),
+                         "sleep 10 && pnpm test:e2e:cucumber tests/e2e/cucumber/**/*[!.%s].feature --tags ~@skip" % ("oc10" if server == "oCIS" else "ocis"),
                      ],
                  }] + \
                  uploadTracingResult(ctx) + \

--- a/tests/e2e/cucumber/features/smoke/spaces/memberExpiry.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/spaces/memberExpiry.ocis.feature
@@ -1,7 +1,7 @@
 Feature: spaces member expiry
 
   # skipped because scroller scrolls up automatically while
-  # tring to select the end of the month dates
+  # trying to select the end of the month dates
   # this test will work at the beginning/mid of a month
   @skip @issue-7513
   Scenario: space members can be invited with an expiration date

--- a/tests/e2e/cucumber/features/smoke/spaces/memberExpiry.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/spaces/memberExpiry.ocis.feature
@@ -1,6 +1,9 @@
 Feature: spaces member expiry
 
-
+  # skipped because scroller scrolls up automatically while
+  # tring to select the end of the month dates
+  # this test will work at the beginning/mid of a month
+  @skip @issue-7513
   Scenario: space members can be invited with an expiration date
     Given "Admin" creates following users using API
       | id    |


### PR DESCRIPTION
The skipped test started to fail because we have a bug in the calendar that the scroller will automatically scroll up while trying to select the end-of-the-month dates https://github.com/owncloud/web/issues/7513 .
This PR skips the test so that it won't obstruct the CI

Also, read the comment below https://github.com/owncloud/web/pull/8905#issuecomment-1521214490

Fixes: https://github.com/owncloud/web/issues/8902