### PR TITLE
[full-ci] Fix sidebar calendar position

### DIFF
--- a/changelog/unreleased/bugfix-calendar-popup-position-in-sidebar
+++ b/changelog/unreleased/bugfix-calendar-popup-position-in-sidebar
@@ -1,0 +1,6 @@
+Bugfix: Calendar popup position in right sidebar
+
+The position of the calendar popup in the right sidebar has been fixed when using small screens.
+
+https://github.com/owncloud/web/issues/7513
+https://github.com/owncloud/web/pull/8909

--- a/packages/design-system/src/components/OcDatepicker/OcDatepicker.vue
+++ b/packages/design-system/src/components/OcDatepicker/OcDatepicker.vue
@@ -1,5 +1,5 @@
 <template>
-  <date-picker ref="datePicker" class="oc-datepicker" v-bind="$attrs">
+  <date-picker ref="datePicker" class="oc-datepicker" v-bind="$attrs" :popover="popperOpts">
     <template #default="args">
       <!-- @slot Default slot to use as the popover anchor for datepicker -->
       <!-- args is undefined during initial render, hence we check it here -->
@@ -14,7 +14,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { computed, defineComponent } from 'vue'
 
 import { DatePicker } from 'v-calendar'
 import 'v-calendar/dist/style.css'
@@ -30,7 +30,33 @@ export default defineComponent({
   components: { DatePicker },
 
   inheritAttrs: true,
+  setup() {
+    const popperOpts = computed(() => {
+      return {
+        modifiers: [
+          {
+            name: 'fixVerticalPosition',
+            enabled: true,
+            phase: 'beforeWrite',
+            requiresIfExists: ['offset', 'flip'],
+            fn({ state }) {
+              const dropHeight =
+                state.modifiersData.fullHeight || state.elements.popper.offsetHeight
+              const rect = state.elements.popper.getBoundingClientRect()
+              const neededScreenSpace =
+                state.elements.reference.offsetHeight + rect.top + dropHeight
 
+              if (state.placement !== 'top-start' && neededScreenSpace > window.innerHeight) {
+                state.styles.popper.top = `-${150}px`
+              }
+            }
+          }
+        ]
+      }
+    })
+
+    return { popperOpts }
+  },
   mounted() {
     this.$el.__datePicker = this.$refs.datePicker
   }

--- a/tests/acceptance/features/webUISharingPublicExpire/shareByPublicLinkExpiringLinks.feature
+++ b/tests/acceptance/features/webUISharingPublicExpire/shareByPublicLinkExpiringLinks.feature
@@ -82,7 +82,7 @@ Feature: Share by public link
       | name        | Public link |
       | expiration  | +6          |
 
-  @issue-ocis-1328 @skipOnOCIS @skipOnOC10 # skipped on oc10 due to https://github.com/owncloud/web/issues/7513
+  @issue-ocis-1328 @skipOnOCIS
   Scenario: user cannot change the expiry date on existing public link to a date past the enforced max expiry date once max expiry date is changed
     Given the setting "shareapi_default_expire_date" of app "core" has been set to "yes" in the server
     And the setting "shareapi_expire_after_n_days" of app "core" has been set to "16" in the server

--- a/tests/e2e/cucumber/features/smoke/spaces/memberExpiry.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/spaces/memberExpiry.ocis.feature
@@ -1,9 +1,5 @@
 Feature: spaces member expiry
 
-  # skipped because scroller scrolls up automatically while
-  # trying to select the end of the month dates
-  # this test will work at the beginning/mid of a month
-  @skip @issue-7513
   Scenario: space members can be invited with an expiration date
     Given "Admin" creates following users using API
       | id    |


### PR DESCRIPTION
## Description
Implements a popper modifier similar to how we do it in `OcDrop` to fix the vertical position of the calendar popup. There could still be edge cases, and the `top` pixels might need some tweaking.

How it basically works: Check if the needed screen space exceeds the window height. If so, move the popup up by quite a bit.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7513

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
