### PR TITLE
[full-ci] Handle `401` status code when fetching notifications

### DIFF
--- a/changelog/unreleased/enhancement-notifications-ocis
+++ b/changelog/unreleased/enhancement-notifications-ocis
@@ -6,6 +6,7 @@ https://github.com/owncloud/web/pull/8518
 https://github.com/owncloud/web/pull/8582
 https://github.com/owncloud/web/pull/8595
 https://github.com/owncloud/web/pull/8703
+https://github.com/owncloud/web/pull/8910
 https://github.com/owncloud/web/issues/8519
 https://github.com/owncloud/web/issues/8520
 https://github.com/owncloud/web/issues/8593

--- a/packages/web-runtime/src/components/Topbar/Notifications.vue
+++ b/packages/web-runtime/src/components/Topbar/Notifications.vue
@@ -103,6 +103,7 @@ import {
 import { useGettext } from 'vue3-gettext'
 import { useTask } from 'vue-concurrency'
 import { createFileRouteOptions } from 'web-pkg/src/helpers/router'
+import { useAuthService } from 'web-pkg/src/composables/authContext/useAuthService'
 
 const POLLING_INTERVAL = 30000
 
@@ -115,6 +116,7 @@ export default {
     const clientService = useClientService()
     const { current: currentLanguage } = useGettext()
     const route = useRoute()
+    const authService = useAuthService()
 
     const notifications = ref<Notification[]>([])
     const loading = ref(false)
@@ -199,7 +201,10 @@ export default {
           service: 'apps/notifications',
           action: 'api/v1/notifications'
         })
-
+        if (response.status === 401) {
+          // FIXME: this can be removed as soon as the server actively informs Web about a logout
+          return authService.handleAuthError(unref(route))
+        }
         if (response.headers.get('Content-Length') === '0') {
           return
         }


### PR DESCRIPTION
## Description
This is a bit of a hacky (and temporary!) solution to detect if the current user session was terminated remotely: As we poll notifications actively every 30 seconds we simply catch a `401` status response and let the auth service perform `handleAuthError`.

This solution can be removed as soon as the server is able to inform the client that a backchannel logout has been performed.

An alternative solution would be to implement another polling interval that constantly performs requests to the IDP. I don't really like that though as it would introduce more network traffic.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8910

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

