### PR TITLE
[tests-only][full-ci] Refactor group store for e2e tests

### DIFF
--- a/tests/e2e/cucumber/environment/index.ts
+++ b/tests/e2e/cucumber/environment/index.ts
@@ -15,9 +15,8 @@ import { config } from '../../config'
 import { api, environment } from '../../support'
 import { World } from './world'
 import { state } from './shared'
-import { createdSpaceStore, createdLinkStore } from '../../support/store'
+import { createdSpaceStore, createdLinkStore, createdGroupStore } from '../../support/store'
 import { User } from '../../support/types'
-import { createdGroupStore } from '../../support/store/group'
 
 export { World }
 

--- a/tests/e2e/cucumber/environment/index.ts
+++ b/tests/e2e/cucumber/environment/index.ts
@@ -17,6 +17,7 @@ import { World } from './world'
 import { state } from './shared'
 import { createdSpaceStore, createdLinkStore } from '../../support/store'
 import { User } from '../../support/types'
+import { createdGroupStore } from '../../support/store/group'
 
 export { World }
 
@@ -110,6 +111,7 @@ After(async function (this: World, { result }: ITestCaseHookParameter) {
 
   await cleanUpSpaces(this.usersEnvironment.getUser({ key: 'admin' }))
 
+  createdGroupStore.clear()
   createdLinkStore.clear()
 })
 

--- a/tests/e2e/cucumber/steps/ui/adminSettings.ts
+++ b/tests/e2e/cucumber/steps/ui/adminSettings.ts
@@ -413,8 +413,7 @@ When(
     }
     await page.reload()
     for (const info of stepTable.hashes()) {
-      const group = this.usersEnvironment.getGroup({ key: info.id })
-      group.uuid = await groupsObject.createGroup({ key: group.displayName })
+      await groupsObject.createGroup({ key: info.id })
     }
   }
 )

--- a/tests/e2e/support/api/graph/userManagement.ts
+++ b/tests/e2e/support/api/graph/userManagement.ts
@@ -84,8 +84,8 @@ export const createGroup = async ({
 
   checkResponseStatus(response, 'Failed while creating group')
 
-  const responseData = await response.json()
-  group.uuid = responseData.id
+  const usersEnvironment = new UsersEnvironment()
+  usersEnvironment.storeGroup({ group: { ...group, uuid: (await response.json()).id } })
   return group
 }
 

--- a/tests/e2e/support/api/graph/userManagement.ts
+++ b/tests/e2e/support/api/graph/userManagement.ts
@@ -85,7 +85,7 @@ export const createGroup = async ({
   checkResponseStatus(response, 'Failed while creating group')
 
   const usersEnvironment = new UsersEnvironment()
-  usersEnvironment.storeGroup({ group: { ...group, uuid: (await response.json()).id } })
+  usersEnvironment.storeCreatedGroup({ group: { ...group, uuid: (await response.json()).id } })
   return group
 }
 

--- a/tests/e2e/support/environment/userManagement.ts
+++ b/tests/e2e/support/environment/userManagement.ts
@@ -74,6 +74,16 @@ export class UsersEnvironment {
     return dummyGroupStore.get(uniqueKey)
   }
 
+  getCreatedGroup({ key }: { key: string }): Group {
+    const uniqueKey = key.toLowerCase()
+
+    if (!createdGroupStore.has(uniqueKey)) {
+      throw new Error(`group with key '${uniqueKey}' not found`)
+    }
+    console.log(createdGroupStore.get(uniqueKey))
+    return createdGroupStore.get(uniqueKey)
+  }
+
   createGroup({ key, group }: { key: string; group: Group }): Group {
     const uniqueKey = key.toLowerCase()
 
@@ -82,6 +92,15 @@ export class UsersEnvironment {
     }
 
     dummyGroupStore.set(uniqueKey, group)
+
+    return group
+  }
+
+  storeGroup({ group }: { group: Group }): Group {
+    if (createdGroupStore.has(group.id)) {
+      throw new Error(`user with key '${group.id}' already exists`)
+    }
+    createdGroupStore.set(group.id, group)
 
     return group
   }

--- a/tests/e2e/support/environment/userManagement.ts
+++ b/tests/e2e/support/environment/userManagement.ts
@@ -1,6 +1,5 @@
 import { Group, User } from '../types'
-import { dummyUserStore, dummyGroupStore } from '../store'
-import { createdUserStore } from '../store/user'
+import { dummyUserStore, dummyGroupStore, createdUserStore, createdGroupStore } from '../store'
 
 export class UsersEnvironment {
   getUser({ key }: { key: string }): User {
@@ -65,38 +64,26 @@ export class UsersEnvironment {
   }
 
   getGroup({ key }: { key: string }): Group {
-    const uniqueKey = key.toLowerCase()
+    const groupKey = key.toLowerCase()
 
-    if (!dummyGroupStore.has(uniqueKey)) {
-      throw new Error(`group with key '${uniqueKey}' not found`)
+    if (!dummyGroupStore.has(groupKey)) {
+      throw new Error(`group with key '${groupKey}' not found`)
     }
 
-    return dummyGroupStore.get(uniqueKey)
+    return dummyGroupStore.get(groupKey)
   }
 
   getCreatedGroup({ key }: { key: string }): Group {
-    const uniqueKey = key.toLowerCase()
+    const groupKey = key.toLowerCase()
 
-    if (!createdGroupStore.has(uniqueKey)) {
-      throw new Error(`group with key '${uniqueKey}' not found`)
-    }
-    console.log(createdGroupStore.get(uniqueKey))
-    return createdGroupStore.get(uniqueKey)
-  }
-
-  createGroup({ key, group }: { key: string; group: Group }): Group {
-    const uniqueKey = key.toLowerCase()
-
-    if (dummyUserStore.has(uniqueKey)) {
-      throw new Error(`group with key '${uniqueKey}' already exists`)
+    if (!createdGroupStore.has(groupKey)) {
+      throw new Error(`group with key '${groupKey}' not found`)
     }
 
-    dummyGroupStore.set(uniqueKey, group)
-
-    return group
+    return createdGroupStore.get(groupKey)
   }
 
-  storeGroup({ group }: { group: Group }): Group {
+  storeCreatedGroup({ group }: { group: Group }): Group {
     if (createdGroupStore.has(group.id)) {
       throw new Error(`user with key '${group.id}' already exists`)
     }

--- a/tests/e2e/support/objects/app-admin-settings/groups/actions.ts
+++ b/tests/e2e/support/objects/app-admin-settings/groups/actions.ts
@@ -18,7 +18,7 @@ const closeEditPanel = '.sidebar-panel__header .header__close'
 const userInput = '#%s-input'
 const compareDialogConfirm = '.compare-save-dialog-confirm-btn'
 
-export const createGroup = async (args: { page: Page; key: string }): Promise<string> => {
+export const createGroup = async (args: { page: Page; key: string }): Promise<Response> => {
   const { page, key } = args
   await page.locator(newGroupBtn).click()
   await page.locator(createGroupInput).fill(key)
@@ -30,8 +30,8 @@ export const createGroup = async (args: { page: Page; key: string }): Promise<st
     ),
     page.locator(actionConfirmButton).click()
   ])
-  const group = await response.json()
-  return group.id
+
+  return await response.json()
 }
 
 export const getDisplayedGroups = async (args: { page: Page }): Promise<string[]> => {

--- a/tests/e2e/support/objects/app-admin-settings/groups/index.ts
+++ b/tests/e2e/support/objects/app-admin-settings/groups/index.ts
@@ -17,21 +17,35 @@ export class Groups {
     this.#usersEnvironment = new UsersEnvironment()
     this.#page = page
   }
+
   getUUID({ key }: { key: string }): string {
-    return this.#usersEnvironment.getGroup({ key }).uuid
+    return this.#usersEnvironment.getCreatedGroup({ key }).uuid
   }
-  async createGroup({ key }: { key: string }): Promise<string> {
-    return await createGroup({ page: this.#page, key: key })
+
+  async createGroup({ key }: { key: string }): Promise<void> {
+    const group = this.#usersEnvironment.getGroup({ key })
+    const response = await createGroup({ page: this.#page, key: group.displayName })
+    this.#usersEnvironment.storeGroup({
+      group: {
+        id: key,
+        uuid: response['id'],
+        displayName: response['displayName']
+      }
+    })
   }
+
   getDisplayedGroups(): Promise<string[]> {
     return getDisplayedGroups({ page: this.#page })
   }
+
   async selectGroup({ key }: { key: string }): Promise<void> {
     await selectGroup({ page: this.#page, uuid: this.getUUID({ key }) })
   }
+
   async deleteGroupUsingBatchAction({ groupIds }: { groupIds: string[] }): Promise<void> {
     await deleteGrouprUsingBatchAction({ page: this.#page, groupIds })
   }
+
   async deleteGroupUsingContextMenu({ key }: { key: string }): Promise<void> {
     await deleteGroupUsingContextMenu({ page: this.#page, uuid: this.getUUID({ key }) })
   }

--- a/tests/e2e/support/objects/app-admin-settings/groups/index.ts
+++ b/tests/e2e/support/objects/app-admin-settings/groups/index.ts
@@ -25,7 +25,7 @@ export class Groups {
   async createGroup({ key }: { key: string }): Promise<void> {
     const group = this.#usersEnvironment.getGroup({ key })
     const response = await createGroup({ page: this.#page, key: group.displayName })
-    this.#usersEnvironment.storeGroup({
+    this.#usersEnvironment.storeCreatedGroup({
       group: {
         id: key,
         uuid: response['id'],

--- a/tests/e2e/support/objects/app-admin-settings/users/actions.ts
+++ b/tests/e2e/support/objects/app-admin-settings/users/actions.ts
@@ -429,5 +429,5 @@ export const waitForEditPanelToBeVisible = async (args: { page: Page }): Promise
 
 const getGroupId = (group: string): string => {
   const usersEnvironment = new UsersEnvironment()
-  return usersEnvironment.getGroup({ key: group }).uuid
+  return usersEnvironment.getCreatedGroup({ key: group }).uuid
 }

--- a/tests/e2e/support/store/index.ts
+++ b/tests/e2e/support/store/index.ts
@@ -1,6 +1,6 @@
 export { actorStore } from './actor'
 export { createdLinkStore } from './link'
 export { createdSpaceStore } from './space'
-export { dummyUserStore } from './user'
-export { dummyGroupStore } from './group'
+export { dummyUserStore, createdUserStore } from './user'
+export { dummyGroupStore, createdGroupStore } from './group'
 export { userRoleStore } from './role'


### PR DESCRIPTION
## Description
This PR removes **dummyGroup** uses other than getting group dummy value at creation time.
Now created group will be stored in **createdGroup**.  Currently, **createdGroupStore** is cleared at `After` hook because we need group id to check whether the group exists after the deletion or nor 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/web/issues/8819
Follow-up PR of 
- https://github.com/owncloud/web/pull/8848
- https://github.com/owncloud/web/pull/8871

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
