### PR TITLE
Fix share loading when adding a link via quick action

### DIFF
--- a/changelog/unreleased/enhancement-share-and-folder-loading-performance
+++ b/changelog/unreleased/enhancement-share-and-folder-loading-performance
@@ -6,3 +6,4 @@ https://github.com/owncloud/web/issues/7721
 https://github.com/owncloud/web/pull/8349
 https://github.com/owncloud/web/pull/8482
 https://github.com/owncloud/web/pull/8667
+https://github.com/owncloud/web/pull/8915

--- a/packages/web-app-files/src/store/actions.ts
+++ b/packages/web-app-files/src/store/actions.ts
@@ -294,12 +294,15 @@ export default {
 
     const shareMethod = isGroupShare ? 'shareFileWithGroup' : 'shareFileWithUser'
     return client.shares[shareMethod](path, shareWith, options)
-      .then((share) => {
+      .then(async (share) => {
         const builtShare = buildCollaboratorShare(
           share.shareInfo,
           context.getters.highlightedFile,
           allowSharePermissions(context.rootGetters)
         )
+        if (context.state.sharesLoading) {
+          await Promise.resolve(context.state.sharesLoading)
+        }
         context.commit('OUTGOING_SHARES_UPSERT', { ...builtShare, outgoing: true })
         context.dispatch('updateCurrentFileShareTypes')
         context.commit('LOAD_INDICATORS', path)
@@ -317,7 +320,10 @@ export default {
       })
   },
   deleteShare(context, { client, share, path, loadIndicators = false }) {
-    return client.shares.deleteShare(share.id, {} as any).then(() => {
+    return client.shares.deleteShare(share.id, {} as any).then(async () => {
+      if (context.state.sharesLoading) {
+        await Promise.resolve(context.state.sharesLoading)
+      }
       context.commit('OUTGOING_SHARES_REMOVE', share)
       context.dispatch('updateCurrentFileShareTypes')
       if (loadIndicators) {
@@ -427,8 +433,11 @@ export default {
     return new Promise((resolve, reject) => {
       client.shares
         .shareFileWithLink(path, { ...params, spaceRef: storageId })
-        .then((data) => {
+        .then(async (data) => {
           const link = buildShare(data.shareInfo, null, allowSharePermissions(context.rootGetters))
+          if (context.state.sharesLoading) {
+            await Promise.resolve(context.state.sharesLoading)
+          }
           context.commit('OUTGOING_SHARES_UPSERT', { ...link, outgoing: true })
           context.dispatch('updateCurrentFileShareTypes')
           context.commit('LOAD_INDICATORS', path)
@@ -454,7 +463,10 @@ export default {
     })
   },
   removeLink(context, { share, client, path, loadIndicators = false }) {
-    return client.shares.deleteShare(share.id).then(() => {
+    return client.shares.deleteShare(share.id).then(async () => {
+      if (context.state.sharesLoading) {
+        await Promise.resolve(context.state.sharesLoading)
+      }
       context.commit('OUTGOING_SHARES_REMOVE', share)
       context.dispatch('updateCurrentFileShareTypes')
       if (loadIndicators) {

--- a/packages/web-app-files/tests/unit/store/actions.spec.ts
+++ b/packages/web-app-files/tests/unit/store/actions.spec.ts
@@ -17,7 +17,8 @@ const stateMock = {
   commit: jest.fn(),
   dispatch: jest.fn(),
   getters: {},
-  rootGetters: {}
+  rootGetters: {},
+  state: {}
 }
 // we need to define $gettext explicitly to make it enumerable on the mock
 const languageMock = mock<Language>({ $gettext: jest.fn() })


### PR DESCRIPTION
## Description
When adding/removing shares while the shares are currently in a loading state, we need to wait for the loading to be finished.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8894
- Fixes https://github.com/owncloud/web/issues/8896

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
