### PR TITLE
[tests-only][full-ci]Added display role text change before assertion

### DIFF
--- a/tests/e2e/cucumber/features/smoke/reshare.feature
+++ b/tests/e2e/cucumber/features/smoke/reshare.feature
@@ -47,9 +47,9 @@ Feature: reshare
     And "Alice" opens the "files" app
     And "Alice" navigates to the personal space page
     Then "Alice" should see the following recipients
-      | resource         | recipient | type  | role   |
-      | folder_to_shared | Brian     | user  | editor |
-      | folder_to_shared | sales     | group | viewer |
+      | resource         | recipient | type  | role     |
+      | folder_to_shared | Brian     | user  | can edit |
+      | folder_to_shared | sales     | group | can view |
     And "Alice" logs out
 
     When "Brian" updates following sharee role

--- a/tests/e2e/cucumber/steps/ui/links.ts
+++ b/tests/e2e/cucumber/steps/ui/links.ts
@@ -85,8 +85,8 @@ When(
   ): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const linkObject = new objects.applicationFiles.Link({ page })
-    const actualRole = await linkObject.changeRole({ linkName, resource, role })
-    expect(role).toBe(actualRole.toLowerCase())
+    const roleText = await linkObject.changeRole({ linkName, resource, role })
+    expect(linkObject.roleDisplayText[role].toLowerCase()).toBe(roleText.toLowerCase())
   }
 )
 
@@ -140,7 +140,7 @@ When(
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const linkObject = new objects.applicationFiles.Link({ page })
     const newPermission = await linkObject.changeRole({ linkName, role, space: true })
-    expect(role).toBe(newPermission.toLowerCase())
+    expect(linkObject.roleDisplayText[role].toLowerCase()).toBe(newPermission.toLowerCase())
   }
 )
 

--- a/tests/e2e/support/objects/app-files/link/index.ts
+++ b/tests/e2e/support/objects/app-files/link/index.ts
@@ -27,6 +27,13 @@ export class Link {
     this.#linksEnvironment = new LinksEnvironment()
   }
 
+  roleDisplayText = {
+    internal: 'Internal',
+    viewer: 'Anyone with the link can view',
+    contributor: 'Anyone with the link can upload',
+    editor: 'Anyone with the link can edit',
+    uploader: 'Secret File drop'
+  }
   async create(args: Omit<createLinkArgs, 'page'>): Promise<void> {
     const startUrl = this.#page.url()
     const url = await createLink({ ...args, page: this.#page })


### PR DESCRIPTION
### Description
Beacuse of the change of this PR https://github.com/owncloud/web/pull/8876. For public link the display text after the selection of different role is now different. So this PR maps different role of public link to different role in displayed in the UI.

### Related Issue:
https://github.com/owncloud/web/issues/8930