### PR TITLE
[full-ci][tests-only]Bump ocis commit id for tests

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=4076bc71e63b4dd4d7931e1ad085ee214f137e38
+OCIS_COMMITID=01f660418296efe4018409f8887e33ec068a70ac
 OCIS_BRANCH=master


### PR DESCRIPTION
This PR bumps ocis commit id for tests
Part of: https://github.com/owncloud/QA/issues/806
https://github.com/owncloud/web/issues/8929