### PR TITLE
fix: infinite login redirect loop

### DIFF
--- a/changelog/unreleased/bugfix-infinite-login-redirect
+++ b/changelog/unreleased/bugfix-infinite-login-redirect
@@ -1,0 +1,8 @@
+Bugfix: Infinite login redirect
+
+We've fixed a bug where a user would fall into an infinite redirect between login and accessDenied page if a) the user had valid IdP credentials but was not permitted in ocis, b) the user has authenticated successfully but then got deleted in the meantime.
+
+https://github.com/owncloud/web/issues/8928
+https://github.com/owncloud/web/issues/7354
+https://github.com/owncloud/web/issues/4677
+https://github.com/owncloud/web/pull/8947

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -219,7 +219,12 @@ export class AuthService {
     }
     if (isUserContext(this.router, route)) {
       await this.userManager.removeUser('authError')
+      return
     }
+    // authGuard is taking care of redirecting the user to the
+    // accessDenied page if hasAuthErrorOccurred is set to true
+    // we can't push the route ourselves, see authGuard for details.
+    this.hasAuthErrorOccurred = true
   }
 
   public async resolvePublicLink(token: string, passwordRequired: boolean, password: string) {


### PR DESCRIPTION
## Description
Fixes login redirect loop when user info or capabilities can't be fetched.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/8928
- Fixes https://github.com/owncloud/web/issues/7354
- Fixes https://github.com/owncloud/web/issues/4677

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
