### PR TITLE
feat: idp auth context

### DIFF
--- a/changelog/unreleased/enhancement-webfinger-app
+++ b/changelog/unreleased/enhancement-webfinger-app
@@ -4,3 +4,4 @@ We've added an app with the name `webfinger` which queries the oCIS webfinger se
 
 https://github.com/owncloud/web/issues/8883
 https://github.com/owncloud/web/pull/8884
+https://github.com/owncloud/web/pull/8950

--- a/packages/web-app-webfinger/src/index.ts
+++ b/packages/web-app-webfinger/src/index.ts
@@ -19,6 +19,9 @@ const routes = () => [
     path: '/',
     redirect: () => {
       return { name: 'webfinger-resolve' }
+    },
+    meta: {
+      authContext: 'anonymous'
     }
   },
   {
@@ -26,7 +29,7 @@ const routes = () => [
     name: 'webfinger-resolve',
     component: Resolve,
     meta: {
-      authContext: 'user',
+      authContext: 'idp',
       title: $gettext('Resolve destination'),
       entryPoint: true
     }

--- a/packages/web-pkg/src/composables/router/types.ts
+++ b/packages/web-pkg/src/composables/router/types.ts
@@ -7,7 +7,7 @@ export type LocationQuery = Dictionary<QueryValue>
 
 export type ParamValue = string
 
-export const authContextValues = ['anonymous', 'user', 'publicLink', 'hybrid'] as const
+export const authContextValues = ['anonymous', 'user', 'idp', 'publicLink', 'hybrid'] as const
 export type AuthContext = typeof authContextValues[number]
 
 export interface WebRouteMeta extends RouteMeta {

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -118,19 +118,6 @@ export const bootstrapApp = async (configurationPath: string): Promise<void> => 
 
   store.watch(
     (state, getters) => {
-      return getters['runtime/auth/isIdpContextReady']
-    },
-    async (idpContextReady) => {
-      if (!idpContextReady) {
-        return
-      }
-      // fake spaces being loaded so that the ApplicationLayout doesn't stay in loading state
-      store.commit('runtime/spaces/SET_SPACES_INITIALIZED', true)
-    }
-  )
-
-  store.watch(
-    (state, getters) => {
       return getters['runtime/auth/isUserContextReady']
     },
     async (userContextReady) => {

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -102,6 +102,7 @@ export const bootstrapApp = async (configurationPath: string): Promise<void> => 
   store.watch(
     (state, getters) =>
       getters['runtime/auth/isUserContextReady'] ||
+      getters['runtime/auth/isIdpContextReady'] ||
       getters['runtime/auth/isPublicLinkContextReady'],
     async (newValue, oldValue) => {
       if (!newValue || newValue === oldValue) {
@@ -112,6 +113,19 @@ export const bootstrapApp = async (configurationPath: string): Promise<void> => 
     },
     {
       immediate: true
+    }
+  )
+
+  store.watch(
+    (state, getters) => {
+      return getters['runtime/auth/isIdpContextReady']
+    },
+    async (idpContextReady) => {
+      if (!idpContextReady) {
+        return
+      }
+      // fake spaces being loaded so that the ApplicationLayout doesn't stay in loading state
+      store.commit('runtime/spaces/SET_SPACES_INITIALIZED', true)
     }
   )
 

--- a/packages/web-runtime/src/layouts/Application.vue
+++ b/packages/web-runtime/src/layouts/Application.vue
@@ -97,7 +97,7 @@ export default defineComponent({
     const requiredAuthContext = useRouteMeta('authContext')
     const { areSpacesLoading } = useSpacesLoading({ store })
     const isLoading = computed(() => {
-      if (unref(requiredAuthContext) === 'anonymous') {
+      if (['anonymous', 'idp'].includes(unref(requiredAuthContext))) {
         return false
       }
       return unref(areSpacesLoading)

--- a/packages/web-runtime/src/router/helpers.ts
+++ b/packages/web-runtime/src/router/helpers.ts
@@ -39,7 +39,7 @@ export const buildUrl = (pathname) => {
 }
 
 /**
- * Checks if the `to` route or the route it was reached from (i.e. the `contextRoute`) needs authentication from the IDP.
+ * Checks if the `to` route or the route it was reached from (i.e. the `contextRoute`) needs authentication from the IdP and a successfully fetched ownCloud user.
  *
  * @param router {Router}
  * @param to {Route}
@@ -58,6 +58,25 @@ export const isUserContext = (router: Router, to: RouteLocation): boolean => {
   return (
     !contextRoute ||
     getRouteMeta({ meta: contextRoute.meta } as RouteLocation).authContext === 'user'
+  )
+}
+
+/**
+ * Checks if the `to` route or the route it was reached from (i.e. the `contextRoute`) needs authentication from the IdP but should not try to fetch an ownCloud user.
+ *
+ * @param router {Router}
+ * @param to {Route}
+ * @returns {boolean}
+ */
+export const isIdpContext = (router: Router, to: RouteLocation): boolean => {
+  const meta = getRouteMeta(to)
+  if (meta.authContext === 'idp') {
+    return true
+  }
+
+  const contextRoute = getContextRoute(router, to)
+  return (
+    contextRoute && getRouteMeta({ meta: contextRoute.meta } as RouteLocation).authContext === 'idp'
   )
 }
 

--- a/packages/web-runtime/src/router/setupAuthGuard.ts
+++ b/packages/web-runtime/src/router/setupAuthGuard.ts
@@ -1,4 +1,4 @@
-import { extractPublicLinkToken, isPublicLinkContext, isUserContext } from './index'
+import { extractPublicLinkToken, isIdpContext, isPublicLinkContext, isUserContext } from './index'
 import { Router, RouteLocation } from 'vue-router'
 import { contextRouteNameKey, queryItemAsString } from 'web-pkg/src/composables'
 import { authService } from '../services/auth/authService'
@@ -38,6 +38,14 @@ export const setupAuthGuard = (router: Router) => {
       }
       return true
     }
+
+    if (isIdpContext(router, to)) {
+      if (!store.getters['runtime/auth/isIdpContextReady']) {
+        return { path: '/login', query: { redirectUrl: to.fullPath } }
+      }
+      return true
+    }
+
     return true
   })
   router.afterEach((to) => {

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -7,6 +7,7 @@ import { RouteLocation, Router } from 'vue-router'
 import {
   extractPublicLinkToken,
   isAnonymousContext,
+  isIdpContext,
   isPublicLinkContext,
   isUserContext
 } from '../../router'
@@ -81,6 +82,8 @@ export class AuthService {
     }
 
     if (!isAnonymousContext(this.router, to)) {
+      const fetchUserData = !isIdpContext(this.router, to)
+
       if (!this.userManager.areEventHandlersRegistered) {
         this.userManager.events.addAccessTokenExpired((...args): void => {
           const handleExpirationError = () => {
@@ -118,7 +121,7 @@ export class AuthService {
             `New User Loaded. access_token： ${user.access_token}, refresh_token: ${user.refresh_token}`
           )
           try {
-            await this.userManager.updateContext(user.access_token)
+            await this.userManager.updateContext(user.access_token, fetchUserData)
           } catch (e) {
             console.error(e)
             await this.handleAuthError(unref(this.router.currentRoute))
@@ -157,7 +160,7 @@ export class AuthService {
       const accessToken = await this.userManager.getAccessToken()
       if (accessToken) {
         try {
-          await this.userManager.updateContext(accessToken)
+          await this.userManager.updateContext(accessToken, fetchUserData)
         } catch (e) {
           console.error(e)
           await this.handleAuthError(unref(this.router.currentRoute))

--- a/packages/web-runtime/src/store/auth.ts
+++ b/packages/web-runtime/src/store/auth.ts
@@ -1,5 +1,6 @@
 const state = {
   accessToken: null,
+  idpContextReady: false,
   userContextReady: false,
   publicLinkToken: null,
   publicLinkPassword: null,
@@ -8,6 +9,7 @@ const state = {
 
 const getters = {
   accessToken: (state) => state.accessToken,
+  isIdpContextReady: (state) => state.idpContextReady,
   isUserContextReady: (state) => state.userContextReady,
   publicLinkToken: (state) => state.publicLinkToken,
   publicLinkPassword: (state) => state.publicLinkPassword,
@@ -17,6 +19,9 @@ const getters = {
 const mutations = {
   SET_ACCESS_TOKEN(state, accessToken) {
     state.accessToken = accessToken
+  },
+  SET_IDP_CONTEXT_READY(state, ready) {
+    state.idpContextReady = ready
   },
   SET_USER_CONTEXT_READY(state, ready) {
     state.userContextReady = ready


### PR DESCRIPTION
## Description

Added an `idp` authContext type and used it for the webfinger resolve page. Idea is that `idp` requires a valid login in contrast to `user` which also requires an ownCloud user. The webfinger app doesn't need an ownCloud backend, only the webfinger service.

As a consequence the `idp` context being ready doesn't lead to loading user, capabilities, spaces, etc.

This again increases the urgency of documenting at least parts of the extension system. The authentication requirements in route definitions are thought through to a good extend, this needs to be written down and explained. Out of scope for this PR though...

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
