### PR TITLE
feat: clear idp user on 401 in webfinger resolve

### DIFF
--- a/changelog/unreleased/enhancement-webfinger-app
+++ b/changelog/unreleased/enhancement-webfinger-app
@@ -5,3 +5,4 @@ We've added an app with the name `webfinger` which queries the oCIS webfinger se
 https://github.com/owncloud/web/issues/8883
 https://github.com/owncloud/web/pull/8884
 https://github.com/owncloud/web/pull/8950
+https://github.com/owncloud/web/pull/8952

--- a/packages/web-app-webfinger/src/views/Resolve.vue
+++ b/packages/web-app-webfinger/src/views/Resolve.vue
@@ -23,9 +23,16 @@
 
 <script lang="ts">
 import { computed, defineComponent, ref, unref, watch } from 'vue'
-import { useClientService, useConfigurationManager, useLoadingService, useRouteMeta } from 'web-pkg'
+import {
+  useClientService,
+  useConfigurationManager,
+  useLoadingService,
+  useRoute,
+  useRouteMeta
+} from 'web-pkg'
 import { OwnCloudServer, WebfingerDiscovery } from 'web-app-webfinger/src/discovery'
 import { useGettext } from 'vue3-gettext'
+import { useAuthService } from 'web-pkg/src/composables/authContext/useAuthService'
 
 export default defineComponent({
   name: 'WebfingerResolve',
@@ -33,6 +40,8 @@ export default defineComponent({
     const configurationManager = useConfigurationManager()
     const clientService = useClientService()
     const loadingService = useLoadingService()
+    const authService = useAuthService()
+    const route = useRoute()
     const { $gettext } = useGettext()
 
     const title = useRouteMeta('title', '')
@@ -52,6 +61,9 @@ export default defineComponent({
         }
       } catch (e) {
         console.error(e)
+        if (e.statusCode === 401) {
+          return authService.handleAuthError(unref(route))
+        }
         hasError.value = true
       }
     })

--- a/packages/web-app-webfinger/src/views/Resolve.vue
+++ b/packages/web-app-webfinger/src/views/Resolve.vue
@@ -61,7 +61,7 @@ export default defineComponent({
         }
       } catch (e) {
         console.error(e)
-        if (e.statusCode === 401) {
+        if (e.response?.status === 401) {
           return authService.handleAuthError(unref(route))
         }
         hasError.value = true

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -220,7 +220,7 @@ export class AuthService {
         query: { redirectUrl: route.fullPath }
       })
     }
-    if (isUserContext(this.router, route)) {
+    if (isUserContext(this.router, route) || isIdpContext(this.router, route)) {
       await this.userManager.removeUser('authError')
       return
     }

--- a/packages/web-runtime/src/store/auth.ts
+++ b/packages/web-runtime/src/store/auth.ts
@@ -38,6 +38,7 @@ const mutations = {
 const actions = {
   clearUserContext({ commit }) {
     commit('SET_ACCESS_TOKEN', null)
+    commit('SET_IDP_CONTEXT_READY', false)
     commit('SET_USER_CONTEXT_READY', false)
   },
   clearPublicLinkContext({ commit }) {


### PR DESCRIPTION
## Description
Clear idp user on 401 from webfinger service. The 401 can happen if the access token was invalidated in the meantime. Then we need to enforce another roundtrip to the IdP.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
