### PR TITLE
Revert remaining link time label

### DIFF
--- a/changelog/unreleased/enhancement-add-expiration-date-hint-to-public-links
+++ b/changelog/unreleased/enhancement-add-expiration-date-hint-to-public-links
@@ -1,6 +1,0 @@
-Enhancement: Add expiration date hint to public links
-
-We've added a expiration date text hint to public links.
-
-https://github.com/owncloud/web/pull/8866
-https://github.com/owncloud/web/issues/8211

--- a/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
@@ -67,10 +67,6 @@
       />
     </p>
     <div :class="{ 'oc-pr-s': !isModifiable }" class="details-buttons">
-      <span
-        class="oc-flex oc-mr-s oc-align-self-center oc-text-muted"
-        v-text="expirationDateHint"
-      />
       <oc-button
         v-if="link.indirect"
         v-oc-tooltip="viaTooltip"
@@ -375,17 +371,6 @@ export default defineComponent({
       return this.$gettext(
         'Expires %{timeToExpiry} (%{expiryDate})',
         { timeToExpiry: this.expirationDateRelative, expiryDate: this.localExpirationDate },
-        true
-      )
-    },
-
-    expirationDateHint() {
-      if (!this.expirationDateRelative) {
-        return ''
-      }
-      return this.$gettext(
-        'Expires %{timeToExpiry}',
-        { timeToExpiry: this.expirationDateRelative },
         true
       )
     },

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Links/__snapshots__/DetailsAndEdit.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Links/__snapshots__/DetailsAndEdit.spec.ts.snap
@@ -55,7 +55,6 @@ exports[`DetailsAndEdit component if user can edit renders dropdown and edit but
     </oc-drop-stub>
   </div>
   <div class="details-buttons">
-    <span class="oc-flex oc-mr-s oc-align-self-center oc-text-muted"></span>
     <!--v-if-->
     <!--v-if-->
     <!--v-if-->
@@ -105,7 +104,6 @@ exports[`DetailsAndEdit component if user can not edit does not render dropdown 
     <span class="link-current-role">Anyone with the link can view</span>
   </p>
   <div class="oc-pr-s details-buttons">
-    <span class="oc-flex oc-mr-s oc-align-self-center oc-text-muted"></span>
     <!--v-if-->
     <!--v-if-->
     <!--v-if-->


### PR DESCRIPTION
Reverting https://github.com/owncloud/web/pull/8866 except for the switch from `$gettextInterpolate` to `$gettext`. The role labels have changed and now the horizontal space is not sufficient anymore for the expiration hint. See screenshot.


### problematic version (current state)

<img width="437" alt="Screenshot 2023-05-02 at 11 23 50" src="https://user-images.githubusercontent.com/3532843/235632919-b89266e3-0783-417b-a9b1-a1cc0e38d694.png">

### with this PR

<img width="430" alt="Screenshot 2023-05-02 at 11 41 05" src="https://user-images.githubusercontent.com/3532843/235633209-d28dc711-b96a-4a60-9109-48c75a835dd0.png">
