### PR TITLE
[tests-only][full-ci]Navigate to folder by click instead of navigate with URL

### DIFF
--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -58,10 +58,10 @@ Feature: Sharing files and folders with internal groups
       | entry_name    |
       | simple-folder |
       | testimage.jpg |
-    And these resources should be listed in the folder "/Shares%2Fsimple-folder" on the webUI
+    And these resources should be listed in the folder "/Shares/simple-folder" on the webUI
       | entry_name |
       | lorem.txt  |
-    But these resources should not be listed in the folder "/Shares%2Fsimple-folder" on the webUI
+    But these resources should not be listed in the folder "/Shares/simple-folder" on the webUI
       | entry_name    |
       | simple-folder |
     When the user browses to the shared-with-me page

--- a/tests/acceptance/pageObjects/FilesPageElement/filesList.js
+++ b/tests/acceptance/pageObjects/FilesPageElement/filesList.js
@@ -210,13 +210,21 @@ module.exports = {
      * @param {string} folder
      */
     navigateToFolder: async function (folder) {
-      await this.waitForFileVisible(folder)
+      const paths = folder.split('/')
+      for (const folderName of paths) {
+        if (folderName === '') {
+          continue
+        }
 
-      await this.useXpath().click(this.getFileLinkSelectorByFileName(folder, 'folder')).useCss()
+        await this.waitForFileVisible(folderName)
 
-      // wait until loading is finished
-      await this.waitForLoadingFinished()
+        await this.useXpath()
+          .click(this.getFileLinkSelectorByFileName(folderName, 'folder'))
+          .useCss()
 
+        // wait until loading is finished
+        await this.waitForLoadingFinished()
+      }
       return this
     },
 

--- a/tests/acceptance/pageObjects/personalPage.js
+++ b/tests/acceptance/pageObjects/personalPage.js
@@ -24,7 +24,6 @@ module.exports = {
      */
     navigateToFolder: async function (folder) {
       await this.page.FilesPageElement.filesList().navigateToFolder(folder)
-      await this.waitForElementVisible('@breadcrumb').assert.containsText('@breadcrumb', folder)
       return this
     },
     /**

--- a/tests/acceptance/pageObjects/personalPage.js
+++ b/tests/acceptance/pageObjects/personalPage.js
@@ -23,10 +23,8 @@ module.exports = {
      * @param {string} folder
      */
     navigateToFolder: async function (folder) {
-      await this.page.FilesPageElement.filesList()
-        .navigateToFolder(folder)
-      await this.waitForElementVisible('@breadcrumb')
-        .assert.containsText('@breadcrumb', folder)
+      await this.page.FilesPageElement.filesList().navigateToFolder(folder)
+      await this.waitForElementVisible('@breadcrumb').assert.containsText('@breadcrumb', folder)
       return this
     },
     /**

--- a/tests/acceptance/pageObjects/personalPage.js
+++ b/tests/acceptance/pageObjects/personalPage.js
@@ -22,11 +22,12 @@ module.exports = {
      *
      * @param {string} folder
      */
-    navigateToFolder: function (folder) {
-      return this.page.FilesPageElement.filesList()
+    navigateToFolder: async function (folder) {
+      await this.page.FilesPageElement.filesList()
         .navigateToFolder(folder)
-        .waitForElementVisible('@breadcrumb')
+      await this.waitForElementVisible('@breadcrumb')
         .assert.containsText('@breadcrumb', folder)
+      return this
     },
     /**
      *

--- a/tests/acceptance/stepDefinitions/filesContext.js
+++ b/tests/acceptance/stepDefinitions/filesContext.js
@@ -797,7 +797,8 @@ Then('these files/folders/resources should be listed on the webUI', function (en
 Then(
   'these files/folders/resources should be listed in the folder {string} on the webUI',
   async function (folder, entryList) {
-    await client.page.personalPage().navigateAndWaitTillLoaded(folder)
+    await client.page.personalPage().navigateAndWaitTillLoaded()
+    await client.page.personalPage().navigateToFolder(folder)
     return theseResourcesShouldBeListed(entryList)
   }
 )


### PR DESCRIPTION
### Description
This PR refactors the folder navigation process. Instead of navigating through the url, it uses the click function to navigate inside the folder. Which makes the tests running. Before with navigating with URL, the UI was not properly rendered.

### related Issue:
 https://github.com/owncloud/ocis/issues/6206