### PR TITLE
Fix preview app file loading

### DIFF
--- a/changelog/unreleased/bugfix-preview-file-loading
+++ b/changelog/unreleased/bugfix-preview-file-loading
@@ -1,0 +1,6 @@
+Bugfix: Preview app file loading
+
+A bug where the preview app would load the files of an image's source location instead of the files in the actual file list has been fixed.
+
+https://github.com/owncloud/web/issues/8932
+https://github.com/owncloud/web/pull/8975

--- a/packages/web-app-preview/src/App.vue
+++ b/packages/web-app-preview/src/App.vue
@@ -266,11 +266,10 @@ export default defineComponent({
     }
   },
 
-  async mounted() {
+  mounted() {
     // keep a local history for this component
     window.addEventListener('popstate', this.handleLocalHistoryEvent)
     document.addEventListener('fullscreenchange', this.handleFullScreenChangeEvent)
-    await this.loadFolderForFileContext(this.currentFileContext)
     this.setActiveFile(unref(this.currentFileContext.driveAliasAndItem))
     ;(this.$refs.preview as HTMLElement).focus()
   },


### PR DESCRIPTION
## Description
Fixes a bug where the preview app would load the files of an image's source location instead of the files in the actual file list.

This happened because the preview app called `loadFolderForFileContext` which loads all files of the current file's source location. This is not needed IMO (at least currently) because you can only open the preview app from a files list where files are already loaded.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8932

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
