### PR TITLE
Limit amount of concurrent tus requests

### DIFF
--- a/changelog/unreleased/bugfix-limit-concurrent-tus-requests
+++ b/changelog/unreleased/bugfix-limit-concurrent-tus-requests
@@ -1,0 +1,6 @@
+Bugfix: Limit amount of concurrent tus requests
+
+The amount of concurrent tus requests when uploading has been reduced to 5. This fixes an issue where the access token renewal failed during an ongoing upload because of the sheer amount of pending requests.
+
+https://github.com/owncloud/web/pull/8987
+https://github.com/owncloud/web/issues/8977

--- a/packages/web-runtime/src/services/uppyService.ts
+++ b/packages/web-runtime/src/services/uppyService.ts
@@ -59,11 +59,15 @@ export class UppyService {
       overridePatchMethod: !!tusHttpMethodOverride,
       retryDelays: [0, 500, 1000],
       uploadDataDuringCreation,
+      limit: 5,
       onBeforeRequest,
       onShouldRetry: (err, retryAttempt, options, next) => {
         // status code 5xx means the upload is gone on the server side
         if (err?.originalResponse?.getStatus() >= 500) {
           return false
+        }
+        if (err?.originalResponse?.getStatus() === 401) {
+          return true
         }
         return next(err)
       }


### PR DESCRIPTION
## Description
Limits the amount of concurrent tus requests when uploading to `5`. The limit defaulted to `20` before, which a normal modern browser can't handle anyways. I benchmarked the upload time before and after the change with a ~700MB folder -> it was roughly the same.

This fixes an issue where the access token renewal failed during an ongoing upload because of the sheer amount of pending requests.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8977

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
