### PR TITLE
Fix endless lazy loading indicator after sorting file table

### DIFF
--- a/changelog/unreleased/bugfix-endless-lazy-loading-when-sorting
+++ b/changelog/unreleased/bugfix-endless-lazy-loading-when-sorting
@@ -1,0 +1,6 @@
+Bugfix: Endless lazy loading indicator after sorting file table
+
+The endless lazy loading indicator when sorting the file table and re-entering it has been fixed.
+
+https://github.com/owncloud/web/issues/6434
+https://github.com/owncloud/web/pull/8988

--- a/packages/design-system/src/composables/useIsVisible/index.ts
+++ b/packages/design-system/src/composables/useIsVisible/index.ts
@@ -17,7 +17,14 @@ export const useIsVisible = ({ target, mode = 'show', rootMargin = '100px' }) =>
 
   const isVisible = ref(false)
   const observer = new IntersectionObserver(
-    ([{ isIntersecting }]) => {
+    (intersectionObserverEntries: IntersectionObserverEntry[]) => {
+      /**
+       * In some edge cases intersectionObserverEntries contains 2 entries with the first one having wrong rootBounds.
+       * This happens for some reason when the table is being re-sorted immediately after being rendered.
+       * Therefore we always check the last entry for isIntersecting.
+       */
+      const isIntersecting = intersectionObserverEntries.at(-1).isIntersecting
+
       isVisible.value = isIntersecting
       /**
        * if given mode is `showHide` we need to keep the observation alive.


### PR DESCRIPTION
## Description
As described in the code comment: In some edge cases (after sorting the file table and re-entering it) the `intersectionObserver` callback contains 2 entries with the first one having wrong `rootBounds`. Therefore we always check the last entry for `isIntersecting`.
       
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/6434

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
