### PR TITLE
[tests-only][full-ci] Cleanup user created by test scenario at after hook

### DIFF
--- a/tests/e2e/cucumber/environment/index.ts
+++ b/tests/e2e/cucumber/environment/index.ts
@@ -15,7 +15,12 @@ import { config } from '../../config'
 import { api, environment } from '../../support'
 import { World } from './world'
 import { state } from './shared'
-import { createdSpaceStore, createdLinkStore, createdGroupStore } from '../../support/store'
+import {
+  createdSpaceStore,
+  createdLinkStore,
+  createdGroupStore,
+  createdUserStore
+} from '../../support/store'
 import { User } from '../../support/types'
 
 export { World }
@@ -108,6 +113,7 @@ After(async function (this: World, { result }: ITestCaseHookParameter) {
     await this.actorsEnvironment.close()
   }
 
+  await cleanUpUser(this.usersEnvironment.getUser({ key: 'admin' }))
   await cleanUpSpaces(this.usersEnvironment.getUser({ key: 'admin' }))
 
   createdGroupStore.clear()
@@ -117,6 +123,19 @@ After(async function (this: World, { result }: ITestCaseHookParameter) {
 AfterAll(() => state.browser && state.browser.close())
 
 setWorldConstructor(World)
+
+const cleanUpUser = async (adminUser: User) => {
+  const requests = []
+  createdUserStore.forEach((user) => {
+    if (config.ocis) {
+      requests.push(api.graph.deleteUser({ user, admin: adminUser }))
+    } else {
+      requests.push(api.user.deleteUser({ user, admin: adminUser }))
+    }
+  })
+  await Promise.all(requests)
+  createdUserStore.clear()
+}
 
 const cleanUpSpaces = async (adminUser: User) => {
   const requests = []

--- a/tests/e2e/cucumber/steps/api.ts
+++ b/tests/e2e/cucumber/steps/api.ts
@@ -12,10 +12,8 @@ Given(
     for (const info of stepTable.hashes()) {
       const user = this.usersEnvironment.getUser({ key: info.id })
       if (config.ocis) {
-        await api.graph.deleteUser({ user, admin })
         await api.graph.createUser({ user, admin })
       } else {
-        await api.user.deleteUser({ user, admin })
         await api.user.createUser({ user, admin })
       }
     }

--- a/tests/e2e/cucumber/steps/ui/adminSettings.ts
+++ b/tests/e2e/cucumber/steps/ui/adminSettings.ts
@@ -300,22 +300,6 @@ When(
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const usersObject = new objects.applicationAdminSettings.Users({ page })
 
-    // deleting a user with a same userName before testing
-    if (attribute === 'userName') {
-      const newUser = this.usersEnvironment.createUser({
-        key: value,
-        user: {
-          id: value,
-          displayName: '',
-          password: 'password',
-          email: ''
-        }
-      })
-      await api.graph.deleteUser({
-        user: newUser,
-        admin: this.usersEnvironment.getUser({ key: stepUser })
-      })
-    }
     await usersObject.changeUser({
       key: user,
       attribute: attribute,
@@ -472,11 +456,6 @@ When(
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const usersObject = new objects.applicationAdminSettings.Users({ page })
     for (const info of stepTable.hashes()) {
-      const user = this.usersEnvironment.getUser({ key: info.name })
-      await api.graph.deleteUser({
-        user: user,
-        admin: this.usersEnvironment.getUser({ key: stepUser })
-      })
       await usersObject.createUser({
         name: info.name,
         displayname: info.displayname,

--- a/tests/e2e/cucumber/steps/ui/session.ts
+++ b/tests/e2e/cucumber/steps/ui/session.ts
@@ -18,7 +18,12 @@ async function createNewSession(world: World, stepUser: string) {
 async function LogInUser(this: World, stepUser: string): Promise<void> {
   const sessionObject = await createNewSession(this, stepUser)
   const { page } = this.actorsEnvironment.getActor({ key: stepUser })
-  const user = this.usersEnvironment.getUser({ key: stepUser })
+
+  const user =
+    stepUser === 'Admin'
+      ? this.usersEnvironment.getUser({ key: stepUser })
+      : this.usersEnvironment.getCreatedUser({ key: stepUser })
+
   await page.goto(config.frontendUrl)
   await sessionObject.login({ user })
   await page.waitForSelector('#web')


### PR DESCRIPTION
## Description
This issue clean-up the user in the `After` hook.

## Related Issue
- https://github.com/owncloud/web/issues/8662

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
