### PR TITLE
Fix endless loading when encountering a public link error

### DIFF
--- a/changelog/unreleased/bugfix-endless-loading-public-link-error
+++ b/changelog/unreleased/bugfix-endless-loading-public-link-error
@@ -1,0 +1,6 @@
+Bugfix: Endless loading when encountering a public link error
+
+An endless loading state that occurred when encountering an error when loading a public link has been fixed.
+
+https://github.com/owncloud/web/issues/9004
+https://github.com/owncloud/web/pull/9006

--- a/packages/web-runtime/src/pages/resolvePublicLink.vue
+++ b/packages/web-runtime/src/pages/resolvePublicLink.vue
@@ -129,6 +129,9 @@ export default defineComponent({
         if (error.statusCode === 401) {
           return true
         }
+        if (error.statusCode === 404) {
+          throw new Error('The resource could not be located, it may not exist anymore.')
+        }
         throw error
       }
     })
@@ -193,6 +196,9 @@ export default defineComponent({
     })
 
     const isLoading = computed<boolean>(() => {
+      if (unref(errorMessage)) {
+        return false
+      }
       if (
         loadTokenInfoTask.isRunning ||
         !loadTokenInfoTask.last ||


### PR DESCRIPTION
## Description
Fixes an endless loading state that occurred when encountering an error when loading a public link.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9004

## Screenshots
(translation is missing)
<img width="459" alt="image" src="https://github.com/owncloud/web/assets/50302941/9f6585dd-9866-470f-ac30-30b1a62a9bf3">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
