### PR TITLE
fix: forbid virtual spaces

### DIFF
--- a/changelog/unreleased/bugfix-forbid-virtual-shares
+++ b/changelog/unreleased/bugfix-forbid-virtual-shares
@@ -1,0 +1,5 @@
+Bugfix: Prevent "virtual" spaces from being displayed in the UI
+
+While ownCloud Web is capable of displaying any type of spaces we found out that it is not valid to display so called "virtual" spaces. In such a case users now get redirected to their default location (personal space for users, project spaces overview  for guests).
+
+https://github.com/owncloud/web/pull/9015

--- a/packages/web-pkg/src/composables/driveResolver/useDriveResolver.ts
+++ b/packages/web-pkg/src/composables/driveResolver/useDriveResolver.ts
@@ -40,7 +40,7 @@ export const useDriveResolver = (options: DriveResolverOptions = {}): DriveResol
   watch(
     [options.driveAliasAndItem, areSpacesLoading],
     ([driveAliasAndItem]) => {
-      if (!driveAliasAndItem) {
+      if (!driveAliasAndItem || driveAliasAndItem.startsWith('virtual/')) {
         space.value = null
         item.value = null
         return


### PR DESCRIPTION
## Description
Preventing access to virtual spaces. Otherwise it's possible to e.g. access the virtual shares space (`virtual/shares`), which we don't want because shares are handled differently in web.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
