### PR TITLE
Fix empty file list after deleting resources

### DIFF
--- a/changelog/unreleased/bugfix-empty-files-list-after-deleting
+++ b/changelog/unreleased/bugfix-empty-files-list-after-deleting
@@ -1,0 +1,6 @@
+Bugfix: Empty file list after deleting resources
+
+Deleting all resources on the last page lead to an empty file list although the other pages still contained resources. This has been fixed by resetting the pagination in such scenario.
+
+https://github.com/owncloud/web/issues/9014
+https://github.com/owncloud/web/pull/9017

--- a/packages/web-app-files/tests/unit/composables/actions/helpers/useFileActionsDeleteResources.spec.ts
+++ b/packages/web-app-files/tests/unit/composables/actions/helpers/useFileActionsDeleteResources.spec.ts
@@ -72,6 +72,7 @@ function getWrapper({
     ...defaultStoreMockOptions
   }
   storeOptions.modules.Files.getters.currentFolder.mockReturnValue(currentFolder)
+  storeOptions.modules.Files.getters.activeFiles.mockReturnValue([])
 
   const store = createStore(storeOptions)
   return {


### PR DESCRIPTION
## Description
Fixes an issue where the file list would be empty after deleting all resources on the last page. The file list now resets the pagination in such scenario.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9014

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

