### PR TITLE
Fix sidebar for spaces on 'Shared via link'-page

### DIFF
--- a/changelog/unreleased/bugfix-spaces-sidebar-shared-via-link
+++ b/changelog/unreleased/bugfix-spaces-sidebar-shared-via-link
@@ -1,0 +1,6 @@
+Bugfix: Sidebar for spaces on "Shared via link"-page
+
+The sidebar for spaces on the "Shared via link"-page has been fixed which acted like the space was a folder resource before.
+
+https://github.com/owncloud/web/issues/9020
+https://github.com/owncloud/web/pull/9023

--- a/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
@@ -540,7 +540,7 @@ export default defineComponent({
         path = `/${resource.name}`
       }
 
-      const lastLinkId = this.outgoingLinks.length === 1 ? this.outgoingLinks[0].id : undefined
+      let lastLinkId = this.outgoingLinks.length === 1 ? this.outgoingLinks[0].id : undefined
       const loadIndicators = this.outgoingLinks.filter((l) => !l.indirect).length === 1
 
       try {
@@ -550,6 +550,10 @@ export default defineComponent({
         })
 
         if (lastLinkId && isLocationSharesActive(this.$router, 'files-shares-via-link')) {
+          if (this.resourceIsSpace) {
+            // spaces need their actual id instead of their share id to be removed from the file list
+            lastLinkId = this.resource.id.toString()
+          }
           this.REMOVE_FILES([{ id: lastLinkId }])
         }
       } catch (e) {

--- a/packages/web-app-files/src/components/SideBar/SideBar.vue
+++ b/packages/web-app-files/src/components/SideBar/SideBar.vue
@@ -226,11 +226,14 @@ export default defineComponent({
 
       // shared resources look different, hence we need to fetch the actual resource here
       try {
-        const shareResource = await (clientService.webdav as WebDAV).getFileInfo(props.space, {
+        let shareResource = await (clientService.webdav as WebDAV).getFileInfo(props.space, {
           path: unref(highlightedFile).path
         })
         shareResource.share = unref(highlightedFile).share
         shareResource.status = unref(highlightedFile).status
+        if (unref(highlightedFileIsSpace)) {
+          shareResource = { ...shareResource, ...unref(highlightedFile) }
+        }
         loadedResource.value = shareResource
       } catch (error) {
         loadedResource.value = resource

--- a/packages/web-app-files/src/fileSideBars.ts
+++ b/packages/web-app-files/src/fileSideBars.ts
@@ -139,7 +139,7 @@ const panelGenerators: (({
       return !!(!multipleSelection && !rootFolder && resource && resource.type !== 'space')
     }
   }),
-  ({ multipleSelection, resource, user }) => ({
+  ({ multipleSelection, resource, router, user }) => ({
     app: 'space-actions',
     icon: 'slideshow-3',
     title: $gettext('Actions'),
@@ -149,6 +149,12 @@ const panelGenerators: (({
         return false
       }
       if (resource?.type !== 'space') {
+        return false
+      }
+      if (
+        !isLocationSpacesActive(router, 'files-spaces-projects') &&
+        !isLocationSpacesActive(router, 'files-spaces-generic')
+      ) {
         return false
       }
       return !![


### PR DESCRIPTION
## Description
Fixes the sidebar for spaces on the "Shared via link"-page which acted like the space was a folder resource before. I also decided to hide the actions panel for spaces in this view because the actions don't have any visible impact anyways here.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9020

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
