### PR TITLE
Fix spaces in search results

### DIFF
--- a/changelog/unreleased/bugfix-spaces-in-search-results
+++ b/changelog/unreleased/bugfix-spaces-in-search-results
@@ -1,6 +1,6 @@
 Bugfix: Spaces in search results
 
-Spaces in search results are no longer being displayed as folder resources, fixing wrong icons and sidebar panels.
+Spaces in search results are no longer being displayed as folder resources, fixing wrong icons, parent folders and sidebar panels.
 
 https://github.com/owncloud/web/issues/9022
 https://github.com/owncloud/web/pull/9026

--- a/changelog/unreleased/bugfix-spaces-in-search-results
+++ b/changelog/unreleased/bugfix-spaces-in-search-results
@@ -1,0 +1,6 @@
+Bugfix: Spaces in search results
+
+Spaces in search results are no longer being displayed as folder resources, fixing wrong icons and sidebar panels.
+
+https://github.com/owncloud/web/issues/9022
+https://github.com/owncloud/web/pull/9026

--- a/packages/web-app-files/src/components/Search/Preview.vue
+++ b/packages/web-app-files/src/components/Search/Preview.vue
@@ -30,7 +30,7 @@ import { mapGetters } from 'vuex'
 import { createLocationShares, createLocationSpaces } from '../../router'
 import { basename, dirname } from 'path'
 import { useCapabilityShareJailEnabled } from 'web-pkg/src/composables'
-import { buildShareSpaceResource, Resource } from 'web-client/src/helpers'
+import { buildShareSpaceResource, isProjectSpaceResource, Resource } from 'web-client/src/helpers'
 import { configurationManager } from 'web-pkg/src/configuration'
 import { eventBus } from 'web-pkg/src/services/eventBus'
 import { createFileRouteOptions } from 'web-pkg/src/helpers/router'
@@ -115,6 +115,10 @@ export default defineComponent({
         return this.$gettext('All files and folders')
       }
 
+      if (isProjectSpaceResource(this.resource)) {
+        return this.$gettext('Spaces')
+      }
+
       if (this.matchingSpace?.driveType === 'project') {
         return this.matchingSpace.name
       }
@@ -133,6 +137,9 @@ export default defineComponent({
     parentFolderLink() {
       if (this.resource.shareId && this.resource.path === '/') {
         return createLocationShares('files-shares-with-me')
+      }
+      if (isProjectSpaceResource(this.resource)) {
+        return createLocationSpaces('files-spaces-projects')
       }
       return this.createFolderLink(dirname(this.resource.path), this.resource.parentFolderId)
     }

--- a/packages/web-app-files/src/search/sdk/list.ts
+++ b/packages/web-app-files/src/search/sdk/list.ts
@@ -1,9 +1,9 @@
 import { SearchList, SearchResult } from 'web-app-search/src/types'
 import ListComponent from '../../components/Search/List.vue'
 import { ClientService } from 'web-pkg/src/services'
-import { buildResource } from 'web-client/src/helpers'
-import { Component } from 'vue'
-import { DavProperties } from 'web-client/src/webdav/constants'
+import { ProjectSpaceResource, buildResource, isProjectSpaceResource } from 'web-client/src/helpers'
+import { Component, computed, Ref, unref } from 'vue'
+import { DavProperties, DavProperty } from 'web-client/src/webdav/constants'
 import { Store } from 'vuex'
 
 export const searchLimit = 200
@@ -12,11 +12,19 @@ export default class List implements SearchList {
   public readonly component: Component
   private readonly store: Store<any>
   private readonly clientService: ClientService
+  private readonly projectSpaces: Ref<ProjectSpaceResource[]>
 
   constructor(store: Store<any>, clientService: ClientService) {
     this.component = ListComponent
     this.store = store
     this.clientService = clientService
+    this.projectSpaces = computed(() =>
+      this.store.getters['runtime/spaces/spaces'].filter((s) => isProjectSpaceResource(s))
+    )
+  }
+
+  getMatchingSpace(id): ProjectSpaceResource {
+    return unref(this.projectSpaces).find((s) => s.id === id)
   }
 
   async search(term: string): Promise<SearchResult> {
@@ -36,7 +44,8 @@ export default class List implements SearchList {
     return {
       totalResults: range ? parseInt(range?.split('/')[1]) : null,
       values: results.map((result) => {
-        const resource = buildResource(result)
+        const matchingSpace = this.getMatchingSpace(result.fileInfo[DavProperty.FileParent])
+        const resource = matchingSpace ? matchingSpace : buildResource(result)
         // info: in oc10 we have no storageId in resources. All resources are mounted into the personal space.
         if (!resource.storageId) {
           resource.storageId = this.store.getters.user.id

--- a/packages/web-app-files/tests/unit/search/sdk.spec.ts
+++ b/packages/web-app-files/tests/unit/search/sdk.spec.ts
@@ -4,25 +4,24 @@ import { Store } from 'vuex'
 import { RouteLocation, Router } from 'vue-router'
 import { mock, mockDeep } from 'jest-mock-extended'
 import { ref } from 'vue'
+import { createStore, defaultStoreMockOptions } from 'web-test-helpers/src'
+import { ProjectSpaceResource } from 'web-client/src/helpers'
+import { DavProperty } from 'web-client/src/webdav/constants'
 
 const searchMock = jest.fn()
 const clientService = mockDeep<ClientService>()
 clientService.owncloudSdk.files.search.mockImplementation(searchMock)
 
-jest.mock('web-client/src/helpers', () => ({
+jest.mock('web-client/src/helpers/resource', () => ({
   buildResource: (v) => v
 }))
 
-const store = mockDeep<Store<any>>({
-  getters: {
-    user: () => ({ id: 1 }),
-    capabilities: {
-      dav: {
-        reports: ['search-files']
-      }
-    }
-  }
-})
+const getStore = (spaces = []) => {
+  const storeOptions = defaultStoreMockOptions
+  storeOptions.getters.capabilities.mockReturnValue({ dav: { reports: ['search-files'] } })
+  storeOptions.modules.runtime.modules.spaces.getters.spaces.mockReturnValue(spaces)
+  return createStore(storeOptions)
+}
 
 const storeWithoutFileSearch = mockDeep<Store<any>>({
   getters: { capabilities: { dav: { reports: [] } } }
@@ -42,7 +41,7 @@ describe('SDKProvider', () => {
         { route: 'bar', available: true }
       ].forEach((v) => {
         const search = new SDKSearch(
-          store,
+          getStore(),
           mock<Router>({
             currentRoute: ref(mock<RouteLocation>({ name: v.route }))
           }),
@@ -54,11 +53,11 @@ describe('SDKProvider', () => {
     })
 
     it('can search', async () => {
-      const search = new SDKSearch(store, mock<Router>(), clientService)
+      const search = new SDKSearch(getStore(), mock<Router>(), clientService)
       const files = [
-        { id: 'foo', name: 'foo' },
-        { id: 'bar', name: 'bar' },
-        { id: 'baz', name: 'baz' }
+        { id: 'foo', name: 'foo', fileInfo: {} },
+        { id: 'bar', name: 'bar', fileInfo: {} },
+        { id: 'baz', name: 'baz', fileInfo: {} }
       ]
 
       const noTerm = await search.previewSearch.search('')
@@ -71,19 +70,39 @@ describe('SDKProvider', () => {
       const withTermCached = await search.previewSearch.search('foo')
       expect(withTermCached.values.map((r) => r.data)).toMatchObject(files)
     })
+    it('properly returns space resources', async () => {
+      const spaceId = '1'
+      const space = mock<ProjectSpaceResource>({ id: spaceId, name: 'foo', driveType: 'project' })
+      const search = new SDKSearch(getStore([space]), mock<Router>(), clientService)
+      const files = [{ id: 'foo', name: 'foo', fileInfo: { [DavProperty.FileParent]: space.id } }]
+
+      searchMock.mockReturnValueOnce({ results: files })
+      const withTerm = (await search.previewSearch.search('foo')) as any
+      expect(withTerm.values.map((r) => r.data)[0].id).toEqual(spaceId)
+    })
   })
   describe('SDKProvider listSearch', () => {
     it('can search', async () => {
-      const search = new SDKSearch(store, mock<Router>(), clientService)
+      const search = new SDKSearch(getStore(), mock<Router>(), clientService)
       const files = [
-        { id: 'foo', name: 'foo' },
-        { id: 'bar', name: 'bar' },
-        { id: 'baz', name: 'baz' }
+        { id: 'foo', name: 'foo', fileInfo: {} },
+        { id: 'bar', name: 'bar', fileInfo: {} },
+        { id: 'baz', name: 'baz', fileInfo: {} }
       ]
 
       searchMock.mockReturnValueOnce({ results: files })
       const withTerm = (await search.listSearch.search('foo')) as any
       expect(withTerm.values.map((r) => r.data)).toMatchObject(files)
+    })
+    it('properly returns space resources', async () => {
+      const spaceId = '1'
+      const space = mock<ProjectSpaceResource>({ id: spaceId, driveType: 'project' })
+      const search = new SDKSearch(getStore([space]), mock<Router>(), clientService)
+      const files = [{ id: 'foo', name: 'foo', fileInfo: { [DavProperty.FileParent]: space.id } }]
+
+      searchMock.mockReturnValueOnce({ results: files })
+      const withTerm = (await search.listSearch.search('foo')) as any
+      expect(withTerm.values.map((r) => r.data)[0].id).toEqual(spaceId)
     })
   })
 })

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -145,6 +145,7 @@ export function buildSpace(data): SpaceResource {
     mdate: data.lastModifiedDateTime,
     size: data.quota?.used,
     indicators: [],
+    tags: [],
     permissions: '',
     starred: false,
     etag: '',


### PR DESCRIPTION
## Description
Fixes wrong icons and sidebar panels for spaces in share results as well as their parent folder below the resource name.

Unfortunately, there is no convenient way to distinguish spaces from folders based on the search response form the server. Although space resources have empty permissions, which differs from folders, it doesn't feel great to distinguish them based on that attribute IMO. I'm open for suggestions though.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9022
- Fixes https://github.com/owncloud/web/issues/8925

## Screenshots
<img width="454" alt="image" src="https://github.com/owncloud/web/assets/50302941/01d8e65f-2d73-4126-867a-e8d078855afd">

<img width="887" alt="image" src="https://github.com/owncloud/web/assets/50302941/02214f72-39bc-4840-9a03-2007f82d1f01">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
