### PR TITLE
fix: resource not found and no content message both displayed

### DIFF
--- a/changelog/unreleased/bugfix-no-content-not-found
+++ b/changelog/unreleased/bugfix-no-content-not-found
@@ -1,0 +1,6 @@
+Bugfix: Resource not found and No content message at the same time
+
+We've fixed a bug where the "Resource not found" and "Empty folder" messages were shown at the same time.
+
+https://github.com/owncloud/web/issues/9061
+https://github.com/owncloud/web/pull/9062

--- a/packages/web-app-files/src/components/FilesList/NotFoundMessage.vue
+++ b/packages/web-app-files/src/components/FilesList/NotFoundMessage.vue
@@ -86,3 +86,8 @@ export default defineComponent({
   }
 })
 </script>
+<style>
+#files-list-not-found-message {
+  height: 75vh;
+}
+</style>

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -22,103 +22,106 @@
       </app-bar>
       <app-loading-spinner v-if="areResourcesLoading" />
       <template v-else>
-        <not-found-message
-          v-if="folderNotFound"
-          :space="space"
-          class="files-not-found oc-height-1-1"
-        />
-        <space-header
-          v-else-if="hasSpaceHeader"
-          :space="space"
-          :side-bar-open="sideBarOpen"
-          class="oc-px-m oc-mt-m"
-        />
+        <not-found-message v-if="folderNotFound" :space="space" class="files-not-found" />
+        <template v-else>
+          <space-header
+            v-if="hasSpaceHeader"
+            :space="space"
+            :side-bar-open="sideBarOpen"
+            class="oc-px-m oc-mt-m"
+          />
 
-        <no-content-message v-if="isEmpty" id="files-space-empty" class="files-empty" icon="folder">
-          <template #message>
-            <span v-text="$gettext('No resources found')" />
-          </template>
-          <template #callToAction>
-            <span v-if="canUpload" class="file-empty-upload-hint" v-text="uploadHint" />
-          </template>
-        </no-content-message>
-        <resource-tiles
-          v-else-if="viewMode === ViewModeConstants.tilesView.name"
-          v-model:selectedIds="selectedResourcesIds"
-          :data="paginatedResources"
-          class="oc-px-m oc-pt-l"
-          :resizable="true"
-          :target-route-callback="resourceTargetRouteCallback"
-          :space="space"
-          :drag-drop="true"
-          :sort-fields="sortFields"
-          :sort-by="sortBy"
-          :sort-dir="sortDir"
-          :view-size="viewSize"
-          @row-mounted="rowMounted"
-          @file-click="triggerDefaultAction"
-          @file-dropped="fileDropped"
-          @sort="handleSort"
-        >
-          <template #contextMenuActions="{ resource }">
-            <context-actions :action-options="{ space, resources: [resource] }" />
-          </template>
-          <template #footer>
-            <pagination :pages="paginationPages" :current-page="paginationPage" />
-            <list-info
-              v-if="paginatedResources.length > 0"
-              class="oc-width-1-1 oc-my-s"
-              :files="totalFilesCount.files"
-              :folders="totalFilesCount.folders"
-              :size="totalFilesSize"
-            />
-          </template>
-        </resource-tiles>
-        <resource-table
-          v-else
-          id="files-space-table"
-          v-model:selectedIds="selectedResourcesIds"
-          class="files-table"
-          :class="{ 'files-table-squashed': sideBarOpen }"
-          :view-mode="viewMode"
-          :are-thumbnails-displayed="displayThumbnails"
-          :resources="paginatedResources"
-          :target-route-callback="resourceTargetRouteCallback"
-          :header-position="fileListHeaderY"
-          :drag-drop="true"
-          :sort-by="sortBy"
-          :sort-dir="sortDir"
-          :space="space"
-          @file-dropped="fileDropped"
-          @file-click="triggerDefaultAction"
-          @row-mounted="rowMounted"
-          @sort="handleSort"
-        >
-          <template #quickActions="{ resource }">
-            <quick-actions
-              :class="resource.preview"
-              class="oc-visible@s"
-              :item="resource"
-              :actions="app.quickActions"
-            />
-          </template>
-          <template #contextMenu="{ resource }">
-            <context-actions
-              v-if="isResourceInSelection(resource)"
-              :action-options="{ space, resources: selectedResources }"
-            />
-          </template>
-          <template #footer>
-            <pagination :pages="paginationPages" :current-page="paginationPage" />
-            <list-info
-              v-if="paginatedResources.length > 0"
-              class="oc-width-1-1 oc-my-s"
-              :files="totalFilesCount.files"
-              :folders="totalFilesCount.folders"
-              :size="totalFilesSize"
-            />
-          </template>
-        </resource-table>
+          <no-content-message
+            v-if="isEmpty"
+            id="files-space-empty"
+            class="files-empty"
+            icon="folder"
+          >
+            <template #message>
+              <span v-text="$gettext('No resources found')" />
+            </template>
+            <template #callToAction>
+              <span v-if="canUpload" class="file-empty-upload-hint" v-text="uploadHint" />
+            </template>
+          </no-content-message>
+          <resource-tiles
+            v-else-if="viewMode === ViewModeConstants.tilesView.name"
+            v-model:selectedIds="selectedResourcesIds"
+            :data="paginatedResources"
+            class="oc-px-m oc-pt-l"
+            :resizable="true"
+            :target-route-callback="resourceTargetRouteCallback"
+            :space="space"
+            :drag-drop="true"
+            :sort-fields="sortFields"
+            :sort-by="sortBy"
+            :sort-dir="sortDir"
+            :view-size="viewSize"
+            @row-mounted="rowMounted"
+            @file-click="triggerDefaultAction"
+            @file-dropped="fileDropped"
+            @sort="handleSort"
+          >
+            <template #contextMenuActions="{ resource }">
+              <context-actions :action-options="{ space, resources: [resource] }" />
+            </template>
+            <template #footer>
+              <pagination :pages="paginationPages" :current-page="paginationPage" />
+              <list-info
+                v-if="paginatedResources.length > 0"
+                class="oc-width-1-1 oc-my-s"
+                :files="totalFilesCount.files"
+                :folders="totalFilesCount.folders"
+                :size="totalFilesSize"
+              />
+            </template>
+          </resource-tiles>
+          <resource-table
+            v-else
+            id="files-space-table"
+            v-model:selectedIds="selectedResourcesIds"
+            class="files-table"
+            :class="{ 'files-table-squashed': sideBarOpen }"
+            :view-mode="viewMode"
+            :are-thumbnails-displayed="displayThumbnails"
+            :resources="paginatedResources"
+            :target-route-callback="resourceTargetRouteCallback"
+            :header-position="fileListHeaderY"
+            :drag-drop="true"
+            :sort-by="sortBy"
+            :sort-dir="sortDir"
+            :space="space"
+            @file-dropped="fileDropped"
+            @file-click="triggerDefaultAction"
+            @row-mounted="rowMounted"
+            @sort="handleSort"
+          >
+            <template #quickActions="{ resource }">
+              <quick-actions
+                :class="resource.preview"
+                class="oc-visible@s"
+                :item="resource"
+                :actions="app.quickActions"
+              />
+            </template>
+            <template #contextMenu="{ resource }">
+              <context-actions
+                v-if="isResourceInSelection(resource)"
+                :action-options="{ space, resources: selectedResources }"
+              />
+            </template>
+            <template #footer>
+              <pagination :pages="paginationPages" :current-page="paginationPage" />
+              <list-info
+                v-if="paginatedResources.length > 0"
+                class="oc-width-1-1 oc-my-s"
+                :files="totalFilesCount.files"
+                :folders="totalFilesCount.folders"
+                :size="totalFilesSize"
+              />
+            </template>
+          </resource-table>
+        </template>
       </template>
     </files-view-wrapper>
     <side-bar :open="sideBarOpen" :active-panel="sideBarActivePanel" :space="space" />
@@ -427,7 +430,7 @@ export default defineComponent({
     },
 
     folderNotFound() {
-      return this.currentFolder === null
+      return !this.currentFolder
     },
 
     displayThumbnails() {


### PR DESCRIPTION
## Description
Fixing two things:
- "Resource not found" obtaining too much height (thus scroll bars were appearing)
- "Resource not found" and "Empty folder" messages appearing at the same time

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9061

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
