### PR TITLE
Fix search result page on mobile view

### DIFF
--- a/changelog/unreleased/enhancement-mobile-navigation
+++ b/changelog/unreleased/enhancement-mobile-navigation
@@ -5,4 +5,6 @@ The navigation for mobile devices <640px has been reworked.
 https://github.com/owncloud/web/issues/8557
 https://github.com/owncloud/web/issues/7253
 https://github.com/owncloud/web/issues/3774
+https://github.com/owncloud/web/issues/9073
 https://github.com/owncloud/web/pull/8757
+https://github.com/owncloud/web/pull/9074

--- a/packages/web-runtime/src/components/MobileNav.vue
+++ b/packages/web-runtime/src/components/MobileNav.vue
@@ -46,7 +46,7 @@ export default defineComponent({
   },
   setup(props) {
     const activeNavItem = computed(() => {
-      return unref(props.navItems).find((n) => n.active)
+      return unref(props.navItems).find((n) => n.active) || props.navItems[0]
     })
 
     return { activeNavItem }


### PR DESCRIPTION
## Description
The issue appeared when there was no active nav item present because the mobile nav uses the label of the active nav item for display. The label now falls back to the first nav item (usually that's `Personal`).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9073

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
