### PR TITLE
Update favorites resources list on remove from favorites

### DIFF
--- a/changelog/unreleased/bugfix-favorites-list-update-on-removal
+++ b/changelog/unreleased/bugfix-favorites-list-update-on-removal
@@ -1,0 +1,5 @@
+Bugfix: Favorites list update on removal
+
+The Favorites list is now updating when a resource is removed from the list in this view
+
+https://github.com/owncloud/web/pull/9078

--- a/packages/web-app-files/src/store/actions.ts
+++ b/packages/web-app-files/src/store/actions.ts
@@ -19,6 +19,7 @@ import { ClientService, LoadingTaskCallbackArguments } from 'web-pkg/src/service
 import { Language } from 'vue3-gettext'
 import { DavProperty } from 'web-client/src/webdav/constants'
 import { AncestorMetaData } from 'web-app-files/src/helpers/resource/ancestorMetaData'
+import { eventBus } from 'web-pkg/src/services/eventBus'
 
 const allowSharePermissions = (getters) => {
   return (
@@ -147,6 +148,9 @@ export default {
           field: 'starred',
           value: newValue
         })
+        if (!newValue) {
+          eventBus.publish('app.files.list.removeFromFavorites')
+        }
       })
       .catch((error) => {
         throw new Error(error)


### PR DESCRIPTION
## Description
Update favorites resources list on remove from favorites

## Related Issue

## Motivation and Context
Currently, the list of resources in "Favorite" view doesn't update when the resource is removed from favorites


## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: <link> 

