### PR TITLE
[tests-only] Fix expect().toBe() usage

### DIFF
--- a/tests/e2e/cucumber/steps/ui/accountMenu.ts
+++ b/tests/e2e/cucumber/steps/ui/accountMenu.ts
@@ -8,8 +8,7 @@ Then(
   async function (this: World, stepUser: string, quota: string): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const accountObject = new objects.account.Account({ page })
-    const quotaValue = await accountObject.getQuotaValue()
-    expect(quotaValue).toBe(quota)
+    expect(await accountObject.getQuotaValue()).toBe(quota)
   }
 )
 
@@ -20,7 +19,7 @@ Then(
     const accountObject = new objects.account.Account({ page })
 
     for (const info of stepTable.hashes()) {
-      expect(info.value).toBe(await accountObject.getUserInfo(info.key))
+      expect(await accountObject.getUserInfo(info.key)).toBe(info.value)
     }
   }
 )

--- a/tests/e2e/cucumber/steps/ui/adminSettings.ts
+++ b/tests/e2e/cucumber/steps/ui/adminSettings.ts
@@ -18,12 +18,7 @@ Then(
 
     for (const info of stepTable.hashes()) {
       const space = await spacesObject.getSpace({ key: info.id })
-      const found = actualList.includes(space.id)
-      if (actionType === 'should') {
-        expect(found).toBe(true)
-      } else {
-        expect(found).toBe(false)
-      }
+      expect(actualList.includes(space.id)).toBe(actionType === 'should')
     }
   }
 )

--- a/tests/e2e/cucumber/steps/ui/links.ts
+++ b/tests/e2e/cucumber/steps/ui/links.ts
@@ -30,7 +30,7 @@ When(
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const linkObject = new objects.applicationFiles.Link({ page })
     const linkName = await linkObject.changeName({ resource, newName })
-    expect(newName).toBe(linkName)
+    expect(linkName).toBe(newName)
   }
 )
 
@@ -40,7 +40,7 @@ When(
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const linkObject = new objects.applicationFiles.Link({ page })
     const linkName = await linkObject.changeName({ newName, space: true })
-    expect(newName).toBe(linkName)
+    expect(linkName).toBe(newName)
   }
 )
 
@@ -86,7 +86,7 @@ When(
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const linkObject = new objects.applicationFiles.Link({ page })
     const roleText = await linkObject.changeRole({ linkName, resource, role })
-    expect(linkObject.roleDisplayText[role].toLowerCase()).toBe(roleText.toLowerCase())
+    expect(roleText.toLowerCase()).toBe(linkObject.roleDisplayText[role].toLowerCase())
   }
 )
 
@@ -103,9 +103,10 @@ Then(
   'public link named {string} should be visible to {string}',
   async function (this: World, linkName: string, stepUser: any): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const expectedPublicLink = this.linksEnvironment.getLink({ name: linkName })
     const linkObject = new objects.applicationFiles.Link({ page })
-    const publicLinkUrls = await linkObject.getPublicLinkUrl({ linkName, space: true })
-    expect(publicLinkUrls[0]).toBe(publicLinkUrls[1])
+    const actualPublicLink = await linkObject.getPublicLinkUrl({ linkName, space: true })
+    expect(actualPublicLink).toBe(expectedPublicLink)
   }
 )
 
@@ -113,9 +114,10 @@ Then(
   'public link named {string} of the resource {string} should be visible to {string}',
   async function (this: World, linkName: string, resource: string, stepUser: any): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const expectedPublicLink = this.linksEnvironment.getLink({ name: linkName })
     const linkObject = new objects.applicationFiles.Link({ page })
-    const publicLinkUrls = await linkObject.getPublicLinkUrl({ linkName, resource })
-    expect(publicLinkUrls[0]).toBe(publicLinkUrls[1])
+    const actualPublicLink = await linkObject.getPublicLinkUrl({ linkName, resource })
+    expect(actualPublicLink).toBe(expectedPublicLink)
   }
 )
 
@@ -140,7 +142,7 @@ When(
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const linkObject = new objects.applicationFiles.Link({ page })
     const newPermission = await linkObject.changeRole({ linkName, role })
-    expect(linkObject.roleDisplayText[role].toLowerCase()).toBe(newPermission.toLowerCase())
+    expect(newPermission.toLowerCase()).toBe(linkObject.roleDisplayText[role].toLowerCase())
   }
 )
 

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -234,12 +234,7 @@ Then(
       keyword: listType as displayedResourceType
     })
     for (const info of stepTable.hashes()) {
-      const found = actualList.includes(info.resource)
-      if (actionType === 'should') {
-        expect(found).toBe(true)
-      } else {
-        expect(found).toBe(false)
-      }
+      expect(actualList.includes(info.resource)).toBe(actionType === 'should')
     }
   }
 )
@@ -344,7 +339,7 @@ export const processDownload = async (
     })
 
     if (actionType === 'sidebar panel') {
-      expect(files.length).toBe(downloads.length)
+      expect(downloads.length).toBe(files.length)
       for (const resource of files) {
         const fileOrFolderName = path.parse(resource.name).name
         if (resource.type === 'file') {

--- a/tests/e2e/support/objects/app-files/link/index.ts
+++ b/tests/e2e/support/objects/app-files/link/index.ts
@@ -87,15 +87,11 @@ export class Link {
     await this.#page.goto(startUrl)
   }
 
-  async getPublicLinkUrl(
-    args: Omit<publicLinkAndItsEditButtonVisibilityArgs, 'page'>
-  ): Promise<string[]> {
-    const linkUrl = this.#linksEnvironment.getLink({ name: args.linkName })
-    const publicLink = await getPublicLinkVisibility({
+  getPublicLinkUrl(args: Omit<publicLinkAndItsEditButtonVisibilityArgs, 'page'>): Promise<string> {
+    return getPublicLinkVisibility({
       ...args,
       page: this.#page
     })
-    return [linkUrl.url, publicLink]
   }
 
   async islinkEditButtonVisibile(linkName): Promise<boolean> {

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -660,7 +660,7 @@ export const deleteResource = async (args: deleteResourceArgs): Promise<void> =>
         page.locator(util.format(actionConfirmationButton, 'Delete')).click()
       ])
       // assertion that the resources actually got deleted
-      expect(resourcesWithInfo.length).toBe(deletetedResources.length)
+      expect(deletetedResources.length).toBe(resourcesWithInfo.length)
       for (const resource of resourcesWithInfo) {
         expect(deletetedResources).toContain(resource.name)
       }


### PR DESCRIPTION
## Description
Fixed `expect()` usage as per:
```js
expect.(<RecievedValue>).toBe(<ExpectedValue>)
```


## Related Issue
- Fixes https://github.com/owncloud/web/issues/9005

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
