### PR TITLE
[full-ci] fix: search syntax when combining filters

### DIFF
--- a/changelog/unreleased/enhancement-search-fulltext-filter
+++ b/changelog/unreleased/enhancement-search-fulltext-filter
@@ -4,4 +4,5 @@ The search result page now has a full-text filter which can be used to filter th
 
 https://github.com/owncloud/web/pull/9059
 https://github.com/owncloud/web/pull/9087
+https://github.com/owncloud/web/pull/9096
 https://github.com/owncloud/web/issues/9058

--- a/changelog/unreleased/enhancement-search-tag-filter
+++ b/changelog/unreleased/enhancement-search-tag-filter
@@ -3,4 +3,5 @@ Enhancement: Search tag filter
 The search result page now has a tag filter which can be used to filter the displayed search result by tags.
 
 https://github.com/owncloud/web/pull/9044
+https://github.com/owncloud/web/pull/9096
 https://github.com/owncloud/web/issues/9054

--- a/packages/web-app-files/tests/unit/components/Search/List.spec.ts
+++ b/packages/web-app-files/tests/unit/components/Search/List.spec.ts
@@ -72,7 +72,9 @@ describe('List component', () => {
           tagFilterQuery
         })
         await wrapper.vm.loadAvailableTagsTask.last
-        expect(wrapper.emitted('search')[0][0]).toEqual(`${searchTerm} Tags:"${tagFilterQuery}"`)
+        expect(wrapper.emitted('search')[0][0]).toEqual(
+          `+Name:*${searchTerm}* +Tags:"${tagFilterQuery}"`
+        )
       })
     })
     describe('fullText', () => {
@@ -88,7 +90,7 @@ describe('List component', () => {
           fullTextSearchEnabled: true
         })
         await wrapper.vm.loadAvailableTagsTask.last
-        expect(wrapper.emitted('search')[0][0]).toEqual(`Content:"${searchTerm}"`)
+        expect(wrapper.emitted('search')[0][0]).toEqual(`+Content:"${searchTerm}"`)
       })
     })
   })

--- a/packages/web-app-search/src/views/List.vue
+++ b/packages/web-app-search/src/views/List.vue
@@ -32,7 +32,16 @@ export default defineComponent({
   methods: {
     async search(term: string) {
       this.loading = true
-      this.searchResult = await this.listSearch.search(term || '')
+      try {
+        this.searchResult = await this.listSearch.search(term || '')
+      } catch (e) {
+        this.searchResult = {
+          values: [],
+          totalResults: null
+        }
+        console.error(e)
+      }
+
       this.loading = false
     }
   }

--- a/packages/web-pkg/src/components/ItemFilter.vue
+++ b/packages/web-pkg/src/components/ItemFilter.vue
@@ -18,33 +18,36 @@
         <div ref="itemFilterListRef">
           <oc-list class="item-filter-list">
             <li v-for="(item, index) in displayedItems" :key="index" class="oc-my-xs">
-              <component
-                :is="isSelectionAllowed(item) ? 'oc-button' : 'div'"
+              <oc-button
                 class="item-filter-list-item oc-flex oc-flex-left oc-flex-middle oc-width-1-1 oc-p-xs"
-                justify-content="left"
+                :class="{ 'item-filter-list-item-active': !allowMultiple && isItemSelected(item) }"
+                justify-content="space-between"
                 appearance="raw"
                 :data-test-value="item[displayNameAttribute]"
                 @click="toggleItemSelection(item)"
               >
-                <div>
+                <div class="oc-flex oc-flex-middle oc-text-truncate">
                   <oc-checkbox
+                    v-if="allowMultiple"
                     size="large"
-                    class="item-filter-checkbox"
+                    class="item-filter-checkbox oc-mr-s"
                     :label="$gettext('Toggle selection')"
                     :model-value="isItemSelected(item)"
-                    :disabled="!isSelectionAllowed(item)"
                     hide-label
                     @update:model-value="toggleItemSelection(item)"
                     @click.stop
                   />
+                  <div>
+                    <slot name="image" :item="item" />
+                  </div>
+                  <div class="oc-text-truncate oc-ml-s">
+                    <slot name="item" :item="item" />
+                  </div>
                 </div>
-                <div>
-                  <slot name="image" :item="item" />
+                <div class="oc-flex">
+                  <oc-icon v-if="!allowMultiple && isItemSelected(item)" name="check" />
                 </div>
-                <div class="oc-text-truncate">
-                  <slot name="item" :item="item" />
-                </div>
-              </component>
+              </oc-button>
             </li>
           </oc-list>
         </div>
@@ -133,16 +136,14 @@ export default defineComponent({
     const isItemSelected = (item) => {
       return !!unref(selectedItems).find((s) => s.id === item.id)
     }
-    const isSelectionAllowed = (item) => {
-      return props.allowMultiple || !unref(selectedItems).length || isItemSelected(item)
-    }
+
     const toggleItemSelection = (item) => {
-      if (!isSelectionAllowed(item)) {
-        return
-      }
       if (isItemSelected(item)) {
         selectedItems.value = unref(selectedItems).filter((s) => s.id !== item.id)
       } else {
+        if (!props.allowMultiple) {
+          selectedItems.value = []
+        }
         selectedItems.value.push(item)
       }
       emit('selectionChange', unref(selectedItems))
@@ -218,7 +219,6 @@ export default defineComponent({
       filterInputRef,
       filterTerm,
       isItemSelected,
-      isSelectionAllowed,
       itemFilterListRef,
       queryParam,
       selectedItems,
@@ -246,7 +246,8 @@ export default defineComponent({
       line-height: 1.5;
       gap: 8px;
 
-      &:hover {
+      &:hover,
+      &-active {
         background-color: var(--oc-color-background-hover) !important;
       }
     }

--- a/packages/web-pkg/tests/unit/components/ItemFilter.spec.ts
+++ b/packages/web-pkg/tests/unit/components/ItemFilter.spec.ts
@@ -13,6 +13,7 @@ const selectors = {
   filterInput: '.item-filter-input input',
   checkboxStub: 'oc-checkbox-stub',
   filterListItem: '.item-filter-list-item',
+  activeFilterListItem: '.item-filter-list-item-active',
   clearBtn: '.oc-filter-chip-clear'
 }
 
@@ -64,22 +65,20 @@ describe('ItemFilter', () => {
       }
       expect(wrapper.vm.selectedItems.length).toBe(wrapper.findAll(selectors.filterListItem).length)
     })
-    it('does not allow selection of multiple items on click when disabled', async () => {
+    it('does not allow selection of multiple items when disabled', async () => {
       const { wrapper } = getWrapper({ props: { allowMultiple: false } })
       const first = wrapper.findAll(selectors.filterListItem).at(0)
       await first.trigger('click')
       expect(wrapper.emitted('selectionChange').length).toBe(1)
-      expect(first.findComponent<any>(selectors.checkboxStub).props('modelValue')).toBeTruthy()
+      expect(wrapper.find(selectors.activeFilterListItem).exists()).toBeTruthy()
 
       const second = wrapper.findAll(selectors.filterListItem).at(1)
       await second.trigger('click')
-      expect(wrapper.emitted('selectionChange').length).toBe(1)
-      expect(second.findComponent<any>(selectors.checkboxStub).props('modelValue')).toBeFalsy()
-      expect(second.findComponent<any>(selectors.checkboxStub).props('disabled')).toBeTruthy()
+      expect(wrapper.emitted('selectionChange').length).toBe(2)
       expect(wrapper.vm.selectedItems.length).toBe(1)
     })
-    it('can always de-select the current selected item', async () => {
-      const { wrapper } = getWrapper({ props: { allowMultiple: false } })
+    it('does de-select the current selected item on click', async () => {
+      const { wrapper } = getWrapper({ props: { allowMultiple: true } })
       const item = wrapper.findAll(selectors.filterListItem).at(0)
       await item.trigger('click')
       await item.trigger('click')
@@ -88,7 +87,7 @@ describe('ItemFilter', () => {
       expect(wrapper.vm.selectedItems.length).toBe(0)
     })
     it('clears the selection when the clear-button is being clicked', async () => {
-      const { wrapper } = getWrapper({ props: { allowMultiple: false } })
+      const { wrapper } = getWrapper({ props: { allowMultiple: true } })
       const item = wrapper.findAll(selectors.filterListItem).at(0)
       await item.trigger('click')
       await wrapper.find(selectors.clearBtn).trigger('click')

--- a/packages/web-pkg/tests/unit/components/__snapshots__/ItemFilter.spec.ts.snap
+++ b/packages/web-pkg/tests/unit/components/__snapshots__/ItemFilter.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`ItemFilter can use a custom attribute as display name 1`] = `
 <div class="item-filter oc-flex item-filter-users">
   <div class="oc-filter-chip oc-flex">
-    <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-filter-chip-button oc-pill" id="oc-filter-chip-5" type="button">
+    <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-filter-chip-button oc-pill" id="oc-filter-chip-3" type="button">
       <!-- @slot Content of the button -->
       <!--v-if-->
       <span class="oc-text-truncate oc-filter-chip-label">Users</span>
@@ -12,29 +12,35 @@ exports[`ItemFilter can use a custom attribute as display name 1`] = `
         <!---->
       </span>
     </button>
-    <div class="oc-drop oc-box-shadow-medium oc-rounded oc-filter-chip-drop" id="oc-drop-6">
+    <div class="oc-drop oc-box-shadow-medium oc-rounded oc-filter-chip-drop" id="oc-drop-4">
       <div class="oc-card oc-card-body oc-background-secondary oc-p-s">
         <!--v-if-->
         <div>
           <ul class="oc-list oc-my-rm oc-mx-rm item-filter-list">
             <li class="oc-my-xs">
-              <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-passive oc-button-passive-raw item-filter-list-item oc-flex oc-flex-left oc-flex-middle oc-width-1-1 oc-p-xs" data-test-value="Albert Einstein" type="button">
+              <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-space-between oc-button-gap-m oc-button-passive oc-button-passive-raw item-filter-list-item oc-flex oc-flex-left oc-flex-middle oc-width-1-1 oc-p-xs" data-test-value="Albert Einstein" type="button">
                 <!-- @slot Content of the button -->
-                <div>
-                  <oc-checkbox-stub class="item-filter-checkbox" disabled="false" hidelabel="true" id="oc-checkbox-7" label="Toggle selection" modelvalue="false" outline="false" size="large"></oc-checkbox-stub>
+                <div class="oc-flex oc-flex-middle oc-text-truncate">
+                  <!--v-if-->
+                  <div></div>
+                  <div class="oc-text-truncate oc-ml-s">Albert Einstein</div>
                 </div>
-                <div></div>
-                <div class="oc-text-truncate">Albert Einstein</div>
+                <div class="oc-flex">
+                  <!--v-if-->
+                </div>
               </button>
             </li>
             <li class="oc-my-xs">
-              <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-passive oc-button-passive-raw item-filter-list-item oc-flex oc-flex-left oc-flex-middle oc-width-1-1 oc-p-xs" data-test-value="Marie Curie" type="button">
+              <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-space-between oc-button-gap-m oc-button-passive oc-button-passive-raw item-filter-list-item oc-flex oc-flex-left oc-flex-middle oc-width-1-1 oc-p-xs" data-test-value="Marie Curie" type="button">
                 <!-- @slot Content of the button -->
-                <div>
-                  <oc-checkbox-stub class="item-filter-checkbox" disabled="false" hidelabel="true" id="oc-checkbox-8" label="Toggle selection" modelvalue="false" outline="false" size="large"></oc-checkbox-stub>
+                <div class="oc-flex oc-flex-middle oc-text-truncate">
+                  <!--v-if-->
+                  <div></div>
+                  <div class="oc-text-truncate oc-ml-s">Marie Curie</div>
                 </div>
-                <div></div>
-                <div class="oc-text-truncate">Marie Curie</div>
+                <div class="oc-flex">
+                  <!--v-if-->
+                </div>
               </button>
             </li>
           </ul>
@@ -64,23 +70,29 @@ exports[`ItemFilter renders all items 1`] = `
         <div>
           <ul class="oc-list oc-my-rm oc-mx-rm item-filter-list">
             <li class="oc-my-xs">
-              <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-passive oc-button-passive-raw item-filter-list-item oc-flex oc-flex-left oc-flex-middle oc-width-1-1 oc-p-xs" data-test-value="Albert Einstein" type="button">
+              <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-space-between oc-button-gap-m oc-button-passive oc-button-passive-raw item-filter-list-item oc-flex oc-flex-left oc-flex-middle oc-width-1-1 oc-p-xs" data-test-value="Albert Einstein" type="button">
                 <!-- @slot Content of the button -->
-                <div>
-                  <oc-checkbox-stub class="item-filter-checkbox" disabled="false" hidelabel="true" id="oc-checkbox-3" label="Toggle selection" modelvalue="false" outline="false" size="large"></oc-checkbox-stub>
+                <div class="oc-flex oc-flex-middle oc-text-truncate">
+                  <!--v-if-->
+                  <div></div>
+                  <div class="oc-text-truncate oc-ml-s">Albert Einstein</div>
                 </div>
-                <div></div>
-                <div class="oc-text-truncate">Albert Einstein</div>
+                <div class="oc-flex">
+                  <!--v-if-->
+                </div>
               </button>
             </li>
             <li class="oc-my-xs">
-              <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-passive oc-button-passive-raw item-filter-list-item oc-flex oc-flex-left oc-flex-middle oc-width-1-1 oc-p-xs" data-test-value="Marie Curie" type="button">
+              <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-space-between oc-button-gap-m oc-button-passive oc-button-passive-raw item-filter-list-item oc-flex oc-flex-left oc-flex-middle oc-width-1-1 oc-p-xs" data-test-value="Marie Curie" type="button">
                 <!-- @slot Content of the button -->
-                <div>
-                  <oc-checkbox-stub class="item-filter-checkbox" disabled="false" hidelabel="true" id="oc-checkbox-4" label="Toggle selection" modelvalue="false" outline="false" size="large"></oc-checkbox-stub>
+                <div class="oc-flex oc-flex-middle oc-text-truncate">
+                  <!--v-if-->
+                  <div></div>
+                  <div class="oc-text-truncate oc-ml-s">Marie Curie</div>
                 </div>
-                <div></div>
-                <div class="oc-text-truncate">Marie Curie</div>
+                <div class="oc-flex">
+                  <!--v-if-->
+                </div>
               </button>
             </li>
           </ul>

--- a/tests/acceptance/features/webUIFilesSearch/search.feature
+++ b/tests/acceptance/features/webUIFilesSearch/search.feature
@@ -1,4 +1,4 @@
-@issue-ocis-1330
+@skipOnOC10 @issue-ocis-6378 @issue-ocis-1330
 Feature: Search
 
   As a user


### PR DESCRIPTION
## Description
Fixes the search syntax when combining multiple filters together with the search term. For now, only one tag can be selected in the filter due to a server restriction. Also updates the `ItemFilter` component to properly display single-select filters.

This is a follow-up for the most recent search filter PRs.

Note that the PR breaks the search for oC10, see here for more detail: https://github.com/owncloud/ocis/issues/6378#issuecomment-1562498414

## Screenshots
<img width="308" alt="image" src="https://github.com/owncloud/web/assets/50302941/96383227-c1b3-4e73-a2f3-218cc3ed5564">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
