### PR TITLE
fix: wrap public link resolve error messages in $gettext

### DIFF
--- a/packages/web-runtime/src/pages/resolvePublicLink.vue
+++ b/packages/web-runtime/src/pages/resolvePublicLink.vue
@@ -89,6 +89,7 @@ export default defineComponent({
     const clientService = useClientService()
     const router = useRouter()
     const store = useStore()
+    const { $gettext } = useGettext()
     const token = useRouteParam('token')
     const redirectUrl = useRouteQuery('redirectUrl')
     const password = ref('')
@@ -130,7 +131,7 @@ export default defineComponent({
           return true
         }
         if (error.statusCode === 404) {
-          throw new Error('The resource could not be located, it may not exist anymore.')
+          throw new Error($gettext('The resource could not be located, it may not exist anymore.'))
         }
         throw error
       }
@@ -138,7 +139,7 @@ export default defineComponent({
     const loadPublicLinkTask = useTask(function* () {
       const resource = yield clientService.webdav.getFileInfo(unref(publicLinkSpace))
       if (!isPublicSpaceResource(resource)) {
-        const e: any = new Error('resolved resource has wrong type')
+        const e: any = new Error($gettext('The resource is not a public link.'))
         e.resource = resource
         throw e
       }
@@ -230,7 +231,6 @@ export default defineComponent({
       }
     })
 
-    const { $gettext } = useGettext()
     const footerSlogan = computed(() => store.getters.configuration.currentTheme.general.slogan)
     const passwordFieldLabel = computed(() => {
       return $gettext('Enter password for public link')


### PR DESCRIPTION
## Description
Translations for public link error messages are completely missing. Added `$gettext` wrapper to the error messages so that the strings can be extracted for transifex.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
