### PR TITLE
[tests-only][full-ci]Bump ocis commit id for tests

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=2dfb20b3547dd265066a514d30fbf01df1c8c07c
+OCIS_COMMITID=151c3f66a99300d95537d617f92cb5ef55d5f9cf
 OCIS_BRANCH=master


### PR DESCRIPTION
Part of: https://github.com/owncloud/QA/issues/809

This PR bumps the ocis commit id for tests 