### PR TITLE
fix: share indicator loading after pasting resources

### DIFF
--- a/changelog/unreleased/bugfix-share-indicator-after-pasting
+++ b/changelog/unreleased/bugfix-share-indicator-after-pasting
@@ -1,0 +1,6 @@
+Bugfix: Share indicator loading after pasting resources
+
+Share indicators are now being displayed correctly after pasting resources into shared folders.
+
+https://github.com/owncloud/web/issues/9030
+https://github.com/owncloud/web/pull/9110

--- a/packages/web-app-files/src/store/actions.ts
+++ b/packages/web-app-files/src/store/actions.ts
@@ -125,7 +125,9 @@ export default {
         }
 
         return Promise.all(loadingResources).then(() => {
+          const currentFolder = context.getters.currentFolder
           context.commit('UPSERT_RESOURCES', fetchedResources)
+          context.commit('LOAD_INDICATORS', currentFolder.path)
         })
       },
       { debounceTime: 0 }


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9030

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
