### PR TITLE
[tests-only] Fix notification selection

### DIFF
--- a/tests/e2e/support/objects/app-files/link/actions.ts
+++ b/tests/e2e/support/objects/app-files/link/actions.ts
@@ -103,8 +103,8 @@ export const createLink = async (args: createLinkArgs): Promise<string> => {
 }
 
 export const waitForPopupNotPresent = async (page): Promise<void> => {
-  await page.locator(linkUpdateDialog).waitFor()
-  await page.locator(linkUpdateDialog).waitFor({ state: 'detached' })
+  await page.locator(linkUpdateDialog).last().waitFor()
+  await page.locator(linkUpdateDialog).last().waitFor({ state: 'detached' })
 }
 
 export const changeRole = async (args: changeRoleArgs): Promise<string> => {
@@ -129,7 +129,7 @@ export const changeRole = async (args: changeRoleArgs): Promise<string> => {
     page.locator(util.format(publicLinkSetRoleButton, role.toLowerCase())).click()
   ])
 
-  const message = await page.locator(linkUpdateDialog).textContent()
+  const message = await page.locator(linkUpdateDialog).last().textContent()
   expect(message.trim()).toBe('Link was updated successfully')
   return await page.locator(publicLinkCurrentRole).textContent()
 }
@@ -149,7 +149,7 @@ export const changeName = async (args: changeNameArgs): Promise<string> => {
   await page.locator(editPublicLinkRenameButton).click()
   await page.locator(editPublicLinkInput).fill(newName)
   await page.locator(editPublicLinkRenameConfirm).click()
-  const message = await page.locator(linkUpdateDialog).textContent()
+  const message = await page.locator(linkUpdateDialog).last().textContent()
   expect(message.trim()).toBe('Link was updated successfully')
   return await page.locator(getMostRecentLink + '//h4').textContent()
 }
@@ -167,7 +167,7 @@ export const addPassword = async (args: addPasswordArgs): Promise<void> => {
   await page.locator(editPublicLinkAddPasswordButton).click()
   await page.locator(editPublicLinkInput).fill(newPassword)
   await page.locator(editPublicLinkRenameConfirm).click()
-  const message = await page.locator(linkUpdateDialog).textContent()
+  const message = await page.locator(linkUpdateDialog).last().textContent()
   expect(message.trim()).toBe('Link was updated successfully')
 }
 
@@ -203,7 +203,7 @@ export const deleteLink = async (args: deleteLinkArgs): Promise<void> => {
   await page.locator(util.format(editPublicLinkButton, name)).click()
   await page.locator(util.format(deleteLinkButton, name)).click()
   await page.locator(confirmDeleteButton).click()
-  const message = await page.locator(linkUpdateDialog).textContent()
+  const message = await page.locator(linkUpdateDialog).last().textContent()
   expect(message.trim()).toBe('Link was deleted successfully')
 }
 


### PR DESCRIPTION
## Description
Select the last notification from the list which is the latest notification for the given action

Fixes the flakiness due to the selector resolving to more than one element

## Related Issue

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
