### PR TITLE
[tests-only][full-ci]Added e2e test admin manage space created by other space admin

### DIFF
--- a/tests/e2e/cucumber/features/smoke/admin-settings/spaces.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/admin-settings/spaces.ocis.feature
@@ -148,18 +148,26 @@ Feature: spaces management
     When "Alice" logs in
     And "Alice" opens the "admin-settings" app
     And "Alice" navigates to the project spaces management page
-    When "Alice" updates the space "team.a" name to "brian team" using the context-menu
-    And "Alice" updates the space "team.b" name to "carol team" using the context-menu
-    And "Alice" updates the space "team.a" quota to "10" using the context-menu
-    And "Alice" updates the space "team.b" quota to "50" using the context-menu
-    And "Alice" disables the space "team.a" using the context-menu
-    And "Alice" disables the space "team.b" using the context-menu
-    And "Alice" enables the space "team.a" using the context-menu
-    And "Alice" enables the space "team.b" using the context-menu
-    And "Alice" disables the space "team.a" using the context-menu
-    And "Alice" disables the space "team.b" using the context-menu
-    And "Alice" deletes the space "team.a" using the context-menu
-    And "Alice" deletes the space "team.b" using the context-menu
+    And "Alice" updates quota of the following spaces to "50" using the batch-actions
+      | id     |
+      | team.a |
+      | team.b |
+    And "Alice" disables the following spaces using the batch-actions
+      | id     |
+      | team.a |
+      | team.b |
+    And "Alice" enables the following spaces using the batch-actions
+      | id     |
+      | team.a |
+      | team.b |
+    And "Alice" disables the following spaces using the batch-actions
+      | id     |
+      | team.a |
+      | team.b |
+    And "Alice" deletes the following spaces using the batch-actions
+      | id     |
+      | team.a |
+      | team.b |
     Then "Alice" should not see the following spaces
       | id     |
       | team.a |

--- a/tests/e2e/cucumber/features/smoke/admin-settings/spaces.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/admin-settings/spaces.ocis.feature
@@ -131,20 +131,20 @@ Feature: spaces management
       | Brian |
       | Carol |
     And "Admin" assigns following roles to the users using API
-      | id    | role  |
-      | Alice | Admin |
-    And "Admin" assigns following roles to the users using API
       | id    | role        |
+      | Alice | Admin       |
       | Brian | Space Admin |
       | Carol | Space Admin |
+    When "Brian" logs in
     And "Brian" creates the following project spaces using API
       | name   | id     |
       | team A | team.a |
+    When "Carol" logs in
     And "Carol" creates the following project spaces using API
       | name   | id     |
       | team B | team.b |
     When "Alice" logs in
-    And "Alice" opens the "admin-settings" app
+    When "Alice" opens the "admin-settings" app
     And "Alice" navigates to the project spaces management page
     When "Alice" updates the space "team.a" name to "brian team" using the context-menu
     And "Alice" updates the space "team.b" name to "carol team" using the context-menu
@@ -163,3 +163,5 @@ Feature: spaces management
       | team.a |
       | team.b |
     And "Alice" logs out
+    And "Brian" logs out
+    And "Carol" logs out

--- a/tests/e2e/cucumber/features/smoke/admin-settings/spaces.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/admin-settings/spaces.ocis.feature
@@ -124,7 +124,7 @@ Feature: spaces management
     And "Alice" logs out
 
 
-  Scenario: admin user can manage the spaces created by other space admin user via context menu
+  Scenario: admin user can manage the spaces created by other space admin user
     Given "Admin" creates following users using API
       | id    |
       | Alice |
@@ -139,12 +139,14 @@ Feature: spaces management
     And "Brian" creates the following project spaces using API
       | name   | id     |
       | team A | team.a |
+    And "Brian" logs out
     When "Carol" logs in
     And "Carol" creates the following project spaces using API
       | name   | id     |
       | team B | team.b |
+    And "Carol" logs out
     When "Alice" logs in
-    When "Alice" opens the "admin-settings" app
+    And "Alice" opens the "admin-settings" app
     And "Alice" navigates to the project spaces management page
     When "Alice" updates the space "team.a" name to "brian team" using the context-menu
     And "Alice" updates the space "team.b" name to "carol team" using the context-menu
@@ -163,5 +165,3 @@ Feature: spaces management
       | team.a |
       | team.b |
     And "Alice" logs out
-    And "Brian" logs out
-    And "Carol" logs out

--- a/tests/e2e/cucumber/features/smoke/admin-settings/spaces.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/admin-settings/spaces.ocis.feature
@@ -122,3 +122,44 @@ Feature: spaces management
       | David | Can view   |
       | Edith | Can view   |
     And "Alice" logs out
+
+
+  Scenario: admin user can manage the spaces created by other space admin user via context menu
+    Given "Admin" creates following users using API
+      | id    |
+      | Alice |
+      | Brian |
+      | Carol |
+    And "Admin" assigns following roles to the users using API
+      | id    | role  |
+      | Alice | Admin |
+    And "Admin" assigns following roles to the users using API
+      | id    | role        |
+      | Brian | Space Admin |
+      | Carol | Space Admin |
+    And "Brian" creates the following project spaces using API
+      | name   | id     |
+      | team A | team.a |
+    And "Carol" creates the following project spaces using API
+      | name   | id     |
+      | team B | team.b |
+    When "Alice" logs in
+    And "Alice" opens the "admin-settings" app
+    And "Alice" navigates to the project spaces management page
+    When "Alice" updates the space "team.a" name to "brian team" using the context-menu
+    And "Alice" updates the space "team.b" name to "carol team" using the context-menu
+    And "Alice" updates the space "team.a" quota to "10" using the context-menu
+    And "Alice" updates the space "team.b" quota to "50" using the context-menu
+    And "Alice" disables the space "team.a" using the context-menu
+    And "Alice" disables the space "team.b" using the context-menu
+    And "Alice" enables the space "team.a" using the context-menu
+    And "Alice" enables the space "team.b" using the context-menu
+    And "Alice" disables the space "team.a" using the context-menu
+    And "Alice" disables the space "team.b" using the context-menu
+    And "Alice" deletes the space "team.a" using the context-menu
+    And "Alice" deletes the space "team.b" using the context-menu
+    Then "Alice" should not see the following spaces
+      | id     |
+      | team.a |
+      | team.b |
+    And "Alice" logs out


### PR DESCRIPTION
### Description
This pr adds e2e test for admin to be able to manage the space create by other space admin users.

### Related issue:
https://github.com/owncloud/web/issues/8763

### TODO after merged
- [ ] back port to stable-7.0
