### PR TITLE
fix: empty tables after deleting items in admin-settings

### DIFF
--- a/changelog/unreleased/enhancement-admin-settings-support-pagination
+++ b/changelog/unreleased/enhancement-admin-settings-support-pagination
@@ -5,3 +5,4 @@ So there will be a page selection at the end of the list if more than 50 items a
 
 https://github.com/owncloud/web/issues/9048
 https://github.com/owncloud/web/pull/9119
+https://github.com/owncloud/web/pull/9136


### PR DESCRIPTION
## Description
Adds a pagination reset after deleting all items on the last page of the users-, groups- and spaces-list. This fixes potential empty tables in such scenarios.

Follow-up for https://github.com/owncloud/web/pull/9119.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
