### PR TITLE
refactor: rename permissions

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=151c3f66a99300d95537d617f92cb5ef55d5f9cf
+OCIS_COMMITID=aff8a7dfb58896a04ed57f12f48901948b1785cc
 OCIS_BRANCH=master

--- a/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsEditQuota.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsEditQuota.ts
@@ -39,7 +39,7 @@ export const useUserActionsEditQuota = () => {
           return false
         }
 
-        return ability.can('set-quota-all', 'Space')
+        return ability.can('set-quota-all', 'Drive')
       },
       componentType: 'button',
       class: 'oc-users-actions-edit-quota-trigger'

--- a/packages/web-app-admin-settings/src/index.ts
+++ b/packages/web-app-admin-settings/src/index.ts
@@ -31,7 +31,7 @@ const routes = ({ $ability }: { $ability: Ability }) => [
       if ($ability.can('read-all', 'Group')) {
         return { name: 'admin-settings-groups' }
       }
-      if ($ability.can('read-all', 'Space')) {
+      if ($ability.can('read-all', 'Drive')) {
         return { name: 'admin-settings-spaces' }
       }
       throw Error('Insufficient permissions')
@@ -87,7 +87,7 @@ const routes = ({ $ability }: { $ability: Ability }) => [
     name: 'admin-settings-spaces',
     component: Spaces,
     beforeEnter: (to, from, next) => {
-      if (!$ability.can('read-all', 'Space')) {
+      if (!$ability.can('read-all', 'Drive')) {
         next({ path: '/' })
       }
       next()
@@ -137,7 +137,7 @@ const navItems = ({ $ability }: { $ability: Ability }): AppNavigationItem[] => [
       path: `/${appInfo.id}/spaces?`
     },
     enabled: () => {
-      return $ability.can('read-all', 'Space')
+      return $ability.can('read-all', 'Drive')
     }
   }
 ]

--- a/packages/web-app-admin-settings/tests/unit/composables/actions/users/useUserActionsEditQuota.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/composables/actions/users/useUserActionsEditQuota.spec.ts
@@ -101,7 +101,7 @@ function getWrapper({
         store,
         mocks,
         pluginOptions: {
-          abilities: canEditSpaceQuota ? [{ action: 'set-quota-all', subject: 'Space' }] : []
+          abilities: canEditSpaceQuota ? [{ action: 'set-quota-all', subject: 'Drive' }] : []
         }
       }
     )

--- a/packages/web-app-files/src/composables/actions/files/useFileActionsCreateSpaceFromResource.ts
+++ b/packages/web-app-files/src/composables/actions/files/useFileActionsCreateSpaceFromResource.ts
@@ -17,7 +17,7 @@ export const useFileActionsCreateSpaceFromResource = ({ store }: { store?: Store
   const { checkSpaceNameModalInput } = useSpaceHelpers()
   const clientService = useClientService()
   const router = useRouter()
-  const hasCreatePermission = computed(() => can('create-all', 'Space'))
+  const hasCreatePermission = computed(() => can('create-all', 'Drive'))
 
   const confirmAction = async ({ spaceName, resources, space }) => {
     const { webdav } = clientService

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -140,7 +140,7 @@ export default defineComponent({
       return loadResourcesTask.isRunning || !loadResourcesTask.last
     })
 
-    const hasCreatePermission = computed(() => can('create-all', 'Space'))
+    const hasCreatePermission = computed(() => can('create-all', 'Drive'))
     const viewModes = computed(() => [ViewModeConstants.tilesView])
 
     onMounted(async () => {

--- a/packages/web-app-files/tests/unit/components/Spaces/SpaceContextActions.spec.ts
+++ b/packages/web-app-files/tests/unit/components/Spaces/SpaceContextActions.spec.ts
@@ -39,7 +39,7 @@ function getWrapper(space) {
         mocks,
         plugins: [
           ...defaultPlugins({
-            abilities: [{ action: 'set-quota-all', subject: 'Space' }]
+            abilities: [{ action: 'set-quota-all', subject: 'Drive' }]
           }),
           store
         ]

--- a/packages/web-app-files/tests/unit/views/spaces/Projects.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/Projects.spec.ts
@@ -68,7 +68,7 @@ describe('Projects view', () => {
   })
   it('should display the "Create Space"-button when permission given', () => {
     const { wrapper } = getMountedWrapper({
-      abilities: [{ action: 'create-all', subject: 'Space' }],
+      abilities: [{ action: 'create-all', subject: 'Drive' }],
       stubAppBar: false
     })
     expect(wrapper.find('create-space-stub').exists()).toBeTruthy()

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -171,19 +171,19 @@ export function buildSpace(data): SpaceResource {
       return true
     },
     canBeDeleted: function ({ user, ability }: { user?: User; ability?: any } = {}) {
-      return this.disabled && (ability?.can('delete-all', 'Space') || this.isManager(user))
+      return this.disabled && (ability?.can('delete-all', 'Drive') || this.isManager(user))
     },
     canRename: function ({ user, ability }: { user?: User; ability?: any } = {}) {
-      return ability?.can('update-all', 'Space') || this.isManager(user)
+      return ability?.can('update-all', 'Drive') || this.isManager(user)
     },
     canEditDescription: function ({ user, ability }: { user?: User; ability?: any } = {}) {
-      return ability?.can('update-all', 'Space') || this.isManager(user)
+      return ability?.can('update-all', 'Drive') || this.isManager(user)
     },
     canRestore: function ({ user, ability }: { user?: User; ability?: any } = {}) {
-      return this.disabled && (ability?.can('update-all', 'Space') || this.isManager(user))
+      return this.disabled && (ability?.can('update-all', 'Drive') || this.isManager(user))
     },
     canDisable: function ({ user, ability }: { user?: User; ability?: any } = {}) {
-      return !this.disabled && (ability?.can('delete-all', 'Space') || this.isManager(user))
+      return !this.disabled && (ability?.can('delete-all', 'Drive') || this.isManager(user))
     },
     canShare: function ({ user }: { user?: User } = {}) {
       return this.isManager(user)

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditQuota.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditQuota.ts
@@ -33,7 +33,7 @@ export const useSpaceActionsEditQuota = ({ store }: { store?: Store<any> } = {})
         if (resources.some((r) => r.spaceQuota === false)) {
           return false
         }
-        return ability.can('set-quota-all', 'Space')
+        return ability.can('set-quota-all', 'Drive')
       },
       componentType: 'button',
       class: 'oc-files-actions-edit-quota-trigger'

--- a/packages/web-pkg/src/utils/types.ts
+++ b/packages/web-pkg/src/utils/types.ts
@@ -19,13 +19,13 @@ export type AbilityActions =
 
 export type AbilitySubjects =
   | 'Account'
+  | 'Drive'
   | 'Group'
   | 'Language'
   | 'Logo'
   | 'PublicLink'
   | 'Role'
   | 'Setting'
-  | 'Space'
 
 export type Ability = MongoAbility<[AbilityActions, AbilitySubjects]>
 

--- a/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsEditQuota.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsEditQuota.spec.ts
@@ -82,7 +82,7 @@ function getWrapper({
         store,
         mocks,
         pluginOptions: {
-          abilities: canEditSpaceQuota ? [{ action: 'set-quota-all', subject: 'Space' }] : []
+          abilities: canEditSpaceQuota ? [{ action: 'set-quota-all', subject: 'Drive' }] : []
         }
       }
     )

--- a/packages/web-runtime/src/services/auth/abilities.ts
+++ b/packages/web-runtime/src/services/auth/abilities.ts
@@ -5,41 +5,41 @@ export const getAbilities = (
   permissions: string[]
 ): SubjectRawRule<AbilityActions, AbilitySubjects, any>[] => {
   const abilities: Record<string, SubjectRawRule<AbilityActions, AbilitySubjects, any>[]> = {
-    'account-management.all': [
+    'Accounts.ReadWrite.all': [
       { action: 'create-all', subject: 'Account' },
       { action: 'delete-all', subject: 'Account' },
       { action: 'read-all', subject: 'Account' },
       { action: 'update-all', subject: 'Account' }
     ],
-    'group-management.all': [
+    'Groups.ReadWrite.all': [
       { action: 'create-all', subject: 'Group' },
       { action: 'delete-all', subject: 'Group' },
       { action: 'read-all', subject: 'Group' },
       { action: 'update-all', subject: 'Group' }
     ],
-    'language-readwrite.all': [
+    'Language.ReadWrite.all': [
       { action: 'read-all', subject: 'Language' },
       { action: 'update-all', subject: 'Language' }
     ],
-    'change-logo.all': [{ action: 'update-all', subject: 'Logo' }],
+    'Logo.Write.all': [{ action: 'update-all', subject: 'Logo' }],
     'PublicLink.Write.all': [{ action: 'create-all', subject: 'PublicLink' }],
-    'role-management.all': [
+    'Roles.ReadWrite.all': [
       { action: 'create-all', subject: 'Role' },
       { action: 'delete-all', subject: 'Role' },
       { action: 'read-all', subject: 'Role' },
       { action: 'update-all', subject: 'Role' }
     ],
-    'settings-management.all': [
+    'Settings.ReadWrite.all': [
       { action: 'read-all', subject: 'Setting' },
       { action: 'update-all', subject: 'Setting' }
     ],
-    'create-space.all': [{ action: 'create-all', subject: 'Space' }],
-    'Drive.ReadWriteEnabled.all': [
-      { action: 'delete-all', subject: 'Space' },
-      { action: 'update-all', subject: 'Space' }
+    'Drives.Create.all': [{ action: 'create-all', subject: 'Drive' }],
+    'Drives.ReadWriteEnabled.all': [
+      { action: 'delete-all', subject: 'Drive' },
+      { action: 'update-all', subject: 'Drive' }
     ],
-    'list-all-spaces.all': [{ action: 'read-all', subject: 'Space' }],
-    'Drive.ReadWriteQuota.Project.all': [{ action: 'set-quota-all', subject: 'Space' }]
+    'Drives.List.all': [{ action: 'read-all', subject: 'Drive' }],
+    'Drives.ReadWriteProjectQuota.all': [{ action: 'set-quota-all', subject: 'Drive' }]
   }
 
   return Object.keys(abilities).reduce((acc, permission) => {

--- a/packages/web-runtime/tests/unit/services/auth/abilities.spec.ts
+++ b/packages/web-runtime/tests/unit/services/auth/abilities.spec.ts
@@ -6,27 +6,27 @@ describe('getAbilities', () => {
     expect(abilities.length).toBe(0)
   })
   it('gets correct abilities for subject "Account"', function () {
-    const abilities = getAbilities(['account-management.all'])
+    const abilities = getAbilities(['Accounts.ReadWrite.all'])
     const expectedActions = ['create-all', 'delete-all', 'read-all', 'update-all']
     expect(abilities).toEqual(expectedActions.map((action) => ({ action, subject: 'Account' })))
   })
   it('gets correct abilities for subject "Group"', function () {
-    const abilities = getAbilities(['group-management.all'])
+    const abilities = getAbilities(['Groups.ReadWrite.all'])
     const expectedActions = ['create-all', 'delete-all', 'read-all', 'update-all']
     expect(abilities).toEqual(expectedActions.map((action) => ({ action, subject: 'Group' })))
   })
   it('gets correct abilities for subject "Language"', function () {
-    const abilities = getAbilities(['language-readwrite.all'])
+    const abilities = getAbilities(['Language.ReadWrite.all'])
     const expectedActions = ['read-all', 'update-all']
     expect(abilities).toEqual(expectedActions.map((action) => ({ action, subject: 'Language' })))
   })
   it('gets correct abilities for subject "Logo"', function () {
-    const abilities = getAbilities(['change-logo.all'])
+    const abilities = getAbilities(['Logo.Write.all'])
     const expectedActions = ['update-all']
     expect(abilities).toEqual(expectedActions.map((action) => ({ action, subject: 'Logo' })))
   })
   it('gets correct abilities for subject "Role"', function () {
-    const abilities = getAbilities(['role-management.all'])
+    const abilities = getAbilities(['Roles.ReadWrite.all'])
     const expectedActions = ['create-all', 'delete-all', 'read-all', 'update-all']
     expect(abilities).toEqual(expectedActions.map((action) => ({ action, subject: 'Role' })))
   })
@@ -36,19 +36,19 @@ describe('getAbilities', () => {
     expect(abilities).toEqual(expectedActions.map((action) => ({ action, subject: 'PublicLink' })))
   })
   it('gets correct abilities for subject "Setting"', function () {
-    const abilities = getAbilities(['settings-management.all'])
+    const abilities = getAbilities(['Settings.ReadWrite.all'])
     const expectedActions = ['read-all', 'update-all']
     expect(abilities).toEqual(expectedActions.map((action) => ({ action, subject: 'Setting' })))
   })
   it.each([
     { permissions: [''], expectedActions: [] },
-    { permissions: ['create-space.all'], expectedActions: ['create-all'] },
-    { permissions: ['list-all-spaces.all'], expectedActions: ['read-all'] },
-    { permissions: ['Drive.ReadWriteEnabled.all'], expectedActions: ['delete-all', 'update-all'] },
-    { permissions: ['Drive.ReadWriteQuota.Project.all'], expectedActions: ['set-quota-all'] }
-  ])('gets correct abilities for subject "Space"', function (data) {
+    { permissions: ['Drives.Create.all'], expectedActions: ['create-all'] },
+    { permissions: ['Drives.List.all'], expectedActions: ['read-all'] },
+    { permissions: ['Drives.ReadWriteEnabled.all'], expectedActions: ['delete-all', 'update-all'] },
+    { permissions: ['Drives.ReadWriteProjectQuota.all'], expectedActions: ['set-quota-all'] }
+  ])('gets correct abilities for subject "Drive"', function (data) {
     const abilities = getAbilities(data.permissions)
-    const expectedResult = data.expectedActions.map((action) => ({ action, subject: 'Space' }))
+    const expectedResult = data.expectedActions.map((action) => ({ action, subject: 'Drive' }))
     expect(abilities).toEqual(expectedResult)
   })
 })


### PR DESCRIPTION
## Description
Renames the permissions to match the new names coming from the server. Also renames the `Space` ability subject to `Drive` to go hand in hand with the server's naming convention.

Needs https://github.com/owncloud/ocis/pull/6391 to run properly.

