### PR TITLE
fix: incorrect pause state in upload info modal

### DIFF
--- a/changelog/unreleased/bugfix-upload-info-incorrect-pause
+++ b/changelog/unreleased/bugfix-upload-info-incorrect-pause
@@ -1,0 +1,6 @@
+Bugfix: Incorrect pause state in upload info
+
+An incorrect pause state in the upload info modal has been fixed.
+
+https://github.com/owncloud/web/issues/9080
+https://github.com/owncloud/web/pull/9141

--- a/packages/web-runtime/src/components/UploadInfo.vue
+++ b/packages/web-runtime/src/components/UploadInfo.vue
@@ -459,6 +459,7 @@ export default defineComponent({
       this.remainingTime = undefined
       this.inPreparation = true
       this.inFinalization = false
+      this.uploadsPaused = false
     },
     displayFileAsResource(file) {
       return !!file.targetRoute


### PR DESCRIPTION
## Description
Fixes an incorrect pause state in the upload info modal.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9080

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
