### PR TITLE
Fix 2 small annoyances in search UI

### DIFF
--- a/packages/design-system/src/components/OcSearchBar/OcSearchBar.vue
+++ b/packages/design-system/src/components/OcSearchBar/OcSearchBar.vue
@@ -369,7 +369,7 @@ export default defineComponent({
   }
 
   &-clear {
-    right: var(--oc-space-large);
+    right: var(--oc-space-large) !important;
   }
 
   &-small {

--- a/packages/web-pkg/src/components/ItemFilter.vue
+++ b/packages/web-pkg/src/components/ItemFilter.vue
@@ -19,8 +19,12 @@
           <oc-list class="item-filter-list">
             <li v-for="(item, index) in displayedItems" :key="index" class="oc-my-xs">
               <oc-button
-                class="item-filter-list-item oc-flex oc-flex-left oc-flex-middle oc-width-1-1 oc-p-xs"
-                :class="{ 'item-filter-list-item-active': !allowMultiple && isItemSelected(item) }"
+                class="item-filter-list-item oc-flex oc-flex-middle oc-width-1-1 oc-p-xs"
+                :class="{
+                  'item-filter-list-item-active': !allowMultiple && isItemSelected(item),
+                  'oc-flex-left': allowMultiple,
+                  'oc-flex-between': !allowMultiple
+                }"
                 justify-content="space-between"
                 appearance="raw"
                 :data-test-value="item[displayNameAttribute]"

--- a/packages/web-pkg/tests/unit/components/__snapshots__/ItemFilter.spec.ts.snap
+++ b/packages/web-pkg/tests/unit/components/__snapshots__/ItemFilter.spec.ts.snap
@@ -18,7 +18,7 @@ exports[`ItemFilter can use a custom attribute as display name 1`] = `
         <div>
           <ul class="oc-list oc-my-rm oc-mx-rm item-filter-list">
             <li class="oc-my-xs">
-              <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-space-between oc-button-gap-m oc-button-passive oc-button-passive-raw item-filter-list-item oc-flex oc-flex-left oc-flex-middle oc-width-1-1 oc-p-xs" data-test-value="Albert Einstein" type="button">
+              <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-space-between oc-button-gap-m oc-button-passive oc-button-passive-raw item-filter-list-item oc-flex oc-flex-middle oc-width-1-1 oc-p-xs oc-flex-between" data-test-value="Albert Einstein" type="button">
                 <!-- @slot Content of the button -->
                 <div class="oc-flex oc-flex-middle oc-text-truncate">
                   <!--v-if-->
@@ -31,7 +31,7 @@ exports[`ItemFilter can use a custom attribute as display name 1`] = `
               </button>
             </li>
             <li class="oc-my-xs">
-              <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-space-between oc-button-gap-m oc-button-passive oc-button-passive-raw item-filter-list-item oc-flex oc-flex-left oc-flex-middle oc-width-1-1 oc-p-xs" data-test-value="Marie Curie" type="button">
+              <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-space-between oc-button-gap-m oc-button-passive oc-button-passive-raw item-filter-list-item oc-flex oc-flex-middle oc-width-1-1 oc-p-xs oc-flex-between" data-test-value="Marie Curie" type="button">
                 <!-- @slot Content of the button -->
                 <div class="oc-flex oc-flex-middle oc-text-truncate">
                   <!--v-if-->
@@ -70,7 +70,7 @@ exports[`ItemFilter renders all items 1`] = `
         <div>
           <ul class="oc-list oc-my-rm oc-mx-rm item-filter-list">
             <li class="oc-my-xs">
-              <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-space-between oc-button-gap-m oc-button-passive oc-button-passive-raw item-filter-list-item oc-flex oc-flex-left oc-flex-middle oc-width-1-1 oc-p-xs" data-test-value="Albert Einstein" type="button">
+              <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-space-between oc-button-gap-m oc-button-passive oc-button-passive-raw item-filter-list-item oc-flex oc-flex-middle oc-width-1-1 oc-p-xs oc-flex-between" data-test-value="Albert Einstein" type="button">
                 <!-- @slot Content of the button -->
                 <div class="oc-flex oc-flex-middle oc-text-truncate">
                   <!--v-if-->
@@ -83,7 +83,7 @@ exports[`ItemFilter renders all items 1`] = `
               </button>
             </li>
             <li class="oc-my-xs">
-              <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-space-between oc-button-gap-m oc-button-passive oc-button-passive-raw item-filter-list-item oc-flex oc-flex-left oc-flex-middle oc-width-1-1 oc-p-xs" data-test-value="Marie Curie" type="button">
+              <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-space-between oc-button-gap-m oc-button-passive oc-button-passive-raw item-filter-list-item oc-flex oc-flex-middle oc-width-1-1 oc-p-xs oc-flex-between" data-test-value="Marie Curie" type="button">
                 <!-- @slot Content of the button -->
                 <div class="oc-flex oc-flex-middle oc-text-truncate">
                   <!--v-if-->


### PR DESCRIPTION
## Description
* [fix: tag filter spacing in advanced search](https://github.com/owncloud/web/commit/1d401b6ab6c790a557c77aa21b2784006ec0d654)
* [fix: clear- and advanced-search buttons overlapping](https://github.com/owncloud/web/commit/e7880e6223a086ae296375e500aca1024e06330d)

## Screenshots

### Before

<img width="61" alt="image" src="https://github.com/owncloud/web/assets/50302941/87c11e9f-6b4f-41c4-8cd8-9e2946454556">
<img width="274" alt="image" src="https://github.com/owncloud/web/assets/50302941/a5bd6d36-370c-44d2-b219-3afb4c65b4e6">

### After

<img width="64" alt="image" src="https://github.com/owncloud/web/assets/50302941/634ac93e-0631-46fb-b4a4-e7d2419e043b">
<img width="268" alt="image" src="https://github.com/owncloud/web/assets/50302941/dad24f12-8d99-439e-b03f-7c3506c54a19">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
