### PR TITLE
fix: canCreate permission check in read-only shares

### DIFF
--- a/packages/web-app-files/src/helpers/resources.ts
+++ b/packages/web-app-files/src/helpers/resources.ts
@@ -219,6 +219,7 @@ export function buildSharedResource(
   resource.extension = extractExtensionFromFile(resource)
   resource.isReceivedShare = () => incomingShares
   resource.canUpload = () => SharePermissions.create.enabled(share.permissions)
+  resource.canCreate = () => SharePermissions.create.enabled(share.permissions)
   resource.isMounted = () => false
   resource.share = buildShare(share, resource, allowSharePermission)
   resource.canDeny = () => SharePermissions.denied.enabled(share.permissions)


### PR DESCRIPTION
## Description
Fixes the `canCreate` permission check in read-only shares. The corresponding method was missing for built shares which could lead to broken share views.

https://github.com/owncloud/web/pull/8938 didn't introduce the problem but made it visible.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9042

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
