### PR TITLE
[full-ci] fix: initial space preloading performance

### DIFF
--- a/changelog/unreleased/bugfix-initial-drive-listing
+++ b/changelog/unreleased/bugfix-initial-drive-listing
@@ -1,0 +1,5 @@
+Bugfix: Reduce space preloading
+
+We've reduced the set of spaces that get preloaded after login / after initial page load. This results in a faster first page rendering and reduces the server load. Loading the remaining spaces will happen on demand.
+
+https://github.com/owncloud/web/pull/9153

--- a/packages/web-app-files/src/composables/parentShare/useIncomingParentShare.ts
+++ b/packages/web-app-files/src/composables/parentShare/useIncomingParentShare.ts
@@ -52,6 +52,9 @@ export function useIncomingParentShare() {
   })
 
   const getParentShare = async (resource) => {
+    await store.dispatch('runtime/spaces/loadMountPoints', {
+      graphClient: clientService.graphAuthenticated
+    })
     // do PROPFINDs on parents until root of accepted share is found in `mountpoint` spaces
     let mountPoint = findMatchingMountPoint(resource.id)
     const sharePathSegments = mountPoint ? [] : [resource.name]

--- a/packages/web-runtime/src/pages/resolvePrivateLink.vue
+++ b/packages/web-runtime/src/pages/resolvePrivateLink.vue
@@ -106,6 +106,9 @@ export default defineComponent({
       } else {
         // no matching space found => the file doesn't lie in own spaces => it's a share.
         // do PROPFINDs on parents until root of accepted share is found in `mountpoint` spaces
+        yield store.dispatch('runtime/spaces/loadMountPoints', {
+          graphClient: clientService.graphAuthenticated
+        })
         let mountPoint = findMatchingMountPoint(id)
         resource.value = yield loadFileInfoByIdTask.perform(id)
         const sharePathSegments = mountPoint ? [] : [unref(resource).name]

--- a/packages/web-runtime/src/store/spaces.ts
+++ b/packages/web-runtime/src/store/spaces.ts
@@ -11,6 +11,7 @@ import { AxiosResponse } from 'axios'
 const state = {
   spaces: [],
   spacesInitialized: false,
+  mountPointsInitialized: false,
   spacesLoading: false,
   spaceMembers: []
 }
@@ -18,6 +19,7 @@ const state = {
 const getters = {
   spaces: (state) => state.spaces,
   spacesInitialized: (state) => state.spacesInitialized,
+  mountPointsInitialized: (state) => state.mountPointsInitialized,
   spacesLoading: (state) => state.spacesLoading,
   spaceMembers: (state) => state.spaceMembers
 }
@@ -29,6 +31,9 @@ const mutations = {
   },
   SET_SPACES_INITIALIZED(state, initialized) {
     state.spacesInitialized = initialized
+  },
+  SET_MOUNT_POINTS_INITIALIZED(state, initialized) {
+    state.mountPointsInitialized = initialized
   },
   SET_SPACES_LOADING(state, loading) {
     state.spacesLoading = loading
@@ -113,29 +118,40 @@ const actions = {
   async loadSpaces(context, { graphClient }: { graphClient: Graph }) {
     context.commit('SET_SPACES_LOADING', true)
     try {
-      const graphResponse = await graphClient.drives.listMyDrives()
-      if (!graphResponse.data) {
-        return
-      }
-      const spaces = graphResponse.data.value.map((space) =>
-        buildSpace({ ...space, serverUrl: configurationManager.serverUrl })
-      )
-      context.commit('ADD_SPACES', spaces)
+      /**
+       * FIXME: this is bad for two reasons:
+       * 1. fetching by specific drive type is bad because if more drive types are being added it needs additional code.
+       *    as soon as the backend allows to filter by `driveType neq virtual` we want to use that here.
+       * 2. fetching the mountpoint drives only on first access is kind of error prone, because mount points are
+       *    trying to be accessed in multiple code locations. all of them need to check now if mountpoints need to be
+       *    fetched first. but at the moment fetching mountpoints is kind of expensive, so we need to accept that for now.
+       */
+      const [personalSpaces, projectSpaces] = await Promise.all([
+        loadSpacesByType({ graphClient, driveType: 'personal' }),
+        loadSpacesByType({ graphClient, driveType: 'project' })
+      ])
+      context.commit('ADD_SPACES', [...personalSpaces, ...projectSpaces])
       context.commit('SET_SPACES_INITIALIZED', true)
     } finally {
       context.commit('SET_SPACES_LOADING', false)
     }
   },
-  async reloadProjectSpaces(context, { graphClient }) {
-    const graphResponse = await graphClient.drives.listMyDrives('name asc', 'driveType eq project')
-    if (!graphResponse.data) {
+  async loadMountPoints(context, { graphClient }: { graphClient: Graph }) {
+    // fetching mount points is particularly expensive, so we do that only on first access.
+    if (context.getters.mountPointsInitialized) {
       return
     }
-    const spaces = graphResponse.data.value.map((space) =>
-      buildSpace({ ...space, serverUrl: configurationManager.serverUrl })
-    )
+    try {
+      const mountPointSpaces = await loadSpacesByType({ graphClient, driveType: 'mountpoint' })
+      context.commit('ADD_SPACES', mountPointSpaces)
+    } finally {
+      context.commit('SET_MOUNT_POINTS_INITIALIZED', true)
+    }
+  },
+  async reloadProjectSpaces(context, { graphClient }) {
+    const projectSpaces = await loadSpacesByType({ graphClient, driveType: 'project' })
     context.commit('CLEAR_PROJECT_SPACES')
-    context.commit('ADD_SPACES', spaces)
+    context.commit('ADD_SPACES', projectSpaces)
   },
   async loadSpaceMembers(
     context,
@@ -248,6 +264,25 @@ const actions = {
 
     context.commit('REMOVE_SPACE_MEMBER', share)
   }
+}
+
+const loadSpacesByType = async ({
+  graphClient,
+  driveType
+}: {
+  graphClient: Graph
+  driveType: string
+}): Promise<SpaceResource[]> => {
+  const graphResponse = await graphClient.drives.listMyDrives(
+    'name asc',
+    `driveType eq ${driveType}`
+  )
+  if (!graphResponse.data) {
+    return []
+  }
+  return graphResponse.data.value.map((space) =>
+    buildSpace({ ...space, serverUrl: configurationManager.serverUrl })
+  )
 }
 
 export default {


### PR DESCRIPTION
## Description
This PR reduces the initial space preloading to only loading `personal` and `project` spaces. The `virtual/shares` space (share jail) is never needed and hence never loaded. The `mountpoint` spaces will be loaded on demand for now. This has some drawbacks (see comment in the code) but is necessary for performance tuning at the moment. Initially preloading the mountpoints might come back at a later point. Preloading the share jail makes no sense, as web doesn't use it, and will not be reintroduced.

## Motivation and Context
Tuning performance and backend load, especially when a lot of users sign in at the same time.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
