### PR TITLE
Automate cert handling with traefik and vite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,4 +65,5 @@ tests/acceptance/report/cucumber_report.html
 
 # dev setup certificates
 /dev/docker/ocis-ca
+/dev/docker/traefik/certificates
 docker-compose.override.yml

--- a/dev/docker/traefik/configs/tls.yml
+++ b/dev/docker/traefik/configs/tls.yml
@@ -1,0 +1,6 @@
+tls:
+  stores:
+    default:
+      defaultCertificate:
+        certFile: /certificates/server.crt
+        keyFile: /certificates/server.key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,6 +188,7 @@ services:
   traefik:
     image: traefik:v2.7.2
     restart: unless-stopped
+    entrypoint: ["/bin/sh", "-c", "apk add openssl && openssl req -subj '/CN=ocis.test' -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -keyout /certificates/server.key -out /certificates/server.crt && ./entrypoint.sh $@"]
     command:
       - "--pilot.dashboard=false"
       - "--log.level=DEBUG"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,7 +188,7 @@ services:
   traefik:
     image: traefik:v2.7.2
     restart: unless-stopped
-    entrypoint: ["/bin/sh", "-c", "[ -f /certificates/server.key ] && ./entrypoint.sh $@ || (apk add openssl && openssl req -subj '/CN=ocis.test' -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -keyout /certificates/server.key -out /certificates/server.crt && ./entrypoint.sh $@)"]
+    entrypoint: ["/bin/sh", "-c", "[ -f /certificates/server.key ] && ./entrypoint.sh $@ || (apk add openssl && openssl req -subj '/CN=ocis.test' -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -keyout /certificates/server.key -out /certificates/server.crt && chmod -R 777 /certificates && ./entrypoint.sh $@)"]
     command:
       - "--pilot.dashboard=false"
       - "--log.level=DEBUG"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,7 +188,7 @@ services:
   traefik:
     image: traefik:v2.7.2
     restart: unless-stopped
-    entrypoint: ["/bin/sh", "-c", "[ -f /certificates/server.key ] && ./entrypoint.sh $@ || (apk add openssl && openssl req -subj '/CN=ocis.test' -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -keyout /certificates/server.key -out /certificates/server.crt && chmod -R 777 /certificates && ./entrypoint.sh $@)"]
+    entrypoint: ["/bin/sh", "-c", "[ -f /certificates/server.key ] && ./entrypoint.sh $@ || (apk add openssl && openssl req -subj '/CN=ocis.test' -x509 -sha256 -nodes -days 3650 -newkey rsa:2048 -keyout /certificates/server.key -out /certificates/server.crt && chmod -R 777 /certificates && ./entrypoint.sh $@)"]
     command:
       - "--pilot.dashboard=false"
       - "--log.level=DEBUG"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,7 +188,7 @@ services:
   traefik:
     image: traefik:v2.7.2
     restart: unless-stopped
-    entrypoint: ["/bin/sh", "-c", "apk add openssl && openssl req -subj '/CN=ocis.test' -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -keyout /certificates/server.key -out /certificates/server.crt && ./entrypoint.sh $@"]
+    entrypoint: ["/bin/sh", "-c", "[ -f /certificates/server.key ] && ./entrypoint.sh $@ || (apk add openssl && openssl req -subj '/CN=ocis.test' -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -keyout /certificates/server.key -out /certificates/server.crt && ./entrypoint.sh $@)"]
     command:
       - "--pilot.dashboard=false"
       - "--log.level=DEBUG"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,8 +216,8 @@ services:
       - "8090:8080"
       - "9200:443"
     volumes:
-      - "./data_traefik/letsencrypt:/letsencrypt"
-      - "./data_traefik/configs:/configs"
+      - "./dev/docker/traefik/certificates:/certificates"
+      - "./dev/docker/traefik/configs:/configs"
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
 volumes:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -160,8 +160,8 @@ export default defineConfig(async ({ mode, command }) => {
         server: {
           port: 9201,
           https: {
-            key: readFileSync('./dev/docker/ocis-ca/server.key'),
-            cert: readFileSync('./dev/docker/ocis-ca/server.crt')
+            key: readFileSync('./dev/docker/traefik/certificates/server.key'),
+            cert: readFileSync('./dev/docker/traefik/certificates/server.crt')
           },
           // workaround: https://github.com/owncloud/ocis/issues/5108
           proxy: Object.fromEntries(


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Depends on #9150 


## Related Issue


## Motivation and Context
Until #9150 ocis generated tls certs and they were used by  vite and ocis.
So (at least in Chromium) one did not have to accept the certs twice.
Now certs are not autogenerated by ocis anymore and cannot be reused by vite.

Let's reestablish more or less the old behavior.


This PR makes traefik and vite the same certs, which are generated by the traefik container

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
