### PR TITLE
[tests-only][full-ci]Bump latest ocis commit on web `stable-7.0`

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=aff8a7dfb58896a04ed57f12f48901948b1785cc
+OCIS_COMMITID=9e85bd8be7a424dc88148e21575807789403b79b
 OCIS_BRANCH=master


### PR DESCRIPTION
### Description
Bump latest ocis commit id to web `stable-7.0`

### Related Issue: 
https://github.com/owncloud/QA/issues/811