### PR TITLE
[tests-only][full-ci]Add e2e tests for space download

### DIFF
--- a/tests/e2e/cucumber/features/smoke/spaces/downloadSpace.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/spaces/downloadSpace.ocis.feature
@@ -1,0 +1,37 @@
+Feature: download space
+  As a user
+  I want to download the project space
+  So that I can store the project resources locally
+
+  Scenario: download space
+    Given "Admin" creates following users using API
+      | id    |
+      | Alice |
+      | Brian |
+    And "Admin" assigns following roles to the users using API
+      | id    | role        |
+      | Alice | Space Admin |
+    And "Alice" logs in
+    And "Alice" creates the following project spaces using API
+      | name | id     |
+      | team | team.1 |
+    And "Alice" creates the following folder in space "team" using API
+      | name        |
+      | spaceFolder |
+    And "Alice" creates the following file in space "team" using API
+      | name                  | content    |
+      | spaceFolder/lorem.txt | space team |
+    And "Alice" opens the "files" app
+    And "Alice" navigates to the projects space page
+    And "Alice" navigates to the project space "team.1"
+    When "Alice" downloads the space "team.1"
+    And "Alice" adds following users to the project space
+      | user     | role     | kind  |
+      | Brian    | Can edit | user  |
+    And "Alice" logs out
+    And "Brian" logs in
+    And "Brian" opens the "files" app
+    And "Brian" navigates to the projects space page
+    And "Brian" navigates to the project space "team.1"
+    When "Brian" downloads the space "team.1"
+    And "Brian" logs out

--- a/tests/e2e/cucumber/features/smoke/spaces/downloadSpace.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/spaces/downloadSpace.ocis.feature
@@ -1,7 +1,7 @@
 Feature: download space
   As a user
   I want to download the project space
-  So that I can store the project resources locally
+  So that I can store the project's resources locally
 
   Scenario: download space
     Given "Admin" creates following users using API

--- a/tests/e2e/cucumber/steps/ui/accountMenu.ts
+++ b/tests/e2e/cucumber/steps/ui/accountMenu.ts
@@ -44,6 +44,7 @@ When(
   async function (this: World, stepUser: string): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const accountObject = new objects.account.Account({ page })
-    await accountObject.downloadGdprExport()
+    const downloadedResource = await accountObject.downloadGdprExport()
+    expect(downloadedResource).toContain('personal_data_export.json')
   }
 )

--- a/tests/e2e/cucumber/steps/ui/spaces.ts
+++ b/tests/e2e/cucumber/steps/ui/spaces.ts
@@ -224,6 +224,7 @@ When(
   async function (this: World, stepUser: string, space: string): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const spacesObject = new objects.applicationFiles.Spaces({ page })
-    await spacesObject.downloadSpace()
+    const downloadedResource = await spacesObject.downloadSpace()
+    expect(downloadedResource).toContain('download.tar')
   }
 )

--- a/tests/e2e/cucumber/steps/ui/spaces.ts
+++ b/tests/e2e/cucumber/steps/ui/spaces.ts
@@ -139,8 +139,7 @@ Then(
   async function (this: World, stepUser: string, space: string): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const spacesObject = new objects.applicationFiles.Spaces({ page })
-    const spaceID = spacesObject.getSpaceID({ key: space })
-    await spacesObject.expectThatSpacesIdNotExist(spaceID)
+    await spacesObject.expectThatSpacesIdNotExist(space)
   }
 )
 
@@ -217,5 +216,14 @@ When(
     const spacesObject = new objects.applicationFiles.Spaces({ page })
     const member = { collaborator: this.usersEnvironment.getUser({ key: memberName }) }
     await spacesObject.removeExpirationDate({ member })
+  }
+)
+
+When(
+  '{string} downloads the space {string}',
+  async function (this: World, stepUser: string, space: string): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const spacesObject = new objects.applicationFiles.Spaces({ page })
+    await spacesObject.downloadSpace()
   }
 )

--- a/tests/e2e/support/objects/account/actions.ts
+++ b/tests/e2e/support/objects/account/actions.ts
@@ -1,4 +1,3 @@
-import { expect } from '@playwright/test'
 import { Page } from 'playwright'
 import util from 'util'
 
@@ -60,7 +59,7 @@ export const requestGdprExport = async (args: { page: Page }): Promise<void> => 
   ])
 }
 
-export const downloadGdprExport = async (args: { page: Page }): Promise<void> => {
+export const downloadGdprExport = async (args: { page: Page }): Promise<string> => {
   const { page } = args
 
   const [download] = await Promise.all([
@@ -73,6 +72,6 @@ export const downloadGdprExport = async (args: { page: Page }): Promise<void> =>
     ),
     page.locator(downloadExportButton).click()
   ])
-  expect(download.suggestedFilename()).toContain('personal_data_export.json')
   await page.locator(requestExportButton).waitFor()
+  return download.suggestedFilename()
 }

--- a/tests/e2e/support/objects/account/index.ts
+++ b/tests/e2e/support/objects/account/index.ts
@@ -24,7 +24,7 @@ export class Account {
     await po.requestGdprExport({ page: this.#page })
   }
 
-  async downloadGdprExport(): Promise<void> {
-    await po.downloadGdprExport({ page: this.#page })
+  downloadGdprExport(): Promise<string> {
+    return po.downloadGdprExport({ page: this.#page })
   }
 }

--- a/tests/e2e/support/objects/app-files/spaces/actions.ts
+++ b/tests/e2e/support/objects/app-files/spaces/actions.ts
@@ -1,5 +1,4 @@
 import { Page } from 'playwright'
-import { expect } from '@playwright/test'
 import util from 'util'
 
 import { sidebar } from '../utils'
@@ -314,7 +313,7 @@ export const removeExpirationDateFromMember = async (args: {
   await Collaborator.removeExpirationDateFromCollaborator({ page, collaborator })
 }
 
-export const downloadSpace = async (page: Page): Promise<void> => {
+export const downloadSpace = async (page: Page): Promise<string> => {
   await openActionsPanel(page)
   const [download] = await Promise.all([
     page.waitForEvent('download'),
@@ -322,5 +321,5 @@ export const downloadSpace = async (page: Page): Promise<void> => {
   ])
   await sidebar.close({ page })
 
-  expect(download.suggestedFilename()).toContain('download.tar')
+  return download.suggestedFilename()
 }

--- a/tests/e2e/support/objects/app-files/spaces/actions.ts
+++ b/tests/e2e/support/objects/app-files/spaces/actions.ts
@@ -1,9 +1,11 @@
 import { Page } from 'playwright'
-import { sidebar } from '../utils'
-import { File } from '../../../types'
+import { expect } from '@playwright/test'
 import util from 'util'
+
+import { sidebar } from '../utils'
 import Collaborator, { ICollaborator } from '../share/collaborator'
 import { createLink } from '../link/actions'
+import { File } from '../../../types'
 
 const newSpaceMenuButton = '#new-space-menu-btn'
 const spaceNameInputField = '.oc-modal input'
@@ -13,6 +15,7 @@ const spacesRenameOptionSelector = '.oc-files-actions-rename-trigger:visible'
 const editSpacesSubtitleOptionSelector = '.oc-files-actions-edit-description-trigger:visible'
 const editQuotaOptionSelector = '.oc-files-actions-edit-quota-trigger:visible'
 const editImageOptionSelector = '.oc-files-actions-upload-space-image-trigger:visible'
+const downloadSpaceSelector = '.oc-files-actions-download-archive-trigger:visible'
 const spacesQuotaSearchField = '.oc-modal .vs__search'
 const selectedQuotaValueField = '.vs--open'
 const quotaValueDropDown = `.vs__dropdown-option :text-is("%s")`
@@ -309,4 +312,15 @@ export const removeExpirationDateFromMember = async (args: {
   const { page, member: collaborator } = args
   await openSharingPanel(page)
   await Collaborator.removeExpirationDateFromCollaborator({ page, collaborator })
+}
+
+export const downloadSpace = async (page: Page): Promise<void> => {
+  await openActionsPanel(page)
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.locator(downloadSpaceSelector).click()
+  ])
+  await sidebar.close({ page })
+
+  expect(download.suggestedFilename()).toContain('download.tar')
 }

--- a/tests/e2e/support/objects/app-files/spaces/index.ts
+++ b/tests/e2e/support/objects/app-files/spaces/index.ts
@@ -16,6 +16,11 @@ export class Spaces {
     this.#linksEnvironment = new LinksEnvironment()
   }
 
+  getSpaceID({ key }: { key: string }): string {
+    const { id } = this.#spacesEnvironment.getSpace({ key })
+    return id
+  }
+
   async create({
     key,
     space
@@ -59,12 +64,8 @@ export class Spaces {
     await po.removeAccessSpaceMembers({ ...args, page: this.#page })
   }
 
-  getSpaceID({ key }: { key: string }): string {
-    const { id } = this.#spacesEnvironment.getSpace({ key })
-    return id
-  }
-
-  async expectThatSpacesIdNotExist(spaceID: string): Promise<void> {
+  async expectThatSpacesIdNotExist(space: string): Promise<void> {
+    const spaceID = this.getSpaceID({ key: space })
     await spaceWithSpaceIDNotExist({ spaceID, page: this.#page })
   }
 
@@ -108,5 +109,9 @@ export class Spaces {
 
   async removeExpirationDate({ member }: { member: Omit<ICollaborator, 'role'> }): Promise<void> {
     await po.removeExpirationDateFromMember({ member, page: this.#page })
+  }
+
+  async downloadSpace(): Promise<void> {
+    await po.downloadSpace(this.#page)
   }
 }

--- a/tests/e2e/support/objects/app-files/spaces/index.ts
+++ b/tests/e2e/support/objects/app-files/spaces/index.ts
@@ -111,7 +111,7 @@ export class Spaces {
     await po.removeExpirationDateFromMember({ member, page: this.#page })
   }
 
-  async downloadSpace(): Promise<void> {
-    await po.downloadSpace(this.#page)
+  downloadSpace(): Promise<string> {
+    return po.downloadSpace(this.#page)
   }
 }


### PR DESCRIPTION
## Description
This PR adds e2e tests for space download. There is no download feature in stable7.0. 

## Note 
- space will be downloaded in compressed form as a download.tar file. Currently we check only the name of downloaded file
-  Should we check the  download.tar contains all resources of the downloaded space ❓ 

## Related Issue
- Fixes <https://github.com/owncloud/ocis/issues/5014>

## How Has This Been Tested?
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
