### PR TITLE
[tests-only][full-ci]Uncomment steps for resume upload and fix test code

### DIFF
--- a/tests/e2e/cucumber/features/smoke/uploadResumable.ocis.feature
+++ b/tests/e2e/cucumber/features/smoke/uploadResumable.ocis.feature
@@ -15,14 +15,12 @@ Feature: Upload large resources
       | largefile.txt |
     And "Alice" pauses the file upload
     And "Alice" cancels the file upload
-    # issue: https://github.com/owncloud/web/issues/9080
-    # Todo: uncomment when the issue is fixed
-    # And "Alice" starts uploading the following large resources from the temp upload directory
-    #   | resource      |
-    #   | largefile.txt |
-    # And "Alice" pauses the file upload
-    # And "Alice" resumes the file upload
-    # Then following resources should be displayed in the files list for user "Alice"
-    #   | resource      |
-    #   | largefile.txt |
+     And "Alice" starts uploading the following large resources from the temp upload directory
+       | resource      |
+       | largefile.txt |
+     And "Alice" pauses the file upload
+     And "Alice" resumes the file upload
+     Then following resources should be displayed in the files list for user "Alice"
+       | resource      |
+       | largefile.txt |
     And "Alice" logs out

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -314,11 +314,11 @@ const performUpload = async (args: uploadResourceArgs): Promise<void> => {
       }
     }
   }
-
   await Promise.all([
     page.waitForResponse(
       (resp) =>
-        [201, 204].includes(resp.status()) && ['POST', 'PUT'].includes(resp.request().method())
+        [201, 204].includes(resp.status()) &&
+        ['POST', 'PUT', 'PATCH'].includes(resp.request().method())
     ),
     uploadAction
   ])


### PR DESCRIPTION
### Description
The fix PR of this issue https://github.com/owncloud/web/issues/9080 has been made with this PR https://github.com/owncloud/web/pull/9141. The steps were comment until the feature has been fixed. This PR uncomment those steps for resume upload. Also upon upload resume the request `PATCH` is sent for uploading.

### Related Issue:
https://github.com/owncloud/web/issues/9080#issuecomment-1577883326