### PR TITLE
Remove vite proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,8 @@ services:
       traefik.enable: true
       traefik.http.routers.ocis.rule: PathPrefix(`/`)
       traefik.http.routers.ocis.entrypoints: websecure
+      # workaround: https://github.com/owncloud/ocis/issues/5108
+      traefik.http.routers.ocis.middlewares: cors
     depends_on:
       - traefik
 
@@ -211,9 +213,11 @@ services:
       traefik.http.middlewares.https_config.headers.sslRedirect: true
       traefik.http.middlewares.https_config.headers.stsSeconds: 63072000
       traefik.http.middlewares.https_config.headers.stsIncludeSubdomains: true
-      traefik.http.middlewares.https_config.headers.accesscontrolallowmethods: OPTIONS,HEAD,GET,PUT,POST,DELETE,PATCH
-      traefik.http.middlewares.https_config.headers.accesscontrolallowheaders: "*"
-      traefik.http.middlewares.https_config.headers.accesscontrolalloworiginlist: "*"
+      traefik.http.middlewares.cors.headers.accesscontrolallowmethods: "*"
+      traefik.http.middlewares.cors.headers.accesscontrolallowheaders: "*"
+      traefik.http.middlewares.cors.headers.accesscontrolalloworiginlist: "*"
+      traefik.http.middlewares.cors.headers.accesscontrolmaxage: 100
+      traefik.http.middlewares.cors.headers.addvaryheader: true
     ports:
       - "80:80"
       - "8090:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,9 @@ services:
       # PROXY
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-true}"
       PROXY_TLS: "false"
+
+      # CORS
+      OCIS_CORS_ALLOW_ORIGINS: "https://host.docker.internal:9201"
     volumes:
       - ./dev/docker/ocis.entrypoint.sh:/usr/bin/entrypoint
       - ./dev/docker/ocis.idp.config.yaml:/etc/ocis/idp.yaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,9 +53,6 @@ services:
       # PROXY
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-true}"
       PROXY_TLS: "false"
-
-      # CORS
-      OCIS_CORS_ALLOW_ORIGINS: "https://host.docker.internal:9201"
     volumes:
       - ./dev/docker/ocis.entrypoint.sh:/usr/bin/entrypoint
       - ./dev/docker/ocis.idp.config.yaml:/etc/ocis/idp.yaml
@@ -69,6 +66,8 @@ services:
       traefik.enable: true
       traefik.http.routers.ocis.rule: PathPrefix(`/`)
       traefik.http.routers.ocis.entrypoints: websecure
+      # workaround: https://github.com/owncloud/ocis/issues/5108
+      traefik.http.routers.ocis.middlewares: cors
     depends_on:
       - traefik
 
@@ -214,6 +213,11 @@ services:
       traefik.http.middlewares.https_config.headers.sslRedirect: true
       traefik.http.middlewares.https_config.headers.stsSeconds: 63072000
       traefik.http.middlewares.https_config.headers.stsIncludeSubdomains: true
+      traefik.http.middlewares.cors.headers.accesscontrolallowmethods: "*"
+      traefik.http.middlewares.cors.headers.accesscontrolallowheaders: "*"
+      traefik.http.middlewares.cors.headers.accesscontrolalloworiginlist: "*"
+      traefik.http.middlewares.cors.headers.accesscontrolmaxage: 100
+      traefik.http.middlewares.cors.headers.addvaryheader: true
     ports:
       - "80:80"
       - "8090:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,9 @@ services:
       # PROXY
       PROXY_ENABLE_BASIC_AUTH: "${PROXY_ENABLE_BASIC_AUTH:-true}"
       PROXY_TLS: "false"
+
+      # CORS
+      OCIS_CORS_ALLOW_ORIGINS: "https://host.docker.internal:9201"
     volumes:
       - ./dev/docker/ocis.entrypoint.sh:/usr/bin/entrypoint
       - ./dev/docker/ocis.idp.config.yaml:/etc/ocis/idp.yaml
@@ -66,8 +69,6 @@ services:
       traefik.enable: true
       traefik.http.routers.ocis.rule: PathPrefix(`/`)
       traefik.http.routers.ocis.entrypoints: websecure
-      # workaround: https://github.com/owncloud/ocis/issues/5108
-      traefik.http.routers.ocis.middlewares: cors
     depends_on:
       - traefik
 
@@ -213,11 +214,6 @@ services:
       traefik.http.middlewares.https_config.headers.sslRedirect: true
       traefik.http.middlewares.https_config.headers.stsSeconds: 63072000
       traefik.http.middlewares.https_config.headers.stsIncludeSubdomains: true
-      traefik.http.middlewares.cors.headers.accesscontrolallowmethods: "*"
-      traefik.http.middlewares.cors.headers.accesscontrolallowheaders: "*"
-      traefik.http.middlewares.cors.headers.accesscontrolalloworiginlist: "*"
-      traefik.http.middlewares.cors.headers.accesscontrolmaxage: 100
-      traefik.http.middlewares.cors.headers.addvaryheader: true
     ports:
       - "80:80"
       - "8090:8080"

--- a/packages/web-pkg/src/services/client/client.ts
+++ b/packages/web-pkg/src/services/client/client.ts
@@ -106,6 +106,7 @@ export class ClientService {
       ...(!!authenticated && { token: this.token }),
       language: this.currentLanguage,
       client: new _HttpClient({
+        baseURL: this.configurationManager.serverUrl,
         headers: {
           'Accept-Language': this.currentLanguage,
           ...(!!authenticated && { Authorization: 'Bearer ' + this.token }),

--- a/tests/drone/identifier-registration.yml
+++ b/tests/drone/identifier-registration.yml
@@ -5,8 +5,8 @@ clients:
   - id: web
     name: OCIS
     application_type: web
-    insecure: yes
-    trusted: yes
+    insecure: true
+    trusted: true
     redirect_uris:
       - https://ocis:9200/oidc-callback.html
       - https://ocis:9200/

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -76,16 +76,6 @@ const getConfigJson = async (url: string, config: UserConfig) => {
   configJson.options.disablePreviews = false
   configJson.options.displayResourcesLazy = true
 
-  const vitePort = config.server.port
-  const viteUrl = `http${config.server.https ? 's' : ''}://host.docker.internal:${vitePort}`
-
-  // oCIS
-  if (configJson.openIdConnect) {
-    // replace server urls in config.json to use the vite proxy
-    configJson.theme = configJson.theme.replace(configJson.server, viteUrl)
-    configJson.server = configJson.server.replace(configJson.server, viteUrl)
-  }
-
   // oC 10
   if (configJson.auth) {
     configJson.auth.clientId =
@@ -162,28 +152,7 @@ export default defineConfig(async ({ mode, command }) => {
           https: {
             key: readFileSync('./dev/docker/traefik/certificates/server.key'),
             cert: readFileSync('./dev/docker/traefik/certificates/server.crt')
-          },
-          // workaround: https://github.com/owncloud/ocis/issues/5108
-          proxy: Object.fromEntries(
-            [
-              'api',
-              'ocs',
-              'graph',
-              'remote.php',
-              'app',
-              'archiver',
-              'branding',
-              'settings.js',
-              'themes'
-            ].map((p) => [
-              `/${p}`,
-              {
-                target: proxiedServerUrl,
-                changeOrigin: true,
-                secure: false
-              }
-            ])
-          )
+          }
         }
       })
     }


### PR DESCRIPTION
## Description
This removes the vite proxy and fixes adding CORS headers to oCIS in traefik.
This is in general a cleaner workaround as it assumes the server is fine and we don't have mismatches in urls with `:9200` and `:9201`

The downside is that we can't simply point vite to any oCIS server and it would still work just like it is right now, but ... I prefer to have companion imports working in vite.

This actually should just be fixed in oCIS and we wouldn't have to deal with it on any server anymore …

## Related Issue
- workaround required because of https://github.com/owncloud/ocis/issues/5108

## Motivation and Context
The occasion for this change is that companion tries to upload to port `:9201` from its container and it doesn't work. Instead of adding yet another hack to keep this working, we can instead just use traefik to add the headers we're missing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
