### PR TITLE
bump info.xml to 7.0.2 

### DIFF
--- a/packages/web-integration-oc10/appinfo/info.xml
+++ b/packages/web-integration-oc10/appinfo/info.xml
@@ -15,7 +15,7 @@ For feedback and bug reports, please use the [public issue tracker](https://gith
 	</description>
 	<licence>AGPL</licence>
 	<author>ownCloud</author>
-	<version>6.0.0</version>
+	<version>7.0.2</version>
 	<category>tools</category>
 	<website>https://github.com/owncloud/web</website>
 	<bugs>https://github.com/owncloud/web/issues</bugs>


### PR DESCRIPTION
I've money-patched that for the release of tag v7.0.2 during the sign process.
-- it still said 6.0.0 all the time from first RC of 7.0.0 to 7.0.2

This should be done before taging, please, next time.