### PR TITLE
[tests-only][full-ci]Bump ocis commit id for tests

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=9e85bd8be7a424dc88148e21575807789403b79b
+OCIS_COMMITID=8c414acfbd8c4a0544923f95a47a0632303b1001
 OCIS_BRANCH=master


### PR DESCRIPTION
This pr bumps the web commit id to the latest
Part of: https://github.com/owncloud/QA/issues/812