### PR TITLE
feat: restyle autocomplete item

### DIFF
--- a/changelog/unreleased/enhancement-restyle-sharees
+++ b/changelog/unreleased/enhancement-restyle-sharees
@@ -1,0 +1,6 @@
+Enhancement: Restyle possible sharees
+
+We've restyled the list of sharee suggestions when sharing files and folders.
+
+https://github.com/owncloud/web/issues/9216
+https://github.com/owncloud/web/pull/9273

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/AutocompleteItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/AutocompleteItem.vue
@@ -38,12 +38,17 @@
     />
     <div class="files-collaborators-autocomplete-user-text oc-text-truncate">
       <span class="files-collaborators-autocomplete-username" v-text="item.label" />
-      <span
+      <template v-if="!isUser && !isSpaceUser && !isGroup && !isSpaceGroup">
+        <span
+          class="files-collaborators-autocomplete-share-type"
+          v-text="`(${$gettext(shareType.label)})`"
+        />
+      </template>
+      <div
         v-if="item.value.shareWithAdditionalInfo"
         class="files-collaborators-autocomplete-additional-info"
-        v-text="`(${item.value.shareWithAdditionalInfo})`"
+        v-text="`${item.value.shareWithAdditionalInfo}`"
       />
-      <div class="files-collaborators-autocomplete-share-type" v-text="$gettext(shareType.label)" />
     </div>
   </div>
 </template>
@@ -102,5 +107,8 @@ export default {
 <style lang="scss">
 .vs__dropdown-option--highlight .files-recipient-suggestion-avatar svg {
   fill: white !important;
+}
+.files-collaborators-autocomplete-additional-info {
+  font-size: var(--oc-font-size-small);
 }
 </style>

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/AutocompleteItem.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/AutocompleteItem.spec.ts
@@ -61,16 +61,25 @@ describe('AutocompleteItem component', () => {
     it('shows additional information when set', () => {
       const { wrapper } = createWrapper({ shareWithAdditionalInfo: 'some text' })
       expect(wrapper.find('.files-collaborators-autocomplete-additional-info').text()).toEqual(
-        '(some text)'
+        'some text'
       )
     })
     it('does not show additional information when not set', () => {
       const { wrapper } = createWrapper({ shareWithAdditionalInfo: undefined })
       expect(wrapper.find('.files-collaborators-autocomplete-additional-info').exists()).toBeFalsy()
     })
-    it('shows the share type', () => {
-      const { wrapper } = createWrapper({ shareType: ShareTypes.user.value })
-      expect(wrapper.find('.files-collaborators-autocomplete-share-type').text()).toEqual('User')
+    it.each([
+      ShareTypes.user.value,
+      ShareTypes.spaceUser.value,
+      ShareTypes.group.value,
+      ShareTypes.spaceGroup.value
+    ])('hides share type for users and groups', (shareType: number) => {
+      const { wrapper } = createWrapper({ shareType })
+      expect(wrapper.find('.files-collaborators-autocomplete-share-type').exists()).toBeFalsy()
+    })
+    it('shows share type for guests', () => {
+      const { wrapper } = createWrapper({ shareType: ShareTypes.guest.value })
+      expect(wrapper.find('.files-collaborators-autocomplete-share-type').text()).toEqual('(Guest)')
     })
   })
 })


### PR DESCRIPTION
## Description
- Show `additionalInfo` for possible sharees in next line
- Hide share type is user or group

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9216

## Screenshots (if appropriate):
<img width="582" alt="Screenshot 2023-06-19 at 16 01 35" src="https://github.com/owncloud/web/assets/3532843/03b9d54b-8f5d-42f7-9980-47e7097334ff">
<img width="593" alt="Screenshot 2023-06-19 at 16 01 49" src="https://github.com/owncloud/web/assets/3532843/12c2e356-b8f5-4fc9-933d-91a8774a2882">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
