### PR TITLE
fix: cloud import into folder with special characters

### DIFF
--- a/changelog/unreleased/enhancement-cloud-import
+++ b/changelog/unreleased/enhancement-cloud-import
@@ -4,3 +4,5 @@ An action to import files from other external cloud providers has been added. On
 
 https://github.com/owncloud/web/issues/9151
 https://github.com/owncloud/web/pull/9150
+https://github.com/owncloud/web/pull/9282
+

--- a/packages/web-app-files/src/HandleUpload.ts
+++ b/packages/web-app-files/src/HandleUpload.ts
@@ -142,7 +142,7 @@ export class HandleUpload extends BasePlugin {
       const directory =
         !relativeFilePath || dirname(relativeFilePath) === '.' ? '' : dirname(relativeFilePath)
 
-      const tusEndpoint = urlJoin(trimmedUploadPath, directory)
+      const tusEndpoint = encodeURI(urlJoin(trimmedUploadPath, directory))
 
       let topLevelFolderId
       if (relativeFilePath) {

--- a/packages/web-app-files/src/helpers/resource/actions/upload.ts
+++ b/packages/web-app-files/src/helpers/resource/actions/upload.ts
@@ -153,9 +153,8 @@ export class ResourceConflict extends ConflictDialog {
           new RegExp(`/${folder}/`),
           `/${newFolderName}/`
         )
-        file.meta.tusEndpoint = file.meta.tusEndpoint.replace(
-          new RegExp(`/${folder}`),
-          `/${newFolderName}`
+        file.meta.tusEndpoint = encodeURI(
+          file.meta.tusEndpoint.replace(new RegExp(`/${folder}`), `/${newFolderName}`)
         )
       }
     }


### PR DESCRIPTION
## Description
Fixes the cloud import when importing files into a folder that has special characters in its name.

Follow-up for https://github.com/owncloud/web/pull/9150.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
