### PR TITLE
fix: uploading to folders that contain special characters

### DIFF
--- a/changelog/unreleased/bugfix-uploading-to-folders-with-special-chars
+++ b/changelog/unreleased/bugfix-uploading-to-folders-with-special-chars
@@ -1,0 +1,6 @@
+Bugfix: Uploading to folders that contain special characters
+
+Uploading resources to folders that contain special characters in their names has been fixed.
+
+https://github.com/owncloud/web/issues/9247
+https://github.com/owncloud/web/pull/9290

--- a/packages/web-app-files/src/helpers/resource/actions/upload.ts
+++ b/packages/web-app-files/src/helpers/resource/actions/upload.ts
@@ -140,6 +140,12 @@ export class ResourceConflict extends ConflictDialog {
       const extension = extractExtensionFromFile({ name: fileName } as Resource)
       file.name = resolveFileNameDuplicate(fileName, extension, this.files)
       file.meta.name = file.name
+      if (file.xhrUpload?.endpoint) {
+        file.xhrUpload.endpoint = file.xhrUpload.endpoint.replace(
+          new RegExp(`/${encodeURIComponent(fileName)}`),
+          `/${encodeURIComponent(file.name)}`
+        )
+      }
     }
     for (const folder of foldersToKeepBoth) {
       const filesInFolder = files.filter((e) => e.meta.relativeFolder.split('/')[1] === folder)
@@ -153,9 +159,16 @@ export class ResourceConflict extends ConflictDialog {
           new RegExp(`/${folder}/`),
           `/${newFolderName}/`
         )
-        file.meta.tusEndpoint = encodeURI(
-          file.meta.tusEndpoint.replace(new RegExp(`/${folder}`), `/${newFolderName}`)
+        file.meta.tusEndpoint = file.meta.tusEndpoint.replace(
+          new RegExp(`/${encodeURIComponent(folder)}`),
+          `/${encodeURIComponent(newFolderName)}`
         )
+        if (file.xhrUpload?.endpoint) {
+          file.xhrUpload.endpoint = file.xhrUpload.endpoint.replace(
+            new RegExp(`/${encodeURIComponent(folder)}`),
+            `/${encodeURIComponent(newFolderName)}`
+          )
+        }
       }
     }
     return files

--- a/packages/web-runtime/src/composables/upload/useUpload.ts
+++ b/packages/web-runtime/src/composables/upload/useUpload.ts
@@ -44,6 +44,9 @@ export interface UppyResource {
     routeDriveAliasAndItem?: string
     routeShareId?: string
   }
+  xhrUpload?: {
+    endpoint: string
+  }
 }
 
 interface UploadOptions {


### PR DESCRIPTION
## Description
Fixes uploading resources to folders that contain special characters in their names. This also includes fixes for name conflict handling when running oC10 as server.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9247

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
