### PR TITLE
[tests-only][full-ci]Fix e2e flaky tests for searching

### DIFF
--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -1007,6 +1007,7 @@ export const getDisplayedResourcesFromSearch = async (page): Promise<string[]> =
 export const getDisplayedResourcesFromFilesList = async (page): Promise<string[]> => {
   const files = []
   await page.locator('[data-test-resource-path]').first().waitFor()
+  await new Promise((resolve) => setTimeout(resolve, 1000))
   const result = await page.locator('[data-test-resource-path]')
 
   const count = await result.count()

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -1007,6 +1007,7 @@ export const getDisplayedResourcesFromSearch = async (page): Promise<string[]> =
 export const getDisplayedResourcesFromFilesList = async (page): Promise<string[]> => {
   const files = []
   await page.locator('[data-test-resource-path]').first().waitFor()
+  // wait for tika indexing
   await new Promise((resolve) => setTimeout(resolve, 1000))
   const result = await page.locator('[data-test-resource-path]')
 

--- a/tests/e2e/support/objects/app-files/search/actions.ts
+++ b/tests/e2e/support/objects/app-files/search/actions.ts
@@ -21,7 +21,16 @@ export interface fullTextSearchArgs {
 export const fullTextSearch = async (args: fullTextSearchArgs): Promise<void> => {
   const { page, keyword } = args
   await page.locator(globalSearchInputSelector).fill(keyword)
+  let waitResponse
+  if (keyword) {
+    waitResponse = page.waitForResponse(
+      (resp) => resp.status() === 207 && resp.request().method() === 'REPORT'
+    )
+  }
   await page.keyboard.press('Enter')
+  if (keyword) {
+    await waitResponse
+  }
 }
 
 export const getSearchResultMessage = ({ page }): Promise<string> => {


### PR DESCRIPTION
fixes: https://github.com/owncloud/web/issues/9312

The scenario is failing intermittently because of the timing issues while indexing with tika. Adding `1` sec pause before grabbing the elements for asserting seems to fix the issue.
Locally I ran scenario `201` times in headless mode and all the scenarios passed

```bash
201 scenarios (201 passed)
6432 steps (6432 passed)
```

Same in CI as well https://drone.owncloud.com/owncloud/web/36898/9/14
```bash
201 scenarios (201 passed)
6432 steps (6432 passed)
56m03.984s (executing steps: 55m46.368s)
```