### PR TITLE
"Shared with me" view: switch columns displayed on small screens

### DIFF
--- a/packages/design-system/changelog/unreleased/bugfix-switch-columns-shared-with-me-view
+++ b/packages/design-system/changelog/unreleased/bugfix-switch-columns-shared-with-me-view
@@ -1,0 +1,6 @@
+Bugfix: switch columns displayed on small screens in "Shared with me" view
+
+Visibility of the resource table columns "Shared by" and "Shared with" has been switched for small screen and tablets (screen size <1200px) in the "Shared with me" view.
+
+https://github.com/owncloud/web/issues/9315
+https://github.com/owncloud/web/pull/9320

--- a/packages/web-app-files/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceTable.vue
@@ -1166,9 +1166,9 @@ export default defineComponent({
 
 // shared with me: on tablets hide shared with column and display owner column instead
 #files-shared-with-me-pending-section .files-table .oc-table-header-cell-owner,
-#files-shared-with-me-pending-section .files-table .oc-table-data-cell-owner, 
+#files-shared-with-me-pending-section .files-table .oc-table-data-cell-owner,
 #files-shared-with-me-accepted-section .files-table .oc-table-header-cell-owner,
-#files-shared-with-me-accepted-section .files-table .oc-table-data-cell-owner, 
+#files-shared-with-me-accepted-section .files-table .oc-table-data-cell-owner,
 #files-shared-with-me-declined-section .files-table .oc-table-header-cell-owner,
 #files-shared-with-me-declined-section .files-table .oc-table-data-cell-owner {
   @media only screen and (min-width: 640px) {
@@ -1179,12 +1179,11 @@ export default defineComponent({
 #files-shared-with-me-pending-section .files-table .oc-table-header-cell-sharedWith,
 #files-shared-with-me-pending-section .files-table .oc-table-data-cell-sharedWith,
 #files-shared-with-me-accepted-section .files-table .oc-table-header-cell-sharedWith,
-#files-shared-with-me-accepted-section .files-table .oc-table-data-cell-sharedWith, 
+#files-shared-with-me-accepted-section .files-table .oc-table-data-cell-sharedWith,
 #files-shared-with-me-declined-section .files-table .oc-table-header-cell-sharedWith,
 #files-shared-with-me-declined-section .files-table .oc-table-data-cell-sharedWith {
   @media only screen and (max-width: 1199px) {
     display: none;
   }
 }
-
 </style>

--- a/packages/web-app-files/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceTable.vue
@@ -1071,6 +1071,7 @@ export default defineComponent({
     }
   }
 }
+
 // Hide files table columns
 .files-table {
   .oc-table-header-cell-size,
@@ -1162,4 +1163,28 @@ export default defineComponent({
     }
   }
 }
+
+// shared with me: on tablets hide shared with column and display owner column instead
+#files-shared-with-me-pending-section .files-table .oc-table-header-cell-owner,
+#files-shared-with-me-pending-section .files-table .oc-table-data-cell-owner, 
+#files-shared-with-me-accepted-section .files-table .oc-table-header-cell-owner,
+#files-shared-with-me-accepted-section .files-table .oc-table-data-cell-owner, 
+#files-shared-with-me-declined-section .files-table .oc-table-header-cell-owner,
+#files-shared-with-me-declined-section .files-table .oc-table-data-cell-owner {
+  @media only screen and (min-width: 640px) {
+    display: table-cell;
+  }
+}
+
+#files-shared-with-me-pending-section .files-table .oc-table-header-cell-sharedWith,
+#files-shared-with-me-pending-section .files-table .oc-table-data-cell-sharedWith,
+#files-shared-with-me-accepted-section .files-table .oc-table-header-cell-sharedWith,
+#files-shared-with-me-accepted-section .files-table .oc-table-data-cell-sharedWith, 
+#files-shared-with-me-declined-section .files-table .oc-table-header-cell-sharedWith,
+#files-shared-with-me-declined-section .files-table .oc-table-data-cell-sharedWith {
+  @media only screen and (max-width: 1199px) {
+    display: none;
+  }
+}
+
 </style>


### PR DESCRIPTION
## Description
Previously in the "Shared with me" view the column "Shared by" was hidden whereas the column "Shared with" was displayed on small screens and tablets (screen size <1200px). I switched the visibility of these two columns for this particular view.

## Related Issue
- Fixes #9315

## Motivation and Context
As a user, when browsing though files shared with me, it would be more interesting to see who shared a resource with me than with whom it was shared since "Shared with" is always the user himself (or a group he/she is part of). Previously the column "Shared by" was hidden whereas the column "Shared with" was displayed on small screens and tablets (screen size <1200px). With the proposed changes the visibility of these two columns are changed for the specified screen sizes for this particular view.

## How Has This Been Tested?
manual testing using the Chrome inbuilt simulator of various mobile devices and screen sizes

## Screenshots (if appropriate):

proposed solution:
![Screenshot_SharedWithMe_proposedSolution](https://github.com/owncloud/web/assets/8348693/8c27bb8f-e7c2-436d-95fb-131a495c235e)

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:

