### PR TITLE
fix: remember location after token invalidation

### DIFF
--- a/changelog/unreleased/bugfix-remember-location-after-token-invalidation
+++ b/changelog/unreleased/bugfix-remember-location-after-token-invalidation
@@ -1,0 +1,6 @@
+Bugfix: Remember location after token invalidation
+
+Fixed an issue where token invalidation in the IDP would result in losing the current location. So logging in after token invalidation now correctly redirects to the page the user was before.
+
+https://github.com/owncloud/web/issues/9261
+https://github.com/owncloud/web/pull/9364

--- a/packages/web-runtime/src/pages/accessDenied.vue
+++ b/packages/web-runtime/src/pages/accessDenied.vue
@@ -24,7 +24,7 @@
       id="exitAnchor"
       type="router-link"
       class="oc-mt-m oc-width-medium"
-      :to="{ name: 'login' }"
+      :to="logoutLink"
       size="large"
       appearance="filled"
       variation="primary"
@@ -34,14 +34,15 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from 'vue'
-import { useStore } from 'web-pkg'
+import { computed, defineComponent, unref } from 'vue'
+import { useRoute, useStore } from 'web-pkg'
 import { useGettext } from 'vue3-gettext'
 
 export default defineComponent({
   name: 'AccessDeniedPage',
   setup() {
     const store = useStore()
+    const route = useRoute()
     const { $gettext } = useGettext()
 
     const logoImg = computed(() => {
@@ -68,6 +69,15 @@ export default defineComponent({
     const navigateToLoginText = computed(() => {
       return $gettext('Log in again')
     })
+    const logoutLink = computed(() => {
+      const redirectUrl = unref(route).query?.redirectUrl
+      return {
+        name: 'login',
+        query: {
+          ...(redirectUrl && { redirectUrl })
+        }
+      }
+    })
 
     return {
       logoImg,
@@ -75,7 +85,8 @@ export default defineComponent({
       cardHint,
       footerSlogan,
       navigateToLoginText,
-      accessDeniedHelpUrl
+      accessDeniedHelpUrl,
+      logoutLink
     }
   }
 })

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -134,7 +134,10 @@ export class AuthService {
 
           if (this.userManager.unloadReason === 'authError') {
             this.hasAuthErrorOccurred = true
-            return this.router.push({ name: 'accessDenied' })
+            return this.router.push({
+              name: 'accessDenied',
+              query: { redirectUrl: unref(this.router.currentRoute)?.fullPath }
+            })
           }
 
           // handle redirect after logout


### PR DESCRIPTION
## Description
Fixes an issue where token invalidation in the IDP would result in losing the current location. So logging in after token invalidation now correctly redirects to the page the user was before.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9261

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
