### PR TITLE
feat: hide upload info actions for cloud imports

### DIFF
--- a/changelog/unreleased/enhancement-cloud-import
+++ b/changelog/unreleased/enhancement-cloud-import
@@ -6,4 +6,4 @@ https://github.com/owncloud/web/issues/9151
 https://github.com/owncloud/web/pull/9150
 https://github.com/owncloud/web/pull/9282
 https://github.com/owncloud/web/pull/9291
-
+https://github.com/owncloud/web/pull/9374

--- a/packages/web-runtime/src/components/UploadInfo.vue
+++ b/packages/web-runtime/src/components/UploadInfo.vue
@@ -43,7 +43,7 @@
           v-text="infoExpanded ? $gettext('Hide details') : $gettext('Show details')"
         ></oc-button>
         <oc-button
-          v-if="!runningUploads && Object.keys(errors).length"
+          v-if="!runningUploads && Object.keys(errors).length && !disableActions"
           v-oc-tooltip="$gettext('Retry all failed uploads')"
           class="oc-ml-s"
           appearance="raw"
@@ -53,7 +53,13 @@
           <oc-icon name="restart" fill-type="line" />
         </oc-button>
         <oc-button
-          v-if="runningUploads && uploadsPausable && !inPreparation && !inFinalization"
+          v-if="
+            runningUploads &&
+            uploadsPausable &&
+            !inPreparation &&
+            !inFinalization &&
+            !disableActions
+          "
           id="pause-upload-info-btn"
           v-oc-tooltip="uploadsPaused ? $gettext('Resume upload') : $gettext('Pause upload')"
           class="oc-ml-s"
@@ -63,7 +69,7 @@
           <oc-icon :name="uploadsPaused ? 'play-circle' : 'pause-circle'" fill-type="line" />
         </oc-button>
         <oc-button
-          v-if="runningUploads && !inPreparation && !inFinalization"
+          v-if="runningUploads && !inPreparation && !inFinalization && !disableActions"
           id="cancel-upload-info-btn"
           v-oc-tooltip="$gettext('Cancel upload')"
           class="oc-ml-s"
@@ -173,7 +179,8 @@ export default defineComponent({
     uploadSpeed: 0,
     filesInEstimation: {},
     timeStarted: null,
-    remainingTime: undefined
+    remainingTime: undefined,
+    disableActions: false // disables the following actions: pause, resume, retry
   }),
   computed: {
     ...mapGetters(['configuration']),
@@ -265,6 +272,10 @@ export default defineComponent({
       this.filesInProgressCount += files.filter((f) => !f.isFolder).length
 
       for (const file of files) {
+        if (!this.disableActions && file.source && file.source !== 'DropTarget') {
+          this.disableActions = true
+        }
+
         if (file.data?.size) {
           this.bytesTotal += file.data.size
         }
@@ -450,6 +461,7 @@ export default defineComponent({
       this.successful = []
       this.filesInProgressCount = 0
       this.runningUploads = 0
+      this.disableActions = false
     },
     resetProgress() {
       this.bytesTotal = 0


### PR DESCRIPTION
## Description
Actions like pausing, resuming and retrying uploads is not (yet) supported by cloud imports, hence hide these.

Fixes https://github.com/owncloud/web/issues/9361

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
