### PR TITLE
Theme switcher for more themes

### DIFF
--- a/packages/web-runtime/src/components/Topbar/ThemeSwitcher.vue
+++ b/packages/web-runtime/src/components/Topbar/ThemeSwitcher.vue
@@ -29,20 +29,20 @@
         </div>
         <div class="oc-card-body theme-switcher-list">
           <oc-list>
-            <li v-for="themeOption in themeOptions" :key="themeOption">
+            <li v-for="(themeName, themeId) in themeOptions" :key="themeId">
               <oc-button
                 class="oc-p-s"
-                @click="selectTheme(themeOption)"
+                @click="selectTheme(themeId)"
                 :class="{
-                  'oc-background-primary-gradient': isSelectedTheme(themeOption),
-                  selected: isSelectedTheme(themeOption)
+                  'oc-background-primary-gradient': isSelectedTheme(themeId),
+                  selected: isSelectedTheme(themeId)
                 }"
-                :appearance="isSelectedTheme(themeOption) ? 'raw-inverse' : 'raw'"
-                :variation="isSelectedTheme(themeOption) ? 'primary' : 'passive'"
+                :appearance="isSelectedTheme(themeId) ? 'raw-inverse' : 'raw'"
+                :variation="isSelectedTheme(themeId) ? 'primary' : 'passive'"
               >
                 <span
                   class="oc-text-bold oc-display-block oc-width-1-1"
-                  v-text="$gettext(themeOption)"
+                  v-text="$gettext(themeName)"
                 />
               </oc-button>
             </li>
@@ -97,7 +97,13 @@ export default defineComponent({
       return Object.keys(this.store.getters.configuration.themes).length > 2
     },
     themeOptions() {
-      return Object.keys(this.store.getters.configuration.themes)
+      return Object.entries(this.store.getters.configuration.themes).reduce(
+        (mapping, [key, value]) => {
+          mapping[key] = value['theme-name']
+          return mapping
+        },
+        {}
+      )
     }
   },
   methods: {

--- a/packages/web-runtime/src/components/Topbar/ThemeSwitcher.vue
+++ b/packages/web-runtime/src/components/Topbar/ThemeSwitcher.vue
@@ -13,7 +13,7 @@
   </oc-button>
   <div v-else class="oc-flex oc-flex-middle">
     <oc-button
-      id="my_filter"
+      id="theme-switcher-button"
       class="oc-mr-s"
       appearance="raw"
       variation="inverse"
@@ -22,33 +22,34 @@
       <oc-icon name="paint" accessible-label="Select theme" class="oc-pr-xs" />
     </oc-button>
 
-    <oc-drop drop-id="oc-drop" toggle="#my_filter" mode="click" close-on-click>
-      <div slot="special" class="oc-card">
-        <div class="oc-card-header">
-          <h3 v-translate class="oc-card-title">Themes</h3>
-        </div>
-        <div class="oc-card-body theme-switcher-list">
-          <oc-list>
-            <li v-for="(themeName, themeId) in themeOptions" :key="themeId">
-              <oc-button
-                class="oc-p-s"
-                @click="selectTheme(themeId)"
-                :class="{
-                  'oc-background-primary-gradient': isSelectedTheme(themeId),
-                  selected: isSelectedTheme(themeId)
-                }"
-                :appearance="isSelectedTheme(themeId) ? 'raw-inverse' : 'raw'"
-                :variation="isSelectedTheme(themeId) ? 'primary' : 'passive'"
-              >
-                <span
-                  class="oc-text-bold oc-display-block oc-width-1-1"
-                  v-text="$gettext(themeName)"
-                />
-              </oc-button>
-            </li>
-          </oc-list>
-        </div>
-      </div>
+    <oc-drop
+      drop-id="oc-drop"
+      toggle="#theme-switcher-button"
+      mode="click"
+      padding-size="small"
+      class="themes-drop"
+      close-on-click
+    >
+      <h3 v-translate class="oc-pl-xs">Themes</h3>
+
+      <oc-list class="themes-drop-list" :aria-label="themesListAriaLabel">
+        <li v-for="(themeName, themeId) in themeOptions" :key="themeId">
+          <oc-button
+            :id="`themes-drop-btn-${themeId}`"
+            appearance="raw"
+            justify-content="space-between"
+            class="themes-drop-btn oc-p-s"
+            :class="{
+              'oc-background-primary-gradient': isSelectedTheme(themeId),
+              selected: isSelectedTheme(themeId)
+            }"
+            :variation="isSelectedTheme(themeId) ? 'inverse' : 'passive'"
+            @click="selectTheme(themeId)"
+          >
+            <span class="oc-flex oc-flex-middle" v-text="$gettext(themeName)" />
+          </oc-button>
+        </li>
+      </oc-list>
     </oc-drop>
   </div>
 </template>
@@ -104,6 +105,9 @@ export default defineComponent({
         },
         {}
       )
+    },
+    themesListAriaLabel() {
+      return this.$gettext('Select theme for the interface')
     }
   },
   methods: {
@@ -120,25 +124,35 @@ export default defineComponent({
 })
 </script>
 
-<style lang="scss">
-.theme-switcher-list {
-  .oc-card {
-    padding-left: 0px !important;
-    padding-right: 0px !important;
-  }
-  text-align: left;
-  white-space: normal;
+<style lang="scss" scoped>
+.themes {
+  &-drop {
+    &-list {
+      &:hover .themes-drop-btn.selected:not(:hover),
+      &:focus .themes-drop-btn.selected:not(:focus) {
+        color: var(--oc-color-swatch-passive-default);
+      }
 
-  a,
-  button,
-  span {
-    display: inline-flex;
-    font-weight: normal !important;
-    gap: 10px;
-    justify-content: flex-start;
-    vertical-align: top;
-    width: 100%;
-    text-align: left;
+      li {
+        margin: var(--oc-space-xsmall) 0;
+      }
+    }
+
+    &-btn {
+      width: 100%;
+      gap: var(--oc-space-medium);
+
+      &:hover,
+      &:focus {
+        background-color: var(--oc-color-background-hover) !important;
+        color: var(--oc-color-swatch-passive-default);
+        text-decoration: none;
+      }
+
+      &.selected {
+        color: var(--oc-color-swatch-inverse-default) !important;
+      }
+    }
   }
 }
 </style>

--- a/packages/web-runtime/src/components/Topbar/ThemeSwitcher.vue
+++ b/packages/web-runtime/src/components/Topbar/ThemeSwitcher.vue
@@ -46,7 +46,10 @@
             :variation="isSelectedTheme(themeId) ? 'inverse' : 'passive'"
             @click="selectTheme(themeId)"
           >
-            <span class="oc-flex oc-flex-middle" v-text="$gettext(themeName)" />
+            <span
+              class="oc-flex oc-flex-middle"
+              v-text="themeName ? $gettext(themeName) : $gettext(themeId)"
+            />
           </oc-button>
         </li>
       </oc-list>

--- a/packages/web-runtime/src/components/Topbar/ThemeSwitcher.vue
+++ b/packages/web-runtime/src/components/Topbar/ThemeSwitcher.vue
@@ -1,5 +1,6 @@
 <template>
   <oc-button
+    v-if="!moreThemes"
     v-oc-tooltip="buttonLabel"
     class="themeswitcher-btn"
     :aria-label="buttonLabel"
@@ -10,6 +11,46 @@
     <span class="oc-visible@s" :aria-label="switchLabel" />
     <oc-icon :name="switchIcon" fill-type="line" variation="inherit" />
   </oc-button>
+  <div v-else class="oc-flex oc-flex-middle">
+    <oc-button
+      id="my_filter"
+      class="oc-mr-s"
+      appearance="raw"
+      variation="inverse"
+      :aria-label="buttonLabel"
+    >
+      <oc-icon name="paint" accessible-label="Select theme" class="oc-pr-xs" />
+    </oc-button>
+
+    <oc-drop drop-id="oc-drop" toggle="#my_filter" mode="click" close-on-click>
+      <div slot="special" class="oc-card">
+        <div class="oc-card-header">
+          <h3 v-translate class="oc-card-title">Themes</h3>
+        </div>
+        <div class="oc-card-body theme-switcher-list">
+          <oc-list>
+            <li v-for="themeOption in themeOptions" :key="themeOption">
+              <oc-button
+                class="oc-p-s"
+                @click="selectTheme(themeOption)"
+                :class="{
+                  'oc-background-primary-gradient': isSelectedTheme(themeOption),
+                  selected: isSelectedTheme(themeOption)
+                }"
+                :appearance="isSelectedTheme(themeOption) ? 'raw-inverse' : 'raw'"
+                :variation="isSelectedTheme(themeOption) ? 'primary' : 'passive'"
+              >
+                <span
+                  class="oc-text-bold oc-display-block oc-width-1-1"
+                  v-text="$gettext(themeOption)"
+                />
+              </oc-button>
+            </li>
+          </oc-list>
+        </div>
+      </div>
+    </oc-drop>
+  </div>
 </template>
 <script lang="ts">
 import { computed, unref, watch, defineComponent } from 'vue'
@@ -36,7 +77,7 @@ export default defineComponent({
       applyTheme(unref(currentTheme))
     })
 
-    return { currentThemeName, currentTheme }
+    return { currentThemeName, currentTheme, store }
   },
   computed: {
     ...mapGetters(['configuration']),
@@ -51,12 +92,47 @@ export default defineComponent({
     },
     switchLabel() {
       return this.$gettext('Currently used theme')
+    },
+    moreThemes() {
+      return Object.keys(this.store.getters.configuration.themes).length > 2
+    },
+    themeOptions() {
+      return Object.keys(this.store.getters.configuration.themes)
     }
   },
   methods: {
     toggleTheme() {
       this.currentThemeName = this.isLightTheme ? themeNameDark : themeNameLight
+    },
+    selectTheme(themeOption) {
+      this.currentThemeName = themeOption
+    },
+    isSelectedTheme(themeOption) {
+      return this.currentThemeName === themeOption
     }
   }
 })
 </script>
+
+<style lang="scss">
+.theme-switcher-list {
+  .oc-card {
+    padding-left: 0px !important;
+    padding-right: 0px !important;
+  }
+  text-align: left;
+  white-space: normal;
+
+  a,
+  button,
+  span {
+    display: inline-flex;
+    font-weight: normal !important;
+    gap: 10px;
+    justify-content: flex-start;
+    vertical-align: top;
+    width: 100%;
+    text-align: left;
+  }
+}
+</style>


### PR DESCRIPTION
## Description
The pr adds the possibility to switch between themes when there are more than 2.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
Improving the accessibility by providing high contrast themes in addition to classical default and default dark 


## Screenshots (if appropriate):
![Screenshot from 2023-07-12 12-17-20](https://github.com/owncloud/web/assets/7430156/936de8e2-9d00-425c-94b5-430276d96c83)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

