### PR TITLE
[tests-only][full-ci] updated element to waitFor

### DIFF
--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -331,7 +331,7 @@ const performUpload = async (args: uploadResourceArgs): Promise<void> => {
 export const uploadLargeNumberOfResources = async (args: uploadResourceArgs): Promise<void> => {
   const { page, resources } = args
   await performUpload(args)
-  await page.locator(uploadInfoCloseButton).waitFor()
+  await page.locator(uploadInfoSuccessLabelSelector).waitFor()
   await expect(page.locator(uploadInfoSuccessLabelSelector)).toHaveText(
     `${resources.length} items uploaded`
   )


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR updates the element to wait after the multiple small files are uploaded. The test related to uploading multiple files is flaky, throwing an error in upload step. 
```
✖ When "Alice" uploads 50 small files in personal space # tests/e2e/cucumber/steps/ui/resources.ts:447
       Error: Timed out 5000ms waiting for expect(received).toHaveText(expected)

       Expected string: "50 items uploaded"
       Received string: ""
       Call log:
         - expect.toHaveText with timeout 5000ms
         - waiting for locator('.upload-info-label.upload-info-success')
         - waiting for locator('.upload-info-label.upload-info-success')

           at Proxy.<anonymous> (/drone/src/webTestRunner/node_modules/.pnpm/@playwright+test@1.29.1/node_modules/@playwright/test/lib/expect.js:130:37)
           at Object.uploadLargeNumberOfResources (/drone/src/webTestRunner/tests/e2e/support/objects/app-files/resource/actions.ts:246:76)
           at runNextTicks (node:internal/process/task_queues:60:5)
           at processImmediate (node:internal/timers:447:9)
           at Resource.uploadLargeNumberOfResources (/drone/src/webTestRunner/tests/e2e/support/objects/app-files/resource/index.ts:50:9)
           at World.<anonymous> (/drone/src/webTestRunner/tests/e2e/cucumber/steps/ui/resources.ts:458:5)
```
So, waiting for the element that displays the upload success message before asserting the text content in that element.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/web/issues/9399

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 