### PR TITLE
chore: bump web to v7.1.0-alpha.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.1.0-alpha.1",
+  "version": "7.1.0-alpha.2",
   "private": true,
   "homepage": "https://github.com/owncloud/web",
   "license": "AGPL-3.0",
@@ -143,7 +143,6 @@
       "@uppy/utils": "https://github.com/owncloud/uppy/releases/download/v3.12.0-owncloud/uppy-utils.tgz",
       "@uppy/webdav": "https://github.com/owncloud/uppy/releases/download/v3.12.0-owncloud/uppy-webdav.tgz",
       "@uppy/xhr-upload": "https://github.com/owncloud/uppy/releases/download/v3.12.0-owncloud/uppy-xhr-upload.tgz"
-
     },
     "packageExtensions": {
       "@adobe/leonardo-contrast-colors": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@
 sonar.projectKey=owncloud_web
 sonar.organization=owncloud-1
 sonar.projectName=Web
-sonar.projectVersion=7.1.0-alpha.1
+sonar.projectVersion=7.1.0-alpha.2
 sonar.host.url=https://sonarcloud.io
 
 # =====================================================


### PR DESCRIPTION
Includes the updated cloud importer. This is probably the last alpha before the first rc.