### PR TITLE
chore: add restart policy to ocis docker container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,7 @@ services:
       traefik.http.routers.ocis.entrypoints: websecure
       # workaround: https://github.com/owncloud/ocis/issues/5108
       traefik.http.routers.ocis.middlewares: cors
+    restart: unless-stopped
     depends_on:
       - traefik
       - tika-service
@@ -253,7 +254,7 @@ services:
     container_name: web_tika
     ports:
       - 9998:9998
-    restart: always
+    restart: unless-stopped
 
 volumes:
   uploads:


### PR DESCRIPTION
Sometimes tika takes too long to initialize, leading to the ocis container exiting. By adding a proper restart policy we ensure that the ocis container comes up again in such scenario.