### PR TITLE
feat: add collapsible table and enable custom vite config for cern

### DIFF
--- a/packages/web-app-files/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-app-files/src/components/FilesList/ResourceTable.vue
@@ -17,6 +17,7 @@
     :sort-by="sortBy"
     :sort-dir="sortDir"
     :lazy="lazyLoading"
+    :grouping-settings="groupingSettings"
     padding-x="medium"
     @highlight="fileClicked"
     @row-mounted="rowMounted"
@@ -248,10 +249,13 @@ import {
 } from 'web-app-files/src/router'
 import get from 'lodash-es/get'
 
+// ODS component import is necessary here for CERN to overwrite OcTable
+import OcTable from 'design-system/src/components/OcTable/OcTable.vue'
+
 const TAGS_MINIMUM_SCREEN_WIDTH = 850
 
 export default defineComponent({
-  components: { ContextMenuQuickAction },
+  components: { ContextMenuQuickAction, OcTable },
   props: {
     /**
      * Resources to be displayed in the table.
@@ -421,6 +425,14 @@ export default defineComponent({
      */
     space: {
       type: Object as PropType<SpaceResource>,
+      required: false,
+      default: null
+    },
+    /**
+     * This is only relevant for CERN and can be ignored in any other cases.
+     */
+    groupingSettings: {
+      type: Object,
       required: false,
       default: null
     }

--- a/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
+++ b/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
@@ -29,6 +29,7 @@
       :header-position="fileListHeaderY"
       :sort-by="sortBy"
       :sort-dir="sortDir"
+      :grouping-settings="groupingSettings"
       @file-click="triggerDefaultAction"
       @row-mounted="rowMounted"
       @sort="sortHandler"
@@ -181,6 +182,14 @@ export default defineComponent({
     fileListHeaderY: {
       type: Number,
       default: 0
+    },
+    /**
+     * This is only relevant for CERN and can be ignored in any other cases.
+     */
+    groupingSettings: {
+      type: Object,
+      required: false,
+      default: null
     }
   },
   setup() {

--- a/packages/web-app-files/src/views/shares/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithMe.vue
@@ -37,6 +37,7 @@
           :sort-dir="acceptedSortDir"
           :sort-handler="acceptedHandleSort"
           :title="acceptedTitle"
+          :grouping-settings="groupingSettings"
         />
 
         <shared-with-me-section
@@ -53,6 +54,7 @@
           :sort-dir="declinedSortDir"
           :sort-handler="declinedHandleSort"
           :title="declinedTitle"
+          :grouping-settings="groupingSettings"
         />
       </template>
     </files-view-wrapper>
@@ -75,6 +77,7 @@ import FilesViewWrapper from '../../components/FilesViewWrapper.vue'
 import { buildShareSpaceResource } from 'web-client/src/helpers'
 import { configurationManager } from 'web-pkg/src/configuration'
 import { useCapabilityShareJailEnabled, useSort, useStore } from 'web-pkg/src/composables'
+import { useGroupingSettings } from 'web-pkg/src/cern/composables'
 
 export default defineComponent({
   components: {
@@ -193,7 +196,10 @@ export default defineComponent({
       declinedHandleSort,
       declinedSortBy,
       declinedSortDir,
-      declinedItems
+      declinedItems,
+
+      // CERN
+      ...useGroupingSettings({ sortBy: acceptedSortBy, sortDir: acceptedSortDir })
     }
   },
 

--- a/packages/web-app-files/src/views/shares/SharedWithOthers.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithOthers.vue
@@ -27,6 +27,7 @@
           :header-position="fileListHeaderY"
           :sort-by="sortBy"
           :sort-dir="sortDir"
+          :grouping-settings="groupingSettings"
           @file-click="triggerDefaultAction"
           @row-mounted="rowMounted"
           @sort="handleSort"
@@ -80,6 +81,7 @@ import { defineComponent } from 'vue'
 import { Resource } from 'web-client'
 import { SpaceResource } from 'web-client/src/helpers'
 import { useStore } from 'web-pkg/src/composables'
+import { useGroupingSettings } from 'web-pkg/src/cern/composables'
 import { getSpaceFromResource } from 'web-app-files/src/helpers/resource/getSpace'
 
 const visibilityObserver = new VisibilityObserver()
@@ -103,10 +105,16 @@ export default defineComponent({
       return getSpaceFromResource({ spaces: store.getters['runtime/spaces/spaces'], resource })
     }
 
+    const resourcesViewDefaults = useResourcesViewDefaults<Resource, any, any[]>()
+    const { sortBy, sortDir } = resourcesViewDefaults
+
     return {
       ...useFileActions(),
-      ...useResourcesViewDefaults<Resource, any, any[]>(),
-      getSpace
+      ...resourcesViewDefaults,
+      getSpace,
+
+      // CERN
+      ...useGroupingSettings({ sortBy, sortDir })
     }
   },
 

--- a/packages/web-pkg/package.json
+++ b/packages/web-pkg/package.json
@@ -17,6 +17,7 @@
     "@casl/ability": "^6.3.3",
     "@casl/vue": "^2.2.1",
     "axios": "^0.27.2 || ^1.0.0",
+    "design-system": "workspace:@ownclouders/design-system@*",
     "filesize": "^9.0.11",
     "fuse.js": "^6.5.3",
     "lodash-es": "^4.17.21",

--- a/packages/web-pkg/src/cern/composables/index.ts
+++ b/packages/web-pkg/src/cern/composables/index.ts
@@ -1,0 +1,1 @@
+export * from './useGroupingSettings'

--- a/packages/web-pkg/src/cern/composables/index.ts
+++ b/packages/web-pkg/src/cern/composables/index.ts
@@ -1,1 +1,2 @@
 export * from './useGroupingSettings'
+export * from './useLoadTokenInfo'

--- a/packages/web-pkg/src/cern/composables/useGroupingSettings.ts
+++ b/packages/web-pkg/src/cern/composables/useGroupingSettings.ts
@@ -1,0 +1,104 @@
+import { computed, Ref, unref } from 'vue'
+
+export const useGroupingSettings = ({
+  sortBy,
+  sortDir
+}: {
+  sortBy: Ref<string>
+  sortDir: Ref<string>
+}) => {
+  const groupingSettings = computed(() => {
+    return {
+      groupingBy: localStorage.getItem('grouping-shared-with-me') || 'Shared on',
+      showGroupingOptions: true,
+      groupingFunctions: {
+        'Name alphabetically': function (row) {
+          localStorage.setItem('grouping-shared-with-me', 'Name alphabetically')
+          if (!isNaN(row.name.charAt(0))) {
+            return '#'
+          }
+          if (row.name.charAt(0) === '.') {
+            return row.name.charAt(1).toLowerCase()
+          }
+          return row.name.charAt(0).toLowerCase()
+        },
+        'Shared on': function (row) {
+          localStorage.setItem('grouping-shared-with-me', 'Shared on')
+          const recently = Date.now() - 604800000
+          const lastMonth = Date.now() - 2592000000
+          if (Date.parse(row.sdate) < lastMonth) {
+            return 'Older'
+          }
+          if (Date.parse(row.sdate) >= recently) {
+            return 'Recently'
+          } else {
+            return 'Last month'
+          }
+        },
+        'Share owner': function (row) {
+          localStorage.setItem('grouping-shared-with-me', 'Share owner')
+          return row.share?.owner?.displayName
+        },
+        None: function () {
+          localStorage.setItem('grouping-shared-with-me', 'None')
+        }
+      },
+      sortGroups: {
+        'Name alphabetically': function (groups) {
+          // sort in alphabetical order by group name
+          const sortedGroups = groups.sort(function (a, b) {
+            if (a.name < b.name) {
+              return -1
+            }
+            if (a.name > b.name) {
+              return 1
+            }
+            return 0
+          })
+          // if sorting is done by name, reverse groups depending on asc/desc
+          if (unref(sortBy) === 'name' && unref(sortDir) === 'desc') {
+            sortedGroups.reverse()
+          }
+          return sortedGroups
+        },
+        'Shared on': function (groups) {
+          // sort in order: 1-Recently, 2-Last month, 3-Older
+          const sortedGroups = []
+          const options = ['Recently', 'Last month', 'Older']
+          for (const o of options) {
+            const found = groups.find((el) => el.name.toLowerCase() === o.toLowerCase())
+            if (found) {
+              sortedGroups.push(found)
+            }
+          }
+          // if sorting is done by sdate, reverse groups depending on asc/desc
+          if (unref(sortBy) === 'sdate' && unref(sortDir) === 'asc') {
+            sortedGroups.reverse()
+          }
+          return sortedGroups
+        },
+        'Share owner': function (groups) {
+          // sort in alphabetical order by group name
+          const sortedGroups = groups.sort(function (a, b) {
+            if (a.name < b.name) {
+              return -1
+            }
+            if (a.name > b.name) {
+              return 1
+            }
+            return 0
+          })
+          // if sorting is done by owner, reverse groups depending on asc/desc
+          if (unref(sortBy) === 'owner' && unref(sortDir) === 'desc') {
+            sortedGroups.reverse()
+          }
+          return sortedGroups
+        }
+      }
+    }
+  })
+
+  return {
+    groupingSettings
+  }
+}

--- a/packages/web-pkg/src/cern/composables/useLoadTokenInfo.ts
+++ b/packages/web-pkg/src/cern/composables/useLoadTokenInfo.ts
@@ -1,0 +1,9 @@
+import { useTask } from 'vue-concurrency'
+
+export function useLoadTokenInfo() {
+  const loadTokenInfoTask = useTask(function* () {
+    return {}
+  })
+
+  return { loadTokenInfoTask }
+}

--- a/packages/web-runtime/src/pages/resolvePublicLink.vue
+++ b/packages/web-runtime/src/pages/resolvePublicLink.vue
@@ -82,8 +82,9 @@ import {
   PublicSpaceResource
 } from 'web-client/src/helpers'
 import isEmpty from 'lodash-es/isEmpty'
-import { useLoadTokenInfo } from '../composables/tokenInfo'
 import { useGettext } from 'vue3-gettext'
+// full import is needed here so it can be overwritten via CERN config
+import { useLoadTokenInfo } from 'web-runtime/src/composables/tokenInfo'
 
 export default defineComponent({
   name: 'ResolvePublicLink',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -903,6 +903,9 @@ importers:
       axios:
         specifier: ^0.27.2 || ^1.0.0
         version: 1.4.0
+      design-system:
+        specifier: workspace:@ownclouders/design-system@*
+        version: link:../design-system
       filesize:
         specifier: ^9.0.11
         version: 9.0.11

--- a/vite.cern.config.ts
+++ b/vite.cern.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vite'
+import _defineConfig from './vite.config'
+
+/**
+ * NOTE: This is a special config file for CERN. It overwrites some of the code paths to implement custom logic
+ * that only applies to CERN. It can and should be ignored in all other cases!
+ *
+ * Web can be run using this config via `pnpm build:w -c vite.cern.config.ts` or `pnpm vite -c vite.cern.config.ts`.
+ */
+
+export default defineConfig(async (args) => {
+  let config
+  if (typeof _defineConfig === 'function') {
+    config = await _defineConfig(args)
+  } else {
+    config = _defineConfig
+  }
+
+  // collapsible table
+  config.resolve.alias['design-system/src/components/OcTable/OcTable.vue'] =
+    'web-pkg/src/cern/components/CollapsibleOcTable.vue'
+  // token info request
+  config.resolve.alias['web-runtime/src/composables/tokenInfo'] =
+    'web-pkg/src/cern/composables/useLoadTokenInfo'
+
+  return config
+})


### PR DESCRIPTION
## Description
Adds a custom vite config for CERN. It overwrites some of our code paths to implement custom logic that only applies to CERN. Web can be built and run using this config via `pnpm build:w -c vite.cern.config.ts` or `pnpm vite -c vite.cern.config.ts`.

This PR already includes 2 things that have been overwritten:

* Collapsible table for the Shared with me/others views
* A custom composable for the `tokenInfo` request to avoid `404` errors.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/9424
- Fixes https://github.com/owncloud/web/issues/9310
- Part of https://github.com/owncloud/web/issues/9278

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
