### PR TITLE
[tests-only][e2e] Wait until readall notification action is done

### DIFF
--- a/tests/e2e/support/objects/runtime/application.ts
+++ b/tests/e2e/support/objects/runtime/application.ts
@@ -59,5 +59,6 @@ export class Application {
     }
     await this.#page.locator(notificationsLoading).waitFor({ state: 'detached' })
     await this.#page.locator(markNotificationsAsReadButton).click()
+    await this.#page.locator(notificationsLoading).waitFor({ state: 'detached' })
   }
 }


### PR DESCRIPTION
## Description
Since oC10 is slower than oCIS, action to mark all notification as read might not have been successful during the test run. And in the test, we hadn't waited for mark-as-read action to complete before doing page reload. This should have cause the tests to fail with oC10.
So, this PR has added the wait after the mark-as-read action ( wait for notification spinner to get detached)

## Related Issue
https://drone.owncloud.com/owncloud/web/37512/9/16
Flaky notification test with oc10

## How Has This Been Tested?
- local
- CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
