### PR TITLE
File versions tooltip with absolute date

### DIFF
--- a/changelog/unreleased/enhancement-absolute-date-file-versions
+++ b/changelog/unreleased/enhancement-absolute-date-file-versions
@@ -1,0 +1,5 @@
+Enhancement: File versions tooltip with absolute date
+
+We've added a tooltip with the absolute date for file versions in file details
+
+https://github.com/owncloud/web/pull/9441

--- a/packages/web-app-files/src/components/SideBar/Versions/FileVersions.vue
+++ b/packages/web-app-files/src/components/SideBar/Versions/FileVersions.vue
@@ -10,9 +10,10 @@
       >
         <div class="version-details">
           <span
+            v-oc-tooltip="formatVersionDate(item)"
             class="version-date oc-font-semibold"
             data-testid="file-versions-file-last-modified-date"
-            >{{ formatVersionDate(item) }}</span
+            >{{ formatVersionDateRelative(item) }}</span
           >
           -
           <span class="version-filesize" data-testid="file-versions-file-size">{{
@@ -61,6 +62,7 @@ import { defineComponent, inject, ref, Ref } from 'vue'
 import { isShareSpaceResource, Resource, SpaceResource } from 'web-client/src/helpers'
 import { SharePermissions } from 'web-client/src/helpers/share'
 import { useDownloadFile } from 'web-pkg/src/composables/download/useDownloadFile'
+import { formatDateFromJSDate } from 'web-pkg/src/helpers'
 
 export default defineComponent({
   name: 'FileVersions',
@@ -136,9 +138,15 @@ export default defineComponent({
       const version = this.currentVersionId(file)
       return this.downloadFile(this.resource, version)
     },
-    formatVersionDate(file) {
+    formatVersionDateRelative(file) {
       return formatRelativeDateFromHTTP(
         file.fileInfo[DavProperty.LastModifiedDate],
+        this.$language.current
+      )
+    },
+    formatVersionDate(file) {
+      return formatDateFromJSDate(
+        new Date(file.fileInfo[DavProperty.LastModifiedDate]),
         this.$language.current
       )
     },


### PR DESCRIPTION
## Description
The pr adds a tooltip with absolute date on version’s relative date in version details

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
Users of CERNBox complain about the visibility of only relative date for versions. Showing absolute dates in tooltip would be consistent with "shared on" in shares and "modified" data

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):
![Screenshot from 2023-07-19 07-23-08](https://github.com/owncloud/web/assets/7430156/624dd010-ff17-4473-89d6-807f93425f14)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
