### PR TITLE
Fix #9382: Inject base tag to all .html files

### DIFF
--- a/oidc-callback.html
+++ b/oidc-callback.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+<head></head>
 <body>
 <script>
   window.onload = function () {

--- a/oidc-silent-redirect.html
+++ b/oidc-silent-redirect.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+<head></head>
 <body>
 <script>
   window.onload = function () {

--- a/vite.cern.config.ts
+++ b/vite.cern.config.ts
@@ -23,5 +23,22 @@ export default defineConfig(async (args) => {
   config.resolve.alias['web-runtime/src/composables/tokenInfo'] =
     'web-pkg/src/cern/composables/useLoadTokenInfo'
 
+  config.plugins.push({
+    name: 'base-href',
+    transformIndexHtml: {
+      transform() {
+        return [
+          {
+            injectTo: 'head-prepend',
+            tag: 'base',
+            attrs: {
+              href: '/'
+            }
+          }
+        ]
+      }
+    }
+  })
+
   return config
 })


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Adds `base` tag for CERN at build time.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #9382

## Motivation and Context
CERN does not want to implement this dynamically on server side like we do and prefers to have a build option.

Unfortunately I needed to move two `.html` files to our project root, I tried very hard but couldn't figure out a way to avoid this. It seems basically impossible to override the output path for `.html` files in vite.
In rollup there seems to be the possibility to provide multiple `input`/`output` values and make it work that way - but that does not work in vite. It might be possibly to use a renaming plugin for rollup/vite but that did not seem worth the trouble just for keeping two files out of the project root...


## How Has This Been Tested?
Done a local CERN build and checked base tag was available in all `.html` files.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
