### PR TITLE
fix: access token renewal during cloud imports

### DIFF
--- a/changelog/unreleased/enhancement-cloud-import
+++ b/changelog/unreleased/enhancement-cloud-import
@@ -3,7 +3,9 @@ Enhancement: Cloud import
 An action to import files from other external cloud providers has been added. OneDrive is currently the only supported option.
 
 https://github.com/owncloud/web/issues/9151
+https://github.com/owncloud/web/issues/9445
 https://github.com/owncloud/web/pull/9150
 https://github.com/owncloud/web/pull/9282
 https://github.com/owncloud/web/pull/9291
 https://github.com/owncloud/web/pull/9374
+https://github.com/owncloud/web/pull/9460

--- a/package.json
+++ b/package.json
@@ -128,21 +128,21 @@
   },
   "pnpm": {
     "overrides": {
-      "@uppy/companion-client": "https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-companion-client.tgz",
-      "@uppy/core": "https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-core.tgz",
-      "@uppy/dashboard": "https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-dashboard.tgz",
-      "@uppy/drop-target": "https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-drop-target.tgz",
-      "@uppy/google-drive": "https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-google-drive.tgz",
-      "@uppy/informer": "https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-informer.tgz",
-      "@uppy/onedrive": "https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-onedrive.tgz",
-      "@uppy/provider-views": "https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-provider-views.tgz",
-      "@uppy/status-bar": "https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-status-bar.tgz",
-      "@uppy/store-default": "https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-store-default.tgz",
-      "@uppy/thumbnail-generator": "https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-thumbnail-generator.tgz",
-      "@uppy/tus": "https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-tus.tgz",
-      "@uppy/utils": "https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-utils.tgz",
-      "@uppy/webdav": "https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-webdav.tgz",
-      "@uppy/xhr-upload": "https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-xhr-upload.tgz"
+      "@uppy/companion-client": "https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-companion-client.tgz",
+      "@uppy/core": "https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-core.tgz",
+      "@uppy/dashboard": "https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-dashboard.tgz",
+      "@uppy/drop-target": "https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-drop-target.tgz",
+      "@uppy/google-drive": "https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-google-drive.tgz",
+      "@uppy/informer": "https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-informer.tgz",
+      "@uppy/onedrive": "https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-onedrive.tgz",
+      "@uppy/provider-views": "https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-provider-views.tgz",
+      "@uppy/status-bar": "https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-status-bar.tgz",
+      "@uppy/store-default": "https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-store-default.tgz",
+      "@uppy/thumbnail-generator": "https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-thumbnail-generator.tgz",
+      "@uppy/tus": "https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-tus.tgz",
+      "@uppy/utils": "https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-utils.tgz",
+      "@uppy/webdav": "https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-webdav.tgz",
+      "@uppy/xhr-upload": "https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-xhr-upload.tgz"
     },
     "packageExtensions": {
       "@adobe/leonardo-contrast-colors": {

--- a/packages/web-app-importer/src/extensions.ts
+++ b/packages/web-app-importer/src/extensions.ts
@@ -1,8 +1,4 @@
-import {
-  useAccessToken,
-  useStore,
-  usePublicLinkContext
-} from '@ownclouders/web-pkg/src/composables'
+import { useStore, usePublicLinkContext } from '@ownclouders/web-pkg/src/composables'
 import { useGettext } from 'vue3-gettext'
 import { useService } from '@ownclouders/web-pkg/src/composables/service'
 import type { UppyService } from 'web-runtime/src/services/uppyService'
@@ -20,7 +16,6 @@ import { ApplicationSetupOptions } from 'web-pkg/src/apps'
 export const extensions = ({ applicationConfig }: ApplicationSetupOptions) => {
   const store = useStore()
   const { $gettext } = useGettext()
-  const accessToken = useAccessToken({ store })
   const uppyService = useService<UppyService>('$uppyService')
   const publicLinkContext = usePublicLinkContext({ store })
 
@@ -54,19 +49,9 @@ export const extensions = ({ applicationConfig }: ApplicationSetupOptions) => {
 
   uppyService.subscribe('uploadCompleted', () => {
     removeUppyPlugins()
-    const tusPlugin = uppyService.getPlugin('Tus')
-    if (tusPlugin) {
-      tusPlugin.setOptions({ headers: {} })
-    }
   })
 
   const handler = async () => {
-    const tusPlugin = uppyService.getPlugin('Tus')
-    if (tusPlugin) {
-      tusPlugin.setOptions({
-        headers: { Authorization: 'Bearer ' + unref(accessToken) }
-      })
-    }
     const modal = {
       variation: 'passive',
       title: $gettext('Import files'),

--- a/packages/web-runtime/src/components/UploadInfo.vue
+++ b/packages/web-runtime/src/components/UploadInfo.vue
@@ -273,7 +273,7 @@ export default defineComponent({
       this.filesInProgressCount += files.filter((f) => !f.isFolder).length
 
       for (const file of files) {
-        if (!this.disableActions && file.source && file.source !== 'DropTarget') {
+        if (!this.disableActions && file.isRemote) {
           this.disableActions = true
         }
 

--- a/packages/web-runtime/src/composables/upload/useUpload.ts
+++ b/packages/web-runtime/src/composables/upload/useUpload.ts
@@ -20,6 +20,7 @@ export interface UppyResource {
   type: string
   size: number
   data: Blob
+  isRemote: boolean
   meta: {
     // IMPORTANT: must only contain primitive types, complex types won't be serialized properly!
     name?: string
@@ -93,11 +94,14 @@ export function useUpload(options: UploadOptions) {
         req.setHeader('X-Request-ID', uuidV4())
         req.setHeader('Accept-Language', unref(headers)['Accept-Language'])
       },
-      headers: (file) => ({
-        'x-oc-mtime': file.data.lastModified / 1000,
-        'X-Request-ID': uuidV4(),
-        ...unref(headers)
-      }),
+      headers: (file) =>
+        !!file.xhrUpload || file?.isRemote
+          ? {
+              'x-oc-mtime': file?.data?.lastModified / 1000,
+              'X-Request-ID': uuidV4(),
+              ...unref(headers)
+            }
+          : {},
       ...(isTusSupported && {
         tusMaxChunkSize: unref(tusMaxChunkSize),
         tusHttpMethodOverride: unref(tusHttpMethodOverride),

--- a/packages/web-runtime/src/services/uppyService.ts
+++ b/packages/web-runtime/src/services/uppyService.ts
@@ -86,12 +86,14 @@ export class UppyService {
     tusMaxChunkSize,
     tusHttpMethodOverride,
     tusExtension,
-    onBeforeRequest
+    onBeforeRequest,
+    headers
   }: {
     tusMaxChunkSize: number
     tusHttpMethodOverride: boolean
     tusExtension: string
     onBeforeRequest: () => void
+    headers: () => uppyHeaders
   }) {
     const chunkSize = tusMaxChunkSize || Infinity
     const uploadDataDuringCreation = tusExtension.includes('creation-with-upload')
@@ -103,6 +105,7 @@ export class UppyService {
       retryDelays: [0, 500, 1000],
       uploadDataDuringCreation,
       limit: 5,
+      headers,
       onBeforeRequest,
       onShouldRetry: (err, retryAttempt, options, next) => {
         // status code 5xx means the upload is gone on the server side

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,21 +1,21 @@
 lockfileVersion: '6.0'
 
 overrides:
-  '@uppy/companion-client': https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-companion-client.tgz
-  '@uppy/core': https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-core.tgz
-  '@uppy/dashboard': https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-dashboard.tgz
-  '@uppy/drop-target': https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-drop-target.tgz
-  '@uppy/google-drive': https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-google-drive.tgz
-  '@uppy/informer': https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-informer.tgz
-  '@uppy/onedrive': https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-onedrive.tgz
-  '@uppy/provider-views': https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-provider-views.tgz
-  '@uppy/status-bar': https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-status-bar.tgz
-  '@uppy/store-default': https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-store-default.tgz
-  '@uppy/thumbnail-generator': https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-thumbnail-generator.tgz
-  '@uppy/tus': https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-tus.tgz
-  '@uppy/utils': https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-utils.tgz
-  '@uppy/webdav': https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-webdav.tgz
-  '@uppy/xhr-upload': https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-xhr-upload.tgz
+  '@uppy/companion-client': https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-companion-client.tgz
+  '@uppy/core': https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-core.tgz
+  '@uppy/dashboard': https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-dashboard.tgz
+  '@uppy/drop-target': https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-drop-target.tgz
+  '@uppy/google-drive': https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-google-drive.tgz
+  '@uppy/informer': https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-informer.tgz
+  '@uppy/onedrive': https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-onedrive.tgz
+  '@uppy/provider-views': https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-provider-views.tgz
+  '@uppy/status-bar': https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-status-bar.tgz
+  '@uppy/store-default': https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-store-default.tgz
+  '@uppy/thumbnail-generator': https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-thumbnail-generator.tgz
+  '@uppy/tus': https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-tus.tgz
+  '@uppy/utils': https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-utils.tgz
+  '@uppy/webdav': https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-webdav.tgz
+  '@uppy/xhr-upload': https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-xhr-upload.tgz
 
 packageExtensionsChecksum: e5e8993047f00ffc73fd28e87ccaecb8
 
@@ -775,17 +775,17 @@ importers:
         specifier: workspace:*
         version: link:../web-pkg
       '@uppy/dashboard':
-        specifier: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-dashboard.tgz
-        version: '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-dashboard.tgz(@uppy/core@3.3.0)'
+        specifier: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-dashboard.tgz
+        version: '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-dashboard.tgz(@uppy/core@3.3.0)'
       '@uppy/google-drive':
-        specifier: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-google-drive.tgz
-        version: '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-google-drive.tgz(@uppy/core@3.3.0)'
+        specifier: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-google-drive.tgz
+        version: '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-google-drive.tgz(@uppy/core@3.3.0)'
       '@uppy/onedrive':
-        specifier: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-onedrive.tgz
-        version: '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-onedrive.tgz(@uppy/core@3.3.0)'
+        specifier: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-onedrive.tgz
+        version: '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-onedrive.tgz(@uppy/core@3.3.0)'
       '@uppy/webdav':
-        specifier: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-webdav.tgz
-        version: '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-webdav.tgz(@uppy/core@3.3.0)'
+        specifier: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-webdav.tgz
+        version: '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-webdav.tgz(@uppy/core@3.3.0)'
 
   packages/web-app-pdf-viewer:
     dependencies:
@@ -967,20 +967,20 @@ importers:
         specifier: 7.55.2
         version: 7.55.2(vue@3.3.4)
       '@uppy/core':
-        specifier: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-core.tgz
-        version: '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-core.tgz'
+        specifier: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-core.tgz
+        version: '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-core.tgz'
       '@uppy/drop-target':
-        specifier: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-drop-target.tgz
-        version: '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-drop-target.tgz(@uppy/core@3.3.0)'
+        specifier: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-drop-target.tgz
+        version: '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-drop-target.tgz(@uppy/core@3.3.0)'
       '@uppy/tus':
-        specifier: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-tus.tgz
-        version: '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-tus.tgz(@uppy/core@3.3.0)'
+        specifier: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-tus.tgz
+        version: '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-tus.tgz(@uppy/core@3.3.0)'
       '@uppy/utils':
-        specifier: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-utils.tgz
-        version: '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-utils.tgz'
+        specifier: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-utils.tgz
+        version: '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-utils.tgz'
       '@uppy/xhr-upload':
-        specifier: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-xhr-upload.tgz
-        version: '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-xhr-upload.tgz(@uppy/core@3.3.0)'
+        specifier: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-xhr-upload.tgz
+        version: '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-xhr-upload.tgz(@uppy/core@3.3.0)'
       '@vueuse/head':
         specifier: 1.1.26
         version: 1.1.26(vue@3.3.4)
@@ -6577,8 +6577,8 @@ packages:
     resolution: {integrity: sha512-LrVplQwFEc1s+rTitLywpf1tjy7ELAIag4Ejrvkij1yEOIRHCXYYVHf8ln761jRwqJ1JDY3Hr6Y+BFnCV2OSIg==}
     dependencies:
       '@transloadit/prettier-bytes': 0.0.9
-      '@uppy/store-default': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-store-default.tgz'
-      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-utils.tgz'
+      '@uppy/store-default': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-store-default.tgz'
+      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-utils.tgz'
       lodash: 4.17.21
       mime-match: 1.0.2
       namespace-emitter: 2.0.1
@@ -6593,11 +6593,11 @@ packages:
     dependencies:
       '@transloadit/prettier-bytes': 0.0.7
       '@uppy/core': 3.3.0
-      '@uppy/informer': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-informer.tgz(@uppy/core@3.3.0)'
-      '@uppy/provider-views': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-provider-views.tgz(@uppy/core@3.3.0)'
-      '@uppy/status-bar': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-status-bar.tgz(@uppy/core@3.3.0)'
-      '@uppy/thumbnail-generator': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-thumbnail-generator.tgz(@uppy/core@3.3.0)'
-      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-utils.tgz'
+      '@uppy/informer': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-informer.tgz(@uppy/core@3.3.0)'
+      '@uppy/provider-views': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-provider-views.tgz(@uppy/core@3.3.0)'
+      '@uppy/status-bar': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-status-bar.tgz(@uppy/core@3.3.0)'
+      '@uppy/thumbnail-generator': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-thumbnail-generator.tgz(@uppy/core@3.3.0)'
+      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-utils.tgz'
       classnames: 2.3.2
       is-shallow-equal: 1.0.1
       lodash: 4.17.21
@@ -6611,10 +6611,10 @@ packages:
     peerDependencies:
       '@uppy/core': ^3.2.0
     dependencies:
-      '@uppy/companion-client': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-companion-client.tgz'
+      '@uppy/companion-client': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-companion-client.tgz'
       '@uppy/core': 3.3.0
-      '@uppy/provider-views': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-provider-views.tgz(@uppy/core@3.3.0)'
-      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-utils.tgz'
+      '@uppy/provider-views': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-provider-views.tgz(@uppy/core@3.3.0)'
+      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-utils.tgz'
       preact: 10.7.1
     dev: false
 
@@ -21515,23 +21515,23 @@ packages:
       - typescript
     dev: false
 
-  '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-companion-client.tgz':
-    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-companion-client.tgz}
+  '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-companion-client.tgz':
+    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-companion-client.tgz}
     name: '@uppy/companion-client'
     version: 3.2.0
     dependencies:
-      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-utils.tgz'
+      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-utils.tgz'
       namespace-emitter: 2.0.1
     dev: false
 
-  '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-core.tgz':
-    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-core.tgz}
+  '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-core.tgz':
+    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-core.tgz}
     name: '@uppy/core'
     version: 3.3.0
     dependencies:
       '@transloadit/prettier-bytes': 0.0.9
-      '@uppy/store-default': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-store-default.tgz'
-      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-utils.tgz'
+      '@uppy/store-default': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-store-default.tgz'
+      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-utils.tgz'
       lodash: 4.17.21
       mime-match: 1.0.2
       namespace-emitter: 2.0.1
@@ -21539,9 +21539,9 @@ packages:
       preact: 10.7.1
     dev: false
 
-  '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-dashboard.tgz(@uppy/core@3.3.0)':
-    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-dashboard.tgz}
-    id: '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-dashboard.tgz'
+  '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-dashboard.tgz(@uppy/core@3.3.0)':
+    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-dashboard.tgz}
+    id: '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-dashboard.tgz'
     name: '@uppy/dashboard'
     version: 3.4.1
     peerDependencies:
@@ -21549,11 +21549,11 @@ packages:
     dependencies:
       '@transloadit/prettier-bytes': 0.0.7
       '@uppy/core': 3.3.0
-      '@uppy/informer': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-informer.tgz(@uppy/core@3.3.0)'
-      '@uppy/provider-views': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-provider-views.tgz(@uppy/core@3.3.0)'
-      '@uppy/status-bar': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-status-bar.tgz(@uppy/core@3.3.0)'
-      '@uppy/thumbnail-generator': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-thumbnail-generator.tgz(@uppy/core@3.3.0)'
-      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-utils.tgz'
+      '@uppy/informer': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-informer.tgz(@uppy/core@3.3.0)'
+      '@uppy/provider-views': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-provider-views.tgz(@uppy/core@3.3.0)'
+      '@uppy/status-bar': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-status-bar.tgz(@uppy/core@3.3.0)'
+      '@uppy/thumbnail-generator': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-thumbnail-generator.tgz(@uppy/core@3.3.0)'
+      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-utils.tgz'
       classnames: 2.3.2
       is-shallow-equal: 1.0.1
       lodash: 4.17.21
@@ -21562,80 +21562,80 @@ packages:
       preact: 10.7.1
     dev: false
 
-  '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-drop-target.tgz(@uppy/core@3.3.0)':
-    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-drop-target.tgz}
-    id: '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-drop-target.tgz'
+  '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-drop-target.tgz(@uppy/core@3.3.0)':
+    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-drop-target.tgz}
+    id: '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-drop-target.tgz'
     name: '@uppy/drop-target'
     version: 2.0.1
     peerDependencies:
       '@uppy/core': ^3.3.0
     dependencies:
-      '@uppy/core': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-core.tgz'
-      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-utils.tgz'
+      '@uppy/core': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-core.tgz'
+      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-utils.tgz'
     dev: false
 
-  '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-google-drive.tgz(@uppy/core@3.3.0)':
-    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-google-drive.tgz}
-    id: '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-google-drive.tgz'
+  '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-google-drive.tgz(@uppy/core@3.3.0)':
+    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-google-drive.tgz}
+    id: '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-google-drive.tgz'
     name: '@uppy/google-drive'
     version: 3.1.1
     peerDependencies:
       '@uppy/core': ^3.3.0
     dependencies:
-      '@uppy/companion-client': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-companion-client.tgz'
+      '@uppy/companion-client': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-companion-client.tgz'
       '@uppy/core': 3.3.0
-      '@uppy/provider-views': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-provider-views.tgz(@uppy/core@3.3.0)'
-      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-utils.tgz'
+      '@uppy/provider-views': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-provider-views.tgz(@uppy/core@3.3.0)'
+      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-utils.tgz'
       preact: 10.7.1
     dev: false
 
-  '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-informer.tgz(@uppy/core@3.3.0)':
-    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-informer.tgz}
-    id: '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-informer.tgz'
+  '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-informer.tgz(@uppy/core@3.3.0)':
+    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-informer.tgz}
+    id: '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-informer.tgz'
     name: '@uppy/informer'
     version: 3.0.2
     peerDependencies:
       '@uppy/core': ^3.3.0
     dependencies:
       '@uppy/core': 3.3.0
-      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-utils.tgz'
+      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-utils.tgz'
       preact: 10.7.1
     dev: false
 
-  '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-onedrive.tgz(@uppy/core@3.3.0)':
-    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-onedrive.tgz}
-    id: '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-onedrive.tgz'
+  '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-onedrive.tgz(@uppy/core@3.3.0)':
+    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-onedrive.tgz}
+    id: '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-onedrive.tgz'
     name: '@uppy/onedrive'
     version: 3.1.1
     peerDependencies:
       '@uppy/core': ^3.3.0
     dependencies:
-      '@uppy/companion-client': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-companion-client.tgz'
+      '@uppy/companion-client': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-companion-client.tgz'
       '@uppy/core': 3.3.0
-      '@uppy/provider-views': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-provider-views.tgz(@uppy/core@3.3.0)'
-      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-utils.tgz'
+      '@uppy/provider-views': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-provider-views.tgz(@uppy/core@3.3.0)'
+      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-utils.tgz'
       preact: 10.7.1
     dev: false
 
-  '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-provider-views.tgz(@uppy/core@3.3.0)':
-    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-provider-views.tgz}
-    id: '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-provider-views.tgz'
+  '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-provider-views.tgz(@uppy/core@3.3.0)':
+    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-provider-views.tgz}
+    id: '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-provider-views.tgz'
     name: '@uppy/provider-views'
     version: 3.3.1
     peerDependencies:
       '@uppy/core': ^3.3.0
     dependencies:
       '@uppy/core': 3.3.0
-      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-utils.tgz'
+      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-utils.tgz'
       classnames: 2.3.2
       nanoid: 4.0.0
       p-queue: 7.3.4
       preact: 10.7.1
     dev: false
 
-  '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-status-bar.tgz(@uppy/core@3.3.0)':
-    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-status-bar.tgz}
-    id: '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-status-bar.tgz'
+  '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-status-bar.tgz(@uppy/core@3.3.0)':
+    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-status-bar.tgz}
+    id: '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-status-bar.tgz'
     name: '@uppy/status-bar'
     version: 3.2.1
     peerDependencies:
@@ -21643,78 +21643,78 @@ packages:
     dependencies:
       '@transloadit/prettier-bytes': 0.0.9
       '@uppy/core': 3.3.0
-      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-utils.tgz'
+      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-utils.tgz'
       classnames: 2.3.2
       preact: 10.7.1
     dev: false
 
-  '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-store-default.tgz':
-    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-store-default.tgz}
+  '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-store-default.tgz':
+    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-store-default.tgz}
     name: '@uppy/store-default'
     version: 3.0.3
     dev: false
 
-  '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-thumbnail-generator.tgz(@uppy/core@3.3.0)':
-    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-thumbnail-generator.tgz}
-    id: '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-thumbnail-generator.tgz'
+  '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-thumbnail-generator.tgz(@uppy/core@3.3.0)':
+    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-thumbnail-generator.tgz}
+    id: '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-thumbnail-generator.tgz'
     name: '@uppy/thumbnail-generator'
     version: 3.0.3
     peerDependencies:
       '@uppy/core': ^3.3.0
     dependencies:
       '@uppy/core': 3.3.0
-      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-utils.tgz'
+      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-utils.tgz'
       exifr: 7.1.3
     dev: false
 
-  '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-tus.tgz(@uppy/core@3.3.0)':
-    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-tus.tgz}
-    id: '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-tus.tgz'
+  '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-tus.tgz(@uppy/core@3.3.0)':
+    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-tus.tgz}
+    id: '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-tus.tgz'
     name: '@uppy/tus'
     version: 3.1.2
     peerDependencies:
       '@uppy/core': ^3.3.0
     dependencies:
-      '@uppy/companion-client': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-companion-client.tgz'
-      '@uppy/core': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-core.tgz'
-      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-utils.tgz'
+      '@uppy/companion-client': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-companion-client.tgz'
+      '@uppy/core': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-core.tgz'
+      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-utils.tgz'
       tus-js-client: 3.0.0
     dev: false
 
-  '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-utils.tgz':
-    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-utils.tgz}
+  '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-utils.tgz':
+    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-utils.tgz}
     name: '@uppy/utils'
     version: 5.4.0
     dependencies:
       lodash: 4.17.21
     dev: false
 
-  '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-webdav.tgz(@uppy/core@3.3.0)':
-    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-webdav.tgz}
-    id: '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-webdav.tgz'
+  '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-webdav.tgz(@uppy/core@3.3.0)':
+    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-webdav.tgz}
+    id: '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-webdav.tgz'
     name: '@uppy/webdav'
     version: 3.1.1
     peerDependencies:
       '@uppy/core': ^3.3.0
     dependencies:
-      '@uppy/companion-client': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-companion-client.tgz'
+      '@uppy/companion-client': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-companion-client.tgz'
       '@uppy/core': 3.3.0
-      '@uppy/provider-views': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-provider-views.tgz(@uppy/core@3.3.0)'
-      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-utils.tgz'
+      '@uppy/provider-views': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-provider-views.tgz(@uppy/core@3.3.0)'
+      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-utils.tgz'
       preact: 10.7.1
     dev: false
 
-  '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-xhr-upload.tgz(@uppy/core@3.3.0)':
-    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-xhr-upload.tgz}
-    id: '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-xhr-upload.tgz'
+  '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-xhr-upload.tgz(@uppy/core@3.3.0)':
+    resolution: {tarball: https://github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-xhr-upload.tgz}
+    id: '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-xhr-upload.tgz'
     name: '@uppy/xhr-upload'
     version: 3.3.1
     peerDependencies:
       '@uppy/core': ^3.3.0
     dependencies:
-      '@uppy/companion-client': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-companion-client.tgz'
-      '@uppy/core': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-core.tgz'
-      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.3-owncloud/uppy-utils.tgz'
+      '@uppy/companion-client': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-companion-client.tgz'
+      '@uppy/core': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-core.tgz'
+      '@uppy/utils': '@github.com/owncloud/uppy/releases/download/v3.12.9-owncloud/uppy-utils.tgz'
       nanoid: 4.0.0
     dev: false
 


### PR DESCRIPTION
## Description
Fixes access tokens not being renewed when they expire during cloud imports.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9445

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
