### PR TITLE
fix: prevent uploads when a cloud import is running

### DIFF
--- a/changelog/unreleased/enhancement-cloud-import
+++ b/changelog/unreleased/enhancement-cloud-import
@@ -5,9 +5,11 @@ An action to import files from other external cloud providers has been added. On
 https://github.com/owncloud/web/issues/9151
 https://github.com/owncloud/web/issues/9445
 https://github.com/owncloud/web/issues/9469
+https://github.com/owncloud/web/issues/9454
 https://github.com/owncloud/web/pull/9150
 https://github.com/owncloud/web/pull/9282
 https://github.com/owncloud/web/pull/9291
 https://github.com/owncloud/web/pull/9374
 https://github.com/owncloud/web/pull/9460
 https://github.com/owncloud/web/pull/9471
+https://github.com/owncloud/web/pull/9470

--- a/packages/web-app-files/tests/unit/components/AppBar/Upload/ResourceUpload.spec.ts
+++ b/packages/web-app-files/tests/unit/components/AppBar/Upload/ResourceUpload.spec.ts
@@ -1,4 +1,5 @@
-import ResourceUpload from '../../../../../src/components/AppBar/Upload/ResourceUpload.vue'
+import { mockDeep } from 'jest-mock-extended'
+import ResourceUpload from 'web-app-files/src/components/AppBar/Upload/ResourceUpload.vue'
 import {
   createStore,
   defaultComponentMocks,
@@ -7,8 +8,7 @@ import {
   defaultStubs,
   mount
 } from 'web-test-helpers'
-
-const Translate = jest.fn()
+import { UppyService } from 'web-runtime/src/services/uppyService'
 
 describe('Resource Upload Component', () => {
   describe('file upload', () => {
@@ -44,12 +44,22 @@ describe('Resource Upload Component', () => {
       expect((fileUploadInput.element as HTMLElement).click).toHaveBeenCalledTimes(1)
     })
   })
+
+  it('should be disabled when a remote upload is running', () => {
+    const uppyService = mockDeep<UppyService>()
+    uppyService.isRemoteUploadInProgress.mockReturnValue(true)
+    const { wrapper } = getWrapper({ isFolder: true }, uppyService)
+    expect(wrapper.findComponent<any>('button').props('disabled')).toBeTruthy()
+  })
 })
 
-function getWrapper(props = {}) {
+function getWrapper(props = {}, uppyService = mockDeep<UppyService>()) {
   const storeOptions = { ...defaultStoreMockOptions }
   const store = createStore(storeOptions)
-  const mocks = defaultComponentMocks()
+  const mocks = {
+    ...defaultComponentMocks(),
+    $uppyService: uppyService
+  }
   return {
     storeOptions,
     mocks,
@@ -58,8 +68,8 @@ function getWrapper(props = {}) {
       global: {
         mocks,
         stubs: defaultStubs,
-        plugins: [...defaultPlugins(), store],
-        directives: { Translate }
+        provide: mocks,
+        plugins: [...defaultPlugins(), store]
       }
     })
   }

--- a/packages/web-app-importer/src/extensions.ts
+++ b/packages/web-app-importer/src/extensions.ts
@@ -116,6 +116,8 @@ export const extensions = ({ applicationConfig }: ApplicationSetupOptions) => {
 
               return unref(canUpload)
             },
+            isDisabled: () => !!Object.keys(uppyService.getCurrentUploads()).length,
+            disabledTooltip: () => $gettext('Please wait until all imports have finished'),
             componentType: 'button',
             class: 'oc-files-actions-import'
           }

--- a/packages/web-app-importer/tests/unit/extensions.spec.ts
+++ b/packages/web-app-importer/tests/unit/extensions.spec.ts
@@ -7,9 +7,10 @@ import {
 } from 'web-test-helpers'
 import { unref } from 'vue'
 import { Resource } from '@ownclouders/web-client'
-import { mock } from 'jest-mock-extended'
+import { mock, mockDeep } from 'jest-mock-extended'
 import { extensions } from '../../src/extensions'
 import { ApplicationSetupOptions } from 'web-pkg/src/apps'
+import { UppyService } from 'web-runtime/src/services/uppyService'
 
 const getAction = (opts: ApplicationSetupOptions) => {
   const { action } = unref(extensions(opts))[0]
@@ -68,15 +69,41 @@ describe('useFileActionsImport', () => {
       })
     })
   })
+  describe('isDisabled', () => {
+    it('is true when uploads are running', () => {
+      const uppyService = mockDeep<UppyService>()
+      uppyService.getCurrentUploads.mockReturnValue({ id: '1' })
+      getWrapper({
+        uppyService,
+        setup: () => {
+          const action = getAction({ applicationConfig: { companionUrl: 'companionUrl' } })
+          expect(action.isDisabled()).toBeTruthy()
+        }
+      })
+    })
+    it('is false when no uploads are running', () => {
+      const uppyService = mockDeep<UppyService>()
+      uppyService.getCurrentUploads.mockReturnValue({})
+      getWrapper({
+        uppyService,
+        setup: () => {
+          const action = getAction({ applicationConfig: { companionUrl: 'companionUrl' } })
+          expect(action.isDisabled()).toBeFalsy()
+        }
+      })
+    })
+  })
 })
 
 function getWrapper({
   routeName = 'files-spaces-generic',
   currentFolder = mock<Resource>(),
+  uppyService = mockDeep<UppyService>(),
   setup = () => undefined
 } = {}) {
   const mocks = {
-    ...defaultComponentMocks({ currentRoute: mock<RouteLocation>({ name: routeName }) })
+    ...defaultComponentMocks({ currentRoute: mock<RouteLocation>({ name: routeName }) }),
+    $uppyService: uppyService
   }
   const storeOptions = defaultStoreMockOptions
   storeOptions.modules.Files.getters.currentFolder.mockReturnValue(currentFolder)

--- a/packages/web-runtime/src/services/uppyService.ts
+++ b/packages/web-runtime/src/services/uppyService.ts
@@ -276,6 +276,14 @@ export class UppyService {
     return this.uppy.cancelAll()
   }
 
+  getCurrentUploads(): Record<string, unknown> {
+    return this.uppy.getState().currentUploads
+  }
+
+  isRemoteUploadInProgress(): boolean {
+    return this.uppy.getFiles().some((f) => f.isRemote && !(f as any).error)
+  }
+
   clearInputs() {
     this.uploadInputs.forEach((item) => {
       item.value = null


### PR DESCRIPTION
## Description
Running other uploads or imports when a cloud import is running causes several issues, hence prevent it from happening.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9454

## Screenshots
<img width="401" alt="Personal" src="https://github.com/owncloud/web/assets/50302941/0049ae58-3188-4faf-bdfe-b74aa5d72782">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
