### PR TITLE
fix: broken cloud import dashboard when upload failed before

### DIFF
--- a/changelog/unreleased/enhancement-cloud-import
+++ b/changelog/unreleased/enhancement-cloud-import
@@ -4,8 +4,10 @@ An action to import files from other external cloud providers has been added. On
 
 https://github.com/owncloud/web/issues/9151
 https://github.com/owncloud/web/issues/9445
+https://github.com/owncloud/web/issues/9469
 https://github.com/owncloud/web/pull/9150
 https://github.com/owncloud/web/pull/9282
 https://github.com/owncloud/web/pull/9291
 https://github.com/owncloud/web/pull/9374
 https://github.com/owncloud/web/pull/9460
+https://github.com/owncloud/web/pull/9471

--- a/packages/web-app-importer/src/extensions.ts
+++ b/packages/web-app-importer/src/extensions.ts
@@ -68,6 +68,8 @@ export const extensions = ({ applicationConfig }: ApplicationSetupOptions) => {
       inline: true,
       target: '.oc-modal-body',
       disableLocalFiles: true,
+      disableStatusBar: true,
+      showSelectedFiles: false,
       locale: {
         strings: {
           cancel: $gettext('Cancel'),


### PR DESCRIPTION
## Description
Files that could not be uploaded stay in the Uppy file queue for retries, which caused the dashboard for the cloud importer to display such files instead of the actual importer UI. This PR simply disables the file display in the dashboard as we don't use it anyway.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9469
- Fixes https://github.com/owncloud/web/issues/9473

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
