### PR TITLE
fix: merging folders

### DIFF
--- a/changelog/unreleased/bugfix-merging-folders
+++ b/changelog/unreleased/bugfix-merging-folders
@@ -1,0 +1,6 @@
+Bugfix: Merging folders
+
+Merging folders as option to handle name conflicts has been fixed.
+
+https://github.com/owncloud/web/issues/9461
+https://github.com/owncloud/web/pull/9477

--- a/packages/web-app-files/src/HandleUpload.ts
+++ b/packages/web-app-files/src/HandleUpload.ts
@@ -330,9 +330,11 @@ export class HandleUpload extends BasePlugin {
           createdSubFolders += `/${subFolder}`
           createdFolders.push(createdSubFolders)
         } catch (error) {
-          console.error(error)
-          failedFolders.push(folderToCreate)
-          this.uppyService.publish('uploadError', { file: uppyResource, error })
+          if (error.statusCode !== 405) {
+            console.error(error)
+            failedFolders.push(folderToCreate)
+            this.uppyService.publish('uploadError', { file: uppyResource, error })
+          }
         }
       }
     }


### PR DESCRIPTION
## Description
Skip folder creation when a folder already exists (= server responds with status code `405`).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9461

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
