### PR TITLE
fix: logo not showing

### DIFF
--- a/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -6,7 +6,12 @@
   >
     <div class="oc-topbar-left oc-flex oc-flex-middle oc-flex-start">
       <applications-menu v-if="appMenuItems.length" :applications-list="appMenuItems" />
-      <router-link ref="navigationSidebarLogo" v-oc-tooltip="$gettext('Back to home')" to="/">
+      <router-link
+        ref="navigationSidebarLogo"
+        v-oc-tooltip="$gettext('Back to home')"
+        to="/"
+        class="oc-width-1-1"
+      >
         <oc-img :src="logoImage" :alt="sidebarLogoAlt" class="oc-logo-image" />
       </router-link>
     </div>


### PR DESCRIPTION
## Description
I don't know why exactly, but sometimes the logo is not showing up after a page reload. Adding `width: 100%` via CSS seems to fix the issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
