### PR TITLE
Bugfix: Space description edit modal is cut off vertically

### DIFF
--- a/packages/web-pkg/src/components/Spaces/ReadmeContentModal.vue
+++ b/packages/web-pkg/src/components/Spaces/ReadmeContentModal.vue
@@ -14,7 +14,6 @@
           id="description-input-area"
           v-model="readmeContent"
           class="oc-width-1-1 oc-height-1-1 oc-input oc-text-input"
-          rows="30"
         ></textarea>
       </template>
     </oc-modal>
@@ -86,3 +85,8 @@ export default defineComponent({
   }
 })
 </script>
+<style lang="scss" scoped>
+#description-input-area {
+  height: 40vh;
+}
+</style>


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
We've fixed the space description modal input, which was cut off at smaller screen sizes.
See https://github.com/owncloud/web/issues/9490

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9490

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

