### PR TITLE
[tests-only][full-ci] Run `tika` service on necessary pipelines

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -78,6 +78,7 @@ config = {
         "oCIS-1": {
             "earlyFail": True,
             "skip": False,
+            "tikaNeeded": True,
             "featurePaths": [
                 "tests/e2e/cucumber/features/{smoke,journeys}/*[!.oc10].feature",
             ],
@@ -1099,6 +1100,7 @@ def e2eTests(ctx):
         "reportTracing": "false",
         "db": "mysql:5.5",
         "featurePaths": "",
+        "tikaNeeded": False,
     }
 
     e2e_trigger = {
@@ -1166,8 +1168,8 @@ def e2eTests(ctx):
             # oCIS specific steps
             steps += setupServerConfigureWeb(params["logLevel"]) + \
                      restoreOcisCache() + \
-                     tikaService() + \
-                     ocisService("e2e-tests") + \
+                     (tikaService() if params["tikaNeeded"] else []) + \
+                     ocisService("e2e-tests", tika_enabled = params["tikaNeeded"]) + \
                      getSkeletonFiles()
 
         steps += [{
@@ -2090,7 +2092,7 @@ def idpService():
         }],
     }]
 
-def ocisService(type):
+def ocisService(type, tika_enabled = False):
     environment = {
         "IDM_ADMIN_PASSWORD": "admin",  # override the random admin password from `ocis init`
         "IDP_IDENTIFIER_REGISTRATION_CONF": "%s" % dir["ocisIdentifierRegistrationConfig"],
@@ -2113,7 +2115,7 @@ def ocisService(type):
         "FRONTEND_OCS_ENABLE_DENIALS": True,
     }
 
-    if type == "e2e-tests":
+    if tika_enabled:
         environment["FRONTEND_FULL_TEXT_SEARCH_ENABLED"] = True
         environment["SEARCH_EXTRACTOR_TYPE"] = "tika"
         environment["SEARCH_EXTRACTOR_TIKA_TIKA_URL"] = "http://tika:9998"


### PR DESCRIPTION
## Description
Currently, this PR refactor drone to run the tika service on e2e-tests-ocis-1  pipeline. `fullTextSearch.feature` need the tika service. 
- Another way separate pipeline with respect to service needed

## Related Issue
- Fixes https://github.com/owncloud/web/issues/9467

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
