### PR TITLE
Search Bar filter translation

### DIFF
--- a/packages/web-pkg/src/components/SearchBarFilter.vue
+++ b/packages/web-pkg/src/components/SearchBarFilter.vue
@@ -4,7 +4,7 @@
       <oc-filter-chip
         :is-toggle="false"
         :is-toggle-active="false"
-        :filter-label="$gettext(currentSelection.title)"
+        :filter-label="currentSelectionTitle"
         :selected-item-names="[]"
         class="oc-search-bar-filter"
         raw
@@ -23,7 +23,7 @@
             :data-test-id="option.id"
             @click="onOptionSelected(option)"
           >
-            <span>{{ $gettext(option.title) }}</span>
+            <span>{{ option.title }}</span>
             <div v-if="option.id === currentSelection.id" class="oc-flex">
               <oc-icon name="check" />
             </div>
@@ -57,19 +57,18 @@ export default defineComponent({
     const { $gettext } = useGettext()
     const useSopeQueryValue = useRouteQuery('useScope')
 
-    const currentFolderEnabled = computed(() => props.currentFolderAvailable)
-
     const currentSelection = ref<LocationOption>()
     const userSelection = ref<LocationOption>()
-    const locationOptions = ref<LocationOption[]>([
+    const currentSelectionTitle = computed(() => $gettext(currentSelection.value?.title))
+    const locationOptions = computed<LocationOption[]>(() => [
       {
         id: SearchLocationFilterConstants.currentFolder,
-        title: 'Current Folder',
-        enabled: currentFolderEnabled
+        title: $gettext('Current Folder'),
+        enabled: props.currentFolderAvailable
       },
       {
         id: SearchLocationFilterConstants.allFiles,
-        title: 'All Files',
+        title: $gettext('All Files'),
         enabled: true
       }
     ])
@@ -122,7 +121,13 @@ export default defineComponent({
       emit('update:modelValue', { value: option })
     }
 
-    return { currentSelection, isIndexGreaterZero, onOptionSelected, locationOptions, $gettext }
+    return {
+      currentSelection,
+      currentSelectionTitle,
+      isIndexGreaterZero,
+      onOptionSelected,
+      locationOptions
+    }
   }
 })
 </script>

--- a/packages/web-pkg/src/components/SearchBarFilter.vue
+++ b/packages/web-pkg/src/components/SearchBarFilter.vue
@@ -4,7 +4,7 @@
       <oc-filter-chip
         :is-toggle="false"
         :is-toggle-active="false"
-        :filter-label="currentSelection.title"
+        :filter-label="$gettext(currentSelection.title)"
         :selected-item-names="[]"
         class="oc-search-bar-filter"
         raw
@@ -23,7 +23,7 @@
             :data-test-id="option.id"
             @click="onOptionSelected(option)"
           >
-            <span>{{ option.title }}</span>
+            <span>{{ $gettext(option.title) }}</span>
             <div v-if="option.id === currentSelection.id" class="oc-flex">
               <oc-icon name="check" />
             </div>
@@ -64,12 +64,12 @@ export default defineComponent({
     const locationOptions = ref<LocationOption[]>([
       {
         id: SearchLocationFilterConstants.currentFolder,
-        title: $gettext('Current Folder'),
+        title: 'Current Folder',
         enabled: currentFolderEnabled
       },
       {
         id: SearchLocationFilterConstants.allFiles,
-        title: $gettext('All Files'),
+        title: 'All Files',
         enabled: true
       }
     ])
@@ -122,7 +122,7 @@ export default defineComponent({
       emit('update:modelValue', { value: option })
     }
 
-    return { currentSelection, isIndexGreaterZero, onOptionSelected, locationOptions }
+    return { currentSelection, isIndexGreaterZero, onOptionSelected, locationOptions, $gettext }
   }
 })
 </script>


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Moving translation to template keeps language and doesn't break "current folder"

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9444

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

