### PR TITLE
shared with action menu expiration date label alignment

### DIFF
--- a/changelog/unreleased/bugfix-align-label
+++ b/changelog/unreleased/bugfix-align-label
@@ -1,0 +1,6 @@
+Bugfix: Shared with action menu label alignment
+
+Adjusted offset of alignment of label for shared with action menu option in Sidebar.
+
+https://github.com/owncloud/web/pull/9529
+https://github.com/owncloud/web/issues/9323

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/EditDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/EditDropdown.vue
@@ -58,7 +58,7 @@
               @click="option.method"
             >
               <oc-icon :name="option.icon" fill-type="line" size="medium" variation="passive" />
-              <span class="oc-ml-s" v-text="option.title" />
+              <span v-text="option.title" />
             </oc-button>
           </template>
         </li>


### PR DESCRIPTION
## Description
Previously in the label of the option "set expiration date" and “edit expiration date” for resources in the Shares sidebar was not in line. The same problem also applied to expiration date of members in Spaces. I removed the spacing between the icons and labels of the options below “set/edit expiration date” so that the design matches with the spacing of the same feature for sharing links. 

## Related Issue
- Fixes #9323

## Motivation and Context
Maintain consistent design in the UI

## How Has This Been Tested?
inspecting HTML code output, manual testing in Chrome 

## Screenshots (if appropriate):

Design Reference for width of spacing
![Screenshot_Shares_Add_Expiration_Date_Design_Reference](https://github.com/owncloud/web/assets/8348693/764e3525-5727-4433-9ad4-2f6b2852545e)

Shares after modification
![Screenshot_Shares_Set_Expiration_Date_after_modification](https://github.com/owncloud/web/assets/8348693/7095abec-5b32-4101-aec0-7925cae7792b)

Spaces after modification
![Screenshot_Spaces_Set_Expiration_Date_after_modification](https://github.com/owncloud/web/assets/8348693/4546fb2b-b8ea-42a4-baf4-f1c3b9306c45)

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] ...