### PR TITLE
fix: filter chip design

### DIFF
--- a/packages/design-system/src/components/OcFilterChip/OcFilterChip.vue
+++ b/packages/design-system/src/components/OcFilterChip/OcFilterChip.vue
@@ -115,7 +115,7 @@ export default defineComponent({
 
 <style lang="scss">
 .oc-filter-chip {
-  &-button {
+  &-button.oc-pill {
     align-items: center;
     background-color: var(--oc-color-background-default) !important;
     color: var(--oc-color-text-muted) !important;
@@ -129,17 +129,16 @@ export default defineComponent({
     max-width: 150px;
     height: 24px;
     padding: var(--oc-space-xsmall) var(--oc-space-small) !important;
-
-    &-selected,
-    &-selected:hover {
-      background-color: var(--oc-color-swatch-primary-default) !important;
-      color: var(--oc-color-text-inverse) !important;
-      border-top-left-radius: 99px !important;
-      border-bottom-left-radius: 99px !important;
-      border-top-right-radius: 0px !important;
-      border-bottom-right-radius: 0px !important;
-      border: 0;
-    }
+  }
+  &-button-selected.oc-pill,
+  &-button-selected.oc-pill:hover {
+    background-color: var(--oc-color-swatch-primary-default) !important;
+    color: var(--oc-color-text-inverse) !important;
+    border-top-left-radius: 99px !important;
+    border-bottom-left-radius: 99px !important;
+    border-top-right-radius: 0px !important;
+    border-bottom-right-radius: 0px !important;
+    border: 0;
   }
   &-clear,
   &-clear:hover {


### PR DESCRIPTION
## Description
This error only happened on master and when using `pnpm build:w`. We still need to figure out why CSS properties have different priorities when using `pnpm vite` and `pnpm build`.

Broken:
<img width="454" alt="image" src="https://github.com/owncloud/web/assets/50302941/3463b888-2501-4861-9067-c87b89f5c3d6">


Fixed:
<img width="444" alt="image" src="https://github.com/owncloud/web/assets/50302941/44f72ace-c5df-4594-90ba-3c55ee6ac706">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
