### PR TITLE
chore: bump sonarcloud to v5.0

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -27,7 +27,7 @@ PLUGINS_S3_CACHE = "plugins/s3-cache:1"
 PLUGINS_SLACK = "plugins/slack:1"
 SELENIUM_STANDALONE_CHROME = "selenium/standalone-chrome:104.0-20220812"
 SELENIUM_STANDALONE_FIREFOX = "selenium/standalone-firefox:104.0-20220812"
-SONARSOURCE_SONAR_SCANNER_CLI = "sonarsource/sonar-scanner-cli:4.7.0"
+SONARSOURCE_SONAR_SCANNER_CLI = "sonarsource/sonar-scanner-cli:5.0"
 TOOLHIPPIE_CALENS = "toolhippie/calens:latest"
 
 WEB_PUBLISH_NPM_PACKAGES = ["babel-preset", "eslint-config", "extension-sdk", "prettier-config", "tsconfig", "web-client", "web-pkg"]


### PR DESCRIPTION
Bump SonarCloud to avoid Java errors.