### PR TITLE
Add note for oC10 version pin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.0.2",
+  "version": "7.0.3",
   "private": true,
   "homepage": "https://github.com/owncloud/web",
   "license": "AGPL-3.0",

--- a/packages/web-integration-oc10/appinfo/info.xml
+++ b/packages/web-integration-oc10/appinfo/info.xml
@@ -12,6 +12,8 @@ ownCloud Web is a single page, standalone frontend based on modern web technolog
 
 To get started, some further configuration is necessary. Find more information on the deployment with this extension in the [documentation](https://owncloud.dev/clients/web/deployments/oc10-app).
 For feedback and bug reports, please use the [public issue tracker](https://github.com/owncloud/web/issues).
+
+Important note: Please be advised that the compatibility of the Web UI for ownCloud 10 is specifically pinned to version 7.0.3. As a result, newer versions of the web UI may not function properly with ownCloud 10 as the backend. Rest assured, security-relevant patches will continue to be delivered to ensure ongoing stability and protection.
 	</description>
 	<licence>AGPL</licence>
 	<author>ownCloud</author>

--- a/packages/web-integration-oc10/appinfo/info.xml
+++ b/packages/web-integration-oc10/appinfo/info.xml
@@ -17,7 +17,7 @@ Important note: Please be advised that the compatibility of the Web UI for ownCl
 	</description>
 	<licence>AGPL</licence>
 	<author>ownCloud</author>
-	<version>7.0.2</version>
+	<version>7.0.3</version>
 	<category>tools</category>
 	<website>https://github.com/owncloud/web</website>
 	<bugs>https://github.com/owncloud/web/issues</bugs>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@
 sonar.projectKey=owncloud_web
 sonar.organization=owncloud-1
 sonar.projectName=Web
-sonar.projectVersion=7.0.2
+sonar.projectVersion=7.0.3
 sonar.host.url=https://sonarcloud.io
 
 # =====================================================


### PR DESCRIPTION
...and bump Web to `v7.0.3`. Fixes https://github.com/owncloud/web/issues/9535.