### PR TITLE
perf: upload preparation time

### DIFF
--- a/packages/web-app-files/src/helpers/resource/actions/upload.ts
+++ b/packages/web-app-files/src/helpers/resource/actions/upload.ts
@@ -170,6 +170,12 @@ export class ResourceConflict extends ConflictDialog {
             `/${encodeURIComponent(newFolderName)}`
           )
         }
+        if (file.tus?.endpoint) {
+          file.tus.endpoint = file.tus.endpoint.replace(
+            new RegExp(`/${encodeURIComponent(folder)}`),
+            `/${encodeURIComponent(newFolderName)}`
+          )
+        }
       }
     }
     return files

--- a/packages/web-app-files/tests/unit/HandleUpload.spec.ts
+++ b/packages/web-app-files/tests/unit/HandleUpload.spec.ts
@@ -1,0 +1,225 @@
+import Uppy, { UppyFile, State, UIPlugin } from '@uppy/core'
+import { HandleUpload } from '../../src/HandleUpload'
+import { mock, mockDeep } from 'jest-mock-extended'
+import { UppyResource } from 'web-runtime/src/composables/upload'
+import { Resource, SpaceResource } from 'web-client/src'
+import { UppyService } from 'web-runtime/src/services/uppyService'
+import { RouteLocationNormalizedLoaded } from 'vue-router'
+import { ref, unref } from 'vue'
+import { ClientService } from 'web-pkg/src'
+import { Language } from 'vue3-gettext'
+import { ResourceConflict } from 'web-app-files/src/helpers/resource/actions'
+
+jest.mock('web-app-files/src/helpers/resource/actions')
+
+describe('HandleUpload', () => {
+  it('installs the handleUpload callback when files are being added', () => {
+    const { instance, mocks } = getWrapper()
+    instance.install()
+    expect(mocks.uppy.on).toHaveBeenCalledWith('files-added', instance.handleUpload)
+  })
+  it('uninstalls the handleUpload callback when files are being added', () => {
+    const { instance, mocks } = getWrapper()
+    instance.uninstall()
+    expect(mocks.uppy.off).toHaveBeenCalledWith('files-added', instance.handleUpload)
+  })
+  it('removes files from the uppy upload queue', () => {
+    const { instance, mocks } = getWrapper()
+    const fileToRemove = mock<UppyResource>()
+    instance.removeFilesFromUpload([fileToRemove])
+    expect(mocks.uppy.removeFile).toHaveBeenCalledWith(fileToRemove.id)
+  })
+  it('correctly prepares all files that need to be uploaded', () => {
+    const { instance, mocks } = getWrapper()
+    mocks.uppy.getPlugin.mockReturnValue(mock<UIPlugin>())
+    const fileToUpload = mock<UppyFile>({ name: 'name' })
+    const processedFiles = instance.prepareFiles([fileToUpload])
+
+    const currentFolder = mocks.opts.store.getters['Files/currentFolder']
+    const route = unref(mocks.opts.route)
+
+    expect(processedFiles[0].tus.endpoint).toEqual('/')
+    expect(processedFiles[0].meta.name).toEqual(fileToUpload.name)
+    expect(processedFiles[0].meta.spaceId).toEqual(mocks.opts.space.id)
+    expect(processedFiles[0].meta.spaceName).toEqual(mocks.opts.space.name)
+    expect(processedFiles[0].meta.driveAlias).toEqual(mocks.opts.space.driveAlias)
+    expect(processedFiles[0].meta.driveType).toEqual(mocks.opts.space.driveType)
+    expect(processedFiles[0].meta.currentFolder).toEqual(currentFolder.path)
+    expect(processedFiles[0].meta.currentFolderId).toEqual(currentFolder.id)
+    expect(processedFiles[0].meta.tusEndpoint).toEqual(currentFolder.path)
+    expect(processedFiles[0].meta.relativeFolder).toEqual('')
+    expect(processedFiles[0].meta.routeName).toEqual(route.name)
+    expect(processedFiles[0].meta.routeDriveAliasAndItem).toEqual(route.params.driveAliasAndItem)
+    expect(processedFiles[0].meta.routeShareId).toEqual(route.query.shareId)
+  })
+  describe('method createDirectoryTree', () => {
+    it('creates a directory for a single file with a relative folder given', async () => {
+      const { instance, mocks } = getWrapper()
+      mocks.uppy.getPlugin.mockReturnValue(mock<UIPlugin>())
+      const relativeFolder = '/relativeFolder'
+      const fileToUpload = mock<UppyResource>({ name: 'name', meta: { relativeFolder } })
+      const createdFolder = mock<Resource>()
+      mocks.opts.clientService.webdav.createFolder.mockResolvedValue(createdFolder)
+
+      const result = await instance.createDirectoryTree([fileToUpload])
+      const currentFolder = mocks.opts.store.getters['Files/currentFolder']
+
+      expect(mocks.opts.uppyService.publish).toHaveBeenCalledWith(
+        'uploadSuccess',
+        expect.objectContaining({
+          name: relativeFolder.split('/')[1],
+          isFolder: true,
+          type: 'folder',
+          meta: expect.objectContaining({
+            spaceId: mocks.opts.space.id,
+            spaceName: mocks.opts.space.name,
+            driveAlias: mocks.opts.space.driveAlias,
+            driveType: mocks.opts.space.driveType,
+            currentFolder: currentFolder.path,
+            currentFolderId: currentFolder.id,
+            relativeFolder: '',
+            routeName: fileToUpload.meta.routeName,
+            routeDriveAliasAndItem: fileToUpload.meta.routeDriveAliasAndItem,
+            routeShareId: fileToUpload.meta.routeShareId,
+            fileId: createdFolder.fileId
+          })
+        })
+      )
+      expect(mocks.opts.clientService.webdav.createFolder).toHaveBeenCalledTimes(1)
+      expect(mocks.opts.clientService.webdav.createFolder).toHaveBeenCalledWith(mocks.opts.space, {
+        path: relativeFolder
+      })
+      expect(result.length).toBe(1)
+    })
+    it('filters out files whose folders could not be created', async () => {
+      jest.spyOn(console, 'error').mockImplementation(() => undefined)
+
+      const { instance, mocks } = getWrapper()
+      mocks.uppy.getPlugin.mockReturnValue(mock<UIPlugin>())
+      const relativeFolder = '/relativeFolder'
+      const fileToUpload = mock<UppyResource>({ name: 'name', meta: { relativeFolder } })
+      mocks.opts.clientService.webdav.createFolder.mockRejectedValue({})
+
+      const result = await instance.createDirectoryTree([fileToUpload])
+
+      expect(mocks.opts.uppyService.publish).toHaveBeenCalledWith('uploadError', expect.anything())
+      expect(mocks.uppy.removeFile).toHaveBeenCalled()
+      expect(result.length).toBe(0)
+    })
+  })
+  describe('method handleUpload', () => {
+    it('prepares files and eventually triggers the upload in uppy', async () => {
+      const { instance, mocks } = getWrapper()
+      const prepareFilesSpy = jest.spyOn(instance, 'prepareFiles')
+      await instance.handleUpload([mock<UppyFile>({ name: 'name' })])
+      expect(prepareFilesSpy).toHaveBeenCalledTimes(1)
+      expect(mocks.opts.uppyService.publish).toHaveBeenCalledWith(
+        'addedForUpload',
+        expect.anything()
+      )
+      expect(mocks.opts.uppyService.uploadFiles).toHaveBeenCalledTimes(1)
+    })
+    describe('quota check', () => {
+      it('checks quota if check enabled', async () => {
+        const { instance } = getWrapper()
+        const checkQuotaExceededSpy = jest.spyOn(instance, 'checkQuotaExceeded')
+        await instance.handleUpload([mock<UppyFile>({ name: 'name' })])
+        expect(checkQuotaExceededSpy).toHaveBeenCalled()
+      })
+      it('does not check quota if check disabled', async () => {
+        const { instance } = getWrapper({ quotaCheckEnabled: false })
+        const checkQuotaExceededSpy = jest.spyOn(instance, 'checkQuotaExceeded')
+        await instance.handleUpload([mock<UppyFile>({ name: 'name' })])
+        expect(checkQuotaExceededSpy).not.toHaveBeenCalled()
+      })
+    })
+    describe('conflict handling check', () => {
+      it('checks for conflicts if check enabled', async () => {
+        const { instance, mocks } = getWrapper()
+        await instance.handleUpload([mock<UppyFile>({ name: 'name' })])
+        expect(mocks.resourceConflict.getConflicts).toHaveBeenCalled()
+      })
+      it('does not check for conflicts if check disabled', async () => {
+        const { instance, mocks } = getWrapper({ conflictHandlingEnabled: false })
+        await instance.handleUpload([mock<UppyFile>({ name: 'name' })])
+        expect(mocks.resourceConflict.getConflicts).not.toHaveBeenCalled()
+      })
+      it('does not start upload if all files were skipped in conflict handling', async () => {
+        const { instance, mocks } = getWrapper({ conflicts: [{}], conflictHandlerResult: [] })
+        const removeFilesFromUploadSpy = jest.spyOn(instance, 'removeFilesFromUpload')
+
+        await instance.handleUpload([mock<UppyFile>({ name: 'name' })])
+        expect(mocks.opts.uppyService.uploadFiles).not.toHaveBeenCalled()
+        expect(mocks.opts.uppyService.clearInputs).toHaveBeenCalled()
+        expect(removeFilesFromUploadSpy).toHaveBeenCalled()
+      })
+      it('sets the result of the conflict handler as uppy file state', async () => {
+        const conflictHandlerResult = [mock<UppyResource>({ id: '1' })]
+        const { instance, mocks } = getWrapper({ conflicts: [{}], conflictHandlerResult })
+        await instance.handleUpload([mock<UppyFile>(), mock<UppyFile>()])
+
+        expect(mocks.uppy.setState).toHaveBeenCalledWith({
+          files: { [conflictHandlerResult[0].id]: conflictHandlerResult[0] }
+        })
+      })
+    })
+    describe('create directory tree', () => {
+      it('creates the directly tree if enabled', async () => {
+        const { instance } = getWrapper()
+        const createDirectoryTreeSpy = jest.spyOn(instance, 'createDirectoryTree')
+        await instance.handleUpload([mock<UppyFile>({ name: 'name' })])
+        expect(createDirectoryTreeSpy).toHaveBeenCalled()
+      })
+      it('does not create the directly tree if disabled', async () => {
+        const { instance } = getWrapper({ directoryTreeCreateEnabled: false })
+        const createDirectoryTreeSpy = jest.spyOn(instance, 'createDirectoryTree')
+        await instance.handleUpload([mock<UppyFile>({ name: 'name' })])
+        expect(createDirectoryTreeSpy).not.toHaveBeenCalled()
+      })
+    })
+  })
+})
+
+const getWrapper = ({
+  conflictHandlingEnabled = true,
+  directoryTreeCreateEnabled = true,
+  quotaCheckEnabled = true,
+  conflicts = [],
+  conflictHandlerResult = []
+} = {}) => {
+  const resourceConflict = mock<ResourceConflict>()
+  resourceConflict.getConflicts.mockReturnValue(conflicts)
+  resourceConflict.displayOverwriteDialog.mockResolvedValue(conflictHandlerResult)
+  jest.mocked(ResourceConflict).mockImplementation(() => resourceConflict)
+
+  const store = {
+    getters: {
+      'Files/currentFolder': mock<Resource>({ path: '/' }),
+      'Files/files': [mock<Resource>()],
+      'runtime/spaces/spaces': mock<SpaceResource>()
+    }
+  } as any
+  const route = mock<RouteLocationNormalizedLoaded>()
+  route.params.driveAliasAndItem = '1'
+  route.query.shareId = '1'
+
+  const uppy = mockDeep<Uppy>()
+  uppy.getState.mockReturnValue(mock<State>({ files: {} }))
+
+  const opts = {
+    clientService: mockDeep<ClientService>(),
+    hasSpaces: ref(true),
+    language: mock<Language>(),
+    route: ref(route),
+    store,
+    space: mock<SpaceResource>(),
+    uppyService: mock<UppyService>(),
+    conflictHandlingEnabled,
+    directoryTreeCreateEnabled,
+    quotaCheckEnabled
+  }
+
+  const mocks = { uppy, opts, resourceConflict }
+  const instance = new HandleUpload(uppy, opts)
+  return { instance, mocks }
+}

--- a/packages/web-runtime/src/composables/upload/useUpload.ts
+++ b/packages/web-runtime/src/composables/upload/useUpload.ts
@@ -45,6 +45,9 @@ export interface UppyResource {
     routeDriveAliasAndItem?: string
     routeShareId?: string
   }
+  tus?: {
+    endpoint: string
+  }
   xhrUpload?: {
     endpoint: string
   }


### PR DESCRIPTION
## Description
Massively improves the upload preparation time. Instead of setting file data on each file, we now accumulate all the data first and then set it in one batch via Uppy's `setState` method.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9458
- Fixes https://github.com/owncloud/web/issues/9553

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
