### PR TITLE
[tests-only] Remove reloading while fetching the notification in e2e tests

### DIFF
--- a/tests/e2e/support/objects/runtime/application.ts
+++ b/tests/e2e/support/objects/runtime/application.ts
@@ -32,7 +32,7 @@ export class Application {
           resp.url().endsWith('notifications?format=json') &&
           resp.status() === 200 &&
           resp.request().method() === 'GET'
-      ),
+      )
     ])
 
     const dropIsOpen = await this.#page.locator(notificationsDrop).isVisible()

--- a/tests/e2e/support/objects/runtime/application.ts
+++ b/tests/e2e/support/objects/runtime/application.ts
@@ -26,8 +26,6 @@ export class Application {
   }
 
   async getNotificationMessages(): Promise<string[]> {
-    // reload will fetch notifications immediately
-    // wait for the notifications to load
     await Promise.all([
       this.#page.waitForResponse(
         (resp) =>
@@ -35,7 +33,6 @@ export class Application {
           resp.status() === 200 &&
           resp.request().method() === 'GET'
       ),
-      this.#page.reload()
     ])
 
     const dropIsOpen = await this.#page.locator(notificationsDrop).isVisible()

--- a/tests/e2e/support/objects/runtime/application.ts
+++ b/tests/e2e/support/objects/runtime/application.ts
@@ -26,15 +26,6 @@ export class Application {
   }
 
   async getNotificationMessages(): Promise<string[]> {
-    await Promise.all([
-      this.#page.waitForResponse(
-        (resp) =>
-          resp.url().endsWith('notifications?format=json') &&
-          resp.status() === 200 &&
-          resp.request().method() === 'GET'
-      )
-    ])
-
     const dropIsOpen = await this.#page.locator(notificationsDrop).isVisible()
     if (!dropIsOpen) {
       await this.#page.locator(notificationsBell).click()


### PR DESCRIPTION
Now the notification can be fetch without the reload so remove it 