### PR TITLE
chore: bump sonarcloud to v5.0 (backport from master)

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -28,7 +28,7 @@ PLUGINS_S3_CACHE = "plugins/s3-cache:1"
 PLUGINS_SLACK = "plugins/slack:1"
 SELENIUM_STANDALONE_CHROME = "selenium/standalone-chrome:104.0-20220812"
 SELENIUM_STANDALONE_FIREFOX = "selenium/standalone-firefox:104.0-20220812"
-SONARSOURCE_SONAR_SCANNER_CLI = "sonarsource/sonar-scanner-cli:4.7.0"
+SONARSOURCE_SONAR_SCANNER_CLI = "sonarsource/sonar-scanner-cli:5.0"
 TOOLHIPPIE_CALENS = "toolhippie/calens:latest"
 
 OC10_VERSION = "latest"


### PR DESCRIPTION
Backports https://github.com/owncloud/web/commit/3bf73afed02188e4f144797a361dd586827cc371 to `stable-7.1`.