### PR TITLE
[tests-only][full-ci]Remove acceptance tests related to search

### DIFF
--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -57,7 +57,7 @@ Other free text and markdown formatting can be used elsewhere in the document if
 -   [webUISharingPublicManagement/shareByPublicLink.feature:110](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature#L111)
 
 ### [Propfind response to trashbin endpoint is different in ocis](https://github.com/owncloud/product/issues/186)
--   [webUIFilesSearch/search.feature:131](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L131)
+-   [webUIFilesSearch/search.feature:60](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIFilesSearch/search.feature#L60)
 
 ### [Conflict / overwrite issues with TUS](https://github.com/owncloud/ocis/issues/1294)
 -   [webUIUpload/uploadFileGreaterThanQuotaSize.feature:11](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature#L11)

--- a/tests/acceptance/features/webUIFilesSearch/search.feature
+++ b/tests/acceptance/features/webUIFilesSearch/search.feature
@@ -16,70 +16,9 @@ Feature: Search
       | simple-empty-folder   |
       | strängé नेपाली folder |
     And user "Alice" has uploaded file "lorem.txt" to "lorem.txt" in the server
-    And user "Alice" has uploaded file "zzzz-must-be-last-file-in-folder.txt" to "zzzz-must-be-last-file-in-folder.txt" in the server
     And user "Alice" has uploaded file "lorem.txt" to "simple-folder/lorem.txt" in the server
-    And user "Alice" has uploaded file "lorem-big.txt" to "lorem-big.txt" in the server
-    And user "Alice" has uploaded file "data.zip" to "data.zip" in the server
     And user "Alice" has logged in using the webUI
     And the user has reloaded the current page of the webUI
-
-  @smokeTest @issue-980
-  Scenario: Simple search
-    When the user searches for "lorem" using the webUI
-    Then file "lorem.txt" should be listed on the webUI
-    And file "lorem-big.txt" should be listed on the webUI
-
-  @issue-980
-  Scenario: search for folders
-    When the user searches for "folder" using the webUI
-    Then folder "simple-folder" should be listed on the webUI
-    And folder "strängé नेपाली folder" should be listed on the webUI
-    And file "zzzz-must-be-last-file-in-folder.txt" should be listed on the webUI
-    But file "lorem.txt" should not be listed on the webUI
-
-  @issue-980
-  Scenario: search in sub folder (with 'Current Folder' filter)
-    When the user opens folder "simple-folder" using the webUI
-    And the user searches for "lorem" using the webUI
-    Then file "simple-folder/lorem.txt" should be listed on the webUI
-    But file "lorem-big.txt" should not be listed on the webUI
-
-
-  Scenario: Search for a shared file
-    Given user "user0" has uploaded file "lorem.txt" to "lorem.txt" in the server
-    And user "user0" has shared file "/lorem.txt" with user "Alice" in the server
-    When the user reloads the current page of the webUI
-    And the user searches for "lorem" using the webUI
-    Then file "lorem.txt" should be listed on the webUI
-
-
-  Scenario: Search for a re-shared file
-    Given the setting "shareapi_auto_accept_share" of app "core" has been set to "no" in the server
-    And the administrator has set the default folder for received shares to "Shares" in the server
-    And user "Brian" has been created with default attributes and without skeleton files in the server
-    And user "Brian" has uploaded file "lorem.txt" to "lorem.txt" in the server
-    And user "Brian" has shared file "/lorem.txt" with user "user0" in the server
-    And user "user0" has accepted the share "Shares//lorem.txt" offered by user "Brian" in the server
-    And user "user0" has shared file "/Shares/lorem.txt" with user "Alice" in the server
-    When the user reloads the current page of the webUI
-    And the user searches for "lorem" using the webUI
-    Then file "lorem.txt" should be listed on the webUI
-
-
-  Scenario: Search for a shared folder
-    Given user "user0" has created folder "simple-folder" in the server
-    And user "user0" has uploaded file "lorem.txt" to "simple-folder/lorem.txt" in the server
-    And user "user0" has shared folder "simple-folder" with user "Alice" in the server
-    When the user reloads the current page of the webUI
-    And the user searches for "simple" using the webUI
-    Then folder "simple-folder" should be listed on the webUI
-
-
-  Scenario: Search for a file after name is changed
-    When the user renames file "lorem.txt" to "torem.txt" using the webUI
-    And the user searches for "torem" using the webUI
-    Then file "lorem.txt" should not be listed on the webUI
-    And file "torem.txt" should be listed on the webUI
 
 
   Scenario: Search for a newly uploaded file
@@ -117,16 +56,6 @@ Feature: Search
     Then folder "not deleted folder" should be listed on the webUI
     And folder "deleted folder" should not be listed on the webUI
 
-  @skipOnOCIS
-  Scenario: Search for favorited folder in favorites page
-    Given user "Alice" has created folder "favorite folder" in the server
-    And user "Alice" has created folder "not favorite folder" in the server
-    And user "Alice" has favorited element "favorite folder" in the server
-    When the user browses to the favorites page
-    And the user searches for "favorite" using the webUI
-    Then folder "favorite folder" should be listed on the webUI
-    And folder "not favorite folder" should be listed on the webUI
-
 
   Scenario: Delete file from search list
     Given user "Alice" has uploaded file with content "uploaded content" to "file-to-delete.txt" in the server
@@ -136,12 +65,3 @@ Feature: Search
     Then file "file-to-delete.txt" should not be listed on the webUI
     And as "Alice" file "file-to-delete.txt" should not exist in the server
     And as "Alice" the file with original path "file-to-delete.txt" should exist in the trashbin in the server
-
-
-  Scenario: Search for files/folders with comma in their name
-    Given user "Alice" has uploaded file with content "A file with comma" to "file,with,comma.txt" in the server
-    And user "Alice" has created folder "C,O,M,M,A" in the server
-    When the user reloads the current page of the webUI
-    And the user searches for "," using the webUI
-    Then file "file,with,comma.txt" should be listed on the webUI
-    And folder "C,O,M,M,A" should be listed on the webUI


### PR DESCRIPTION
We have coverage for search in e2e tests so some of the duplicate acceptance tests can be removed.

Part of: https://github.com/owncloud/web/issues/9157