### PR TITLE
fix: loading pdf files with Safari

### DIFF
--- a/changelog/unreleased/bugfix-pdf-loading-safari
+++ b/changelog/unreleased/bugfix-pdf-loading-safari
@@ -1,0 +1,6 @@
+Bugfix: PDF loading Safari
+
+Loading PDF files with Safari has been fixed.
+
+https://github.com/owncloud/web/issues/9483
+https://github.com/owncloud/web/pull/9565

--- a/packages/web-app-pdf-viewer/src/App.vue
+++ b/packages/web-app-pdf-viewer/src/App.vue
@@ -4,12 +4,12 @@
     <loading-screen v-if="loading" />
     <error-screen v-else-if="loadingError" />
     <div v-else class="oc-height-1-1">
-      <object class="pdf-viewer oc-height-1-1 oc-width-1-1" :data="url" type="application/pdf" />
+      <object class="pdf-viewer oc-height-1-1 oc-width-1-1" :data="url" :type="objectType" />
     </div>
   </main>
 </template>
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { computed, defineComponent } from 'vue'
 import { useAppDefaults } from 'web-pkg/src/composables'
 import AppTopBar from 'web-pkg/src/components/AppTopBar.vue'
 import ErrorScreen from './components/ErrorScreen.vue'
@@ -23,10 +23,18 @@ export default defineComponent({
     LoadingScreen
   },
   setup() {
+    const isSafari = () =>
+      navigator.userAgent?.includes('Safari') && !navigator.userAgent?.includes('Chrome')
+
+    const objectType = computed(() => {
+      // object type must not be 'application/pdf' for Safari due to a bug
+      return isSafari() ? undefined : 'application/pdf'
+    })
     return {
       ...useAppDefaults({
         applicationId: 'pdf-viewer'
-      })
+      }),
+      objectType
     }
   },
   data: () => ({


### PR DESCRIPTION
## Description
Due to a Safari bug, we must not use `application/pdf` as object type when loading PDF files. See https://discussions.apple.com/thread/252247740 e.g.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9483

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
