### PR TITLE
fix(type-check): remove unnecessary passing of arg in useKeyboardActions

### DIFF
--- a/packages/web-app-admin-settings/src/components/Groups/GroupsList.vue
+++ b/packages/web-app-admin-settings/src/components/Groups/GroupsList.vue
@@ -257,7 +257,7 @@ export default defineComponent({
       total: totalPages
     } = usePagination({ items, perPageDefault, perPageStoragePrefix })
 
-    const keyActions = useKeyboardActions('group-list')
+    const keyActions = useKeyboardActions()
     useKeyboardTableNavigation(
       keyActions,
       paginatedItems,

--- a/packages/web-app-admin-settings/src/components/Spaces/SpacesList.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/SpacesList.vue
@@ -455,7 +455,7 @@ export default defineComponent({
       eventBus.publish(SideBarEventTopics.open)
     }
 
-    const keyActions = useKeyboardActions('space-list')
+    const keyActions = useKeyboardActions()
     useKeyboardTableNavigation(
       keyActions,
       paginatedItems,

--- a/packages/web-app-admin-settings/src/components/Users/UsersList.vue
+++ b/packages/web-app-admin-settings/src/components/Users/UsersList.vue
@@ -304,7 +304,7 @@ export default defineComponent({
       emit('unSelectAllUsers')
     })
 
-    const keyActions = useKeyboardActions('user-list')
+    const keyActions = useKeyboardActions()
     useKeyboardTableNavigation(
       keyActions,
       paginatedItems,


### PR DESCRIPTION
## Description
command `pnpm check:style` is failing with:
```
packages/web-app-admin-settings/src/components/Groups/GroupsList.vue(260,43): error TS2554: Expected 0 arguments, but got 1.
packages/web-app-admin-settings/src/components/Spaces/SpacesList.vue(458,43): error TS2554: Expected 0 arguments, but got 1.
packages/web-app-admin-settings/src/components/Users/UsersList.vue(307,43): error TS2554: Expected 0 arguments, but got 1.
 ELIFECYCLE  Command failed with exit code 2.
```
I have removed the unnecessary passing of arg in function `useKeyboardActions`. The change was introduced in https://github.com/owncloud/web/pull/9559

## Related Issue
- Fixes https://github.com/owncloud/web/issues/9569

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
