### PR TITLE
chore: revert recent commits until 7.1.0-rc.5

### DIFF
--- a/changelog/unreleased/bugfix-pdf-loading-safari
+++ b/changelog/unreleased/bugfix-pdf-loading-safari
@@ -1,6 +1,0 @@
-Bugfix: PDF loading Safari
-
-Loading PDF files with Safari has been fixed.
-
-https://github.com/owncloud/web/issues/9483
-https://github.com/owncloud/web/pull/9565

--- a/changelog/unreleased/bugfix-set-or-remove-expiration-date-on-group-share-not-possible
+++ b/changelog/unreleased/bugfix-set-or-remove-expiration-date-on-group-share-not-possible
@@ -1,6 +1,0 @@
-Bugfix: Set or remove expiration date on group share not possible
-
-We've fixed a bug where setting or removing an expiration on a group share wasn't possible.
-
-https://github.com/owncloud/web/pull/9513
-https://github.com/owncloud/web/issues/8419

--- a/packages/web-app-admin-settings/src/components/Spaces/SpacesList.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/SpacesList.vue
@@ -340,10 +340,6 @@ export default defineComponent({
       return formatRelativeDateFromJSDate(new Date(date), currentLanguage)
     }
     const getTotalQuota = (space: SpaceResource) => {
-      if (space.spaceQuota.total === 0) {
-        return $gettext('Unrestricted')
-      }
-
       return formatFileSize(space.spaceQuota.total, currentLanguage)
     }
     const getUsedQuota = (space: SpaceResource) => {

--- a/packages/web-app-files/src/components/Search/List.vue
+++ b/packages/web-app-files/src/components/Search/List.vue
@@ -15,7 +15,6 @@
           :items="availableTags"
           :option-filter-label="$gettext('Filter tags')"
           :show-option-filter="true"
-          :close-on-click="true"
           class="files-search-filter-tags oc-mr-s"
           display-name-attribute="label"
           filter-name="tags"

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/EditDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/EditDropdown.vue
@@ -28,11 +28,7 @@
                 @click="togglePopover"
               >
                 <oc-icon name="calendar-event" fill-type="line" size="medium" variation="passive" />
-                <span
-                  class="oc-ml-s"
-                  v-if="isExpirationDateSet"
-                  v-text="$gettext('Edit expiration date')"
-                />
+                <span v-if="isExpirationDateSet" v-text="$gettext('Edit expiration date')" />
                 <span v-else v-text="$gettext('Set expiration date')" />
               </oc-button>
             </template>
@@ -190,7 +186,10 @@ export default defineComponent({
     },
 
     isExpirationSupported() {
-      return this.editingUser || this.editingGroup
+      return (
+        (this.editingUser && this.userExpirationDate) ||
+        (this.editingGroup && this.groupExpirationDate)
+      )
     },
 
     isExpirationDateSet() {
@@ -249,14 +248,14 @@ export default defineComponent({
 
     isExpirationDateEnforced() {
       if (this.editingUser) {
-        return this.userExpirationDate?.enforced
+        return this.userExpirationDate.enforced
       }
 
       if (this.editingGroup) {
-        return this.groupExpirationDate?.enforced
+        return this.groupExpirationDate.enforced
       }
 
-      return this.userExpirationDate?.enforced || this.groupExpirationDate?.enforced
+      return this.userExpirationDate.enforced || this.groupExpirationDate.enforced
     },
 
     maxExpirationDate() {

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/ExpirationDatepicker.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/ExpirationDatepicker.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="oc-flex oc-flex-middle oc-flex-nowrap">
+  <div v-if="available" class="oc-flex oc-flex-middle oc-flex-nowrap">
     <oc-datepicker
       v-model="dateCurrent"
       :min-date="dateMin"
@@ -72,6 +72,7 @@ export default defineComponent({
     const capabilities = computed(() => store.getters.capabilities)
     const optionsUser = computed(() => capabilities.value.files_sharing.user?.expire_date)
     const optionsGroup = computed(() => capabilities.value.files_sharing.group?.expire_date)
+    const available = computed(() => optionsUser.value || optionsGroup.value)
     const enforced = computed(() => optionsUser.value?.enforced || optionsGroup.value?.enforced)
     const dateMin = DateTime.now().setLocale(language.current).toJSDate()
     const dateDefault = computed(() => {
@@ -150,6 +151,7 @@ export default defineComponent({
     return {
       language,
       enforced,
+      available,
       dateCurrent,
       dateMin,
       dateMax,

--- a/packages/web-app-files/src/helpers/contextualHelpers.ts
+++ b/packages/web-app-files/src/helpers/contextualHelpers.ts
@@ -52,7 +52,7 @@ export const shareInviteCollaboratorHelp = (options: ContextualHelperOptions) =>
           )
         }
       ],
-      readMoreLink: 'https://doc.owncloud.com/go?to=webui-users-sharing'
+      readMoreLink: 'https://doc.owncloud.com/webui/next/owncloud_web/web_for_users.html#sharing'
     },
     options
   )
@@ -92,7 +92,7 @@ export const shareSpaceAddMemberHelp = (options: ContextualHelperOptions) =>
           )
         }
       ],
-      readMoreLink: 'https://doc.owncloud.com/go?to=webui-users-sharing'
+      readMoreLink: 'https://doc.owncloud.com/webui/next/owncloud_web/web_for_users.html#sharing'
     },
     options
   )
@@ -120,7 +120,7 @@ export const shareViaLinkHelp = (options: ContextualHelperOptions) =>
           )
         }
       ],
-      readMoreLink: 'https://doc.owncloud.com/go?to=webui-users-sharing'
+      readMoreLink: 'https://doc.owncloud.com/webui/next/owncloud_web/web_for_users.html#sharing'
     },
     options
   )
@@ -140,7 +140,7 @@ export const shareViaIndirectLinkHelp = (options: ContextualHelperOptions) =>
           )
         }
       ],
-      readMoreLink: 'https://doc.owncloud.com/go?to=webui-users-sharing'
+      readMoreLink: 'https://doc.owncloud.com/webui/next/owncloud_web/web_for_users.html#sharing'
     },
     options
   )

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -179,7 +179,7 @@ export default defineComponent({
     const clientService = useClientService()
     const { selectedResourcesIds } = useSelectedResources({ store })
     const { can } = useAbility()
-    const { current: currentLanguage, $gettext } = useGettext()
+    const { current: currentLanguage } = useGettext()
 
     const runtimeSpaces = computed((): SpaceResource[] => {
       return store.getters['runtime/spaces/spaces'].filter((s) => isProjectSpaceResource(s)) || []
@@ -244,10 +244,6 @@ export default defineComponent({
     }
 
     const getTotalQuota = (space: SpaceResource) => {
-      if (space.spaceQuota.total === 0) {
-        return $gettext('Unrestricted')
-      }
-
       return formatFileSize(space.spaceQuota.total, currentLanguage)
     }
     const getUsedQuota = (space: SpaceResource) => {

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/ExpirationDatepicker.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/ExpirationDatepicker.spec.ts
@@ -43,6 +43,11 @@ const enforcedCapabilities = merge({}, enabledCapabilities, {
 })
 
 describe('InviteCollaborator ExpirationDatepicker', () => {
+  it('only gets displayed if share expiration is supported', () => {
+    const { wrapper } = createWrapper()
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
   it('renders a button to open the datepicker and set an expiration date', () => {
     const { wrapper } = createWrapper({ capabilities: bareCapabilities })
     expect(wrapper.find('[data-testid="recipient-datepicker-btn"]').exists()).toBe(true)

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/__snapshots__/ExpirationDatepicker.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/__snapshots__/ExpirationDatepicker.spec.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InviteCollaborator ExpirationDatepicker only gets displayed if share expiration is supported 1`] = `<!--v-if-->`;

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/FileShares.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/FileShares.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`FileShares collaborators list renders sharedWithLabel and sharee list 1
 <div class="oc-position-relative" id="oc-files-sharing-sidebar">
   <div class="oc-flex">
     <h3 class="oc-text-bold oc-text-medium oc-m-rm" data-current-language="en" data-msgid="Share with people">Share with people</h3>
-    <oc-contextual-helper-stub class="oc-pl-xs" endtext="" list="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" readmorelink="https://doc.owncloud.com/go?to=webui-users-sharing" text="Use the input field to search for users and groups. Select them to share the item." title="Share with people"></oc-contextual-helper-stub>
+    <oc-contextual-helper-stub class="oc-pl-xs" endtext="" list="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" readmorelink="https://doc.owncloud.com/webui/next/owncloud_web/web_for_users.html#sharing" text="Use the input field to search for users and groups. Select them to share the item." title="Share with people"></oc-contextual-helper-stub>
   </div>
   <invite-collaborator-form-stub class="oc-my-s" invitelabel="" savebuttonlabel="Share"></invite-collaborator-form-stub>
   <div class="avatars-wrapper oc-flex oc-flex-middle oc-flex-between">
@@ -35,7 +35,7 @@ exports[`FileShares current space loads space members if a space is given and th
 <div class="oc-position-relative" id="oc-files-sharing-sidebar">
   <div class="oc-flex">
     <h3 class="oc-text-bold oc-text-medium oc-m-rm" data-current-language="en" data-msgid="Share with people">Share with people</h3>
-    <oc-contextual-helper-stub class="oc-pl-xs" endtext="" list="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" readmorelink="https://doc.owncloud.com/go?to=webui-users-sharing" text="Use the input field to search for users and groups. Select them to share the item." title="Share with people"></oc-contextual-helper-stub>
+    <oc-contextual-helper-stub class="oc-pl-xs" endtext="" list="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" readmorelink="https://doc.owncloud.com/webui/next/owncloud_web/web_for_users.html#sharing" text="Use the input field to search for users and groups. Select them to share the item." title="Share with people"></oc-contextual-helper-stub>
   </div>
   <invite-collaborator-form-stub class="oc-my-s" invitelabel="" savebuttonlabel="Share"></invite-collaborator-form-stub>
   <div class="avatars-wrapper oc-flex oc-flex-middle oc-flex-between">

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/SpaceMembers.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/SpaceMembers.spec.ts.snap
@@ -28,7 +28,7 @@ exports[`SpaceMembers filter toggles the filter on click 1`] = `
                 <dd>Members with the Manager role are able to edit all properties and content of a Space, such as adding or removing members, sharing subfolders with non-members, or creating links to share.</dd>
               </dl>
               <!--v-if-->
-              <a class="oc-button oc-rounded oc-button-s oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw info-more-link" href="https://doc.owncloud.com/go?to=webui-users-sharing" target="_blank">Read more</a>
+              <a class="oc-button oc-rounded oc-button-s oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw info-more-link" href="https://doc.owncloud.com/webui/next/owncloud_web/web_for_users.html#sharing" target="_blank">Read more</a>
             </div>
           </div>
         </div>

--- a/packages/web-app-pdf-viewer/src/App.vue
+++ b/packages/web-app-pdf-viewer/src/App.vue
@@ -4,12 +4,12 @@
     <loading-screen v-if="loading" />
     <error-screen v-else-if="loadingError" />
     <div v-else class="oc-height-1-1">
-      <object class="pdf-viewer oc-height-1-1 oc-width-1-1" :data="url" :type="objectType" />
+      <object class="pdf-viewer oc-height-1-1 oc-width-1-1" :data="url" type="application/pdf" />
     </div>
   </main>
 </template>
 <script lang="ts">
-import { computed, defineComponent } from 'vue'
+import { defineComponent } from 'vue'
 import { useAppDefaults } from 'web-pkg/src/composables'
 import AppTopBar from 'web-pkg/src/components/AppTopBar.vue'
 import ErrorScreen from './components/ErrorScreen.vue'
@@ -23,18 +23,10 @@ export default defineComponent({
     LoadingScreen
   },
   setup() {
-    const isSafari = () =>
-      navigator.userAgent?.includes('Safari') && !navigator.userAgent?.includes('Chrome')
-
-    const objectType = computed(() => {
-      // object type must not be 'application/pdf' for Safari due to a bug
-      return isSafari() ? undefined : 'application/pdf'
-    })
     return {
       ...useAppDefaults({
         applicationId: 'pdf-viewer'
-      }),
-      objectType
+      })
     }
   },
   data: () => ({

--- a/packages/web-pkg/src/components/ItemFilter.vue
+++ b/packages/web-pkg/src/components/ItemFilter.vue
@@ -3,7 +3,6 @@
     <oc-filter-chip
       :filter-label="filterLabel"
       :selected-item-names="selectedItems.map((i) => i[displayNameAttribute])"
-      :close-on-click="closeOnClick"
       @clear-filter="clearFilter"
       @show-drop="showDrop"
     >
@@ -108,10 +107,6 @@ export default defineComponent({
       type: Array,
       required: false,
       default: () => []
-    },
-    closeOnClick: {
-      type: Boolean,
-      default: false
     }
   },
   emits: ['selectionChange'],

--- a/packages/web-pkg/src/components/SearchBarFilter.vue
+++ b/packages/web-pkg/src/components/SearchBarFilter.vue
@@ -4,7 +4,7 @@
       <oc-filter-chip
         :is-toggle="false"
         :is-toggle-active="false"
-        :filter-label="currentSelectionTitle"
+        :filter-label="currentSelection.title"
         :selected-item-names="[]"
         class="oc-search-bar-filter"
         raw
@@ -57,14 +57,15 @@ export default defineComponent({
     const { $gettext } = useGettext()
     const useSopeQueryValue = useRouteQuery('useScope')
 
+    const currentFolderEnabled = computed(() => props.currentFolderAvailable)
+
     const currentSelection = ref<LocationOption>()
     const userSelection = ref<LocationOption>()
-    const currentSelectionTitle = computed(() => $gettext(currentSelection.value?.title))
-    const locationOptions = computed<LocationOption[]>(() => [
+    const locationOptions = ref<LocationOption[]>([
       {
         id: SearchLocationFilterConstants.currentFolder,
         title: $gettext('Current Folder'),
-        enabled: props.currentFolderAvailable
+        enabled: currentFolderEnabled
       },
       {
         id: SearchLocationFilterConstants.allFiles,
@@ -121,13 +122,7 @@ export default defineComponent({
       emit('update:modelValue', { value: option })
     }
 
-    return {
-      currentSelection,
-      currentSelectionTitle,
-      isIndexGreaterZero,
-      onOptionSelected,
-      locationOptions
-    }
+    return { currentSelection, isIndexGreaterZero, onOptionSelected, locationOptions }
   }
 })
 </script>


### PR DESCRIPTION
Temporarily reverts all recent commits since `7.1.0-rc.5` to make sure we can tag the final `7.1.0` on the very same state as the rc. We will add those commits later again once `7.1.0` has been released (probably end this week - beginning next week).