### PR TITLE
fix: internally resolved public links triggering default action

### DIFF
--- a/changelog/unreleased/bugfix-internal-public-link-resolving
+++ b/changelog/unreleased/bugfix-internal-public-link-resolving
@@ -1,0 +1,6 @@
+Bugfix: Internal public link resolving
+
+An issue where internally resolved public links instantly triggered the default file action has been fixed.
+
+https://github.com/owncloud/web/pull/9587
+https://github.com/owncloud/web/issues/9578

--- a/packages/web-app-files/src/views/spaces/DriveResolver.vue
+++ b/packages/web-app-files/src/views/spaces/DriveResolver.vue
@@ -86,7 +86,6 @@ export default defineComponent({
           fileId: resourceId,
           path: resourcePath
         })
-
         return router.push(
           createLocationSpaces('files-spaces-generic', {
             params,
@@ -96,7 +95,11 @@ export default defineComponent({
       }
 
       // no internal space found -> share -> resolve via private link as it holds all the necessary logic
-      return router.push({ name: 'resolvePrivateLink', params: { fileId: unref(fileId) } })
+      return router.push({
+        name: 'resolvePrivateLink',
+        params: { fileId: unref(fileId) },
+        query: { openWithDefaultApp: 'false' }
+      })
     }
 
     onMounted(async () => {

--- a/packages/web-app-files/tests/unit/views/spaces/DriveResolver.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/DriveResolver.spec.ts
@@ -93,7 +93,10 @@ describe('DriveResolver view', () => {
 
     await wrapper.vm.$nextTick()
     expect(mocks.$router.push).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'resolvePrivateLink' })
+      expect.objectContaining({
+        name: 'resolvePrivateLink',
+        query: { openWithDefaultApp: 'false' }
+      })
     )
   })
 })

--- a/packages/web-runtime/src/pages/resolvePrivateLink.vue
+++ b/packages/web-runtime/src/pages/resolvePrivateLink.vue
@@ -87,6 +87,9 @@ export default defineComponent({
 
     const clientService = useClientService()
 
+    const openWithDefaultAppQuery = useRouteQuery('openWithDefaultApp')
+    const openWithDefaultApp = computed(() => queryItemAsString(unref(openWithDefaultAppQuery)))
+
     const detailsQuery = useRouteQuery('details')
     const details = computed(() => {
       return queryItemAsString(unref(detailsQuery))
@@ -163,9 +166,10 @@ export default defineComponent({
               ? matchingSpace.shareId
               : unref(resource).fileId,
           ...(unref(details) && { details: unref(details) }),
-          ...(configurationManager.options.openLinksWithDefaultApp && {
-            openWithDefaultApp: 'true'
-          })
+          ...(configurationManager.options.openLinksWithDefaultApp &&
+            unref(openWithDefaultApp) !== 'false' && {
+              openWithDefaultApp: 'true'
+            })
         }
       }
       router.push(location)


### PR DESCRIPTION
## Description
Fixes an issue where internally resolved public links instantly triggered the default file action. This behavior is not intended to work for public links if they resolve into an internal space.

## Note
**Only merge after `7.1.0` has been released!**

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9578

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
