### PR TITLE
fix: loading audio and video on Shared with me page

### DIFF
--- a/changelog/unreleased/bugfix-audio-video-loading-shared-with-me
+++ b/changelog/unreleased/bugfix-audio-video-loading-shared-with-me
@@ -1,0 +1,6 @@
+Bugfix: Audio- & video-loading on Shared with me page
+
+Loading audio and video on the Shared with me page with the preview app has been fixed.
+
+https://github.com/owncloud/web/issues/9593
+https://github.com/owncloud/web/pull/9595

--- a/packages/web-client/src/webdav/getFileUrl.ts
+++ b/packages/web-client/src/webdav/getFileUrl.ts
@@ -1,4 +1,5 @@
 import { Resource, SpaceResource } from '../helpers'
+import { urlJoin } from '../utils'
 import { GetFileContentsFactory } from './getFileContents'
 import { WebDavOptions } from './types'
 
@@ -28,7 +29,7 @@ export const GetFileUrlFactory = (
       let signed = true
       if (!downloadURL && !inlineDisposition) {
         // compute unsigned url
-        const webDavPath = `${space.webDavPath}/${path}`
+        const webDavPath = urlJoin(space.webDavPath, path)
         downloadURL = sdk.files.getFileUrl(webDavPath)
 
         // sign url


### PR DESCRIPTION
## Description
Fixes loading audio and video on the Shared with me page with the preview app. The problem was with a potential trailing slash in the download URL.

## Note
**Only merge after `7.1.0` has been released!**

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9593
- Fixes https://github.com/owncloud/enterprise/issues/5964

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

