### PR TITLE
[tests-only][full-ci]Add log tracing result in nightly as well

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2057,6 +2057,7 @@ def logTracingResult(ctx, suite):
             "status": status,
             "event": [
                 "pull_request",
+                "cron",
             ],
         },
     }]


### PR DESCRIPTION
### Description
The log tracing result was not ran in nightly for `e2e` tests. Since tests might be failed in nightly and the tracing would be more helpful for debugging. So this PR adds that step in `nightly` build as well.

### Related Issue:
Fixes https://github.com/owncloud/web/issues/9581