### PR TITLE
[tests-only][full-ci]Run office-suites app-provider tests in nightly as well

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -721,7 +721,7 @@ def e2eTests(ctx):
         for item in default:
             params[item] = matrix[item] if item in matrix else default[item]
 
-        if suite == "oCIS-app-provider" and not "full-ci" in ctx.build.title.lower():
+        if suite == "oCIS-app-provider" and not "full-ci" in ctx.build.title.lower() and ctx.build.event != "cron":
             continue
 
         if params["skip"]:


### PR DESCRIPTION
### Description
The recently added `office-suites` app provider tests is not ran in nightly. Its better to run it at least in nightly since it is only ran with `full-ci` tag for the pull request. So this PR runs the test in every nightly.


### Related Issue:
Fixes https://github.com/owncloud/web/issues/9580