### PR TITLE
[tests-only] refactor delete step to be ready for response before clicking

### DIFF
--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -856,18 +856,20 @@ export const deleteResource = async (args: deleteResourceArgs): Promise<void> =>
         throw new Error('Single resource or objects cannot be deleted with batch action')
       }
 
-      await page.locator(deleteButtonBatchAction).click()
-      await page.waitForResponse((resp) => {
-        if (resp.status() === 204 && resp.request().method() === 'DELETE') {
-          deletetedResources.push(decodeURIComponent(resp.url().split('/').pop()))
-        }
-        // waiting for GET response after all the resource are deleted with batch action
-        return (
-          resp.url().includes('graph/v1.0/drives') &&
-          resp.status() === 200 &&
-          resp.request().method() === 'GET'
-        )
-      })
+      await Promise.all([
+        page.waitForResponse((resp) => {
+          if (resp.status() === 204 && resp.request().method() === 'DELETE') {
+            deletetedResources.push(decodeURIComponent(resp.url().split('/').pop()))
+          }
+          // waiting for GET response after all the resource are deleted with batch action
+          return (
+            resp.url().includes('graph/v1.0/drives') &&
+            resp.status() === 200 &&
+            resp.request().method() === 'GET'
+          )
+        }),
+        page.locator(deleteButtonBatchAction).click()
+      ])
       // assertion that the resources actually got deleted
       expect(deletetedResources.length).toBe(resourcesWithInfo.length)
       for (const resource of resourcesWithInfo) {


### PR DESCRIPTION
## Description
In the kindergarten feature of e2e tests, the deletion steps fails some time when test is unable to record all the responses when the speed of  clicking and checking the response do not match. Due to this all the expected responses are not caught. So, this pr implements the deletion steps where the response checking is made ready before the clicking.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/9589

## Motivation and Context
to solve the flaky issue in batch delete step in kindergarten feature of e2e tests.

## How Has This Been Tested?
- test environment:
- locally
- Ci

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
