### PR TITLE
[full-ci] [tests-only] Bump ocis commit id to latest

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=43ee37d02ed652b89e88c03c6bbeb5c89a62ce16
+OCIS_COMMITID=085c5d5c8d3d4422d99070a3f1810449f19b4d8d
 OCIS_BRANCH=master


### PR DESCRIPTION
This PR bumps latest ocis commit id.
Part of https://github.com/owncloud/QA/issues/824