### PR TITLE
[full-ci] - use KQL as default search query language

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=9c3511d2b08de25b16be3d309d0a7710b6848747
-OCIS_BRANCH=master
+OCIS_COMMITID=5d1d0a68bd34e5a12abba010152c7a2228974f52
+OCIS_BRANCH=enable-kql

--- a/changelog/unreleased/enhancement-kql-search-query-language
+++ b/changelog/unreleased/enhancement-kql-search-query-language
@@ -18,10 +18,5 @@ More advanced syntax like grouping combined with boolean property restriction is
 `(name:"sample*" name:"*txt") tag:important OR tag:report content:"annual*"`
 
 https://github.com/owncloud/web/pull/9653
-https://github.com/owncloud/ocis/pull/7212
-https://github.com/owncloud/ocis/pull/7043
-https://github.com/owncloud/ocis/issues/7042
-https://github.com/owncloud/ocis/issues/7179
-https://github.com/owncloud/ocis/issues/7114
 https://github.com/owncloud/web/issues/9636
 https://github.com/owncloud/web/issues/9646

--- a/changelog/unreleased/enhancement-kql-search-query-language
+++ b/changelog/unreleased/enhancement-kql-search-query-language
@@ -1,0 +1,27 @@
+Enhancement: Keyword Query Language (KQL) search syntax
+
+We've introduced [KQL](https://learn.microsoft.com/en-us/sharepoint/dev/general-development/keyword-query-language-kql-syntax-reference) as our default query language.
+Previously we used our own simple language for queries which is now replaced by kql.
+
+`sample.tx* Tags:important Tags:report Content:annual*`
+
+becomes
+
+`name:"sample.tx*" AND tag:important AND tag:report AND content:"annual*"`
+
+by default KQL uses `AND` as property restriction and the query described above can also be formulated as follows
+
+`name:"sample.tx*" tag:important tag:report content:"annual*"`
+
+More advanced syntax like grouping combined with boolean property restriction is supported too
+
+`(name:"sample*" name:"*txt") tag:important OR tag:report content:"annual*"`
+
+https://github.com/owncloud/web/pull/9653
+https://github.com/owncloud/ocis/pull/7212
+https://github.com/owncloud/ocis/pull/7043
+https://github.com/owncloud/ocis/issues/7042
+https://github.com/owncloud/ocis/issues/7179
+https://github.com/owncloud/ocis/issues/7114
+https://github.com/owncloud/web/issues/9636
+https://github.com/owncloud/web/issues/9646

--- a/packages/web-app-files/src/components/Search/List.vue
+++ b/packages/web-app-files/src/components/Search/List.vue
@@ -264,8 +264,6 @@ export default defineComponent({
 
       const humanTagsParams = queryItemAsString(unref(tagParam))
       if (humanTagsParams) {
-        // in the legacy implementation there was the option to query by multiple tags, e.g. string.split("+")
-        // this was not in use(?) and is removed.
         add('tag', `"${humanTagsParams}"`)
 
         if (manuallyUpdateFilterChip && unref(tagFilter)) {

--- a/packages/web-app-files/src/components/Search/List.vue
+++ b/packages/web-app-files/src/components/Search/List.vue
@@ -242,24 +242,31 @@ export default defineComponent({
     }
 
     const buildSearchTerm = (manuallyUpdateFilterChip = false) => {
-      let term = ''
-      if (unref(searchTerm)) {
-        term = `+Name:*${unref(searchTerm)}*`
+      let query = ''
+      const add = (k: string, v: string) => {
+        query = (query + ` ${k}:${v}`).trimStart()
       }
 
-      const fullTextQuery = queryItemAsString(unref(fullTextParam))
-      if (fullTextQuery) {
-        term = `+Content:"${unref(searchTerm)}"`
-      }
-      if (unref(scopeQuery) && unref(doUseScope) === 'true') {
-        term += ` scope:${unref(scopeQuery)}`
+      const humanSearchTerm = unref(searchTerm)
+      const isContentOnlySearch = queryItemAsString(unref(fullTextParam)) == 'true'
+
+      if (isContentOnlySearch && !!humanSearchTerm) {
+        add('content', `"${humanSearchTerm}"`)
+      } else if (!!humanSearchTerm) {
+        add('name', `"*${humanSearchTerm}*"`)
       }
 
-      const tagsQuery = queryItemAsString(unref(tagParam))
-      if (tagsQuery) {
-        tagsQuery.split('+')?.forEach((tag) => {
-          term += ` +Tags:"${unref(tag)}"`
-        })
+      const humanScopeQuery = unref(scopeQuery)
+      const isScopedSearch = unref(doUseScope) === 'true'
+      if (isScopedSearch && humanScopeQuery) {
+        add('scope', `${humanScopeQuery}`)
+      }
+
+      const humanTagsParams = queryItemAsString(unref(tagParam))
+      if (humanTagsParams) {
+        // in the legacy implementation there was the option to query by multiple tags, e.g. string.split("+")
+        // this was not in use(?) and is removed.
+        add('tag', `"${humanTagsParams}"`)
 
         if (manuallyUpdateFilterChip && unref(tagFilter)) {
           /**
@@ -272,7 +279,7 @@ export default defineComponent({
         }
       }
 
-      return term.trimStart()
+      return query
     }
 
     const breadcrumbs = computed(() => {

--- a/packages/web-app-files/tests/unit/components/Search/List.spec.ts
+++ b/packages/web-app-files/tests/unit/components/Search/List.spec.ts
@@ -50,7 +50,7 @@ describe('List component', () => {
       const searchTerm = 'term'
       const { wrapper } = getWrapper({ searchTerm })
       const appBar = wrapper.findComponent<any>('app-bar-stub')
-      expect(appBar.props('breadcrumbs')[0].text).toContain(searchTerm)
+      expect(appBar.props('breadcrumbs')[0].text).toEqual(`Search results for "${searchTerm}"`)
     })
   })
   describe('filter', () => {
@@ -75,13 +75,13 @@ describe('List component', () => {
         const searchTerm = 'term'
         const tagFilterQuery = 'tag1'
         const { wrapper } = getWrapper({
-          availableTags: ['tag1'],
+          availableTags: [tagFilterQuery],
           searchTerm,
           tagFilterQuery
         })
         await wrapper.vm.loadAvailableTagsTask.last
         expect(wrapper.emitted('search')[0][0]).toEqual(
-          `+Name:*${searchTerm}* +Tags:"${tagFilterQuery}"`
+          `name:"*${searchTerm}*" tag:"${tagFilterQuery}"`
         )
       })
     })
@@ -98,7 +98,7 @@ describe('List component', () => {
           fullTextSearchEnabled: true
         })
         await wrapper.vm.loadAvailableTagsTask.last
-        expect(wrapper.emitted('search')[0][0]).toEqual(`+Content:"${searchTerm}"`)
+        expect(wrapper.emitted('search')[0][0]).toEqual(`content:"${searchTerm}"`)
       })
     })
   })

--- a/packages/web-pkg/src/components/SearchBarFilter.vue
+++ b/packages/web-pkg/src/components/SearchBarFilter.vue
@@ -55,7 +55,7 @@ export default defineComponent({
   emits: ['update:modelValue'],
   setup(props, { emit }) {
     const { $gettext } = useGettext()
-    const useSopeQueryValue = useRouteQuery('useScope')
+    const useScopeQueryValue = useRouteQuery('useScope')
 
     const currentSelection = ref<LocationOption>()
     const userSelection = ref<LocationOption>()
@@ -80,8 +80,8 @@ export default defineComponent({
     watch(
       () => props.currentFolderAvailable,
       () => {
-        if (unref(useSopeQueryValue)) {
-          const useScope = unref(useSopeQueryValue).toString() === 'true'
+        if (unref(useScopeQueryValue)) {
+          const useScope = unref(useScopeQueryValue).toString() === 'true'
           if (useScope) {
             currentSelection.value = unref(locationOptions).find(
               ({ id }) => id === SearchLocationFilterConstants.inHere

--- a/packages/web-pkg/src/composables/search/constants.ts
+++ b/packages/web-pkg/src/composables/search/constants.ts
@@ -1,5 +1,4 @@
 export abstract class SearchLocationFilterConstants {
-  static readonly defaultModeName: string = 'everywhere'
   static readonly everywhere: string = 'everywhere'
   static readonly inHere: string = 'in-here'
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true


### PR DESCRIPTION
## Description
We've introduced [KQL](https://learn.microsoft.com/en-us/sharepoint/dev/general-development/keyword-query-language-kql-syntax-reference) as our default query language.
Previously we used our own simple language for queries which is now replaced by kql.

`sample.tx* Tags:important Tags:report Content:annual*`

becomes

`name:"sample.tx*" AND tag:important AND tag:report AND content:"annual*"`

by default KQL uses `AND` as property restriction and the query described above can also be formulated as follows

`name:"sample.tx*" tag:important tag:report content:"annual*"`

More advanced syntax like grouping combined with boolean property restriction is supported too

`(name:"sample*" name:"*txt") tag:important OR tag:report content:"annual*"`

## Related Issue
* https://github.com/owncloud/ocis/pull/7212
* https://github.com/owncloud/ocis/issues/7042
* https://github.com/owncloud/ocis/issues/7179
* https://github.com/owncloud/ocis/issues/7114
* https://github.com/owncloud/ocis/pull/7043
* https://github.com/owncloud/web/issues/9636
* https://github.com/owncloud/web/issues/9646

## Motivation and Context
Defining a own query language is error prone and leads to a lot of documentation, the oCIS team decided in that [ADR](https://github.com/owncloud/ocis/blob/docs/ocis/adr/0020-file-search-query-language.md) to use KQL as our standard. A clear set of rules is set by MS and the dictionary fits well in our usecase.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- unit tests have been adjusted
- acceptance tests have been adjusted 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [X] Code changes
- [X] Unit tests added
- [X] Acceptance tests added
- [ ] Documentation ticket raised: <link> 