### PR TITLE
fix: prevent browser auth prompt after failed SSE requests

### DIFF
--- a/changelog/unreleased/enhancement-sse-get-notifications-instantly
+++ b/changelog/unreleased/enhancement-sse-get-notifications-instantly
@@ -5,4 +5,6 @@ about new notifications instantly and from the server without polling
 every few seconds.
 
 https://github.com/owncloud/web/pull/9451
+https://github.com/owncloud/web/pull/9654
 https://github.com/owncloud/web/issues/9434
+https://github.com/owncloud/web/issues/9635

--- a/packages/web-pkg/src/composables/sse/useServerSentEvents.ts
+++ b/packages/web-pkg/src/composables/sse/useServerSentEvents.ts
@@ -37,7 +37,8 @@ export const useServerSentEvents = (options: ServerSentEventsOptions) => {
           headers: {
             Authorization: `Bearer ${accessToken.value}`,
             'Accept-Language': unref(language).current,
-            'X-Request-ID': uuidV4()
+            'X-Request-ID': uuidV4(),
+            'X-Requested-With': 'XMLHttpRequest'
           },
           async onopen(response) {
             if (response.status === 401) {


### PR DESCRIPTION
## Description
The SSE request was missing the `X-Requested-With: XMLHttpRequest` header which caused the browser to display an auth prompt in case the request failed with a `401` status code.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9635

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
