### PR TITLE
[tests-only][full-ci]Discard new tab wait for file creation and public link open

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -764,10 +764,10 @@ def e2eTests(ctx):
             # oCIS specific steps
             steps += copyFilesForUpload() + \
                      (tikaService() if params["tikaNeeded"] else []) + \
-                     ocisService("e2e-tests", tika_enabled = params["tikaNeeded"]) + \
-                     getSkeletonFiles()
+                     ocisService("e2e-tests", tika_enabled = params["tikaNeeded"])
 
-        steps += [{
+        steps += getSkeletonFiles() + \
+                 [{
                      "name": "e2e-tests",
                      "image": OC_CI_NODEJS,
                      "environment": environment,


### PR DESCRIPTION
### Description
The hard failure was due to previously web `master` while creating files would open then office suites files into a new tab but now all those files are created and opened in the same tab. So This PR adjusts the test code for it. but in web `stable-7.1` it is passing since it opens the new tab during the file creation.

### Related issue:
https://github.com/owncloud/web/issues/9674