### PR TITLE
[docs] Donot generate docs on stable branch

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1197,6 +1197,7 @@ def documentation(ctx):
                         "pages_directory": "docs/",
                         "copy_contents": "true",
                         "target_branch": "docs",
+                        "delete": "true",
                     },
                     "when": {
                         "ref": {
@@ -1210,7 +1211,6 @@ def documentation(ctx):
             "trigger": {
                 "ref": [
                     "refs/heads/master",
-                    "refs/heads/stable-*",
                     "refs/pull/**",
                 ],
             },


### PR DESCRIPTION
trying to fix https://github.com/owncloud/ocis/issues/7323
we generate documentation twice: in the stable branch and in the master branch. This can lead to duplication 

- [x] don't generate docs twice in the stable and master branch. Same behavior in the `ocis` repo
- [x] set delete flag 
