### PR TITLE
feat: introduce extension disabling via config

### DIFF
--- a/changelog/unreleased/enhancement-disabling-extensions
+++ b/changelog/unreleased/enhancement-disabling-extensions
@@ -1,0 +1,6 @@
+Enhancement: Disabling extensions
+
+A new configuration `disabledExtensions` has been added which enables disabling specific extensions via their id.
+
+https://github.com/owncloud/web/pull/9441
+https://github.com/owncloud/web/issues/8524

--- a/packages/web-pkg/src/composables/piniaStores/extensionRegistry.ts
+++ b/packages/web-pkg/src/composables/piniaStores/extensionRegistry.ts
@@ -1,7 +1,9 @@
 import { Action } from '../actions'
 import { SearchProvider } from '../../components/Search'
 import { defineStore } from 'pinia'
-import { Ref, unref } from 'vue'
+import { Ref, hasInjectionContext, unref } from 'vue'
+import { useConfigurationManager } from '../configuration'
+import { ConfigurationManager } from '../../configuration'
 
 export type BaseExtension = {
   id: string
@@ -20,20 +22,32 @@ export interface SearchExtension extends BaseExtension {
 
 export type Extension = ActionExtension | SearchExtension
 
-export const useExtensionRegistry = defineStore('extensionRegistry', {
-  state: () => ({ extensions: [] as Ref<Extension[]>[] }),
-  actions: {
-    registerExtensions(extensions: Ref<Extension[]>) {
-      this.extensions.push(extensions)
-    }
-  },
-  getters: {
-    requestExtensions:
-      (state) =>
-      <ExtensionType extends Extension>(type: string) => {
-        return state.extensions
-          .map((e) => unref(e).filter((e) => e.type === type))
-          .flat() as ExtensionType[]
-      }
+export const useExtensionRegistry = ({
+  configurationManager
+}: { configurationManager?: ConfigurationManager } = {}) => {
+  if (!hasInjectionContext() && !configurationManager) {
+    throw new Error('no injection context, you need to pass configuration manager via options')
   }
-})
+
+  const { options } = configurationManager || useConfigurationManager()
+
+  return defineStore('extensionRegistry', {
+    state: () => ({ extensions: [] as Ref<Extension[]>[] }),
+    actions: {
+      registerExtensions(extensions: Ref<Extension[]>) {
+        this.extensions.push(extensions)
+      }
+    },
+    getters: {
+      requestExtensions:
+        (state) =>
+        <ExtensionType extends Extension>(type: string) => {
+          return state.extensions
+            .map((e) =>
+              unref(e).filter((e) => e.type === type && !options.disabledExtensions.includes(e.id))
+            )
+            .flat() as ExtensionType[]
+        }
+    }
+  })()
+}

--- a/packages/web-pkg/src/configuration/manager.ts
+++ b/packages/web-pkg/src/configuration/manager.ts
@@ -104,6 +104,7 @@ export class ConfigurationManager {
     set(this.optionsConfiguration, 'upload.companionUrl', get(options, 'upload.companionUrl', ''))
     set(this.optionsConfiguration, 'tokenStorageLocal', get(options, 'tokenStorageLocal', true))
     set(this.optionsConfiguration, 'loginUrl', get(options, 'loginUrl', ''))
+    set(this.optionsConfiguration, 'disabledExtensions', get(options, 'disabledExtensions', []))
   }
 
   get options(): OptionsConfiguration {

--- a/packages/web-pkg/src/configuration/types.ts
+++ b/packages/web-pkg/src/configuration/types.ts
@@ -25,6 +25,7 @@ export interface OptionsConfiguration {
   openAppsInTab?: boolean
   openLinksWithDefaultApp?: boolean
   tokenStorageLocal?: boolean
+  disabledExtensions?: string[]
 }
 
 export interface OAuth2Configuration {

--- a/packages/web-runtime/src/container/application/classic.ts
+++ b/packages/web-runtime/src/container/application/classic.ts
@@ -5,7 +5,7 @@ import { isFunction, isObject } from 'lodash-es'
 import { NextApplication } from './next'
 import { Store } from 'vuex'
 import { Router } from 'vue-router'
-import { RuntimeError } from '@ownclouders/web-pkg'
+import { ConfigurationManager, RuntimeError } from '@ownclouders/web-pkg'
 import { AppConfigObject, AppReadyHookArgs, ClassicApplicationScript } from '@ownclouders/web-pkg'
 import { useExtensionRegistry } from '@ownclouders/web-pkg'
 import type { Language } from 'vue3-gettext'
@@ -84,7 +84,8 @@ export const convertClassicApplication = async ({
   store,
   router,
   gettext,
-  supportedLanguages
+  supportedLanguages,
+  configurationManager
 }: {
   app: App
   applicationScript: ClassicApplicationScript
@@ -93,6 +94,7 @@ export const convertClassicApplication = async ({
   router: Router
   gettext: Language
   supportedLanguages: { [key: string]: string }
+  configurationManager: ConfigurationManager
 }): Promise<NextApplication> => {
   if (applicationScript.setup) {
     applicationScript = app.runWithContext(() => {
@@ -130,7 +132,7 @@ export const convertClassicApplication = async ({
   await store.dispatch('registerApp', applicationScript.appInfo)
 
   if (applicationScript.extensions) {
-    useExtensionRegistry().registerExtensions(applicationScript.extensions)
+    useExtensionRegistry({ configurationManager }).registerExtensions(applicationScript.extensions)
   }
 
   return new ClassicApplication(runtimeApi, applicationScript, app)

--- a/packages/web-runtime/src/container/application/index.ts
+++ b/packages/web-runtime/src/container/application/index.ts
@@ -130,7 +130,8 @@ export const buildApplication = async ({
         store,
         router,
         gettext,
-        supportedLanguages
+        supportedLanguages,
+        configurationManager
       }).catch()
     }
   } catch (err) {

--- a/packages/web-runtime/src/store/config.ts
+++ b/packages/web-runtime/src/store/config.ts
@@ -72,7 +72,8 @@ const state = {
     loginUrl: '',
     privacyUrl: '',
     imprintUrl: '',
-    accessDeniedHelpUrl: ''
+    accessDeniedHelpUrl: '',
+    disabledExtensions: []
   }
 }
 


### PR DESCRIPTION
## Description
Adds a config option `disabledExtensions` which enables disabling specific extensions via their id.

oCIS part for the config: https://github.com/owncloud/ocis/pull/7486

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8524

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
