### PR TITLE
[cern] feat: restrict copy action above space root

### DIFF
--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCopy.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCopy.ts
@@ -23,6 +23,8 @@ export const useFileActionsCopy = ({ store }: { store?: Store<any> } = {}) => {
     return window.navigator.platform.match('Mac')
   })
 
+  const runningOnEos = computed<boolean>(() => store.getters.configuration?.options?.runningOnEos)
+
   const copyShortcutString = computed(() => {
     if (unref(isMacOs)) {
       return $pgettext('Keyboard shortcut for macOS for copying files', '⌘ + C')
@@ -72,6 +74,14 @@ export const useFileActionsCopy = ({ store }: { store?: Store<any> } = {}) => {
             resources.every((r) => isProjectSpaceResource(r))
           ) {
             return false
+          }
+
+          if (unref(runningOnEos)) {
+            // CERNBox does not allow actions above home/project root
+            const elems = resources[0].path?.split('/').filter(Boolean) || [] //"/eos/project/c/cernbox"
+            if (isLocationSpacesActive(router, 'files-spaces-generic') && elems.length < 5) {
+              return false
+            }
           }
 
           // copy can't be restricted in authenticated context, because


### PR DESCRIPTION
## Description
See https://github.com/owncloud/web/issues/9218 and https://github.com/owncloud/web/commit/1563e15a2a051833718eb4a662b3525e3f996278.

As discussed it makes no sense to implement an entry point for extensions here. We could add functionality for disabling specific file actions in the future. CERN would then need to implement a custom copy action which includes the added check. However, for now we decided this is the way to handle this.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9218

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
