### PR TITLE
feat: add permission checks for creating shares and favorites

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=c4d3ec7e5b07abe00ce3d9c322387eba80224ecf
+OCIS_COMMITID=a9366caa0cb97de0c4a68a43f05156cc584bee16
 OCIS_BRANCH=master

--- a/changelog/unreleased/enhancement-share-and-favorite-permission-checks
+++ b/changelog/unreleased/enhancement-share-and-favorite-permission-checks
@@ -1,0 +1,6 @@
+Enhancement: Permission checks for shares and favorites
+
+Permission checks for creating shares and favorites have been added.
+
+https://github.com/owncloud/ocis/issues/7497
+https://github.com/owncloud/web/pull/9810

--- a/packages/web-app-files/src/components/FilesList/QuickActions.vue
+++ b/packages/web-app-files/src/components/FilesList/QuickActions.vue
@@ -49,7 +49,7 @@ export default defineComponent({
     const language = useGettext()
 
     const filteredActions = computed(() =>
-      pickBy(props.actions, (action) => action.displayed(props.item, store) === true)
+      pickBy(props.actions, (action) => action.displayed(props.item, store, ability) === true)
     )
 
     return {

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
@@ -122,6 +122,7 @@ import {
 import * as uuid from 'uuid'
 import { defineComponent, inject, PropType, ComponentPublicInstance } from 'vue'
 import {
+  useAbility,
   useCapabilityFilesSharingAllowCustomPermissions,
   useCapabilityFilesSharingResharingDefault,
   useStore
@@ -166,7 +167,9 @@ export default defineComponent({
   emits: ['optionChange'],
   setup() {
     const store = useStore()
+    const ability = useAbility()
     return {
+      ability,
       resource: inject<Resource>('resource'),
       incomingParentShare: inject<Share>('incomingParentShare'),
       hasRoleCustomPermissions: useCapabilityFilesSharingAllowCustomPermissions(store),
@@ -202,7 +205,7 @@ export default defineComponent({
       return PeopleShareRoles.custom(this.resource.isFolder)
     },
     resourceIsSharable() {
-      return this.allowSharePermission && this.resource.canShare()
+      return this.allowSharePermission && this.resource.canShare({ ability: this.ability })
     },
     availableRoles() {
       if (this.resourceIsSpace) {

--- a/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
@@ -158,7 +158,8 @@ export default defineComponent({
   },
   setup() {
     const store = useStore()
-    const { can } = useAbility()
+    const ability = useAbility()
+    const { can } = ability
     const passwordPolicyService = usePasswordPolicyService()
     const hasResharing = useCapabilityFilesSharingResharing()
 
@@ -206,7 +207,7 @@ export default defineComponent({
         return false
       }
 
-      return unref(resource).canShare({ user: store.getters.user })
+      return unref(resource).canShare({ user: store.getters.user, ability })
     })
 
     const canEditLink = ({ permissions }: Share) => {

--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -89,6 +89,7 @@
 <script lang="ts">
 import { mapGetters, mapActions, mapState, mapMutations } from 'vuex'
 import {
+  useAbility,
   useStore,
   useCapabilityProjectSpacesEnabled,
   useCapabilityShareJailEnabled,
@@ -125,6 +126,7 @@ export default defineComponent({
   },
   setup() {
     const store = useStore()
+    const ability = useAbility()
     const { getMatchingSpace } = useGetMatchingSpace()
 
     const resource = inject<Ref<Resource>>('resource')
@@ -164,6 +166,7 @@ export default defineComponent({
 
     return {
       ...useShares(),
+      ability,
       resource,
       space: inject<Ref<SpaceResource>>('space'),
       matchingSpace,
@@ -270,7 +273,7 @@ export default defineComponent({
       if (isShareJail && !this.hasResharing) {
         return false
       }
-      return this.resource.canShare({ user: this.user })
+      return this.resource.canShare({ user: this.user, ability: this.ability })
     },
 
     noResharePermsMessage() {

--- a/packages/web-app-files/src/index.ts
+++ b/packages/web-app-files/src/index.ts
@@ -76,7 +76,7 @@ export const navItems = (context): AppNavigationItem[] => {
         path: `/${appInfo.id}/favorites`
       },
       enabled(capabilities) {
-        return capabilities.files?.favorites
+        return capabilities.files?.favorites && context.$ability.can('read-all', 'Favorite')
       },
       priority: 20
     },

--- a/packages/web-client/src/helpers/resource/functions.ts
+++ b/packages/web-client/src/helpers/resource/functions.ts
@@ -155,8 +155,10 @@ export function buildResource(resource: WebDavResponseResource): Resource {
     canRename: function () {
       return this.permissions.indexOf(DavPermission.Renameable) >= 0
     },
-    canShare: function () {
-      return this.permissions.indexOf(DavPermission.Shareable) >= 0
+    canShare: function ({ ability }) {
+      return (
+        ability.can('create-all', 'Share') && this.permissions.indexOf(DavPermission.Shareable) >= 0
+      )
     },
     canCreate: function () {
       return this.permissions.indexOf(DavPermission.FolderCreateable) >= 0
@@ -182,7 +184,7 @@ export function buildResource(resource: WebDavResponseResource): Resource {
       return this.permissions.indexOf(DavPermission.Deny) >= 0
     },
     getDomSelector: () => extractDomSelector(id)
-  }
+  } satisfies Resource
   Object.defineProperty(r, 'nodeId', {
     get() {
       return extractNodeId(this.id)

--- a/packages/web-client/src/helpers/resource/types.ts
+++ b/packages/web-client/src/helpers/resource/types.ts
@@ -18,6 +18,7 @@ export type AbilityActions =
 export type AbilitySubjects =
   | 'Account'
   | 'Drive'
+  | 'Favorite'
   | 'Group'
   | 'Language'
   | 'Logo'
@@ -25,6 +26,7 @@ export type AbilitySubjects =
   | 'ReadOnlyPublicLinkPassword'
   | 'Role'
   | 'Setting'
+  | 'Share'
 
 export type Ability = MongoAbility<[AbilityActions, AbilitySubjects]>
 export type AbilityRule = SubjectRawRule<AbilityActions, AbilitySubjects, any>
@@ -84,7 +86,7 @@ export interface Resource {
   canCreate?(): boolean
   canUpload?({ user }: { user?: User }): boolean
   canDownload?(): boolean
-  canShare?({ user }?: { user?: User }): boolean
+  canShare?({ user, ability }?: { user?: User; ability?: Ability }): boolean
   canRename?({ user }?: { user?: User; ability?: Ability }): boolean
   canBeDeleted?({ user }?: { user?: User; ability?: Ability }): boolean
   canBeRestored?(): boolean

--- a/packages/web-pkg/src/components/AppBar/AppBar.vue
+++ b/packages/web-pkg/src/components/AppBar/AppBar.vue
@@ -100,6 +100,7 @@ import {
   useFileActionsRestore
 } from '../../composables/actions'
 import {
+  useAbility,
   useCapabilitySpacesMaxQuota,
   useFileActionsToggleHideShare,
   useRouteMeta,
@@ -165,6 +166,7 @@ export default defineComponent({
   setup(props, { emit }) {
     const store = useStore()
     const { $gettext } = useGettext()
+    const { can } = useAbility()
 
     const { actions: acceptShareActions } = useFileActionsAcceptShare({ store })
     const { actions: hideShareActions } = useFileActionsToggleHideShare({ store })
@@ -188,7 +190,9 @@ export default defineComponent({
     const breadcrumbMaxWidth = ref<number>(0)
     const isSearchLocation = useActiveLocation(isLocationCommonActive, 'files-common-search')
 
-    const hasSharesNavigation = computed(() => useSlots().hasOwnProperty('navigation'))
+    const hasSharesNavigation = computed(
+      () => useSlots().hasOwnProperty('navigation') && can('create-all', 'Share')
+    )
 
     const batchActions = computed(() => {
       let actions = [

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCreateQuicklink.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCreateQuicklink.ts
@@ -56,7 +56,7 @@ export const useFileActionsCreateQuickLink = ({
             return false
           }
         }
-        return canShare(resources[0], store)
+        return canShare(resources[0], store, ability)
       },
       componentType: 'button',
       class: 'oc-files-actions-create-quicklink-trigger'

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsFavorite.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsFavorite.ts
@@ -8,6 +8,7 @@ import { FileAction, FileActionOptions, useIsFilesAppActive } from '../../action
 import { useStore } from '../../store'
 import { useRouter } from '../../router'
 import { useClientService } from '../../clientService'
+import { useAbility } from '../../ability'
 
 export const useFileActionsFavorite = ({ store }: { store?: Store<any> } = {}) => {
   store = store || useStore()
@@ -16,6 +17,8 @@ export const useFileActionsFavorite = ({ store }: { store?: Store<any> } = {}) =
   const clientService = useClientService()
   const hasFavorites = useCapabilityFilesFavorites()
   const isFilesAppActive = useIsFilesAppActive()
+  const ability = useAbility()
+
   const handler = ({ resources }: FileActionOptions) => {
     store
       .dispatch('Files/markFavorite', {
@@ -58,7 +61,7 @@ export const useFileActionsFavorite = ({ store }: { store?: Store<any> } = {}) =
           return false
         }
 
-        return unref(hasFavorites)
+        return unref(hasFavorites) && ability.can('create-all', 'Favorite')
       },
       componentType: 'button',
       class: 'oc-files-actions-favorite-trigger'

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsShowShares.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsShowShares.ts
@@ -10,10 +10,12 @@ import { useRouter } from '../../router'
 import { useStore } from '../../store'
 import { Store } from 'vuex'
 import { FileAction, FileActionOptions } from '../types'
+import { useAbility } from '../../ability'
 
 export const useFileActionsShowShares = ({ store }: { store?: Store<any> } = {}) => {
   store = store || useStore()
   const router = useRouter()
+  const ability = useAbility()
   const { $gettext } = useGettext()
   const isFilesAppActive = useIsFilesAppActive()
 
@@ -46,7 +48,7 @@ export const useFileActionsShowShares = ({ store }: { store?: Store<any> } = {})
             return false
           }
         }
-        return canShare(resources[0], store)
+        return canShare(resources[0], store, ability)
       },
       componentType: 'button',
       class: 'oc-files-actions-show-shares-trigger'

--- a/packages/web-pkg/src/quickActions.ts
+++ b/packages/web-pkg/src/quickActions.ts
@@ -8,7 +8,7 @@ import { Ability } from '@ownclouders/web-client/src/helpers/resource/types'
 import { Store } from 'vuex'
 import { ApplicationQuickActions } from './apps'
 
-export function canShare(item, store) {
+export function canShare(item: Resource, store: Store<any>, ability: Ability) {
   const { capabilities } = store.state.user
   if (!capabilities.files_sharing || !capabilities.files_sharing.api_enabled) {
     return false
@@ -16,7 +16,7 @@ export function canShare(item, store) {
   if (item.isReceivedShare() && !capabilities.files_sharing.resharing) {
     return false
   }
-  return item.canShare()
+  return item.canShare({ ability })
 }
 
 export function showQuickLinkPasswordModal({ $gettext, store, passwordPolicyService }, onConfirm) {

--- a/packages/web-runtime/src/services/auth/abilities.ts
+++ b/packages/web-runtime/src/services/auth/abilities.ts
@@ -11,6 +11,11 @@ export const getAbilities = (
       { action: 'read-all', subject: 'Account' },
       { action: 'update-all', subject: 'Account' }
     ],
+    'Favorits.List.all': [{ action: 'read-all', subject: 'Favorite' }],
+    'Favorits.Write.all': [
+      { action: 'create-all', subject: 'Favorite' },
+      { action: 'update-all', subject: 'Favorite' }
+    ],
     'Groups.ReadWrite.all': [
       { action: 'create-all', subject: 'Group' },
       { action: 'delete-all', subject: 'Group' },
@@ -32,6 +37,7 @@ export const getAbilities = (
       { action: 'read-all', subject: 'Role' },
       { action: 'update-all', subject: 'Role' }
     ],
+    'Share.Create.all': [{ action: 'create-all', subject: 'Share' }],
     'Settings.ReadWrite.all': [
       { action: 'read-all', subject: 'Setting' },
       { action: 'update-all', subject: 'Setting' }

--- a/packages/web-runtime/src/services/auth/abilities.ts
+++ b/packages/web-runtime/src/services/auth/abilities.ts
@@ -11,8 +11,8 @@ export const getAbilities = (
       { action: 'read-all', subject: 'Account' },
       { action: 'update-all', subject: 'Account' }
     ],
-    'Favorits.List.all': [{ action: 'read-all', subject: 'Favorite' }],
-    'Favorits.Write.all': [
+    'Favorites.List.all': [{ action: 'read-all', subject: 'Favorite' }],
+    'Favorites.Write.all': [
       { action: 'create-all', subject: 'Favorite' },
       { action: 'update-all', subject: 'Favorite' }
     ],

--- a/packages/web-runtime/src/services/auth/abilities.ts
+++ b/packages/web-runtime/src/services/auth/abilities.ts
@@ -37,7 +37,10 @@ export const getAbilities = (
       { action: 'read-all', subject: 'Role' },
       { action: 'update-all', subject: 'Role' }
     ],
-    'Share.Create.all': [{ action: 'create-all', subject: 'Share' }],
+    'Shares.Write.all': [
+      { action: 'create-all', subject: 'Share' },
+      { action: 'update-all', subject: 'Share' }
+    ],
     'Settings.ReadWrite.all': [
       { action: 'read-all', subject: 'Setting' },
       { action: 'update-all', subject: 'Setting' }

--- a/packages/web-runtime/tests/unit/services/auth/abilities.spec.ts
+++ b/packages/web-runtime/tests/unit/services/auth/abilities.spec.ts
@@ -45,8 +45,8 @@ describe('getAbilities', () => {
     expect(abilities).toEqual(expectedActions.map((action) => ({ action, subject: 'PublicLink' })))
   })
   it('gets correct abilities for subject "Share"', function () {
-    const abilities = getAbilities(['Share.Create.all'])
-    const expectedActions = ['create-all']
+    const abilities = getAbilities(['Shares.Write.all'])
+    const expectedActions = ['create-all', 'update-all']
     expect(abilities).toEqual(expectedActions.map((action) => ({ action, subject: 'Share' })))
   })
   it('gets correct abilities for subject "Setting"', function () {

--- a/packages/web-runtime/tests/unit/services/auth/abilities.spec.ts
+++ b/packages/web-runtime/tests/unit/services/auth/abilities.spec.ts
@@ -44,6 +44,11 @@ describe('getAbilities', () => {
     const expectedActions = ['create-all']
     expect(abilities).toEqual(expectedActions.map((action) => ({ action, subject: 'PublicLink' })))
   })
+  it('gets correct abilities for subject "Share"', function () {
+    const abilities = getAbilities(['Share.Create.all'])
+    const expectedActions = ['create-all']
+    expect(abilities).toEqual(expectedActions.map((action) => ({ action, subject: 'Share' })))
+  })
   it('gets correct abilities for subject "Setting"', function () {
     const abilities = getAbilities(['Settings.ReadWrite.all'])
     const expectedActions = ['read-all', 'update-all']

--- a/packages/web-runtime/tests/unit/services/auth/abilities.spec.ts
+++ b/packages/web-runtime/tests/unit/services/auth/abilities.spec.ts
@@ -15,6 +15,15 @@ describe('getAbilities', () => {
     const expectedActions = ['create-all', 'delete-all', 'read-all', 'update-all']
     expect(abilities).toEqual(expectedActions.map((action) => ({ action, subject: 'Group' })))
   })
+  it.each([
+    { permissions: [''], expectedActions: [] },
+    { permissions: ['Favorites.List.all'], expectedActions: ['read-all'] },
+    { permissions: ['Favorites.Write.all'], expectedActions: ['create-all', 'update-all'] }
+  ])('gets correct abilities for subject "Favorites"', function (data) {
+    const abilities = getAbilities(data.permissions)
+    const expectedResult = data.expectedActions.map((action) => ({ action, subject: 'Favorite' }))
+    expect(abilities).toEqual(expectedResult)
+  })
   it('gets correct abilities for subject "Language"', function () {
     const abilities = getAbilities(['Language.ReadWrite.all'])
     const expectedActions = ['read-all', 'update-all']


### PR DESCRIPTION
## Description
Add and enforce permission checks for creating shares and favorites. Note that you need a current oCIS docker image for testing.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Works towards https://github.com/owncloud/web/issues/9381

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
