### PR TITLE
[test-only] loosen the checking url in test

### DIFF
--- a/tests/e2e/support/objects/app-files/spaces/actions.ts
+++ b/tests/e2e/support/objects/app-files/spaces/actions.ts
@@ -54,7 +54,7 @@ export const createSpace = async (args: createSpaceArgs): Promise<string> => {
   )
   const mkcolResponsePromise = page.waitForResponse(
     (resp) =>
-      resp.status() === 201 && resp.request().method() === 'MKCOL' && resp.url().endsWith('.space')
+      resp.status() === 201 && resp.request().method() === 'MKCOL' && resp.url().includes('.space')
   )
   const putResponsePromise = page.waitForResponse(
     (resp) =>


### PR DESCRIPTION
I have a red CI in ocis because we have differences in the MKCOL request url: 

ocis binary: with `/` at the end
![image](https://github.com/owncloud/web/assets/84779829/3c4e71ef-7ac7-44a4-9780-d658c61a95a4)


ocis docker-compose:  without `/` at the end
<img width="416" alt="image" src="https://github.com/owncloud/web/assets/84779829/1beeee4c-98da-4999-b0e0-17b0e986ac0c">
