### PR TITLE
[tests-only][full-ci]added e2e test for show password, copy password and generate password buttons

### DIFF
--- a/tests/e2e/cucumber/features/smoke/spaces/publicLink.feature
+++ b/tests/e2e/cucumber/features/smoke/spaces/publicLink.feature
@@ -87,9 +87,17 @@ Feature: spaces public link
       """
       Unfortunately, your password is commonly used. please pick a harder-to-guess password for your safety
       """
+    And "Alice" closes the public link password dialog box
     When "Alice" tries to sets the password of the public link named "myPublicLink" of resource "lorem.txt" to "12345678"
     Then "Alice" should see an error message
       """
       Unfortunately, your password is commonly used. please pick a harder-to-guess password for your safety
       """
+    And "Alice" reveals the password of the public link
+    And "Alice" hides the password of the public link
+    And "Alice" generates the password for the public link
+    And "Alice" copies the password of the public link
+    And "Alice" sets the password of the public link
+    And "Anonymous" opens the public link "myPublicLink"
+    And "Anonymous" unlocks the public link with password "%copied_password%"
     And "Alice" logs out

--- a/tests/e2e/cucumber/steps/ui/links.ts
+++ b/tests/e2e/cucumber/steps/ui/links.ts
@@ -90,6 +90,51 @@ When(
 )
 
 When(
+  /^"([^"]*)" (reveals|hides) the password of the public link$/,
+  async function (this: World, stepUser: string, showOrHide: string): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const linkObject = new objects.applicationFiles.Link({ page })
+    await linkObject.showOrHidePassword({ showOrHide })
+  }
+)
+
+When(
+  '{string} closes the public link password dialog box',
+  async function (this: World, stepUser: string): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const linkObject = new objects.applicationFiles.Link({ page })
+    await linkObject.clickOnCancelButton()
+  }
+)
+
+When(
+  '{string} copies the password of the public link',
+  async function (this: World, stepUser: string): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const linkObject = new objects.applicationFiles.Link({ page })
+    await linkObject.copyEnteredPassword()
+  }
+)
+
+When(
+  '{string} generates the password for the public link',
+  async function (this: World, stepUser: string): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const linkObject = new objects.applicationFiles.Link({ page })
+    await linkObject.generatePassword()
+  }
+)
+
+When(
+  '{string} sets the password of the public link',
+  async function (this: World, stepUser: string): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const linkObject = new objects.applicationFiles.Link({ page })
+    await linkObject.setPassword()
+  }
+)
+
+When(
   '{string} edits the public link named {string} of resource {string} changing role to {string}',
   async function (
     this: World,
@@ -158,7 +203,6 @@ Then(
     const linkObject = new objects.applicationFiles.Link({ page })
     const actualErrorMessage = await linkObject.checkErrorMessage()
     expect(actualErrorMessage).toBe(errorMessage)
-    await linkObject.clickOnCancelButton()
   }
 )
 

--- a/tests/e2e/cucumber/steps/ui/public.ts
+++ b/tests/e2e/cucumber/steps/ui/public.ts
@@ -32,6 +32,9 @@ When(
   async function (this: World, stepUser: string, password: string): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const pageObject = new objects.applicationFiles.page.Public({ page })
+    if (password === '%copied_password%') {
+      password = await page.evaluate('navigator.clipboard.readText()')
+    }
     await pageObject.authenticate({ password })
   }
 )

--- a/tests/e2e/support/objects/app-files/link/index.ts
+++ b/tests/e2e/support/objects/app-files/link/index.ts
@@ -59,6 +59,22 @@ export class Link {
     await po.fillPassword({ page: this.#page, ...args })
   }
 
+  async showOrHidePassword(args): Promise<void> {
+    return po.showOrHidePassword({ page: this.#page, ...args })
+  }
+
+  async copyEnteredPassword(): Promise<void> {
+    return po.copyEnteredPassword(this.#page)
+  }
+
+  async generatePassword(): Promise<void> {
+    return po.generatePassword(this.#page)
+  }
+
+  async setPassword(): Promise<void> {
+    return po.setPassword(this.#page)
+  }
+
   async changeRole(args: Omit<po.changeRoleArgs, 'page'>): Promise<string> {
     const startUrl = this.#page.url()
     const role = await po.changeRole({ page: this.#page, ...args })


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
In this PR, added the step implementation for new buttons,
- Show/Hide Password
- Copy Password
- Generate Password

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/web/issues/9795

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] e2e tests added
- [ ] Documentation ticket raised: <link> 
