### PR TITLE
[test-only] delete unnecessary envs

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1256,7 +1256,6 @@ def ocisService(type, tika_enabled = False):
         "WEB_ASSET_PATH": "%s/dist" % dir["web"],
         "FRONTEND_SEARCH_MIN_LENGTH": "2",
         "FRONTEND_OCS_ENABLE_DENIALS": True,
-        "FRONTEND_AUTO_ACCEPT_SHARES": True,
         "FRONTEND_PASSWORD_POLICY_BANNED_PASSWORDS_LIST": "%s/tests/drone/banned-passwords.txt" % dir["web"],
     }
     if type == "app-provider":

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
       FRONTEND_OCS_ENABLE_DENIALS: "true"
       FRONTEND_FULL_TEXT_SEARCH_ENABLED: "true"
       FRONTEND_PASSWORD_POLICY_BANNED_PASSWORDS_LIST: '/etc/ocis/password-policy-banned-passwords.txt'
-      FRONTEND_AUTO_ACCEPT_SHARES: "true"
 
       # IDM
       IDM_CREATE_DEMO_USERS: "${DEMO_USERS:-true}"


### PR DESCRIPTION
https://github.com/owncloud/ocis/pull/7477/files#diff-03814e90d6610960b5be6dacceaebdcbe234eafc6b504711dfbb199481c20fac

By default, auto-accept is set to true, so we don't need `FRONTEND_AUTO_ACCEPT_SHARES: "true"`