### PR TITLE
fix: webkit quicklinks copy for webkit

### DIFF
--- a/changelog/unreleased/bugfix-webkit-copy-quicklinks
+++ b/changelog/unreleased/bugfix-webkit-copy-quicklinks
@@ -1,0 +1,6 @@
+Bugfix: Copy quicklinks for webkit navigator
+
+Copying quicklinks didn't work on safari or other webkit based browsers and is fixed now.
+
+https://github.com/owncloud/web/pull/9832
+https://github.com/owncloud/web/issues/9166

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCreateQuicklink.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCreateQuicklink.ts
@@ -1,5 +1,5 @@
 import quickActions, { canShare } from '../../../quickActions'
-import { createQuicklink } from '../../../helpers/share'
+import { copyQuicklink } from '../../../helpers/share'
 import { ShareStatus } from '@ownclouders/web-client/src/helpers/share'
 
 import { isLocationSharesActive } from '../../../router'
@@ -22,7 +22,7 @@ export const useFileActionsCreateQuickLink = ({ store }: { store?: Store<any> } 
 
   const handler = async ({ space, resources }: FileActionOptions) => {
     const [resource] = resources
-    await createQuicklink({
+    await copyQuicklink({
       clientService,
       resource,
       storageId: space?.id || resource?.fileId || resource?.id,

--- a/packages/web-pkg/src/helpers/share/link.ts
+++ b/packages/web-pkg/src/helpers/share/link.ts
@@ -36,7 +36,7 @@ export const copyQuicklink = async (args: CreateQuicklink) => {
   //
   // https://webkit.org/blog/10855/
   const doCopy = async () => {
-    if (typeof ClipboardItem && navigator && navigator.clipboard && navigator.clipboard.write) {
+    if (typeof ClipboardItem && navigator?.clipboard?.write) {
       await navigator.clipboard.write([
         new ClipboardItem({
           'text/plain': createQuicklink(args).then(

--- a/packages/web-pkg/src/quickActions.ts
+++ b/packages/web-pkg/src/quickActions.ts
@@ -1,4 +1,4 @@
-import { createQuicklink } from './helpers/share'
+import { copyQuicklink } from './helpers/share'
 import { eventBus } from './services/eventBus'
 import { SideBarEventTopics } from './composables/sideBar/eventTopics'
 import { Resource } from '@ownclouders/web-client'
@@ -82,7 +82,7 @@ export default {
         return showQuickLinkPasswordModal(
           { store, $gettext: language.$gettext, passwordPolicyService },
           async (password) => {
-            await createQuicklink({
+            await copyQuicklink({
               ability,
               clientService,
               language,
@@ -94,7 +94,7 @@ export default {
         )
       }
 
-      await createQuicklink({
+      await copyQuicklink({
         ability,
         clientService,
         language,

--- a/packages/web-pkg/tests/unit/helpers/share/link.spec.ts
+++ b/packages/web-pkg/tests/unit/helpers/share/link.spec.ts
@@ -1,4 +1,4 @@
-import { createQuicklink, CreateQuicklink } from '../../../../src/helpers/share'
+import { copyQuicklink, createQuicklink, CreateQuicklink } from '../../../../src/helpers/share'
 import { DateTime } from 'luxon'
 import { Store } from 'vuex'
 import { ClientService } from '../../../../src/services'
@@ -65,6 +65,7 @@ describe('createQuicklink', () => {
     expect(link).toBeDefined()
     expect(link.url).toBeDefined()
 
+    await copyQuicklink(args)
     expect(useClipboard).toHaveBeenCalled()
 
     expect(mockStore.dispatch).toHaveBeenCalledWith('Files/addLink', {
@@ -106,6 +107,7 @@ describe('createQuicklink', () => {
       expect(link).toBeDefined()
       expect(link.url).toBeDefined()
 
+      await copyQuicklink(args)
       expect(useClipboard).toHaveBeenCalled()
 
       expect(mockStore.dispatch).toHaveBeenCalledWith('Files/addLink', {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 overrides:
   '@uppy/companion-client': https://github.com/owncloud/uppy/releases/download/v3.12.13-owncloud/uppy-companion-client.tgz
   '@uppy/core': https://github.com/owncloud/uppy/releases/download/v3.12.13-owncloud/uppy-core.tgz
@@ -22750,3 +22746,7 @@ packages:
       lodash: 4.17.21
       vue: 3.3.4
     dev: true
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
## Description
copying quicklings was broken on webkit based browsers, this is fixed now.

* https://developer.apple.com/forums/thread/691873
* https://webkit.org/blog/10855/

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixeshttps://github.com/owncloud/web/issues/9166

## Motivation and Context
... hmmmm, no bugs, happy dev 🤣
![ezgif-2-09128abecb](https://github.com/owncloud/web/assets/49308105/63df230f-e212-4c53-b2d9-2ecd57e19662)


## How Has This Been Tested?
- unit tests

## Screenshots (if appropriate):
![Screenshot 2023-10-19 at 15 25 10](https://github.com/owncloud/web/assets/49308105/c1333917-7ca4-4d0d-8864-bbdce249e064)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [X] Code changes
- [X] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
