### PR TITLE
fix: resolving external URLs via file ID

### DIFF
--- a/changelog/unreleased/bugfix-external-url-resolving
+++ b/changelog/unreleased/bugfix-external-url-resolving
@@ -1,0 +1,6 @@
+Bugfix: Resolving external URLs
+
+Resolving external URLs when only the file ID is given has been fixed.
+
+https://github.com/owncloud/web/issues/9804
+https://github.com/owncloud/web/pull/9833

--- a/packages/design-system/src/components/OcNotificationMessage/OcNotificationMessage.vue
+++ b/packages/design-system/src/components/OcNotificationMessage/OcNotificationMessage.vue
@@ -11,7 +11,7 @@
             {{ title }}
           </div>
         </div>
-        <oc-button appearance="raw" @click="close" :aria-label="$gettext('Close')"
+        <oc-button appearance="raw" :aria-label="$gettext('Close')" @click="close"
           ><oc-icon name="close"
         /></oc-button>
       </div>

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -83,10 +83,10 @@ export default defineComponent({
 
     const driveAliasAndItem = useRouteParam('driveAliasAndItem')
 
-    const getMatchingSpace = (id): SpaceResource => {
+    const getMatchingSpaceByFileId = (id): SpaceResource => {
       return store.getters['runtime/spaces/spaces'].find((space) => id.startsWith(space.id))
     }
-    const findMatchingMountPoint = (id: string | number): SpaceResource => {
+    const getMatchingMountPoint = (id: string | number): SpaceResource => {
       return store.getters['runtime/spaces/spaces'].find(
         (space) => isMountPointSpaceResource(space) && space.root?.remoteItem?.id === id
       )
@@ -95,7 +95,7 @@ export default defineComponent({
     const addMissingDriveAliasAndItem = async () => {
       const id = unref(fileId)
       let path: string
-      let matchingSpace = getMatchingSpace(id)
+      let matchingSpace = getMatchingSpaceByFileId(id)
       if (matchingSpace) {
         path = await clientService.owncloudSdk.files.getPathForFileId(id)
         const driveAliasAndItem = matchingSpace.getDriveAliasAndItem({ path } as Resource)
@@ -116,7 +116,7 @@ export default defineComponent({
       await store.dispatch('runtime/spaces/loadMountPoints', {
         graphClient: clientService.graphAuthenticated
       })
-      let mountPoint = findMatchingMountPoint(id)
+      let mountPoint = getMatchingMountPoint(id)
       const resource = await loadFileInfoByIdTask.perform(id)
       const sharePathSegments = mountPoint ? [] : [unref(resource).name]
       let tmpResource = unref(resource)
@@ -126,7 +126,7 @@ export default defineComponent({
         } catch (e) {
           throw Error(e)
         }
-        mountPoint = findMatchingMountPoint(tmpResource.id)
+        mountPoint = getMatchingMountPoint(tmpResource.id)
         if (!mountPoint) {
           sharePathSegments.unshift(tmpResource.name)
         }

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -39,10 +39,26 @@ import { mapGetters } from 'vuex'
 import { computed, defineComponent, unref } from 'vue'
 import { urlJoin } from 'web-client/src/utils'
 import AppTopBar from 'web-pkg/src/components/AppTopBar.vue'
-import { queryItemAsString, useAppDefaults, useRouteQuery } from 'web-pkg/src/composables'
+import {
+  queryItemAsString,
+  useAppDefaults,
+  useClientService,
+  useRoute,
+  useRouteParam,
+  useRouteQuery,
+  useRouter,
+  useStore
+} from 'web-pkg/src/composables'
 import { configurationManager } from 'web-pkg/src/configuration'
 import ErrorScreen from './components/ErrorScreen.vue'
 import LoadingScreen from './components/LoadingScreen.vue'
+import {
+  Resource,
+  SpaceResource,
+  buildShareSpaceResource,
+  isMountPointSpaceResource
+} from 'web-client/src/helpers'
+import { useLoadFileInfoById } from 'web-pkg/src/composables/fileInfo'
 
 export default defineComponent({
   name: 'ExternalApp',
@@ -52,14 +68,99 @@ export default defineComponent({
     LoadingScreen
   },
   setup() {
+    const store = useStore()
+    const router = useRouter()
+    const currentRoute = useRoute()
+    const clientService = useClientService()
+    const { loadFileInfoByIdTask } = useLoadFileInfoById({ clientService })
     const appName = useRouteQuery('app')
     const applicationName = computed(() => queryItemAsString(unref(appName)))
+
+    const fileIdQueryItem = useRouteQuery('fileId')
+    const fileId = computed(() => {
+      return queryItemAsString(unref(fileIdQueryItem))
+    })
+
+    const driveAliasAndItem = useRouteParam('driveAliasAndItem')
+
+    const getMatchingSpace = (id): SpaceResource => {
+      return store.getters['runtime/spaces/spaces'].find((space) => id.startsWith(space.id))
+    }
+    const findMatchingMountPoint = (id: string | number): SpaceResource => {
+      return store.getters['runtime/spaces/spaces'].find(
+        (space) => isMountPointSpaceResource(space) && space.root?.remoteItem?.id === id
+      )
+    }
+
+    const addMissingDriveAliasAndItem = async () => {
+      const id = unref(fileId)
+      let path: string
+      let matchingSpace = getMatchingSpace(id)
+      if (matchingSpace) {
+        path = await clientService.owncloudSdk.files.getPathForFileId(id)
+        const driveAliasAndItem = matchingSpace.getDriveAliasAndItem({ path } as Resource)
+        console.log(unref(currentRoute).query)
+        return router.push({
+          params: {
+            ...unref(currentRoute).params,
+            driveAliasAndItem
+          },
+          query: {
+            ...(unref(currentRoute).query?.app && { app: unref(currentRoute).query?.app }),
+            contextRouteName: 'files-spaces-generic'
+          }
+        })
+      }
+
+      // no matching space found => the file doesn't lie in own spaces => it's a share.
+      // do PROPFINDs on parents until root of accepted share is found in `mountpoint` spaces
+      await store.dispatch('runtime/spaces/loadMountPoints', {
+        graphClient: clientService.graphAuthenticated
+      })
+      let mountPoint = findMatchingMountPoint(id)
+      const resource = await loadFileInfoByIdTask.perform(id)
+      const sharePathSegments = mountPoint ? [] : [unref(resource).name]
+      let tmpResource = unref(resource)
+      while (!mountPoint) {
+        try {
+          tmpResource = await loadFileInfoByIdTask.perform(tmpResource.parentFolderId)
+        } catch (e) {
+          throw Error(e)
+        }
+        mountPoint = findMatchingMountPoint(tmpResource.id)
+        if (!mountPoint) {
+          sharePathSegments.unshift(tmpResource.name)
+        }
+      }
+      matchingSpace = buildShareSpaceResource({
+        shareId: mountPoint.nodeId,
+        shareName: mountPoint.name,
+        serverUrl: configurationManager.serverUrl
+      })
+      path = urlJoin(...sharePathSegments)
+
+      const driveAliasAndItem = matchingSpace.getDriveAliasAndItem({ path } as Resource)
+      return router.push({
+        params: {
+          ...unref(currentRoute).params,
+          driveAliasAndItem
+        },
+        query: {
+          shareId: matchingSpace.shareId,
+          ...(unref(currentRoute).query?.app && { app: unref(currentRoute).query?.app }),
+          contextRouteName: 'files-shares-with-me'
+        }
+      })
+    }
+
     return {
       ...useAppDefaults({
         applicationId: 'external',
         applicationName
       }),
-      applicationName
+      applicationName,
+      driveAliasAndItem,
+      addMissingDriveAliasAndItem
     }
   },
 
@@ -94,6 +195,10 @@ export default defineComponent({
   async created() {
     this.loading = true
     try {
+      if (!this.driveAliasAndItem) {
+        await this.addMissingDriveAliasAndItem()
+      }
+
       this.resource = await this.getFileInfo(this.currentFileContext, {
         davProperties: []
       })

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -99,7 +99,6 @@ export default defineComponent({
       if (matchingSpace) {
         path = await clientService.owncloudSdk.files.getPathForFileId(id)
         const driveAliasAndItem = matchingSpace.getDriveAliasAndItem({ path } as Resource)
-        console.log(unref(currentRoute).query)
         return router.push({
           params: {
             ...unref(currentRoute).params,

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -59,6 +59,7 @@ import {
   isMountPointSpaceResource
 } from 'web-client/src/helpers'
 import { useLoadFileInfoById } from 'web-pkg/src/composables/fileInfo'
+import { dirname } from 'path'
 
 export default defineComponent({
   name: 'ExternalApp',
@@ -105,8 +106,10 @@ export default defineComponent({
             driveAliasAndItem
           },
           query: {
+            fileId: id,
             ...(unref(currentRoute).query?.app && { app: unref(currentRoute).query?.app }),
-            contextRouteName: 'files-spaces-generic'
+            contextRouteName: 'files-spaces-generic',
+            contextRouteParams: { driveAliasAndItem: dirname(driveAliasAndItem) } as any
           }
         })
       }
@@ -145,9 +148,16 @@ export default defineComponent({
           driveAliasAndItem
         },
         query: {
+          fileId: id,
           shareId: matchingSpace.shareId,
           ...(unref(currentRoute).query?.app && { app: unref(currentRoute).query?.app }),
-          contextRouteName: 'files-shares-with-me'
+          contextRouteName: path === '/' ? 'files-shares-with-me' : 'files-spaces-generic',
+          contextRouteParams: {
+            driveAliasAndItem: dirname(driveAliasAndItem)
+          } as any,
+          contextRouteQuery: {
+            shareId: matchingSpace.shareId
+          } as any
         }
       })
     }

--- a/packages/web-app-external/tests/unit/app.spec.ts
+++ b/packages/web-app-external/tests/unit/app.spec.ts
@@ -11,6 +11,7 @@ import { useAppDefaultsMock } from 'web-test-helpers/src/mocks/useAppDefaultsMoc
 import { ref } from 'vue'
 import { mock } from 'jest-mock-extended'
 import { RouteLocation } from 'web-test-helpers'
+import { useRouteParam } from 'web-pkg/src/composables/router/useRouteParam'
 
 jest.mock('web-pkg/src/composables/appDefaults', () => {
   const { queryItemAsString } = jest.requireActual('web-pkg/src/composables/appDefaults')
@@ -20,6 +21,8 @@ jest.mock('web-pkg/src/composables/appDefaults', () => {
     queryItemAsString
   }
 })
+
+jest.mock('web-pkg/src/composables/router/useRouteParam')
 
 const componentStubs = {
   AppTopBar: true,
@@ -124,6 +127,7 @@ function createShallowMountWrapper(makeRequest = jest.fn().mockResolvedValue({ s
       makeRequest
     })
   )
+  jest.mocked(useRouteParam).mockReturnValue(ref('foo'))
 
   const storeOptions = defaultStoreMockOptions
   storeOptions.getters.capabilities.mockImplementation(() => ({

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/EditDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/EditDropdown.vue
@@ -29,8 +29,8 @@
               >
                 <oc-icon name="calendar-event" fill-type="line" size="medium" variation="passive" />
                 <span
-                  class="oc-ml-s"
                   v-if="isExpirationDateSet"
+                  class="oc-ml-s"
                   v-text="$gettext('Edit expiration date')"
                 />
                 <span v-else v-text="$gettext('Set expiration date')" />

--- a/packages/web-pkg/src/composables/fileInfo/index.ts
+++ b/packages/web-pkg/src/composables/fileInfo/index.ts
@@ -1,0 +1,1 @@
+export * from './useLoadFileInfoById'

--- a/packages/web-pkg/src/composables/fileInfo/useLoadFileInfoById.ts
+++ b/packages/web-pkg/src/composables/fileInfo/useLoadFileInfoById.ts
@@ -1,0 +1,38 @@
+import { ClientService } from 'web-pkg/src/services'
+import { useClientService } from 'web-pkg/src/composables'
+import { useTask } from 'vue-concurrency'
+import { buildSpace, buildWebDavSpacesPath } from 'web-client/src/helpers'
+import { DavProperty } from 'web-client/src/webdav/constants'
+
+export interface LoadFileInfoByIdOptions {
+  clientService?: ClientService
+  davProperties?: DavProperty[]
+}
+
+export const useLoadFileInfoById = (options: LoadFileInfoByIdOptions) => {
+  const { webdav } = options.clientService || useClientService()
+  const davProperties = options.davProperties || [
+    DavProperty.FileId,
+    DavProperty.FileParent,
+    DavProperty.Name,
+    DavProperty.ResourceType
+  ]
+
+  const loadFileInfoByIdTask = useTask(function* (signal, fileId: string | number) {
+    const space = buildSpace({
+      id: fileId,
+      webDavPath: buildWebDavSpacesPath(fileId)
+    })
+    return yield webdav.getFileInfo(
+      space,
+      {},
+      {
+        davProperties
+      }
+    )
+  })
+
+  return {
+    loadFileInfoByIdTask
+  }
+}


### PR DESCRIPTION
## Description
External URLs coming from the `open-with-web` endpoint only have a file ID. This PR fixes resolving such URLs.

I basically copied most of the logic from our private link resolving, which works the same under the hood. Normally I would refactor this code and make it re-usable, but this solution is not applicable to master anyway because the external app handling has changed completely. This means we need to implement another (proper) solution on master anyways.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/9804

## How Has This Been Tested?
- Make sure you have OnlyOffice running
- Create a `docx` file
- Request an external URL for that file via `https://host.docker.internal:9200/app/open-with-web` and params `fileId=YOUR_ID` and `appName=OnlyOffice`
```
https://host.docker.internal:9200/external/open-with-web?appName=collabora&fileId=e92cc4ae-70f9-4553-8fdf-5e826c65a186%2463010b6b-5c91-4734-9d9d-1904ee3562dc%2112a1280e-18f2-4958-a875-8e7efe7542b0
```
- Open the returned URL

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
