### PR TITLE
feat: show only folder create action in embed mode

### DIFF
--- a/changelog/unreleased/enhancement-embed-folder-creation
+++ b/changelog/unreleased/enhancement-embed-folder-creation
@@ -1,0 +1,7 @@
+Enhancement: Show only create folder button in embed mode
+
+We've changed the actions in the AppBar in Files app to show only create folder button instead of create and upload actions.
+In embed mode, it is possible to only create a new folder so it does not make sense to hide this action inside of a dropdown.
+
+https://github.com/owncloud/web/pull/9853
+https://github.com/owncloud/web/issues/9768

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -15,7 +15,25 @@
         @item-dropped="fileDropped"
       >
         <template #actions="{ limitedScreenSpace }">
+          <oc-button
+            v-if="isEmbedModeEnabled"
+            key="new-folder-btn"
+            v-oc-tooltip="limitedScreenSpace ? $gettext('Create a new folder') : ''"
+            data-testid="btn-new-folder"
+            :aria-label="$gettext('Create a new folder')"
+            appearance="filled"
+            variation="primary"
+            :disabled="!canUpload"
+            @click="createNewFolderAction"
+          >
+            <oc-icon name="add" />
+            <span v-if="!limitedScreenSpace" v-text="$gettext('Create a new folder')" />
+          </oc-button>
+
           <create-and-upload
+            v-else
+            key="create-and-upload-actions"
+            data-testid="actions-create-and-upload"
             :space="space"
             :item="item"
             :item-id="itemId"
@@ -152,7 +170,7 @@ import {
   SpaceResource
 } from '@ownclouders/web-client/src/helpers'
 
-import { useFileActions } from '@ownclouders/web-pkg'
+import { useEmbedMode, useFileActions, useFileActionsCreateNewFolder } from '@ownclouders/web-pkg'
 
 import { AppBar } from '@ownclouders/web-pkg'
 import { ContextActions } from '@ownclouders/web-pkg'
@@ -247,6 +265,11 @@ export default defineComponent({
     const clientService = useClientService()
     const hasShareJail = useCapabilityShareJailEnabled()
     const { breadcrumbsFromPath, concatBreadcrumbs } = useBreadcrumbsFromPath()
+    const { actions: createNewFolder } = useFileActionsCreateNewFolder({
+      store,
+      space: props.space
+    })
+    const { isEnabled: isEmbedModeEnabled } = useEmbedMode()
 
     let loadResourcesEventToken
 
@@ -503,6 +526,8 @@ export default defineComponent({
       )
     }
 
+    const createNewFolderAction = computed(() => unref(createNewFolder)[0].handler)
+
     return {
       ...useFileActions(),
       ...resourcesViewDefaults,
@@ -520,7 +545,9 @@ export default defineComponent({
       ),
       whitespaceContextMenu,
       clientService,
-      hasShareJail
+      hasShareJail,
+      createNewFolderAction,
+      isEmbedModeEnabled
     }
   },
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Hide the create and upload actions in embed mode and provide a single create folder button instead.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs #9768

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Since the embed mode provides only create folder action, it does not make sense to hide this in a dropdown.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: local
- test case 1: open web in embed mode and see the correct action being displayed
- test case 2: open web in default mode and see the original actions still present

## Screenshots (if appropriate):

![localhost_9200__mode=embed](https://github.com/owncloud/web/assets/25989331/7467ebbf-4f8b-4b9e-951a-1507bcb4d862)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
