### PR TITLE
enhancement: search query term linking

### DIFF
--- a/changelog/unreleased/enhancement-search-term-linking
+++ b/changelog/unreleased/enhancement-search-term-linking
@@ -1,0 +1,16 @@
+Enhancement: Search query term linking
+
+We've added the option to search for multiple terms with the same type,
+at the moment only the tag search benefits from it.
+
+This makes it possible to search for multiple resources with different tags in one query.
+The UI now empowers the user to perform advanced searches like:
+
+* all resources with the tags `tag1` OR `tag2`
+* all resources with the tags `tag1` OR `tag2` AND containing text `content`
+
+as a rule of thumb, if a property appears multiple times (like `tag1` OR `tag2`)
+the search combines the query with an `OR` and different keys are linked with an `AND`.
+
+https://github.com/owncloud/web/pull/9854
+https://github.com/owncloud/web/issues/9829

--- a/packages/web-app-files/src/components/Search/List.vue
+++ b/packages/web-app-files/src/components/Search/List.vue
@@ -10,6 +10,7 @@
         <item-filter
           v-if="availableTags.length"
           ref="tagFilter"
+          :allow-multiple="true"
           :filter-label="$gettext('Tags')"
           :filterable-attributes="['label']"
           :items="availableTags"
@@ -136,7 +137,17 @@ import { debounce } from 'lodash-es'
 import { mapMutations, mapGetters, mapActions } from 'vuex'
 import { useGettext } from 'vue3-gettext'
 import { AppBar } from '@ownclouders/web-pkg'
-import { computed, defineComponent, nextTick, onMounted, ref, unref, VNodeRef, watch } from 'vue'
+import {
+  computed,
+  defineComponent,
+  nextTick,
+  onMounted,
+  Ref,
+  ref,
+  unref,
+  VNodeRef,
+  watch
+} from 'vue'
 import ListInfo from '../FilesList/ListInfo.vue'
 import { Pagination } from '@ownclouders/web-pkg'
 import { useFileActions } from '@ownclouders/web-pkg'
@@ -295,34 +306,28 @@ export default defineComponent({
         q['scope'] = `${humanScopeQuery}`
       }
 
-      const humanTagsParams = queryItemAsString(unref(tagParam))
-      if (humanTagsParams) {
-        q['tag'] = humanTagsParams.split('+').map((t) => `"${t}"`)
-
-        if (manuallyUpdateFilterChip && unref(tagFilter)) {
+      const updateFilter = (v: Ref) => {
+        if (manuallyUpdateFilterChip && unref(v)) {
           /**
            * Handles edge cases where a filter is not being applied via the filter directly,
            * e.g. when clicking on a tag in the files list.
            * We need to manually update the selected items in the ItemFilter component because normally
            * it only does this on mount or when interacting with the filter directly.
            */
-          ;(unref(tagFilter) as any).setSelectedItemsBasedOnQuery()
+          ;(unref(v) as any).setSelectedItemsBasedOnQuery()
         }
+      }
+
+      const humanTagsParams = queryItemAsString(unref(tagParam))
+      if (humanTagsParams) {
+        q['tag'] = humanTagsParams.split('+').map((t) => `"${t}"`)
+        updateFilter(tagFilter)
       }
 
       const lastModifiedParams = queryItemAsString(unref(lastModifiedParam))
       if (lastModifiedParams) {
         q['mtime'] = `"${lastModifiedParams}"`
-
-        if (manuallyUpdateFilterChip && unref(lastModifiedFilter)) {
-          /**
-           * Handles edge cases where a filter is not being applied via the filter directly,
-           * e.g. when clicking on a tag in the files list.
-           * We need to manually update the selected items in the ItemFilter component because normally
-           * it only does this on mount or when interacting with the filter directly.
-           */
-          ;(unref(lastModifiedFilter) as any).setSelectedItemsBasedOnQuery()
-        }
+        updateFilter(lastModifiedFilter)
       }
 
       return (

--- a/packages/web-app-files/src/components/Search/List.vue
+++ b/packages/web-app-files/src/components/Search/List.vue
@@ -16,7 +16,6 @@
           :items="availableTags"
           :option-filter-label="$gettext('Filter tags')"
           :show-option-filter="true"
-          :close-on-click="true"
           class="files-search-filter-tags oc-mr-s"
           display-name-attribute="label"
           filter-name="tags"
@@ -289,21 +288,21 @@ export default defineComponent({
     )
 
     const buildSearchTerm = (manuallyUpdateFilterChip = false) => {
-      const q = {}
+      const query = {}
 
       const humanSearchTerm = unref(searchTerm)
       const isContentOnlySearch = queryItemAsString(unref(fullTextParam)) == 'true'
 
       if (isContentOnlySearch && !!humanSearchTerm) {
-        q['content'] = `"${humanSearchTerm}"`
+        query['content'] = `"${humanSearchTerm}"`
       } else if (!!humanSearchTerm) {
-        q['name'] = `"*${humanSearchTerm}*"`
+        query['name'] = `"*${humanSearchTerm}*"`
       }
 
       const humanScopeQuery = unref(scopeQuery)
       const isScopedSearch = unref(doUseScope) === 'true'
       if (isScopedSearch && humanScopeQuery) {
-        q['scope'] = `${humanScopeQuery}`
+        query['scope'] = `${humanScopeQuery}`
       }
 
       const updateFilter = (v: Ref) => {
@@ -320,13 +319,13 @@ export default defineComponent({
 
       const humanTagsParams = queryItemAsString(unref(tagParam))
       if (humanTagsParams) {
-        q['tag'] = humanTagsParams.split('+').map((t) => `"${t}"`)
+        query['tag'] = humanTagsParams.split('+').map((t) => `"${t}"`)
         updateFilter(tagFilter)
       }
 
       const lastModifiedParams = queryItemAsString(unref(lastModifiedParam))
       if (lastModifiedParams) {
-        q['mtime'] = `"${lastModifiedParams}"`
+        query['mtime'] = `"${lastModifiedParams}"`
         updateFilter(lastModifiedFilter)
       }
 
@@ -338,16 +337,16 @@ export default defineComponent({
         // * request readability
         // * code readability
         // * complex cases readability
-        Object.keys(q)
-          .reduce((acc, k) => {
-            const isArrayValue = Array.isArray(q[k])
+        Object.keys(query)
+          .reduce((acc, prop) => {
+            const isArrayValue = Array.isArray(query[prop])
 
             if (!isArrayValue) {
-              acc.push(`${k}:${q[k]}`)
+              acc.push(`${prop}:${query[prop]}`)
             }
 
             if (isArrayValue) {
-              acc.push(`${k}:(${q[k].join(' OR ')})`)
+              acc.push(`${prop}:(${query[prop].join(' OR ')})`)
             }
 
             return acc

--- a/packages/web-app-files/tests/unit/components/Search/List.spec.ts
+++ b/packages/web-app-files/tests/unit/components/Search/List.spec.ts
@@ -79,15 +79,15 @@ describe('List component', () => {
       })
       it('should set initial filter when tags are given via query param', async () => {
         const searchTerm = 'term'
-        const tagFilterQuery = 'tag1'
+        const availableTags = ['tag1', 'tag2']
         const { wrapper } = getWrapper({
-          availableTags: [tagFilterQuery],
+          availableTags,
           searchTerm,
-          tagFilterQuery
+          tagFilterQuery: availableTags.join('+')
         })
         await wrapper.vm.loadAvailableTagsTask.last
         expect(wrapper.emitted('search')[0][0]).toEqual(
-          `name:"*${searchTerm}*" tag:"${tagFilterQuery}"`
+          `name:"*${searchTerm}*" AND tag:("${availableTags[0]}" OR "${availableTags[1]}")`
         )
       })
     })

--- a/packages/web-app-files/tests/unit/components/Search/List.spec.ts
+++ b/packages/web-app-files/tests/unit/components/Search/List.spec.ts
@@ -140,7 +140,7 @@ describe('List component', () => {
         })
         await wrapper.vm.loadAvailableTagsTask.last
         expect(wrapper.emitted('search')[0][0]).toEqual(
-          `name:"*${searchTerm}*" mtime:"${lastModifiedFilterQuery}"`
+          `name:"*${searchTerm}*" AND mtime:"${lastModifiedFilterQuery}"`
         )
       })
     })


### PR DESCRIPTION
## Description
With this its possible to search for multiple terms with the same type,
at the moment only the tag search benefits from it.

This makes it possible to search for multiple resources with different tags in one query.
The UI now empowers the user to perform advanced searches like:

* all resources with the tags `tag1` OR `tag2`
* all resources with the tags `tag1` OR `tag2` AND containing text `content`

as a rule of thumb, if a property appears multiple times (like `tag1` OR `tag2`)
the search combines the query with an `OR` and different keys are linked with an `AND`.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/9829
- Maybe!? https://github.com/owncloud/web/pull/9831

## Motivation and Context
with the introduction of KQL in ocis the search syntax is defined by the MS spec, this brings web a step closer to it and empowers the user to submit even more complex queries.

## How Has This Been Tested?
- unit tests, (+ CI)

## Screenshots (if appropriate):
![276558127-538b6b67-02bf-427d-8797-da5f5f04856d](https://github.com/owncloud/web/assets/49308105/b351bf8e-fd96-46ec-a350-089773df2adb)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [X] Code changes
- [X] Unit tests ~~added~~ updated
- [ ] ~~Acceptance tests added~~
- [ ] ~~Documentation ticket raised: <link>~~

## Open tasks:
- [ ] wait for CI
