### PR TITLE
Allow to delete passwords on public links when password is enforced but permission is set

### DIFF
--- a/changelog/unreleased/enhancement-delete-public-links-passwords-when-password-is-enforced
+++ b/changelog/unreleased/enhancement-delete-public-links-passwords-when-password-is-enforced
@@ -1,0 +1,8 @@
+Enhancement: Add permission to delete link passwords when password is enforced
+
+We've enabled to ability to allow delete passwords on public links, even if the password is enforced.
+Therefore, the user needs respective permission, granted by the server.
+This feature is only possible on public links that have the viewer role.
+
+https://github.com/owncloud/web/pull/9857
+https://github.com/owncloud/ocis/issues/7538

--- a/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
@@ -445,7 +445,7 @@ export default defineComponent({
     checkLinkToUpdate({ link }) {
       const params = this.getParamsForLink(link)
 
-      if (!link.password && this.isPasswordEnforcedFor(link)) {
+      if (!link.password && !this.canDeletePublicLinkPassword(link)) {
         showQuickLinkPasswordModal(
           {
             ...this.$language,

--- a/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
@@ -228,6 +228,10 @@ export default defineComponent({
       type: Boolean,
       default: false
     },
+    isPasswordRemovable: {
+      type: Boolean,
+      default: false
+    },
     link: {
       type: Object,
       required: true
@@ -323,7 +327,7 @@ export default defineComponent({
           method: this.showPasswordModal
         })
 
-        if (!this.isPasswordEnforced) {
+        if (this.isPasswordRemovable) {
           result.push({
             id: 'remove-password',
             title: this.$gettext('Remove password'),

--- a/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
@@ -530,6 +530,7 @@ export default defineComponent({
     width: 100%;
   }
 }
+
 @media (min-width: $oc-breakpoint-medium-default) {
   .edit-public-link-role-dropdown {
     width: 400px;
@@ -546,6 +547,7 @@ export default defineComponent({
   &:first-child {
     margin-top: 0;
   }
+
   &:last-child {
     margin-bottom: 0;
   }

--- a/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
@@ -342,7 +342,7 @@ export default defineComponent({
           })
         }
       }
-      if (!this.isPasswordEnforced && !this.link.password && !this.isAliasLink) {
+      if (!this.link.password && !this.isAliasLink) {
         result.push({
           id: 'add-password',
           title: this.$gettext('Add password'),

--- a/packages/web-client/src/helpers/resource/types.ts
+++ b/packages/web-client/src/helpers/resource/types.ts
@@ -22,6 +22,7 @@ export type AbilitySubjects =
   | 'Language'
   | 'Logo'
   | 'PublicLink'
+  | 'ReadOnlyPublicLinkPassword'
   | 'Role'
   | 'Setting'
 

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCreateQuicklink.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCreateQuicklink.ts
@@ -11,19 +11,27 @@ import { useStore } from '../../store'
 import { useGettext } from 'vue3-gettext'
 import { Store } from 'vuex'
 import { FileAction, FileActionOptions } from '../types'
+import { usePasswordPolicyService } from '../../passwordPolicyService'
 
-export const useFileActionsCreateQuickLink = ({ store }: { store?: Store<any> } = {}) => {
+export const useFileActionsCreateQuickLink = ({
+  store
+}: {
+  store?: Store<any>
+} = {}) => {
   store = store || useStore()
   const router = useRouter()
   const language = useGettext()
   const { $gettext } = language
   const ability = useAbility()
   const clientService = useClientService()
+  const passwordPolicyService = usePasswordPolicyService()
 
   const handler = async ({ space, resources }: FileActionOptions) => {
     const [resource] = resources
+
     await copyQuicklink({
       clientService,
+      passwordPolicyService,
       resource,
       storageId: space?.id || resource?.fileId || resource?.id,
       store,

--- a/packages/web-pkg/src/composables/capability/useCapability.ts
+++ b/packages/web-pkg/src/composables/capability/useCapability.ts
@@ -134,11 +134,6 @@ export const useCapabilityFilesSharingPublicAlias = createCapabilityComposable(
   'files_sharing.public.alias',
   false
 )
-
-export const useCapabilityPasswordEnforcedForPublicReadOnlyLink = createCapabilityComposable(
-  'files_sharing.public.password?.enforced_for.read_only',
-  true
-)
 export const useCapabilityNotifications = createCapabilityComposable(
   'notifications.ocs-endpoints',
   []

--- a/packages/web-pkg/src/composables/capability/useCapability.ts
+++ b/packages/web-pkg/src/composables/capability/useCapability.ts
@@ -134,6 +134,11 @@ export const useCapabilityFilesSharingPublicAlias = createCapabilityComposable(
   'files_sharing.public.alias',
   false
 )
+
+export const useCapabilityPasswordEnforcedForPublicReadOnlyLink = createCapabilityComposable(
+  'files_sharing.public.password?.enforced_for.read_only',
+  true
+)
 export const useCapabilityNotifications = createCapabilityComposable(
   'notifications.ocs-endpoints',
   []

--- a/packages/web-pkg/src/helpers/share/link.ts
+++ b/packages/web-pkg/src/helpers/share/link.ts
@@ -3,17 +3,22 @@ import {
   LinkShareRoles,
   Share,
   linkRoleInternalFolder,
-  linkRoleViewerFolder
+  linkRoleViewerFolder,
+  ShareTypes,
+  buildShare
 } from '@ownclouders/web-client/src/helpers/share'
 import { Store } from 'vuex'
-import { ClientService } from '../../services'
+import { ClientService, PasswordPolicyService } from '../../services'
 import { useClipboard } from '@vueuse/core'
 import { Ability } from '@ownclouders/web-client/src/helpers/resource/types'
 import { Resource } from '@ownclouders/web-client'
 import { Language } from 'vue3-gettext'
+import { unref } from 'vue'
+import { showQuickLinkPasswordModal } from '../../quickActions'
 
 export interface CreateQuicklink {
   clientService: ClientService
+  passwordPolicyService: PasswordPolicyService
   language: Language
   store: Store<any>
   storageId?: any
@@ -22,37 +27,36 @@ export interface CreateQuicklink {
   ability: Ability
 }
 
-export const copyQuicklink = async (args: CreateQuicklink) => {
-  const { store, language } = args
+// doCopy creates the requested link and copies the url to the clipboard,
+// the copy action uses the clipboard // clipboardItem api to work around the webkit limitations.
+//
+// https://developer.apple.com/forums/thread/691873
+//
+// if those apis not available (or like in firefox behind dom.events.asyncClipboard.clipboardItem)
+// it has a fallback to the vue-use implementation.
+//
+// https://webkit.org/blog/10855/
+const doCopy = async ({
+  store,
+  language,
+  quickLinkUrl
+}: {
+  store: Store<unknown>
+  language: Language
+  quickLinkUrl: string
+}) => {
   const { $gettext } = language
-
-  // doCopy creates the requested link and copies the url to the clipboard,
-  // the copy action uses the clipboard // clipboardItem api to work around the webkit limitations.
-  //
-  // https://developer.apple.com/forums/thread/691873
-  //
-  // if those apis not available (or like in firefox behind dom.events.asyncClipboard.clipboardItem)
-  // it has a fallback to the vue-use implementation.
-  //
-  // https://webkit.org/blog/10855/
-  const doCopy = async () => {
+  try {
     if (typeof ClipboardItem && navigator?.clipboard?.write) {
       await navigator.clipboard.write([
         new ClipboardItem({
-          'text/plain': createQuicklink(args).then(
-            (link) => new Blob([link.url], { type: 'text/plain' })
-          )
+          'text/plain': new Blob([quickLinkUrl], { type: 'text/plain' })
         })
       ])
     } else {
-      const link = await createQuicklink(args)
       const { copy } = useClipboard({ legacy: true })
-      await copy(link.url)
+      await copy(quickLinkUrl)
     }
-  }
-
-  try {
-    await doCopy()
     await store.dispatch('showMessage', {
       title: $gettext('The link has been copied to your clipboard.')
     })
@@ -63,6 +67,40 @@ export const copyQuicklink = async (args: CreateQuicklink) => {
       error: e
     })
   }
+}
+export const copyQuicklink = async (args: CreateQuicklink) => {
+  const { store, language, resource, clientService, passwordPolicyService } = args
+  const { $gettext } = language
+
+  const linkSharesForResource = await clientService.owncloudSdk.shares.getShares(resource.path, {
+    share_types: ShareTypes.link.value.toString(),
+    include_tags: false
+  })
+
+  const existingQuickLink = linkSharesForResource
+    .map((share: any) => buildShare(share.shareInfo, null, null))
+    .find((share: Share) => share.quicklink === true)
+
+  if (existingQuickLink) {
+    return doCopy({ store, language, quickLinkUrl: existingQuickLink.url })
+  }
+
+  const isPasswordEnforced =
+    store.getters.capabilities?.files_sharing?.public?.password?.enforced_for?.read_only === true
+
+  if (unref(isPasswordEnforced)) {
+    return showQuickLinkPasswordModal(
+      { $gettext, store, passwordPolicyService },
+      async (password: string) => {
+        await store.dispatch('hideModal')
+        const quickLink = await createQuicklink({ ...args, password })
+        return doCopy({ store, language, quickLinkUrl: quickLink.url })
+      }
+    )
+  }
+
+  const quickLink = await createQuicklink(args)
+  return doCopy({ store, language, quickLinkUrl: quickLink.url })
 }
 
 export const createQuicklink = async (args: CreateQuicklink): Promise<Share> => {
@@ -87,7 +125,9 @@ export const createQuicklink = async (args: CreateQuicklink): Promise<Share> => 
     canContribute,
     alias
   ).bitmask(allowResharing)
-  const params: { [key: string]: unknown } = {
+  const params: {
+    [key: string]: unknown
+  } = {
     name: $gettext('Link'),
     permissions: permissions.toString(),
     quicklink: true

--- a/packages/web-pkg/src/helpers/share/link.ts
+++ b/packages/web-pkg/src/helpers/share/link.ts
@@ -18,13 +18,16 @@ import { showQuickLinkPasswordModal } from '../../quickActions'
 
 export interface CreateQuicklink {
   clientService: ClientService
-  passwordPolicyService: PasswordPolicyService
   language: Language
   store: Store<any>
   storageId?: any
   resource: Resource
   password?: string
   ability: Ability
+}
+
+export interface CopyQuickLink extends CreateQuicklink {
+  passwordPolicyService: PasswordPolicyService
 }
 
 // doCopy creates the requested link and copies the url to the clipboard,
@@ -68,12 +71,12 @@ const doCopy = async ({
     })
   }
 }
-export const copyQuicklink = async (args: CreateQuicklink) => {
+export const copyQuicklink = async (args: CopyQuickLink) => {
   const { store, language, resource, clientService, passwordPolicyService } = args
   const { $gettext } = language
 
   const linkSharesForResource = await clientService.owncloudSdk.shares.getShares(resource.path, {
-    share_types: ShareTypes.link.value.toString(),
+    share_types: ShareTypes?.link?.value?.toString(),
     include_tags: false
   })
 

--- a/packages/web-pkg/src/quickActions.ts
+++ b/packages/web-pkg/src/quickActions.ts
@@ -81,15 +81,20 @@ export default {
       if (passwordEnforced) {
         return showQuickLinkPasswordModal(
           { store, $gettext: language.$gettext, passwordPolicyService },
-          async (password) => {
-            await copyQuicklink({
-              ability,
-              clientService,
-              language,
-              password,
-              resource: item,
-              store
-            })
+          async (password: string) => {
+            try {
+              await copyQuicklink({
+                ability,
+                clientService,
+                language,
+                password,
+                resource: item,
+                store
+              })
+              store.dispatch('hideModal')
+            } catch (e) {
+              console.error(e)
+            }
           }
         )
       }

--- a/packages/web-pkg/src/quickActions.ts
+++ b/packages/web-pkg/src/quickActions.ts
@@ -74,33 +74,9 @@ export default {
       store,
       passwordPolicyService
     }: QuickLinkContext) => {
-      const passwordEnforced =
-        store.getters.capabilities?.files_sharing?.public?.password?.enforced_for?.read_only ===
-        true
-
-      if (passwordEnforced) {
-        return showQuickLinkPasswordModal(
-          { store, $gettext: language.$gettext, passwordPolicyService },
-          async (password: string) => {
-            try {
-              await copyQuicklink({
-                ability,
-                clientService,
-                language,
-                password,
-                resource: item,
-                store
-              })
-              store.dispatch('hideModal')
-            } catch (e) {
-              console.error(e)
-            }
-          }
-        )
-      }
-
       await copyQuicklink({
         ability,
+        passwordPolicyService,
         clientService,
         language,
         resource: item,

--- a/packages/web-runtime/src/services/auth/abilities.ts
+++ b/packages/web-runtime/src/services/auth/abilities.ts
@@ -23,6 +23,9 @@ export const getAbilities = (
     ],
     'Logo.Write.all': [{ action: 'update-all', subject: 'Logo' }],
     'PublicLink.Write.all': [{ action: 'create-all', subject: 'PublicLink' }],
+    'ReadOnlyPublicLinkPassword.Delete.all': [
+      { action: 'delete-all', subject: 'ReadOnlyPublicLinkPassword' }
+    ],
     'Roles.ReadWrite.all': [
       { action: 'create-all', subject: 'Role' },
       { action: 'delete-all', subject: 'Role' },


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
We've enabled to ability to allow delete passwords on public links, even if the password is enforced.
Therefore, the user needs respective permission, granted by the server.
This feature is only possible on public links that have the viewer role.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/7538

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
