### PR TITLE
Remove Settings-Icon from Search Bar

### DIFF
--- a/changelog/unreleased/enhancement-remove-settings-icon-from-search-bar
+++ b/changelog/unreleased/enhancement-remove-settings-icon-from-search-bar
@@ -1,0 +1,6 @@
+Enhancement: Remove settings icon from searchbar
+
+We removed the settings icon from the searchbar.
+
+https://github.com/owncloud/web/pull/9858
+https://github.com/owncloud/web/issues/9664

--- a/packages/design-system/src/components/OcSearchBar/OcSearchBar.spec.ts
+++ b/packages/design-system/src/components/OcSearchBar/OcSearchBar.spec.ts
@@ -4,7 +4,7 @@ import OcSearchBar from './OcSearchBar.vue'
 describe('OcSearchBar', () => {
   const selectors = {
     searchButton: '.oc-search-button',
-    advancedSearchButton: '.oc-advanced-search',
+    advancedSearchButton: '.oc-search-button-icon',
     searchInput: '.oc-search-input',
     searchButtonWrapper: '.oc-search-button-wrapper',
     searchClearButton: '.oc-search-clear'
@@ -183,21 +183,6 @@ describe('OcSearchBar', () => {
       const searchButton = wrapper.find(selectors.searchButton)
       await searchButton.trigger('click')
       expect(wrapper.emitted('search')).toBeFalsy()
-    })
-  })
-  describe('advanced search button', () => {
-    it('should be visible', () => {
-      const wrapper = getWrapper()
-      expect(wrapper.find(selectors.advancedSearchButton).exists()).toBeTruthy()
-    })
-    it('should not be visible if disabled', () => {
-      const wrapper = getWrapper({ showAdvancedSearchButton: false })
-      expect(wrapper.find(selectors.advancedSearchButton).exists()).toBeFalsy()
-    })
-    it('should trigger the "advancedSearch"-event on click', async () => {
-      const wrapper = getWrapper()
-      await wrapper.find(selectors.advancedSearchButton).trigger('click')
-      expect(wrapper.emitted('advancedSearch').length).toBeGreaterThan(0)
     })
   })
 })

--- a/packages/design-system/src/components/OcSearchBar/OcSearchBar.spec.ts
+++ b/packages/design-system/src/components/OcSearchBar/OcSearchBar.spec.ts
@@ -4,7 +4,6 @@ import OcSearchBar from './OcSearchBar.vue'
 describe('OcSearchBar', () => {
   const selectors = {
     searchButton: '.oc-search-button',
-    advancedSearchButton: '.oc-search-button-icon',
     searchInput: '.oc-search-input',
     searchButtonWrapper: '.oc-search-button-wrapper',
     searchClearButton: '.oc-search-clear'
@@ -42,10 +41,6 @@ describe('OcSearchBar', () => {
   describe('icon prop', () => {
     describe('when icon prop is not false', () => {
       const wrapper = getWrapper({ icon: 'mdi-icon' })
-      it('should add icon class to search input', () => {
-        const searchInput = wrapper.find(selectors.searchInput)
-        expect(searchInput.attributes('class')).toContain('oc-search-input-icon')
-      })
       it('should render icon', () => {
         const iconStub = wrapper.find('oc-icon-stub[name="mdi-icon"]')
         expect(iconStub.exists()).toBeTruthy()

--- a/packages/design-system/src/components/OcSearchBar/OcSearchBar.vue
+++ b/packages/design-system/src/components/OcSearchBar/OcSearchBar.vue
@@ -6,14 +6,6 @@
     :class="{ 'oc-search-small': small }"
   >
     <div class="oc-width-expand oc-position-relative">
-      <span v-if="icon" class="oc-search-icon" @click="focusSearchInput">
-        <oc-icon v-show="!loading" :name="icon" fill-type="line" />
-        <oc-spinner
-          v-show="loading"
-          :size="spinnerSize"
-          :aria-label="loadingAccessibleLabelValue"
-        />
-      </span>
       <input
         ref="searchInput"
         :class="inputClass"
@@ -27,14 +19,14 @@
       />
       <slot name="locationFilter" />
       <oc-button
-        v-if="showAdvancedSearchButton"
-        v-oc-tooltip="$gettext('Open advanced search')"
-        :aria-label="$gettext('Open advanced search')"
-        class="oc-advanced-search oc-position-small oc-position-center-right oc-mt-rm"
+        v-if="icon"
+        v-oc-tooltip="$gettext('Search')"
+        :aria-label="$gettext('Search')"
+        class="oc-search-button-icon oc-position-small oc-position-center-right oc-mt-rm"
         appearance="raw"
         @click.prevent.stop="$emit('advancedSearch', $event)"
       >
-        <oc-icon name="equalizer" size="small" variation="passive" />
+        <oc-icon :name="icon" fill-type="line" variation="passive" />
       </oc-button>
     </div>
     <div class="oc-search-button-wrapper" :class="{ 'oc-invisible-sr': buttonHidden }">
@@ -198,13 +190,6 @@ export default defineComponent({
       default: false
     },
     /**
-     * Show a "Advanced search button.
-     */
-    showAdvancedSearchButton: {
-      type: Boolean,
-      default: true
-    },
-    /**
      * Variation of the cancel button
      */
     cancelButtonVariation: {
@@ -263,7 +248,6 @@ export default defineComponent({
     inputClass() {
       const classes = ['oc-search-input', 'oc-input']
 
-      this.icon && classes.push('oc-search-input-icon')
       !this.buttonHidden && classes.push('oc-search-input-button')
 
       return classes
@@ -333,6 +317,7 @@ export default defineComponent({
   &-input {
     border-radius: 25px !important;
     border: none;
+    padding: var(--oc-space-medium);
     color: var(--oc-color-input-text-muted) !important;
 
     &:focus {

--- a/packages/design-system/src/components/OcSearchBar/OcSearchBar.vue
+++ b/packages/design-system/src/components/OcSearchBar/OcSearchBar.vue
@@ -22,7 +22,7 @@
         v-if="icon"
         v-oc-tooltip="$gettext('Search')"
         :aria-label="$gettext('Search')"
-        class="oc-search-button-icon oc-position-small oc-position-center-right oc-mt-rm"
+        class="oc-position-small oc-position-center-right oc-mt-rm"
         appearance="raw"
         @click.prevent.stop="$emit('advancedSearch', $event)"
       >

--- a/packages/design-system/src/components/OcSearchBar/OcSearchBar.vue
+++ b/packages/design-system/src/components/OcSearchBar/OcSearchBar.vue
@@ -26,7 +26,12 @@
         appearance="raw"
         @click.prevent.stop="$emit('advancedSearch', $event)"
       >
-        <oc-icon :name="icon" fill-type="line" variation="passive" />
+        <oc-icon v-show="!loading" :name="icon" size="small" fill-type="line" variation="passive" />
+        <oc-spinner
+          v-show="loading"
+          :size="spinnerSize"
+          :aria-label="loadingAccessibleLabelValue"
+        />
       </oc-button>
     </div>
     <div class="oc-search-button-wrapper" :class="{ 'oc-invisible-sr': buttonHidden }">


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
see https://github.com/owncloud/web/issues/9664
we removed the search-icon on the left side and moved it to the right side as a replacement for the settings-icon.

## Screenshots:
![Screenshot (85)](https://github.com/owncloud/web/assets/786551/2abfc8a7-1fcb-4b47-b782-27c33ef50170)


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9664
