### PR TITLE
Make DavProperties available to apps

### DIFF
--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -5,8 +5,9 @@ import { ocs, OCS } from './ocs'
 export type { Graph } from './graph'
 export type { OCS } from './ocs'
 
-export * as helpers from './helpers'
 export * as errors from './errors'
+export * as helpers from './helpers'
+export * as webdav from './webdav'
 
 export type { Resource, SpaceResource, User } from './helpers'
 

--- a/packages/web-client/src/webdav/index.ts
+++ b/packages/web-client/src/webdav/index.ts
@@ -17,6 +17,7 @@ import { GetPathForFileIdFactory } from './getPathForFileId'
 import { DAV } from './client/dav'
 import { ListFileVersionsFactory } from './listFileVersions'
 
+export * from './constants'
 export * from './types'
 
 export const webdav = (options: WebDavOptions): WebDAV => {


### PR DESCRIPTION
## Description
As the title says, make DavProperties and other things from web-client/webdav available to apps which need to import from `web-client` without path. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
