### PR TITLE
feat: add location picker into embed mode

### DIFF
--- a/changelog/unreleased/enhancement-location-picker
+++ b/changelog/unreleased/enhancement-location-picker
@@ -1,0 +1,7 @@
+Enhancement: Location picker in embed mode
+
+We've added a new query param called `embed-target` which can have value `location`. This value is then saved in the `configuration.options` object as `embedTarget`.
+When the value is set to `location`, it allows selecting the `currentFolder` as location instead of selecting resources.
+
+https://github.com/owncloud/web/pull/9863
+https://github.com/owncloud/web/issues/9768

--- a/docs/embed-mode/_index.md
+++ b/docs/embed-mode/_index.md
@@ -29,3 +29,39 @@ The app is emitting various events depending on the goal of the user. All events
 | **owncloud-embed:select** | Resource[] | Gets emitted when user selects resources via the "Attach as copy" action |
 | **owncloud-embed:share** | string[] | Gets emitted when user selects resources and shares them via the "Share links" action |
 | **owncloud-embed:cancel** | void | Gets emitted when user attempts to close the embedded instance via "Cancel" action |
+
+### Example
+
+```html
+<iframe src="https://my-owncloud-web-instance?mode=embed"></iframe>
+
+<script>
+  function selectEventHandler(event) {
+    const resources = event.detail
+
+    doSomethingWithSelectedResources(resources)
+  }
+
+  window.addEventListener('owncloud-embed:select', selectEventHandler)
+</script>
+```
+
+## Location picker
+
+By default, the Embed mode allows users to select resources. In certain cases (e.g. uploading a file), this needs to be changed to allow selecting a location. This can be achieved by running the embed mode with additional parameter `embed-target=location`. With this parameter, resource selection is disabled and the selected resources array always includes the current folder as the only item.
+
+### Example
+
+```html
+<iframe src="https://my-owncloud-web-instance?mode=embed&embed-target=location"></iframe>
+
+<script>
+  function selectEventHandler(event) {
+    const currentFolder = event.detail[0]
+
+    uploadIntoCurrentFolder(currentFolder)
+  }
+
+  window.addEventListener('owncloud-embed:select', selectEventHandler)
+</script>
+```

--- a/packages/web-app-files/src/components/EmbedActions/EmbedActions.vue
+++ b/packages/web-app-files/src/components/EmbedActions/EmbedActions.vue
@@ -4,6 +4,8 @@
       $gettext('Cancel')
     }}</oc-button>
     <oc-button
+      v-if="!isLocationPicker"
+      key="btn-share"
       data-testid="button-share"
       variation="inverse"
       appearance="filled"
@@ -17,7 +19,7 @@
       appearance="filled"
       :disabled="areSelectActionsDisabled"
       @click="emitSelect"
-      >{{ $gettext('Attach as copy') }}</oc-button
+      >{{ selectLabel }}</oc-button
     >
   </section>
 </template>
@@ -29,6 +31,7 @@ import {
   showQuickLinkPasswordModal,
   useAbility,
   useClientService,
+  useEmbedMode,
   usePasswordPolicyService,
   useStore
 } from '@ownclouders/web-pkg'
@@ -42,14 +45,23 @@ export default {
     const clientService = useClientService()
     const passwordPolicyService = usePasswordPolicyService()
     const language = useGettext()
+    const { isLocationPicker } = useEmbedMode()
 
     const selectedFiles = computed<Resource[]>(() => {
+      if (isLocationPicker.value) {
+        return [store.getters['Files/currentFolder']]
+      }
+
       return store.getters['Files/selectedFiles']
     })
 
     const areSelectActionsDisabled = computed<boolean>(() => selectedFiles.value.length < 1)
 
     const canCreatePublicLinks = computed<boolean>(() => ability.can('create-all', 'PublicLink'))
+
+    const selectLabel = computed<string>(() =>
+      isLocationPicker.value ? language.$gettext('Choose') : language.$gettext('Attach as copy')
+    )
 
     const emitSelect = (): void => {
       const event: CustomEvent<Resource[]> = new CustomEvent('owncloud-embed:select', {
@@ -132,6 +144,8 @@ export default {
     return {
       areSelectActionsDisabled,
       canCreatePublicLinks,
+      isLocationPicker,
+      selectLabel,
       sharePublicLinks,
       emitCancel,
       emitSelect

--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -27,7 +27,7 @@
     @sort="sort"
     @update:model-value="$emit('update:modelValue', $event)"
   >
-    <template #selectHeader>
+    <template v-if="!isLocationPicker" #selectHeader>
       <div class="resource-table-select-all">
         <oc-checkbox
           id="resource-table-select-all"
@@ -39,7 +39,7 @@
         />
       </div>
     </template>
-    <template #select="{ item }">
+    <template v-if="!isLocationPicker" #select="{ item }">
       <oc-checkbox
         :id="`resource-table-select-${resourceDomSelector(item)}`"
         :label="getResourceCheckboxLabel(item)"
@@ -227,7 +227,8 @@ import {
   ViewModeConstants,
   useConfigurationManager,
   useGetMatchingSpace,
-  useFolderLink
+  useFolderLink,
+  useEmbedMode
 } from '../../composables'
 import { EVENT_TROW_MOUNTED, EVENT_FILE_DROPPED, ImageDimension } from '../../constants'
 import { eventBus } from '../../services'
@@ -441,6 +442,7 @@ export default defineComponent({
     const configurationManager = useConfigurationManager()
     const { getMatchingSpace } = useGetMatchingSpace()
     const { $gettext } = useGettext()
+    const { isLocationPicker } = useEmbedMode()
 
     const { width } = useWindowSize()
     const hasTags = computed(
@@ -487,7 +489,8 @@ export default defineComponent({
       ...useFolderLink({
         space: ref(props.space),
         targetRouteCallback: computed(() => props.targetRouteCallback)
-      })
+      }),
+      isLocationPicker
     }
   },
   data() {

--- a/packages/web-pkg/src/composables/embedMode/useEmbedMode.ts
+++ b/packages/web-pkg/src/composables/embedMode/useEmbedMode.ts
@@ -6,5 +6,9 @@ export const useEmbedMode = () => {
 
   const isEnabled = computed<boolean>(() => store.getters.configuration.options.mode === 'embed')
 
-  return { isEnabled }
+  const isLocationPicker = computed<boolean>(() => {
+    return store.getters.configuration.options.embedTarget === 'location'
+  })
+
+  return { isEnabled, isLocationPicker }
 }

--- a/packages/web-pkg/src/configuration/types.ts
+++ b/packages/web-pkg/src/configuration/types.ts
@@ -28,6 +28,7 @@ export interface OptionsConfiguration {
   disabledExtensions?: string[]
   mode?: string
   isRunningOnEos?: boolean
+  embedTarget?: string
 }
 
 export interface OAuth2Configuration {

--- a/packages/web-pkg/tests/unit/components/FilesList/ResourceTable.spec.ts
+++ b/packages/web-pkg/tests/unit/components/FilesList/ResourceTable.spec.ts
@@ -268,6 +268,26 @@ describe('ResourceTable', () => {
         expect((wrapper.emitted('update:selectedIds')[0][0] as any).length).toBe(0)
       })
     })
+
+    describe('embed mode location target', () => {
+      it('should not hide checkboxes when embed mode does not have location as target', () => {
+        const { wrapper } = getMountedWrapper({
+          configuration: { options: { embedTarget: undefined } }
+        })
+
+        expect(wrapper.find('.resource-table-select-all').exists()).toBe(true)
+        expect(wrapper.find('.resource-table-select-all .oc-checkbox').exists()).toBe(true)
+      })
+
+      it('should hide checkboxes when embed mode has location as target', () => {
+        const { wrapper } = getMountedWrapper({
+          configuration: { options: { embedTarget: 'location' } }
+        })
+
+        expect(wrapper.find('.resource-table-select-all').exists()).toBe(false)
+        expect(wrapper.find('.resource-table-select-all .oc-checkbox').exists()).toBe(false)
+      })
+    })
   })
 
   describe('resource activation', () => {
@@ -429,7 +449,8 @@ describe('ResourceTable', () => {
 function getMountedWrapper({
   props = {},
   isUserContextReady = true,
-  addProcessingResources = false
+  addProcessingResources = false,
+  configuration = { options: {} }
 } = {}) {
   const storeOptions = defaultStoreMockOptions
   storeOptions.modules.runtime.modules.auth.getters.isUserContextReady.mockReturnValue(
@@ -438,6 +459,17 @@ function getMountedWrapper({
   storeOptions.getters.capabilities.mockImplementation(() => ({
     files: {
       tags: true
+    }
+  }))
+  storeOptions.getters.configuration.mockImplementation(() => ({
+    currentTheme: { general: { slogan: '' } },
+    ...configuration,
+    options: {
+      editor: {
+        autosaveEnabled: false,
+        autosaveInterval: 120
+      },
+      ...configuration?.options
     }
   }))
 

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -55,6 +55,13 @@ export const announceConfiguration = async (path: string): Promise<RuntimeConfig
     rawConfig.options = { ...rawConfig.options, mode: getQueryParam('mode') ?? 'web' }
   }
 
+  // Can enable location picker in embed mode
+  const embedTarget = getQueryParam('embed-target')
+
+  if (embedTarget) {
+    rawConfig.options.embedTarget = embedTarget
+  }
+
   configurationManager.initialize(rawConfig)
   // TODO: we might want to get rid of exposing the raw config. needs more refactoring though.
   return rawConfig


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Add a new query param called `embed-target` which is then added into the `configuration.options` object as `embedTarget`. When this parameter has value `location`, it switches the embed mode into location picker. In location picker, resources cannot be selected (checkboxes to do so are hidden), share action is hidden and select action emits the `currentFolder` instead.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs #9768

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Enable picking location to e.g. upload files into instead of only selecting resources.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: local
- test case 1: run web UI with `mode=embed&embed-target=location` query params

## Screenshots (if appropriate):

The empty space above files (where create and upload actions would be) will be filled with create folder action once #9853 is merged.

![localhost_9200_files_spaces_personal_einstein_fileId=91b3fbd1-7964-4fbf-9d9c-0b94c6962fea%244c510ada-c86b-4815-8820-42cdf82c3d51%214c510ada-c86b-4815-8820-42cdf82c3d51 items-per-page=100 files-spaces-generic-view-mode=resource-table tiles-s](https://github.com/owncloud/web/assets/25989331/a80c3a0b-9409-4cb2-bc3c-8f5b8cdc9660)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
