### PR TITLE
feat: add portal targets for file and space details

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -96,6 +96,7 @@
         <portal-target
           name="app.files.sidebar.file.details.table"
           :slot-props="{ space, resource }"
+          :multiple="true"
         />
         <tr v-if="showTags" data-testid="tags">
           <th scope="col" class="oc-pr-s oc-font-semibold" v-text="$gettext('Tags')" />

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -38,6 +38,7 @@
       <role-dropdown
         :allow-share-permission="hasResharing || resourceIsSpace"
         mode="create"
+        :show-icon="isRunningOnEos"
         class="role-selection-dropdown"
         @option-change="collaboratorRoleChanged"
       />
@@ -125,7 +126,7 @@ import {
   useStore
 } from '@ownclouders/web-pkg'
 
-import { defineComponent, inject, ref, unref, watch } from 'vue'
+import { computed, defineComponent, inject, ref, unref, watch } from 'vue'
 import { Resource } from '@ownclouders/web-client'
 import { useShares } from 'web-app-files/src/composables'
 import {
@@ -197,6 +198,7 @@ export default defineComponent({
       resharingDefault: useCapabilityFilesSharingResharingDefault(store),
       hasShareJail: useCapabilityShareJailEnabled(store),
       hasRoleCustomPermissions: useCapabilityFilesSharingAllowCustomPermissions(store),
+      isRunningOnEos: computed(() => store.getters.configuration?.options?.runningOnEos),
       clientService,
       saving,
       savingDelayed,

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
@@ -1,6 +1,7 @@
 <template>
   <span v-if="selectedRole" class="oc-flex oc-flex-middle">
     <span v-if="availableRoles.length === 1">
+      <oc-icon v-if="showIcon" :name="selectedRole.icon" class="oc-mr-s" />
       <span v-if="!existingRole" v-text="inviteLabel" />
       <span v-else>{{ $gettext(selectedRole.label) }}</span>
     </span>
@@ -12,6 +13,7 @@
       gap-size="none"
       :aria-label="mode === 'create' ? $gettext('Select permission') : $gettext('Edit permission')"
     >
+      <oc-icon v-if="showIcon" :name="selectedRole.icon" class="oc-mr-s" />
       <span v-if="!existingRole" class="oc-text-truncate" v-text="inviteLabel" />
       <span v-else class="oc-text-truncate" v-text="$gettext(selectedRole.label)" />
       <oc-icon name="arrow-down-s" />
@@ -155,6 +157,10 @@ export default defineComponent({
       type: String,
       required: false,
       default: 'create'
+    },
+    showIcon: {
+      type: Boolean,
+      default: false
     }
   },
   emits: ['optionChange'],

--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -22,6 +22,7 @@
       <portal-target
         name="app.files.sidebar.sharing.shared-with.top"
         :slot-props="{ space, resource }"
+        :multiple="true"
       />
       <ul
         id="files-collaborators-list"
@@ -44,6 +45,7 @@
         <portal-target
           name="app.files.sidebar.sharing.shared-with.bottom"
           :slot-props="{ space, resource }"
+          :multiple="true"
         />
       </ul>
       <div v-if="showShareToggle" class="oc-flex oc-flex-center">

--- a/packages/web-app-files/tests/unit/components/FilesList/__snapshots__/ResourceDetails.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/FilesList/__snapshots__/ResourceDetails.spec.ts.snap
@@ -33,7 +33,7 @@ exports[`ResourceDetails component renders resource details correctly 1`] = `
           </span>
         </div>
         <!--v-if-->
-        <portal-target name="app.files.sidebar.file.details.table" slot-props="[object Object]"></portal-target>
+        <portal-target multiple="true" name="app.files.sidebar.file.details.table" slot-props="[object Object]"></portal-target>
         <table aria-label="Overview of the information about the selected file" class="details-table">
           <tbody>
             <tr>

--- a/packages/web-app-files/tests/unit/components/FilesList/__snapshots__/ResourceDetails.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/FilesList/__snapshots__/ResourceDetails.spec.ts.snap
@@ -33,6 +33,7 @@ exports[`ResourceDetails component renders resource details correctly 1`] = `
           </span>
         </div>
         <!--v-if-->
+        <portal-target name="app.files.sidebar.file.details.table" slot-props="[object Object]"></portal-target>
         <table aria-label="Overview of the information about the selected file" class="details-table">
           <tbody>
             <tr>
@@ -50,9 +51,7 @@ exports[`ResourceDetails component renders resource details correctly 1`] = `
               <td>24 kB</td>
             </tr>
             <!--v-if-->
-            <!--v-if-->
-            <!--v-if-->
-            <!--v-if-->
+
             <!--v-if-->
           </tbody>
         </table>

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.ts
@@ -39,9 +39,6 @@ const getResourceMock = ({
   })
 
 const selectors = {
-  eosPath: '[data-testid="eosPath"]',
-  eosDirectLink: '[data-testid="eosDirectLink"]',
-  sambaPath: '[data-testid="sambaPath"]',
   ownerDisplayName: '[data-testid="ownerDisplayName"]',
   preview: '[data-testid="preview"]',
   resourceIcon: '.details-icon',
@@ -153,21 +150,6 @@ describe('Details SideBar Panel', () => {
       expect(wrapper.find(selectors.versionsInfo).exists()).toBeFalsy()
     })
   })
-  describe('running on EOS', () => {
-    it('shows eos path and direct link', () => {
-      const resource = getResourceMock()
-      const { wrapper } = createWrapper({ resource, runningOnEos: true })
-      expect(wrapper.find(selectors.eosPath).exists()).toBeTruthy()
-      expect(wrapper.find(selectors.eosDirectLink).exists()).toBeTruthy()
-    })
-  })
-  describe('CERN features', () => {
-    it('show samba link', () => {
-      const resource = getResourceMock({ path: '/eos/user/t/test/123.png' })
-      const { wrapper } = createWrapper({ resource, cernFeatures: true })
-      expect(wrapper.find(selectors.sambaPath).exists()).toBeTruthy()
-    })
-  })
   describe('tags', () => {
     it('show if given', () => {
       const resource = getResourceMock({ tags: ['moon', 'mars'] })
@@ -189,8 +171,6 @@ describe('Details SideBar Panel', () => {
 
 function createWrapper({
   resource = null,
-  runningOnEos = false,
-  cernFeatures = false,
   isPublicLinkContext = false,
   ancestorMetaData = {},
   user = { id: 'marie' },
@@ -198,7 +178,6 @@ function createWrapper({
 } = {}) {
   const storeOptions = defaultStoreMockOptions
   storeOptions.getters.user.mockReturnValue(user)
-  storeOptions.getters.configuration.mockReturnValue({ options: { runningOnEos, cernFeatures } })
   storeOptions.modules.Files.getters.versions.mockReturnValue(versions)
   storeOptions.getters.capabilities.mockReturnValue({ files: { tags: true } })
   storeOptions.modules.runtime.modules.ancestorMetaData.getters.ancestorMetaData.mockReturnValue(

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/ListItem.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/ListItem.spec.ts.snap
@@ -14,7 +14,7 @@ exports[`Collaborator ListItem component share inheritance indicators show when 
         </div>
         <div>
           <div class="oc-flex oc-flex-nowrap oc-flex-middle">
-            <role-dropdown-stub allowsharepermission="true" class="files-collaborators-collaborator-role" domselector="asdf" existingpermissions="" existingrole="[object Object]" mode="edit"></role-dropdown-stub>
+            <role-dropdown-stub allowsharepermission="true" class="files-collaborators-collaborator-role" domselector="asdf" existingpermissions="" existingrole="[object Object]" mode="edit" showicon="false"></role-dropdown-stub>
           </div>
         </div>
       </div>

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/RoleDropdown.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/RoleDropdown.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`RoleDropdown renders a button with existing role if given for resource type file 1`] = `
 <span class="oc-flex oc-flex-middle">
   <oc-button-stub appearance="raw" arialabel="Select permission" class="files-recipient-role-select-btn" disabled="false" gapsize="none" id="files-collaborators-role-button-new" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive">
+    <!--v-if-->
     <span class="oc-text-truncate">Can view</span>
     <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="arrow-down-s" size="medium" type="span" variation="passive"></oc-icon-stub>
   </oc-button-stub>
@@ -73,6 +74,7 @@ exports[`RoleDropdown renders a button with existing role if given for resource 
 exports[`RoleDropdown renders a button with existing role if given for resource type folder 1`] = `
 <span class="oc-flex oc-flex-middle">
   <oc-button-stub appearance="raw" arialabel="Select permission" class="files-recipient-role-select-btn" disabled="false" gapsize="none" id="files-collaborators-role-button-new" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive">
+    <!--v-if-->
     <span class="oc-text-truncate">Can view</span>
     <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="arrow-down-s" size="medium" type="span" variation="passive"></oc-icon-stub>
   </oc-button-stub>
@@ -143,6 +145,7 @@ exports[`RoleDropdown renders a button with existing role if given for resource 
 exports[`RoleDropdown renders a button with invite text if no existing role given for resource type file 1`] = `
 <span class="oc-flex oc-flex-middle">
   <oc-button-stub appearance="raw" arialabel="Select permission" class="files-recipient-role-select-btn" disabled="false" gapsize="none" id="files-collaborators-role-button-new" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive">
+    <!--v-if-->
     <span class="oc-text-truncate">Can view</span>
     <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="arrow-down-s" size="medium" type="span" variation="passive"></oc-icon-stub>
   </oc-button-stub>
@@ -207,6 +210,7 @@ exports[`RoleDropdown renders a button with invite text if no existing role give
 exports[`RoleDropdown renders a button with invite text if no existing role given for resource type folder 1`] = `
 <span class="oc-flex oc-flex-middle">
   <oc-button-stub appearance="raw" arialabel="Select permission" class="files-recipient-role-select-btn" disabled="false" gapsize="none" id="files-collaborators-role-button-new" justifycontent="center" showspinner="false" size="medium" submit="button" type="button" variation="passive">
+    <!--v-if-->
     <span class="oc-text-truncate">Can view</span>
     <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="arrow-down-s" size="medium" type="span" variation="passive"></oc-icon-stub>
   </oc-button-stub>

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/FileShares.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/FileShares.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`FileShares collaborators list renders sharedWithLabel and sharee list 1
   <div class="avatars-wrapper oc-flex oc-flex-middle oc-flex-between">
     <h4 class="oc-text-bold oc-my-rm">Shared with</h4>
   </div>
-  <portal-target name="app.files.sidebar.sharing.shared-with.top" slot-props="[object Object]"></portal-target>
+  <portal-target multiple="true" name="app.files.sidebar.sharing.shared-with.top" slot-props="[object Object]"></portal-target>
   <ul aria-label="Share receivers" class="oc-list oc-list-divider oc-overflow-hidden oc-m-rm" id="files-collaborators-list">
     <li>
       <collaborator-list-item-stub deniable="false" issharedenied="false" modifiable="true" resourcename="[Function]" share="[object Object]"></collaborator-list-item-stub>
@@ -24,7 +24,7 @@ exports[`FileShares collaborators list renders sharedWithLabel and sharee list 1
     <li>
       <collaborator-list-item-stub deniable="false" issharedenied="false" modifiable="true" resourcename="[Function]" share="[object Object]"></collaborator-list-item-stub>
     </li>
-    <portal-target name="app.files.sidebar.sharing.shared-with.bottom" slot-props="[object Object]"></portal-target>
+    <portal-target multiple="true" name="app.files.sidebar.sharing.shared-with.bottom" slot-props="[object Object]"></portal-target>
   </ul>
   <div class="oc-flex oc-flex-center">
     <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw toggle-shares-list-btn" type="button">Show less</button>
@@ -43,12 +43,12 @@ exports[`FileShares current space loads space members if a space is given and th
   <div class="avatars-wrapper oc-flex oc-flex-middle oc-flex-between">
     <h4 class="oc-text-bold oc-my-rm">Shared with</h4>
   </div>
-  <portal-target name="app.files.sidebar.sharing.shared-with.top" slot-props="[object Object]"></portal-target>
+  <portal-target multiple="true" name="app.files.sidebar.sharing.shared-with.top" slot-props="[object Object]"></portal-target>
   <ul aria-label="Share receivers" class="oc-list oc-list-divider oc-overflow-hidden oc-mb-l" id="files-collaborators-list">
     <li>
       <collaborator-list-item-stub deniable="false" issharedenied="false" modifiable="false" resourcename="[Function]" share="[object Object]"></collaborator-list-item-stub>
     </li>
-    <portal-target name="app.files.sidebar.sharing.shared-with.bottom" slot-props="[object Object]"></portal-target>
+    <portal-target multiple="true" name="app.files.sidebar.sharing.shared-with.bottom" slot-props="[object Object]"></portal-target>
   </ul>
   <!--v-if-->
   <h4 class="oc-text-bold oc-my-s">Space members</h4>

--- a/packages/web-pkg/src/components/SideBar/Spaces/Details/SpaceDetails.vue
+++ b/packages/web-pkg/src/components/SideBar/Spaces/Details/SpaceDetails.vue
@@ -85,6 +85,7 @@
       <portal-target
         name="app.files.sidebar.space.details.table"
         :slot-props="{ space: resource, resource }"
+        :multiple="true"
       />
     </table>
   </div>

--- a/packages/web-pkg/src/components/SideBar/Spaces/Details/SpaceDetails.vue
+++ b/packages/web-pkg/src/components/SideBar/Spaces/Details/SpaceDetails.vue
@@ -82,6 +82,10 @@
           </oc-button>
         </td>
       </tr>
+      <portal-target
+        name="app.files.sidebar.space.details.table"
+        :slot-props="{ space: resource, resource }"
+      />
     </table>
   </div>
 </template>

--- a/packages/web-pkg/tests/unit/components/sidebar/Spaces/Details/__snapshots__/SpaceDetails.spec.ts.snap
+++ b/packages/web-pkg/tests/unit/components/sidebar/Spaces/Details/__snapshots__/SpaceDetails.spec.ts.snap
@@ -11,6 +11,7 @@ exports[`Details SideBar Panel displays the details side panel 1`] = `
     <p>This space has 1 member.</p>
     <oc-button-stub appearance="raw" arialabel="Open share panel" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="small" submit="button" type="button" variation="passive"></oc-button-stub>
   </div>
+  <portal-target name="app.files.sidebar.space.details.table" slot-props="[object Object]"></portal-target>
   <table aria-label="Overview of the information about the selected space" class="details-table oc-width-1-1">
     <colgroup>
       <col class="oc-width-1-3">
@@ -35,6 +36,7 @@ exports[`Details SideBar Panel displays the details side panel 1`] = `
         </td>
       </tr>
       <!--v-if-->
+
     </tbody>
   </table>
 </div>

--- a/packages/web-pkg/tests/unit/components/sidebar/Spaces/Details/__snapshots__/SpaceDetails.spec.ts.snap
+++ b/packages/web-pkg/tests/unit/components/sidebar/Spaces/Details/__snapshots__/SpaceDetails.spec.ts.snap
@@ -11,7 +11,7 @@ exports[`Details SideBar Panel displays the details side panel 1`] = `
     <p>This space has 1 member.</p>
     <oc-button-stub appearance="raw" arialabel="Open share panel" disabled="false" gapsize="medium" justifycontent="center" showspinner="false" size="small" submit="button" type="button" variation="passive"></oc-button-stub>
   </div>
-  <portal-target name="app.files.sidebar.space.details.table" slot-props="[object Object]"></portal-target>
+  <portal-target multiple="true" name="app.files.sidebar.space.details.table" slot-props="[object Object]"></portal-target>
   <table aria-label="Overview of the information about the selected space" class="details-table oc-width-1-1">
     <colgroup>
       <col class="oc-width-1-3">


### PR DESCRIPTION
## Description
Adds portal targets for file and space details. Also adds a share role icon next to the share role dropdown for CERN.

The removed CERN-code can now be implemented via extension instead (see https://github.com/cernbox/web-extensions/pull/25).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Works towards https://github.com/owncloud/web/issues/9865 and https://github.com/owncloud/web/issues/9376

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
