### PR TITLE
web-app-external: view mode

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -73,6 +73,7 @@ Depending on the backend you are using, there are sample config files provided i
 - `options.upload.xhr.timeout` Specifies the timeout for XHR uploads in milliseconds.
 - `options.editor.autosaveEnabled` Specifies if the autosave for the editor apps is enabled.
 - `options.editor.autosaveInterval` Specifies the time interval for the autosave of editor apps in seconds.
+- `options.editor.openAsPreview` Specifies if non-personal files i.e. files in shares, spaces or public links are being opened in read only mode so the user needs to manually switch to edit mode. Can be set to `true`, `false` or an array of web app/editor names.
 - `options.contextHelpersReadMore` Specifies whether the "Read more" link should be displayed or not.
 - `options.openLinksWithDefaultApp` Specifies whether single file link shares should be opened with default app or not.
 - `options.tokenStorageLocal` Specifies whether the access token will be stored in the local storage when set to `true` or in the session storage when set to `false`. If stored in the local storage, login state will be persisted across multiple browser tabs, means no additional logins are required. Defaults to `true`.

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -38,7 +38,11 @@ import {
   useRouteQuery,
   useStore
 } from '@ownclouders/web-pkg'
-import { isPublicSpaceResource, isShareSpaceResource } from '@ownclouders/web-client/src/helpers'
+import {
+  isProjectSpaceResource,
+  isPublicSpaceResource,
+  isShareSpaceResource
+} from '@ownclouders/web-client/src/helpers'
 
 export default defineComponent({
   name: 'ExternalApp',
@@ -151,7 +155,7 @@ export default defineComponent({
     }).restartable()
 
     const determineOpenAsPreview = (appName: string) => {
-      const openAsPreview = configurationManager.options.editors.openAsPreview
+      const openAsPreview = configurationManager.options.editor.openAsPreview
       return (
         openAsPreview === true || (Array.isArray(openAsPreview) && openAsPreview.includes(appName))
       )
@@ -191,7 +195,9 @@ export default defineComponent({
         let viewMode = props.isReadOnly ? 'view' : 'write'
         if (
           determineOpenAsPreview(unref(applicationName)) &&
-          (isShareSpaceResource(props.space) || isPublicSpaceResource(props.space))
+          (isShareSpaceResource(props.space) ||
+            isPublicSpaceResource(props.space) ||
+            isProjectSpaceResource(props.space))
         ) {
           viewMode = 'view'
         }

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -84,6 +84,13 @@ export default defineComponent({
 
     const loadAppUrl = useTask(function* (signal, viewMode: string) {
       try {
+        if (props.isReadOnly && viewMode === 'write') {
+          store.dispatch('showErrorMessage', {
+            title: $gettext('Cannot open file in edit mode as it is read-only')
+          })
+          return
+        }
+
         const fileId = props.resource.fileId
         const baseUrl = urlJoin(
           configurationManager.serverUrl,
@@ -146,10 +153,6 @@ export default defineComponent({
     const catchClickMicrosoftEdit = (event) => {
       try {
         if (JSON.parse(event.data)?.MessageId === 'UI_Edit') {
-          if (props.isReadOnly) {
-            console.error('Cannot switch to write mode as file is read-only')
-            return
-          }
           loadAppUrl.perform('write')
         }
       } catch (e) {}

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -160,7 +160,6 @@ export default defineComponent({
     watch(
       applicationName,
       (newAppName, oldAppName) => {
-        console.log('appNames', newAppName, oldAppName)
         if (newAppName === 'Office365' && newAppName !== oldAppName) {
           window.addEventListener('message', catchClickMicrosoftEdit)
         } else {

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -175,20 +175,19 @@ export default defineComponent({
     watch(
       [props.resource],
       ([newResource], [oldResource]) => {
-        let viewMode = 'write'
-        // FIXME: introduce config option (?)
-        const featureFlag = true
-        if (!isSameResource(newResource, oldResource)) {
-          if (props.isReadOnly) {
-            viewMode = 'view'
-          } else if (
-            featureFlag &&
-            (isShareSpaceResource(props.space) || isPublicSpaceResource(props.space))
-          ) {
-            viewMode = 'view'
-          }
+        if (isSameResource(newResource, oldResource)) {
+          return
         }
 
+        let viewMode = props.isReadOnly ? 'view' : 'write'
+        // FIXME: introduce config option (?)
+        const featureFlag = true
+        if (
+          featureFlag &&
+          (isShareSpaceResource(props.space) || isPublicSpaceResource(props.space))
+        ) {
+          viewMode = 'view'
+        }
         loadAppUrl.perform(unref(viewMode))
       },
       { immediate: true, deep: true }

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -38,7 +38,6 @@ import {
   useRouteQuery,
   useStore
 } from '@ownclouders/web-pkg'
-import { configurationManager } from '@ownclouders/web-pkg'
 import { isPublicSpaceResource, isShareSpaceResource } from '@ownclouders/web-client/src/helpers'
 
 export default defineComponent({

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -188,7 +188,7 @@ export default defineComponent({
         ) {
           viewMode = 'view'
         }
-        loadAppUrl.perform(unref(viewMode))
+        loadAppUrl.perform(viewMode)
       },
       { immediate: true, deep: true }
     )

--- a/packages/web-app-external/tests/unit/app.spec.ts
+++ b/packages/web-app-external/tests/unit/app.spec.ts
@@ -1,11 +1,11 @@
-import { mock } from 'jest-mock-extended'
+import { mock, mockDeep } from 'jest-mock-extended'
 import {
   createStore,
   defaultPlugins,
   defaultStoreMockOptions,
   shallowMount
 } from 'web-test-helpers'
-import { useRequest, useRouteQuery } from '@ownclouders/web-pkg'
+import { ConfigurationManager, useRequest, useRouteQuery } from '@ownclouders/web-pkg'
 import { ref } from 'vue'
 
 import { Resource } from '@ownclouders/web-client'
@@ -14,7 +14,15 @@ import App from '../../src/App.vue'
 jest.mock('@ownclouders/web-pkg', () => ({
   ...jest.requireActual('@ownclouders/web-pkg'),
   useRequest: jest.fn(),
-  useRouteQuery: jest.fn()
+  useRouteQuery: jest.fn(),
+  useConfigurationManager: () =>
+    mockDeep<ConfigurationManager>({
+      options: {
+        editors: {
+          openAsPreview: false
+        }
+      }
+    })
 }))
 
 const appUrl = 'https://example.test/d12ab86/loe009157-MzBw'
@@ -36,10 +44,6 @@ const providerSuccessResponseGet = {
 describe('The app provider extension', () => {
   beforeEach(() => {
     jest.spyOn(console, 'error').mockImplementation(() => undefined)
-  })
-
-  afterEach(() => {
-    jest.clearAllMocks()
   })
 
   it('should fail for unauthenticated users', async () => {

--- a/packages/web-app-external/tests/unit/app.spec.ts
+++ b/packages/web-app-external/tests/unit/app.spec.ts
@@ -18,7 +18,7 @@ jest.mock('@ownclouders/web-pkg', () => ({
   useConfigurationManager: () =>
     mockDeep<ConfigurationManager>({
       options: {
-        editors: {
+        editor: {
           openAsPreview: false
         }
       }

--- a/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
+++ b/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
@@ -418,6 +418,7 @@ export default defineComponent({
 
     const slotAttrs = computed(() => ({
       url: unref(url),
+      space: unref(unref(currentFileContext).space),
       resource: unref(resource),
       isDirty: unref(isDirty),
       isReadOnly: unref(isReadOnly),

--- a/packages/web-pkg/src/configuration/manager.ts
+++ b/packages/web-pkg/src/configuration/manager.ts
@@ -103,12 +103,12 @@ export class ConfigurationManager {
     )
 
     // when this setting is enabled, non-personal files i.e. files in shares, spaces or public links
-    // are opened in read only mode and the user needs another click to switch to edit mode
-    // it can be set to true/false or an array of wopi app names
+    // are opened in read only mode and the user needs another click to switch to edit mode.
+    // it can be set to true/false or an array of web app/editor names.
     set(
       this.optionsConfiguration,
-      'editors.openAsPreview',
-      get(options, 'editors.openAsPreview', false)
+      'editor.openAsPreview',
+      get(options, 'editor.openAsPreview', false)
     )
 
     set(this.optionsConfiguration, 'upload.companionUrl', get(options, 'upload.companionUrl', ''))

--- a/packages/web-pkg/src/configuration/manager.ts
+++ b/packages/web-pkg/src/configuration/manager.ts
@@ -101,6 +101,16 @@ export class ConfigurationManager {
       'openLinksWithDefaultApp',
       get(options, 'openLinksWithDefaultApp', true)
     )
+
+    // when this setting is enabled, non-personal files i.e. files in shares, spaces or public links
+    // are opened in read only mode and the user needs another click to switch to edit mode
+    // it can be set to true/false or an array of wopi app names
+    set(
+      this.optionsConfiguration,
+      'editors.openAsPreview',
+      get(options, 'editors.openAsPreview', false)
+    )
+
     set(this.optionsConfiguration, 'upload.companionUrl', get(options, 'upload.companionUrl', ''))
     set(this.optionsConfiguration, 'tokenStorageLocal', get(options, 'tokenStorageLocal', true))
     set(this.optionsConfiguration, 'loginUrl', get(options, 'loginUrl', ''))

--- a/packages/web-pkg/src/configuration/types.ts
+++ b/packages/web-pkg/src/configuration/types.ts
@@ -29,6 +29,9 @@ export interface OptionsConfiguration {
   mode?: string
   isRunningOnEos?: boolean
   embedTarget?: string
+  editors?: {
+    openAsPreview?: boolean | string[]
+  }
 }
 
 export interface OAuth2Configuration {

--- a/packages/web-pkg/src/configuration/types.ts
+++ b/packages/web-pkg/src/configuration/types.ts
@@ -29,7 +29,7 @@ export interface OptionsConfiguration {
   mode?: string
   isRunningOnEos?: boolean
   embedTarget?: string
-  editors?: {
+  editor?: {
     openAsPreview?: boolean | string[]
   }
 }


### PR DESCRIPTION
## Description
Open non-personal files in "view" (readonly) mode when enabled via config: `editor.openAsPreview`.

Based on the logic implemented by CERN this currently is the case for all files in shares and public links.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9255

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

