### PR TITLE
chore: change to the search query triggers only one request

### DIFF
--- a/changelog/unreleased/bugfix-duplicated-file-search-request
+++ b/changelog/unreleased/bugfix-duplicated-file-search-request
@@ -3,4 +3,5 @@ Bugfix: Duplicated file search request
 We have fixed a bug where the search was sent unnecessarily twice.
 
 https://github.com/owncloud/web/pull/9861
+https://github.com/owncloud/web/pull/9880
 https://github.com/owncloud/web/issues/9787


### PR DESCRIPTION
## Description
add test to validate that search queries only emit a search request if one of the params changes

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- tests for: https://github.com/owncloud/web/pull/9861
- tests for: https://github.com/owncloud/web/issues/9787

## Motivation and Context
have query changes tested

## How Has This Been Tested?
- unit test

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests

## Checklist:
- [ ] Code changes
- [X] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 