### PR TITLE
enhancement: context aware preview app media rendering

### DIFF
--- a/changelog/unreleased/enhancement-context-aware-media-preview
+++ b/changelog/unreleased/enhancement-context-aware-media-preview
@@ -1,0 +1,23 @@
+Enhancement: Context aware preview app media rendering
+
+Until now, the preview app had always displayed all images,
+regardless of what the user had selected or where the request came from.
+
+Of course, permissions have been taken into account so far,\
+but the behavior was still wrong in certain cases.
+
+In the following scenarios, the app displayed all media from the same folder:
+
+* the user created a single file public link, navigated to the `shared via link` panel,
+  clicked the single shared resource.
+* the user created a single file share (regardless of access permissions), navigated to the
+  `shared with others` panel, clicked the single shared resource.
+* the user searched for a file, clicked one of the media search results.
+* the user marked a single file as favorite, navigated to the favorites list,
+  clicked on one from that list.
+
+now the behavior is changed and the preview app takes the referer into consideration and displays
+only the selected resource in one of the above cases.
+
+https://github.com/owncloud/web/pull/9882
+https://github.com/owncloud/web/issues/8932

--- a/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
+++ b/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
@@ -125,7 +125,6 @@ export default defineComponent({
       getFileContents,
       getFileInfo,
       getUrlForResource,
-      loadFolderForFileContext,
       putFileContents,
       replaceInvalidFileRoute,
       revokeUrl


### PR DESCRIPTION
## Description
Until now, the preview app had always displayed all images,
regardless of what the user had selected or where the request came from.

Of course, permissions have been taken into account so far,\
but the behavior was still wrong in certain cases.

In the following scenarios, the app displayed all media from the same folder:

* the user created a single file public link, navigated to the `shared via link` panel,
  clicked the single shared resource.
* the user created a single file share (regardless of access permissions), navigated to the
  `shared with others` panel, clicked the single shared resource.
* the user searched for a file, clicked one of the media search results.
* the user marked a single file as favorite, navigated to the favorites list,
  clicked on one from that list.

now the behavior is changed and the preview app takes the referer into consideration and displays
only the selected resource in one of the above cases.

not sure if its the perfect way to have a explicit list of those context's, maybe a exclude list would be more (everything expect the direct space referer)!? what do you think?

## Related Issue
- fixes https://github.com/owncloud/web/issues/8932

## Motivation and Context
![ezgif-2-09128abecb](https://github.com/owncloud/web/assets/49308105/d8824f9a-bc6e-48bb-900a-825e237ac613)

## How Has This Been Tested?
- unit testst
- e2e tests (ci)

## Screenshots (if appropriate):
https://github.com/owncloud/web/assets/49308105/2c43bab0-dff1-4fb8-9bd4-6c3c3046e385

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests

## Checklist:
- [X] Code changes
- [X] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 