### PR TITLE
fix: tag action when resoruces are not loaded yet

### DIFF
--- a/changelog/unreleased/bugfix-tags-not-editable-locked-files
+++ b/changelog/unreleased/bugfix-tags-not-editable-locked-files
@@ -3,4 +3,5 @@ Bugfix: Tags are no longer editable for a locked file
 Tags are no longer editable for files that are currently locked.
 
 https://github.com/owncloud/web/pull/9873
+https://github.com/owncloud/web/pull/9883
 https://github.com/owncloud/web/issues/9789

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsShowEditTags.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsShowEditTags.ts
@@ -34,7 +34,7 @@ export const useFileActionsShowEditTags = ({ store }: { store?: Store<any> } = {
           return false
         }
 
-        if (resources[0].locked === true) {
+        if (resources[0]?.locked === true) {
           return false
         }
 


### PR DESCRIPTION
## Description
Fixes an issue where the file list would break because of the tag action when no resources are loaded (yet).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Regression of https://github.com/owncloud/web/pull/9873

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
