### PR TITLE
Organize "New" menu | Add default extension to menu item

### DIFF
--- a/changelog/unreleased/enhancement-reorganize-new-menu
+++ b/changelog/unreleased/enhancement-reorganize-new-menu
@@ -1,0 +1,7 @@
+Enhancment: Reorganize "New" menu
+
+We've reorganized the "new" menu and added optional file extension indicators that will show if the user has
+file extensions enabled in the files view.
+
+https://github.com/owncloud/web/pull/9906
+https://github.com/owncloud/web/issues/9847

--- a/changelog/unreleased/enhancement-reorganize-new-menu
+++ b/changelog/unreleased/enhancement-reorganize-new-menu
@@ -1,4 +1,4 @@
-Enhancment: Reorganize "New" menu
+Enhancement: Reorganize "New" menu
 
 We've reorganized the "new" menu and added optional file extension indicators that will show if the user has
 file extensions enabled in the files view.

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -35,6 +35,26 @@
               <span v-text="$gettext('Folder')" />
             </oc-button>
           </li>
+          <template v-if="mimetypesAllowedForCreation">
+            <li
+              v-for="(mimeTypeAction, key) in createNewFileMimeTypeActions"
+              :key="`file-creation-item-external-${key}`"
+              class="create-list-file oc-menu-item-hover"
+            >
+              <oc-button appearance="raw" @click="mimeTypeAction.handler">
+                <oc-resource-icon :resource="getIconResource(mimeTypeAction)" size="medium" />
+                <span v-text="$gettext(mimeTypeAction.label())" />
+              </oc-button>
+            </li>
+            <li class="bottom-seperator"></li>
+          </template>
+          <li class="create-list-shortcut oc-menu-item-hover">
+            <oc-button id="new-shortcut-btn" appearance="raw" @click="createNewShortcutAction">
+              <oc-icon name="external-link" size="medium" />
+              <span v-text="$gettext('Shortcut')" />
+            </oc-button>
+          </li>
+
           <li
             v-for="(fileAction, key) in createNewFileActions"
             :key="`file-creation-item-${key}`"
@@ -47,24 +67,6 @@
             >
               <oc-resource-icon :resource="getIconResource(fileAction)" size="medium" />
               <span>{{ fileAction.label() }}</span>
-            </oc-button>
-          </li>
-          <template v-if="mimetypesAllowedForCreation">
-            <li
-              v-for="(mimeTypeAction, key) in createNewFileMimeTypeActions"
-              :key="`file-creation-item-external-${key}`"
-              class="create-list-file oc-menu-item-hover"
-            >
-              <oc-button appearance="raw" @click="mimeTypeAction.handler">
-                <oc-resource-icon :resource="getIconResource(mimeTypeAction)" size="medium" />
-                <span v-text="$gettext(mimeTypeAction.label())" />
-              </oc-button>
-            </li>
-          </template>
-          <li class="create-list-shortcut oc-menu-item-hover">
-            <oc-button id="new-shortcut-btn" appearance="raw" @click="createNewShortcutAction">
-              <oc-icon name="external-link" size="medium" />
-              <span v-text="$gettext('Shortcut')" />
             </oc-button>
           </li>
         </oc-list>
@@ -297,6 +299,7 @@ export default defineComponent({
       space: props.space,
       mimetypesAllowedForCreation: mimetypesAllowedForCreation
     })
+    console.log('mime-types', createNewFileMimeTypeActions)
 
     const extensionRegistry = useExtensionRegistry()
     const extensionActions = computed(() => {
@@ -541,6 +544,10 @@ export default defineComponent({
 
 #extension-list {
   border-top: 1px solid var(--oc-color-border);
+}
+
+.bottom-seperator {
+  border-bottom: 1px solid var(--oc-color-border) !important;
 }
 
 #clipboard-btns {

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -54,8 +54,11 @@
                 />
               </oc-button>
             </li>
-            <li class="bottom-seperator"></li>
           </template>
+          <li
+            v-if="mimetypesAllowedForCreation && createNewFileMimeTypeActions.length > 0"
+            class="bottom-seperator"
+          />
           <li class="create-list-shortcut oc-menu-item-hover">
             <oc-button id="new-shortcut-btn" appearance="raw" @click="createNewShortcutAction">
               <oc-icon name="external-link" size="medium" />
@@ -63,7 +66,7 @@
               <span
                 v-if="areFileExtensionsShown"
                 class="create-list-file-item-extension"
-                v-text="'.url'"
+                v-text="'url'"
               />
             </oc-button>
           </li>

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -41,11 +41,7 @@
               :key="`file-creation-item-external-${key}`"
               class="create-list-file oc-menu-item-hover"
             >
-              <oc-button
-                style="display: inline-flex"
-                appearance="raw"
-                @click="mimeTypeAction.handler"
-              >
+              <oc-button appearance="raw" @click="mimeTypeAction.handler">
                 <oc-resource-icon :resource="getIconResource(mimeTypeAction)" size="medium" />
                 <span
                   class="create-list-file-item-text"

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -42,19 +42,16 @@
               class="create-list-file oc-menu-item-hover"
             >
               <oc-button
-                style="display: inline-flex; text-align: left; justify-content: flex-start; gap 10px;"
+                style="display: inline-flex"
                 appearance="raw"
                 @click="mimeTypeAction.handler"
               >
                 <oc-resource-icon :resource="getIconResource(mimeTypeAction)" size="medium" />
                 <span
-                  style="display: inline-flex; text-align: left; justify-content: flex-start"
+                  class="create-list-file-item-text"
                   v-text="$gettext(mimeTypeAction.label())"
                 />
-                <span
-                  style="display: inline-flex; text-align: left; justify-content: right; gap: 10px"
-                  v-text="mimeTypeAction.ext"
-                />
+                <span class="create-list-file-item-extension" v-text="mimeTypeAction.ext" />
               </oc-button>
             </li>
             <li class="bottom-seperator"></li>
@@ -77,8 +74,8 @@
               @click="fileAction.handler"
             >
               <oc-resource-icon :resource="getIconResource(fileAction)" size="medium" />
-              <span>{{ fileAction.label() }}</span>
-              <span>{{ fileAction.ext }}</span>
+              <span class="create-list-file-item-text">{{ fileAction.label() }}</span>
+              <span class="create-list-file-item-extension">{{ fileAction.ext }}</span>
             </oc-button>
           </li>
         </oc-list>
@@ -522,6 +519,7 @@ export default defineComponent({
     border: 1px solid transparent;
 
     button {
+      display: inline-flex;
       gap: 10px;
       justify-content: left;
       width: 100%;
@@ -538,6 +536,25 @@ export default defineComponent({
 
   .create-list-file:nth-child(2) button {
     margin-top: 6px;
+  }
+}
+
+.create-list {
+  &-file-item {
+    &-text {
+      display: inline-flex;
+      text-align: left;
+      justify-content: flex-start;
+    }
+    &-extension {
+      display: inline-flex;
+      text-align: left;
+      justify-content: right;
+      flex: 1;
+      font-weight: normal !important;
+      font-size: var(--oc-font-size-small);
+      opacity: 0.7;
+    }
   }
 }
 

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -28,7 +28,7 @@
         class="oc-width-auto"
         padding-size="small"
       >
-        <oc-list id="create-list">
+        <oc-list id="create-list" :class="areFileExtensionsShown ? 'expanded-list' : null">
           <li class="create-list-folder oc-menu-item-hover">
             <oc-button id="new-folder-btn" appearance="raw" @click="createNewFolderAction">
               <oc-resource-icon :resource="folderIconResource" size="medium" />
@@ -48,7 +48,7 @@
                   v-text="$gettext(mimeTypeAction.label())"
                 />
                 <span
-                  v-if="areFileExtensionsShown"
+                  v-if="areFileExtensionsShown && mimeTypeAction.ext"
                   class="create-list-file-item-extension"
                   v-text="mimeTypeAction.ext"
                 />
@@ -60,6 +60,11 @@
             <oc-button id="new-shortcut-btn" appearance="raw" @click="createNewShortcutAction">
               <oc-icon name="external-link" size="medium" />
               <span v-text="$gettext('Shortcut')" />
+              <span
+                v-if="areFileExtensionsShown"
+                class="create-list-file-item-extension"
+                v-text="'.url'"
+              />
             </oc-button>
           </li>
 
@@ -75,9 +80,11 @@
             >
               <oc-resource-icon :resource="getIconResource(fileAction)" size="medium" />
               <span class="create-list-file-item-text">{{ fileAction.label() }}</span>
-              <span v-if="areFileExtensionsShown" class="create-list-file-item-extension">{{
-                fileAction.ext
-              }}</span>
+              <span
+                v-if="areFileExtensionsShown && fileAction.ext"
+                class="create-list-file-item-extension"
+                >{{ fileAction.ext }}</span
+              >
             </oc-button>
           </li>
         </oc-list>
@@ -563,9 +570,12 @@ export default defineComponent({
 
 #upload-list,
 #new-file-menu-drop {
-  min-width: 280px;
+  min-width: 230px;
 }
 
+.expanded-list {
+  min-width: 280px !important;
+}
 #create-list,
 #upload-list,
 #new-file-menu-drop {

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -51,7 +51,11 @@
                   class="create-list-file-item-text"
                   v-text="$gettext(mimeTypeAction.label())"
                 />
-                <span class="create-list-file-item-extension" v-text="mimeTypeAction.ext" />
+                <span
+                  v-if="areFileExtensionsShown"
+                  class="create-list-file-item-extension"
+                  v-text="mimeTypeAction.ext"
+                />
               </oc-button>
             </li>
             <li class="bottom-seperator"></li>
@@ -75,7 +79,9 @@
             >
               <oc-resource-icon :resource="getIconResource(fileAction)" size="medium" />
               <span class="create-list-file-item-text">{{ fileAction.label() }}</span>
-              <span class="create-list-file-item-extension">{{ fileAction.ext }}</span>
+              <span v-if="areFileExtensionsShown" class="create-list-file-item-extension">{{
+                fileAction.ext
+              }}</span>
             </oc-button>
           </li>
         </oc-list>
@@ -253,6 +259,7 @@ export default defineComponent({
     const route = useRoute()
     const language = useGettext()
     const hasSpaces = useCapabilitySpacesEnabled(store)
+    const areFileExtensionsShown = computed(() => unref(store.state.Files.areFileExtensionsShown))
 
     useUpload({ uppyService })
 
@@ -308,7 +315,6 @@ export default defineComponent({
       space: props.space,
       mimetypesAllowedForCreation: mimetypesAllowedForCreation
     })
-    console.log('mime-types', createNewFileMimeTypeActions)
 
     const extensionRegistry = useExtensionRegistry()
     const extensionActions = computed(() => {
@@ -436,6 +442,7 @@ export default defineComponent({
       showDrop,
       isCreateNewShortcutModalOpen,
       closeCreateNewShortcutModal,
+      areFileExtensionsShown,
 
       // HACK: exported for unit tests:
       onUploadComplete

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -59,18 +59,6 @@
             v-if="mimetypesAllowedForCreation && createNewFileMimeTypeActions.length > 0"
             class="bottom-seperator"
           />
-          <li class="create-list-shortcut oc-menu-item-hover">
-            <oc-button id="new-shortcut-btn" appearance="raw" @click="createNewShortcutAction">
-              <oc-icon name="external-link" size="medium" />
-              <span v-text="$gettext('Shortcut')" />
-              <span
-                v-if="areFileExtensionsShown"
-                class="create-list-file-item-extension"
-                v-text="'url'"
-              />
-            </oc-button>
-          </li>
-
           <li
             v-for="(fileAction, key) in createNewFileActions"
             :key="`file-creation-item-${key}`"
@@ -88,6 +76,17 @@
                 class="create-list-file-item-extension"
                 >{{ fileAction.ext }}</span
               >
+            </oc-button>
+          </li>
+          <li class="create-list-shortcut oc-menu-item-hover">
+            <oc-button id="new-shortcut-btn" appearance="raw" @click="createNewShortcutAction">
+              <oc-icon name="external-link" size="medium" />
+              <span v-text="$gettext('Shortcut')" />
+              <span
+                v-if="areFileExtensionsShown"
+                class="create-list-file-item-extension"
+                v-text="'url'"
+              />
             </oc-button>
           </li>
         </oc-list>

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -41,9 +41,20 @@
               :key="`file-creation-item-external-${key}`"
               class="create-list-file oc-menu-item-hover"
             >
-              <oc-button appearance="raw" @click="mimeTypeAction.handler">
+              <oc-button
+                style="display: inline-flex; text-align: left; justify-content: flex-start; gap 10px;"
+                appearance="raw"
+                @click="mimeTypeAction.handler"
+              >
                 <oc-resource-icon :resource="getIconResource(mimeTypeAction)" size="medium" />
-                <span v-text="$gettext(mimeTypeAction.label())" />
+                <span
+                  style="display: inline-flex; text-align: left; justify-content: flex-start"
+                  v-text="$gettext(mimeTypeAction.label())"
+                />
+                <span
+                  style="display: inline-flex; text-align: left; justify-content: right; gap: 10px"
+                  v-text="mimeTypeAction.ext"
+                />
               </oc-button>
             </li>
             <li class="bottom-seperator"></li>
@@ -67,6 +78,7 @@
             >
               <oc-resource-icon :resource="getIconResource(fileAction)" size="medium" />
               <span>{{ fileAction.label() }}</span>
+              <span>{{ fileAction.ext }}</span>
             </oc-button>
           </li>
         </oc-list>
@@ -531,7 +543,7 @@ export default defineComponent({
 
 #upload-list,
 #new-file-menu-drop {
-  min-width: 230px;
+  min-width: 280px;
 }
 
 #create-list,
@@ -548,6 +560,7 @@ export default defineComponent({
 
 .bottom-seperator {
   border-bottom: 1px solid var(--oc-color-border) !important;
+  margin-bottom: 8px;
 }
 
 #clipboard-btns {

--- a/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.ts
+++ b/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.ts
@@ -90,6 +90,13 @@ describe('CreateAndUpload component', () => {
       const { wrapper } = getWrapper({ newFileHandlers: fileHandlerMocks })
       expect(wrapper.html()).toMatchSnapshot()
     })
+    it('should show file extension if file extensions are enabled', () => {
+      const { wrapper } = getWrapper({
+        newFileHandlers: fileHandlerMocks,
+        areFileExtensionsShown: true
+      })
+      expect(wrapper.html()).toMatchSnapshot()
+    })
   })
   describe('clipboard buttons', () => {
     it('should show if clipboard is empty', () => {
@@ -175,7 +182,8 @@ function getWrapper({
   spaces = [],
   item = undefined,
   itemId = undefined,
-  newFileAction = false
+  newFileAction = false,
+  areFileExtensionsShown = false
 } = {}) {
   jest.mocked(useRequest).mockImplementation(() => ({
     makeRequest: jest.fn().mockResolvedValue({ status: 200 })
@@ -197,6 +205,7 @@ function getWrapper({
   storeOptions.getters.apps.mockImplementation(() => ({
     fileEditors: []
   }))
+  storeOptions.modules.Files.state.areFileExtensionsShown = areFileExtensionsShown
   storeOptions.modules.Files.getters.currentFolder.mockImplementation(() => currentFolder)
   storeOptions.modules.Files.getters.clipboardResources.mockImplementation(() => clipboardResources)
   storeOptions.modules.runtime.modules.spaces.getters.spaces.mockReturnValue(spaces)

--- a/packages/web-app-files/tests/unit/components/AppBar/__snapshots__/CreateAndUpload.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/AppBar/__snapshots__/CreateAndUpload.spec.ts.snap
@@ -58,15 +58,6 @@ exports[`CreateAndUpload component file handlers should show additional handlers
         </button>
       </li>
       <!--v-if-->
-      <li class="create-list-shortcut oc-menu-item-hover">
-        <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="new-shortcut-btn" type="button">
-          <!--v-if-->
-          <!-- @slot Content of the button -->
-          <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="external-link" size="medium" type="span" variation="passive"></oc-icon-stub>
-          <span>Shortcut</span>
-          <!--v-if-->
-        </button>
-      </li>
       <li class="create-list-file oc-menu-item-hover">
         <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw new-file-btn-txt" type="button">
           <!--v-if-->
@@ -91,6 +82,15 @@ exports[`CreateAndUpload component file handlers should show additional handlers
           <!-- @slot Content of the button -->
           <oc-resource-icon-stub resource="[object Object]" size="medium"></oc-resource-icon-stub>
           <span class="create-list-file-item-text">Draw.io document</span>
+          <!--v-if-->
+        </button>
+      </li>
+      <li class="create-list-shortcut oc-menu-item-hover">
+        <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="new-shortcut-btn" type="button">
+          <!--v-if-->
+          <!-- @slot Content of the button -->
+          <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="external-link" size="medium" type="span" variation="passive"></oc-icon-stub>
+          <span>Shortcut</span>
           <!--v-if-->
         </button>
       </li>
@@ -142,15 +142,6 @@ exports[`CreateAndUpload component file handlers should show file extension if f
         </button>
       </li>
       <!--v-if-->
-      <li class="create-list-shortcut oc-menu-item-hover">
-        <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="new-shortcut-btn" type="button">
-          <!--v-if-->
-          <!-- @slot Content of the button -->
-          <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="external-link" size="medium" type="span" variation="passive"></oc-icon-stub>
-          <span>Shortcut</span>
-          <span class="create-list-file-item-extension">url</span>
-        </button>
-      </li>
       <li class="create-list-file oc-menu-item-hover">
         <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw new-file-btn-txt" type="button">
           <!--v-if-->
@@ -176,6 +167,15 @@ exports[`CreateAndUpload component file handlers should show file extension if f
           <oc-resource-icon-stub resource="[object Object]" size="medium"></oc-resource-icon-stub>
           <span class="create-list-file-item-text">Draw.io document</span>
           <span class="create-list-file-item-extension">drawio</span>
+        </button>
+      </li>
+      <li class="create-list-shortcut oc-menu-item-hover">
+        <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="new-shortcut-btn" type="button">
+          <!--v-if-->
+          <!-- @slot Content of the button -->
+          <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="external-link" size="medium" type="span" variation="passive"></oc-icon-stub>
+          <span>Shortcut</span>
+          <span class="create-list-file-item-extension">url</span>
         </button>
       </li>
     </oc-list-stub>

--- a/packages/web-app-files/tests/unit/components/AppBar/__snapshots__/CreateAndUpload.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/AppBar/__snapshots__/CreateAndUpload.spec.ts.snap
@@ -48,7 +48,7 @@ exports[`CreateAndUpload component file handlers should show additional handlers
     </button>
   </span>
   <oc-drop-stub class="oc-width-auto" closeonclick="true" dropid="new-file-menu-drop" isnested="false" mode="click" paddingsize="small" position="bottom-start" toggle="#new-file-menu-btn">
-    <oc-list-stub id="create-list" raw="false">
+    <oc-list-stub class="" id="create-list" raw="false">
       <li class="create-list-folder oc-menu-item-hover">
         <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="new-folder-btn" type="button">
           <!--v-if-->
@@ -57,13 +57,14 @@ exports[`CreateAndUpload component file handlers should show additional handlers
           <span>Folder</span>
         </button>
       </li>
-      <li class="bottom-seperator"></li>
+      <!--v-if-->
       <li class="create-list-shortcut oc-menu-item-hover">
         <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="new-shortcut-btn" type="button">
           <!--v-if-->
           <!-- @slot Content of the button -->
           <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="external-link" size="medium" type="span" variation="passive"></oc-icon-stub>
           <span>Shortcut</span>
+          <!--v-if-->
         </button>
       </li>
       <li class="create-list-file oc-menu-item-hover">
@@ -91,6 +92,90 @@ exports[`CreateAndUpload component file handlers should show additional handlers
           <oc-resource-icon-stub resource="[object Object]" size="medium"></oc-resource-icon-stub>
           <span class="create-list-file-item-text">Draw.io document</span>
           <!--v-if-->
+        </button>
+      </li>
+    </oc-list-stub>
+  </oc-drop-stub>
+  <span>
+    <button aria-label="Upload files or folders" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-outline" id="upload-menu-btn" type="button">
+      <!--v-if-->
+      <!-- @slot Content of the button -->
+      <oc-icon-stub accessiblelabel="" color="" filltype="line" name="upload" size="medium" type="span" variation="passive"></oc-icon-stub>
+      <span>Upload</span>
+    </button>
+  </span>
+  <oc-drop-stub class="oc-width-auto" closeonclick="true" dropid="upload-menu-drop" isnested="false" mode="click" paddingsize="small" position="bottom-start" toggle="#upload-menu-btn">
+    <oc-list-stub class="" id="upload-list" raw="false">
+      <li class="oc-menu-item-hover">
+        <resource-upload-stub btnclass="oc-width-1-1" btnlabel="" isfolder="false"></resource-upload-stub>
+      </li>
+      <li class="oc-menu-item-hover">
+        <resource-upload-stub btnclass="oc-width-1-1" btnlabel="" isfolder="true"></resource-upload-stub>
+      </li>
+    </oc-list-stub>
+    <!--v-if-->
+  </oc-drop-stub>
+  <!--v-if-->
+</div>
+`;
+
+exports[`CreateAndUpload component file handlers should show file extension if file extensions are enabled 1`] = `
+<!--v-if-->
+
+<div class="create-and-upload-actions oc-flex-inline oc-mr-s">
+  <span>
+    <button aria-label="Create new files or folders" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-primary oc-button-primary-filled" id="new-file-menu-btn" type="button">
+      <!--v-if-->
+      <!-- @slot Content of the button -->
+      <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="add" size="medium" type="span" variation="passive"></oc-icon-stub>
+      <span>New</span>
+    </button>
+  </span>
+  <oc-drop-stub class="oc-width-auto" closeonclick="true" dropid="new-file-menu-drop" isnested="false" mode="click" paddingsize="small" position="bottom-start" toggle="#new-file-menu-btn">
+    <oc-list-stub class="expanded-list" id="create-list" raw="false">
+      <li class="create-list-folder oc-menu-item-hover">
+        <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="new-folder-btn" type="button">
+          <!--v-if-->
+          <!-- @slot Content of the button -->
+          <oc-resource-icon-stub resource="[object Object]" size="medium"></oc-resource-icon-stub>
+          <span>Folder</span>
+        </button>
+      </li>
+      <!--v-if-->
+      <li class="create-list-shortcut oc-menu-item-hover">
+        <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="new-shortcut-btn" type="button">
+          <!--v-if-->
+          <!-- @slot Content of the button -->
+          <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="external-link" size="medium" type="span" variation="passive"></oc-icon-stub>
+          <span>Shortcut</span>
+          <span class="create-list-file-item-extension">url</span>
+        </button>
+      </li>
+      <li class="create-list-file oc-menu-item-hover">
+        <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw new-file-btn-txt" type="button">
+          <!--v-if-->
+          <!-- @slot Content of the button -->
+          <oc-resource-icon-stub resource="[object Object]" size="medium"></oc-resource-icon-stub>
+          <span class="create-list-file-item-text">Plain text file</span>
+          <span class="create-list-file-item-extension">txt</span>
+        </button>
+      </li>
+      <li class="create-list-file oc-menu-item-hover">
+        <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw new-file-btn-md" type="button">
+          <!--v-if-->
+          <!-- @slot Content of the button -->
+          <oc-resource-icon-stub resource="[object Object]" size="medium"></oc-resource-icon-stub>
+          <span class="create-list-file-item-text">Mark-down file</span>
+          <span class="create-list-file-item-extension">md</span>
+        </button>
+      </li>
+      <li class="create-list-file oc-menu-item-hover">
+        <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw new-file-btn-drawio" type="button">
+          <!--v-if-->
+          <!-- @slot Content of the button -->
+          <oc-resource-icon-stub resource="[object Object]" size="medium"></oc-resource-icon-stub>
+          <span class="create-list-file-item-text">Draw.io document</span>
+          <span class="create-list-file-item-extension">drawio</span>
         </button>
       </li>
     </oc-list-stub>

--- a/packages/web-app-files/tests/unit/components/AppBar/__snapshots__/CreateAndUpload.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/AppBar/__snapshots__/CreateAndUpload.spec.ts.snap
@@ -57,12 +57,22 @@ exports[`CreateAndUpload component file handlers should show additional handlers
           <span>Folder</span>
         </button>
       </li>
+      <li class="bottom-seperator"></li>
+      <li class="create-list-shortcut oc-menu-item-hover">
+        <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="new-shortcut-btn" type="button">
+          <!--v-if-->
+          <!-- @slot Content of the button -->
+          <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="external-link" size="medium" type="span" variation="passive"></oc-icon-stub>
+          <span>Shortcut</span>
+        </button>
+      </li>
       <li class="create-list-file oc-menu-item-hover">
         <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw new-file-btn-txt" type="button">
           <!--v-if-->
           <!-- @slot Content of the button -->
           <oc-resource-icon-stub resource="[object Object]" size="medium"></oc-resource-icon-stub>
-          <span>Plain text file</span>
+          <span class="create-list-file-item-text">Plain text file</span>
+          <!--v-if-->
         </button>
       </li>
       <li class="create-list-file oc-menu-item-hover">
@@ -70,7 +80,8 @@ exports[`CreateAndUpload component file handlers should show additional handlers
           <!--v-if-->
           <!-- @slot Content of the button -->
           <oc-resource-icon-stub resource="[object Object]" size="medium"></oc-resource-icon-stub>
-          <span>Mark-down file</span>
+          <span class="create-list-file-item-text">Mark-down file</span>
+          <!--v-if-->
         </button>
       </li>
       <li class="create-list-file oc-menu-item-hover">
@@ -78,15 +89,8 @@ exports[`CreateAndUpload component file handlers should show additional handlers
           <!--v-if-->
           <!-- @slot Content of the button -->
           <oc-resource-icon-stub resource="[object Object]" size="medium"></oc-resource-icon-stub>
-          <span>Draw.io document</span>
-        </button>
-      </li>
-      <li class="create-list-shortcut oc-menu-item-hover">
-        <button class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="new-shortcut-btn" type="button">
+          <span class="create-list-file-item-text">Draw.io document</span>
           <!--v-if-->
-          <!-- @slot Content of the button -->
-          <oc-icon-stub accessiblelabel="" color="" filltype="fill" name="external-link" size="medium" type="span" variation="passive"></oc-icon-stub>
-          <span>Shortcut</span>
         </button>
       </li>
     </oc-list-stub>

--- a/packages/web-test-helpers/src/mocks/store/filesModuleMockOptions.ts
+++ b/packages/web-test-helpers/src/mocks/store/filesModuleMockOptions.ts
@@ -4,7 +4,8 @@ export const filesModuleMockOptions = {
     state: {
       highlightedFile: undefined,
       currentFolder: undefined,
-      latestSelectedId: undefined
+      latestSelectedId: undefined,
+      areFileExtensionsShown: undefined
     },
     getters: {
       currentFolder: jest.fn(),


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
See https://github.com/owncloud/web/issues/9846

## Related Issue
- Fixes https://github.com/owncloud/web/issues/9846

## Screenshots (if appropriate):
![Screenshot (89)](https://github.com/owncloud/web/assets/786551/f1bc208e-bcdc-4454-8ad5-56bcc0fcfc12)
![Screenshot (88)](https://github.com/owncloud/web/assets/786551/54234f8c-af50-4050-81c0-421fb9de9cfe)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
