### PR TITLE
Keep both conflict

### DIFF
--- a/changelog/unreleased/bugfix-keep-both-conflict
+++ b/changelog/unreleased/bugfix-keep-both-conflict
@@ -1,4 +1,4 @@
-Bugfix: Keep both folders and their files when parent and child folder has same name
+Bugfix: Keep both folders conflict in same-named folders
 
 Parsing has been adjusted to account for edge case of multiple folders and sub-folders with the same name
 

--- a/changelog/unreleased/bugfix-keep-both-conflict
+++ b/changelog/unreleased/bugfix-keep-both-conflict
@@ -1,0 +1,6 @@
+Bugfix: Keep both folders and their files when parent and child folder has same name
+
+Parsing has been adjusted to account for edge case of multiple folders and sub-folders with the same name
+
+https://github.com/owncloud/web/pull/9915
+https://github.com/owncloud/web/issues/9158

--- a/packages/web-app-files/src/helpers/resource/actions/upload.ts
+++ b/packages/web-app-files/src/helpers/resource/actions/upload.ts
@@ -73,13 +73,10 @@ export class ResourceConflict extends ConflictDialog {
     let allConflictsStrategy
     let doForAllConflictsFolders = false
     let allConflictsStrategyFolders
-    console.log('upload.ts executed')
 
     for (const conflict of conflicts) {
-      console.log(conflict, 'conflict')
       const isFolder = conflict.type === 'folder'
       const conflictArray = isFolder ? resolvedFolderConflicts : resolvedFileConflicts
-      console.log(conflict, 'conflictArr')
 
       if (doForAllConflicts && !isFolder) {
         conflictArray.push({

--- a/packages/web-app-files/src/helpers/resource/actions/upload.ts
+++ b/packages/web-app-files/src/helpers/resource/actions/upload.ts
@@ -73,10 +73,13 @@ export class ResourceConflict extends ConflictDialog {
     let allConflictsStrategy
     let doForAllConflictsFolders = false
     let allConflictsStrategyFolders
+    console.log('upload.ts executed')
 
     for (const conflict of conflicts) {
+      console.log(conflict, 'conflict')
       const isFolder = conflict.type === 'folder'
       const conflictArray = isFolder ? resolvedFolderConflicts : resolvedFileConflicts
+      console.log(conflict, 'conflictArr')
 
       if (doForAllConflicts && !isFolder) {
         conflictArray.push({
@@ -165,18 +168,18 @@ export class ResourceConflict extends ConflictDialog {
           `/${newFolderName}/`
         )
         file.meta.tusEndpoint = file.meta.tusEndpoint.replace(
-          new RegExp(`/${encodeURIComponent(folder)}`),
+          new RegExp(`/${encodeURIComponent(folder)}$`),
           `/${encodeURIComponent(newFolderName)}`
         )
         if (file.xhrUpload?.endpoint) {
           file.xhrUpload.endpoint = file.xhrUpload.endpoint.replace(
-            new RegExp(`/${encodeURIComponent(folder)}`),
+            new RegExp(`/${encodeURIComponent(folder)}$`),
             `/${encodeURIComponent(newFolderName)}`
           )
         }
         if (file.tus?.endpoint) {
           file.tus.endpoint = file.tus.endpoint.replace(
-            new RegExp(`/${encodeURIComponent(folder)}`),
+            new RegExp(`/${encodeURIComponent(folder)}$`),
             `/${encodeURIComponent(newFolderName)}`
           )
         }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
In case of /folder/folder where result should be /folder/folder (1) to resolve conflict, regex updated URL to /folder(1)/folder

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9158


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

