### PR TITLE
fix: closing editors on search result page

### DIFF
--- a/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
+++ b/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
@@ -172,8 +172,8 @@ export default defineComponent({
             driveAliasAndItem
           },
           query: {
+            ...unref(currentRoute).query,
             fileId: id,
-            ...(unref(currentRoute).query?.app && { app: unref(currentRoute).query?.app }),
             contextRouteName: 'files-spaces-generic',
             contextRouteParams: { driveAliasAndItem: dirname(driveAliasAndItem) } as any
           }
@@ -186,9 +186,9 @@ export default defineComponent({
           driveAliasAndItem
         },
         query: {
+          ...unref(currentRoute).query,
           fileId: id,
           shareId: space.shareId,
-          ...(unref(currentRoute).query?.app && { app: unref(currentRoute).query?.app }),
           contextRouteName: path === '/' ? 'files-shares-with-me' : 'files-spaces-generic',
           contextRouteParams: {
             driveAliasAndItem: dirname(driveAliasAndItem)


### PR DESCRIPTION
## Description
We noticed this error in the ocis pipeline: https://drone.owncloud.com/owncloud/ocis/28475/40/12. For some reason it didn't fail in Web...

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Regression from https://github.com/owncloud/web/pull/9891.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
