### PR TITLE
Vite serve cern

### DIFF
--- a/vite.cern.config.ts
+++ b/vite.cern.config.ts
@@ -19,6 +19,11 @@ export default defineConfig(async (args) => {
     config = _defineConfig
   }
 
+  config.server = {
+    port: 9201,
+    strictPort: true
+  }
+
   // collapsible table
   config.resolve.alias['design-system/src/components/OcTable/OcTable.vue'] = join(
     projectRootDir,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -163,13 +163,6 @@ export default defineConfig(async ({ mode, command }) => {
   const configUrl =
     process.env.OWNCLOUD_WEB_CONFIG_URL || 'https://host.docker.internal:9200/config.json'
 
-  let proxiedServerUrl
-  if (command === 'serve') {
-    // determine server url
-    const configJson = await getJson(configUrl)
-    proxiedServerUrl = configJson.server
-  }
-
   config = {
     ...(!production && {
       server: {


### PR DESCRIPTION
This allows us to run in debug mode in our config behind nginx (removes ssl which is handled by nginx, basically).

I've also deleted some code from your main config file... This code was not being used anywhere, but I don't know if you use it to check if accessing the config file succeeds while you build. Either way, you would notice it as soon as you launch web, as it will try to load the config either way, no?
If not, I can download our config by passing the env var with a diff url.