### PR TITLE
fix: respect details query on private links

### DIFF
--- a/changelog/unreleased/bugfix-respect-details-query
+++ b/changelog/unreleased/bugfix-respect-details-query
@@ -1,0 +1,6 @@
+Bugfix: Respect "details"-query on private links
+
+The "details"-query on private links is now being respected properly when `openLinksWithDefaultApp` is enabled. This fixed an issue where the sidebar would not open despite requesting to do so.
+
+https://github.com/owncloud/web/issues/9868
+https://github.com/owncloud/web/pull/9947

--- a/packages/web-runtime/src/pages/resolvePrivateLink.vue
+++ b/packages/web-runtime/src/pages/resolvePrivateLink.vue
@@ -120,16 +120,18 @@ export default defineComponent({
         }
 
         const { params, query } = createFileRouteOptions(space, { fileId, path })
+        const openWithDefault =
+          configurationManager.options.openLinksWithDefaultApp &&
+          unref(openWithDefaultApp) !== 'false' &&
+          !unref(details)
+
         targetLocation.params = params
         targetLocation.query = {
           ...query,
           scrollTo:
             targetLocation.name === 'files-shares-with-me' ? space.shareId : unref(resource).fileId,
           ...(unref(details) && { details: unref(details) }),
-          ...(configurationManager.options.openLinksWithDefaultApp &&
-            unref(openWithDefaultApp) !== 'false' && {
-              openWithDefaultApp: 'true'
-            })
+          ...(openWithDefault && { openWithDefaultApp: 'true' })
         }
 
         router.push(targetLocation)

--- a/packages/web-runtime/src/pages/resolvePrivateLink.vue
+++ b/packages/web-runtime/src/pages/resolvePrivateLink.vue
@@ -5,7 +5,7 @@
     <div class="oc-card oc-text-center oc-width-large">
       <template v-if="loading">
         <div class="oc-card-header">
-          <h2 key="private-link-loading">
+          <h2 key="private-link-loading" class="oc-link-resolve-loading">
             <span v-text="$gettext('Resolving private link…')" />
           </h2>
         </div>
@@ -198,7 +198,10 @@ export default defineComponent({
       resource,
       isUnacceptedShareError,
       sharedWithMeRoute,
-      openSharedWithMeLabel
+      openSharedWithMeLabel,
+
+      // HACK: for unit tests
+      resolvePrivateLinkTask
     }
   }
 })

--- a/packages/web-runtime/tests/unit/pages/resolvePrivateLink.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/resolvePrivateLink.spec.ts
@@ -1,5 +1,149 @@
-import { describe } from '@jest/globals'
+import resolvePrivateLink from '../../../src/pages/resolvePrivateLink.vue'
+import {
+  defaultPlugins,
+  defaultComponentMocks,
+  createStore,
+  shallowMount,
+  defaultStoreMockOptions
+} from 'web-test-helpers'
+import { mock } from 'jest-mock-extended'
+import {
+  ConfigurationManager,
+  queryItemAsString,
+  useConfigurationManager,
+  useGetResourceContext
+} from '@ownclouders/web-pkg'
+import { Resource, SpaceResource } from '@ownclouders/web-client'
 
-describe('resolvePrivateLink view', () => {
-  it.todo('Write tests')
+jest.mock('@ownclouders/web-pkg', () => ({
+  ...jest.requireActual('@ownclouders/web-pkg'),
+  useRouteQuery: jest.fn(),
+  useRouteParam: jest.fn(),
+  queryItemAsString: jest.fn(),
+  useGetResourceContext: jest.fn(),
+  useConfigurationManager: jest.fn()
+}))
+
+const selectors = {
+  loadingHeadline: '.oc-link-resolve-loading'
+}
+
+describe('resolvePrivateLink', () => {
+  it('is in a loading state initially', () => {
+    const { wrapper } = getWrapper()
+    expect(wrapper.find(selectors.loadingHeadline).exists()).toBeTruthy()
+  })
+  it('resolves to "files-spaces-generic" and passes the scrollTo query', async () => {
+    const fileId = '1'
+    const driveAliasAndItem = 'personal/home'
+    const space = mock<SpaceResource>({ getDriveAliasAndItem: () => driveAliasAndItem })
+    const resource = mock<Resource>({ fileId })
+    const { wrapper, mocks } = getWrapper({ space, resource, fileId })
+    await wrapper.vm.resolvePrivateLinkTask.last
+    expect(mocks.$router.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'files-spaces-generic',
+        params: expect.objectContaining({ driveAliasAndItem }),
+        query: expect.objectContaining({ scrollTo: fileId })
+      })
+    )
+  })
+  it('resolves to "files-shares-with-me" for received single file shares', async () => {
+    const fileId = '1'
+    const driveAliasAndItem = 'shares/someShare'
+    const space = mock<SpaceResource>({
+      driveType: 'share',
+      getDriveAliasAndItem: () => driveAliasAndItem
+    })
+    const resource = mock<Resource>({ fileId, type: 'file' })
+    const { wrapper, mocks } = getWrapper({ space, resource, fileId, path: '/' })
+    await wrapper.vm.resolvePrivateLinkTask.last
+    expect(mocks.$router.push).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'files-shares-with-me' })
+    )
+  })
+  it('passes the details query paramif given via query', async () => {
+    const details = 'sharing'
+    const { wrapper, mocks } = getWrapper({ details })
+    await wrapper.vm.resolvePrivateLinkTask.last
+    expect(mocks.$router.push).toHaveBeenCalledWith(
+      expect.objectContaining({ query: expect.objectContaining({ details }) })
+    )
+  })
+  describe('openWithDefaultApp', () => {
+    it('correctly passes the openWithDefaultApp param if enabled and given via query', async () => {
+      const { wrapper, mocks } = getWrapper()
+      await wrapper.vm.resolvePrivateLinkTask.last
+      expect(mocks.$router.push).toHaveBeenCalledWith(
+        expect.objectContaining({ query: expect.objectContaining({ openWithDefaultApp: 'true' }) })
+      )
+    })
+    it('does not pass the openWithDefaultApp param when details param is given', async () => {
+      const { wrapper, mocks } = getWrapper({ details: 'sharing' })
+      await wrapper.vm.resolvePrivateLinkTask.last
+      expect(mocks.$router.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.not.objectContaining({ openWithDefaultApp: 'true' })
+        })
+      )
+    })
+    it('does not pass the openWithDefaultApp param when disabled via config', async () => {
+      const { wrapper, mocks } = getWrapper({ openLinksWithDefaultApp: false })
+      await wrapper.vm.resolvePrivateLinkTask.last
+      expect(mocks.$router.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.not.objectContaining({ openWithDefaultApp: 'true' })
+        })
+      )
+    })
+    it('does not pass the openWithDefaultApp param when not requested via query', async () => {
+      const { wrapper, mocks } = getWrapper({ openWithDefaultAppQuery: 'false' })
+      await wrapper.vm.resolvePrivateLinkTask.last
+      expect(mocks.$router.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.not.objectContaining({ openWithDefaultApp: 'true' })
+        })
+      )
+    })
+  })
 })
+
+function getWrapper({
+  space = mock<SpaceResource>(),
+  resource = mock<Resource>(),
+  path = '',
+  fileId = '',
+  details = '',
+  openWithDefaultAppQuery = 'true',
+  openLinksWithDefaultApp = true
+} = {}) {
+  jest.mocked(queryItemAsString).mockReturnValueOnce(fileId)
+  jest.mocked(queryItemAsString).mockReturnValueOnce(openWithDefaultAppQuery)
+  jest.mocked(queryItemAsString).mockReturnValueOnce(details)
+
+  jest.mocked(useGetResourceContext).mockReturnValue({
+    getResourceContext: jest.fn().mockResolvedValue({ space, resource, path })
+  })
+  jest.mocked(useConfigurationManager).mockImplementation(() =>
+    mock<ConfigurationManager>({
+      options: {
+        openLinksWithDefaultApp
+      }
+    })
+  )
+
+  const mocks = { ...defaultComponentMocks() }
+  const storeOptions = defaultStoreMockOptions
+  const store = createStore(storeOptions)
+
+  return {
+    mocks,
+    wrapper: shallowMount(resolvePrivateLink, {
+      global: {
+        plugins: [...defaultPlugins(), store],
+        mocks,
+        provide: mocks
+      }
+    })
+  }
+}


### PR DESCRIPTION
## Description
Properly respect the `details` query on private links when `openLinksWithDefaultApp` is enabled. This fixes an issue where the sidebar would not open despite requesting to do so.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9868

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
