### PR TITLE
[full-ci] change e2e test for enforce pass

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -882,7 +882,7 @@ def acceptance(ctx):
                         services = browserService(alternateSuiteName, browser) + middlewareService()
 
                         # Services and steps required for running tests with oCIS
-                        steps += restoreOcisCache() + ocisService("acceptance-tests") + getSkeletonFiles()
+                        steps += restoreOcisCache() + ocisService("acceptance-tests", enforce_password_public_link_disabled = True) + getSkeletonFiles()
 
                         # Wait for test-related services to be up
                         steps += waitForBrowserService()
@@ -1263,7 +1263,7 @@ def webService():
         ],
     }]
 
-def ocisService(type, tika_enabled = False):
+def ocisService(type, tika_enabled = False, enforce_password_public_link_disabled = False):
     environment = {
         "IDM_ADMIN_PASSWORD": "admin",  # override the random admin password from `ocis init`
         "OCIS_INSECURE": "true",
@@ -1276,12 +1276,6 @@ def ocisService(type, tika_enabled = False):
         "FRONTEND_SEARCH_MIN_LENGTH": "2",
         "FRONTEND_OCS_ENABLE_DENIALS": True,
         "FRONTEND_PASSWORD_POLICY_BANNED_PASSWORDS_LIST": "%s/tests/drone/banned-passwords.txt" % dir["web"],
-        "OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD": False,
-        "FRONTEND_PASSWORD_POLICY_MIN_CHARACTERS": 0,
-        "FRONTEND_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS": 0,
-        "FRONTEND_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS": 0,
-        "FRONTEND_PASSWORD_POLICY_MIN_DIGITS": 0,
-        "FRONTEND_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS": 0,
     }
     if type == "app-provider":
         environment["GATEWAY_GRPC_ADDR"] = "0.0.0.0:9142"
@@ -1296,6 +1290,14 @@ def ocisService(type, tika_enabled = False):
         environment["SEARCH_EXTRACTOR_TYPE"] = "tika"
         environment["SEARCH_EXTRACTOR_TIKA_TIKA_URL"] = "http://tika:9998"
         environment["SEARCH_EXTRACTOR_CS3SOURCE_INSECURE"] = True
+
+    if enforce_password_public_link_disabled:
+        environment["OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD"] = False
+        environment["FRONTEND_PASSWORD_POLICY_MIN_CHARACTERS"] = 0
+        environment["FRONTEND_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS"] = 0
+        environment["FRONTEND_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS"] = 0
+        environment["FRONTEND_PASSWORD_POLICY_MIN_DIGITS"] = 0
+        environment["FRONTEND_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS"] = 0
 
     return [
         {

--- a/.drone.star
+++ b/.drone.star
@@ -882,7 +882,7 @@ def acceptance(ctx):
                         services = browserService(alternateSuiteName, browser) + middlewareService()
 
                         # Services and steps required for running tests with oCIS
-                        steps += restoreOcisCache() + ocisService("acceptance-tests", enforce_password_public_link_disabled = True) + getSkeletonFiles()
+                        steps += restoreOcisCache() + ocisService("acceptance-tests", enforce_password_public_link = True) + getSkeletonFiles()
 
                         # Wait for test-related services to be up
                         steps += waitForBrowserService()
@@ -1263,7 +1263,7 @@ def webService():
         ],
     }]
 
-def ocisService(type, tika_enabled = False, enforce_password_public_link_disabled = False):
+def ocisService(type, tika_enabled = False, enforce_password_public_link = False):
     environment = {
         "IDM_ADMIN_PASSWORD": "admin",  # override the random admin password from `ocis init`
         "OCIS_INSECURE": "true",
@@ -1291,7 +1291,7 @@ def ocisService(type, tika_enabled = False, enforce_password_public_link_disable
         environment["SEARCH_EXTRACTOR_TIKA_TIKA_URL"] = "http://tika:9998"
         environment["SEARCH_EXTRACTOR_CS3SOURCE_INSECURE"] = True
 
-    if enforce_password_public_link_disabled:
+    if enforce_password_public_link:
         environment["OCIS_SHARING_PUBLIC_SHARE_MUST_HAVE_PASSWORD"] = False
         environment["FRONTEND_PASSWORD_POLICY_MIN_CHARACTERS"] = 0
         environment["FRONTEND_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS"] = 0

--- a/dev/docker/ocis/password-policy-banned-passwords.txt
+++ b/dev/docker/ocis/password-policy-banned-passwords.txt
@@ -1,2 +1,3 @@
 password
 12345678
+ownCloud-1

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -82,7 +82,8 @@ Various options are available via ENV variables, e.g.
 - `SLOW_MO=n` to slow the execution time by `n` milliseconds
 - `TIMEOUT=n` to set tests to timeout after `n` milliseconds
 - `HEADLESS=bool` to open the browser while the tests run (defaults to true => headless mode)
-- `BROWSER=name` to run tests against a specific browser. Defaults to Chrome, available are Chrome, Firefox, Webkit, Chromium
+- `BROWSER=name` to run tests against a specific browser. Defaults to chromium, available are chromium, firefox, webkit, chromium
+- `ADMIN_PASSWORD` to set administrator password. By default, the `admin` password is used in the test
 
 For debugging reasons, you may want to record a video or traces of your test run.
 Again, you can use the following ENV variables in your command:
@@ -137,7 +138,7 @@ If you're using a M1 Mac, you need to use `seleniarm/standalone-chromium:4.7.0-2
 #### Run acceptance tests
 
 - Change the directory to `tests/acceptance`
-- Install all the test dependencies with `pnpm` command
+- Install all the test dependencies with `pnpm install` command
 - Run the tests
 
   ```shell

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -190,8 +190,6 @@ export default defineComponent({
           return
         }
 
-        debugger
-
         let viewMode = props.isReadOnly ? 'view' : 'write'
         if (
           determineOpenAsPreview(unref(applicationName)) &&

--- a/tests/drone/banned-passwords.txt
+++ b/tests/drone/banned-passwords.txt
@@ -1,2 +1,3 @@
 password
 12345678
+ownCloud-1

--- a/tests/e2e/cucumber/features/smoke/app-provider/officeSuites.feature
+++ b/tests/e2e/cucumber/features/smoke/app-provider/officeSuites.feature
@@ -16,10 +16,11 @@ Feature: Integrate with online office suites like Collabora and OnlyOffice
     When "Alice" creates the following resources
       | resource         | type         | content              |
       | OpenDocument.odt | OpenDocument | OpenDocument Content |
-    And "Alice" creates a public link for the resource "OpenDocument.odt" using the sidebar panel
+    And "Alice" creates a public link for the resource "OpenDocument.odt" with password "%public%" using the sidebar panel
     And "Alice" edits the public link named "Link" of resource "OpenDocument.odt" changing role to "Can edit"
     And "Alice" logs out
     And "Anonymous" opens the public link "Link"
+    And "Anonymous" unlocks the public link with password "%public%"
     Then "Anonymous" should see the content "OpenDocument Content" in editor "Collabora"
 
 
@@ -27,8 +28,9 @@ Feature: Integrate with online office suites like Collabora and OnlyOffice
     When "Alice" creates the following resources
       | resource           | type           | content                |
       | MicrosoftWord.docx | Microsoft Word | Microsoft Word Content |
-    And "Alice" creates a public link for the resource "MicrosoftWord.docx" using the sidebar panel
+    And "Alice" creates a public link for the resource "MicrosoftWord.docx" with password "%public%" using the sidebar panel
     And "Alice" edits the public link named "Link" of resource "MicrosoftWord.docx" changing role to "Can edit"
     And "Alice" logs out
     And "Anonymous" opens the public link "Link"
+    And "Anonymous" unlocks the public link with password "%public%"
     Then "Anonymous" should see the content "Microsoft Word Content" in editor "OnlyOffice"

--- a/tests/e2e/cucumber/features/smoke/internalLink.feature
+++ b/tests/e2e/cucumber/features/smoke/internalLink.feature
@@ -1,5 +1,6 @@
 Feature: internal link share
 
+
   Scenario: share a link with internal role
     Given "Admin" creates following users using API
       | id    |
@@ -13,7 +14,7 @@ Feature: internal link share
       | resource | recipient | type | role     |
       | myfolder | Brian     | user | Can edit |
     And "Alice" opens the "files" app
-    And "Alice" creates a public link for the resource "myfolder" using the sidebar panel
+    And "Alice" creates a public link for the resource "myfolder" with password "%public%" using the sidebar panel
     When "Alice" edits the public link named "Link" of resource "myfolder" changing role to "Invited people"
     And "Brian" opens the public link "Link"
     And "Brian" logs in from the internal link

--- a/tests/e2e/cucumber/features/smoke/link.feature
+++ b/tests/e2e/cucumber/features/smoke/link.feature
@@ -15,13 +15,12 @@ Feature: link
     And "Alice" uploads the following resources
       | resource  | to           |
       | lorem.txt | folderPublic |
-    And "Alice" creates a public link for the resource "folderPublic" using the sidebar panel
+    And "Alice" creates a public link for the resource "folderPublic" with password "%public%" using the sidebar panel
     And "Alice" renames the most recently created public link of resource "folderPublic" to "myPublicLink"
     And "Alice" edits the public link named "myPublicLink" of resource "folderPublic" changing role to "Secret File Drop"
     And "Alice" sets the expiration date of the public link named "myPublicLink" of resource "folderPublic" to "+5 days"
-    And "Alice" sets the password of the public link named "myPublicLink" of resource "folderPublic" to "12345"
     When "Anonymous" opens the public link "myPublicLink"
-    And "Anonymous" unlocks the public link with password "12345"
+    And "Anonymous" unlocks the public link with password "%public%"
     And "Anonymous" drop uploads following resources
       | resource     |
       | textfile.txt |
@@ -57,8 +56,9 @@ Feature: link
       | pathToFile             | content     |
       | folderPublic/lorem.txt | lorem ipsum |
     And "Alice" opens the "files" app
-    When "Alice" copies quick link of the resource "folderPublic" from the context menu
+    When "Alice" creates quick link of the resource "folderPublic" with password "%public%" from the context menu
     And "Anonymous" opens the public link "Link"
+    And "Anonymous" unlocks the public link with password "%public%"
     And "Anonymous" downloads the following public link resources using the sidebar panel
       | resource  | type |
       | lorem.txt | file |
@@ -86,28 +86,37 @@ Feature: link
       | folderPublic   | Brian     | user | Can edit |
       | simple.pdf     | Brian     | user | Can edit |
       | testavatar.jpg | Brian     | user | Can edit |
-    And "Alice" creates a public link for the resource "folderPublic" using the sidebar panel
+    And "Alice" creates a public link for the resource "folderPublic" with password "%public%" using the sidebar panel
     And "Alice" renames the most recently created public link of resource "folderPublic" to "folderLink"
-    And "Alice" creates a public link for the resource "folderPublic/shareToBrian.txt" using the sidebar panel
+    And "Alice" creates a public link for the resource "folderPublic/shareToBrian.txt" with password "%public%" using the sidebar panel
     And "Alice" renames the most recently created public link of resource "folderPublic/shareToBrian.txt" to "textLink"
-    And "Alice" creates a public link for the resource "folderPublic/shareToBrian.md" using the sidebar panel
+    And "Alice" creates a public link for the resource "folderPublic/shareToBrian.md" with password "%public%" using the sidebar panel
     And "Alice" renames the most recently created public link of resource "folderPublic/shareToBrian.md" to "markdownLink"
-    And "Alice" creates a public link for the resource "simple.pdf" using the sidebar panel
+    And "Alice" creates a public link for the resource "simple.pdf" with password "%public%" using the sidebar panel
     And "Alice" renames the most recently created public link of resource "simple.pdf" to "pdfLink"
-    And "Alice" creates a public link for the resource "testavatar.jpg" using the sidebar panel
+    And "Alice" creates a public link for the resource "testavatar.jpg" with password "%public%" using the sidebar panel
     And "Alice" renames the most recently created public link of resource "testavatar.jpg" to "imageLink"
     And "Alice" logs out
     And "Brian" logs in
     When "Brian" opens the public link "folderLink"
+    And "Brian" unlocks the public link with password "%public%"
     And "Brian" uploads the following resources
       | resource  |
       | lorem.txt |
     When "Brian" opens the public link "textLink"
+    And "Brian" unlocks the public link with password "%public%"
+    Then "Brian" is in a text-editor
     And "Brian" closes the file viewer
     When "Brian" opens the public link "markdownLink"
+    And "Brian" unlocks the public link with password "%public%"
+    Then "Brian" is in a text-editor
     And "Brian" closes the file viewer
     When "Brian" opens the public link "pdfLink"
+    And "Brian" unlocks the public link with password "%public%"
+    Then "Brian" is in a pdf-viewer
     And "Brian" closes the file viewer
     When "Brian" opens the public link "imageLink"
+    And "Brian" unlocks the public link with password "%public%"
+    Then "Brian" is in a image-viewer
     And "Brian" closes the file viewer
     And "Brian" logs out

--- a/tests/e2e/cucumber/features/smoke/share.feature
+++ b/tests/e2e/cucumber/features/smoke/share.feature
@@ -37,7 +37,7 @@ Feature: share
     When "Brian" accepts the following share from the context menu
       | name          |
       | shared_folder |
-    And "Brian" copies quick link of the resource "shared_folder" from the context menu
+    And "Brian" creates quick link of the resource "shared_folder" with password "%public%" from the context menu
     And "Brian" declines the following share from the context menu
       | name          |
       | shared_folder |
@@ -107,7 +107,7 @@ Feature: share
     When "Brian" accepts the following share from the context menu
       | name           |
       | sharedFile.txt |
-    And "Brian" copies quick link of the resource "sharedFile.txt" from the context menu
+    And "Brian" creates quick link of the resource "sharedFile.txt" with password "%public%" from the context menu
     And "Brian" declines the following share from the context menu
       | name           |
       | sharedFile.txt |

--- a/tests/e2e/cucumber/features/smoke/spaces/internalLink.feature
+++ b/tests/e2e/cucumber/features/smoke/spaces/internalLink.feature
@@ -26,11 +26,12 @@ Feature: internal link share in project space
     And "Alice" navigates to the projects space page
     And "Alice" navigates to the project space "marketing.1"
     # internal link to space
-    And "Alice" creates a public link for the space using the sidebar panel
+
+    And "Alice" creates a public link for the space with password "%public%" using the sidebar panel
     And "Alice" renames the most recently created public link of space to "spaceLink"
     And "Alice" edits the public link named "spaceLink" of the space changing role to "Invited people"
     # internal link to folder
-    And "Alice" creates a public link for the resource "myfolder" using the sidebar panel
+    And "Alice" creates a public link for the resource "myfolder" with password "%public%" using the sidebar panel
     When "Alice" edits the public link named "Link" of resource "myfolder" changing role to "Invited people"
     And "Alice" logs out
 

--- a/tests/e2e/cucumber/features/smoke/spaces/participantManagement.feature
+++ b/tests/e2e/cucumber/features/smoke/spaces/participantManagement.feature
@@ -62,9 +62,10 @@ Feature: spaces participant management
     Then "Carol" should see folder "parent" but should not be able to edit
     # page reload is necessary to fetch all the changes made by user Brian
     When "Alice" reloads the spaces page
-    And "Alice" creates a public link for the resource "parent" using the sidebar panel
+    And "Alice" creates a public link for the resource "parent" with password "%public%" using the sidebar panel
     And "Alice" edits the public link named "Link" of resource "parent" changing role to "Can edit"
     And "Anonymous" opens the public link "Link"
+    And "Anonymous" unlocks the public link with password "%public%"
     And "Anonymous" uploads the following resources in public link page
       | resource     |
       | textfile.txt |

--- a/tests/e2e/cucumber/features/smoke/spaces/project.feature
+++ b/tests/e2e/cucumber/features/smoke/spaces/project.feature
@@ -48,11 +48,10 @@ Feature: spaces.personal
       | lorem.txt | folderPublic     |
       | lorem.txt | folder_to_shared |
 
-    And "Alice" creates a public link for the resource "folderPublic" using the sidebar panel
+    And "Alice" creates a public link for the resource "folderPublic" with password "%public%" using the sidebar panel
     And "Alice" renames the most recently created public link of resource "folderPublic" to "team.1"
     And "Alice" edits the public link named "team.1" of resource "folderPublic" changing role to "Secret File Drop"
     And "Alice" sets the expiration date of the public link named "team.1" of resource "folderPublic" to "+5 days"
-    And "Alice" sets the password of the public link named "team.1" of resource "folderPublic" to "12345"
 
     # borrowed from share.feature
     When "Alice" shares the following resource using the sidebar panel
@@ -75,15 +74,15 @@ Feature: spaces.personal
       | resource  | to           |
       | lorem.txt | folderPublic |
 
-    And "Alice" creates a public link for the resource "folderPublic" using the sidebar panel
+    And "Alice" creates a public link for the resource "folderPublic" with password "%public%" using the sidebar panel
     And "Alice" renames the most recently created public link of resource "folderPublic" to "team.2"
     And "Alice" edits the public link named "team.2" of resource "folderPublic" changing role to "Secret File Drop"
     And "Alice" sets the expiration date of the public link named "team.2" of resource "folderPublic" to "+5 days"
-    And "Alice" sets the password of the public link named "team.2" of resource "folderPublic" to "54321"
+    And "Alice" changes the password of the public link named "team.2" of resource "folderPublic" to "new-strongPass1"
 
     # borrowed from link.feature, all existing resource actions can be reused
     When "Anonymous" opens the public link "team.1"
-    And "Anonymous" unlocks the public link with password "12345"
+    And "Anonymous" unlocks the public link with password "%public%"
     And "Anonymous" drop uploads following resources
       | resource     |
       | textfile.txt |
@@ -118,7 +117,7 @@ Feature: spaces.personal
 
     # borrowed from link.feature, all existing resource actions can be reused
     When "Anonymous" opens the public link "team.2"
-    And "Anonymous" unlocks the public link with password "54321"
+    And "Anonymous" unlocks the public link with password "new-strongPass1"
     And "Anonymous" drop uploads following resources
       | resource     |
       | textfile.txt |

--- a/tests/e2e/cucumber/features/smoke/spaces/publicLink.feature
+++ b/tests/e2e/cucumber/features/smoke/spaces/publicLink.feature
@@ -32,42 +32,54 @@ Feature: spaces public link
       | resource       |
       | simple.pdf     |
       | testavatar.jpg |
-    And "Alice" creates a public link for the space using the sidebar panel
+    And "Alice" creates a public link for the space with password "%public%" using the sidebar panel
     And "Alice" renames the most recently created public link of space to "spaceLink"
-    And "Alice" creates a public link for the resource "spaceFolder" using the sidebar panel
+    And "Alice" creates a public link for the resource "spaceFolder" with password "%public%" using the sidebar panel
     And "Alice" renames the most recently created public link of resource "spaceFolder" to "folderLink"
-    And "Alice" creates a public link for the resource "spaceFolder/shareToBrian.txt" using the sidebar panel
+    And "Alice" creates a public link for the resource "spaceFolder/shareToBrian.txt" with password "%public%" using the sidebar panel
     And "Alice" renames the most recently created public link of resource "spaceFolder/shareToBrian.txt" to "textLink"
-    And "Alice" creates a public link for the resource "spaceFolder/subFolder/shareToBrian.md" using the sidebar panel
+    And "Alice" creates a public link for the resource "spaceFolder/subFolder/shareToBrian.md" with password "%public%" using the sidebar panel
     And "Alice" renames the most recently created public link of resource "spaceFolder/subFolder/shareToBrian.md" to "markdownLink"
-    And "Alice" creates a public link for the resource "simple.pdf" using the sidebar panel
+    And "Alice" creates a public link for the resource "simple.pdf" with password "%public%" using the sidebar panel
     And "Alice" renames the most recently created public link of resource "simple.pdf" to "pdfLink"
-    And "Alice" creates a public link for the resource "testavatar.jpg" using the sidebar panel
+    And "Alice" creates a public link for the resource "testavatar.jpg" with password "%public%" using the sidebar panel
     And "Alice" renames the most recently created public link of resource "testavatar.jpg" to "imageLink"
     And "Alice" logs out
     When "Brian" logs in
     And "Brian" opens the public link "spaceLink"
+    And "Brian" unlocks the public link with password "%public%"
     Then "Brian" should not be able to edit the public link named "spaceLink"
     And "Brian" should not be able to edit the public link named "folderLink"
     When "Brian" opens the public link "textLink"
+    And "Brian" unlocks the public link with password "%public%"
+    Then "Brian" is in a text-editor
     And "Brian" closes the file viewer
     When "Brian" opens the public link "markdownLink"
+    And "Brian" unlocks the public link with password "%public%"
+    Then "Brian" is in a text-editor
     And "Brian" closes the file viewer
     And "Brian" logs out
     When "Carol" logs in
     And "Carol" opens the public link "spaceLink"
+    And "Carol" unlocks the public link with password "%public%"
     But "Carol" should not be able to edit the public link named "spaceLink"
     And "Carol" should not be able to edit the public link named "folderLink"
     When "Carol" opens the public link "folderLink"
+    And "Carol" unlocks the public link with password "%public%"
     Then "Carol" should see folder "subFolder" but should not be able to edit
     When "Carol" opens the public link "pdfLink"
+    And "Carol" unlocks the public link with password "%public%"
+    Then "Carol" is in a pdf-viewer
     And "Carol" closes the file viewer
     And "Carol" logs out
     When "David" logs in
     And "David" opens the public link "spaceLink"
+    And "David" unlocks the public link with password "%public%"
     And "David" edits the public link named "spaceLink" of the space changing role to "Can edit"
     And "David" edits the public link named "folderLink" of resource "spaceFolder" changing role to "Can edit"
     When "David" opens the public link "imageLink"
+    And "David" unlocks the public link with password "%public%"
+    Then "David" is in a image-viewer
     And "David" closes the file viewer
     And "David" logs out
 
@@ -80,15 +92,15 @@ Feature: spaces public link
     And "Alice" uploads the following resources
       | resource  |
       | lorem.txt |
-    And "Alice" creates a public link for the resource "lorem.txt" using the sidebar panel
+    And "Alice" creates a public link for the resource "lorem.txt" with password "%public%" using the sidebar panel
     And "Alice" renames the most recently created public link of resource "lorem.txt" to "myPublicLink"
-    When "Alice" tries to sets the password of the public link named "myPublicLink" of resource "lorem.txt" to "password"
+    When "Alice" tries to sets a new password "ownCloud-1" of the public link named "myPublicLink" of resource "lorem.txt"
     Then "Alice" should see an error message
       """
       Unfortunately, your password is commonly used. please pick a harder-to-guess password for your safety
       """
     And "Alice" closes the public link password dialog box
-    When "Alice" tries to sets the password of the public link named "myPublicLink" of resource "lorem.txt" to "12345678"
+    When "Alice" tries to sets a new password "ownCloud-1" of the public link named "myPublicLink" of resource "lorem.txt"
     Then "Alice" should see an error message
       """
       Unfortunately, your password is commonly used. please pick a harder-to-guess password for your safety

--- a/tests/e2e/cucumber/steps/ui/links.ts
+++ b/tests/e2e/cucumber/steps/ui/links.ts
@@ -4,23 +4,27 @@ import { World } from '../../environment'
 import { objects } from '../../../support'
 
 When(
-  '{string} creates a public link for the resource {string} using the sidebar panel',
-  async function (this: World, stepUser: string, resource: string) {
+  '{string} creates a public link for the resource {string} with password {string} using the sidebar panel',
+  async function (this: World, stepUser: string, resource: string, password: string) {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const linkObject = new objects.applicationFiles.Link({ page })
+    password = password === '%public%' ? linkObject.securePassword : password
     await linkObject.create({
       resource,
-      name: 'Link'
+      name: 'Link',
+      password
     })
   }
 )
 
 When(
-  '{string} creates a public link for the space using the sidebar panel',
-  async function (this: World, stepUser: string): Promise<void> {
+  '{string} creates a public link for the space with password {string} using the sidebar panel',
+  async function (this: World, stepUser: string, password: string): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const spaceObject = new objects.applicationFiles.Spaces({ page })
-    await spaceObject.createPublicLink()
+    const linkObject = new objects.applicationFiles.Link({ page })
+    password = password === '%public%' ? linkObject.securePassword : password
+    await spaceObject.createPublicLink({ password })
   }
 )
 
@@ -60,7 +64,7 @@ When(
 )
 
 When(
-  '{string} sets the password of the public link named {string} of resource {string} to {string}',
+  '{string} changes the password of the public link named {string} of resource {string} to {string}',
   async function (
     this: World,
     stepUser: string,
@@ -75,13 +79,13 @@ When(
 )
 
 When(
-  '{string} tries to sets the password of the public link named {string} of resource {string} to {string}',
+  '{string} tries to sets a new password {string} of the public link named {string} of resource {string}',
   async function (
     this: World,
     stepUser: string,
+    newPassword: string,
     linkName: string,
-    resource: string,
-    newPassword: string
+    resource: string
   ): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const linkObject = new objects.applicationFiles.Link({ page })

--- a/tests/e2e/cucumber/steps/ui/public.ts
+++ b/tests/e2e/cucumber/steps/ui/public.ts
@@ -61,8 +61,8 @@ Then(
   /^"([^"]*)" is in a (text-editor|pdf-viewer|image-viewer)$/,
   async function (this: World, stepUser: string, fileViewerType: string): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
-    const isOpen = await editor.isOpen({ page, fileViewerType })
-    await expect(isOpen).toBeVisible()
+    const fileViewerLocator = await editor.fileViewerLocator({ page, fileViewerType })
+    await expect(fileViewerLocator).toBeVisible()
   }
 )
 

--- a/tests/e2e/cucumber/steps/ui/public.ts
+++ b/tests/e2e/cucumber/steps/ui/public.ts
@@ -31,8 +31,11 @@ When(
   async function (this: World, stepUser: string, password: string): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const pageObject = new objects.applicationFiles.page.Public({ page })
+    const linkObject = new objects.applicationFiles.Link({ page })
     if (password === '%copied_password%') {
       password = await page.evaluate('navigator.clipboard.readText()')
+    } else {
+      password = password === '%public%' ? linkObject.securePassword : password
     }
     await pageObject.authenticate({ password })
   }
@@ -51,6 +54,15 @@ When(
   async function (this: World, stepUser: string): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     await editor.save(page)
+  }
+)
+
+Then(
+  /^"([^"]*)" is in a (text-editor|pdf-viewer|image-viewer)$/,
+  async function (this: World, stepUser: string, fileViewerType: string): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const isOpen = await editor.isOpen({ page, fileViewerType })
+    await expect(isOpen).toBeVisible()
   }
 )
 

--- a/tests/e2e/cucumber/steps/ui/shares.ts
+++ b/tests/e2e/cucumber/steps/ui/shares.ts
@@ -182,13 +182,20 @@ When(
 )
 
 When(
-  '{string} copies quick link of the resource {string} from the context menu',
-  async function (this: World, stepUser: string, resource: string): Promise<void> {
+  '{string} creates quick link of the resource {string} with password {string} from the context menu',
+  async function (
+    this: World,
+    stepUser: string,
+    resource: string,
+    password: string
+  ): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const shareObject = new objects.applicationFiles.Share({ page })
-    await shareObject.copyQuickLink({
+    const linkObject = new objects.applicationFiles.Link({ page })
+    password = password === '%public%' ? linkObject.securePassword : password
+    await shareObject.createQuickLink({
       resource,
-      via: 'CONTEXT_MENU'
+      password
     })
   }
 )

--- a/tests/e2e/support/objects/app-files/link/actions.ts
+++ b/tests/e2e/support/objects/app-files/link/actions.ts
@@ -10,6 +10,7 @@ export interface createLinkArgs {
   resource?: string
   name?: string
   space?: boolean
+  password?: string
 }
 
 export interface copyLinkArgs {
@@ -82,7 +83,7 @@ const editPublicLinkRenameButton =
 const editPublicLinkSetExpirationButton =
   '//div[contains(@id,"edit-public-link-dropdown")]//button/span[text()="Set expiration date"]'
 const editPublicLinkAddPasswordButton =
-  '//div[contains(@id,"edit-public-link-dropdown")]//button/span[text()="Add password"]'
+  '//div[contains(@id,"edit-public-link-dropdown")]//button/span[text()="Edit password"]'
 const editPublicLinkInput = '.oc-modal-body input.oc-text-input'
 const editPublicLinkRenameConfirm = '.oc-modal-body-actions-confirm'
 const deleteLinkButton =
@@ -106,7 +107,7 @@ const getRecentLinkName = async (page: Page): Promise<string> => {
 }
 
 export const createLink = async (args: createLinkArgs): Promise<string> => {
-  const { space, page, resource } = args
+  const { space, page, resource, password } = args
   if (!space) {
     const resourcePaths = resource.split('/')
     const resourceName = resourcePaths.pop()
@@ -117,6 +118,8 @@ export const createLink = async (args: createLinkArgs): Promise<string> => {
     await sidebar.openPanel({ page: page, name: 'sharing' })
   }
   await page.locator(addPublicLinkButton).click()
+  await page.locator(editPublicLinkInput).fill(password)
+  setPassword(page)
   await clearCurrentPopup(page)
   return await getRecentLinkUrl(page)
 }

--- a/tests/e2e/support/objects/app-files/link/index.ts
+++ b/tests/e2e/support/objects/app-files/link/index.ts
@@ -18,6 +18,8 @@ export class Link {
     'Can edit': 'Anyone with the link can edit',
     'Secret File Drop': 'Secret File drop'
   }
+  securePassword = 'Pwd:12345'
+
   async create(args: Omit<po.createLinkArgs, 'page'>): Promise<void> {
     const startUrl = this.#page.url()
     const url = await po.createLink({ ...args, page: this.#page })

--- a/tests/e2e/support/objects/app-files/share/index.ts
+++ b/tests/e2e/support/objects/app-files/share/index.ts
@@ -1,7 +1,7 @@
 import { Page } from '@playwright/test'
 import * as po from './actions'
 import { resourceIsNotOpenable, isAcceptedSharePresent, resourceIsSynced } from './utils'
-import { copyLinkArgs } from '../link/actions'
+import { createLinkArgs } from '../link/actions'
 export class Share {
   #page: Page
 
@@ -54,8 +54,8 @@ export class Share {
     return await po.hasPermissionToShare({ page: this.#page, resource })
   }
 
-  async copyQuickLink(args: Omit<copyLinkArgs, 'page'>): Promise<void> {
-    await po.copyQuickLink({ ...args, page: this.#page })
+  async createQuickLink(args: Omit<createLinkArgs, 'page'>): Promise<void> {
+    await po.createQuickLink({ ...args, page: this.#page })
   }
 
   async resourceIsNotOpenable(resource): Promise<boolean> {

--- a/tests/e2e/support/objects/app-files/spaces/actions.ts
+++ b/tests/e2e/support/objects/app-files/spaces/actions.ts
@@ -294,10 +294,13 @@ export const changeSpaceRole = async (args: SpaceMembersArgs): Promise<void> => 
   }
 }
 
-export const createPublicLinkForSpace = async (args: { page: Page }): Promise<string> => {
-  const { page } = args
+export const createPublicLinkForSpace = async (args: {
+  page: Page
+  password: string
+}): Promise<string> => {
+  const { page, password } = args
   await openSharingPanel(page)
-  return createLink({ page: page, space: true })
+  return createLink({ page: page, space: true, password: password })
 }
 
 export const addExpirationDateToMember = async (args: {

--- a/tests/e2e/support/objects/app-files/spaces/index.ts
+++ b/tests/e2e/support/objects/app-files/spaces/index.ts
@@ -89,8 +89,8 @@ export class Spaces {
     await po.changeSpaceImage({ id, resource, page: this.#page })
   }
 
-  async createPublicLink(): Promise<void> {
-    const url = await po.createPublicLinkForSpace({ page: this.#page })
+  async createPublicLink({ password }: { password: string }): Promise<void> {
+    const url = await po.createPublicLinkForSpace({ page: this.#page, password })
     this.#linksEnvironment.createLink({
       key: 'Link',
       link: { name: 'Link', url }

--- a/tests/e2e/support/objects/app-files/utils/editor.ts
+++ b/tests/e2e/support/objects/app-files/utils/editor.ts
@@ -20,7 +20,7 @@ export const save = async (page: Page): Promise<unknown> => {
   ])
 }
 
-export const isOpen = async ({
+export const fileViewerLocator = async ({
   page,
   fileViewerType
 }: {
@@ -29,11 +29,11 @@ export const isOpen = async ({
 }): Promise<Locator> => {
   switch (fileViewerType) {
     case 'text-editor':
-      return await page.locator(texEditor)
+      return page.locator(texEditor)
     case 'pdf-viewer':
-      return await page.locator(pdfViewer)
+      return page.locator(pdfViewer)
     case 'image-viewer':
-      return await page.locator(imageViewer)
+      return page.locator(imageViewer)
     default:
       throw new Error(`${fileViewerType} not implemented`)
   }

--- a/tests/e2e/support/objects/app-files/utils/editor.ts
+++ b/tests/e2e/support/objects/app-files/utils/editor.ts
@@ -1,7 +1,10 @@
-import { Page } from '@playwright/test'
+import { Locator, Page } from '@playwright/test'
 
 const closeTextEditorOrViewerButton = '#app-top-bar-close'
 const saveTextEditorOrViewerButton = '#app-save-action'
+const texEditor = '#text-editor'
+const pdfViewer = '#pdf-viewer'
+const imageViewer = '#preview'
 
 export const close = (page: Page): Promise<unknown> => {
   return Promise.all([
@@ -15,4 +18,23 @@ export const save = async (page: Page): Promise<unknown> => {
     page.waitForResponse((res) => res.request().method() === 'PUT' && res.status() === 204),
     page.locator(saveTextEditorOrViewerButton).click()
   ])
+}
+
+export const isOpen = async ({
+  page,
+  fileViewerType
+}: {
+  page: Page
+  fileViewerType: string
+}): Promise<Locator> => {
+  switch (fileViewerType) {
+    case 'text-editor':
+      return await page.locator(texEditor)
+    case 'pdf-viewer':
+      return await page.locator(pdfViewer)
+    case 'image-viewer':
+      return await page.locator(imageViewer)
+    default:
+      throw new Error(`${fileViewerType} not implemented`)
+  }
 }

--- a/tests/e2e/support/store/user.ts
+++ b/tests/e2e/support/store/user.ts
@@ -6,7 +6,7 @@ export const dummyUserStore = new Map<string, User>([
     {
       id: 'admin',
       displayName: process.env.ADMIN_USERNAME || 'admin',
-      password: 'admin',
+      password: process.env.ADMIN_PASSWORD || 'admin',
       email: 'admin@example.org'
     }
   ],


### PR DESCRIPTION
- [x] enable enforced public link password for e2e tests
- [x] I disabled enforced public link password for old UI-tests.
- [x] fixed flaky https://github.com/owncloud/web/issues/9941
- [x] added checking that user is in the file viewer https://github.com/owncloud/web/pull/9821#discussion_r1377057491   
- [x] some small improvements


ToDo: get rid of:
- all warnings related `pnpm lint`
- page.locator.isVisible() - flaky https://playwright.dev/docs/api/class-locator#locator-is-visible 
- deprecated methods like `page.waitForNavigation()`