### PR TITLE
Use postMessage in embed mode instead of custom events

### DIFF
--- a/changelog/unreleased/enhancement-embed-mode-actions
+++ b/changelog/unreleased/enhancement-embed-mode-actions
@@ -3,4 +3,5 @@ Enhancement: Add embed mode actions
 We've added three new actions available in the embed mode. These actions are "Share", "Select" and "Share". They are emitting events with an optional payload. For more information, check the documentation.
 
 https://github.com/owncloud/web/pull/9841
+https://github.com/owncloud/web/pull/9981
 https://github.com/owncloud/web/issues/9768

--- a/changelog/unreleased/enhancement-location-picker
+++ b/changelog/unreleased/enhancement-location-picker
@@ -4,4 +4,5 @@ We've added a new query param called `embed-target` which can have value `locati
 When the value is set to `location`, it allows selecting the `currentFolder` as location instead of selecting resources.
 
 https://github.com/owncloud/web/pull/9863
+https://github.com/owncloud/web/pull/9981
 https://github.com/owncloud/web/issues/9768

--- a/packages/web-app-files/src/components/EmbedActions/EmbedActions.vue
+++ b/packages/web-app-files/src/components/EmbedActions/EmbedActions.vue
@@ -45,7 +45,7 @@ export default {
     const clientService = useClientService()
     const passwordPolicyService = usePasswordPolicyService()
     const language = useGettext()
-    const { isLocationPicker } = useEmbedMode()
+    const { isLocationPicker, postMessage } = useEmbedMode()
 
     const selectedFiles = computed<Resource[]>(() => {
       if (isLocationPicker.value) {
@@ -64,27 +64,20 @@ export default {
     )
 
     const emitSelect = (): void => {
-      const event: CustomEvent<Resource[]> = new CustomEvent('owncloud-embed:select', {
-        detail: selectedFiles.value
-      })
-
-      window.parent.dispatchEvent(event)
+      postMessage<Resource[]>(
+        'owncloud-embed:select',
+        JSON.parse(JSON.stringify(selectedFiles.value))
+      )
     }
 
     const emitCancel = (): void => {
-      const event: CustomEvent<void> = new CustomEvent('owncloud-embed:cancel')
-
-      window.parent.dispatchEvent(event)
+      postMessage<null>('owncloud-embed:cancel', null)
     }
 
     const emitShare = (links: string[]): void => {
       if (!canCreatePublicLinks.value) return
 
-      const event: CustomEvent<string[]> = new CustomEvent('owncloud-embed:share', {
-        detail: links
-      })
-
-      window.parent.dispatchEvent(event)
+      postMessage<string[]>('owncloud-embed:share', links)
     }
 
     const sharePublicLinks = async (): Promise<string[]> => {

--- a/packages/web-app-files/tests/unit/components/EmbedActions/EmbedActions.spec.ts
+++ b/packages/web-app-files/tests/unit/components/EmbedActions/EmbedActions.spec.ts
@@ -39,56 +39,107 @@ describe('EmbedActions', () => {
     })
 
     it('should emit select event when the select action is triggered', async () => {
-      window.parent.dispatchEvent = jest.fn()
+      window.parent.postMessage = jest.fn()
       global.CustomEvent = jest.fn().mockImplementation(mockCustomEvent)
 
       const { wrapper } = getWrapper({ selectedFiles: [{ id: 1 }] })
 
       await wrapper.find(selectors.btnSelect).trigger('click')
 
-      expect(window.parent.dispatchEvent).toHaveBeenCalledWith({
-        name: 'owncloud-embed:select',
-        payload: { detail: [{ id: 1 }] }
-      })
+      expect(window.parent.postMessage).toHaveBeenCalledWith(
+        {
+          name: 'owncloud-embed:select',
+          data: [{ id: 1 }]
+        },
+        {}
+      )
     })
 
     it('should enable select action when embedTarget is set to location', () => {
-      const { wrapper } = getWrapper({ configuration: { options: { embedTarget: 'location' } } })
+      const { wrapper } = getWrapper({
+        configuration: { options: { embed: { target: 'location' } } }
+      })
 
       expect(wrapper.find(selectors.btnSelect).attributes()).not.toHaveProperty('disabled')
     })
 
     it('should emit select event with currentFolder as selected resource when select action is triggered', async () => {
-      window.parent.dispatchEvent = jest.fn()
+      window.parent.postMessage = jest.fn()
       global.CustomEvent = jest.fn().mockImplementation(mockCustomEvent)
 
       const { wrapper } = getWrapper({
         currentFolder: { id: 1 },
-        configuration: { options: { embedTarget: 'location' } }
+        configuration: { options: { embed: { target: 'location' } } }
       })
 
       await wrapper.find(selectors.btnSelect).trigger('click')
 
-      expect(window.parent.dispatchEvent).toHaveBeenCalledWith({
-        name: 'owncloud-embed:select',
-        payload: { detail: [{ id: 1 }] }
+      expect(window.parent.postMessage).toHaveBeenCalledWith(
+        {
+          name: 'owncloud-embed:select',
+          data: [{ id: 1 }]
+        },
+        {}
+      )
+    })
+
+    it('should specify the targetOrigin when it is set in the config', async () => {
+      window.parent.postMessage = jest.fn()
+      global.CustomEvent = jest.fn().mockImplementation(mockCustomEvent)
+
+      const { wrapper } = getWrapper({
+        selectedFiles: [{ id: 1 }],
+        configuration: { options: { embed: { messagesOrigin: 'https://example.org' } } }
       })
+
+      await wrapper.find(selectors.btnSelect).trigger('click')
+
+      expect(window.parent.postMessage).toHaveBeenCalledWith(
+        {
+          name: 'owncloud-embed:select',
+          data: [{ id: 1 }]
+        },
+        { targetOrigin: 'https://example.org' }
+      )
     })
   })
 
   describe('cancel action', () => {
     it('should emit cancel event when the cancel action is triggered', async () => {
-      window.parent.dispatchEvent = jest.fn()
+      window.parent.postMessage = jest.fn()
       global.CustomEvent = jest.fn().mockImplementation(mockCustomEvent)
 
       const { wrapper } = getWrapper({ selectedFiles: [{ id: 1 }] })
 
       await wrapper.find(selectors.btnCancel).trigger('click')
 
-      expect(window.parent.dispatchEvent).toHaveBeenCalledWith({
-        name: 'owncloud-embed:cancel',
-        payload: undefined
+      expect(window.parent.postMessage).toHaveBeenCalledWith(
+        {
+          name: 'owncloud-embed:cancel',
+          data: null
+        },
+        {}
+      )
+    })
+
+    it('should specify the targetOrigin when it is set in the config', async () => {
+      window.parent.postMessage = jest.fn()
+      global.CustomEvent = jest.fn().mockImplementation(mockCustomEvent)
+
+      const { wrapper } = getWrapper({
+        selectedFiles: [{ id: 1 }],
+        configuration: { options: { embed: { messagesOrigin: 'https://example.org' } } }
       })
+
+      await wrapper.find(selectors.btnCancel).trigger('click')
+
+      expect(window.parent.postMessage).toHaveBeenCalledWith(
+        {
+          name: 'owncloud-embed:cancel',
+          data: null
+        },
+        { targetOrigin: 'https://example.org' }
+      )
     })
   })
 
@@ -115,7 +166,7 @@ describe('EmbedActions', () => {
     })
 
     it('should emit share event when share action is triggered', async () => {
-      window.parent.dispatchEvent = jest.fn()
+      window.parent.postMessage = jest.fn()
       global.CustomEvent = jest.fn().mockImplementation(mockCustomEvent)
 
       const { wrapper } = getWrapper({
@@ -125,14 +176,17 @@ describe('EmbedActions', () => {
 
       await wrapper.find(selectors.btnShare).trigger('click')
 
-      expect(window.parent.dispatchEvent).toHaveBeenCalledWith({
-        name: 'owncloud-embed:share',
-        payload: { detail: ['link-1'] }
-      })
+      expect(window.parent.postMessage).toHaveBeenCalledWith(
+        {
+          name: 'owncloud-embed:share',
+          data: ['link-1']
+        },
+        {}
+      )
     })
 
     it('should ask for password first when required when share action is triggered', async () => {
-      window.parent.dispatchEvent = jest.fn()
+      window.parent.postMessage = jest.fn()
       global.CustomEvent = jest.fn().mockImplementation(mockCustomEvent)
 
       const { wrapper } = getWrapper({
@@ -145,16 +199,42 @@ describe('EmbedActions', () => {
 
       await wrapper.find(selectors.btnShare).trigger('click')
 
-      expect(window.parent.dispatchEvent).toHaveBeenCalledWith({
-        name: 'owncloud-embed:share',
-        payload: { detail: ['password-link-1'] }
-      })
+      expect(window.parent.postMessage).toHaveBeenCalledWith(
+        {
+          name: 'owncloud-embed:share',
+          data: ['password-link-1']
+        },
+        {}
+      )
     })
 
     it('should hide share action when embedTarget is set to location', () => {
-      const { wrapper } = getWrapper({ configuration: { options: { embedTarget: 'location' } } })
+      const { wrapper } = getWrapper({
+        configuration: { options: { embed: { target: 'location' } } }
+      })
 
       expect(wrapper.find(selectors.btnShare).exists()).toBe(false)
+    })
+
+    it('should specify the targetOrigin when it is set in the config', async () => {
+      window.parent.postMessage = jest.fn()
+      global.CustomEvent = jest.fn().mockImplementation(mockCustomEvent)
+
+      const { wrapper } = getWrapper({
+        selectedFiles: [{ id: 1 }],
+        configuration: { options: { embed: { messagesOrigin: 'https://example.org' } } },
+        abilities: [{ action: 'create-all', subject: 'PublicLink' }]
+      })
+
+      await wrapper.find(selectors.btnShare).trigger('click')
+
+      expect(window.parent.postMessage).toHaveBeenCalledWith(
+        {
+          name: 'owncloud-embed:share',
+          data: ['link-1']
+        },
+        { targetOrigin: 'https://example.org' }
+      )
     })
   })
 })

--- a/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
@@ -233,7 +233,7 @@ describe('GenericSpace view', () => {
     it('should render create folder button when in embed mode', () => {
       const { wrapper } = getMountedWrapper({
         stubs: { 'app-bar': AppBarStub, CreateAndUpload: true },
-        configurationOptions: { mode: 'embed' }
+        configurationOptions: { embed: { enabled: true } }
       })
 
       expect(wrapper.find(selectors.btnCreateFolder).exists()).toBe(true)
@@ -242,7 +242,7 @@ describe('GenericSpace view', () => {
     it('should not render create and upload actions when in embed mode', () => {
       const { wrapper } = getMountedWrapper({
         stubs: { 'app-bar': AppBarStub, CreateAndUpload: true },
-        configurationOptions: { mode: 'embed' }
+        configurationOptions: { embed: { enabled: true } }
       })
 
       expect(wrapper.find(selectors.actionsCreateAndUpload).exists()).toBe(false)
@@ -251,7 +251,7 @@ describe('GenericSpace view', () => {
     it('should call createNewFolderAction when create folder button is clicked', () => {
       const { wrapper } = getMountedWrapper({
         stubs: { 'app-bar': AppBarStub, CreateAndUpload: true },
-        configurationOptions: { mode: 'embed' }
+        configurationOptions: { embed: { enabled: true } }
       })
 
       // @ts-expect-error even though the vm object is not specified on WrapperLike, it actually is present there

--- a/packages/web-pkg/src/composables/embedMode/useEmbedMode.ts
+++ b/packages/web-pkg/src/composables/embedMode/useEmbedMode.ts
@@ -4,11 +4,25 @@ import { useStore } from '../store'
 export const useEmbedMode = () => {
   const store = useStore()
 
-  const isEnabled = computed<boolean>(() => store.getters.configuration.options.mode === 'embed')
+  const isEnabled = computed<boolean>(() => store.getters.configuration.options.embed?.enabled)
 
   const isLocationPicker = computed<boolean>(() => {
-    return store.getters.configuration.options.embedTarget === 'location'
+    return store.getters.configuration.options.embed?.target === 'location'
   })
 
-  return { isEnabled, isLocationPicker }
+  const messagesTargetOrigin = computed<string>(
+    () => store.getters.configuration.options.embed?.messagesOrigin
+  )
+
+  const postMessage = <Payload>(name: string, data?: Payload): void => {
+    const options: WindowPostMessageOptions = {}
+
+    if (messagesTargetOrigin.value) {
+      options.targetOrigin = messagesTargetOrigin.value
+    }
+
+    window.parent.postMessage({ name, data }, options)
+  }
+
+  return { isEnabled, isLocationPicker, messagesTargetOrigin, postMessage }
 }

--- a/packages/web-pkg/src/configuration/types.ts
+++ b/packages/web-pkg/src/configuration/types.ts
@@ -26,14 +26,17 @@ export interface OptionsConfiguration {
   openLinksWithDefaultApp?: boolean
   tokenStorageLocal?: boolean
   disabledExtensions?: string[]
-  mode?: string
   isRunningOnEos?: boolean
-  embedTarget?: string
   editor?: {
     openAsPreview?: boolean | string[]
   }
   ocm?: {
     openRemotely?: boolean
+  }
+  embed?: {
+    enabled?: boolean
+    target?: string
+    messagesOrigin?: string
   }
 }
 

--- a/packages/web-pkg/tests/unit/components/FilesList/ResourceTable.spec.ts
+++ b/packages/web-pkg/tests/unit/components/FilesList/ResourceTable.spec.ts
@@ -272,7 +272,7 @@ describe('ResourceTable', () => {
     describe('embed mode location target', () => {
       it('should not hide checkboxes when embed mode does not have location as target', () => {
         const { wrapper } = getMountedWrapper({
-          configuration: { options: { embedTarget: undefined } }
+          configuration: { options: { embed: { target: undefined } } }
         })
 
         expect(wrapper.find('.resource-table-select-all').exists()).toBe(true)
@@ -281,7 +281,7 @@ describe('ResourceTable', () => {
 
       it('should hide checkboxes when embed mode has location as target', () => {
         const { wrapper } = getMountedWrapper({
-          configuration: { options: { embedTarget: 'location' } }
+          configuration: { options: { embed: { target: 'location' } } }
         })
 
         expect(wrapper.find('.resource-table-select-all').exists()).toBe(false)

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -51,15 +51,21 @@ export const announceConfiguration = async (path: string): Promise<RuntimeConfig
     throw new Error(`config could not be parsed. ${error}`)
   })) as RawConfig
 
-  if (!rawConfig.options?.mode) {
-    rawConfig.options = { ...rawConfig.options, mode: getQueryParam('mode') ?? 'web' }
+  if (
+    !rawConfig.options?.embed ||
+    !Object.prototype.hasOwnProperty.call(rawConfig.options.embed, 'enabled')
+  ) {
+    rawConfig.options = {
+      ...rawConfig.options,
+      embed: { ...rawConfig.options?.embed, enabled: getQueryParam('embed') === 'true' }
+    }
   }
 
   // Can enable location picker in embed mode
   const embedTarget = getQueryParam('embed-target')
 
   if (embedTarget) {
-    rawConfig.options.embedTarget = embedTarget
+    rawConfig.options.embed = { ...rawConfig.options.embed, target: embedTarget }
   }
 
   configurationManager.initialize(rawConfig)

--- a/packages/web-runtime/src/store/config.ts
+++ b/packages/web-runtime/src/store/config.ts
@@ -73,7 +73,12 @@ const state = {
     privacyUrl: '',
     imprintUrl: '',
     accessDeniedHelpUrl: '',
-    disabledExtensions: []
+    disabledExtensions: [],
+    embed: {
+      enabled: false,
+      target: 'resources',
+      messagesOrigin: null
+    }
   }
 }
 

--- a/packages/web-runtime/tests/unit/components/Topbar/TopBar.spec.ts
+++ b/packages/web-runtime/tests/unit/components/Topbar/TopBar.spec.ts
@@ -45,7 +45,7 @@ describe('Top Bar component', () => {
     'should hide %s when mode is "embed"',
     (componentName) => {
       const { wrapper } = getWrapper({
-        configuration: { options: { disableFeedbackLink: false, mode: 'embed' } }
+        configuration: { options: { disableFeedbackLink: false, embed: { enabled: true } } }
       })
       expect(wrapper.find(`${componentName}-stub`).exists()).toBeFalsy()
     }
@@ -54,7 +54,7 @@ describe('Top Bar component', () => {
     'should not hide %s when mode is not "embed"',
     (componentName) => {
       const { wrapper } = getWrapper({
-        configuration: { options: { disableFeedbackLink: false, mode: 'web' } },
+        configuration: { options: { disableFeedbackLink: false, embed: { enabled: false } } },
         capabilities: {
           notifications: { 'ocs-endpoints': ['list', 'get', 'delete'] }
         }

--- a/packages/web-runtime/tests/unit/container/bootstrap.spec.ts
+++ b/packages/web-runtime/tests/unit/container/bootstrap.spec.ts
@@ -122,39 +122,39 @@ describe('announceConfiguration', () => {
     jest.clearAllMocks()
   })
 
-  it('should set "web" as the default mode when none is set', async () => {
+  it('should not enable embed mode when it is not set', async () => {
     fetchMock.mockResponseOnce('{}')
     const config = await announceConfiguration('/config.json')
-    expect(config.options.mode).toStrictEqual('web')
+    expect(config.options.embed.enabled).toStrictEqual(false)
   })
 
-  it('should use the mode that is defined in config.json', async () => {
-    fetchMock.mockResponseOnce('{ "options": { "mode": "config-mode" } }')
+  it('should embed mode when it is set in config.json', async () => {
+    fetchMock.mockResponseOnce('{ "options": { "embed": { "enabled": true } } }')
     const config = await announceConfiguration('/config.json')
-    expect(config.options.mode).toStrictEqual('config-mode')
+    expect(config.options.embed.enabled).toStrictEqual(true)
   })
 
-  it('should use the mode that is defined in URL query when config.json does not set it', async () => {
+  it('should enable embed mode when it is set in URL query but config.json does not set it', async () => {
     Object.defineProperty(window, 'location', {
       value: {
-        search: '?mode=query-mode'
+        search: '?embed=true'
       },
       writable: true
     })
     fetchMock.mockResponseOnce('{}')
     const config = await announceConfiguration('/config.json')
-    expect(config.options.mode).toStrictEqual('query-mode')
+    expect(config.options.embed.enabled).toStrictEqual(true)
   })
 
-  it('should not use the mode that is defined in URL query when config.json sets one', async () => {
+  it('should not enable the embed mode when it is set in URL query but config.json disables it', async () => {
     Object.defineProperty(window, 'location', {
       value: {
-        search: '?mode=query-mode'
+        search: '?embed=true'
       },
       writable: true
     })
-    fetchMock.mockResponseOnce('{ "options": { "mode": "config-mode" } }')
+    fetchMock.mockResponseOnce('{ "options": { "embed": { "enabled": false } } }')
     const config = await announceConfiguration('/config.json')
-    expect(config.options.mode).toStrictEqual('config-mode')
+    expect(config.options.embed.enabled).toStrictEqual(false)
   })
 })


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

We have switched to using `postMessage` method in the embed mode instead of emitting custom events. This mitigates the issue when running the embed mode on different origin blocked the access to the `dispatchEvent` method.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Solve issues with forbidden access when hosting the iframe on different origin.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: local
- test case 1: run the embed mode and check the correct events being emitted

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
