### PR TITLE
Do not open OcSelect Dropdown on focus

### DIFF
--- a/packages/design-system/src/components/OcSelect/OcSelect.vue
+++ b/packages/design-system/src/components/OcSelect/OcSelect.vue
@@ -311,8 +311,7 @@ export default defineComponent({
       dropdownEnabled.value = enabled
     }
 
-    const selectDropdownShouldOpen = (vueSelect) => {
-      const { noDrop, open, mutableLoading } = vueSelect
+    const selectDropdownShouldOpen = ({ noDrop, open, mutableLoading }) => {
       return !noDrop && open && !mutableLoading && unref(dropdownEnabled)
     }
 

--- a/packages/design-system/src/components/OcSelect/OcSelect.vue
+++ b/packages/design-system/src/components/OcSelect/OcSelect.vue
@@ -16,8 +16,13 @@
       :multiple="multiple"
       class="oc-select"
       style="background: transparent"
+      :dropdown-should-open="selectDropdownShouldOpen"
+      :map-keydown="selectMapKeydown"
       v-bind="additionalAttributes"
       @update:model-value="$emit('update:modelValue', $event)"
+      @click="onSelectClick()"
+      @search:blur="onSelectBlur()"
+      @keydown="onSelectKeyDown($event)"
     >
       <template #search="{ attributes, events }">
         <input class="vs__search" v-bind="attributes" @input="userInput" v-on="events" />
@@ -98,6 +103,11 @@ import {
 import { useGettext } from 'vue3-gettext'
 import 'vue-select/dist/vue-select.css'
 import { ContextualHelper } from '../../helpers'
+
+// the keycode property is deprecated in the JS event API, vue-select still works with it though
+enum KeyCode {
+  Enter = 13
+}
 
 /**
  * Select component with a trigger and dropdown based on [Vue Select](https://vue-select.org/)
@@ -296,7 +306,55 @@ export default defineComponent({
       setComboBoxAriaLabel()
     })
 
-    return { select, userInput }
+    const dropdownEnabled = ref(false)
+    const setDropdownEnabled = (enabled) => {
+      dropdownEnabled.value = enabled
+    }
+
+    const selectDropdownShouldOpen = (vueSelect) => {
+      const { noDrop, open, mutableLoading } = vueSelect
+      return !noDrop && open && !mutableLoading && unref(dropdownEnabled)
+    }
+
+    const onSelectClick = () => {
+      setDropdownEnabled(true)
+    }
+
+    const onSelectBlur = () => {
+      setDropdownEnabled(false)
+    }
+
+    const selectMapKeydown = (map, vm) => {
+      return {
+        ...map,
+        [KeyCode.Enter]: (e: KeyboardEvent) => {
+          if (!unref(dropdownEnabled)) {
+            setDropdownEnabled(true)
+            return
+          }
+          map[KeyCode.Enter](e)
+          unref(select).searchEl.focus()
+        }
+      }
+    }
+
+    const onSelectKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === 'Tab') {
+        return
+      }
+
+      setDropdownEnabled(true)
+    }
+
+    return {
+      select,
+      userInput,
+      selectDropdownShouldOpen,
+      selectMapKeydown,
+      onSelectKeyDown,
+      onSelectBlur,
+      onSelectClick
+    }
   },
   computed: {
     additionalAttributes() {

--- a/tests/e2e/support/objects/account/actions.ts
+++ b/tests/e2e/support/objects/account/actions.ts
@@ -82,7 +82,7 @@ export const downloadGdprExport = async (args: { page: Page }): Promise<string> 
 export const changeLanguage = async (args: { page: Page; language: string }): Promise<string> => {
   const { page, language } = args
   await page.locator(languageInput).waitFor()
-  await page.locator(languageInput).fill(language)
+  await page.locator(languageInput).pressSequentially(language)
   await Promise.all([
     page.waitForResponse(
       (res) =>

--- a/tests/e2e/support/objects/app-admin-settings/groups/actions.ts
+++ b/tests/e2e/support/objects/app-admin-settings/groups/actions.ts
@@ -105,7 +105,7 @@ export const changeGroup = async (args: {
   value: string
 }): Promise<void> => {
   const { page, attribute, value, uuid } = args
-  await page.locator(util.format(userInput, attribute)).fill(value)
+  await page.locator(util.format(userInput, attribute)).pressSequentially(value)
 
   await Promise.all([
     page.waitForResponse(

--- a/tests/e2e/support/objects/app-admin-settings/spaces/actions.ts
+++ b/tests/e2e/support/objects/app-admin-settings/spaces/actions.ts
@@ -84,7 +84,7 @@ export const changeSpaceQuota = async (args: {
   await performAction({ page, action: 'edit-quota', context, id: spaceIds[0] })
 
   const searchLocator = page.locator(spacesQuotaSearchField)
-  await searchLocator.fill(value)
+  await searchLocator.pressSequentially(value)
   await page.locator(selectedQuotaValueField).waitFor()
   await page.locator(util.format(quotaValueDropDown, `${value} GB`)).click()
   await confirmAction({

--- a/tests/e2e/support/objects/app-admin-settings/users/actions.ts
+++ b/tests/e2e/support/objects/app-admin-settings/users/actions.ts
@@ -122,8 +122,8 @@ export const changeQuotaUsingBatchAction = async (args: {
 }): Promise<void> => {
   const { page, value, userIds } = args
   await page.locator(editQuotaBtn).click()
-  await page.locator(quotaInputBatchAction).fill(value)
-  await page.locator(util.format(quotaValueDropDown, `${value} GB`)).click()
+  await page.locator(quotaInputBatchAction).pressSequentially(value, { delay: 100 });
+  await page.locator(quotaInputBatchAction).press('Enter');
 
   const checkResponses = []
   for (const id of userIds) {

--- a/tests/e2e/support/objects/app-admin-settings/users/actions.ts
+++ b/tests/e2e/support/objects/app-admin-settings/users/actions.ts
@@ -122,8 +122,8 @@ export const changeQuotaUsingBatchAction = async (args: {
 }): Promise<void> => {
   const { page, value, userIds } = args
   await page.locator(editQuotaBtn).click()
-  await page.locator(quotaInputBatchAction).pressSequentially(value, { delay: 100 });
-  await page.locator(quotaInputBatchAction).press('Enter');
+  await page.locator(quotaInputBatchAction).pressSequentially(value, { delay: 100 })
+  await page.locator(quotaInputBatchAction).press('Enter')
 
   const checkResponses = []
   for (const id of userIds) {

--- a/tests/e2e/support/objects/app-admin-settings/users/actions.ts
+++ b/tests/e2e/support/objects/app-admin-settings/users/actions.ts
@@ -101,7 +101,7 @@ export const changeQuota = async (args: {
   value: string
 }): Promise<void> => {
   const { page, value, uuid } = args
-  await page.locator(quotaInput).fill(value)
+  await page.locator(quotaInput).pressSequentially(value)
   await page.locator(util.format(quotaValueDropDown, `${value} GB`)).click()
 
   await Promise.all([
@@ -176,7 +176,7 @@ export const addSelectedUsersToGroups = async (args: {
   for (const group of groups) {
     groupIds.push(getGroupId(group))
     await page.locator(groupsModalInput).click()
-    await page.locator(groupsModalInput).fill(group)
+    await page.locator(groupsModalInput).pressSequentially(group)
     await page.keyboard.press('Enter')
   }
 
@@ -268,6 +268,7 @@ export const changeUser = async (args: {
 }): Promise<unknown> => {
   const { page, attribute, value, uuid } = args
   await page.locator(util.format(userInput, attribute)).fill(value)
+  await page.locator(util.format(userInput, attribute)).press('Enter')
 
   if (attribute === 'role') {
     await page.locator(util.format(roleValueDropDown, value)).click()
@@ -302,7 +303,7 @@ export const addUserToGroups = async (args: {
   const groupIds = []
   for (const group of groups) {
     groupIds.push(getGroupId(group))
-    await page.locator(groupsInput).fill(group)
+    await page.locator(groupsInput).pressSequentially(group)
     await page.keyboard.press('Enter')
   }
 

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -1333,7 +1333,8 @@ export const addTagsToResource = async (args: resourceTagsArgs): Promise<void> =
   const inputForm = page.locator(tagFormInput)
 
   for (const tag of tags) {
-    await inputForm.fill(tag)
+    await inputForm.pressSequentially(tag)
+
     await Promise.all([
       page.waitForResponse(
         (resp) =>

--- a/tests/e2e/support/objects/app-files/share/collaborator.ts
+++ b/tests/e2e/support/objects/app-files/share/collaborator.ts
@@ -119,7 +119,7 @@ export default class Collaborator {
     await collaboratorInputLocator.click()
     await Promise.all([
       page.waitForResponse((resp) => resp.url().includes('sharees') && resp.status() === 200),
-      collaboratorInputLocator.fill(collaborator.id)
+      collaboratorInputLocator.pressSequentially(collaborator.id)
     ])
     await collaboratorInputLocator.focus()
     await page.locator('.vs--open').waitFor()

--- a/tests/e2e/support/objects/app-files/spaces/actions.ts
+++ b/tests/e2e/support/objects/app-files/spaces/actions.ts
@@ -172,7 +172,7 @@ export const changeQuota = async (args: {
 
   await page.locator(editQuotaOptionSelector).click()
   const searchLocator = page.locator(spacesQuotaSearchField)
-  await searchLocator.fill(value)
+  await searchLocator.pressSequentially(value)
   await page.locator(selectedQuotaValueField).waitFor()
   await page.locator(util.format(quotaValueDropDown, `${value} GB`)).click()
 


### PR DESCRIPTION


<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Do not open the oc-select dropdown when oc-select gets focus, only on enter or mouse click.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
When vue-select gets focus, it immediately opens its dropdown. This is very odd in a formular, where the first item is a oc-select and the dropdown opens on page load (or when a modal opens). Apart from that it behaves differently from native select boxes and usually it's a good idea to stick as closely as possible to native behaviors if native components can't be used for whatever reason.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
