### PR TITLE
perf: disable fetching oidc userinfo

### DIFF
--- a/packages/web-runtime/src/services/auth/userManager.ts
+++ b/packages/web-runtime/src/services/auth/userManager.ts
@@ -67,7 +67,7 @@ export class UserManager extends OidcUserManager {
     if (options.configurationManager.isOIDC) {
       Object.assign(openIdConfig, {
         scope: 'openid profile',
-        loadUserInfo: true,
+        loadUserInfo: false,
         ...options.configurationManager.oidc
       })
     } else if (options.configurationManager.isOAuth2) {


### PR DESCRIPTION
## Description

We're not relying on the userinfo data in web. Instead we fetch the user from OCS or graph and use all that information. Hence it's a good idea to save one request by disabling fetching the oidc userinfo.

cc and thank you @butonic who brought this idea up.

## How Has This Been Tested?
Just explorative testing so far. Let's see what our e2e tests have to say. Edit: looks good to CI. ✅ 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
