### PR TITLE
Add available languages

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=a4e7a64cd066d40a6320ddc00eb70ed800dd59b0
+OCIS_COMMITID=2726eb8a52291a0289609b87c83674a3e8275720
 OCIS_BRANCH=master

--- a/changelog/unreleased/enhancement-additional-languages
+++ b/changelog/unreleased/enhancement-additional-languages
@@ -1,0 +1,7 @@
+Enhancement: Additional languages
+
+We've added some items to the list of available languages because of good translation coverage in transifex.
+
+https://github.com/owncloud/web/issues/10007
+https://github.com/owncloud/web/pull/10008
+https://github.com/owncloud/ocis/pull/7754

--- a/packages/web-runtime/l10n/Makefile
+++ b/packages/web-runtime/l10n/Makefile
@@ -20,7 +20,7 @@ OUTPUT_DIR = .
 TEMPLATE_FILE = ./template.pot
 
 # Available locales for the app.
-LOCALES = ar bg de cs es fr gl he it pl ru sk sq tr
+LOCALES = bg cs de es fr it nl ko sq sv tr
 
 # Name of the generated .po files for each available locale.
 LOCALE_FILES ?= $(foreach app,$(APPS),$(patsubst %,$(app)/l10n/locale/%/LC_MESSAGES/app.po,$(LOCALES))) $(patsubst %,./locale/%/LC_MESSAGES/app.po,$(LOCALES))

--- a/packages/web-runtime/src/defaults/languages.ts
+++ b/packages/web-runtime/src/defaults/languages.ts
@@ -1,9 +1,14 @@
 export const supportedLanguages = {
-  cs: 'Czech',
-  de: 'Deutsch',
+  bg: 'български - Bulgarian',
+  cs: 'Čeština - Czech',
+  de: 'Deutsch - German',
   en: 'English',
-  es: 'Español',
-  fr: 'Français',
-  gl: 'Galego',
-  it: 'Italiano'
+  es: 'Español - Spanish',
+  fr: 'Français - French',
+  it: 'Italiano - Italian',
+  nl: 'Nederlands - Dutch',
+  ko: '한국어 - Korean',
+  sq: 'Shqipja - Albanian',
+  sv: 'Svenska - Swedish',
+  tr: 'Türkçe - Turkish'
 }

--- a/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.ts.snap
+++ b/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.ts.snap
@@ -26,7 +26,7 @@ exports[`account page account information displays basic user information 1`] = 
   <div class="account-page-info-language oc-mb oc-width-1-2@s">
     <dt class="oc-text-normal oc-text-muted">Language</dt>
     <dd>
-      <oc-select-stub clearable="false" disabled="false" filter="[Function]" fixmessageline="false" getoptionlabel="[Function]" id="oc-select-11" loading="false" multiple="false" optionlabel="label" options="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" placeholder="Please choose..." readonly="false" searchable="true"></oc-select-stub>
+      <oc-select-stub clearable="false" disabled="false" filter="[Function]" fixmessageline="false" getoptionlabel="[Function]" id="oc-select-11" loading="false" multiple="false" optionlabel="label" options="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" placeholder="Please choose..." readonly="false" searchable="true"></oc-select-stub>
     </dd>
   </div>
   <div class="account-page-logout-all-devices oc-mb oc-width-1-2@s">

--- a/tests/e2e/cucumber/features/smoke/languageChange.feature
+++ b/tests/e2e/cucumber/features/smoke/languageChange.feature
@@ -21,12 +21,12 @@ Feature: language settings
 
     And "Alice" logs in
     And "Alice" opens the user menu
-    And "Alice" changes the language to "Deutsch"
+    And "Alice" changes the language to "Deutsch - German"
     When "Alice" logs out
     And "Alice" logs in
     Then "Alice" should see the following notifications
       | message                                          |
       | Brian Murphy hat check_message mit Ihnen geteilt |
     And "Alice" logs out
-    
+
 


### PR DESCRIPTION
## Description
Adds additional languages to the web ui, namely those which have good translation coverage in transifex + swedish as requested by a community member. Removed Galician, as it only had 14%, seems rather unmaintained.

Note: please use up to date ocis image to test this. There was a change in the settings service to make saving these preferred language values possible...

## Related Issue
- Fixes https://github.com/owncloud/web/issues/10007

## Motivation and Context
Make community happy.

## Screenshots
<img width="751" alt="Screenshot 2023-11-21 at 22 25 04" src="https://github.com/owncloud/web/assets/3532843/b74e21e6-8591-49ea-bea2-688089de5079">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
