### PR TITLE
feat: add shared by filter on 'Shared with me'-page

### DIFF
--- a/changelog/unreleased/enhancement-shared-by-filter
+++ b/changelog/unreleased/enhancement-shared-by-filter
@@ -1,0 +1,6 @@
+Enhancement: Shared by filter
+
+The received shares on the "Shared with me"-page can now be filtered by the users that created the share.
+
+https://github.com/owncloud/web/issues/10013
+https://github.com/owncloud/web/pull/10029

--- a/packages/web-app-files/src/views/shares/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithMe.vue
@@ -20,7 +20,6 @@
             @toggle-filter="setAreHiddenFilesShown"
           />
           <item-filter
-            v-if="shareTypes.length > 1"
             :allow-multiple="true"
             :filter-label="$gettext('Share Type')"
             :filterable-attributes="['label']"

--- a/packages/web-app-files/src/views/shares/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithMe.vue
@@ -172,7 +172,7 @@ export default defineComponent({
 
     const shareTypes = computed(() => {
       const uniqueShareTypes = uniq(unref(storeItems).map((i) => i.share?.shareType))
-      return ShareTypes.getByValues(uniqueShareTypes)
+      return ShareTypes.getByValues(uniqueShareTypes).map(({ label, key }) => ({ label, key }))
     })
 
     onMounted(() => {

--- a/packages/web-app-files/tests/unit/views/shares/SharedWithMe.spec.ts
+++ b/packages/web-app-files/tests/unit/views/shares/SharedWithMe.spec.ts
@@ -102,6 +102,27 @@ describe('SharedWithMe view', () => {
         expect(wrapper.find('.share-type-filter').exists()).toBeFalsy()
       })
     })
+    describe('shared by', () => {
+      it('shows all available collaborators as filter option', () => {
+        const collaborator1 = { username: 'user1', displayName: 'user1' }
+        const collaborator2 = { username: 'user2', displayName: 'user2' }
+        const { wrapper } = getMountedWrapper({
+          files: [
+            mock<Resource>({
+              owner: [collaborator1],
+              share: { shareType: ShareTypes.user.value }
+            }),
+            mock<Resource>({
+              owner: [collaborator2],
+              share: { shareType: ShareTypes.user.value }
+            })
+          ]
+        })
+        const filterItems = wrapper.findComponent<any>('.shared-by-filter').props('items')
+        expect(wrapper.find('.shared-by-filter').exists()).toBeTruthy()
+        expect(filterItems).toEqual([collaborator1, collaborator2])
+      })
+    })
   })
 })
 
@@ -119,6 +140,8 @@ function getMountedWrapper({
   )
   jest.mocked(useSort).mockImplementation((options) => useSortMock({ items: ref(options.items) }))
   // selected share types
+  jest.mocked(queryItemAsString).mockImplementationOnce(() => undefined)
+  // selected shared by
   jest.mocked(queryItemAsString).mockImplementationOnce(() => undefined)
   // openWithDefaultAppQuery
   jest.mocked(queryItemAsString).mockImplementationOnce(() => openWithDefaultAppQuery)

--- a/packages/web-app-files/tests/unit/views/shares/SharedWithMe.spec.ts
+++ b/packages/web-app-files/tests/unit/views/shares/SharedWithMe.spec.ts
@@ -86,20 +86,21 @@ describe('SharedWithMe view', () => {
       })
     })
     describe('share type', () => {
-      it('shows filter if more than one share types are present', () => {
+      it('shows all available share types as filter option', () => {
+        const shareType1 = ShareTypes.user
+        const shareType2 = ShareTypes.group
         const { wrapper } = getMountedWrapper({
           files: [
-            mock<Resource>({ share: { shareType: ShareTypes.user.value } }),
-            mock<Resource>({ share: { shareType: ShareTypes.group.value } })
+            mock<Resource>({ share: { shareType: shareType1.value } }),
+            mock<Resource>({ share: { shareType: shareType2.value } })
           ]
         })
+        const filterItems = wrapper.findComponent<any>('.share-type-filter').props('items')
         expect(wrapper.find('.share-type-filter').exists()).toBeTruthy()
-      })
-      it('does not show filter if only one share type is present', () => {
-        const { wrapper } = getMountedWrapper({
-          files: [mock<Resource>({ share: { shareType: ShareTypes.user.value } })]
-        })
-        expect(wrapper.find('.share-type-filter').exists()).toBeFalsy()
+        expect(filterItems).toEqual([
+          { label: shareType1.label, key: shareType1.key },
+          { label: shareType2.label, key: shareType2.key }
+        ])
       })
     })
     describe('shared by', () => {


### PR DESCRIPTION
## Description
Adds a "Shared by"-filter to the received shares on the "Shared with me"-page. Also fixes a bug where the share type labels were empty inside the "Share type"-filter and ensures to always show it.

## Screenshot
<img width="607" alt="image" src="https://github.com/owncloud/web/assets/50302941/127de715-330d-4710-a937-ee3626b3bbb6">

## Related Issue
- Fixes https://github.com/owncloud/web/issues/10013
- Fixes https://github.com/owncloud/web/issues/10027

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
