### PR TITLE
feat: add docxf icon mapping and fix document icon colors

### DIFF
--- a/changelog/unreleased/enhancement-provide-neutral-file-icons
+++ b/changelog/unreleased/enhancement-provide-neutral-file-icons
@@ -2,5 +2,6 @@ Enhancement: Provide vendor neutral file icons
 
 We replaced the icons for Document, Spreadsheet, Presentation, Forms and Markdown
 
-https://github.com/owncloud/web/pull/9911
 https://github.com/owncloud/web/issues/9847
+https://github.com/owncloud/web/pull/9911
+https://github.com/owncloud/web/pull/10037

--- a/packages/design-system/src/helpers/resourceIconMapping.json
+++ b/packages/design-system/src/helpers/resourceIconMapping.json
@@ -163,6 +163,10 @@
     "name": "resource-type-document",
     "color": "var(--oc-color-icon-document)"
   },
+  "docxf": {
+    "name": "resource-type-form",
+    "color": "var(--oc-color-icon-form)"
+  },
   "dot": {
     "name": "resource-type-document",
     "color": "var(--oc-color-icon-document)"
@@ -293,7 +297,7 @@
   },
   "md": {
     "name": "resource-type-markdown",
-    "color": "var(--oc-color-text-default)"
+    "color": "var(--oc-color-icon-markdown)"
   },
   "mdb": {
     "name": "resource-type-text",

--- a/packages/design-system/src/tokens/ods/color.yaml
+++ b/packages/design-system/src/tokens/ods/color.yaml
@@ -153,6 +153,10 @@ color:
       value: rgb(0, 182, 87)
     document:
       value: rgb(44, 101, 255)
+    form:
+      value: rgb(102, 166, 163)
+    markdown:
+      value: rgb(75, 100, 137)
     video:
       value: rgb(0, 187, 219)
     audio:


### PR DESCRIPTION
## Description
Followup for https://github.com/owncloud/web/pull/9911 - adding the docxf icon mapping and adjusting colors.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/9847 again

## Screenshot
<img width="490" alt="Screenshot 2023-11-22 at 22 23 53" src="https://github.com/owncloud/web/assets/3532843/1416761a-1107-418b-82aa-77bd3d41be46">



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
