### PR TITLE
feat: respect default link permissions

### DIFF
--- a/changelog/unreleased/enhancement-default-link-permissions
+++ b/changelog/unreleased/enhancement-default-link-permissions
@@ -1,0 +1,6 @@
+Enhancement: Default link permission
+
+When creating a new link, Web now respects the default permissions coming from the server.
+
+https://github.com/owncloud/web/pull/10037
+https://github.com/owncloud/web/issues/9919

--- a/packages/web-app-files/src/components/EmbedActions/EmbedActions.vue
+++ b/packages/web-app-files/src/components/EmbedActions/EmbedActions.vue
@@ -28,6 +28,7 @@
 import { computed } from 'vue'
 import {
   createQuicklink,
+  getDefaultLinkPermissions,
   showQuickLinkPasswordModal,
   useAbility,
   useClientService,
@@ -37,6 +38,7 @@ import {
 } from '@ownclouders/web-pkg'
 import { Resource } from '@ownclouders/web-client'
 import { useGettext } from 'vue3-gettext'
+import { SharePermissionBit } from '@ownclouders/web-client/src/helpers'
 
 export default {
   setup() {
@@ -88,7 +90,9 @@ export default {
           store.getters.capabilities?.files_sharing?.public?.password?.enforced_for?.read_only ===
           true
 
-        if (passwordEnforced) {
+        const permissions = getDefaultLinkPermissions({ ability, store })
+
+        if (passwordEnforced && permissions > SharePermissionBit.Internal) {
           showQuickLinkPasswordModal(
             { store, $gettext: language.$gettext, passwordPolicyService },
             async (password) => {

--- a/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
@@ -122,7 +122,8 @@ import {
   useCapabilityFilesSharingPublicCanContribute,
   useCapabilityFilesSharingPublicAlias,
   useAbility,
-  usePasswordPolicyService
+  usePasswordPolicyService,
+  getDefaultLinkPermissions
 } from '@ownclouders/web-pkg'
 import { shareViaLinkHelp, shareViaIndirectLinkHelp } from '../../../helpers/contextualHelpers'
 import {
@@ -219,6 +220,7 @@ export default defineComponent({
 
     return {
       $store: store,
+      ability,
       space,
       resource,
       incomingParentShare: inject<Share>('incomingParentShare'),
@@ -417,7 +419,10 @@ export default defineComponent({
       this.checkLinkToCreate({
         link: {
           name: this.$gettext('Link'),
-          permissions: this.canCreatePublicLinks ? 1 : 0,
+          permissions: getDefaultLinkPermissions({
+            ability: this.ability,
+            store: this.$store
+          }).toString(),
           expiration: this.expirationDate.default,
           password: false
         }

--- a/packages/web-app-files/tests/unit/components/EmbedActions/EmbedActions.spec.ts
+++ b/packages/web-app-files/tests/unit/components/EmbedActions/EmbedActions.spec.ts
@@ -5,13 +5,16 @@ import {
   shallowMount
 } from 'web-test-helpers'
 import EmbedActions from 'web-app-files/src/components/EmbedActions/EmbedActions.vue'
+import { getDefaultLinkPermissions } from '@ownclouders/web-pkg'
+import { SharePermissionBit } from '@ownclouders/web-client/src/helpers'
 
 jest.mock('@ownclouders/web-pkg', () => ({
   ...jest.requireActual('@ownclouders/web-pkg'),
   createQuicklink: jest.fn().mockImplementation(({ resource, password }) => ({
     url: (password ? password + '-' : '') + 'link-' + resource.id
   })),
-  showQuickLinkPasswordModal: jest.fn().mockImplementation((_options, cb) => cb('password'))
+  showQuickLinkPasswordModal: jest.fn().mockImplementation((_options, cb) => cb('password')),
+  getDefaultLinkPermissions: jest.fn()
 }))
 
 const selectors = Object.freeze({
@@ -192,6 +195,7 @@ describe('EmbedActions', () => {
       const { wrapper } = getWrapper({
         selectedFiles: [{ id: 1 }],
         abilities: [{ action: 'create-all', subject: 'PublicLink' }],
+        defaultLinkPermissions: SharePermissionBit.Read,
         capabilities: jest.fn().mockReturnValue({
           files_sharing: { public: { password: { enforced_for: { read_only: true } } } }
         })
@@ -245,13 +249,15 @@ function getWrapper(
     abilities = [],
     capabilities = jest.fn().mockReturnValue({}),
     configuration = { options: {} },
-    currentFolder = {}
+    currentFolder = {},
+    defaultLinkPermissions = SharePermissionBit.Internal
   } = {
     selectedFiles: [],
     abilities: [],
     capabilities: jest.fn().mockReturnValue({})
   }
 ) {
+  jest.mocked(getDefaultLinkPermissions).mockReturnValue(defaultLinkPermissions)
   const storeOptions = {
     ...defaultStoreMockOptions,
     getters: {

--- a/packages/web-pkg/src/composables/capability/useCapability.ts
+++ b/packages/web-pkg/src/composables/capability/useCapability.ts
@@ -8,6 +8,7 @@ import {
   MediaTypeCapability,
   PasswordPolicyCapability
 } from '@ownclouders/web-client/src/ocs/capabilities'
+import { SharePermissionBit } from '@ownclouders/web-client/src/helpers'
 
 export const useCapability = <T>(
   store: Store<any>,
@@ -38,10 +39,6 @@ export const useCapabilityCoreSSE = createCapabilityComposable('core.support-sse
 export const useCapabilityGraphPersonalDataExport = createCapabilityComposable(
   'graph.personal-data-export',
   false
-)
-export const useCapabilityFilesSharingQuickLinkDefaultRole = createCapabilityComposable(
-  'files_sharing.quick_link.default_role',
-  'viewer'
 )
 export const useCapabilityFilesSharingResharing = createCapabilityComposable(
   'files_sharing.resharing',
@@ -135,6 +132,10 @@ export const useCapabilityFilesSharingPublicCanContribute = createCapabilityComp
 export const useCapabilityFilesSharingPublicAlias = createCapabilityComposable(
   'files_sharing.public.alias',
   false
+)
+export const useCapabilityFilesSharingPublicDefaultPermissions = createCapabilityComposable(
+  'files_sharing.public.default_permissions',
+  SharePermissionBit.Read
 )
 export const useCapabilityNotifications = createCapabilityComposable(
   'notifications.ocs-endpoints',


### PR DESCRIPTION
## Description
When creating a new link, Web now respects the default permissions coming from the server.

Needs a reva update in oCIS for Web to properly read the config from the server. Without, Web just defaults to `1` for the permission (the same as the server will).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9919

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
