### PR TITLE
fix: sse resource upsert

### DIFF
--- a/changelog/unreleased/enhancement-new-file-event-handling
+++ b/changelog/unreleased/enhancement-new-file-event-handling
@@ -7,3 +7,4 @@ Currently this only works for completely new files with content. It is not yet i
 https://github.com/owncloud/web/issues/9782
 https://github.com/owncloud/web/pull/10026
 https://github.com/owncloud/web/pull/10042
+https://github.com/owncloud/web/pull/10053

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -35,6 +35,7 @@ import { z } from 'zod'
 import { Resource } from '@ownclouders/web-client'
 import PQueue from 'p-queue'
 import { extractNodeId, extractStorageId } from '@ownclouders/web-client/src/helpers'
+import { urlJoin } from '@ownclouders/web-client/src/utils'
 
 /**
  * fetch runtime configuration, this step is optional, all later steps can use a static
@@ -590,7 +591,7 @@ const fileReadyEventSchema = z.object({
   parentitemid: z.string()
 })
 
-const onSSEProcessingFinishedEvent = async ({
+const onSSEProcessingFinishedEvent = ({
   store,
   msg,
   clientService,
@@ -630,6 +631,7 @@ const onSSEProcessingFinishedEvent = async ({
         const { resource } = await clientService.webdav.listFilesById({
           fileId: postProcessingData.itemid
         })
+        resource.path = urlJoin(currentFolder.path, resource.name)
         store.commit('Files/UPSERT_RESOURCE', resource)
       })
     }


### PR DESCRIPTION
## Description
Resources that were upserted via the SSE post-processing event always had `/` as path, which is incorrect. It should be the current folder's path and the resource name concatenated.

This lead to some issues with file duplicates in the files list.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10045

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
