### PR TITLE
ci: add missing NO_INSTALL param in ci build step

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1097,6 +1097,9 @@ def buildRelease(ctx):
             {
                 "name": "make",
                 "image": OC_CI_NODEJS,
+                "environment": {
+                    "NO_INSTALL": "true",
+                },
                 "commands": [
                     "cd %s" % dir["web"],
                     "make -f Makefile.release",


### PR DESCRIPTION
Follow-up for https://github.com/owncloud/web/pull/10052.