### PR TITLE
perf: speed up folder tree creation during upload

### DIFF
--- a/changelog/unreleased/enhancement-upload-folder-tree-creation
+++ b/changelog/unreleased/enhancement-upload-folder-tree-creation
@@ -1,0 +1,6 @@
+Enhancement: Folder tree creation during upload
+
+The performance of the folder tree creation during upload has been improved.
+
+https://github.com/owncloud/web/pull/10057
+https://github.com/owncloud/web/issues/9817

--- a/changelog/unreleased/enhancement-upload-preparation-time
+++ b/changelog/unreleased/enhancement-upload-preparation-time
@@ -1,0 +1,6 @@
+Enhancement: Upload preparation time
+
+The performance of the preparation time before each upload has been improved.
+
+https://github.com/owncloud/web/pull/9552
+https://github.com/owncloud/web/issues/9817

--- a/packages/web-app-files/tests/unit/HandleUpload.spec.ts
+++ b/packages/web-app-files/tests/unit/HandleUpload.spec.ts
@@ -90,7 +90,8 @@ describe('HandleUpload', () => {
       )
       expect(mocks.opts.clientService.webdav.createFolder).toHaveBeenCalledTimes(1)
       expect(mocks.opts.clientService.webdav.createFolder).toHaveBeenCalledWith(mocks.opts.space, {
-        path: relativeFolder
+        path: relativeFolder,
+        fetchFolder: true
       })
       expect(result.length).toBe(1)
     })

--- a/packages/web-client/src/webdav/createFolder.ts
+++ b/packages/web-client/src/webdav/createFolder.ts
@@ -12,11 +12,16 @@ export const CreateFolderFactory = (
   { accessToken }: WebDavOptions
 ) => {
   return {
-    async createFolder(space: SpaceResource, { path }: { path?: string }): Promise<FolderResource> {
+    async createFolder(
+      space: SpaceResource,
+      { path, fetchFolder = true }: { path?: string; fetchFolder?: boolean }
+    ): Promise<FolderResource> {
       const headers = buildAuthHeader(unref(accessToken), space)
       await dav.mkcol(urlJoin(space.webDavPath, path, { leadingSlash: true }), { headers })
 
-      return getFileInfoFactory.getFileInfo(space, { path })
+      if (fetchFolder) {
+        return getFileInfoFactory.getFileInfo(space, { path })
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
Speeds up the folder tree creation during upload by running the process asynchronously and by saving up PROPFIND requests on nested folders.

In my test with a folder including 155 sub folders the time for creating those decreased from 20-30 seconds to 5-7. That's still quite a bit, but most likely as good as it can get when doing this on the client-side.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/9817

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
