### PR TITLE
fix: showing the logout page after token expiry

### DIFF
--- a/changelog/unreleased/bugfix-logout-page-after-token-expiry
+++ b/changelog/unreleased/bugfix-logout-page-after-token-expiry
@@ -1,0 +1,6 @@
+Bugfix: Logout page after token expiry
+
+Wrongly showing the logout page after revisiting Web with an expired token has been fixed. Users now get redirected to the login page instead.
+
+https://github.com/owncloud/web/pull/10065
+https://github.com/owncloud/web/issues/10063

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -227,6 +227,16 @@ export class AuthService {
       })
     }
     if (isUserContext(this.router, route) || isIdpContext(this.router, route)) {
+      // defines a number of seconds after a token expired.
+      // if that threshold surpasses we assume a regular token expiry instead of an auth error.
+      // as a result, the user will be logged out.
+      const TOKEN_EXPIRY_THRESHOLD = 5
+
+      const user = await this.userManager.getUser()
+      if (user?.expires_in && user.expires_in < -TOKEN_EXPIRY_THRESHOLD) {
+        return this.logoutUser()
+      }
+
       await this.userManager.removeUser('authError')
       return
     }

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -265,8 +265,7 @@ export class AuthService {
     await this.store.dispatch('resetUserState')
     await Promise.all([
       this.store.dispatch('clearDynamicNavItems'),
-      this.store.dispatch('hideModal'),
-      this.store.dispatch('clearSettingsValues')
+      this.store.dispatch('hideModal')
     ])
   }
 }


### PR DESCRIPTION
## Description
Fixes wrongly showing the logout page after revisiting Web with an expired token. Users now get redirected to the login page instead.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10063
- Fixes https://github.com/owncloud/web/issues/9715

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
