### PR TITLE
[tests-only][full-ci]Down grade the `wopiserver` version for `app-provider` e2e tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2119,7 +2119,7 @@ def wopiServer():
         {
             "name": "wopiserver",
             "type": "docker",
-            "image": "cs3org/wopiserver:v10.2.1",
+            "image": "cs3org/wopiserver:v9.4.1",
             "detach": True,
             "commands": [
                 "echo 'LoremIpsum567' > /etc/wopi/wopisecret",


### PR DESCRIPTION
### Description
This PR downgrades the version of the `wopiserver` for the e2e app-provider tests since the upgraded version was failing in nightly CI.

### Related Issue:
https://github.com/owncloud/web/issues/10060