### PR TITLE
feat: hide quick actions for files in embed mode

### DIFF
--- a/changelog/unreleased/enhancement-embed-mode-actions
+++ b/changelog/unreleased/enhancement-embed-mode-actions
@@ -4,4 +4,5 @@ We've added three new actions available in the embed mode. These actions are "Sh
 
 https://github.com/owncloud/web/pull/9841
 https://github.com/owncloud/web/pull/9981
+https://github.com/owncloud/web/pull/10071
 https://github.com/owncloud/web/issues/9768

--- a/packages/web-app-files/src/components/FilesList/QuickActions.vue
+++ b/packages/web-app-files/src/components/FilesList/QuickActions.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="oc-flex">
+  <div v-if="!isEmbedModeEnabled" class="oc-flex">
     <oc-button
       v-for="action in filteredActions"
       :key="action.label($gettext)"
@@ -23,6 +23,7 @@ import { computed, defineComponent } from 'vue'
 import {
   useAbility,
   useClientService,
+  useEmbedMode,
   usePasswordPolicyService,
   useStore
 } from '@ownclouders/web-pkg'
@@ -47,6 +48,7 @@ export default defineComponent({
     const clientService = useClientService()
     const passwordPolicyService = usePasswordPolicyService()
     const language = useGettext()
+    const { isEnabled: isEmbedModeEnabled } = useEmbedMode()
 
     const filteredActions = computed(() =>
       pickBy(props.actions, (action) => action.displayed(props.item, store, ability) === true)
@@ -58,7 +60,8 @@ export default defineComponent({
       passwordPolicyService,
       store,
       language,
-      filteredActions
+      filteredActions,
+      isEmbedModeEnabled
     }
   }
 })

--- a/packages/web-app-files/tests/unit/components/FilesList/QuickActions.spec.ts
+++ b/packages/web-app-files/tests/unit/components/FilesList/QuickActions.spec.ts
@@ -1,5 +1,13 @@
+import { useEmbedMode } from '@ownclouders/web-pkg'
 import QuickActions from '../../../../src/components/FilesList/QuickActions.vue'
 import { defaultComponentMocks, defaultPlugins, shallowMount } from 'web-test-helpers'
+import { mock } from 'jest-mock-extended'
+import { ref } from 'vue'
+
+jest.mock('@ownclouders/web-pkg', () => ({
+  ...jest.requireActual('@ownclouders/web-pkg'),
+  useEmbedMode: jest.fn()
+}))
 
 const collaboratorAction = {
   displayed: jest.fn(() => true),
@@ -25,10 +33,6 @@ const testItem = {
 }
 
 describe('QuickActions', () => {
-  afterEach(() => {
-    jest.clearAllMocks()
-  })
-
   describe('when multiple actions are provided', () => {
     const { wrapper } = getWrapper()
 
@@ -67,9 +71,18 @@ describe('QuickActions', () => {
       })
     })
   })
+
+  it('does not show actions in embed mode', () => {
+    const { wrapper } = getWrapper({ embedModeEnabled: true })
+    expect(wrapper.findAll('.oc-button').length).toBe(0)
+  })
 })
 
-function getWrapper() {
+function getWrapper({ embedModeEnabled = false } = {}) {
+  jest
+    .mocked(useEmbedMode)
+    .mockReturnValue(mock<ReturnType<typeof useEmbedMode>>({ isEnabled: ref(embedModeEnabled) }))
+
   return {
     wrapper: shallowMount(QuickActions, {
       props: {


### PR DESCRIPTION
## Description
We decided to hide the quick actions in embed mode because the user is supposed to work with the actions provided by the embed mode. No need to clutter the UI with unnecessary stuff.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
