### PR TITLE
feat: decouple creating links from the highlighted file

### DIFF
--- a/packages/web-app-files/tests/unit/store/actions.spec.ts
+++ b/packages/web-app-files/tests/unit/store/actions.spec.ts
@@ -190,59 +190,71 @@ describe('vuex store actions', () => {
     })
   })
 
-  describe('updateCurrentFileShareTypes', () => {
+  describe('updateFileShareTypes', () => {
     const stateMock = { outgoingShares: [], ancestorMetaData: {} }
-    const getRootStateMock = (highlightedFile: Resource) => ({
+    const getRootStateMock = (file: Resource) => ({
       runtime: {
         ancestorMetaData: {
-          ancestorMetaData: highlightedFile ? { [highlightedFile.path]: {} } : {}
+          ancestorMetaData: file ? { [file.path]: {} } : {}
         }
       }
     })
     const commitSpy = jest.fn()
 
     it('updates the resource if given', () => {
-      const highlightedFile = mockDeep<Resource>()
-      const getters = { highlightedFile }
-      actions.updateCurrentFileShareTypes({
-        state: stateMock,
-        rootState: getRootStateMock(null),
-        getters,
-        commit: commitSpy
-      })
+      const file = mockDeep<Resource>({ path: '/foo' })
+      const getters = { files: [file] }
+      actions.updateFileShareTypes(
+        {
+          state: stateMock,
+          rootState: getRootStateMock(null),
+          getters,
+          commit: commitSpy
+        },
+        file.path
+      )
       expect(commitSpy).toHaveBeenCalledTimes(1)
     })
     it('does not update the resource if not given', () => {
-      const highlightedFile = undefined
-      const getters = { highlightedFile }
-      actions.updateCurrentFileShareTypes({
-        state: stateMock,
-        rootState: getRootStateMock(highlightedFile),
-        getters,
-        commit: commitSpy
-      })
+      const file = undefined
+      const getters = { files: [file] }
+      actions.updateFileShareTypes(
+        {
+          state: stateMock,
+          rootState: getRootStateMock(file),
+          getters,
+          commit: commitSpy
+        },
+        '/foo'
+      )
       expect(commitSpy).toHaveBeenCalledTimes(0)
     })
     it('does not update project space resources', () => {
-      const highlightedFile = mockDeep<SpaceResource>({ driveType: 'project' })
-      const getters = { highlightedFile }
-      actions.updateCurrentFileShareTypes({
-        state: stateMock,
-        rootState: getRootStateMock(highlightedFile),
-        getters,
-        commit: commitSpy
-      })
+      const file = mockDeep<SpaceResource>({ driveType: 'project' })
+      const getters = { files: [file] }
+      actions.updateFileShareTypes(
+        {
+          state: stateMock,
+          rootState: getRootStateMock(file),
+          getters,
+          commit: commitSpy
+        },
+        file.path
+      )
       expect(commitSpy).toHaveBeenCalledTimes(0)
     })
     it('updates the ancestor if found', () => {
-      const highlightedFile = mockDeep<Resource>({ path: '/path' })
-      const getters = { highlightedFile }
-      actions.updateCurrentFileShareTypes({
-        state: { outgoingShares: [] },
-        rootState: getRootStateMock(highlightedFile),
-        getters,
-        commit: commitSpy
-      })
+      const file = mockDeep<Resource>({ path: '/path' })
+      const getters = { files: [file] }
+      actions.updateFileShareTypes(
+        {
+          state: { outgoingShares: [] },
+          rootState: getRootStateMock(file),
+          getters,
+          commit: commitSpy
+        },
+        file.path
+      )
       expect(commitSpy).toHaveBeenCalledTimes(2)
     })
   })


### PR DESCRIPTION
## Description
Previously, creating links was coupled to the highlighted file in some ways. As a result, share types were only updated for the highlighted file and the determination whether the link is direct or indirect was done by checking the highlighted file. This is bad because the highlighted file is always the first selected file, though we want to be able to create links for multiple selected files in the future.

This change retrieves the actual file from the store instead of using the highlighted file.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
