### PR TITLE
feat: delegate auth in embed mode

### DIFF
--- a/changelog/unreleased/enhancement-add-auth-delegation
+++ b/changelog/unreleased/enhancement-add-auth-delegation
@@ -1,0 +1,7 @@
+Enhancement: Add authentication delegation in the Embed mode
+
+We've added authentication delegation so that the user does not need to reauthenticate when the parent application already holds a
+valid access token for the user.
+
+https://github.com/owncloud/web/pull/10082
+https://github.com/owncloud/web/issues/10072

--- a/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { mock, mockDeep } from 'jest-mock-extended'
 import { Resource, SpaceResource } from '@ownclouders/web-client/src/helpers'
 import GenericSpace from 'web-app-files/src/views/spaces/GenericSpace.vue'
@@ -17,6 +17,7 @@ import { ConfigurationManager, useBreadcrumbsFromPath } from '@ownclouders/web-p
 import { useBreadcrumbsFromPathMock } from '../../../mocks/useBreadcrumbsFromPathMock'
 
 const mockCreateFolder = jest.fn()
+const mockUseEmbedMode = jest.fn().mockReturnValue({ isEnabled: computed(() => false) })
 
 jest.mock('web-app-files/src/composables/resourcesViewDefaults')
 jest.mock('web-app-files/src/composables/keyboardActions')
@@ -33,7 +34,8 @@ jest.mock('@ownclouders/web-pkg', () => ({
     }),
   useFileActionsCreateNewFolder: () => ({
     actions: [{ handler: mockCreateFolder }]
-  })
+  }),
+  useEmbedMode: jest.fn().mockImplementation(() => mockUseEmbedMode())
 }))
 
 const selectors = Object.freeze({
@@ -231,27 +233,36 @@ describe('GenericSpace view', () => {
     })
 
     it('should render create folder button when in embed mode', () => {
+      mockUseEmbedMode.mockReturnValue({
+        isEnabled: computed(() => true)
+      })
+
       const { wrapper } = getMountedWrapper({
-        stubs: { 'app-bar': AppBarStub, CreateAndUpload: true },
-        configurationOptions: { embed: { enabled: true } }
+        stubs: { 'app-bar': AppBarStub, CreateAndUpload: true }
       })
 
       expect(wrapper.find(selectors.btnCreateFolder).exists()).toBe(true)
     })
 
     it('should not render create and upload actions when in embed mode', () => {
+      mockUseEmbedMode.mockReturnValue({
+        isEnabled: computed(() => true)
+      })
+
       const { wrapper } = getMountedWrapper({
-        stubs: { 'app-bar': AppBarStub, CreateAndUpload: true },
-        configurationOptions: { embed: { enabled: true } }
+        stubs: { 'app-bar': AppBarStub, CreateAndUpload: true }
       })
 
       expect(wrapper.find(selectors.actionsCreateAndUpload).exists()).toBe(false)
     })
 
     it('should call createNewFolderAction when create folder button is clicked', () => {
+      mockUseEmbedMode.mockReturnValue({
+        isEnabled: computed(() => true)
+      })
+
       const { wrapper } = getMountedWrapper({
-        stubs: { 'app-bar': AppBarStub, CreateAndUpload: true },
-        configurationOptions: { embed: { enabled: true } }
+        stubs: { 'app-bar': AppBarStub, CreateAndUpload: true }
       })
 
       // @ts-expect-error even though the vm object is not specified on WrapperLike, it actually is present there
@@ -272,8 +283,7 @@ function getMountedWrapper({
   runningOnEos = false,
   space = { id: 1, getDriveAliasAndItem: jest.fn(), name: 'Personal space', driveType: '' },
   breadcrumbsFromPath = [],
-  stubs = {},
-  configurationOptions = {}
+  stubs = {}
 } = {}) {
   const resourcesViewDetailsMock = useResourcesViewDefaultsMock({
     paginatedResources: ref(files),
@@ -298,8 +308,7 @@ function getMountedWrapper({
         return {
           currentTheme: { general: { slogan: 'Public link slogan' } },
           options: {
-            runningOnEos,
-            ...configurationOptions
+            runningOnEos
           }
         }
       }

--- a/packages/web-pkg/src/composables/embedMode/useEmbedMode.ts
+++ b/packages/web-pkg/src/composables/embedMode/useEmbedMode.ts
@@ -1,28 +1,49 @@
-import { computed } from 'vue'
-import { useStore } from '../store'
+import { computed, unref } from 'vue'
+import { useConfigurationManager } from '../configuration'
 
 export const useEmbedMode = () => {
-  const store = useStore()
+  const configuration = useConfigurationManager()
 
-  const isEnabled = computed<boolean>(() => store.getters.configuration.options.embed?.enabled)
+  const isEnabled = computed(() => configuration.options.embed?.enabled)
 
-  const isLocationPicker = computed<boolean>(() => {
-    return store.getters.configuration.options.embed?.target === 'location'
+  const isLocationPicker = computed(() => {
+    return configuration.options.embed?.target === 'location'
   })
 
-  const messagesTargetOrigin = computed<string>(
-    () => store.getters.configuration.options.embed?.messagesOrigin
+  const messagesTargetOrigin = computed(() => configuration.options.embed?.messagesOrigin)
+
+  const isDelegatingAuthentication = computed(
+    () => unref(isEnabled) && configuration.options.embed.delegateAuthentication
+  )
+
+  const delegateAuthenticationOrigin = computed(
+    () => configuration.options.embed.delegateAuthenticationOrigin
   )
 
   const postMessage = <Payload>(name: string, data?: Payload): void => {
     const options: WindowPostMessageOptions = {}
 
-    if (messagesTargetOrigin.value) {
-      options.targetOrigin = messagesTargetOrigin.value
+    if (unref(messagesTargetOrigin)) {
+      options.targetOrigin = unref(messagesTargetOrigin)
     }
 
     window.parent.postMessage({ name, data }, options)
   }
 
-  return { isEnabled, isLocationPicker, messagesTargetOrigin, postMessage }
+  const verifyDelegatedAuthenticationOrigin = (eventOrigin: string): boolean => {
+    if (!unref(delegateAuthenticationOrigin)) {
+      return true
+    }
+
+    return unref(delegateAuthenticationOrigin) === eventOrigin
+  }
+
+  return {
+    isEnabled,
+    isLocationPicker,
+    messagesTargetOrigin,
+    isDelegatingAuthentication,
+    postMessage,
+    verifyDelegatedAuthenticationOrigin
+  }
 }

--- a/packages/web-pkg/src/configuration/manager.ts
+++ b/packages/web-pkg/src/configuration/manager.ts
@@ -118,6 +118,24 @@ export class ConfigurationManager {
     set(this.optionsConfiguration, 'isRunningOnEos', get(options, 'isRunningOnEos', false))
 
     set(this.optionsConfiguration, 'ocm.openRemotely', get(options, 'ocm.openRemotely', false))
+
+    set(this.optionsConfiguration, 'embed.enabled', get(options, 'embed.enabled', false))
+    set(this.optionsConfiguration, 'embed.target', get(options, 'embed.target', 'resources'))
+    set(
+      this.optionsConfiguration,
+      'embed.messagesOrigin',
+      get(options, 'embed.messagesOrigin', null)
+    )
+    set(
+      this.optionsConfiguration,
+      'embed.delegateAuthentication',
+      get(options, 'embed.delegateAuthentication', false)
+    )
+    set(
+      this.optionsConfiguration,
+      'embed.delegateAuthenticationOrigin',
+      get(options, 'embed.delegateAuthenticationOrigin', null)
+    )
   }
 
   get options(): OptionsConfiguration {

--- a/packages/web-pkg/src/configuration/types.ts
+++ b/packages/web-pkg/src/configuration/types.ts
@@ -36,7 +36,9 @@ export interface OptionsConfiguration {
   embed?: {
     enabled?: boolean
     target?: string
-    messagesOrigin?: string
+    messagesOrigin?: string | null
+    delegateAuthentication?: boolean
+    delegateAuthenticationOrigin?: string | null
   }
 }
 

--- a/packages/web-pkg/tests/unit/composables/embedMode/useEmbedMode.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/embedMode/useEmbedMode.spec.ts
@@ -1,0 +1,235 @@
+import { configurationManager, useEmbedMode } from '../../../../src'
+import { defaultComponentMocks, getComposableWrapper } from 'web-test-helpers'
+import { unref } from 'vue'
+
+describe('useEmbedMode', () => {
+  describe('isEnabled', () => {
+    it('when embed mode is disabled should return false', () => {
+      configurationManager.initialize({
+        server: 'http://server/address/',
+        options: { embed: { enabled: false } }
+      })
+
+      getComposableWrapper(
+        () => {
+          const { isEnabled } = useEmbedMode()
+
+          expect(unref(isEnabled)).toStrictEqual(false)
+        },
+        { mocks: defaultComponentMocks() }
+      )
+    })
+
+    it('when embed mode is enabled should return true', () => {
+      configurationManager.initialize({
+        server: 'http://server/address/',
+        options: { embed: { enabled: true } }
+      })
+
+      getComposableWrapper(
+        () => {
+          const { isEnabled } = useEmbedMode()
+
+          expect(unref(isEnabled)).toStrictEqual(true)
+        },
+        { mocks: defaultComponentMocks() }
+      )
+    })
+  })
+
+  describe('isLocationPicker', () => {
+    it('when target is not location should return false', () => {
+      configurationManager.initialize({
+        server: 'http://server/address/',
+        options: { embed: { target: 'resources' } }
+      })
+
+      getComposableWrapper(
+        () => {
+          const { isLocationPicker } = useEmbedMode()
+
+          expect(unref(isLocationPicker)).toStrictEqual(false)
+        },
+        { mocks: defaultComponentMocks() }
+      )
+    })
+
+    it('when target is location should return true', () => {
+      configurationManager.initialize({
+        server: 'http://server/address/',
+        options: { embed: { target: 'location' } }
+      })
+
+      getComposableWrapper(
+        () => {
+          const { isLocationPicker } = useEmbedMode()
+
+          expect(unref(isLocationPicker)).toStrictEqual(true)
+        },
+        { mocks: defaultComponentMocks() }
+      )
+    })
+  })
+
+  describe('messagesTargetOrigin', () => {
+    it('when messagesOrigin is set should return it', () => {
+      configurationManager.initialize({
+        server: 'http://server/address/',
+        options: { embed: { messagesOrigin: 'message-origin' } }
+      })
+
+      getComposableWrapper(
+        () => {
+          const { messagesTargetOrigin } = useEmbedMode()
+
+          expect(unref(messagesTargetOrigin)).toStrictEqual('message-origin')
+        },
+        { mocks: defaultComponentMocks() }
+      )
+    })
+  })
+
+  describe('isDelegatingAuthentication', () => {
+    it('when delegation is enabled but embed mode is not enabled should return false', () => {
+      configurationManager.initialize({
+        server: 'http://server/address/',
+        options: { embed: { enabled: false, delegateAuthentication: true } }
+      })
+
+      getComposableWrapper(
+        () => {
+          const { isDelegatingAuthentication } = useEmbedMode()
+
+          expect(unref(isDelegatingAuthentication)).toStrictEqual(false)
+        },
+        { mocks: defaultComponentMocks() }
+      )
+    })
+
+    it('when delegation is enabled and embed mode is enabled should return true', () => {
+      configurationManager.initialize({
+        server: 'http://server/address/',
+        options: { embed: { enabled: true, delegateAuthentication: true } }
+      })
+
+      getComposableWrapper(
+        () => {
+          const { isDelegatingAuthentication } = useEmbedMode()
+
+          expect(unref(isDelegatingAuthentication)).toStrictEqual(true)
+        },
+        { mocks: defaultComponentMocks() }
+      )
+    })
+
+    it('when delegation is disabled and embed mode is enabled should return false', () => {
+      configurationManager.initialize({
+        server: 'http://server/address/',
+        options: { embed: { enabled: true, delegateAuthentication: false } }
+      })
+
+      getComposableWrapper(
+        () => {
+          const { isDelegatingAuthentication } = useEmbedMode()
+
+          expect(unref(isDelegatingAuthentication)).toStrictEqual(false)
+        },
+        { mocks: defaultComponentMocks() }
+      )
+    })
+  })
+
+  describe('postMessage', () => {
+    it('when targetOrigin is not set should call postMessage without any origin', () => {
+      window.parent.postMessage = jest.fn()
+
+      getComposableWrapper(
+        () => {
+          const { postMessage } = useEmbedMode()
+
+          postMessage('owncloud-embed:request-token', { hello: 'world' })
+
+          expect(window.parent.postMessage).toHaveBeenCalledWith(
+            {
+              name: 'owncloud-embed:request-token',
+              data: { hello: 'world' }
+            },
+            {}
+          )
+        },
+        { mocks: defaultComponentMocks() }
+      )
+    })
+
+    it('when targetOrigin is set should call postMessage with its value as origin', () => {
+      window.parent.postMessage = jest.fn()
+
+      configurationManager.initialize({
+        server: 'http://server/address/',
+        options: { embed: { messagesOrigin: 'messages-origin' } }
+      })
+
+      getComposableWrapper(
+        () => {
+          const { postMessage } = useEmbedMode()
+
+          postMessage('owncloud-embed:request-token', { hello: 'world' })
+
+          expect(window.parent.postMessage).toHaveBeenCalledWith(
+            {
+              name: 'owncloud-embed:request-token',
+              data: { hello: 'world' }
+            },
+            { targetOrigin: 'messages-origin' }
+          )
+        },
+        { mocks: defaultComponentMocks() }
+      )
+    })
+  })
+
+  describe('verifyDelegatedAuthenticationOrigin', () => {
+    it('when delegateAuthenticationOrigin is not set should return true', () => {
+      getComposableWrapper(
+        () => {
+          const { verifyDelegatedAuthenticationOrigin } = useEmbedMode()
+
+          expect(verifyDelegatedAuthenticationOrigin('event-origin')).toStrictEqual(true)
+        },
+        { mocks: defaultComponentMocks() }
+      )
+    })
+
+    it('when delegateAuthenticationOrigin is set and origins match should return true', () => {
+      getComposableWrapper(
+        () => {
+          configurationManager.initialize({
+            server: 'http://server/address/',
+            options: { embed: { delegateAuthenticationOrigin: 'event-origin' } }
+          })
+
+          const { verifyDelegatedAuthenticationOrigin } = useEmbedMode()
+
+          expect(verifyDelegatedAuthenticationOrigin('event-origin')).toStrictEqual(true)
+        },
+        { mocks: defaultComponentMocks() }
+      )
+    })
+
+    it('when delegateAuthenticationOrigin is set but origins do not match should return false', () => {
+      getComposableWrapper(
+        () => {
+          configurationManager.initialize({
+            server: 'http://server/address/',
+            options: { embed: { delegateAuthenticationOrigin: 'authentication-origin' } }
+          })
+
+          const { verifyDelegatedAuthenticationOrigin } = useEmbedMode()
+
+          expect(verifyDelegatedAuthenticationOrigin('event-origin')).toStrictEqual(false)
+        },
+        { mocks: defaultComponentMocks() }
+      )
+    })
+  })
+})

--- a/packages/web-runtime/src/services/auth/userManager.ts
+++ b/packages/web-runtime/src/services/auth/userManager.ts
@@ -61,7 +61,11 @@ export class UserManager extends OidcUserManager {
       post_logout_redirect_uri: buildUrl(router, '/'),
       accessTokenExpiringNotificationTimeInSeconds: 10,
       authority: '',
-      client_id: ''
+      client_id: '',
+
+      automaticSilentRenew: options.configurationManager.options.embed?.enabled
+        ? !options.configurationManager.options.embed.delegateAuthentication
+        : true
     }
 
     if (options.configurationManager.isOIDC) {

--- a/packages/web-runtime/src/store/config.ts
+++ b/packages/web-runtime/src/store/config.ts
@@ -77,7 +77,9 @@ const state = {
     embed: {
       enabled: false,
       target: 'resources',
-      messagesOrigin: null
+      messagesOrigin: null,
+      delegateAuthentication: false,
+      delegateAuthenticationOrigin: null
     }
   }
 }

--- a/packages/web-runtime/tests/unit/pages/oidcCallback.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/oidcCallback.spec.ts
@@ -1,0 +1,151 @@
+import {
+  RouteLocation,
+  createStore,
+  defaultComponentMocks,
+  defaultPlugins,
+  defaultStoreMockOptions,
+  shallowMount
+} from 'web-test-helpers'
+import oidcCallback from '../../../src/pages/oidcCallback.vue'
+import { authService } from 'web-runtime/src/services/auth'
+import { mock } from 'jest-mock-extended'
+import { computed } from 'vue'
+
+const mockUseEmbedMode = jest.fn()
+
+jest.mock('@ownclouders/web-pkg', () => ({
+  ...jest.requireActual('@ownclouders/web-pkg'),
+  useRoute: jest.fn().mockReturnValue({ query: {} }),
+  useEmbedMode: jest.fn().mockImplementation(() => mockUseEmbedMode())
+}))
+
+const postMessageMock = jest.fn()
+
+describe('oidcCallback page', () => {
+  describe('delegated authentication', () => {
+    it('when authentication is delegated does not call signInCallback immediately', () => {
+      mockUseEmbedMode.mockReturnValue({
+        isDelegatingAuthentication: computed(() => true),
+        postMessage: postMessageMock,
+        verifyDelegatedAuthenticationOrigin: jest.fn().mockReturnValue(true)
+      })
+
+      const signInCallbackSpy = jest
+        .spyOn(authService, 'signInCallback')
+        .mockImplementation(() => Promise.resolve())
+
+      getWrapper()
+
+      expect(signInCallbackSpy).not.toHaveBeenCalled()
+    })
+
+    it('when authentication is not delegated calls signInCallback immediately', () => {
+      mockUseEmbedMode.mockReturnValue({
+        isDelegatingAuthentication: computed(() => false),
+        verifyDelegatedAuthenticationOrigin: jest.fn().mockReturnValue(true)
+      })
+
+      const signInCallbackSpy = jest
+        .spyOn(authService, 'signInCallback')
+        .mockImplementation(() => Promise.resolve())
+
+      getWrapper()
+
+      expect(signInCallbackSpy).toHaveBeenCalled()
+    })
+
+    it('when authentication is delegated calls postMessage with token request event', () => {
+      mockUseEmbedMode.mockReturnValue({
+        isDelegatingAuthentication: computed(() => true),
+        postMessage: postMessageMock,
+        verifyDelegatedAuthenticationOrigin: jest.fn().mockReturnValue(true)
+      })
+
+      jest.spyOn(authService, 'signInCallback').mockImplementation(() => Promise.resolve())
+
+      getWrapper()
+
+      expect(postMessageMock).toHaveBeenCalledWith('owncloud-embed:request-token')
+    })
+
+    it('when token update event is received calls signInCallback', async () => {
+      mockUseEmbedMode.mockReturnValue({
+        isDelegatingAuthentication: computed(() => true),
+        postMessage: postMessageMock,
+        verifyDelegatedAuthenticationOrigin: jest.fn().mockReturnValue(true)
+      })
+
+      const signInCallbackSpy = jest
+        .spyOn(authService, 'signInCallback')
+        .mockImplementation(() => Promise.resolve())
+
+      getWrapper()
+
+      window.postMessage(
+        {
+          name: 'owncloud-embed:update-token',
+          data: { access_token: 'access-token' }
+        },
+        '*'
+      )
+
+      await new Promise<void>((resolve) => setTimeout(() => resolve(), 10))
+
+      expect(signInCallbackSpy).toHaveBeenCalledWith('access-token')
+    })
+
+    it('when token update event is received but name is incorrect does not call signInCallback', async () => {
+      mockUseEmbedMode.mockReturnValue({
+        isDelegatingAuthentication: computed(() => true),
+        postMessage: postMessageMock,
+        verifyDelegatedAuthenticationOrigin: jest.fn().mockReturnValue(true)
+      })
+
+      const signInCallbackSpy = jest
+        .spyOn(authService, 'signInCallback')
+        .mockImplementation(() => Promise.resolve())
+
+      getWrapper()
+
+      window.postMessage(
+        {
+          name: 'update-token',
+          data: { access_token: 'access-token' }
+        },
+        '*'
+      )
+
+      await new Promise<void>((resolve) => setTimeout(() => resolve(), 10))
+
+      expect(signInCallbackSpy).not.toHaveBeenCalled()
+    })
+  })
+})
+
+function getWrapper() {
+  const storeOptions = { ...defaultStoreMockOptions }
+
+  storeOptions.getters.configuration.mockReturnValue({
+    server: 'http://server/address/',
+    currentTheme: { logo: {}, general: {} }
+  })
+
+  const store = createStore(storeOptions)
+
+  const mocks = {
+    ...defaultComponentMocks({
+      currentRoute: mock<RouteLocation>({ query: {} })
+    })
+  }
+
+  return {
+    storeOptions,
+    wrapper: shallowMount(oidcCallback, {
+      global: {
+        plugins: [...defaultPlugins(), store],
+        mocks,
+        provide: {}
+      }
+    })
+  }
+}

--- a/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
+++ b/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
@@ -1,3 +1,4 @@
+import { ConfigurationManager } from '@ownclouders/web-pkg'
 import { AuthService } from 'web-runtime/src/services/auth/authService'
 import { createRouter } from 'web-test-helpers/src'
 
@@ -18,6 +19,7 @@ describe('AuthService', () => {
       'parses query params and passes them explicitly to router.replace: %s => %s %s',
       async (url, path, query: any) => {
         const authService = new AuthService()
+        const configurationManager = new ConfigurationManager()
 
         jest.replaceProperty(authService as any, 'userManager', {
           signinRedirectCallback: jest.fn(),
@@ -27,7 +29,12 @@ describe('AuthService', () => {
         const router = createRouter()
         const replaceSpy = jest.spyOn(router, 'replace')
 
-        authService.initialize(null, null, null, router, null, null)
+        configurationManager.initialize({
+          server: 'http://server/address/',
+          options: { embed: { enabled: false } }
+        })
+
+        authService.initialize(configurationManager, null, null, router, null, null)
 
         await authService.signInCallback()
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Add option to delegate authentication to parent application when Web is included in Embed mode. The automatic token refresh is disabled in such configuration and token is set/updated via events.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #10073
- fixes #10072

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Do not force the user to authenticate twice when the parent application already has valid access_token.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: local
- test case 1: open web in embed mode with delegated authentication and manually post an existing access_token with `postMessage` method

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
