### PR TITLE
fix: checking for internal links

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
@@ -432,7 +432,10 @@ export default defineComponent({
     },
 
     isAliasLink() {
-      return [linkRoleInternalFolder, linkRoleInternalFile].includes(this.currentLinkRole)
+      if (this.isFolderShare) {
+        return parseInt(this.link.permissions) == linkRoleInternalFolder.bitmask(false)
+      }
+      return parseInt(this.link.permissions) == linkRoleInternalFile.bitmask(false)
     },
 
     currentLinkNotifyUploads() {


### PR DESCRIPTION
## Description
Changes the check for internal links in the `DetailsAndEdit` component so it doesn't compare objects against each other. That always feels unstable and broke our unit tests recently.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10087

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
