### PR TITLE
feat: allow disabling the actions of a modal

### DIFF
--- a/packages/design-system/src/components/OcModal/OcModal.vue
+++ b/packages/design-system/src/components/OcModal/OcModal.vue
@@ -65,7 +65,7 @@
           </div>
         </div>
 
-        <div class="oc-modal-body-actions oc-flex oc-flex-right">
+        <div v-if="!hideActions" class="oc-modal-body-actions oc-flex oc-flex-right">
           <oc-button
             ref="cancelButton"
             class="oc-modal-body-actions-cancel"
@@ -388,6 +388,13 @@ export default defineComponent({
       type: String,
       required: false,
       default: null
+    },
+    /**
+     * Hide the actions at the bottom of the modal
+     */
+    hideActions: {
+      type: Boolean,
+      default: false
     }
   },
   emits: [

--- a/packages/web-runtime/src/App.vue
+++ b/packages/web-runtime/src/App.vue
@@ -32,6 +32,7 @@
       :checkbox-label="modal.checkboxLabel"
       :contextual-helper-label="modal.contextualHelperLabel"
       :contextual-helper-data="modal.contextualHelperData"
+      :hide-actions="modal.hideActions"
       @cancel="onModalCancel"
       @confirm="onModalConfirm"
       @input="modal.onInput"

--- a/packages/web-runtime/src/store/modal.ts
+++ b/packages/web-runtime/src/store/modal.ts
@@ -29,7 +29,8 @@ const state = {
   onConfirmSecondary: emptyReturn,
   contextualHelperLabel: '',
   contextualHelperData: {},
-  customContent: ''
+  customContent: '',
+  hideActions: false
 }
 
 const actions = {
@@ -90,6 +91,7 @@ const mutations = {
     state.customContent = modal.customContent || ''
     state.onPasswordChallengeCompleted = modal.onPasswordChallengeCompleted
     state.onPasswordChallengeFailed = modal.onPasswordChallengeFailed
+    state.hideActions = modal.hideActions || false
   },
 
   HIDE_MODAL(state) {


### PR DESCRIPTION
## Description
The predefined actions are hardly customizable, which can be a problem when using a custom component that also needs custom actions in a modal. By hiding the modal's actions the custom component can take care of it by itself.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
