### PR TITLE
fix: disable router-links for pending and declined shares

### DIFF
--- a/changelog/unreleased/enhancement-show-hide-shares
+++ b/changelog/unreleased/enhancement-show-hide-shares
@@ -7,3 +7,4 @@ Furthermore, accepting and rejecting shares has been renamed to "enable sync"/"d
 
 https://github.com/owncloud/web/issues/9531
 https://github.com/owncloud/web/pull/9718
+https://github.com/owncloud/web/pull/10097

--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -66,7 +66,7 @@
           :is-thumbnail-displayed="shouldDisplayThumbnails(item)"
           :is-icon-displayed="!$slots['image']"
           :is-extension-displayed="areFileExtensionsShown"
-          :is-resource-clickable="isResourceClickable(item.id)"
+          :is-resource-clickable="isResourceClickable(item)"
           :folder-link="getFolderLink(item)"
           :parent-folder-link="getParentFolderLink(item)"
           :parent-folder-link-icon-additional-attributes="
@@ -215,7 +215,7 @@ import { mapGetters, mapActions, mapState } from 'vuex'
 import { useWindowSize } from '@vueuse/core'
 import { Resource } from '@ownclouders/web-client'
 import { extractDomSelector, SpaceResource } from '@ownclouders/web-client/src/helpers'
-import { ShareTypes } from '@ownclouders/web-client/src/helpers/share'
+import { ShareStatus, ShareTypes } from '@ownclouders/web-client/src/helpers/share'
 
 import {
   useCapabilityFilesTags,
@@ -893,12 +893,17 @@ export default defineComponent({
        */
       this.$emit('fileClick', { space, resources: [resource] })
     },
-    isResourceClickable(resourceId) {
+    isResourceClickable({ id, status }: Resource) {
       if (!this.areResourcesClickable) {
         return false
       }
 
-      return !this.disabledResources.includes(resourceId)
+      // TODO: remove as soon as pending & declined shares are accessible
+      if (status === ShareStatus.pending || status === ShareStatus.declined) {
+        return false
+      }
+
+      return !this.disabledResources.includes(id)
     },
     getResourceCheckboxLabel(resource) {
       if (resource.type === 'folder') {


### PR DESCRIPTION
## Description
This is only a temporary fix until those shares can be accessed properly, which will be possible with the new sharing NG. No unit tests added because of that.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10094

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
