### PR TITLE
fix: skip reusing old token in embed mode with delegated auth

### DIFF
--- a/changelog/unreleased/bugfix-skip-token-reuse-in-embed-mode
+++ b/changelog/unreleased/bugfix-skip-token-reuse-in-embed-mode
@@ -1,0 +1,6 @@
+Bugfix: Skip reusing saved token in Embed mode with delegated authentication
+
+We've stopped reusing saved token in the AuthService when Web is included in Embed mode with delegated authentication.
+The parent application is responsible for handling the access_token.
+
+https://github.com/owncloud/web/pull/10113

--- a/changelog/unreleased/bugfix-skip-token-reuse-in-embed-mode
+++ b/changelog/unreleased/bugfix-skip-token-reuse-in-embed-mode
@@ -1,6 +1,0 @@
-Bugfix: Skip reusing saved token in Embed mode with delegated authentication
-
-We've stopped reusing saved token in the AuthService when Web is included in Embed mode with delegated authentication.
-The parent application is responsible for handling the access_token.
-
-https://github.com/owncloud/web/pull/10113

--- a/changelog/unreleased/enhancement-add-auth-delegation
+++ b/changelog/unreleased/enhancement-add-auth-delegation
@@ -3,5 +3,6 @@ Enhancement: Add authentication delegation in the Embed mode
 We've added authentication delegation so that the user does not need to reauthenticate when the parent application already holds a
 valid access token for the user.
 
-https://github.com/owncloud/web/pull/10082
 https://github.com/owncloud/web/issues/10072
+https://github.com/owncloud/web/pull/10082
+https://github.com/owncloud/web/pull/10113

--- a/packages/web-runtime/src/pages/oidcCallback.vue
+++ b/packages/web-runtime/src/pages/oidcCallback.vue
@@ -47,6 +47,9 @@ export default defineComponent({
         return
       }
 
+      console.info(
+        '[page:oidcCallback:handleRequestedTokenEvent] - received delegated access_token'
+      )
       authService.signInCallback(event.data.data.access_token)
     }
 
@@ -60,8 +63,10 @@ export default defineComponent({
       }
 
       if (unref(isDelegatingAuthentication)) {
-        postMessage<void>('owncloud-embed:request-token')
+        console.info('[page:oidcCallback:hook:mounted] - adding update-token event listener')
         window.addEventListener('message', handleRequestedTokenEvent)
+        console.info('[page:oidcCallback:hook:mounted] - requesting delegated access_token')
+        postMessage<void>('owncloud-embed:request-token')
 
         return
       }
@@ -78,6 +83,7 @@ export default defineComponent({
         return
       }
 
+      console.info('[page:oidcCallback:hook:beforeUnmount] - removing update-token event listener')
       window.removeEventListener('message', handleRequestedTokenEvent)
     })
 

--- a/packages/web-runtime/src/pages/oidcCallback.vue
+++ b/packages/web-runtime/src/pages/oidcCallback.vue
@@ -47,7 +47,7 @@ export default defineComponent({
         return
       }
 
-      console.info(
+      console.debug(
         '[page:oidcCallback:handleRequestedTokenEvent] - received delegated access_token'
       )
       authService.signInCallback(event.data.data.access_token)
@@ -63,9 +63,9 @@ export default defineComponent({
       }
 
       if (unref(isDelegatingAuthentication)) {
-        console.info('[page:oidcCallback:hook:mounted] - adding update-token event listener')
+        console.debug('[page:oidcCallback:hook:mounted] - adding update-token event listener')
         window.addEventListener('message', handleRequestedTokenEvent)
-        console.info('[page:oidcCallback:hook:mounted] - requesting delegated access_token')
+        console.debug('[page:oidcCallback:hook:mounted] - requesting delegated access_token')
         postMessage<void>('owncloud-embed:request-token')
 
         return
@@ -83,7 +83,7 @@ export default defineComponent({
         return
       }
 
-      console.info('[page:oidcCallback:hook:beforeUnmount] - removing update-token event listener')
+      console.debug('[page:oidcCallback:hook:beforeUnmount] - removing update-token event listener')
       window.removeEventListener('message', handleRequestedTokenEvent)
     })
 

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -174,7 +174,7 @@ export class AuthService {
       // no userLoaded event and no signInCallback gets triggered
       const accessToken = await this.userManager.getAccessToken()
       if (accessToken) {
-        console.info('[authService:initializeContext] - updating context with saved access_token')
+        console.debug('[authService:initializeContext] - updating context with saved access_token')
 
         try {
           await this.userManager.updateContext(accessToken, fetchUserData)
@@ -201,11 +201,11 @@ export class AuthService {
         this.configurationManager.options.embed.delegateAuthentication &&
         accessToken
       ) {
-        console.info('[authService:signInCallback] - setting access_token and fetching user')
+        console.debug('[authService:signInCallback] - setting access_token and fetching user')
         await this.userManager.updateContext(accessToken, true)
 
         // Setup a listener to handle token refresh
-        console.info('[authService:signInCallback] - adding listener to update-token event')
+        console.debug('[authService:signInCallback] - adding listener to update-token event')
         window.addEventListener('message', this.handleDelegatedTokenUpdate)
       } else {
         await this.userManager.signinRedirectCallback(this.buildSignInCallbackUrl())
@@ -316,7 +316,7 @@ export class AuthService {
       return
     }
 
-    console.info('[authService:handleDelegatedTokenUpdate] - going to update the access_token')
+    console.debug('[authService:handleDelegatedTokenUpdate] - going to update the access_token')
     this.userManager.updateContext(event.data, false)
   }
 }

--- a/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
+++ b/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
@@ -1,6 +1,11 @@
 import { ConfigurationManager } from '@ownclouders/web-pkg'
+import { mock } from 'jest-mock-extended'
+import { Store } from 'vuex'
 import { AuthService } from 'web-runtime/src/services/auth/authService'
-import { createRouter } from 'web-test-helpers/src'
+import { UserManager } from 'web-runtime/src/services/auth/userManager'
+import { RouteLocation, createRouter } from 'web-test-helpers/src'
+
+const mockUpdateContext = jest.fn()
 
 describe('AuthService', () => {
   describe('signInCallback', () => {
@@ -44,5 +49,127 @@ describe('AuthService', () => {
         })
       }
     )
+  })
+
+  describe('initializeContext', () => {
+    it('when embed mode is disabled and access_token is present, should call updateContext', async () => {
+      const authService = new AuthService()
+      const configurationManager = new ConfigurationManager()
+
+      jest.replaceProperty(
+        authService as any,
+        'userManager',
+        mock<UserManager>({
+          getAccessToken: jest.fn().mockResolvedValue('access-token'),
+          updateContext: mockUpdateContext
+        })
+      )
+
+      configurationManager.initialize({
+        server: 'http://server/address/',
+        options: { embed: { enabled: false } }
+      })
+      authService.initialize(configurationManager, null, mock<Store<any>>({}), null, null, null)
+
+      await authService.initializeContext(mock<RouteLocation>({}))
+
+      expect(mockUpdateContext).toHaveBeenCalledWith('access-token', true)
+    })
+
+    it('when embed mode is disabled and access_token is not present, should not call updateContext', async () => {
+      const authService = new AuthService()
+      const configurationManager = new ConfigurationManager()
+
+      jest.replaceProperty(
+        authService as any,
+        'userManager',
+        mock<UserManager>({
+          getAccessToken: jest.fn().mockResolvedValue(null),
+          updateContext: mockUpdateContext
+        })
+      )
+
+      configurationManager.initialize({
+        server: 'http://server/address/',
+        options: { embed: { enabled: false } }
+      })
+      authService.initialize(configurationManager, null, mock<Store<any>>({}), null, null, null)
+
+      await authService.initializeContext(mock<RouteLocation>({}))
+
+      expect(mockUpdateContext).not.toHaveBeenCalled()
+    })
+
+    it('when embed mode is enabled, access_token is present but auth is not delegated, should call updateContext', async () => {
+      const authService = new AuthService()
+      const configurationManager = new ConfigurationManager()
+
+      jest.replaceProperty(
+        authService as any,
+        'userManager',
+        mock<UserManager>({
+          getAccessToken: jest.fn().mockResolvedValue('access-token'),
+          updateContext: mockUpdateContext
+        })
+      )
+
+      configurationManager.initialize({
+        server: 'http://server/address/',
+        options: { embed: { enabled: true, delegateAuthentication: false } }
+      })
+      authService.initialize(configurationManager, null, mock<Store<any>>({}), null, null, null)
+
+      await authService.initializeContext(mock<RouteLocation>({}))
+
+      expect(mockUpdateContext).toHaveBeenCalledWith('access-token', true)
+    })
+
+    it('when embed mode is enabled, access_token is present and auth is delegated, should not call updateContext', async () => {
+      const authService = new AuthService()
+      const configurationManager = new ConfigurationManager()
+
+      jest.replaceProperty(
+        authService as any,
+        'userManager',
+        mock<UserManager>({
+          getAccessToken: jest.fn().mockResolvedValue('access-token'),
+          updateContext: mockUpdateContext
+        })
+      )
+
+      configurationManager.initialize({
+        server: 'http://server/address/',
+        options: { embed: { enabled: true, delegateAuthentication: true } }
+      })
+      authService.initialize(configurationManager, null, mock<Store<any>>({}), null, null, null)
+
+      await authService.initializeContext(mock<RouteLocation>({}))
+
+      expect(mockUpdateContext).not.toHaveBeenCalled()
+    })
+
+    it('when embed mode is disabled, access_token is present and auth is delegated, should call updateContext', async () => {
+      const authService = new AuthService()
+      const configurationManager = new ConfigurationManager()
+
+      jest.replaceProperty(
+        authService as any,
+        'userManager',
+        mock<UserManager>({
+          getAccessToken: jest.fn().mockResolvedValue('access-token'),
+          updateContext: mockUpdateContext
+        })
+      )
+
+      configurationManager.initialize({
+        server: 'http://server/address/',
+        options: { embed: { enabled: false, delegateAuthentication: true } }
+      })
+      authService.initialize(configurationManager, null, mock<Store<any>>({}), null, null, null)
+
+      await authService.initializeContext(mock<RouteLocation>({}))
+
+      expect(mockUpdateContext).toHaveBeenCalledWith('access-token', true)
+    })
   })
 })


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

When Web is included in an iframe in embed mode with delegated authentication, skip reusing the old token. The parent application is responsible for handling the token and we do not really care about reloading there which the reuse seems to be intended to handle. If the old token is reused, it can lead to an error when fetching user with expired token. That will then lead to a redirect to access denied page once the delegated access_token is received.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Fixing a bug which leads to access denied page.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: local
- test case 1: embed web in an iframe with delegated auth, postMessage with valid token, wait for the token to expire, remove the iframe, build the iframe again with expired token, postMessage with new valid token

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] add tests
- [x] add changelog
