### PR TITLE
feat: retrieve audio and location metadata

### DIFF
--- a/packages/web-client/src/helpers/resource/functions.ts
+++ b/packages/web-client/src/helpers/resource/functions.ts
@@ -143,6 +143,8 @@ export function buildResource(resource: WebDavResponseResource): Resource {
     ownerId: resource.props[DavProperty.OwnerId],
     ownerDisplayName: resource.props[DavProperty.OwnerDisplayName],
     tags: (resource.props[DavProperty.Tags] || '').split(',').filter(Boolean),
+    audio: resource.props[DavProperty.Audio],
+    location: resource.props[DavProperty.Location],
     canUpload: function () {
       return this.permissions.indexOf(DavPermission.FolderCreateable) >= 0
     },

--- a/packages/web-client/src/helpers/resource/types.ts
+++ b/packages/web-client/src/helpers/resource/types.ts
@@ -2,6 +2,7 @@ import { DavFileInfoResponse } from '@ownclouders/web-client/src/webdav/constant
 import { User } from '../user'
 import { MongoAbility, SubjectRawRule } from '@casl/ability'
 import { DAVResultResponseProps, FileStat } from 'webdav'
+import { Audio, GeoCoordinates } from '../../generated'
 
 export type AbilityActions =
   | 'create'
@@ -48,6 +49,8 @@ export interface Resource {
   readonly nodeId?: string
   name?: string
   tags?: string[]
+  audio?: Audio
+  location?: GeoCoordinates
   disabled?: boolean
   path: string
   webDavPath?: string

--- a/packages/web-client/src/webdav/constants/dav.ts
+++ b/packages/web-client/src/webdav/constants/dav.ts
@@ -1,3 +1,5 @@
+import { Audio, GeoCoordinates } from '../../generated'
+
 export abstract class DavPermission {
   static readonly Shared: string = 'S'
   static readonly Shareable: string = 'R'
@@ -50,6 +52,14 @@ const DavPropertyMapping = {
   ContentSize: defNumber('size' as const),
   LastModifiedDate: defString('getlastmodified' as const),
   Tags: defString('tags' as const),
+  Audio: {
+    value: 'audio',
+    type: null as Audio
+  },
+  Location: {
+    value: 'location',
+    type: null as GeoCoordinates
+  },
   ETag: defString('getetag' as const),
   MimeType: defString('getcontenttype' as const),
   ResourceType: defStringArray('resourcetype' as const),
@@ -116,7 +126,9 @@ export abstract class DavProperties {
     DavProperty.MimeType,
     DavProperty.ResourceType,
     DavProperty.DownloadURL,
-    DavProperty.Tags
+    DavProperty.Tags,
+    DavProperty.Audio,
+    DavProperty.Location
   ]
 
   static readonly PublicLink: DavPropertyValue[] = DavProperties.Default.concat([


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Load `audio` and `location` metadata in propfinds.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Depends on https://github.com/owncloud/ocis/pull/7898

## Motivation and Context
I want to make metadata available to extensions, especially sidebar panels (c.f. #10111)
MS Graph API returns `audio` and `location` facets as soon as they are available for a `driveItem` - assuming oCIS wants to stay compatible with that and that we are going to switch to graph api at some point, I think we don't need to add complexity for loading these props only on demand.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
