### PR TITLE
fix: use unique key for search result table

### DIFF
--- a/packages/web-app-files/src/components/Search/List.vue
+++ b/packages/web-app-files/src/components/Search/List.vue
@@ -102,6 +102,7 @@
           :sort-by="sortBy"
           :sort-dir="sortDir"
           :fields-displayed="['name', 'size', 'tags', 'mdate']"
+          :resource-dom-selector="resourceDomSelector"
           @file-click="triggerDefaultAction"
           @row-mounted="rowMounted"
           @sort="handleSort"
@@ -203,6 +204,7 @@ import {
   useKeyboardTableMouseActions,
   useKeyboardTableActions
 } from 'web-app-files/src/composables/keyboardActions'
+import { extractDomSelector } from '@ownclouders/web-client/src/helpers'
 
 const visibilityObserver = new VisibilityObserver()
 
@@ -434,6 +436,14 @@ export default defineComponent({
       ]
     })
 
+    const resourceDomSelector = ({ id, shareId }: Resource) => {
+      let selectorStr = id.toString()
+      if (shareId) {
+        selectorStr += shareId
+      }
+      return extractDomSelector(selectorStr)
+    }
+
     onMounted(async () => {
       // Store resources are shared across table views, therefore
       // the store state needs a reset to prevent the old list of resources
@@ -492,7 +502,8 @@ export default defineComponent({
       lastModifiedFilter,
       mediaTypeFilter,
       availableMediaTypeValues,
-      getFakeResourceForIcon
+      getFakeResourceForIcon,
+      resourceDomSelector
     }
   },
   computed: {


### PR DESCRIPTION
## Description
Since the search result table can hold one resource multiple times through different shares we need to include the `shareId` when creating a unique key for each table row.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7727

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
