### PR TITLE
fix: selection after space duplication

### DIFF
--- a/changelog/unreleased/enhancement-duplicate-space
+++ b/changelog/unreleased/enhancement-duplicate-space
@@ -5,4 +5,5 @@ This includes copying the contents, the space name, subtitle, description, and i
 like tags or members.
 
 https://github.com/owncloud/web/pull/10024
+https://github.com/owncloud/web/pull/10132
 https://github.com/owncloud/web/issues/10016

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsDuplicate.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsDuplicate.ts
@@ -11,6 +11,8 @@ import { buildSpace, isProjectSpaceResource } from '@ownclouders/web-client/src/
 import { Drive } from '@ownclouders/web-client/src/generated'
 import { resolveFileNameDuplicate } from '../../../helpers'
 import PQueue from 'p-queue'
+import { useRouter } from '../../router'
+import { isLocationSpacesActive } from '../../../router'
 
 export const useSpaceActionsDuplicate = ({
   store
@@ -18,10 +20,13 @@ export const useSpaceActionsDuplicate = ({
   store?: Store<any>
 } = {}) => {
   store = store || useStore()
+  const router = useRouter()
   const { $gettext } = useGettext()
   const ability = useAbility()
   const clientService = useClientService()
   const loadingService = useLoadingService()
+
+  const isProjectsLocation = isLocationSpacesActive(router, 'files-spaces-projects')
 
   const duplicateSpace = async (existingSpace: SpaceResource) => {
     const projectSpaces: SpaceResource[] = store.getters['runtime/spaces/spaces'].filter(
@@ -96,6 +101,10 @@ export const useSpaceActionsDuplicate = ({
       }
 
       store.commit('runtime/spaces/UPSERT_SPACE', duplicatedSpace)
+      if (isProjectsLocation) {
+        store.commit('Files/UPSERT_RESOURCE', duplicatedSpace)
+      }
+
       store.dispatch('showMessage', {
         title: $gettext('Space "%{space}" was duplicated successfully', {
           space: existingSpace.name


### PR DESCRIPTION
## Description
Spaces are listed as regular resources on the projects page, hence we need to make sure to insert duplicated spaces as such.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10124

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
