### PR TITLE
fix: radio background color

### DIFF
--- a/packages/design-system/src/components/OcRadio/OcRadio.vue
+++ b/packages/design-system/src/components/OcRadio/OcRadio.vue
@@ -149,7 +149,7 @@ export default defineComponent({
   }
 
   &:checked {
-    background-color: var(--oc-color-background-highlight);
+    background-color: var(--oc-color-background-highlight) !important;
   }
 
   &.oc-radio-s {


### PR DESCRIPTION
## Description
Fixes the known issue with `pnpm vite` and `pnpm build` prioritizing CSS coming from the ODS differently.

## Screenshots

before -> after

<img width="437" alt="Pasted Graphic" src="https://github.com/owncloud/web/assets/50302941/8eb90adc-9f29-4419-b47e-c3478a44ac31">

<img width="429" alt="Pasted Graphic 1" src="https://github.com/owncloud/web/assets/50302941/304eefbf-27c6-4424-882e-8c3d94718fbb">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
