### PR TITLE
fix: resolve share jail private link in both formats

### DIFF
--- a/packages/web-runtime/src/pages/resolvePrivateLink.vue
+++ b/packages/web-runtime/src/pages/resolvePrivateLink.vue
@@ -91,7 +91,12 @@ export default defineComponent({
 
     const resolvePrivateLinkTask = useTask(function* (signal, id) {
       try {
-        if (id === `${SHARE_JAIL_ID}$${SHARE_JAIL_ID}!${SHARE_JAIL_ID}`) {
+        if (
+          [
+            `${SHARE_JAIL_ID}$${SHARE_JAIL_ID}!${SHARE_JAIL_ID}`,
+            `${SHARE_JAIL_ID}$${SHARE_JAIL_ID}`
+          ].includes(id)
+        ) {
           return router.push(createLocationShares('files-shares-with-me'))
         }
 


### PR DESCRIPTION
## Description
The private link of the share jail needs to redirect to the shared with me page. This was already the case for the 3-segment id. The drives API exposes the 2-segment id as well, so we need this, too.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/10141
- Relates to https://github.com/owncloud/web/issues/9867

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 