### PR TITLE
fix: resolving links without drive alias

### DIFF
--- a/changelog/unreleased/bugfix-resolve-link-without-drive-alias
+++ b/changelog/unreleased/bugfix-resolve-link-without-drive-alias
@@ -1,0 +1,6 @@
+Bugfix: Resolving links without drive alias
+
+Resolving links without a drive alias has been fixed in case a fileId is given via query param.
+
+https://github.com/owncloud/web/pull/10154
+https://github.com/owncloud/web/issues/9269

--- a/packages/web-app-files/src/views/spaces/DriveResolver.vue
+++ b/packages/web-app-files/src/views/spaces/DriveResolver.vue
@@ -129,6 +129,18 @@ export default defineComponent({
     }
 
     onMounted(async () => {
+      if (!unref(driveAliasAndItem) && unref(fileId)) {
+        return router.push({
+          name: 'resolvePrivateLink',
+          params: { fileId: unref(fileId) },
+          query: {
+            ...(configurationManager.options.openLinksWithDefaultApp && {
+              openWithDefaultApp: 'true'
+            })
+          }
+        })
+      }
+
       const space = unref(resolvedDrive.space)
       if (space && isPublicSpaceResource(space)) {
         const isRunningOnEos = store.getters.configuration?.options?.runningOnEos

--- a/packages/web-app-files/tests/unit/views/spaces/DriveResolver.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/DriveResolver.spec.ts
@@ -1,5 +1,5 @@
 import DriveResolver from '../../../../src/views/spaces/DriveResolver.vue'
-import { useDriveResolver } from '@ownclouders/web-pkg'
+import { queryItemAsString, useDriveResolver, useRouteParam } from '@ownclouders/web-pkg'
 import { computed, ref } from 'vue'
 import { mock, mockDeep } from 'jest-mock-extended'
 import { ClientService } from '@ownclouders/web-pkg'
@@ -21,7 +21,9 @@ import {
 jest.mock('@ownclouders/web-pkg', () => ({
   ...jest.requireActual('@ownclouders/web-pkg'),
   useGetMatchingSpace: jest.fn(),
-  useDriveResolver: jest.fn()
+  useDriveResolver: jest.fn(),
+  useRouteParam: jest.fn(),
+  queryItemAsString: jest.fn()
 }))
 
 describe('DriveResolver view', () => {
@@ -102,6 +104,16 @@ describe('DriveResolver view', () => {
       })
     )
   })
+  it('redirects to private link if no drive alias but a fileId is given', async () => {
+    const { wrapper, mocks } = getMountedWrapper({ driveAliasAndItem: '' })
+    await wrapper.vm.$nextTick()
+
+    expect(mocks.$router.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'resolvePrivateLink'
+      })
+    )
+  })
 })
 
 function getMountedWrapper({
@@ -109,8 +121,12 @@ function getMountedWrapper({
   space = undefined,
   internalSpace = undefined,
   currentRouteName = 'files-spaces-generic',
-  isUserContextReady = false
+  isUserContextReady = false,
+  driveAliasAndItem = 'personal/einstein/file',
+  fileId = '1'
 } = {}) {
+  jest.mocked(useRouteParam).mockReturnValue(ref(driveAliasAndItem))
+  jest.mocked(queryItemAsString).mockReturnValue(fileId)
   jest.mocked(useDriveResolver).mockImplementation(() => ({
     space,
     item: ref('/'),


### PR DESCRIPTION
## Description
We can simply use our private link resolving in case a drive alias is missing while a `fileId` is present.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9269

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
