### PR TITLE
fix: uploading the same files parallel

### DIFF
--- a/changelog/unreleased/bugfix-parallel-uploads
+++ b/changelog/unreleased/bugfix-parallel-uploads
@@ -1,0 +1,6 @@
+Bugfix: Uploading the same files parallel
+
+An issue where uploading the same files parallel would cause the upload to fail has been fixed.
+
+https://github.com/owncloud/web/pull/10156
+https://github.com/owncloud/web/issues/9220

--- a/packages/web-app-files/src/HandleUpload.ts
+++ b/packages/web-app-files/src/HandleUpload.ts
@@ -370,6 +370,10 @@ export class HandleUpload extends BasePlugin {
    * Eventually triggers to upload in Uppy.
    */
   async handleUpload(files: UppyFile[]) {
+    if (!files.length) {
+      return
+    }
+
     let filesToUpload = this.prepareFiles(files)
 
     // quota check


### PR DESCRIPTION

## Description
Fixes uploading the same files parallel. Uppy is smart enough to not add duplicated files to the upload queue, we just need to early return in that case.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9220

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
