### PR TITLE
fix: gdpr export polling

### DIFF
--- a/changelog/unreleased/bugfix-gdpr-export-polling
+++ b/changelog/unreleased/bugfix-gdpr-export-polling
@@ -1,0 +1,6 @@
+Bugfix: GDPR export polling
+
+Periodically checking for a processed GDPR export in the account menu has been fixed.
+
+https://github.com/owncloud/web/pull/10158
+https://github.com/owncloud/web/issues/8862

--- a/packages/web-runtime/src/components/Account/GdprExport.vue
+++ b/packages/web-runtime/src/components/Account/GdprExport.vue
@@ -52,7 +52,7 @@ export default defineComponent({
     const { downloadFile } = useDownloadFile()
 
     const loading = ref(true)
-    const checkInterval = ref()
+    const checkInterval = ref<ReturnType<typeof setInterval>>()
     const exportFile = ref<Resource>()
     const exportInProgress = ref(false)
 
@@ -80,6 +80,7 @@ export default defineComponent({
         exportInProgress.value = false
         if (unref(checkInterval)) {
           clearInterval(unref(checkInterval))
+          checkInterval.value = undefined
         }
       } catch (e) {
         if (e.statusCode !== 404) {


### PR DESCRIPTION

## Description
Fixes periodically checking for new gdpr exports which didn't work reliably due to never resetting the polling interval.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/8862

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
