### PR TITLE
fix: reset password input for internal links

### DIFF
--- a/changelog/unreleased/enhancement-create-link-modal
+++ b/changelog/unreleased/enhancement-create-link-modal
@@ -4,3 +4,5 @@ When creating a link while passwords are enfoced, Web will now display a modal t
 
 https://github.com/owncloud/web/pull/10104
 https://github.com/owncloud/web/pull/10145
+https://github.com/owncloud/web/pull/10159
+https://github.com/owncloud/web/issues/10157

--- a/packages/web-pkg/src/components/CreateLinkModal.vue
+++ b/packages/web-pkg/src/components/CreateLinkModal.vue
@@ -40,6 +40,7 @@
   <div>
     <oc-text-input
       v-if="!onlyInternalLinksAllowed"
+      :key="passwordInputKey"
       :model-value="password.value"
       type="password"
       :password-policy="passwordPolicy"
@@ -136,6 +137,7 @@
 
 <script lang="ts">
 import { DateTime } from 'luxon'
+import { v4 as uuidV4 } from 'uuid'
 import { useGettext } from 'vue3-gettext'
 import {
   computed,
@@ -207,6 +209,7 @@ export default defineComponent({
 
     const isFolder = computed(() => props.resources.every(({ isFolder }) => isFolder))
 
+    const passwordInputKey = ref(uuidV4())
     const roleRefs = ref<Record<string, ComponentPublicInstance>>({})
 
     const password = reactive({ value: '', error: undefined })
@@ -348,7 +351,11 @@ export default defineComponent({
       selectedRole.value = role
       if (unref(selectedRoleIsInternal)) {
         password.value = ''
+        password.error = ''
         selectedExpiry.value = undefined
+
+        // re-render password because it's the only way to remove policy messages
+        passwordInputKey.value = uuidV4()
       }
     }
 
@@ -369,6 +376,7 @@ export default defineComponent({
       passwordEnforced,
       passwordPolicy,
       generatePasswordMethod: () => passwordPolicyService.generatePassword(),
+      passwordInputKey,
       selectedExpiry,
       expirationDateTooltip,
       expirationRules,


### PR DESCRIPTION
## Description
Resets the password input in the link creation modal when selecting the internal link role since it doesn't support passwords. This way, unrelated error messages and policy information gets cleared.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10157

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
