### PR TITLE
test: re-enable e2e test for changing logo

### DIFF
--- a/tests/e2e/cucumber/features/smoke/admin-settings/general.feature
+++ b/tests/e2e/cucumber/features/smoke/admin-settings/general.feature
@@ -1,11 +1,11 @@
 Feature: general management
 
-  # Scenario: logo can be changed in the admin settings
-  #   When "Admin" logs in
-  #   And "Admin" opens the "admin-settings" app
-  #   And "Admin" navigates to the general management page
-  #   Then "Admin" should be able to upload a logo from the local file "filesForUpload/testavatar.png"
-  #   And "Admin" navigates to the general management page
-  #   And "Admin" should be able to reset the logo
-  #   And "Admin" logs out
+  Scenario: logo can be changed in the admin settings
+    When "Admin" logs in
+    And "Admin" opens the "admin-settings" app
+    And "Admin" navigates to the general management page
+    Then "Admin" should be able to upload a logo from the local file "filesForUpload/testavatar.png"
+    And "Admin" navigates to the general management page
+    And "Admin" should be able to reset the logo
+    And "Admin" logs out
 


### PR DESCRIPTION
## Description
We disabled the test with https://github.com/owncloud/web/pull/9698 to get the pipeline green. oCIS has been updated meanwhile, which means we can re-enable the test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
