### PR TITLE
Readonly versions panel

### DIFF
--- a/changelog/unreleased/bugfix-versions-readonly
+++ b/changelog/unreleased/bugfix-versions-readonly
@@ -1,0 +1,5 @@
+Bugfix: Make versions panel readonly in viewers and editors
+
+We've made the versions right sidebar panel readonly when opening the right sidebar from within a viewer or editor.
+
+https://github.com/owncloud/web/pull/10182

--- a/packages/web-app-files/src/components/SideBar/Actions/FileActions.vue
+++ b/packages/web-app-files/src/components/SideBar/Actions/FileActions.vue
@@ -22,7 +22,7 @@ export default defineComponent({
     ActionMenuItem
   },
   setup() {
-    const resource = inject<Resource>('resource')
+    const resource = inject<Ref<Resource>>('resource')
     const space = inject<Ref<SpaceResource>>('space')
     const resources = computed(() => {
       return [unref(resource)]

--- a/packages/web-app-files/src/components/SideBar/Actions/SpaceActions.vue
+++ b/packages/web-app-files/src/components/SideBar/Actions/SpaceActions.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, inject, ref, unref, VNodeRef } from 'vue'
+import { computed, defineComponent, inject, Ref, ref, unref, VNodeRef } from 'vue'
 import { SpaceResource } from '@ownclouders/web-client'
 import { ActionMenuItem } from '@ownclouders/web-pkg'
 import { QuotaModal } from '@ownclouders/web-pkg'
@@ -58,7 +58,7 @@ export default defineComponent({
   setup() {
     const store = useStore()
     const previewService = usePreviewService()
-    const resource = inject<SpaceResource>('resource')
+    const resource = inject<Ref<SpaceResource>>('resource')
     const actionOptions = computed(() => ({
       resources: [unref(resource)]
     }))

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -173,7 +173,7 @@ export default defineComponent({
     const { getMatchingSpace } = useGetMatchingSpace()
     const language = useGettext()
 
-    const resource = inject<Resource>('resource')
+    const resource = inject<Ref<Resource>>('resource')
     const space = inject<Ref<SpaceResource>>('space')
     const isPublicLinkContext = usePublicLinkContext({ store })
     const previewService = usePreviewService()

--- a/packages/web-app-files/src/fileSideBars.ts
+++ b/packages/web-app-files/src/fileSideBars.ts
@@ -200,6 +200,9 @@ export const sideBarPanels = () => {
             icon: 'git-branch',
             title: () => $gettext('Versions'),
             component: FileVersions,
+            componentAttrs: () => ({
+              isReadOnly: !unref(isFilesAppActive)
+            }),
             isVisible: ({ items }) => {
               if (items?.length !== 1) {
                 return false

--- a/packages/web-pkg/src/composables/download/useDownloadFile.ts
+++ b/packages/web-pkg/src/composables/download/useDownloadFile.ts
@@ -5,12 +5,19 @@ import { useStore } from '../store'
 import { triggerDownloadWithFilename } from '../../../src/helpers'
 import { useGettext } from 'vue3-gettext'
 import { useCapabilityCoreSupportUrlSigning } from '../capability'
+import { Store } from 'vuex'
+import { ClientService } from '../../services'
 
-export const useDownloadFile = () => {
-  const store = useStore()
+export interface DownloadFileOptions {
+  store?: Store<any>
+  clientService?: ClientService
+}
+
+export const useDownloadFile = (options?: DownloadFileOptions) => {
+  const store = options?.store || useStore()
   const isPublicLinkContext = usePublicLinkContext({ store })
   const isUrlSigningEnabled = useCapabilityCoreSupportUrlSigning()
-  const clientService = useClientService()
+  const clientService = options?.clientService || useClientService()
   const { $gettext } = useGettext()
 
   const downloadFile = async (file, version = null) => {


### PR DESCRIPTION
## Description
Make versions panel readonly when the right sidebar is opened from within a viewer or editor.
Reason for that is that it would require complex user interaction to make reverting versions from within an editor view (= the file content is already displayed) possible. Let's avoid that by only allowing the download action, not the revert action.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
