### PR TITLE
refactor: quota modal usage

### DIFF
--- a/packages/web-app-admin-settings/src/components/Spaces/ContextActions.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/ContextActions.vue
@@ -1,20 +1,14 @@
 <template>
   <div>
     <context-action-menu :menu-sections="menuSections" :action-options="{ resources: items }" />
-    <quota-modal
-      v-if="quotaModalIsOpen"
-      :cancel="closeQuotaModal"
-      :spaces="items"
-      :max-quota="maxQuota"
-    />
   </div>
 </template>
 
 <script lang="ts">
 import { computed, defineComponent, PropType, unref } from 'vue'
 import { SpaceResource } from '@ownclouders/web-client'
-import { ContextActionMenu, QuotaModal } from '@ownclouders/web-pkg'
-import { useCapabilitySpacesMaxQuota, useStore } from '@ownclouders/web-pkg'
+import { ContextActionMenu } from '@ownclouders/web-pkg'
+import { useStore } from '@ownclouders/web-pkg'
 
 import {
   useSpaceActionsDelete,
@@ -28,7 +22,7 @@ import {
 
 export default defineComponent({
   name: 'ContextActions',
-  components: { ContextActionMenu, QuotaModal },
+  components: { ContextActionMenu },
   props: {
     items: {
       type: Array as PropType<SpaceResource[]>,
@@ -41,11 +35,7 @@ export default defineComponent({
 
     const { actions: deleteActions } = useSpaceActionsDelete({ store })
     const { actions: disableActions } = useSpaceActionsDisable({ store })
-    const {
-      actions: editQuotaActions,
-      modalOpen: quotaModalIsOpen,
-      closeModal: closeQuotaModal
-    } = useSpaceActionsEditQuota({ store })
+    const { actions: editQuotaActions } = useSpaceActionsEditQuota({ store })
     const { actions: editDescriptionActions } = useSpaceActionsEditDescription({ store })
     const { actions: renameActions } = useSpaceActionsRename({ store })
     const { actions: restoreActions } = useSpaceActionsRestore({ store })
@@ -93,10 +83,7 @@ export default defineComponent({
     })
 
     return {
-      maxQuota: useCapabilitySpacesMaxQuota(),
-      menuSections,
-      quotaModalIsOpen,
-      closeQuotaModal
+      menuSections
     }
   }
 })

--- a/packages/web-app-admin-settings/src/components/Spaces/SideBar/ActionsPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/SideBar/ActionsPanel.vue
@@ -1,11 +1,5 @@
 <template>
   <div>
-    <quota-modal
-      v-if="quotaModalIsOpen"
-      :cancel="closeQuotaModal"
-      :spaces="resources"
-      :max-quota="maxQuota"
-    />
     <oc-list id="oc-spaces-actions-sidebar" class-name="oc-mt-s">
       <action-menu-item
         v-for="(action, index) in actions"
@@ -28,14 +22,13 @@ import {
   useSpaceActionsRename,
   useSpaceActionsRestore
 } from '@ownclouders/web-pkg'
-import { QuotaModal } from '@ownclouders/web-pkg'
 import { computed, defineComponent, inject, unref } from 'vue'
 import { SpaceResource } from '@ownclouders/web-client'
-import { useCapabilitySpacesMaxQuota, useStore } from '@ownclouders/web-pkg'
+import { useStore } from '@ownclouders/web-pkg'
 
 export default defineComponent({
   name: 'ActionsPanel',
-  components: { ActionMenuItem, QuotaModal },
+  components: { ActionMenuItem },
   setup() {
     const store = useStore()
     const resource = inject<SpaceResource>('resource')
@@ -49,11 +42,7 @@ export default defineComponent({
     const { actions: deleteActions } = useSpaceActionsDelete({ store })
     const { actions: disableActions } = useSpaceActionsDisable({ store })
     const { actions: editDescriptionActions } = useSpaceActionsEditDescription({ store })
-    const {
-      actions: editQuotaActions,
-      modalOpen: quotaModalIsOpen,
-      closeModal: closeQuotaModal
-    } = useSpaceActionsEditQuota({ store })
+    const { actions: editQuotaActions } = useSpaceActionsEditQuota({ store })
     const { actions: renameActions } = useSpaceActionsRename({ store })
     const { actions: restoreActions } = useSpaceActionsRestore({ store })
 
@@ -71,9 +60,6 @@ export default defineComponent({
     return {
       actions,
       actionOptions,
-      maxQuota: useCapabilitySpacesMaxQuota(),
-      quotaModalIsOpen,
-      closeQuotaModal,
       resources
     }
   }

--- a/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsAddToGroups.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsAddToGroups.ts
@@ -22,10 +22,10 @@ export const useUserActionsAddToGroups = ({ groups }: { groups: Ref<Group[]> }) 
       ),
       hideActions: true,
       customComponent: AddToGroupsModal,
-      customComponentAttrs: {
-        users: [...resources],
+      customComponentAttrs: () => ({
+        users: resources,
         groups: unref(groups)
-      }
+      })
     })
   }
 

--- a/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsEditLogin.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsEditLogin.ts
@@ -22,9 +22,9 @@ export const useUserActionsEditLogin = () => {
       ),
       hideActions: true,
       customComponent: LoginModal,
-      customComponentAttrs: {
-        users: [...resources]
-      }
+      customComponentAttrs: () => ({
+        users: resources
+      })
     })
   }
 

--- a/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsRemoveFromGroups.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsRemoveFromGroups.ts
@@ -22,10 +22,10 @@ export const useUserActionsRemoveFromGroups = ({ groups }: { groups: Ref<Group[]
       ),
       hideActions: true,
       customComponent: RemoveFromGroupsModal,
-      customComponentAttrs: {
-        users: [...resources],
+      customComponentAttrs: () => ({
+        users: resources,
         groups: unref(groups)
-      }
+      })
     })
   }
 

--- a/packages/web-app-admin-settings/src/views/Spaces.vue
+++ b/packages/web-app-admin-settings/src/views/Spaces.vue
@@ -21,12 +21,6 @@
         />
       </template>
       <template #mainContent>
-        <quota-modal
-          v-if="quotaModalIsOpen"
-          :cancel="closeQuotaModal"
-          :spaces="selectedSpaces"
-          :max-quota="maxQuota"
-        />
         <no-content-message
           v-if="!spaces.length"
           id="admin-settings-spaces-empty"
@@ -64,7 +58,6 @@ import MembersPanel from '../components/Spaces/SideBar/MembersPanel.vue'
 import ActionsPanel from '../components/Spaces/SideBar/ActionsPanel.vue'
 import {
   NoContentMessage,
-  QuotaModal,
   SideBarPanel,
   SideBarPanelContext,
   SpaceAction,
@@ -76,7 +69,6 @@ import {
   configurationManager,
   queryItemAsString,
   useAccessToken,
-  useCapabilitySpacesMaxQuota,
   useClientService,
   useRouteQuery,
   useSideBar,
@@ -98,8 +90,7 @@ export default defineComponent({
     AppTemplate,
     NoContentMessage,
     ContextActions,
-    SpaceInfo,
-    QuotaModal
+    SpaceInfo
   },
   provide() {
     return {
@@ -115,7 +106,7 @@ export default defineComponent({
     const { isSideBarOpen, sideBarActivePanel } = useSideBar()
 
     const loadResourcesEventToken = ref(null)
-    let updateQuotaForSpaceEventToken
+    let updateQuotaForSpaceEventToken: string
     const template = ref(null)
     const selectedSpaces = ref([])
 
@@ -173,11 +164,7 @@ export default defineComponent({
 
     const { actions: deleteActions } = useSpaceActionsDelete({ store })
     const { actions: disableActions } = useSpaceActionsDisable({ store })
-    const {
-      actions: editQuotaActions,
-      modalOpen: quotaModalIsOpen,
-      closeModal: closeQuotaModal
-    } = useSpaceActionsEditQuota({ store })
+    const { actions: editQuotaActions } = useSpaceActionsEditQuota({ store })
     const { actions: restoreActions } = useSpaceActionsRestore({ store })
 
     const batchActions = computed((): SpaceAction[] => {
@@ -281,7 +268,6 @@ export default defineComponent({
     })
 
     return {
-      maxQuota: useCapabilitySpacesMaxQuota(),
       isSideBarOpen,
       sideBarActivePanel,
       spaces,
@@ -295,9 +281,7 @@ export default defineComponent({
       template,
       selectSpaces,
       toggleSelectSpace,
-      unselectAllSpaces,
-      quotaModalIsOpen,
-      closeQuotaModal
+      unselectAllSpaces
     }
   }
 })

--- a/packages/web-app-admin-settings/tests/unit/composables/actions/users/useUserActionsEditQuota.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/composables/actions/users/useUserActionsEditQuota.spec.ts
@@ -11,7 +11,7 @@ import { unref } from 'vue'
 describe('useUserActionsEditQuota', () => {
   describe('isEnabled property', () => {
     it('should be false when not resource given', () => {
-      const { wrapper } = getWrapper({
+      getWrapper({
         setup: ({ actions }) => {
           expect(unref(actions)[0].isEnabled({ resources: [] })).toBe(false)
         }
@@ -25,7 +25,7 @@ describe('useUserActionsEditQuota', () => {
           quota: {}
         }
       }
-      const { wrapper } = getWrapper({
+      getWrapper({
         canEditSpaceQuota: true,
         setup: ({ actions }) => {
           expect(unref(actions)[0].isEnabled({ resources: [userMock] })).toBe(true)
@@ -40,7 +40,7 @@ describe('useUserActionsEditQuota', () => {
           quota: {}
         }
       }
-      const { wrapper } = getWrapper({
+      getWrapper({
         canEditSpaceQuota: false,
         setup: ({ actions }) => {
           expect(unref(actions)[0].isEnabled({ resources: [userMock] })).toBe(false)
@@ -63,6 +63,16 @@ describe('useUserActionsEditQuota', () => {
             }
           })
           expect(unref(actions)[0].isEnabled({ resources: [userMock] })).toEqual(false)
+        }
+      })
+    })
+  })
+  describe('handler', () => {
+    it('should create a modal', () => {
+      getWrapper({
+        setup: async ({ actions }, { storeOptions }) => {
+          await unref(actions)[0].handler({ resources: [] })
+          expect(storeOptions.actions.createModal).toHaveBeenCalled()
         }
       })
     })

--- a/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Spaces.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Spaces.spec.ts.snap
@@ -16,7 +16,6 @@ exports[`Spaces view loading states should render spaces list after loading has 
           <!--v-if-->
         </div>
       </div>
-      <!--v-if-->
       <div>
         <spaces-list-stub class="" selectedspaces="" spaces="[object Object]"></spaces-list-stub>
       </div>

--- a/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Users.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Users.spec.ts.snap
@@ -52,7 +52,6 @@ exports[`Users view list view renders initially warning if filters are mandatory
     </div>
     <!--v-if-->
   </main>
-  <!--v-if-->
 </div>
 `;
 
@@ -194,6 +193,5 @@ exports[`Users view list view renders list initially 1`] = `
     </div>
     <!--v-if-->
   </main>
-  <!--v-if-->
 </div>
 `;

--- a/packages/web-app-files/src/components/SideBar/Actions/SpaceActions.vue
+++ b/packages/web-app-files/src/components/SideBar/Actions/SpaceActions.vue
@@ -1,11 +1,5 @@
 <template>
   <div>
-    <quota-modal
-      v-if="quotaModalIsOpen"
-      :cancel="closeQuotaModal"
-      :spaces="[actionOptions.resources[0]]"
-      :max-quota="maxQuota"
-    />
     <input
       id="space-image-upload-input"
       ref="spaceImageInput"
@@ -31,8 +25,7 @@
 import { computed, defineComponent, inject, Ref, ref, unref, VNodeRef } from 'vue'
 import { SpaceResource } from '@ownclouders/web-client'
 import { ActionMenuItem } from '@ownclouders/web-pkg'
-import { QuotaModal } from '@ownclouders/web-pkg'
-import { useCapabilitySpacesMaxQuota, useStore, usePreviewService } from '@ownclouders/web-pkg'
+import { useStore, usePreviewService } from '@ownclouders/web-pkg'
 import {
   useSpaceActionsDelete,
   useSpaceActionsDisable,
@@ -48,7 +41,7 @@ import { useFileActionsDownloadArchive } from '@ownclouders/web-pkg'
 
 export default defineComponent({
   name: 'SpaceActions',
-  components: { ActionMenuItem, QuotaModal },
+  components: { ActionMenuItem },
   setup() {
     const store = useStore()
     const previewService = usePreviewService()
@@ -66,11 +59,7 @@ export default defineComponent({
     const { actions: disableActions } = useSpaceActionsDisable({ store })
     const { actions: duplicateActions } = useSpaceActionsDuplicate({ store })
     const { actions: editDescriptionActions } = useSpaceActionsEditDescription({ store })
-    const {
-      actions: editQuotaActions,
-      modalOpen: quotaModalIsOpen,
-      closeModal: closeQuotaModal
-    } = useSpaceActionsEditQuota({ store })
+    const { actions: editQuotaActions } = useSpaceActionsEditQuota({ store })
     const { actions: editReadmeContentActions } = useSpaceActionsEditReadmeContent({ store })
     const { actions: renameActions } = useSpaceActionsRename({ store })
     const { actions: restoreActions } = useSpaceActionsRestore({ store })
@@ -96,17 +85,13 @@ export default defineComponent({
     )
 
     return {
-      maxQuota: useCapabilitySpacesMaxQuota(),
       actions,
       actionOptions,
       spaceImageInput,
       supportedSpaceImageMimeTypes,
 
       uploadImageActions,
-      uploadImageSpace,
-
-      quotaModalIsOpen,
-      closeQuotaModal
+      uploadImageSpace
     }
   }
 })

--- a/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
@@ -274,7 +274,7 @@ export default defineComponent({
         title: $gettext('Set password'),
         hideActions: true,
         customComponent: SetLinkPasswordModal,
-        customComponentAttrs: { link: params }
+        customComponentAttrs: () => ({ link: params })
       })
     }
 

--- a/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
@@ -245,7 +245,7 @@ export default defineComponent({
         title: props.link.password ? $gettext('Edit password') : $gettext('Add password'),
         hideActions: true,
         customComponent: SetLinkPasswordModal,
-        customComponentAttrs: { link: props.link }
+        customComponentAttrs: () => ({ link: props.link })
       })
     }
 

--- a/packages/web-app-files/src/components/Spaces/SpaceContextActions.vue
+++ b/packages/web-app-files/src/components/Spaces/SpaceContextActions.vue
@@ -1,12 +1,6 @@
 <template>
   <div>
     <context-action-menu :menu-sections="menuSections" :action-options="_actionOptions" />
-    <quota-modal
-      v-if="quotaModalIsOpen"
-      :cancel="closeQuotaModal"
-      :spaces="_actionOptions.resources"
-      :max-quota="maxQuota"
-    />
     <input
       id="space-image-upload-input"
       ref="spaceImageInput"
@@ -22,8 +16,6 @@
 
 <script lang="ts">
 import { ContextActionMenu, useSpaceActionsNavigateToTrash } from '@ownclouders/web-pkg'
-import { QuotaModal } from '@ownclouders/web-pkg'
-
 import { useFileActionsShowDetails } from '@ownclouders/web-pkg'
 import { useSpaceActionsUploadImage } from 'web-app-files/src/composables'
 import {
@@ -39,19 +31,13 @@ import {
 } from '@ownclouders/web-pkg'
 import { isLocationSpacesActive } from '@ownclouders/web-pkg'
 import { computed, defineComponent, PropType, Ref, ref, toRef, unref, VNodeRef } from 'vue'
-import {
-  useCapabilitySpacesMaxQuota,
-  useRouter,
-  useStore,
-  usePreviewService
-} from '@ownclouders/web-pkg'
+import { useRouter, useStore, usePreviewService } from '@ownclouders/web-pkg'
 import { FileActionOptions, SpaceActionOptions } from '@ownclouders/web-pkg'
 import { useFileActionsDownloadArchive } from '@ownclouders/web-pkg'
 
 export default defineComponent({
   name: 'SpaceContextActions',
-  components: { ContextActionMenu, QuotaModal },
-
+  components: { ContextActionMenu },
   props: {
     actionOptions: {
       type: Object as PropType<SpaceActionOptions>,
@@ -72,11 +58,7 @@ export default defineComponent({
     const { actions: deleteActions } = useSpaceActionsDelete({ store })
     const { actions: disableActions } = useSpaceActionsDisable({ store })
     const { actions: duplicateActions } = useSpaceActionsDuplicate({ store })
-    const {
-      actions: editQuotaActions,
-      modalOpen: quotaModalIsOpen,
-      closeModal: closeQuotaModal
-    } = useSpaceActionsEditQuota({ store })
+    const { actions: editQuotaActions } = useSpaceActionsEditQuota({ store })
     const { actions: editDescriptionActions } = useSpaceActionsEditDescription({ store })
     const { actions: editReadmeContentActions } = useSpaceActionsEditReadmeContent({ store })
     const { actions: renameActions } = useSpaceActionsRename({ store })
@@ -165,15 +147,11 @@ export default defineComponent({
     return {
       _actionOptions: actionOptions,
       menuSections,
-      maxQuota: useCapabilitySpacesMaxQuota(),
       spaceImageInput,
       uploadImageActions,
       uploadImageSpace,
 
-      supportedSpaceImageMimeTypes,
-
-      quotaModalIsOpen,
-      closeQuotaModal
+      supportedSpaceImageMimeTypes
     }
   }
 })

--- a/packages/web-app-files/tests/unit/components/Spaces/__snapshots__/SpaceContextActions.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/Spaces/__snapshots__/SpaceContextActions.spec.ts.snap
@@ -58,7 +58,6 @@ exports[`SpaceContextActions action handlers renders actions that are always ava
       </li>
     </ul>
   </div>
-  <!--v-if-->
   <input accept="" id="space-image-upload-input" multiple="" name="file" tabindex="-1" type="file">
 </div>
 `;

--- a/packages/web-pkg/src/components/AppBar/AppBar.vue
+++ b/packages/web-pkg/src/components/AppBar/AppBar.vue
@@ -1,11 +1,5 @@
 <template>
   <div id="files-app-bar" ref="filesAppBar" :class="{ 'files-app-bar-squashed': isSideBarOpen }">
-    <quota-modal
-      v-if="quotaModalIsOpen"
-      :cancel="closeQuotaModal"
-      :spaces="selectedFiles"
-      :max-quota="maxQuota"
-    />
     <oc-hidden-announcer :announcement="selectedResourcesAnnouncement" level="polite" />
 
     <div class="files-topbar oc-py-s">
@@ -79,7 +73,6 @@ import {
 } from '@ownclouders/web-client/src/helpers'
 import BatchActions from '../BatchActions.vue'
 import ContextActions from '../FilesList/ContextActions.vue'
-import QuotaModal from '../Spaces/QuotaModal.vue'
 import ViewOptions from '../ViewOptions.vue'
 import { isLocationCommonActive, isLocationTrashActive } from '../../router'
 import { ViewMode } from '../../ui/types'
@@ -97,7 +90,6 @@ import {
 } from '../../composables/actions'
 import {
   useAbility,
-  useCapabilitySpacesMaxQuota,
   useFileActionsToggleHideShare,
   useRouteMeta,
   useStore,
@@ -121,8 +113,7 @@ export default defineComponent({
   components: {
     BatchActions,
     ContextActions,
-    ViewOptions,
-    QuotaModal
+    ViewOptions
   },
   props: {
     viewModeDefault: {
@@ -173,11 +164,7 @@ export default defineComponent({
     const { actions: restoreActions } = useFileActionsRestore({ store })
     const { actions: deleteSpaceActions } = useSpaceActionsDelete({ store })
     const { actions: disableSpaceActions } = useSpaceActionsDisable({ store })
-    const {
-      actions: editSpaceQuotaActions,
-      modalOpen: quotaModalIsOpen,
-      closeModal: closeQuotaModal
-    } = useSpaceActionsEditQuota({ store })
+    const { actions: editSpaceQuotaActions } = useSpaceActionsEditQuota({ store })
     const { actions: restoreSpaceActions } = useSpaceActionsRestore({ store })
 
     const breadcrumbMaxWidth = ref<number>(0)
@@ -273,10 +260,7 @@ export default defineComponent({
       breadcrumbMaxWidth,
       breadcrumbTruncationOffset,
       fileDroppedBreadcrumb,
-      pageTitle,
-      quotaModalIsOpen,
-      closeQuotaModal,
-      maxQuota: useCapabilitySpacesMaxQuota()
+      pageTitle
     }
   },
   data: function () {

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCreateLink.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCreateLink.ts
@@ -76,12 +76,12 @@ export const useFileActionsCreateLink = ({
           { resourceName: resources[0].name }
         ),
         customComponent: CreateLinkModal,
-        customComponentAttrs: {
+        customComponentAttrs: () => ({
           space,
           resources,
           isQuickLink,
           callbackFn: proceedResult
-        },
+        }),
         hideActions: true
       })
     }

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCreateNewShortcut.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCreateNewShortcut.ts
@@ -15,7 +15,7 @@ export const useFileActionsCreateNewShortcut = ({ space }: { space: SpaceResourc
       title: $gettext('Create a Shortcut'),
       hideActions: true,
       customComponent: CreateShortcutModal,
-      customComponentAttrs: { space }
+      customComponentAttrs: () => ({ space })
     })
   }
 

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditQuota.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditQuota.ts
@@ -1,22 +1,39 @@
 import { Store } from 'vuex'
-import { computed, ref } from 'vue'
-import { SpaceAction } from '../types'
+import { computed } from 'vue'
+import { SpaceAction, SpaceActionOptions } from '../types'
 import { useGettext } from 'vue3-gettext'
 import { useAbility } from '../../ability'
-import { isProjectSpaceResource } from '@ownclouders/web-client/src/helpers'
+import { SpaceResource, isProjectSpaceResource } from '@ownclouders/web-client/src/helpers'
+import { useStore } from '../../store'
+import { QuotaModal } from '../../../components'
 
 export const useSpaceActionsEditQuota = ({ store }: { store?: Store<any> } = {}) => {
+  store = store || useStore()
   const { $gettext } = useGettext()
   const ability = useAbility()
 
-  const modalOpen = ref(false)
-
-  const closeModal = () => {
-    modalOpen.value = false
+  const getModalTitle = ({ resources }: { resources: SpaceResource[] }) => {
+    if (resources.length === 1) {
+      return $gettext('Change quota for Space "%{name}"', {
+        name: resources[0].name
+      })
+    }
+    return $gettext('Change quota for %{count} Spaces', {
+      count: resources.length.toString()
+    })
   }
 
-  const handler = () => {
-    modalOpen.value = true
+  const handler = ({ resources }: SpaceActionOptions) => {
+    return store.dispatch('createModal', {
+      variation: 'passive',
+      title: getModalTitle({ resources }),
+      customComponent: QuotaModal,
+      customComponentAttrs: () => ({
+        spaces: resources,
+        resourceType: 'space'
+      }),
+      hideActions: true
+    })
   }
 
   const actions = computed((): SpaceAction[] => [
@@ -42,8 +59,6 @@ export const useSpaceActionsEditQuota = ({ store }: { store?: Store<any> } = {})
   ])
 
   return {
-    modalOpen,
-    closeModal,
     actions
   }
 }

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditReadmeContent.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditReadmeContent.ts
@@ -16,7 +16,7 @@ export const useSpaceActionsEditReadmeContent = ({ store }: { store?: Store<any>
         name: resources[0].name
       }),
       customComponent: ReadmeContentModal,
-      customComponentAttrs: { space: resources[0] }
+      customComponentAttrs: () => ({ space: resources[0] })
     })
   }
 

--- a/packages/web-pkg/tests/unit/components/AppBar/__snapshots__/AppBar.spec.ts.snap
+++ b/packages/web-pkg/tests/unit/components/AppBar/__snapshots__/AppBar.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`AppBar component renders by default no breadcrumbs, no bulkactions, no sharesnavigation but viewoptions and sidebartoggle 1`] = `
 <div class="" displayviewmodeswitch="false" hassidebartoggle="true" id="files-app-bar">
-  <!--v-if-->
   <oc-hidden-announcer-stub announcement="No items selected." level="polite"></oc-hidden-announcer-stub>
   <div class="files-topbar oc-py-s">
     <h1 class="oc-invisible-sr">ExampleTitle</h1>
@@ -26,7 +25,6 @@ exports[`AppBar component renders by default no breadcrumbs, no bulkactions, no 
 
 exports[`AppBar component renders if given, with content in the actions slot 1`] = `
 <div class="" displayviewmodeswitch="false" hassidebartoggle="true" id="files-app-bar">
-  <!--v-if-->
   <oc-hidden-announcer-stub announcement="No items selected." level="polite"></oc-hidden-announcer-stub>
   <div class="files-topbar oc-py-s">
     <h1 class="oc-invisible-sr">ExampleTitle</h1>
@@ -50,7 +48,6 @@ exports[`AppBar component renders if given, with content in the actions slot 1`]
 
 exports[`AppBar component renders if given, with content in the content slot 1`] = `
 <div class="" displayviewmodeswitch="false" hassidebartoggle="true" id="files-app-bar">
-  <!--v-if-->
   <oc-hidden-announcer-stub announcement="No items selected." level="polite"></oc-hidden-announcer-stub>
   <div class="files-topbar oc-py-s">
     <h1 class="oc-invisible-sr">ExampleTitle</h1>

--- a/packages/web-pkg/tests/unit/components/Spaces/QuotaModal.spec.ts
+++ b/packages/web-pkg/tests/unit/components/Spaces/QuotaModal.spec.ts
@@ -25,7 +25,7 @@ describe('QuotaModal', () => {
           }
         })
       )
-      await wrapper.vm.editQuota()
+      await wrapper.vm.onConfirm()
 
       expect(
         storeOptions.modules.runtime.modules.spaces.mutations.UPDATE_SPACE_FIELD
@@ -37,7 +37,7 @@ describe('QuotaModal', () => {
       jest.spyOn(console, 'error').mockImplementation(() => undefined)
       const { wrapper, mocks, storeOptions } = getWrapper()
       mocks.$clientService.graphAuthenticated.drives.updateDrive.mockRejectedValue(new Error())
-      await wrapper.vm.editQuota()
+      await wrapper.vm.onConfirm()
 
       expect(
         storeOptions.modules.runtime.modules.spaces.mutations.UPDATE_SPACE_FIELD
@@ -56,7 +56,6 @@ function getWrapper() {
     storeOptions,
     wrapper: mount(QuotaModal, {
       props: {
-        cancel: jest.fn(),
         spaces: [
           {
             id: '1fe58d8b-aa69-4c22-baf7-97dd57479f22',
@@ -70,7 +69,7 @@ function getWrapper() {
         ]
       },
       global: {
-        stubs: { ...defaultStubs, portal: true, 'oc-modal': true },
+        stubs: { ...defaultStubs },
         mocks,
         provide: mocks,
         plugins: [...defaultPlugins(), store]

--- a/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsEditQuota.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsEditQuota.spec.ts
@@ -13,7 +13,7 @@ import { Drive } from '@ownclouders/web-client/src/generated'
 describe('editQuota', () => {
   describe('isEnabled property', () => {
     it('should be false when not resource given', () => {
-      const { wrapper } = getWrapper({
+      getWrapper({
         setup: ({ actions }) => {
           expect(unref(actions)[0].isEnabled({ resources: [] })).toBe(false)
         }
@@ -29,7 +29,7 @@ describe('editQuota', () => {
         driveType: 'project',
         special: null
       })
-      const { wrapper } = getWrapper({
+      getWrapper({
         canEditSpaceQuota: true,
         setup: ({ actions }) => {
           expect(unref(actions)[0].isEnabled({ resources: [buildSpace(spaceMock)] })).toBe(true)
@@ -46,10 +46,20 @@ describe('editQuota', () => {
         driveType: 'project',
         special: null
       })
-      const { wrapper } = getWrapper({
+      getWrapper({
         canEditSpaceQuota: false,
         setup: ({ actions }) => {
           expect(unref(actions)[0].isEnabled({ resources: [buildSpace(spaceMock)] })).toBe(false)
+        }
+      })
+    })
+  })
+  describe('handler', () => {
+    it('should create a modal', () => {
+      getWrapper({
+        setup: async ({ actions }, { storeOptions }) => {
+          await unref(actions)[0].handler({ resources: [] })
+          expect(storeOptions.actions.createModal).toHaveBeenCalled()
         }
       })
     })

--- a/packages/web-runtime/src/App.vue
+++ b/packages/web-runtime/src/App.vue
@@ -46,7 +46,7 @@
           v-else
           ref="modalComponent"
           :modal="modal"
-          v-bind="modal.customComponentAttrs"
+          v-bind="modal.customComponentAttrs?.() || {}"
         />
       </template>
     </oc-modal>


### PR DESCRIPTION
## Description
Before, the state of the quota modal was handled by the outside where it was being used. This caused quite some boilerplate code because it's effectively always the same.

Refactors the quota modal usage so that the modal state handling is done via the quota action instead, meaning the consuming party doesn't need to care about it anymore.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/10095

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
