### PR TITLE
refactor: space readme modal usage

### DIFF
--- a/packages/design-system/src/components/OcModal/OcModal.vue
+++ b/packages/design-system/src/components/OcModal/OcModal.vue
@@ -43,14 +43,10 @@
               :placeholder="inputPlaceholder"
               :label="inputLabel"
               :type="inputType"
-              :password-policy="inputPasswordPolicy"
-              :generate-password-method="inputGeneratePasswordMethod"
               :description-message="inputDescription"
               :disabled="inputDisabled"
               :fix-message-line="true"
               :selection-range="inputSelectionRange"
-              @password-challenge-completed="$emit('passwordChallengeCompleted')"
-              @password-challenge-failed="$emit('passwordChallengeFailed')"
               @update:model-value="inputOnInput"
               @keydown.enter.prevent="confirm"
             />
@@ -107,7 +103,6 @@ import OcIcon from '../OcIcon/OcIcon.vue'
 import OcTextInput from '../OcTextInput/OcTextInput.vue'
 import { FocusTrap } from 'focus-trap-vue'
 import { FocusTargetOrFalse, FocusTargetValueOrFalse } from 'focus-trap'
-import { PasswordPolicy } from '../../helpers'
 
 /**
  * Modals are generally used to force the user to focus on confirming or completing a single action.
@@ -365,22 +360,6 @@ export default defineComponent({
       default: false
     },
     /**
-     * Password policy for the input
-     */
-    inputPasswordPolicy: {
-      type: Object as PropType<PasswordPolicy>,
-      required: false,
-      default: () => ({})
-    },
-    /**
-     * Method to generate random password for the input
-     */
-    inputGeneratePasswordMethod: {
-      type: Function as PropType<(...args: unknown[]) => string>,
-      required: false,
-      default: null
-    },
-    /**
      * Overwrite default focused element
      * Can be `#id, .class`.
      */
@@ -397,15 +376,7 @@ export default defineComponent({
       default: false
     }
   },
-  emits: [
-    'cancel',
-    'confirm',
-    'confirm-secondary',
-    'input',
-    'checkbox-changed',
-    'passwordChallengeCompleted',
-    'passwordChallengeFailed'
-  ],
+  emits: ['cancel', 'confirm', 'confirm-secondary', 'input', 'checkbox-changed'],
   setup() {
     const primaryButton = ref(null)
     const secondaryButton = ref(null)

--- a/packages/web-app-files/src/components/Modals/SetLinkPasswordModal.vue
+++ b/packages/web-app-files/src/components/Modals/SetLinkPasswordModal.vue
@@ -1,0 +1,106 @@
+<template>
+  <oc-text-input
+    :model-value="password"
+    :label="$gettext('Password')"
+    type="password"
+    :password-policy="inputPasswordPolicy"
+    :generate-password-method="inputGeneratePasswordMethod"
+    :fix-message-line="true"
+    :placeholder="link.password ? '●●●●●●●●' : null"
+    :error-message="errorMessage"
+    class="oc-modal-body-input"
+    @password-challenge-completed="confirmDisabled = false"
+    @password-challenge-failed="confirmDisabled = true"
+    @keydown.enter.prevent="onConfirm"
+    @update:model-value="onInput"
+  />
+  <div class="oc-flex oc-flex-right oc-flex-middle oc-mt-m">
+    <oc-button
+      class="oc-modal-body-actions-cancel oc-ml-s"
+      appearance="outline"
+      variation="passive"
+      @click="onCancel"
+      >{{ $gettext('Cancel') }}
+    </oc-button>
+    <oc-button
+      class="oc-modal-body-actions-confirm oc-ml-s"
+      appearance="filled"
+      variation="primary"
+      :disabled="confirmDisabled"
+      @click="onConfirm"
+      >{{ link.password ? $gettext('Apply') : $gettext('Set') }}
+    </oc-button>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, unref, PropType } from 'vue'
+import { useGettext } from 'vue3-gettext'
+import { useClientService, usePasswordPolicyService, useStore } from '@ownclouders/web-pkg'
+import { Share } from '@ownclouders/web-client/src/helpers'
+
+export default defineComponent({
+  name: 'SetLinkPasswordModal',
+  props: {
+    link: { type: Object as PropType<Share>, required: true }
+  },
+  setup(props, { expose }) {
+    const store = useStore()
+    const clientService = useClientService()
+    const passwordPolicyService = usePasswordPolicyService()
+    const { $gettext } = useGettext()
+
+    const password = ref('')
+    const errorMessage = ref<string>()
+    const confirmDisabled = ref(true)
+
+    const onInput = (value: string) => {
+      password.value = value
+      errorMessage.value = undefined
+    }
+
+    const onConfirm = async () => {
+      try {
+        await store.dispatch('Files/updateLink', {
+          id: props.link.id,
+          client: clientService.owncloudSdk,
+          params: { ...props.link, password: unref(password) }
+        })
+        store.dispatch('hideModal')
+        store.dispatch('showMessage', {
+          title: $gettext('Link was updated successfully')
+        })
+      } catch (e) {
+        // Human-readable error message is provided, for example when password is on banned list
+        if (e.statusCode === 400) {
+          errorMessage.value = $gettext(e.message)
+          return
+        }
+
+        store.dispatch('showErrorMessage', {
+          title: $gettext('Failed to update link'),
+          error: e
+        })
+      }
+    }
+
+    const onCancel = () => {
+      store.dispatch('hideModal')
+    }
+
+    expose({ onConfirm, onCancel })
+
+    return {
+      password,
+      confirmDisabled,
+      onInput,
+      onConfirm,
+      onCancel,
+      errorMessage,
+      passwordPolicyService,
+      inputPasswordPolicy: passwordPolicyService.getPolicy(),
+      inputGeneratePasswordMethod: () => passwordPolicyService.generatePassword()
+    }
+  }
+})
+</script>

--- a/packages/web-app-files/src/components/SideBar/Actions/SpaceActions.vue
+++ b/packages/web-app-files/src/components/SideBar/Actions/SpaceActions.vue
@@ -1,10 +1,5 @@
 <template>
   <div>
-    <readme-content-modal
-      v-if="readmeContentModalIsOpen"
-      :cancel="closeReadmeContentModal"
-      :space="actionOptions.resources[0]"
-    ></readme-content-modal>
     <quota-modal
       v-if="quotaModalIsOpen"
       :cancel="closeQuotaModal"
@@ -37,7 +32,6 @@ import { computed, defineComponent, inject, Ref, ref, unref, VNodeRef } from 'vu
 import { SpaceResource } from '@ownclouders/web-client'
 import { ActionMenuItem } from '@ownclouders/web-pkg'
 import { QuotaModal } from '@ownclouders/web-pkg'
-import { ReadmeContentModal } from '@ownclouders/web-pkg'
 import { useCapabilitySpacesMaxQuota, useStore, usePreviewService } from '@ownclouders/web-pkg'
 import {
   useSpaceActionsDelete,
@@ -54,7 +48,7 @@ import { useFileActionsDownloadArchive } from '@ownclouders/web-pkg'
 
 export default defineComponent({
   name: 'SpaceActions',
-  components: { ActionMenuItem, QuotaModal, ReadmeContentModal },
+  components: { ActionMenuItem, QuotaModal },
   setup() {
     const store = useStore()
     const previewService = usePreviewService()
@@ -77,11 +71,7 @@ export default defineComponent({
       modalOpen: quotaModalIsOpen,
       closeModal: closeQuotaModal
     } = useSpaceActionsEditQuota({ store })
-    const {
-      actions: editReadmeContentActions,
-      modalOpen: readmeContentModalIsOpen,
-      closeModal: closeReadmeContentModal
-    } = useSpaceActionsEditReadmeContent({ store })
+    const { actions: editReadmeContentActions } = useSpaceActionsEditReadmeContent({ store })
     const { actions: renameActions } = useSpaceActionsRename({ store })
     const { actions: restoreActions } = useSpaceActionsRestore({ store })
     const { actions: uploadImageActions, uploadImageSpace } = useSpaceActionsUploadImage({
@@ -114,9 +104,6 @@ export default defineComponent({
 
       uploadImageActions,
       uploadImageSpace,
-
-      readmeContentModalIsOpen,
-      closeReadmeContentModal,
 
       quotaModalIsOpen,
       closeQuotaModal

--- a/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
@@ -154,7 +154,8 @@ import * as EmailValidator from 'email-validator'
 import {
   createLocationSpaces,
   useConfigurationManager,
-  LinkRoleDropdown
+  LinkRoleDropdown,
+  useStore
 } from '@ownclouders/web-pkg'
 import {
   linkRoleInternalFile,
@@ -170,6 +171,7 @@ import { createFileRouteOptions } from '@ownclouders/web-pkg'
 import { OcDrop } from 'design-system/src/components'
 import { usePasswordPolicyService, ExpirationRules } from '@ownclouders/web-pkg'
 import { useGettext } from 'vue3-gettext'
+import SetLinkPasswordModal from '../../../Modals/SetLinkPasswordModal.vue'
 
 export default defineComponent({
   name: 'DetailsAndEdit',
@@ -210,7 +212,8 @@ export default defineComponent({
   },
   emits: ['removePublicLink', 'updateLink'],
   setup(props, { emit }) {
-    const { current } = useGettext()
+    const store = useStore()
+    const { $gettext, current } = useGettext()
     const configurationManager = useConfigurationManager()
     const passwordPolicyService = usePasswordPolicyService()
 
@@ -236,6 +239,16 @@ export default defineComponent({
       })
     }
 
+    const showPasswordModal = () => {
+      return store.dispatch('createModal', {
+        variation: 'passive',
+        title: props.link.password ? $gettext('Edit password') : $gettext('Add password'),
+        hideActions: true,
+        customComponent: SetLinkPasswordModal,
+        customComponentAttrs: { link: props.link }
+      })
+    }
+
     return {
       space: inject<Ref<SpaceResource>>('space'),
       resource: inject<Ref<Resource>>('resource'),
@@ -244,7 +257,8 @@ export default defineComponent({
       updateLink,
       updateSelectedRole,
       currentLinkRole,
-      isRunningOnEos: computed(() => configurationManager.options.isRunningOnEos)
+      isRunningOnEos: computed(() => configurationManager.options.isRunningOnEos),
+      showPasswordModal
     }
   },
   data() {
@@ -500,38 +514,6 @@ export default defineComponent({
           })
       }
 
-      this.createModal(modal)
-    },
-
-    showPasswordModal() {
-      const modal = {
-        variation: 'passive',
-        title: this.link.password ? this.$gettext('Edit password') : this.$gettext('Add password'),
-        cancelText: this.$gettext('Cancel'),
-        confirmText: this.link.password ? this.$gettext('Apply') : this.$gettext('Set'),
-        hasInput: true,
-        confirmDisabled: true,
-        inputLabel: this.$gettext('Password'),
-        inputPasswordPolicy: this.passwordPolicyService.getPolicy(),
-        inputGeneratePasswordMethod: () => this.passwordPolicyService.generatePassword(),
-        inputPlaceholder: this.link.password ? '●●●●●●●●' : null,
-        inputType: 'password',
-        onCancel: this.hideModal,
-        onInput: () => this.setModalInputErrorMessage(''),
-        onPasswordChallengeCompleted: () => this.setModalConfirmButtonDisabled(false),
-        onPasswordChallengeFailed: () => this.setModalConfirmButtonDisabled(true),
-        onConfirm: (password) => {
-          this.updateLink({
-            link: {
-              ...this.link,
-              password
-            },
-            onSuccess: () => {
-              this.hideModal()
-            }
-          })
-        }
-      }
       this.createModal(modal)
     },
 

--- a/packages/web-app-files/src/components/Spaces/SpaceContextActions.vue
+++ b/packages/web-app-files/src/components/Spaces/SpaceContextActions.vue
@@ -7,11 +7,6 @@
       :spaces="_actionOptions.resources"
       :max-quota="maxQuota"
     />
-    <readme-content-modal
-      v-if="readmeContentModalIsOpen"
-      :cancel="closeReadmeContentModal"
-      :space="_actionOptions.resources[0]"
-    />
     <input
       id="space-image-upload-input"
       ref="spaceImageInput"
@@ -28,7 +23,6 @@
 <script lang="ts">
 import { ContextActionMenu, useSpaceActionsNavigateToTrash } from '@ownclouders/web-pkg'
 import { QuotaModal } from '@ownclouders/web-pkg'
-import { ReadmeContentModal } from '@ownclouders/web-pkg'
 
 import { useFileActionsShowDetails } from '@ownclouders/web-pkg'
 import { useSpaceActionsUploadImage } from 'web-app-files/src/composables'
@@ -56,7 +50,7 @@ import { useFileActionsDownloadArchive } from '@ownclouders/web-pkg'
 
 export default defineComponent({
   name: 'SpaceContextActions',
-  components: { ContextActionMenu, QuotaModal, ReadmeContentModal },
+  components: { ContextActionMenu, QuotaModal },
 
   props: {
     actionOptions: {
@@ -84,11 +78,7 @@ export default defineComponent({
       closeModal: closeQuotaModal
     } = useSpaceActionsEditQuota({ store })
     const { actions: editDescriptionActions } = useSpaceActionsEditDescription({ store })
-    const {
-      actions: editReadmeContentActions,
-      modalOpen: readmeContentModalIsOpen,
-      closeModal: closeReadmeContentModal
-    } = useSpaceActionsEditReadmeContent({ store })
+    const { actions: editReadmeContentActions } = useSpaceActionsEditReadmeContent({ store })
     const { actions: renameActions } = useSpaceActionsRename({ store })
     const { actions: restoreActions } = useSpaceActionsRestore({ store })
     const { actions: showDetailsActions } = useFileActionsShowDetails({ store })
@@ -181,9 +171,6 @@ export default defineComponent({
       uploadImageSpace,
 
       supportedSpaceImageMimeTypes,
-
-      readmeContentModalIsOpen,
-      closeReadmeContentModal,
 
       quotaModalIsOpen,
       closeQuotaModal

--- a/packages/web-app-files/tests/unit/components/Modals/SetLinkPasswordModal.spec.ts
+++ b/packages/web-app-files/tests/unit/components/Modals/SetLinkPasswordModal.spec.ts
@@ -1,0 +1,54 @@
+import SetLinkPasswordModal from '../../../../src/components/Modals/SetLinkPasswordModal.vue'
+import {
+  createStore,
+  defaultComponentMocks,
+  defaultPlugins,
+  defaultStoreMockOptions,
+  shallowMount
+} from 'web-test-helpers'
+
+describe('SetLinkPasswordModal', () => {
+  it('should render a text input field for the password', () => {
+    const { wrapper } = getWrapper()
+
+    expect(wrapper.find('oc-text-input-stub').exists()).toBeTruthy()
+  })
+  describe('method "onConfirm"', () => {
+    it('updates the link', async () => {
+      const { wrapper, storeOptions } = getWrapper()
+      await wrapper.vm.onConfirm()
+
+      expect(storeOptions.modules.Files.actions.updateLink).toHaveBeenCalled()
+      expect(storeOptions.actions.showMessage).toHaveBeenCalled()
+    })
+    it('shows an error message on error', async () => {
+      const { wrapper, storeOptions } = getWrapper()
+      storeOptions.modules.Files.actions.updateLink.mockRejectedValue(new Error(''))
+      await wrapper.vm.onConfirm()
+
+      expect(storeOptions.actions.showErrorMessage).toHaveBeenCalled()
+    })
+  })
+})
+
+function getWrapper({ link = {} } = {}) {
+  const mocks = { ...defaultComponentMocks() }
+
+  const storeOptions = defaultStoreMockOptions
+  const store = createStore(storeOptions)
+
+  return {
+    mocks,
+    storeOptions,
+    wrapper: shallowMount(SetLinkPasswordModal, {
+      props: {
+        link
+      },
+      global: {
+        plugins: [...defaultPlugins(), store],
+        mocks,
+        provide: mocks
+      }
+    })
+  }
+}

--- a/packages/web-app-files/tests/unit/components/Spaces/__snapshots__/SpaceContextActions.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/Spaces/__snapshots__/SpaceContextActions.spec.ts.snap
@@ -59,7 +59,6 @@ exports[`SpaceContextActions action handlers renders actions that are always ava
     </ul>
   </div>
   <!--v-if-->
-  <!--v-if-->
   <input accept="" id="space-image-upload-input" multiple="" name="file" tabindex="-1" type="file">
 </div>
 `;

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditReadmeContent.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditReadmeContent.ts
@@ -1,21 +1,23 @@
 import { Store } from 'vuex'
 import { useStore } from '../../store'
 import { SpaceAction, SpaceActionOptions } from '../types'
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import { useGettext } from 'vue3-gettext'
+import { ReadmeContentModal } from '../../../components'
 
 export const useSpaceActionsEditReadmeContent = ({ store }: { store?: Store<any> } = {}) => {
   store = store || useStore()
   const { $gettext } = useGettext()
 
-  const modalOpen = ref(false)
-
-  const closeModal = () => {
-    modalOpen.value = false
-  }
-
-  const handler = ({}: SpaceActionOptions) => {
-    modalOpen.value = true
+  const handler = ({ resources }: SpaceActionOptions) => {
+    return store.dispatch('createModal', {
+      variation: 'passive',
+      title: $gettext('Edit description for space %{name}', {
+        name: resources[0].name
+      }),
+      customComponent: ReadmeContentModal,
+      customComponentAttrs: { space: resources[0] }
+    })
   }
 
   const actions = computed((): SpaceAction[] => [
@@ -43,8 +45,6 @@ export const useSpaceActionsEditReadmeContent = ({ store }: { store?: Store<any>
   ])
 
   return {
-    modalOpen,
-    closeModal,
     actions
   }
 }

--- a/packages/web-pkg/tests/unit/components/Spaces/ReadmeContentModal.spec.ts
+++ b/packages/web-pkg/tests/unit/components/Spaces/ReadmeContentModal.spec.ts
@@ -13,17 +13,17 @@ import { Resource } from '@ownclouders/web-client/src'
 import { mock } from 'jest-mock-extended'
 
 describe('ReadmeContentModal', () => {
-  describe('method "editReadme"', () => {
+  describe('method "onConfirm"', () => {
     it('should show message on success', async () => {
       const { wrapper, storeOptions } = getWrapper()
-      await wrapper.vm.editReadme()
+      await wrapper.vm.onConfirm()
       expect(storeOptions.actions.showMessage).toHaveBeenCalledTimes(1)
     })
 
     it('should show message on error', async () => {
       jest.spyOn(console, 'error').mockImplementation(() => undefined)
       const { wrapper, storeOptions } = getWrapper(false)
-      await wrapper.vm.editReadme()
+      await wrapper.vm.onConfirm()
       expect(storeOptions.actions.showErrorMessage).toHaveBeenCalledTimes(1)
     })
   })

--- a/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsEditReadmeContent.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsEditReadmeContent.spec.ts
@@ -1,5 +1,5 @@
 import { useSpaceActionsEditReadmeContent } from '../../../../../src/composables/actions'
-import { buildSpace } from '@ownclouders/web-client/src/helpers'
+import { SpaceResource, buildSpace } from '@ownclouders/web-client/src/helpers'
 import { createStore, defaultStoreMockOptions, getComposableWrapper } from 'web-test-helpers'
 import { unref } from 'vue'
 import { mock } from 'jest-mock-extended'
@@ -16,7 +16,7 @@ describe('editReadmeContent', () => {
         special: [{ specialFolder: { name: 'readme' } }]
       })
 
-      const { wrapper } = getWrapper({
+      getWrapper({
         setup: ({ actions }) => {
           expect(
             unref(actions)[0].isEnabled({
@@ -27,7 +27,7 @@ describe('editReadmeContent', () => {
       })
     })
     it('should be false when not resource given', () => {
-      const { wrapper } = getWrapper({
+      getWrapper({
         setup: ({ actions }) => {
           expect(unref(actions)[0].isEnabled({ resources: [] })).toBe(false)
         }
@@ -42,7 +42,7 @@ describe('editReadmeContent', () => {
         special: null
       })
 
-      const { wrapper } = getWrapper({
+      getWrapper({
         setup: ({ actions }) => {
           expect(
             unref(actions)[0].isEnabled({
@@ -61,13 +61,23 @@ describe('editReadmeContent', () => {
         special: null
       })
 
-      const { wrapper } = getWrapper({
+      getWrapper({
         setup: ({ actions }) => {
           expect(
             unref(actions)[0].isEnabled({
               resources: [buildSpace(spaceMock)]
             })
           ).toBe(false)
+        }
+      })
+    })
+  })
+  describe('method "handler"', () => {
+    it('creates a modal', () => {
+      getWrapper({
+        setup: async ({ actions }, { storeOptions }) => {
+          await unref(actions)[0].handler({ resources: [mock<SpaceResource>()] })
+          expect(storeOptions.actions.createModal).toHaveBeenCalled()
         }
       })
     })

--- a/packages/web-runtime/src/App.vue
+++ b/packages/web-runtime/src/App.vue
@@ -16,8 +16,6 @@
       :has-input="modal.hasInput"
       :input-description="modal.inputDescription"
       :input-placeholder="modal.inputPlaceholder"
-      :input-password-policy="modal.inputPasswordPolicy"
-      :input-generate-password-method="modal.inputGeneratePasswordMethod"
       :input-disabled="modal.inputDisabled"
       :input-error="modal.inputError"
       :input-label="modal.inputLabel"
@@ -38,8 +36,6 @@
       @input="modal.onInput"
       @checkbox-changed="modal.onCheckboxValueChanged"
       @confirm-secondary="onModalConfirmSecondary"
-      @passwordChallengeCompleted="modal.onPasswordChallengeCompleted"
-      @passwordChallengeFailed="modal.onPasswordChallengeFailed"
       @mounted="focusModal"
       @before-unmount="focusModal"
     >

--- a/packages/web-runtime/src/store/modal.ts
+++ b/packages/web-runtime/src/store/modal.ts
@@ -72,8 +72,6 @@ const mutations = {
     state.onConfirm = modal.onConfirm
     state.hasInput = modal.hasInput || false
     state.inputValue = modal.inputValue || null
-    state.inputPasswordPolicy = modal.inputPasswordPolicy || {}
-    state.inputGeneratePasswordMethod = modal.inputGeneratePasswordMethod || null
     state.inputSelectionRange = modal.inputSelectionRange
     state.inputDescription = modal.inputDescription || null
     state.inputPlaceholder = modal.inputPlaceholder || null
@@ -89,8 +87,6 @@ const mutations = {
     state.customComponent = modal.customComponent
     state.customComponentAttrs = modal.customComponentAttrs
     state.customContent = modal.customContent || ''
-    state.onPasswordChallengeCompleted = modal.onPasswordChallengeCompleted
-    state.onPasswordChallengeFailed = modal.onPasswordChallengeFailed
     state.hideActions = modal.hideActions || false
   },
 

--- a/packages/web-test-helpers/src/mocks/store/filesModuleMockOptions.ts
+++ b/packages/web-test-helpers/src/mocks/store/filesModuleMockOptions.ts
@@ -47,6 +47,7 @@ export const filesModuleMockOptions = {
       loadVersions: jest.fn(),
       loadShares: jest.fn(),
       deleteShare: jest.fn(),
+      updateLink: jest.fn(),
       clearTrashBin: jest.fn(),
       removeFilesFromTrashbin: jest.fn(),
       changeShare: jest.fn(),


### PR DESCRIPTION
## Description
Before, the state of the space readme modal was handled by the outside where it was being used. Refactors the modal usage so that the modal state handling is done via the edit space readme action instead, meaning the consuming party doesn't need to care about it anymore.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/10095

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
