### PR TITLE
e2e tests: switch "yesterday" to "last 7 days"

### DIFF
--- a/tests/e2e/cucumber/features/smoke/search.feature
+++ b/tests/e2e/cucumber/features/smoke/search.feature
@@ -237,25 +237,34 @@ Feature: Search
       | name       |
       | mainFolder |
     And "Alice" creates the following files with mtime into personal space using API
-      | pathToFile               | content             | mtime     |
-      | mainFolder/mediaTest.txt | yesterday's content | yesterday |
-      | mainFolder/mediaTest.md  | I'm a Document      |           |
+      | pathToFile               | content             | mtimeDeltaDays |
+      | mainFolder/mediaTest.pdf | created 29 days ago | -29 days       |
+      | mainFolder/mediaTest.txt | created 5 days ago  | -5 days        |
+      | mainFolder/mediaTest.md  | created today       |                |
     And "Alice" opens the "files" app
     When "Alice" opens folder "mainFolder"
     And "Alice" searches "mediaTest" using the global search and the "in here" filter and presses enter
-    And "Alice" selects lastModified "yesterday" from the search result filter chip
+    And "Alice" selects lastModified "last 30 days" from the search result filter chip
+    Then following resources should be displayed in the files list for user "Alice"
+      | resource                 |
+      | mainFolder/mediaTest.pdf |
+      | mainFolder/mediaTest.txt |
+      | mainFolder/mediaTest.md  |
+    When "Alice" selects lastModified "last 7 days" from the search result filter chip
     Then following resources should be displayed in the files list for user "Alice"
       | resource                 |
       | mainFolder/mediaTest.txt |
+      | mainFolder/mediaTest.md  |
     But following resources should not be displayed in the files list for user "Alice"
-      | resource                |
-      | mainFolder/mediaTest.md |
+      | resource                 |
+      | mainFolder/mediaTest.pdf |
     When "Alice" selects lastModified "today" from the search result filter chip
     Then following resources should be displayed in the files list for user "Alice"
       | resource                |
       | mainFolder/mediaTest.md |
     But following resources should not be displayed in the files list for user "Alice"
       | resource                 |
+      | mainFolder/mediaTest.pdf |
       | mainFolder/mediaTest.txt |
     And "Alice" clears lastModified filter
     And "Alice" logs out

--- a/tests/e2e/cucumber/steps/api.ts
+++ b/tests/e2e/cucumber/steps/api.ts
@@ -120,7 +120,7 @@ Given(
         user,
         pathToFile: info.pathToFile,
         content: info.content,
-        mtime: info.mtime
+        mtimeDeltaDays: info.mtimeDeltaDays
       })
     }
   }

--- a/tests/e2e/support/api/davSpaces/spaces.ts
+++ b/tests/e2e/support/api/davSpaces/spaces.ts
@@ -56,13 +56,13 @@ const createFile = async ({
   pathToFile,
   content,
   webDavEndPathToRoot, // the root of the WebDAV path. This is `spaces/<space-id>` for ocis or `files/<user>` for oC10
-  mtime
+  mtimeDeltaDays
 }: {
   user: User
   pathToFile: string
   content?: string
   webDavEndPathToRoot: string
-  mtime?: string
+  mtimeDeltaDays?: string
 }): Promise<void> => {
   const today = new Date()
   const response = await request({
@@ -70,7 +70,9 @@ const createFile = async ({
     path: join('remote.php', 'dav', webDavEndPathToRoot, pathToFile),
     body: content,
     user: user,
-    header: mtime === 'yesterday' ? { 'X-OC-Mtime': today.getTime() / 1000 - 86400 } : {}
+    header: mtimeDeltaDays
+      ? { 'X-OC-Mtime': today.getTime() / 1000 + parseInt(mtimeDeltaDays) * 86400 }
+      : {}
   })
 
   checkResponseStatus(response, `Failed while uploading file '${pathToFile}' in personal space`)
@@ -80,15 +82,15 @@ export const uploadFileInPersonalSpace = async ({
   user,
   pathToFile,
   content,
-  mtime
+  mtimeDeltaDays
 }: {
   user: User
   pathToFile: string
   content: string
-  mtime?: string
+  mtimeDeltaDays?: string
 }): Promise<void> => {
   const webDavEndPathToRoot = 'spaces/' + (await getPersonalSpaceId({ user }))
-  await createFile({ user, pathToFile, content, webDavEndPathToRoot, mtime })
+  await createFile({ user, pathToFile, content, webDavEndPathToRoot, mtimeDeltaDays })
 }
 
 export const createFolderInsideSpaceBySpaceName = async ({


### PR DESCRIPTION
## Description
I'm about to remove the `yesterday` mtime filter option from the backend, see https://github.com/owncloud/ocis/pull/7919
Switching it over to `last 7 days` in the e2e tests.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Prerequisite for https://github.com/owncloud/web/issues/9779#issuecomment-1807930111

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 