### PR TITLE
fix: loading indicator showing during conflict dialog

### DIFF
--- a/changelog/unreleased/bugfix-loading-indicator-conflict-dialog
+++ b/changelog/unreleased/bugfix-loading-indicator-conflict-dialog
@@ -1,0 +1,6 @@
+Bugfix: Loading indicator during conflict dialog
+
+An issue where the loading indicator was showing before taking action in the resource conflict dialog has been fixed.
+
+https://github.com/owncloud/web/pull/10220
+https://github.com/owncloud/web/issues/10215

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -508,7 +508,7 @@ export default defineComponent({
     }
   },
   methods: {
-    ...mapActions('Files', ['clearClipboardFiles', 'pasteSelectedFiles']),
+    ...mapActions('Files', ['clearClipboardFiles']),
     ...mapActions(['showMessage', 'createModal', 'hideModal']),
 
     getIconResource(fileHandler) {

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsPaste.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsPaste.ts
@@ -52,20 +52,18 @@ export const useFileActionsPaste = ({ store }: { store?: Store<any> } = {}) => {
       }, {})
     const promises = Object.values(resourceSpaceMapping).map(
       ({ space: sourceSpace, resources: resourcesToCopy }) => {
-        return loadingService.addTask(() => {
-          return store.dispatch('Files/pasteSelectedFiles', {
-            targetSpace,
-            sourceSpace: sourceSpace,
-            resources: resourcesToCopy,
-            clientService,
-            loadingService,
-            createModal: (...args) => store.dispatch('createModal', ...args),
-            hideModal: (...args) => store.dispatch('hideModal', ...args),
-            showMessage: (...args) => store.dispatch('showMessage', ...args),
-            showErrorMessage: (...args) => store.dispatch('showErrorMessage', ...args),
-            $gettext,
-            $ngettext
-          })
+        return store.dispatch('Files/pasteSelectedFiles', {
+          targetSpace,
+          sourceSpace: sourceSpace,
+          resources: resourcesToCopy,
+          clientService,
+          loadingService,
+          createModal: (...args) => store.dispatch('createModal', ...args),
+          hideModal: (...args) => store.dispatch('hideModal', ...args),
+          showMessage: (...args) => store.dispatch('showMessage', ...args),
+          showErrorMessage: (...args) => store.dispatch('showErrorMessage', ...args),
+          $gettext,
+          $ngettext
         })
       }
     )


### PR DESCRIPTION

## Description
Fixes an issue where the loading indicator would show before taking any action in the resource conflict modal.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10215

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
