### PR TITLE
refactor: remove deprecated extension point for adding quick actions 

### DIFF
--- a/changelog/unreleased/change-remove-deprecated-quick-actions-extension-point
+++ b/changelog/unreleased/change-remove-deprecated-quick-actions-extension-point
@@ -1,0 +1,6 @@
+Change: Remove deprecated extension point for adding quick actions
+
+BREAKING CHANGE for developers: The old way of registering quick actions via the `quickaction` property of an app has been removed. Quick actions should be registered as extension via our extension registry. They need to be of type `action` and have the `files.quick-action` scope.
+
+https://github.com/owncloud/web/pull/10102
+https://github.com/owncloud/web/pull/10223

--- a/packages/web-app-files/tests/__fixtures__/fileActions.ts
+++ b/packages/web-app-files/tests/__fixtures__/fileActions.ts
@@ -56,19 +56,6 @@ export const editors = [
   }
 ]
 
-const sideBars = [
-  {
-    app: 'details',
-    enabled: jest.fn(),
-    icon: 'information'
-  },
-  {
-    app: 'actions',
-    enabled: jest.fn(),
-    icon: 'information'
-  }
-]
-
 export const apps = {
   customFileListIndicators: [],
   file: {
@@ -76,7 +63,6 @@ export const apps = {
     path: ''
   },
   fileEditors: editors,
-  fileSideBars: sideBars,
   newFileHandlers: editors,
   meta
 }

--- a/packages/web-pkg/src/apps/types.ts
+++ b/packages/web-pkg/src/apps/types.ts
@@ -39,15 +39,6 @@ export interface ApplicationQuickAction {
   displayed?: (...args) => boolean | boolean
 }
 
-/**
- * ApplicationQuickActions describes a map of application actions that are used in the runtime
- *
- * @deprecated Quick actions should be registered as extension via the `files.quick-action` scope.
- */
-export interface ApplicationQuickActions {
-  [key: string]: ApplicationQuickAction
-}
-
 export type AppConfigObject = Record<string, any>
 
 export interface ApplicationMenuItem {
@@ -83,8 +74,6 @@ export interface ClassicApplicationScript {
   store?: Module<unknown, unknown>
   routes?: ((...args) => RouteRecordRaw[]) | RouteRecordRaw[]
   navItems?: ((...args) => AppNavigationItem[]) | AppNavigationItem[]
-  /** @deprecated Quick actions should be registered as extension via the `files.quick-action` scope. */
-  quickActions?: ApplicationQuickActions
   translations?: ApplicationTranslations
   extensions?: Ref<Extension[]>
   initialize?: () => void

--- a/packages/web-pkg/src/apps/types.ts
+++ b/packages/web-pkg/src/apps/types.ts
@@ -55,7 +55,6 @@ export interface ApplicationInformation {
   isFileEditor?: boolean
   extensions?: any[]
   defaultExtension?: string
-  fileSideBars?: any[]
   applicationMenu?: ApplicationMenuItem
 }
 

--- a/packages/web-runtime/src/container/api.ts
+++ b/packages/web-runtime/src/container/api.ts
@@ -5,11 +5,7 @@ import { ApiError } from '@ownclouders/web-pkg'
 import { get, isEqual, isObject, isArray, merge } from 'lodash-es'
 import { Module, Store } from 'vuex'
 import { App, Component, h } from 'vue'
-import {
-  ApplicationQuickActions,
-  ApplicationTranslations,
-  AppNavigationItem
-} from '@ownclouders/web-pkg'
+import { ApplicationTranslations, AppNavigationItem } from '@ownclouders/web-pkg'
 import type { Language } from 'vue3-gettext'
 
 /**
@@ -119,23 +115,6 @@ const announceTranslations = (
       gettext.translations = merge(gettext.translations, { [lang]: appTranslations[lang] })
     }
   })
-}
-
-/**
- * inject application specific quickActions into runtime
- *
- * @param store
- * @param quickActions
- */
-const announceQuickActions = (
-  store: Store<unknown>,
-  quickActions: ApplicationQuickActions
-): void => {
-  if (!isObject(quickActions)) {
-    throw new ApiError("quickActions can't be blank")
-  }
-
-  store.commit('ADD_QUICK_ACTIONS', quickActions)
 }
 
 /**
@@ -258,8 +237,6 @@ export const buildRuntimeApi = ({
       announceNavigationItems(applicationId, store, navigationItems),
     announceTranslations: (appTranslations: ApplicationTranslations): void =>
       announceTranslations(supportedLanguages, gettext, appTranslations),
-    announceQuickActions: (quickActions: ApplicationQuickActions): void =>
-      announceQuickActions(store, quickActions),
     announceStore: (applicationStore: Module<unknown, unknown>): void =>
       announceStore(applicationName, store, applicationStore),
     announceExtension: (extension: { [key: string]: unknown }): void =>

--- a/packages/web-runtime/src/container/application/classic.ts
+++ b/packages/web-runtime/src/container/application/classic.ts
@@ -25,7 +25,7 @@ class ClassicApplication extends NextApplication {
   }
 
   initialize(): Promise<void> {
-    const { routes, navItems, translations, quickActions, store } = this.applicationScript
+    const { routes, navItems, translations, store } = this.applicationScript
     const { globalProperties } = this.app.config
     const _routes = typeof routes === 'function' ? routes(globalProperties) : routes
     const _navItems = typeof navItems === 'function' ? navItems(globalProperties) : navItems
@@ -33,7 +33,6 @@ class ClassicApplication extends NextApplication {
     routes && this.runtimeApi.announceRoutes(_routes)
     navItems && this.runtimeApi.announceNavigationItems(_navItems)
     translations && this.runtimeApi.announceTranslations(translations)
-    quickActions && this.runtimeApi.announceQuickActions(quickActions)
     store && this.runtimeApi.announceStore(store)
 
     return Promise.resolve(undefined)

--- a/packages/web-runtime/src/container/types.ts
+++ b/packages/web-runtime/src/container/types.ts
@@ -1,11 +1,7 @@
 import { Module, Store } from 'vuex'
 import { Router, RouteRecordRaw } from 'vue-router'
 import { App, Component } from 'vue'
-import {
-  AppNavigationItem,
-  ApplicationQuickActions,
-  ApplicationTranslations
-} from '@ownclouders/web-pkg'
+import { AppNavigationItem, ApplicationTranslations } from '@ownclouders/web-pkg'
 
 /** shim configuration for now, should be typed in a later step */
 export type RuntimeConfiguration = any
@@ -15,7 +11,6 @@ export interface RuntimeApi {
   announceRoutes: (routes: RouteRecordRaw[]) => void
   announceNavigationItems: (navigationItems: AppNavigationItem[]) => void
   announceTranslations: (appTranslations: ApplicationTranslations) => void
-  announceQuickActions: (quickActions: ApplicationQuickActions) => void
   announceStore: (applicationStore: Module<unknown, unknown>) => void
   announceExtension: (extension: { [key: string]: unknown }) => void
   requestStore: () => Store<unknown>

--- a/packages/web-runtime/src/store/app.ts
+++ b/packages/web-runtime/src/store/app.ts
@@ -1,6 +1,5 @@
 const state = {
-  messages: [],
-  quickActions: {}
+  messages: []
 }
 
 const actions = {
@@ -58,9 +57,6 @@ const mutations = {
   },
   REMOVE_MESSAGE(state, item) {
     state.messages.splice(state.messages.indexOf(item), 1)
-  },
-  ADD_QUICK_ACTIONS(state, quickActions) {
-    state.quickActions = Object.assign(state.quickActions, quickActions)
   }
 }
 

--- a/packages/web-test-helpers/src/mocks/store/defaultStoreMockOptions.ts
+++ b/packages/web-test-helpers/src/mocks/store/defaultStoreMockOptions.ts
@@ -26,9 +26,6 @@ export const defaultStoreMockOptions = {
       state: {
         fileEditors: [],
         meta: {}
-      },
-      getters: {
-        fileSideBars: jest.fn(() => [])
       }
     },
     External: {


### PR DESCRIPTION
## Description
Removes the old and deprecated way of registering quick actions via the `quickaction` property of an app as well as leftovers from the sidebar extension rework.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
