### PR TITLE
Replace pgettext with gettext

### DIFF
--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCopy.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCopy.ts
@@ -17,7 +17,7 @@ export const useFileActionsCopy = ({ store }: { store?: Store<any> } = {}) => {
   const router = useRouter()
 
   const language = useGettext()
-  const { $pgettext } = language
+  const { $gettext } = language
 
   const isMacOs = computed(() => {
     return window.navigator.platform.match('Mac')
@@ -27,9 +27,9 @@ export const useFileActionsCopy = ({ store }: { store?: Store<any> } = {}) => {
 
   const copyShortcutString = computed(() => {
     if (unref(isMacOs)) {
-      return $pgettext('Keyboard shortcut for macOS for copying files', '⌘ + C')
+      return $gettext('⌘ + C')
     }
-    return $pgettext('Keyboard shortcut for non-macOS systems for copying files', 'Ctrl + C')
+    return $gettext('Ctrl + C')
   })
 
   const handler = ({ space, resources }: FileActionOptions) => {
@@ -47,8 +47,7 @@ export const useFileActionsCopy = ({ store }: { store?: Store<any> } = {}) => {
         icon: 'file-copy-2',
         handler,
         shortcut: unref(copyShortcutString),
-        label: () =>
-          $pgettext('Action in the files list row to initiate copying resources', 'Copy'),
+        label: () => $gettext('Copy'),
         isEnabled: ({ resources }) => {
           if (
             !isLocationSpacesActive(router, 'files-spaces-generic') &&

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsEmptyTrashBin.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsEmptyTrashBin.ts
@@ -15,7 +15,7 @@ import { useLoadingService } from '../../loadingService'
 export const useFileActionsEmptyTrashBin = ({ store }: { store?: Store<any> } = {}) => {
   store = store || useStore()
   const router = useRouter()
-  const { $gettext, $pgettext } = useGettext()
+  const { $gettext } = useGettext()
   const clientService = useClientService()
   const loadingService = useLoadingService()
   const hasPermanentDeletion = useCapabilityFilesPermanentDeletion()
@@ -32,10 +32,7 @@ export const useFileActionsEmptyTrashBin = ({ store }: { store?: Store<any> } = 
       .catch((error) => {
         console.error(error)
         store.dispatch('showErrorMessage', {
-          title: $pgettext(
-            'Error message in case emptying trash bin fails',
-            'Failed to empty trash bin'
-          ),
+          title: $gettext('Failed to empty trash bin'),
           error
         })
       })

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsMove.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsMove.ts
@@ -15,7 +15,7 @@ export const useFileActionsMove = ({ store }: { store?: Store<any> } = {}) => {
   store = store || useStore()
   const router = useRouter()
   const language = useGettext()
-  const { $pgettext } = language
+  const { $gettext } = language
 
   const isMacOs = computed(() => {
     return window.navigator.platform.match('Mac')
@@ -23,9 +23,9 @@ export const useFileActionsMove = ({ store }: { store?: Store<any> } = {}) => {
 
   const cutShortcutString = computed(() => {
     if (unref(isMacOs)) {
-      return $pgettext('Keyboard shortcut for macOS for cutting files', '⌘ + X')
+      return $gettext('⌘ + X')
     }
-    return $pgettext('Keyboard shortcut for non-macOS systems for cutting files', 'Ctrl + X')
+    return $gettext('Ctrl + X')
   })
 
   const handler = ({ space, resources }: ActionOptions) => {
@@ -37,7 +37,7 @@ export const useFileActionsMove = ({ store }: { store?: Store<any> } = {}) => {
       icon: 'scissors',
       handler,
       shortcut: unref(cutShortcutString),
-      label: () => $pgettext('Action in the files list row to initiate cutting resources', 'Cut'),
+      label: () => $gettext('Cut'),
       isEnabled: ({ resources }) => {
         if (
           !isLocationSpacesActive(router, 'files-spaces-generic') &&

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsNavigate.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsNavigate.ts
@@ -21,7 +21,7 @@ import { FileAction } from '../types'
 export const useFileActionsNavigate = ({ store }: { store?: Store<any> } = {}) => {
   store = store || useStore()
   const router = useRouter()
-  const { $pgettext } = useGettext()
+  const { $gettext } = useGettext()
   const { getMatchingSpace } = useGetMatchingSpace()
 
   const getSpace = (space: SpaceResource, resource: Resource) => {
@@ -40,7 +40,7 @@ export const useFileActionsNavigate = ({ store }: { store?: Store<any> } = {}) =
     {
       name: 'navigate',
       icon: 'folder-open',
-      label: () => $pgettext('Action in the files list row to open a folder', 'Open folder'),
+      label: () => $gettext('Open folder'),
       isEnabled: ({ resources }) => {
         if (isLocationTrashActive(router, 'files-trash-generic')) {
           return false

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsPaste.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsPaste.ts
@@ -20,7 +20,7 @@ export const useFileActionsPaste = ({ store }: { store?: Store<any> } = {}) => {
   const clientService = useClientService()
   const loadingService = useLoadingService()
   const { getMatchingSpace } = useGetMatchingSpace()
-  const { $gettext } = useGettext()
+  const { $gettext, $ngettext } = useGettext()
 
   const isMacOs = computed(() => {
     return window.navigator.platform.match('Mac')

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsPaste.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsPaste.ts
@@ -20,7 +20,7 @@ export const useFileActionsPaste = ({ store }: { store?: Store<any> } = {}) => {
   const clientService = useClientService()
   const loadingService = useLoadingService()
   const { getMatchingSpace } = useGetMatchingSpace()
-  const { $gettext, $pgettext, $ngettext } = useGettext()
+  const { $gettext } = useGettext()
 
   const isMacOs = computed(() => {
     return window.navigator.platform.match('Mac')
@@ -28,9 +28,9 @@ export const useFileActionsPaste = ({ store }: { store?: Store<any> } = {}) => {
 
   const pasteShortcutString = computed(() => {
     if (unref(isMacOs)) {
-      return $pgettext('Keyboard shortcut for macOS for pasting files', '⌘ + V')
+      return $gettext('⌘ + V')
     }
-    return $pgettext('Keyboard shortcut for non-macOS systems for pasting files', 'Ctrl + V')
+    return $gettext('Ctrl + V')
   })
 
   const handler = async ({ space: targetSpace }: FileActionOptions) => {
@@ -78,7 +78,7 @@ export const useFileActionsPaste = ({ store }: { store?: Store<any> } = {}) => {
       name: 'paste',
       icon: 'clipboard',
       handler,
-      label: () => $pgettext('Action in the files list row to initiate pasting resources', 'Paste'),
+      label: () => $gettext('Paste'),
       shortcut: unref(pasteShortcutString),
       isEnabled: ({ resources }) => {
         if (store.getters['Files/clipboardResources'].length === 0) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
We removed pgettext, since we merge all translations.json files into one global json file for vue-gettext it is not possible to have two translation types, one created via $gettext (e.G `{"Copy": "Kopieren"}`) and one via $pgettext (e.G `{"Copy":{"Action in the files list row to initiate copying resources":"Kopieren"}}`  in one json file as the keys are identical.

So those compete against each other and one get lost, and lead to a non translated string 


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10216

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
