### PR TITLE
chore: use the project's typescript version in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,6 @@
   },
   "editor.formatOnSave": true,
   "eslint.format.enable": true,
-  "eslint.packageManager": "pnpm",
   "jest.autoRun": {
     "watch": false,
     "onStartup": true
@@ -27,5 +26,6 @@
   "cucumberautocomplete.steps": [
     "tests/e2e/cucumber/steps/**/*.ts"
   ],
-  "cucumberautocomplete.strictGherkinCompletion": true
+  "cucumberautocomplete.strictGherkinCompletion": true,
+  "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
At least for me this causes much less issues in vscode. Otherwise it would use typescript `5.3` which is not yet compatible with Web.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
