### PR TITLE
[full-ci] [tests-only] Bump ocis commit id to stable 5.0

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=bf40d9d7dd1f752e4cb78aadaaac6fb026f6df41
+OCIS_COMMITID=7eeb61bcb789fd30c02547d8a2bcd29054e79e7b
 OCIS_BRANCH=stable-5.0


### PR DESCRIPTION
Part of https://github.com/owncloud/QA/issues/839