### PR TITLE
chore: bump chromedriver to v120.0.1 (security)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1299,8 +1299,8 @@ importers:
         specifier: ^7.0.0-bridge.0
         version: 7.0.0-bridge.0(@babel/core@7.23.7)
       chromedriver:
-        specifier: ^93.0.1
-        version: 93.0.1
+        specifier: 120.0.1
+        version: 120.0.1
       core-js:
         specifier: ^3.15.2
         version: 3.19.1
@@ -1318,7 +1318,7 @@ importers:
         version: 4.17.21
       nightwatch:
         specifier: 1.7.11
-        version: 1.7.11(chromedriver@93.0.1)
+        version: 1.7.11(chromedriver@120.0.1)
       nightwatch-api:
         specifier: 3.0.1
         version: 3.0.1(nightwatch@1.7.11)
@@ -4121,8 +4121,8 @@ packages:
     engines: {node: '>=10.17'}
     dev: true
 
-  /@testim/chrome-version@1.1.3:
-    resolution: {integrity: sha512-g697J3WxV/Zytemz8aTuKjTGYtta9+02kva3C1xc7KXB8GdbfE1akGJIsZLyY/FSh2QrnE+fiB7vmWU3XNcb6A==}
+  /@testim/chrome-version@1.1.4:
+    resolution: {integrity: sha512-kIhULpw9TrGYnHp/8VfdcneIcxKnLixmADtukQRtJUmsVlMg0niMkwV0xZmi8hqa57xqilIHjWFA0GKvEjVU5g==}
     dev: true
 
   /@tippyjs/react@4.1.0(react-dom@18.2.0)(react@18.2.0):
@@ -5714,14 +5714,6 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /axios@0.21.4:
-    resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
-    dependencies:
-      follow-redirects: 1.15.1(debug@4.3.4)
-    transitivePeerDependencies:
-      - debug
-    dev: true
-
   /axios@1.6.3:
     resolution: {integrity: sha512-fWyNdeawGam70jXSVlKl+SUNVcL6j6W79CuSIPfi6HnDUmSCH6gyUys/HrqHeA/wU0Az41rRgean494d0Jb+ww==}
     dependencies:
@@ -5730,7 +5722,6 @@ packages:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
-    dev: false
 
   /babel-core@7.0.0-bridge.0(@babel/core@7.23.7):
     resolution: {integrity: sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==}
@@ -6647,15 +6638,15 @@ packages:
     engines: {node: '>=6.0'}
     dev: true
 
-  /chromedriver@93.0.1:
-    resolution: {integrity: sha512-KDzbW34CvQLF5aTkm3b5VdlTrvdIt4wEpCzT2p4XJIQWQZEPco5pNce7Lu9UqZQGkhQ4mpZt4Ky6NKVyIS2N8A==}
-    engines: {node: '>=10'}
+  /chromedriver@120.0.1:
+    resolution: {integrity: sha512-ETTJlkibcAmvoKsaEoq2TFqEsJw18N0O9gOQZX6Uv/XoEiOV8p+IZdidMeIRYELWJIgCZESvlOx5d1QVnB4v0w==}
+    engines: {node: '>=18'}
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@testim/chrome-version': 1.1.3
-      axios: 0.21.4
-      del: 6.1.1
+      '@testim/chrome-version': 1.1.4
+      axios: 1.6.3
+      compare-versions: 6.1.0
       extract-zip: 2.0.1
       https-proxy-agent: 5.0.1
       proxy-from-env: 1.1.0
@@ -6984,6 +6975,10 @@ packages:
 
   /commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
+    dev: true
+
+  /compare-versions@6.1.0:
+    resolution: {integrity: sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg==}
     dev: true
 
   /component-emitter@1.3.0:
@@ -8027,20 +8022,6 @@ packages:
       p-map: 2.1.0
       pify: 4.0.1
       rimraf: 2.7.1
-    dev: true
-
-  /del@6.1.1:
-    resolution: {integrity: sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==}
-    engines: {node: '>=10'}
-    dependencies:
-      globby: 11.1.0
-      graceful-fs: 4.2.10
-      is-glob: 4.0.3
-      is-path-cwd: 2.2.0
-      is-path-inside: 3.0.3
-      p-map: 4.0.0
-      rimraf: 3.0.2
-      slash: 3.0.0
     dev: true
 
   /delayed-stream@1.0.0:
@@ -13630,12 +13611,12 @@ packages:
     dependencies:
       '@types/debug': 4.1.7
       debug: 4.3.4(supports-color@8.1.1)
-      nightwatch: 1.7.11(chromedriver@93.0.1)
+      nightwatch: 1.7.11(chromedriver@120.0.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /nightwatch@1.7.11(chromedriver@93.0.1):
+  /nightwatch@1.7.11(chromedriver@120.0.1):
     resolution: {integrity: sha512-yV795EBXZ/myeoCvBtjC/QwvIprxF7SKh0XCeFnpoOtWXDb0yv+ATLRipKGfp+avyGtagqq38ucA4Uh6WPcnhQ==}
     engines: {node: '>= 8.0.0'}
     hasBin: true
@@ -13650,7 +13631,7 @@ packages:
     dependencies:
       assertion-error: 1.1.0
       chai-nightwatch: 0.4.2
-      chromedriver: 93.0.1
+      chromedriver: 120.0.1
       ci-info: 2.0.0
       didyoumean: 1.2.2
       dotenv: 7.0.0

--- a/tests/acceptance/package.json
+++ b/tests/acceptance/package.json
@@ -15,7 +15,7 @@
     "@cucumber/pretty-formatter": "^1.0.0-alpha.1",
     "archiver": "^5.3.0",
     "babel-core": "^7.0.0-bridge.0",
-    "chromedriver": "^93.0.1",
+    "chromedriver": "120.0.1",
     "core-js": "^3.15.2",
     "fs-extra": "^10.0.0",
     "join-path": "^1.1.1",


### PR DESCRIPTION
## Description
Updates `chromedriver` to v120.0.1 for a security patch.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [x] Maintenance (e.g. dependency updates or tooling)
