### PR TITLE
chore: set oidc-client-ts log level to WARN

### DIFF
--- a/packages/web-runtime/src/services/auth/userManager.ts
+++ b/packages/web-runtime/src/services/auth/userManager.ts
@@ -99,7 +99,7 @@ export class UserManager extends OidcUserManager {
     }
 
     Log.setLogger(console)
-    Log.setLevel(Log.INFO)
+    Log.setLevel(Log.WARN)
 
     super(openIdConfig)
     this.storePrefix = storePrefix


### PR DESCRIPTION
## Description
With log level `INFO` for the `oidc-client-ts` lib we see a `user loaded` log message on each route change (because the authService needs to re-initialize the context for the respective route and for we need to query the access token from the user manager... the `oidc-client-ts` lib then prints the `user loaded` log message, no matter if the user is already cached or not. That's just log noise, we should reduce that to warnings.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [x] Maintenance (e.g. dependency updates or tooling)
