### PR TITLE
chore: exclude test helpers from SonarCloud coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -32,4 +32,4 @@ sonar.pullrequest.key=${env.SONAR_PULL_REQUEST_KEY}
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 
 # Exclude files
-sonar.exclusions=docs/**,node_modules/**,deployments/**,**/tests/**,**/*.spec.ts,__mocks__/**,__fixtures__/**,dist/**,changelog/**,config/**,docker/**,release/**,**/package.json,package.json,rollup.config.js,nightwatch.conf.js,Makefile,Makefile.release,CHANGELOG.md,README.md,packages/web-client/src/generated/**
+sonar.exclusions=docs/**,node_modules/**,deployments/**,**/tests/**,**/*.spec.ts,__mocks__/**,__fixtures__/**,dist/**,changelog/**,config/**,docker/**,release/**,**/package.json,package.json,rollup.config.js,nightwatch.conf.js,Makefile,Makefile.release,CHANGELOG.md,README.md,packages/web-client/src/generated/**,packages/web-test-helpers/**


### PR DESCRIPTION
## Description
Since the test helpers don't include tests themselves they shouldn't affect SonarCloud's code coverage.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
