### PR TITLE
refactor: remove dynamic nav items

### DIFF
--- a/packages/web-runtime/src/layouts/Application.vue
+++ b/packages/web-runtime/src/layouts/Application.vue
@@ -179,7 +179,7 @@ export default defineComponent({
     }
   },
   computed: {
-    ...mapGetters(['apps', 'activeMessages', 'configuration', 'getExtensionsWithNavItems']),
+    ...mapGetters(['apps', 'activeMessages', 'configuration']),
     isIE11() {
       return !!(window as any).MSInputMethodContext && !!(document as any).documentMode
     },

--- a/packages/web-runtime/src/store/navigation.ts
+++ b/packages/web-runtime/src/store/navigation.ts
@@ -1,8 +1,6 @@
 const state = {
   // static nav items are set during extension loading and will not be modified later on
   staticNavItems: {},
-  // dynamic nav items are initially empty and can be created e.g. from loaded data
-  dynamicNavItems: {},
   closed: false
 }
 
@@ -21,32 +19,6 @@ const mutations = {
     staticNavItems[extension] = navItems
     state.staticNavItems = staticNavItems
   },
-  /**
-   * Use this mutation to dynamically add nav items after initialization phase, e.g. from loaded
-   * data. If there already is a nav item with the same name, that one will be replaced.
-   *
-   * @param state
-   * @param extension
-   * @param navItem
-   * @constructor
-   */
-  ADD_NAV_ITEM(state, { extension, navItem }) {
-    const dynamicNavItems = { ...state.dynamicNavItems }
-    dynamicNavItems[extension] = dynamicNavItems[extension] || []
-    const index = dynamicNavItems[extension].findIndex(
-      (item) => item.route.path === navItem.route.path
-    )
-    if (index >= 0) {
-      dynamicNavItems[extension][index] = navItem
-    } else {
-      dynamicNavItems[extension].push(navItem)
-    }
-    state.dynamicNavItems = dynamicNavItems
-  },
-  /* Sets dynamic nav items */
-  SET_DYNAMIC_NAV_ITEMS(state, navItems) {
-    state.dynamicNavItems = navItems
-  },
   SET_CLOSED(state, closed) {
     state.closed = closed
   }
@@ -62,8 +34,7 @@ const getters = {
    */
   getNavItemsByExtension: (state, getters) => (extension) => {
     const staticNavItems = state.staticNavItems[extension] || []
-    const dynamicNavItems = state.dynamicNavItems[extension] || []
-    return [...staticNavItems, ...dynamicNavItems].filter((navItem) => {
+    return staticNavItems.filter((navItem) => {
       if (!navItem.enabled) {
         // when `enabled` callback not provided: count as enabled.
         return true
@@ -75,15 +46,6 @@ const getters = {
         return false
       }
     })
-  },
-  getExtensionsWithNavItems: (state, getters) => {
-    // get a unique list of extension ids by collecting the ids in a set and then spreading them into an array.
-    const extensions = [
-      ...new Set([...Object.keys(state.staticNavItems), ...Object.keys(state.dynamicNavItems)])
-    ]
-    // return only those extension ids that really have at least one nav item.
-    // Context: NavItems can be removed, so the map key could still exist with an empty array of nav items.
-    return extensions.filter((extension) => getters.getNavItemsByExtension(extension).length > 0)
   }
 }
 
@@ -93,9 +55,6 @@ const actions = {
   },
   closeNavigation({ commit }) {
     commit('SET_CLOSED', true)
-  },
-  clearDynamicNavItems({ commit }) {
-    commit('SET_DYNAMIC_NAV_ITEMS', {})
   }
 }
 export default {


### PR DESCRIPTION
## Description
Removes the code for registering dynamic nav items since this is no longer possible.

## Related Issue
- refs https://github.com/owncloud/web/issues/10210

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
