### PR TITLE
[full-ci] [tests-only] Bump ocis commit-id to include fix for ocis build pipeline

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=0e8394e83a94dca98d1e268806edce4c3cf6cf17
+OCIS_COMMITID=a7b840d140e253a42586078a015a0737f5347ae8
 OCIS_BRANCH=stable-4.0


### PR DESCRIPTION
The Ocis build pipeline break fix is merged in Ocis (https://github.com/owncloud/ocis/pull/8158). So, bumping OCIS commit ID.
https://drone.owncloud.com/owncloud/web/41712/5/4