### PR TITLE
chore: fix ocis natsjs name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 x-ocis-server: &ocis-service
   image: ${OCIS_IMAGE:-owncloud/ocis:latest}
   entrypoint: /bin/sh
-  command: [ '-c', 'ocis init || true && ocis server' ]
+  command: ['-c', 'ocis init || true && ocis server']
   environment: &ocis-environment
     OCIS_INSECURE: '${OCIS_INSECURE:-true}'
     OCIS_LOG_LEVEL: '${OCIS_LOG_LEVEL:-error}'
@@ -18,7 +18,6 @@ x-ocis-server: &ocis-service
     WEB_ASSET_PATH: ${WEB_ASSET_PATH:-/web/dist}
     WEB_UI_THEME_PATH: ${WEB_UI_THEME_PATH:-/themes/owncloud/theme.json}
     WEB_UI_CONFIG_FILE: ${WEB_UI_CONFIG_FILE:-/web/config.json}
-
 
     #FRONTEND
     FRONTEND_SEARCH_MIN_LENGTH: '2'
@@ -90,7 +89,7 @@ services:
       OCIS_CORS_ALLOW_ORIGINS: 'https://host.docker.internal:9201'
       OCM_WEBAPP_TEMPLATE: https://host.docker.internal:9201/o/{{.Token}}/{relative-path-to-shared-resource}
       # make the registry available to the app provider containers
-      MICRO_REGISTRY: 'natsjs'
+      MICRO_REGISTRY: 'nats-js-kv'
       MICRO_REGISTRY_ADDRESS: 0.0.0.0:9233
     labels:
       traefik.enable: true


### PR DESCRIPTION
## Description
Changes the nats registry name to `nats-js-kv`, which prevents the container from restarting over and over again. Also see https://github.com/owncloud/ocis/pull/8141.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
