### PR TITLE
[test-only]e2e test. create link with role

### DIFF
--- a/tests/e2e/cucumber/features/smoke/app-provider/officeSuites.feature
+++ b/tests/e2e/cucumber/features/smoke/app-provider/officeSuites.feature
@@ -16,8 +16,9 @@ Feature: Integrate with online office suites like Collabora and OnlyOffice
     When "Alice" creates the following resources
       | resource         | type         | content              |
       | OpenDocument.odt | OpenDocument | OpenDocument Content |
-    And "Alice" creates a public link for the resource "OpenDocument.odt" with password "%public%" using the sidebar panel
-    And "Alice" edits the public link named "Link" of resource "OpenDocument.odt" changing role to "Can edit"
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource         | role     | password |
+      | OpenDocument.odt | Can edit | %public% |
     And "Alice" logs out
     And "Anonymous" opens the public link "Link"
     And "Anonymous" unlocks the public link with password "%public%"
@@ -28,8 +29,9 @@ Feature: Integrate with online office suites like Collabora and OnlyOffice
     When "Alice" creates the following resources
       | resource           | type           | content                |
       | MicrosoftWord.docx | Microsoft Word | Microsoft Word Content |
-    And "Alice" creates a public link for the resource "MicrosoftWord.docx" with password "%public%" using the sidebar panel
-    And "Alice" edits the public link named "Link" of resource "MicrosoftWord.docx" changing role to "Can edit"
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource           | role     | password |
+      | MicrosoftWord.docx | Can edit | %public% |
     And "Alice" logs out
     And "Anonymous" opens the public link "Link"
     And "Anonymous" unlocks the public link with password "%public%"

--- a/tests/e2e/cucumber/features/smoke/internalLink.feature
+++ b/tests/e2e/cucumber/features/smoke/internalLink.feature
@@ -14,7 +14,9 @@ Feature: internal link share
       | resource | recipient | type | role     |
       | myfolder | Brian     | user | Can edit |
     And "Alice" opens the "files" app
-    And "Alice" creates a public link for the resource "myfolder" with password "%public%" using the sidebar panel
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource | password |
+      | myfolder | %public% |
     When "Alice" edits the public link named "Link" of resource "myfolder" changing role to "Invited people"
     And "Brian" opens the public link "Link"
     And "Brian" logs in from the internal link

--- a/tests/e2e/cucumber/features/smoke/languageChange.feature
+++ b/tests/e2e/cucumber/features/smoke/languageChange.feature
@@ -13,7 +13,6 @@ Feature: language settings
     And "Brian" creates the following folder in personal space using API
       | name          |
       | check_message |
-    And "Brian" opens the "files" app
     And "Brian" shares the following resource using API
       | resource      | recipient | type | role     |
       | check_message | Alice     | user | Can edit |
@@ -29,19 +28,22 @@ Feature: language settings
       | Brian Murphy hat check_message mit Ihnen geteilt |
     And "Alice" logs out
 
+
   Scenario: anonymous user language change
     When "Alice" logs in
+    And "Alice" creates the following folder in personal space using API
+      | name         |
+      | folderPublic |
+    And "Alice" uploads the following local file into personal space using API
+      | localFile                | to        |
+      | filesForUpload/lorem.txt | lorem.txt |
+
     And "Alice" opens the "files" app
-    And "Alice" creates the following resources
-      | resource     | type   |
-      | folderPublic | folder |
-    And "Alice" uploads the following resources
-      | resource  | to           |
-      | lorem.txt | folderPublic |
-    And "Alice" creates a public link for the resource "folderPublic" with password "%public%" using the sidebar panel
-    And "Alice" renames the most recently created public link of resource "folderPublic" to "myPublicLink"
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource     | password |
+      | folderPublic | %public% |
     And "Alice" logs out
-    When "Anonymous" opens the public link "myPublicLink"
+    When "Anonymous" opens the public link "Link"
     And "Anonymous" unlocks the public link with password "%public%"
     And "Anonymous" opens the user menu
     And "Anonymous" changes the language to "Deutsch - German"

--- a/tests/e2e/cucumber/features/smoke/link.feature
+++ b/tests/e2e/cucumber/features/smoke/link.feature
@@ -8,13 +8,14 @@ Feature: link
 
   Scenario: public link
     When "Alice" logs in
+    And "Alice" creates the following folders in personal space using API
+      | name         |
+      | folderPublic |
+    And "Alice" creates the following files into personal space using API
+      | pathToFile             | content     |
+      | folderPublic/lorem.txt | lorem ipsum |
+
     And "Alice" opens the "files" app
-    And "Alice" creates the following resources
-      | resource     | type   |
-      | folderPublic | folder |
-    And "Alice" uploads the following resources
-      | resource  | to           |
-      | lorem.txt | folderPublic |
     And "Alice" creates a public link creates a public link of following resource using the sidebar panel
       | resource     | role             | password |
       | folderPublic | Secret File Drop | %public% |
@@ -57,6 +58,7 @@ Feature: link
     And "Alice" creates the following files into personal space using API
       | pathToFile             | content     |
       | folderPublic/lorem.txt | lorem ipsum |
+
     And "Alice" opens the "files" app
     When "Alice" creates quick link of the resource "folderPublic" with password "%public%" from the context menu
     And "Anonymous" opens the public link "Link"
@@ -72,33 +74,35 @@ Feature: link
       | id    |
       | Brian |
     And "Alice" logs in
-    And "Alice" creates the following resources
-      | resource     | type   |
-      | folderPublic | folder |
-    And "Alice" creates the following resources
-      | resource                      | type    | content   |
-      | folderPublic/shareToBrian.txt | txtFile | some text |
-      | folderPublic/shareToBrian.md  | mdFile  | readme    |
-    And "Alice" uploads the following resources via drag-n-drop
-      | resource       |
-      | simple.pdf     |
-      | testavatar.jpg |
-    And "Alice" shares the following resources using the sidebar panel
+    And "Alice" creates the following folders in personal space using API
+      | name         |
+      | folderPublic |
+    And "Alice" creates the following files into personal space using API
+      | pathToFile                    | content   |
+      | folderPublic/shareToBrian.txt | some text |
+      | folderPublic/shareToBrian.md  | readme    |
+    And "Alice" uploads the following local file into personal space using API
+      | localFile                     | to             |
+      | filesForUpload/simple.pdf     | simple.pdf     |
+      | filesForUpload/testavatar.jpg | testavatar.jpg |
+    And "Alice" shares the following resource using API
       | resource       | recipient | type | role     |
       | folderPublic   | Brian     | user | Can edit |
       | simple.pdf     | Brian     | user | Can edit |
       | testavatar.jpg | Brian     | user | Can edit |
+
+    And "Alice" opens the "files" app
     And "Alice" creates a public link creates a public link of following resource using the sidebar panel
       | resource     | password |
       | folderPublic | %public% |
     And "Alice" renames the most recently created public link of resource "folderPublic" to "folderLink"
     And "Alice" creates a public link creates a public link of following resource using the sidebar panel
-      | resource                     | password |
-      | olderPublic/shareToBrian.txt | %public% |
-    And "Alice" renames the most recently created public link of resource "folderPublic/shareToBrian.txt" to "textLink"
-    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
       | resource                      | password |
       | folderPublic/shareToBrian.txt | %public% |
+    And "Alice" renames the most recently created public link of resource "folderPublic/shareToBrian.txt" to "textLink"
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource                     | password |
+      | folderPublic/shareToBrian.md | %public% |
     And "Alice" renames the most recently created public link of resource "folderPublic/shareToBrian.md" to "markdownLink"
     And "Alice" creates a public link creates a public link of following resource using the sidebar panel
       | resource   | password |
@@ -136,20 +140,21 @@ Feature: link
 
   Scenario: add banned password for public link
     When "Alice" logs in
-    And "Alice" uploads the following resources
-      | resource  |
-      | lorem.txt |
+    And "Alice" creates the following files into personal space using API
+      | pathToFile | content   |
+      | lorem.txt  | some text |
+
+    And "Alice" opens the "files" app
     And "Alice" creates a public link creates a public link of following resource using the sidebar panel
       | resource  | password |
       | lorem.txt | %public% |
-    And "Alice" renames the most recently created public link of resource "lorem.txt" to "myPublicLink"
-    When "Alice" tries to sets a new password "ownCloud-1" of the public link named "myPublicLink" of resource "lorem.txt"
+    When "Alice" tries to sets a new password "ownCloud-1" of the public link named "Link" of resource "lorem.txt"
     Then "Alice" should see an error message
       """
       Unfortunately, your password is commonly used. please pick a harder-to-guess password for your safety
       """
     And "Alice" closes the public link password dialog box
-    When "Alice" tries to sets a new password "ownCloud-1" of the public link named "myPublicLink" of resource "lorem.txt"
+    When "Alice" tries to sets a new password "ownCloud-1" of the public link named "Link" of resource "lorem.txt"
     Then "Alice" should see an error message
       """
       Unfortunately, your password is commonly used. please pick a harder-to-guess password for your safety
@@ -159,6 +164,6 @@ Feature: link
     And "Alice" generates the password for the public link
     And "Alice" copies the password of the public link
     And "Alice" sets the password of the public link
-    And "Anonymous" opens the public link "myPublicLink"
+    And "Anonymous" opens the public link "Link"
     And "Anonymous" unlocks the public link with password "%copied_password%"
     And "Alice" logs out

--- a/tests/e2e/cucumber/features/smoke/link.feature
+++ b/tests/e2e/cucumber/features/smoke/link.feature
@@ -15,7 +15,9 @@ Feature: link
     And "Alice" uploads the following resources
       | resource  | to           |
       | lorem.txt | folderPublic |
-    And "Alice" creates a public link for the resource "folderPublic" with password "%public%" using the sidebar panel
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource     | role             | password |
+      | folderPublic | Secret File Drop | %public% |
     And "Alice" renames the most recently created public link of resource "folderPublic" to "myPublicLink"
     And "Alice" edits the public link named "myPublicLink" of resource "folderPublic" changing role to "Secret File Drop"
     And "Alice" sets the expiration date of the public link named "myPublicLink" of resource "folderPublic" to "+5 days"
@@ -86,15 +88,25 @@ Feature: link
       | folderPublic   | Brian     | user | Can edit |
       | simple.pdf     | Brian     | user | Can edit |
       | testavatar.jpg | Brian     | user | Can edit |
-    And "Alice" creates a public link for the resource "folderPublic" with password "%public%" using the sidebar panel
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource     | password |
+      | folderPublic | %public% |
     And "Alice" renames the most recently created public link of resource "folderPublic" to "folderLink"
-    And "Alice" creates a public link for the resource "folderPublic/shareToBrian.txt" with password "%public%" using the sidebar panel
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource                     | password |
+      | olderPublic/shareToBrian.txt | %public% |
     And "Alice" renames the most recently created public link of resource "folderPublic/shareToBrian.txt" to "textLink"
-    And "Alice" creates a public link for the resource "folderPublic/shareToBrian.md" with password "%public%" using the sidebar panel
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource                      | password |
+      | folderPublic/shareToBrian.txt | %public% |
     And "Alice" renames the most recently created public link of resource "folderPublic/shareToBrian.md" to "markdownLink"
-    And "Alice" creates a public link for the resource "simple.pdf" with password "%public%" using the sidebar panel
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource   | password |
+      | simple.pdf | %public% |
     And "Alice" renames the most recently created public link of resource "simple.pdf" to "pdfLink"
-    And "Alice" creates a public link for the resource "testavatar.jpg" with password "%public%" using the sidebar panel
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource       | password |
+      | testavatar.jpg | %public% |
     And "Alice" renames the most recently created public link of resource "testavatar.jpg" to "imageLink"
     And "Alice" logs out
     And "Brian" logs in
@@ -127,7 +139,9 @@ Feature: link
     And "Alice" uploads the following resources
       | resource  |
       | lorem.txt |
-    And "Alice" creates a public link for the resource "lorem.txt" with password "%public%" using the sidebar panel
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource  | password |
+      | lorem.txt | %public% |
     And "Alice" renames the most recently created public link of resource "lorem.txt" to "myPublicLink"
     When "Alice" tries to sets a new password "ownCloud-1" of the public link named "myPublicLink" of resource "lorem.txt"
     Then "Alice" should see an error message
@@ -148,4 +162,3 @@ Feature: link
     And "Anonymous" opens the public link "myPublicLink"
     And "Anonymous" unlocks the public link with password "%copied_password%"
     And "Alice" logs out
-    

--- a/tests/e2e/cucumber/features/smoke/rename.feature
+++ b/tests/e2e/cucumber/features/smoke/rename.feature
@@ -19,9 +19,9 @@ Feature: rename
     And "Alice" shares the following resource using API
       | resource | recipient | type | role     |
       | folder   | Brian     | user | Can edit |
-    And "Alice" creates a public link for the resource "folder" with password "%public%" using the sidebar panel
-    And "Alice" renames the most recently created public link of resource "folder" to "myPublicLink"
-    And "Alice" edits the public link named "myPublicLink" of resource "folder" changing role to "Can edit"
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource | role     | password |
+      | folder   | Can edit | %public% |
     And "Brian" logs in
     And "Brian" opens the "files" app
     And "Brian" navigates to the shared with me page
@@ -34,7 +34,7 @@ Feature: rename
     And "Brian" logs out
 
     # rename in the public link
-    When "Anonymous" opens the public link "myPublicLink"
+    When "Anonymous" opens the public link "Link"
     And "Anonymous" unlocks the public link with password "%public%"
     When "Anonymous" renames the following resource
       | resource           | as                     |

--- a/tests/e2e/cucumber/features/smoke/shortcut.feature
+++ b/tests/e2e/cucumber/features/smoke/shortcut.feature
@@ -21,7 +21,9 @@ Feature: Users can create shortcuts for resources and sites
       | resource | recipient | type | role     |
       | logo.jpg | Brian     | user | Can view |
     And "Alice" opens the "files" app
-    And "Alice" creates a public link for the resource "docs/notice.txt" with password "%public%" using the sidebar panel
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource        | password |
+      | docs/notice.txt | %public% |
     And "Alice" renames the most recently created public link of resource "docs/notice.txt" to "myPublicLink"
     And "Alice" opens the "files" app
 

--- a/tests/e2e/cucumber/features/smoke/spaces/internalLink.feature
+++ b/tests/e2e/cucumber/features/smoke/spaces/internalLink.feature
@@ -31,8 +31,10 @@ Feature: internal link share in project space
     And "Alice" renames the most recently created public link of space to "spaceLink"
     And "Alice" edits the public link named "spaceLink" of the space changing role to "Invited people"
     # internal link to folder
-    And "Alice" creates a public link for the resource "myfolder" with password "%public%" using the sidebar panel
-    When "Alice" edits the public link named "Link" of resource "myfolder" changing role to "Invited people"
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource | role           | password |
+      | myfolder | Invited people | %public% |
+    # When "Alice" edits the public link named "Link" of resource "myfolder" changing role to "Invited people"
     And "Alice" logs out
 
     And "Brian" opens the public link "Link"

--- a/tests/e2e/cucumber/features/smoke/spaces/participantManagement.feature
+++ b/tests/e2e/cucumber/features/smoke/spaces/participantManagement.feature
@@ -62,8 +62,9 @@ Feature: spaces participant management
     Then "Carol" should see folder "parent" but should not be able to edit
     # page reload is necessary to fetch all the changes made by user Brian
     When "Alice" reloads the spaces page
-    And "Alice" creates a public link for the resource "parent" with password "%public%" using the sidebar panel
-    And "Alice" edits the public link named "Link" of resource "parent" changing role to "Can edit"
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource | role     | password |
+      | parent   | Can edit | %public% |
     And "Anonymous" opens the public link "Link"
     And "Anonymous" unlocks the public link with password "%public%"
     And "Anonymous" uploads the following resources in public link page

--- a/tests/e2e/cucumber/features/smoke/spaces/project.feature
+++ b/tests/e2e/cucumber/features/smoke/spaces/project.feature
@@ -48,9 +48,10 @@ Feature: spaces.personal
       | lorem.txt | folderPublic     |
       | lorem.txt | folder_to_shared |
 
-    And "Alice" creates a public link for the resource "folderPublic" with password "%public%" using the sidebar panel
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource     | role             | password |
+      | folderPublic | Secret File Drop | %public% |
     And "Alice" renames the most recently created public link of resource "folderPublic" to "team.1"
-    And "Alice" edits the public link named "team.1" of resource "folderPublic" changing role to "Secret File Drop"
     And "Alice" sets the expiration date of the public link named "team.1" of resource "folderPublic" to "+5 days"
 
     # borrowed from share.feature
@@ -74,7 +75,9 @@ Feature: spaces.personal
       | resource  | to           |
       | lorem.txt | folderPublic |
 
-    And "Alice" creates a public link for the resource "folderPublic" with password "%public%" using the sidebar panel
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource     | password |
+      | folderPublic | %public% |
     And "Alice" renames the most recently created public link of resource "folderPublic" to "team.2"
     And "Alice" edits the public link named "team.2" of resource "folderPublic" changing role to "Secret File Drop"
     And "Alice" sets the expiration date of the public link named "team.2" of resource "folderPublic" to "+5 days"
@@ -168,5 +171,5 @@ Feature: spaces.personal
       | textfile.txt | parent |
     And "Brian" restores following resources
       | resource     | to     | version | openDetailsPanel |
-      | textfile.txt | parent | 1       |true              |
+      | textfile.txt | parent | 1       | true             |
     And "Brian" logs out

--- a/tests/e2e/cucumber/features/smoke/spaces/publicLink.feature
+++ b/tests/e2e/cucumber/features/smoke/spaces/publicLink.feature
@@ -47,8 +47,8 @@ Feature: spaces public link
       | spaceFolder/subFolder/shareToBrian.md | %public% |
     And "Alice" renames the most recently created public link of resource "spaceFolder/subFolder/shareToBrian.md" to "markdownLink"
     And "Alice" creates a public link creates a public link of following resource using the sidebar panel
-      | resource                              | password |
-      | spaceFolder/subFolder/shareToBrian.md | %public% |
+      | resource   | password |
+      | simple.pdf | %public% |
     And "Alice" renames the most recently created public link of resource "simple.pdf" to "pdfLink"
     And "Alice" creates a public link creates a public link of following resource using the sidebar panel
       | resource       | password |

--- a/tests/e2e/cucumber/features/smoke/spaces/publicLink.feature
+++ b/tests/e2e/cucumber/features/smoke/spaces/publicLink.feature
@@ -34,15 +34,25 @@ Feature: spaces public link
       | testavatar.jpg |
     And "Alice" creates a public link for the space with password "%public%" using the sidebar panel
     And "Alice" renames the most recently created public link of space to "spaceLink"
-    And "Alice" creates a public link for the resource "spaceFolder" with password "%public%" using the sidebar panel
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource    | password |
+      | spaceFolder | %public% |
     And "Alice" renames the most recently created public link of resource "spaceFolder" to "folderLink"
-    And "Alice" creates a public link for the resource "spaceFolder/shareToBrian.txt" with password "%public%" using the sidebar panel
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource                     | password |
+      | spaceFolder/shareToBrian.txt | %public% |
     And "Alice" renames the most recently created public link of resource "spaceFolder/shareToBrian.txt" to "textLink"
-    And "Alice" creates a public link for the resource "spaceFolder/subFolder/shareToBrian.md" with password "%public%" using the sidebar panel
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource                              | password |
+      | spaceFolder/subFolder/shareToBrian.md | %public% |
     And "Alice" renames the most recently created public link of resource "spaceFolder/subFolder/shareToBrian.md" to "markdownLink"
-    And "Alice" creates a public link for the resource "simple.pdf" with password "%public%" using the sidebar panel
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource                              | password |
+      | spaceFolder/subFolder/shareToBrian.md | %public% |
     And "Alice" renames the most recently created public link of resource "simple.pdf" to "pdfLink"
-    And "Alice" creates a public link for the resource "testavatar.jpg" with password "%public%" using the sidebar panel
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource       | password |
+      | testavatar.jpg | %public% |
     And "Alice" renames the most recently created public link of resource "testavatar.jpg" to "imageLink"
     And "Alice" logs out
     When "Brian" logs in

--- a/tests/e2e/cucumber/steps/ui/links.ts
+++ b/tests/e2e/cucumber/steps/ui/links.ts
@@ -1,19 +1,22 @@
-import { Then, When } from '@cucumber/cucumber'
+import { DataTable, Then, When } from '@cucumber/cucumber'
 import { expect } from '@playwright/test'
 import { World } from '../../environment'
 import { objects } from '../../../support'
 
 When(
-  '{string} creates a public link for the resource {string} with password {string} using the sidebar panel',
-  async function (this: World, stepUser: string, resource: string, password: string) {
+  '{string} creates a public link creates a public link of following resource using the sidebar panel',
+  async function (this: World, stepUser: string, stepTable: DataTable) {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const linkObject = new objects.applicationFiles.Link({ page })
-    password = password === '%public%' ? linkObject.securePassword : password
-    await linkObject.create({
-      resource,
-      name: 'Link',
-      password
-    })
+
+    for (const info of stepTable.hashes()) {
+      await linkObject.create({
+        resource: info.resource,
+        role: info.role,
+        password: info.password === '%public%' ? linkObject.securePassword : info.password,
+        name: 'Link'
+      })
+    }
   }
 )
 


### PR DESCRIPTION
I've added the ability to create a public link with the role added immediately at the time of creation

if we create public link with `Invited people` role - password is not required so I check message `Password cannot be set for internal links`

I would add Given step for creating link but want to do it when we switch to sharing NG