### PR TITLE
refactor: remove searched files from store

### DIFF
--- a/packages/web-app-files/src/store/actions.ts
+++ b/packages/web-app-files/src/store/actions.ts
@@ -190,7 +190,6 @@ export default {
     }
     return Promise.all(promises).then(() => {
       context.commit('REMOVE_FILES', removedFiles)
-      context.commit('REMOVE_FILES_FROM_SEARCHED', removedFiles)
       context.commit('RESET_SELECTION')
       context.commit('PRUNE_SHARES')
 
@@ -212,11 +211,9 @@ export default {
   clearTrashBin(context) {
     context.commit('CLEAR_FILES')
     context.commit('RESET_SELECTION')
-    context.commit('CLEAR_FILES_SEARCHED')
   },
   removeFilesFromTrashbin(context, files) {
     context.commit('REMOVE_FILES', files)
-    context.commit('REMOVE_FILES_FROM_SEARCHED', files)
     context.commit('RESET_SELECTION')
   },
   updateFileShareTypes({ state, getters, commit, rootState }, path) {

--- a/packages/web-app-files/src/store/getters.ts
+++ b/packages/web-app-files/src/store/getters.ts
@@ -3,12 +3,11 @@ import { ShareTypes } from '@ownclouders/web-client/src/helpers/share'
 
 export default {
   selectedFiles: (state, getters) => {
-    return getters.filesAll.filter((f) => state.selectedIds.includes(f.id))
+    return getters.files.filter((f) => state.selectedIds.includes(f.id))
   },
   files: (state) => {
     return state.files
   },
-  filesAll: (state) => state.filesSearched || state.files,
   currentFolder: (state) => {
     return state.currentFolder
   },
@@ -19,7 +18,7 @@ export default {
     return state.clipboardAction
   },
   activeFiles: (state, getters) => {
-    let files = [].concat(getters.filesAll)
+    let files = [].concat(getters.files)
 
     if (!state.areHiddenFilesShown) {
       files = files.filter((file) => !file.name.startsWith('.'))
@@ -28,12 +27,12 @@ export default {
     return files
   },
   totalFilesSize: (state, getters) => {
-    return getters.filesAll.map((file) => parseInt(file.size)).reduce((x, y) => x + y, 0)
+    return getters.files.map((file) => parseInt(file.size)).reduce((x, y) => x + y, 0)
   },
   totalFilesCount: (state, getters) => {
-    const fileCount = getters.filesAll.filter((file) => file.type === 'file').length
-    const folderCount = getters.filesAll.filter((file) => file.type === 'folder').length
-    const spaceCount = getters.filesAll.filter((file) => isProjectSpaceResource(file)).length
+    const fileCount = getters.files.filter((file) => file.type === 'file').length
+    const folderCount = getters.files.filter((file) => file.type === 'folder').length
+    const spaceCount = getters.files.filter((file) => isProjectSpaceResource(file)).length
     return {
       files: fileCount,
       folders: folderCount,

--- a/packages/web-app-files/src/store/mutations.ts
+++ b/packages/web-app-files/src/store/mutations.ts
@@ -13,19 +13,6 @@ export default {
   CLEAR_FILES(state) {
     state.files = []
   },
-  LOAD_FILES_SEARCHED(state, files) {
-    state.filesSearched = files
-  },
-  REMOVE_FILES_FROM_SEARCHED(state, files) {
-    if (!state.filesSearched) {
-      return
-    }
-
-    state.filesSearched = state.filesSearched.filter((i) => !files.find((f) => f.id === i.id))
-  },
-  CLEAR_FILES_SEARCHED(state) {
-    state.filesSearched = null
-  },
   CLEAR_CLIPBOARD(state) {
     state.clipboardResources = []
     state.clipboardAction = null
@@ -182,7 +169,7 @@ export default {
    * @param params.value the value that will be attached to the key
    */
   UPDATE_RESOURCE_FIELD(state, params) {
-    let fileSource = state.filesSearched || state.files
+    let fileSource = state.files
     let index = fileSource.findIndex((r) => r.id === params.id)
     if (index < 0) {
       if (state.currentFolder?.id === params.id) {
@@ -231,8 +218,6 @@ function $_upsertResource(state, resource, allowInsert) {
     index = files.findIndex((r) => r.webDavPath === resource.webDavPath)
   }
   const found = index > -1
-
-  state.filesSearched = null
 
   if (!found && !allowInsert) {
     return

--- a/packages/web-app-files/src/store/state.ts
+++ b/packages/web-app-files/src/store/state.ts
@@ -1,7 +1,6 @@
 export default {
   currentFolder: null,
   files: [],
-  filesSearched: null,
   selectedIds: [],
   latestSelectedId: null,
   clipboardResources: [],

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -610,7 +610,7 @@ export default defineComponent({
 
   methods: {
     ...mapActions('Files', ['loadPreview']),
-    ...mapMutations('Files', ['REMOVE_FILES', 'REMOVE_FILES_FROM_SEARCHED', 'RESET_SELECTION']),
+    ...mapMutations('Files', ['REMOVE_FILES', 'RESET_SELECTION']),
 
     async fileDropped(fileTarget) {
       const selected = [...this.selectedResources]
@@ -659,7 +659,6 @@ export default defineComponent({
       )
       const movedResources = await copyMove.perform(TransferType.MOVE)
       this.REMOVE_FILES(movedResources)
-      this.REMOVE_FILES_FROM_SEARCHED(movedResources)
       this.RESET_SELECTION()
     },
 

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -328,7 +328,6 @@ export default defineComponent({
     const { scrollToResourceFromRoute } = useScrollTo()
 
     const loadResourcesTask = useTask(function* () {
-      store.commit('Files/CLEAR_FILES_SEARCHED')
       store.commit('Files/CLEAR_CURRENT_FILES_LIST')
       yield spacesStore.reloadProjectSpaces({ graphClient: clientService.graphAuthenticated })
       store.commit('Files/LOAD_FILES', { currentFolder: null, files: unref(spaces) })

--- a/packages/web-app-files/src/views/trash/Overview.vue
+++ b/packages/web-app-files/src/views/trash/Overview.vue
@@ -117,7 +117,6 @@ export default defineComponent({
     )
 
     const loadResourcesTask = useTask(function* () {
-      store.commit('Files/CLEAR_FILES_SEARCHED')
       store.commit('Files/CLEAR_CURRENT_FILES_LIST')
       yield spacesStore.reloadProjectSpaces({ graphClient: clientService.graphAuthenticated })
       store.commit('Files/LOAD_FILES', { currentFolder: null, files: unref(spaces) })

--- a/packages/web-app-files/tests/unit/store/getters.spec.ts
+++ b/packages/web-app-files/tests/unit/store/getters.spec.ts
@@ -22,8 +22,8 @@ describe('Getters', () => {
     it.each(cases)('%s hidden files if areHiddenFilesShown is set to %s', (value) => {
       state.areHiddenFilesShown = value
 
-      const { activeFiles, filesAll } = getters
-      const result = activeFiles(state, { filesAll: filesAll(state) })
+      const { activeFiles, files } = getters
+      const result = activeFiles(state, { files: files(state) })
 
       expect(result.length).toEqual(mockedFiles.length)
     })

--- a/packages/web-test-helpers/src/mocks/store/filesModuleMockOptions.ts
+++ b/packages/web-test-helpers/src/mocks/store/filesModuleMockOptions.ts
@@ -36,7 +36,6 @@ export const filesModuleMockOptions = {
       REMOVE_FILES: jest.fn(),
       RESET_SELECTION: jest.fn(),
       SET_LATEST_SELECTED_FILE_ID: jest.fn(),
-      CLEAR_FILES_SEARCHED: jest.fn(),
       CLEAR_CLIPBOARD: jest.fn()
     },
     actions: {


### PR DESCRIPTION
## Description
The `filesSearched` store state didn't seem to be used at all, so this removes it from it (including all related mutations). Also removes the `filesAll` getter since it's now the same as `files`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/10210

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
