### PR TITLE
Remove clipboard from files store

### DIFF
--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -177,7 +177,7 @@
       <oc-button
         :disabled="uploadOrFileCreationBlocked"
         class="clear-clipboard-btn"
-        @click="clearClipboardFiles"
+        @click="clearClipboard"
       >
         <oc-icon fill-type="line" name="close" />
       </oc-button>
@@ -186,12 +186,12 @@
 </template>
 
 <script lang="ts">
-import { mapActions, mapGetters } from 'vuex'
 import {
   isLocationPublicActive,
   isLocationSpacesActive,
   useAppsStore,
   useCapabilityStore,
+  useClipboardStore,
   useFileActions,
   useFileActionsCreateNewShortcut,
   useMessages,
@@ -274,6 +274,11 @@ export default defineComponent({
     const capabilityRefs = storeToRefs(capabilityStore)
     const route = useRoute()
     const language = useGettext()
+
+    const clipboardStore = useClipboardStore()
+    const { clearClipboard } = clipboardStore
+    const { resources: clipboardResources } = storeToRefs(clipboardStore)
+
     const areFileExtensionsShown = computed(() => unref(store.state.Files.areFileExtensionsShown))
 
     useUpload({ uppyService })
@@ -359,7 +364,7 @@ export default defineComponent({
 
     const handlePasteFileEvent = (event) => {
       // Ignore file in clipboard if there are already files from owncloud in the clipboard
-      if (store.state.Files.clipboardResources.length || !unref(canUpload)) {
+      if (unref(clipboardResources).length || !unref(canUpload)) {
         return
       }
       // Browsers only allow single files to be pasted for security reasons
@@ -456,14 +461,14 @@ export default defineComponent({
       actionKeySuffix,
       showDrop,
       areFileExtensionsShown,
+      clearClipboard,
+      clipboardResources,
 
       // HACK: exported for unit tests:
       onUploadComplete
     }
   },
   computed: {
-    ...mapGetters('Files', ['clipboardResources']),
-
     showPasteHereButton() {
       return this.clipboardResources && this.clipboardResources.length !== 0
     },
@@ -521,8 +526,6 @@ export default defineComponent({
     }
   },
   methods: {
-    ...mapActions('Files', ['clearClipboardFiles']),
-
     getIconResource(fileHandler) {
       return { type: 'file', extension: fileHandler.ext } as Resource
     }

--- a/packages/web-app-files/src/composables/keyboardActions/useKeyboardTableActions.ts
+++ b/packages/web-app-files/src/composables/keyboardActions/useKeyboardTableActions.ts
@@ -1,17 +1,11 @@
-import { Key, KeyboardActions, ModifierKey, useMessages } from '@ownclouders/web-pkg'
+import { Key, KeyboardActions, ModifierKey, useClipboardStore } from '@ownclouders/web-pkg'
 import { useStore } from '@ownclouders/web-pkg'
-import { useGettext } from 'vue3-gettext'
 
 export const useKeyboardTableActions = (keyActions: KeyboardActions) => {
   const store = useStore()
-  const messageStore = useMessages()
-  const language = useGettext()
+  const { copyResources } = useClipboardStore()
 
   keyActions.bindKeyAction({ modifier: ModifierKey.Ctrl, primary: Key.C }, () => {
-    store.dispatch('Files/copySelectedFiles', {
-      ...language,
-      resources: store.getters['Files/selectedFiles'],
-      messageStore
-    })
+    copyResources(store.getters['Files/selectedFiles'])
   })
 }

--- a/packages/web-app-files/src/composables/keyboardActions/useKeyboardTableSpaceActions.ts
+++ b/packages/web-app-files/src/composables/keyboardActions/useKeyboardTableSpaceActions.ts
@@ -1,25 +1,18 @@
-import { Key, KeyboardActions, ModifierKey, useMessages } from '@ownclouders/web-pkg'
+import { Key, KeyboardActions, ModifierKey, useClipboardStore } from '@ownclouders/web-pkg'
 import { SpaceResource } from '@ownclouders/web-client'
 import { useStore } from '@ownclouders/web-pkg'
-import { useGettext } from 'vue3-gettext'
 import { unref } from 'vue'
 import { useFileActionsPaste } from '@ownclouders/web-pkg'
 
 export const useKeyboardTableSpaceActions = (keyActions: KeyboardActions, space: SpaceResource) => {
   const store = useStore()
-  const messageStore = useMessages()
-  const language = useGettext()
+  const { copyResources, cutResources } = useClipboardStore()
 
   const { actions: pasteFileActions } = useFileActionsPaste({ store })
   const pasteFileAction = unref(pasteFileActions)[0].handler
 
   keyActions.bindKeyAction({ modifier: ModifierKey.Ctrl, primary: Key.C }, () => {
-    store.dispatch('Files/copySelectedFiles', {
-      ...language,
-      space: space,
-      resources: store.getters['Files/selectedFiles'],
-      messageStore
-    })
+    copyResources(store.getters['Files/selectedFiles'])
   })
 
   keyActions.bindKeyAction({ modifier: ModifierKey.Ctrl, primary: Key.V }, () => {
@@ -27,11 +20,6 @@ export const useKeyboardTableSpaceActions = (keyActions: KeyboardActions, space:
   })
 
   keyActions.bindKeyAction({ modifier: ModifierKey.Ctrl, primary: Key.X }, () => {
-    store.dispatch('Files/cutSelectedFiles', {
-      ...language,
-      space: space,
-      resources: store.getters['Files/selectedFiles'],
-      messageStore
-    })
+    cutResources(store.getters['Files/selectedFiles'])
   })
 }

--- a/packages/web-app-files/src/helpers/resource/actions/index.ts
+++ b/packages/web-app-files/src/helpers/resource/actions/index.ts
@@ -1,3 +1,1 @@
-export * from './transfer'
 export * from './upload'
-export * from './types'

--- a/packages/web-app-files/src/helpers/resource/actions/types.ts
+++ b/packages/web-app-files/src/helpers/resource/actions/types.ts
@@ -1,4 +1,0 @@
-export enum TransferType {
-  COPY,
-  MOVE
-}

--- a/packages/web-app-files/src/store/actions.ts
+++ b/packages/web-app-files/src/store/actions.ts
@@ -45,34 +45,18 @@ export default {
       context.commit('ADD_FILE_SELECTION', file)
     }
   },
-  copySelectedFiles(
-    context,
-    options: { resources: Resource[]; messageStore: MessageStore } & Language
-  ) {
-    const { $gettext } = options
-    context.commit('CLIPBOARD_SELECTED', options)
-    context.commit('SET_CLIPBOARD_ACTION', ClipboardActions.Copy)
-    options.messageStore.showMessage({ title: $gettext('Copied to clipboard!'), status: 'success' })
-  },
-  cutSelectedFiles(
-    context,
-    options: {
-      space: SpaceResource
-      resources: Resource[]
-      messageStore: MessageStore
-    } & Language
-  ) {
-    const { $gettext } = options
-    context.commit('CLIPBOARD_SELECTED', options)
-    context.commit('SET_CLIPBOARD_ACTION', ClipboardActions.Cut)
-    options.messageStore.showMessage({ title: $gettext('Cut to clipboard!'), status: 'success' })
-  },
-  clearClipboardFiles(context) {
-    context.commit('CLEAR_CLIPBOARD')
-  },
   pasteSelectedFiles(
     context,
-    { targetSpace, clientService, loadingService, $gettext, $ngettext, sourceSpace, resources }
+    {
+      targetSpace,
+      clientService,
+      loadingService,
+      $gettext,
+      $ngettext,
+      sourceSpace,
+      resources,
+      clipboardStore
+    }
   ) {
     const copyMove = new ResourceTransfer(
       sourceSpace,
@@ -85,10 +69,10 @@ export default {
       $ngettext
     )
     let movedResourcesPromise
-    if (context.state.clipboardAction === ClipboardActions.Cut) {
+    if (clipboardStore.action === ClipboardActions.Cut) {
       movedResourcesPromise = copyMove.perform(TransferType.MOVE)
     }
-    if (context.state.clipboardAction === ClipboardActions.Copy) {
+    if (clipboardStore.action === ClipboardActions.Copy) {
       movedResourcesPromise = copyMove.perform(TransferType.COPY)
     }
     return movedResourcesPromise.then((movedResources) => {

--- a/packages/web-app-files/src/store/actions.ts
+++ b/packages/web-app-files/src/store/actions.ts
@@ -1,13 +1,6 @@
 import PQueue from 'p-queue'
 
-import {
-  MessageStore,
-  CapabilityStore,
-  getParentPaths,
-  ConfigStore,
-  ResourceTransfer,
-  TransferType
-} from '@ownclouders/web-pkg'
+import { MessageStore, CapabilityStore, ConfigStore, getParentPaths } from '@ownclouders/web-pkg'
 import {
   buildShare,
   buildCollaboratorShare,
@@ -16,7 +9,6 @@ import {
 import { avatarUrl } from '../helpers/user'
 import { has } from 'lodash-es'
 import get from 'lodash-es/get'
-import { ClipboardActions } from '@ownclouders/web-pkg'
 import {
   buildResource,
   isProjectSpaceResource,
@@ -50,58 +42,6 @@ export default {
     } else {
       context.commit('ADD_FILE_SELECTION', file)
     }
-  },
-  pasteSelectedFiles(
-    context,
-    {
-      targetSpace,
-      clientService,
-      loadingService,
-      $gettext,
-      $ngettext,
-      sourceSpace,
-      resources,
-      clipboardStore
-    }
-  ) {
-    const copyMove = new ResourceTransfer(
-      sourceSpace,
-      resources,
-      targetSpace,
-      context.state.currentFolder,
-      clientService,
-      loadingService,
-      $gettext,
-      $ngettext
-    )
-    let movedResourcesPromise
-    if (clipboardStore.action === ClipboardActions.Cut) {
-      movedResourcesPromise = copyMove.perform(TransferType.MOVE)
-    }
-    if (clipboardStore.action === ClipboardActions.Copy) {
-      movedResourcesPromise = copyMove.perform(TransferType.COPY)
-    }
-    return movedResourcesPromise.then((movedResources) => {
-      const loadingResources = []
-      const fetchedResources = []
-      for (const resource of movedResources) {
-        loadingResources.push(
-          (async () => {
-            const movedResource = await (clientService.webdav as WebDAV).getFileInfo(
-              targetSpace,
-              resource
-            )
-            fetchedResources.push(movedResource)
-          })()
-        )
-      }
-
-      return Promise.all(loadingResources).then(() => {
-        const currentFolder = context.getters.currentFolder
-        context.commit('UPSERT_RESOURCES', fetchedResources)
-        context.commit('LOAD_INDICATORS', currentFolder.path)
-      })
-    })
   },
   resetFileSelection(context) {
     context.commit('RESET_SELECTION')

--- a/packages/web-app-files/src/store/actions.ts
+++ b/packages/web-app-files/src/store/actions.ts
@@ -1,12 +1,18 @@
 import PQueue from 'p-queue'
 
-import { MessageStore, CapabilityStore, getParentPaths, ConfigStore } from '@ownclouders/web-pkg'
+import {
+  MessageStore,
+  CapabilityStore,
+  getParentPaths,
+  ConfigStore,
+  ResourceTransfer,
+  TransferType
+} from '@ownclouders/web-pkg'
 import {
   buildShare,
   buildCollaboratorShare,
   ShareTypes
 } from '@ownclouders/web-client/src/helpers/share'
-import { ResourceTransfer, TransferType } from '../helpers/resource'
 import { avatarUrl } from '../helpers/user'
 import { has } from 'lodash-es'
 import get from 'lodash-es/get'

--- a/packages/web-app-files/src/store/getters.ts
+++ b/packages/web-app-files/src/store/getters.ts
@@ -11,12 +11,6 @@ export default {
   currentFolder: (state) => {
     return state.currentFolder
   },
-  clipboardResources: (state) => {
-    return state.clipboardResources
-  },
-  clipboardAction: (state) => {
-    return state.clipboardAction
-  },
   activeFiles: (state, getters) => {
     let files = [].concat(getters.files)
 

--- a/packages/web-app-files/src/store/mutations.ts
+++ b/packages/web-app-files/src/store/mutations.ts
@@ -1,6 +1,5 @@
 import { set, has } from 'lodash-es'
 import { getIndicators } from '@ownclouders/web-pkg'
-import { Resource } from '@ownclouders/web-client/src/helpers'
 
 export default {
   LOAD_FILES(state, { currentFolder, files }) {
@@ -12,16 +11,6 @@ export default {
   },
   CLEAR_FILES(state) {
     state.files = []
-  },
-  CLEAR_CLIPBOARD(state) {
-    state.clipboardResources = []
-    state.clipboardAction = null
-  },
-  CLIPBOARD_SELECTED(state, { resources }: { resources: Resource[] }) {
-    state.clipboardResources = resources
-  },
-  SET_CLIPBOARD_ACTION(state, action) {
-    state.clipboardAction = action
   },
   SET_LATEST_SELECTED_FILE_ID(state, fileId) {
     state.latestSelectedId = fileId

--- a/packages/web-app-files/src/store/state.ts
+++ b/packages/web-app-files/src/store/state.ts
@@ -3,8 +3,6 @@ export default {
   files: [],
   selectedIds: [],
   latestSelectedId: null,
-  clipboardResources: [],
-  clipboardAction: null,
   versions: [],
 
   /**

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -169,6 +169,8 @@ import {
 
 import {
   ProcessorType,
+  ResourceTransfer,
+  TransferType,
   useCapabilityStore,
   useConfigStore,
   useEmbedMode,
@@ -212,7 +214,6 @@ import SpaceHeader from '../../components/Spaces/SpaceHeader.vue'
 import WhitespaceContextMenu from 'web-app-files/src/components/Spaces/WhitespaceContextMenu.vue'
 import { eventBus } from '@ownclouders/web-pkg'
 import { useResourcesViewDefaults } from '../../composables'
-import { ResourceTransfer, TransferType } from '../../helpers/resource'
 import { FolderLoaderOptions } from '../../services/folder'
 import { BreadcrumbItem } from 'design-system/src/components/OcBreadcrumb/types'
 import { v4 as uuidv4 } from 'uuid'

--- a/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.ts
+++ b/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.ts
@@ -8,7 +8,8 @@ import {
   useRequest,
   useSpacesStore,
   CapabilityStore,
-  useClipboardStore
+  useClipboardStore,
+  useFileActionsPaste
 } from '@ownclouders/web-pkg'
 import { eventBus, UppyResource } from '@ownclouders/web-pkg'
 import {
@@ -28,7 +29,8 @@ jest.mock('@ownclouders/web-pkg', () => ({
   useExtensionRegistry: jest.fn(),
   useRequest: jest.fn(),
   useFileActionsCreateNewFile: jest.fn(),
-  useFileActions: jest.fn()
+  useFileActions: jest.fn(),
+  useFileActionsPaste: jest.fn()
 }))
 
 const elSelector = {
@@ -106,7 +108,7 @@ describe('CreateAndUpload component', () => {
       expect(wrapper.findAll(`${elSelector.clipboardBtns} .oc-button`).length).toBe(2)
     })
     it('call the "paste files"-action', async () => {
-      const { wrapper, storeOptions } = getWrapper({
+      const { wrapper, mocks } = getWrapper({
         clipboardResources: [
           mock<Resource>({
             shareRoot: undefined
@@ -114,7 +116,7 @@ describe('CreateAndUpload component', () => {
         ]
       })
       await wrapper.find(elSelector.pasteFilesBtn).trigger('click')
-      expect(storeOptions.modules.Files.actions.pasteSelectedFiles).toHaveBeenCalled()
+      expect(mocks.pasteActionHandler).toHaveBeenCalled()
     })
     it('call "clear clipboard"-action', async () => {
       const { wrapper } = getWrapper({ clipboardResources: [mock<Resource>()] })
@@ -196,13 +198,21 @@ function getWrapper({
     })
   )
 
+  const pasteActionHandler = jest.fn()
+  jest.mocked(useFileActionsPaste).mockReturnValue(
+    mock<ReturnType<typeof useFileActionsPaste>>({
+      actions: ref([mock<FileAction>({ handler: pasteActionHandler })])
+    })
+  )
+
   const storeOptions = { ...defaultStoreMockOptions }
   storeOptions.modules.Files.state.areFileExtensionsShown = areFileExtensionsShown
   storeOptions.modules.Files.getters.currentFolder.mockImplementation(() => currentFolder)
   storeOptions.modules.Files.getters.files.mockImplementation(() => files)
   const store = createStore(storeOptions)
   const mocks = {
-    ...defaultComponentMocks({ currentRoute: mock<RouteLocation>({ name: currentRouteName }) })
+    ...defaultComponentMocks({ currentRoute: mock<RouteLocation>({ name: currentRouteName }) }),
+    pasteActionHandler
   }
   const capabilities = {
     spaces: { enabled: true },

--- a/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.ts
+++ b/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.ts
@@ -7,7 +7,8 @@ import {
   useFileActionsCreateNewFile,
   useRequest,
   useSpacesStore,
-  CapabilityStore
+  CapabilityStore,
+  useClipboardStore
 } from '@ownclouders/web-pkg'
 import { eventBus, UppyResource } from '@ownclouders/web-pkg'
 import {
@@ -116,9 +117,10 @@ describe('CreateAndUpload component', () => {
       expect(storeOptions.modules.Files.actions.pasteSelectedFiles).toHaveBeenCalled()
     })
     it('call "clear clipboard"-action', async () => {
-      const { wrapper, storeOptions } = getWrapper({ clipboardResources: [mock<Resource>()] })
+      const { wrapper } = getWrapper({ clipboardResources: [mock<Resource>()] })
       await wrapper.find(elSelector.clearClipboardBtn).trigger('click')
-      expect(storeOptions.modules.Files.actions.clearClipboardFiles).toHaveBeenCalled()
+      const clipboardStore = useClipboardStore()
+      expect(clipboardStore.clearClipboard).toHaveBeenCalled()
     })
   })
   describe('method "onUploadComplete"', () => {
@@ -197,7 +199,6 @@ function getWrapper({
   const storeOptions = { ...defaultStoreMockOptions }
   storeOptions.modules.Files.state.areFileExtensionsShown = areFileExtensionsShown
   storeOptions.modules.Files.getters.currentFolder.mockImplementation(() => currentFolder)
-  storeOptions.modules.Files.getters.clipboardResources.mockImplementation(() => clipboardResources)
   storeOptions.modules.Files.getters.files.mockImplementation(() => files)
   const store = createStore(storeOptions)
   const mocks = {
@@ -224,7 +225,8 @@ function getWrapper({
             piniaOptions: {
               appsState: { fileExtensions },
               spacesState: { spaces: spaces as any },
-              capabilityState: { capabilities }
+              capabilityState: { capabilities },
+              clipboardState: { resources: clipboardResources }
             }
           }),
           store

--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -230,7 +230,8 @@ import {
   useEmbedMode,
   useAuthStore,
   useCapabilityStore,
-  useConfigStore
+  useConfigStore,
+  useClipboardStore
 } from '../../composables'
 import ResourceListItem from './ResourceListItem.vue'
 import ResourceGhostElement from './ResourceGhostElement.vue'
@@ -457,6 +458,9 @@ export default defineComponent({
     const configStore = useConfigStore()
     const { options: configOptions } = storeToRefs(configStore)
 
+    const clipboardStore = useClipboardStore()
+    const { resources: clipboardResources, action: clipboardAction } = storeToRefs(clipboardStore)
+
     const authStore = useAuthStore()
     const { userContextReady } = storeToRefs(authStore)
 
@@ -500,6 +504,8 @@ export default defineComponent({
       hasProjectSpaces: capabilityRefs.spacesEnabled,
       userContextReady,
       getMatchingSpace,
+      clipboardResources,
+      clipboardAction,
       ...useResourceRouteResolver(
         {
           space: ref(props.space),
@@ -523,12 +529,7 @@ export default defineComponent({
     }
   },
   computed: {
-    ...mapState('Files', [
-      'areFileExtensionsShown',
-      'latestSelectedId',
-      'clipboardResources',
-      'clipboardAction'
-    ]),
+    ...mapState('Files', ['areFileExtensionsShown', 'latestSelectedId']),
 
     fields() {
       if (this.resources.length === 0) {

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCopy.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCopy.ts
@@ -11,14 +11,13 @@ import { FileAction, FileActionOptions } from '../types'
 import { isProjectSpaceResource } from '@ownclouders/web-client/src/helpers'
 import { useRouter } from '../../router'
 import { useStore } from '../../store'
-import { useConfigStore, useMessages } from '../../piniaStores'
+import { useConfigStore, useClipboardStore } from '../../piniaStores'
 
 export const useFileActionsCopy = ({ store }: { store?: Store<any> } = {}) => {
   store = store || useStore()
   const configStore = useConfigStore()
-  const messageStore = useMessages()
   const router = useRouter()
-
+  const { copyResources } = useClipboardStore()
   const language = useGettext()
   const { $gettext } = language
 
@@ -33,12 +32,12 @@ export const useFileActionsCopy = ({ store }: { store?: Store<any> } = {}) => {
     return $gettext('Ctrl + C')
   })
 
-  const handler = ({ space, resources }: FileActionOptions) => {
+  const handler = ({ resources }: FileActionOptions) => {
     if (isLocationCommonActive(router, 'files-common-search')) {
       resources = resources.filter((r) => !isProjectSpaceResource(r))
     }
 
-    store.dispatch('Files/copySelectedFiles', { ...language, space, resources, messageStore })
+    copyResources(resources)
   }
 
   const actions = computed((): FileAction[] => {

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsMove.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsMove.ts
@@ -10,12 +10,13 @@ import { ActionOptions, FileAction } from '../types'
 import { computed, unref } from 'vue'
 import { useRouter } from '../../router'
 import { useStore } from '../../store'
-import { useMessages } from '../../piniaStores'
+import { useClipboardStore } from '../../piniaStores'
+import { Resource } from '@ownclouders/web-client'
 
 export const useFileActionsMove = ({ store }: { store?: Store<any> } = {}) => {
   store = store || useStore()
-  const messageStore = useMessages()
   const router = useRouter()
+  const { cutResources } = useClipboardStore()
   const language = useGettext()
   const { $gettext } = language
 
@@ -30,8 +31,8 @@ export const useFileActionsMove = ({ store }: { store?: Store<any> } = {}) => {
     return $gettext('Ctrl + X')
   })
 
-  const handler = ({ space, resources }: ActionOptions) => {
-    store.dispatch('Files/cutSelectedFiles', { ...language, space, resources, messageStore })
+  const handler = ({ resources }: ActionOptions) => {
+    cutResources(resources as Resource[])
   }
   const actions = computed((): FileAction[] => [
     {

--- a/packages/web-pkg/src/composables/piniaStores/clipboard.ts
+++ b/packages/web-pkg/src/composables/piniaStores/clipboard.ts
@@ -1,0 +1,44 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { Resource } from '@ownclouders/web-client'
+import { ClipboardActions } from '../../helpers'
+import { useGettext } from 'vue3-gettext'
+import { useMessages } from './messages'
+
+export const useClipboardStore = defineStore('clipboard', () => {
+  const { $gettext } = useGettext()
+  const { showMessage } = useMessages()
+
+  const action = ref<ClipboardActions>()
+  const resources = ref<Resource[]>([])
+
+  const copyResources = (r: Resource[]) => {
+    action.value = ClipboardActions.Copy
+    resources.value = r
+
+    showMessage({ title: $gettext('Copied to clipboard!'), status: 'success' })
+  }
+
+  const cutResources = (r: Resource[]) => {
+    action.value = ClipboardActions.Cut
+    resources.value = r
+
+    showMessage({ title: $gettext('Cut to clipboard!'), status: 'success' })
+  }
+
+  const clearClipboard = () => {
+    action.value = undefined
+    resources.value = []
+  }
+
+  return {
+    action,
+    resources,
+
+    copyResources,
+    cutResources,
+    clearClipboard
+  }
+})
+
+export type ClipboardStore = ReturnType<typeof useClipboardStore>

--- a/packages/web-pkg/src/composables/piniaStores/index.ts
+++ b/packages/web-pkg/src/composables/piniaStores/index.ts
@@ -1,6 +1,7 @@
 export * from './apps'
 export * from './auth'
 export * from './capabilities'
+export * from './clipboard'
 export * from './config'
 export * from './extensionRegistry'
 export * from './messages'

--- a/packages/web-pkg/src/helpers/resource/conflictHandling/index.ts
+++ b/packages/web-pkg/src/helpers/resource/conflictHandling/index.ts
@@ -1,3 +1,4 @@
 export * from './conflictDialog'
 export * from './conflictUtils'
+export * from './transfer'
 export * from './types'

--- a/packages/web-pkg/src/helpers/resource/conflictHandling/transfer.ts
+++ b/packages/web-pkg/src/helpers/resource/conflictHandling/transfer.ts
@@ -2,20 +2,15 @@ import { Resource } from '@ownclouders/web-client'
 import { basename, join } from 'path'
 import { SpaceResource } from '@ownclouders/web-client/src/helpers'
 import {
-  ClientService,
-  LoadingService,
-  LoadingTaskCallbackArguments,
-  useMessages
-} from '@ownclouders/web-pkg'
-import {
   ConflictDialog,
+  FileConflict,
   ResolveStrategy,
+  TransferType,
   isResourceBeeingMovedToSameLocation,
-  resolveFileNameDuplicate,
-  FileConflict
-} from '@ownclouders/web-pkg'
-
-import { TransferType } from '.'
+  resolveFileNameDuplicate
+} from '.'
+import { ClientService, LoadingService, LoadingTaskCallbackArguments } from '../../../services'
+import { useMessages } from '../../../composables'
 
 export class ResourceTransfer extends ConflictDialog {
   constructor(
@@ -165,8 +160,9 @@ export class ResourceTransfer extends ConflictDialog {
       let targetName = resource.name
       let overwriteTarget = false
       if (hasConflict) {
-        const resolveStrategy = resolvedConflicts.find((e) => e.resource.id === resource.id)
-          ?.strategy
+        const resolveStrategy = resolvedConflicts.find(
+          (e) => e.resource.id === resource.id
+        )?.strategy
         if (resolveStrategy === ResolveStrategy.SKIP) {
           continue
         }

--- a/packages/web-pkg/src/helpers/resource/conflictHandling/transfer.ts
+++ b/packages/web-pkg/src/helpers/resource/conflictHandling/transfer.ts
@@ -160,9 +160,8 @@ export class ResourceTransfer extends ConflictDialog {
       let targetName = resource.name
       let overwriteTarget = false
       if (hasConflict) {
-        const resolveStrategy = resolvedConflicts.find(
-          (e) => e.resource.id === resource.id
-        )?.strategy
+        const resolveStrategy = resolvedConflicts.find((e) => e.resource.id === resource.id)
+          ?.strategy
         if (resolveStrategy === ResolveStrategy.SKIP) {
           continue
         }

--- a/packages/web-pkg/src/helpers/resource/conflictHandling/types.ts
+++ b/packages/web-pkg/src/helpers/resource/conflictHandling/types.ts
@@ -8,3 +8,8 @@ export interface ResolveConflict {
   strategy: ResolveStrategy
   doForAllConflicts: boolean
 }
+
+export enum TransferType {
+  COPY,
+  MOVE
+}

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsCopy.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsCopy.spec.ts
@@ -10,6 +10,7 @@ import {
   getComposableWrapper
 } from 'web-test-helpers'
 import { useFileActionsCopy } from '../../../../../src/composables/actions/files'
+import { useClipboardStore } from '../../../../../src/composables/piniaStores'
 
 describe('copy', () => {
   describe('search context', () => {
@@ -32,13 +33,11 @@ describe('copy', () => {
         ])('should filter non copyable resources', ({ resources, copyAbleResources }) => {
           getWrapper({
             searchLocation: true,
-            setup: ({ actions }, { storeOptions }) => {
+            setup: ({ actions }) => {
               unref(actions)[0].handler({ space: null, resources })
-              expect(storeOptions.modules.Files.actions.copySelectedFiles).toHaveBeenCalledWith(
-                expect.anything(),
-                expect.objectContaining({
-                  resources: resources.filter((r) => copyAbleResources.includes(r.id as string))
-                })
+              const clipboardStore = useClipboardStore()
+              expect(clipboardStore.copyResources).toHaveBeenCalledWith(
+                resources.filter((r) => copyAbleResources.includes(r.id as string))
               )
             }
           })

--- a/packages/web-pkg/tests/unit/helpers/resource/conflictHandling/resourcesTransfer.spec.ts
+++ b/packages/web-pkg/tests/unit/helpers/resource/conflictHandling/resourcesTransfer.spec.ts
@@ -1,11 +1,19 @@
-import { ClientService, LoadingService, LoadingTaskCallbackArguments } from '@ownclouders/web-pkg'
-import { ResourceTransfer, TransferType } from '../../../../src/helpers/resource'
-import { ResolveConflict, resolveFileNameDuplicate } from '@ownclouders/web-pkg'
+import {
+  ResolveConflict,
+  ResourceTransfer,
+  TransferType,
+  resolveFileNameDuplicate
+} from '../../../../../src/helpers/resource/conflictHandling'
 import { mock, mockDeep, mockReset } from 'jest-mock-extended'
 import { buildSpace, Resource } from '@ownclouders/web-client/src/helpers'
 import { ListFilesResult } from '@ownclouders/web-client/src/webdav/listFiles'
 import { Drive } from '@ownclouders/web-client/src/generated'
 import { createTestingPinia } from 'web-test-helpers'
+import {
+  ClientService,
+  LoadingService,
+  LoadingTaskCallbackArguments
+} from '../../../../../src/services'
 
 const clientServiceMock = mockDeep<ClientService>()
 const loadingServiceMock = mock<LoadingService>({

--- a/packages/web-test-helpers/src/mocks/pinia.ts
+++ b/packages/web-test-helpers/src/mocks/pinia.ts
@@ -5,9 +5,9 @@ import { Message, Modal, WebThemeType } from '../../../web-pkg/src/composables/p
 import { Capabilities } from '../../../web-client/src/ocs'
 import { mock } from 'jest-mock-extended'
 import { SpaceResource } from '../../../web-client/src'
-import { Share } from '../../../web-client/src/helpers'
-import { ApplicationFileExtension } from '../../../web-pkg/types'
 import { OptionsConfig } from '../../../web-pkg/src/composables/piniaStores/config/types'
+import { Resource, Share } from '../../../web-client/src/helpers'
+import { ApplicationFileExtension, ClipboardActions } from '../../../web-pkg/types'
 
 export { createTestingPinia }
 
@@ -21,6 +21,7 @@ export type PiniaMockOptions = {
     publicLinkContextReady?: boolean
   }
   themeState?: { availableThemes?: WebThemeType[]; currentTheme?: WebThemeType }
+  clipboardState?: { action?: ClipboardActions; resources?: Resource[] }
   configState?: {
     server?: string
     options?: OptionsConfig
@@ -39,6 +40,7 @@ export function createMockStore({
   stubActions = true,
   appsState = {},
   authState = {},
+  clipboardState = {},
   configState = {},
   themeState = {},
   messagesState = {},
@@ -63,6 +65,7 @@ export function createMockStore({
     initialState: {
       apps: { ...appsState },
       auth: { ...authState },
+      clipboard: { resources: [], ...clipboardState },
       config: {
         apps: [],
         external_apps: [],

--- a/packages/web-test-helpers/src/mocks/store/filesModuleMockOptions.ts
+++ b/packages/web-test-helpers/src/mocks/store/filesModuleMockOptions.ts
@@ -38,7 +38,6 @@ export const filesModuleMockOptions = {
     },
     actions: {
       deleteFiles: jest.fn(),
-      pasteSelectedFiles: jest.fn(),
       loadIndicators: jest.fn(),
       loadVersions: jest.fn(),
       loadShares: jest.fn(),

--- a/packages/web-test-helpers/src/mocks/store/filesModuleMockOptions.ts
+++ b/packages/web-test-helpers/src/mocks/store/filesModuleMockOptions.ts
@@ -12,7 +12,6 @@ export const filesModuleMockOptions = {
       files: jest.fn(() => []),
       activeFiles: jest.fn(),
       highlightedFile: jest.fn(),
-      clipboardResources: jest.fn(() => []),
       selectedFiles: jest.fn(() => []),
       versions: jest.fn(() => []),
       outgoingCollaborators: jest.fn(() => []),
@@ -35,13 +34,11 @@ export const filesModuleMockOptions = {
       REMOVE_FILE: jest.fn(),
       REMOVE_FILES: jest.fn(),
       RESET_SELECTION: jest.fn(),
-      SET_LATEST_SELECTED_FILE_ID: jest.fn(),
-      CLEAR_CLIPBOARD: jest.fn()
+      SET_LATEST_SELECTED_FILE_ID: jest.fn()
     },
     actions: {
       deleteFiles: jest.fn(),
       pasteSelectedFiles: jest.fn(),
-      clearClipboardFiles: jest.fn(),
       loadIndicators: jest.fn(),
       loadVersions: jest.fn(),
       loadShares: jest.fn(),
@@ -52,8 +49,6 @@ export const filesModuleMockOptions = {
       changeShare: jest.fn(),
       addLink: jest.fn(),
       addShare: jest.fn(),
-      copySelectedFiles: jest.fn(),
-      cutSelectedFiles: jest.fn(),
       resetFileSelection: jest.fn(),
       toggleFileSelection: jest.fn()
     }


### PR DESCRIPTION
## Description
Removes the clipboard from the vuex file store and adds a slim pinia store instead. There is no need for that to be coupled in any file store.

Also, moves the `pasteSelectedFiles` method from the files store into its corresponding action composable. Again, not really needed in a store since the action is the only place where this is being called. The `ResourceTransfer` component needed to be moved to `web-pkg` for this to happen.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/10210

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
