### PR TITLE
refactor: remove highlightedFile getter from store

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -517,6 +517,7 @@ export default defineComponent({
             try {
               await addMethod({
                 client: this.$client,
+                resource: this.resource,
                 graphClient: this.clientService.graphAuthenticated,
                 path,
                 shareWith: collaborator.value.shareWith,

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
@@ -143,8 +143,8 @@ import {
   useUserStore,
   useCapabilityStore
 } from '@ownclouders/web-pkg'
-import { extractDomSelector } from '@ownclouders/web-client/src/helpers/resource'
-import { computed, defineComponent, PropType } from 'vue'
+import { Resource, extractDomSelector } from '@ownclouders/web-client/src/helpers/resource'
+import { computed, defineComponent, inject, PropType, Ref } from 'vue'
 import * as uuid from 'uuid'
 import { formatDateFromDateTime, formatRelativeDateFromDateTime } from '@ownclouders/web-pkg'
 import { useClientService } from '@ownclouders/web-pkg'
@@ -236,6 +236,7 @@ export default defineComponent({
     }
 
     return {
+      resource: inject<Ref<Resource>>('resource'),
       changeSpaceMember,
       user,
       hasResharing: capabilityRefs.sharingResharing,
@@ -475,6 +476,7 @@ export default defineComponent({
         changeMethod({
           client: this.$client,
           graphClient: this.clientService.graphAuthenticated,
+          resource: this.resource,
           share: this.share,
           permissions: bitmask,
           expirationDate: expirationDate || '',

--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -393,6 +393,7 @@ export default defineComponent({
         try {
           await this.addShare({
             client: this.$client,
+            resource: this.resource,
             shareWith: share.collaborator.name,
             displayName: share.collaborator.displayName,
             shareType: share.shareType,

--- a/packages/web-app-files/src/store/getters.ts
+++ b/packages/web-app-files/src/store/getters.ts
@@ -49,12 +49,6 @@ export default {
     })
   },
   sharesLoading: (state) => state.sharesLoading,
-  highlightedFile: (state, getters) => {
-    if (getters.selectedFiles.length > 0) {
-      return getters.selectedFiles[0]
-    }
-    return state.currentFolder
-  },
   versions: (state) => {
     return state.versions
   },

--- a/packages/web-app-files/tests/unit/store/actions.spec.ts
+++ b/packages/web-app-files/tests/unit/store/actions.spec.ts
@@ -40,6 +40,7 @@ describe('vuex store actions', () => {
       clientMock.shares.updateShare.mockResolvedValue({})
       await actions.changeShare(stateMock, {
         client: clientMock,
+        resource: mock<Resource>(),
         share: mockDeep<Share>({ shareType: ShareTypes.user.value }),
         permissions: spaceRoleManager.bitmask(false),
         role: spaceRoleManager,
@@ -54,6 +55,7 @@ describe('vuex store actions', () => {
       await expect(
         actions.changeShare(stateMock, {
           client: clientMock,
+          resource: mock<Resource>(),
           share: mockDeep<Share>({ shareType: ShareTypes.user.value }),
           permissions: spaceRoleManager.bitmask(false),
           role: spaceRoleManager,
@@ -74,6 +76,7 @@ describe('vuex store actions', () => {
       clientMock.shares[data.shareMethod].mockResolvedValue({})
       await actions.addShare(stateMock, {
         client: clientMock,
+        resource: mock<Resource>(),
         path: '/someFile.txt',
         shareWith: 'user',
         shareType: data.shareType,
@@ -92,6 +95,7 @@ describe('vuex store actions', () => {
       await expect(
         actions.addShare(stateMock, {
           client: clientMock,
+          resource: mock<Resource>(),
           path: '/someFile.txt',
           shareWith: 'user',
           shareType: ShareTypes.user.value,
@@ -134,9 +138,8 @@ describe('vuex store actions', () => {
         }
       }
     }
-    const gettersMock = {
-      highlightedFile: () => mock<Resource>({ path: 'someFolder/someFile.txt' })
-    }
+
+    const resource = mock<Resource>({ path: 'someFolder/someFile.txt' })
     let outgoingShares = []
     let incomingShares = []
     const commitMock = jest.fn((mutation, value) => {
@@ -161,9 +164,10 @@ describe('vuex store actions', () => {
       clientMock.shares.getShares.mockResolvedValueOnce([{ shareInfo: { id: 4 } }])
 
       await actions.loadShares(
-        { state: stateMock, getters: gettersMock, commit: commitMock, rootState: rootStateMock },
+        { state: stateMock, commit: commitMock, rootState: rootStateMock },
         {
           client: clientMock,
+          resource,
           configStore: useConfigStore(),
           path: '/someFolder/someFile.txt',
           storageId: '1',
@@ -187,9 +191,10 @@ describe('vuex store actions', () => {
       const clientMock = mockDeep<OwnCloudSdk>()
 
       await actions.loadShares(
-        { state: stateMock, getters: gettersMock, commit: commitMock, rootState: rootStateMock },
+        { state: stateMock, commit: commitMock, rootState: rootStateMock },
         {
           client: clientMock,
+          resource,
           configStore: useConfigStore(),
           path: '/someFile.txt',
           storageId: '1',

--- a/packages/web-pkg/src/components/SideBar/FileSideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/FileSideBar.vue
@@ -195,6 +195,7 @@ export default defineComponent({
         if (!unref(isPublicFilesLocation) && !unref(isTrashLocation)) {
           store.dispatch('Files/loadShares', {
             client: clientService.owncloudSdk,
+            resource: resource,
             configStore,
             path: resource.path,
             storageId: resource.fileId,

--- a/packages/web-test-helpers/src/mocks/store/filesModuleMockOptions.ts
+++ b/packages/web-test-helpers/src/mocks/store/filesModuleMockOptions.ts
@@ -2,7 +2,6 @@ export const filesModuleMockOptions = {
   Files: {
     namespaced: true,
     state: {
-      highlightedFile: undefined,
       currentFolder: undefined,
       latestSelectedId: undefined,
       areFileExtensionsShown: undefined
@@ -11,7 +10,6 @@ export const filesModuleMockOptions = {
       currentFolder: jest.fn(),
       files: jest.fn(() => []),
       activeFiles: jest.fn(),
-      highlightedFile: jest.fn(),
       selectedFiles: jest.fn(() => []),
       versions: jest.fn(() => []),
       outgoingCollaborators: jest.fn(() => []),


### PR DESCRIPTION
## Description
Removes the `highlightedFile` getter from the vuex file store. The reason behind this decision is that the getter was really opaque to use as it sometimes referred to the current folder and sometimes to the first selected file (which is already confusing in itself since the user can highlight more than 1 resources).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10210

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
