### PR TITLE
[docs-only] update documentation of visibility classes

### DIFF
--- a/packages/design-system/docs/visibility.md
+++ b/packages/design-system/docs/visibility.md
@@ -7,10 +7,10 @@ Add one or more of the following classes to any element to display elements only
 | Class            | Description                                              |
 | ---------------- | -------------------------------------------------------- |
 | .oc-invisible    | Hides element without removing it from the document flow |
-| .oc-visible@s    | Displays element on screens smaller than 640px           |
-| .oc-visible@m    | Displays element on screens smaller than 960px           |
-| .oc-visible@l    | Displays element on screens smaller than 1200px          |
-| .oc-visible@xl   | Displays element on screens smaller than 1600px          |
+| .oc-visible@s    | Displays element on screens bigger or equal to 640px     |
+| .oc-visible@m    | Displays element on screens bigger or equal to 960px     |
+| .oc-visible@l    | Displays element on screens bigger or equal to 1200px    |
+| .oc-visible@xl   | Displays element on screens bigger or equal to 1600px    |
 | .oc-invisible-sr | Hides element, keeping it accessible for screen readers  |
 
 ### Hidden


### PR DESCRIPTION
## Description
It seems like the documentation about the use of `.oc-visible@s`, `.oc-visible@m`, `.oc-visible@l` and `.oc-visible@xl` to display elements only on certain screen sizes is not correct. Working with these classes I noticed that these classes hide the element on screen sizes that are smaller than the given breakpoint and display them on devices with screen sizes bigger or equal to the given breakpoint – as their name also implies (see also css code examples below generated by applying these classes). However the documentation says exactly the opposite which is confusing for developers who want to use these classes.

```
@media (max-width: 959px)
.oc-visible\@m {
    display: none !important;
}

@media (max-width: 639px)
.oc-visible\@s {
    display: none !important;
}
```

## Related Issue
no issue created so far since this is to my understanding no bug but expected behaviour of the given css classes

## Motivation and Context
update documentation to match it with actual code behaviour and make it thus easier for developers :)

## How Has This Been Tested?
applying the css classes mentioned above in the development of [web-app-dicom-viewer](https://github.com/owncloud/web-app-dicom-viewer)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [x] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
none
