### PR TITLE
[tests-only][full-ci]update compose make image versions consistent in CI and compose

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2115,7 +2115,7 @@ def wopiServer():
         {
             "name": "wopiserver",
             "type": "docker",
-            "image": "cs3org/wopiserver:v10.2.1",
+            "image": "cs3org/wopiserver:v10.2.2",
             "detach": True,
             "commands": [
                 "echo 'LoremIpsum567' > /etc/wopi/wopisecret",
@@ -2137,7 +2137,7 @@ def collaboraService():
         {
             "name": "collabora",
             "type": "docker",
-            "image": "collabora/code:23.05.5.4.1",
+            "image": "collabora/code:23.05.6.5.1",
             "detach": True,
             "environment": {
                 "DONT_GEN_SSL_CERT": "set",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,7 +215,7 @@ services:
       APP_PROVIDER_WOPI_WOPI_SERVER_EXTERNAL_URL: https://${WOPISERVER_DOMAIN:-host.docker.internal:8880}
       APP_PROVIDER_WOPI_FOLDER_URL_BASE_URL: https://${OCIS_DOMAIN:-host.docker.internal:9200}
       # share the registry with the ocis container
-      MICRO_REGISTRY: 'natsjs'
+      MICRO_REGISTRY: 'nats-js-kv'
       MICRO_REGISTRY_ADDRESS: http://ocis:9233
     volumes:
       - ocis-config:/etc/ocis
@@ -246,7 +246,7 @@ services:
       APP_PROVIDER_WOPI_WOPI_SERVER_EXTERNAL_URL: https://${WOPISERVER_DOMAIN:-host.docker.internal:8880}
       APP_PROVIDER_WOPI_FOLDER_URL_BASE_URL: https://${OCIS_DOMAIN:-host.docker.internal:9200}
       # share the registry with the ocis container
-      MICRO_REGISTRY: 'natsjs'
+      MICRO_REGISTRY: 'nats-js-kv'
       MICRO_REGISTRY_ADDRESS: http://ocis:9233
     volumes:
       - ./dev/docker/ocis-appprovider-onlyoffice/entrypoint-override.sh:/entrypoint-override.sh


### PR DESCRIPTION
### Description
This PR updates docker compose file since there were some difference while running app-provider services in CI and compose. It makes them consistent in both CI and compose. And also makes the services version same in both CI and compose file.

### Related Issue
 https://github.com/owncloud/web/issues/10359