### PR TITLE
refactor: remove file versions from vuex files store module

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Versions/FileVersions.vue
+++ b/packages/web-app-files/src/components/SideBar/Versions/FileVersions.vue
@@ -63,7 +63,7 @@ import {
   useDownloadFile,
   useStore
 } from '@ownclouders/web-pkg'
-import { computed, defineComponent, inject, Ref, unref, watch } from 'vue'
+import { computed, defineComponent, inject, Ref, ref, unref, watch } from 'vue'
 import { isShareSpaceResource, Resource, SpaceResource } from '@ownclouders/web-client/src/helpers'
 import { SharePermissions } from '@ownclouders/web-client/src/helpers/share'
 import { useTask } from 'vue-concurrency'
@@ -87,15 +87,13 @@ export default defineComponent({
     const space = inject<Ref<SpaceResource>>('space')
     const resource = inject<Ref<Resource>>('resource')
 
-    const versions = computed(() => {
-      return store.getters['Files/versions']
-    })
-
+    const versions = ref<Resource[]>([])
     const fetchVersionsTask = useTask(function* () {
-      yield store.dispatch('Files/loadVersions', {
-        client: clientService.webdav,
-        fileId: unref(resource).fileId
-      })
+      try {
+        versions.value = yield clientService.webdav.listFileVersions(unref(resource).fileId)
+      } catch (e) {
+        console.error(e)
+      }
     })
     const areVersionsLoading = computed(() => {
       return !fetchVersionsTask.last || fetchVersionsTask.isRunning

--- a/packages/web-app-files/src/store/actions.ts
+++ b/packages/web-app-files/src/store/actions.ts
@@ -7,7 +7,6 @@ import {
   Resource,
   SpaceResource
 } from '@ownclouders/web-client/src/helpers'
-import { WebDAV } from '@ownclouders/web-client/src/webdav'
 import { ClientService, LoadingTaskCallbackArguments } from '@ownclouders/web-pkg'
 import { Language } from 'vue3-gettext'
 import { eventBus } from '@ownclouders/web-pkg'
@@ -159,16 +158,6 @@ export default {
         { root: true }
       )
     }
-  },
-  async loadVersions(context, { client, fileId }: { client: WebDAV; fileId: Resource['fileId'] }) {
-    let response
-    try {
-      response = await client.listFileVersions(fileId)
-    } catch (e) {
-      console.error(e)
-      response = []
-    }
-    context.commit('SET_VERSIONS', response)
   },
   loadAvatars(
     { commit },

--- a/packages/web-app-files/src/store/getters.ts
+++ b/packages/web-app-files/src/store/getters.ts
@@ -32,9 +32,6 @@ export default {
       spaces: spaceCount
     }
   },
-  versions: (state) => {
-    return state.versions
-  },
   areHiddenFilesShown: (state) => {
     return state.areHiddenFilesShown
   },

--- a/packages/web-app-files/src/store/state.ts
+++ b/packages/web-app-files/src/store/state.ts
@@ -3,7 +3,6 @@ export default {
   files: [],
   selectedIds: [],
   latestSelectedId: null,
-  versions: [],
 
   /**
    * View settings

--- a/packages/web-app-files/tests/unit/components/FilesList/ResourceDetails.spec.ts
+++ b/packages/web-app-files/tests/unit/components/FilesList/ResourceDetails.spec.ts
@@ -53,6 +53,7 @@ describe('ResourceDetails component', () => {
         })
       })
     }
+    mocks.$clientService.webdav.listFileVersions.mockResolvedValue([])
     const storeOptions = { ...defaultStoreMockOptions }
     const store = createStore(storeOptions)
 
@@ -82,6 +83,7 @@ describe('ResourceDetails component', () => {
           mocks,
           plugins: [...defaultPlugins(), store],
           provide: {
+            ...mocks,
             space,
             resource: file
           }

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.ts
@@ -141,9 +141,10 @@ describe('Details SideBar Panel', () => {
     })
   })
   describe('versions', () => {
-    it('show if given for files on a private page', () => {
+    it('show if given for files on a private page', async () => {
       const resource = getResourceMock()
       const { wrapper } = createWrapper({ resource, versions: ['1'] })
+      await wrapper.vm.$nextTick()
       expect(wrapper.find(selectors.versionsInfo).exists()).toBeTruthy()
     })
     it('do not show for folders on a private page', () => {
@@ -203,7 +204,6 @@ function createWrapper({
   tagsEnabled = true
 } = {}) {
   const storeOptions = defaultStoreMockOptions
-  storeOptions.modules.Files.getters.versions.mockReturnValue(versions)
   storeOptions.modules.runtime.modules.ancestorMetaData.getters.ancestorMetaData.mockReturnValue(
     ancestorMetaData
   )
@@ -213,6 +213,7 @@ function createWrapper({
   const publicLocation = createLocationPublic('files-public-link')
   const currentRoute = isPublicLinkContext ? publicLocation : spacesLocation
   const mocks = defaultComponentMocks({ currentRoute: mock<RouteLocation>(currentRoute as any) })
+  mocks.$clientService.webdav.listFileVersions.mockResolvedValue(versions)
   const capabilities = { files: { tags: tagsEnabled } }
   return {
     wrapper: mount(FileDetails, {

--- a/packages/web-app-files/tests/unit/components/SideBar/Versions/FileVersions.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Versions/FileVersions.spec.ts
@@ -177,12 +177,6 @@ function getMountedWrapper({
   loadingStateDelay = 0
 } = {}) {
   const storeOptions = defaultStoreMockOptions
-  storeOptions.modules.Files.getters.versions.mockImplementation(() => versions)
-  storeOptions.modules.Files.actions.loadVersions.mockImplementation(() => {
-    if (loadingStateDelay > 0) {
-      return new Promise((res) => setTimeout(res, loadingStateDelay))
-    }
-  })
   const store = createStore(storeOptions)
   const downloadFile = jest.fn()
   jest.mocked(useDownloadFile).mockReturnValue({ downloadFile })
@@ -191,6 +185,13 @@ function getMountedWrapper({
     downloadFile
   }
   mocks.$clientService.webdav.getFileInfo.mockResolvedValue(mock<Resource>({ id: '1' }))
+  mocks.$clientService.webdav.listFileVersions.mockImplementation(() => {
+    if (loadingStateDelay > 0) {
+      return new Promise((res) => setTimeout(() => res(versions), loadingStateDelay))
+    }
+    return new Promise((res) => res(versions))
+  })
+
   return {
     wrapper: mountType(FileVersions, {
       global: {

--- a/packages/web-test-helpers/src/mocks/store/filesModuleMockOptions.ts
+++ b/packages/web-test-helpers/src/mocks/store/filesModuleMockOptions.ts
@@ -10,8 +10,7 @@ export const filesModuleMockOptions = {
       currentFolder: jest.fn(),
       files: jest.fn(() => []),
       activeFiles: jest.fn(),
-      selectedFiles: jest.fn(() => []),
-      versions: jest.fn(() => [])
+      selectedFiles: jest.fn(() => [])
     },
     mutations: {
       SET_FILE_SELECTION: jest.fn(),
@@ -34,7 +33,6 @@ export const filesModuleMockOptions = {
     actions: {
       deleteFiles: jest.fn(),
       loadIndicators: jest.fn(),
-      loadVersions: jest.fn(),
       clearTrashBin: jest.fn(),
       removeFilesFromTrashbin: jest.fn(),
       resetFileSelection: jest.fn(),


### PR DESCRIPTION
## Description
Removes the file versions from the vuex files store module because there is no need to store them in any store.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/10210

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
