### PR TITLE
fix: initial focus on modals

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -63,7 +63,7 @@
     "deepmerge": "^4.2.2",
     "file-loader": "^6.2.0",
     "filesize": "^9.0.11",
-    "focus-trap": "^7.2.0",
+    "focus-trap": "7.2.0",
     "focus-trap-vue": "^4.0.1",
     "fuse.js": "6.6.2",
     "glob": "^10.0.0",
@@ -129,7 +129,7 @@
   "peerDependencies": {
     "@popperjs/core": "^2.11.5",
     "filesize": "^9.0.11",
-    "focus-trap": "^7.2.0",
+    "focus-trap": "7.2.0",
     "focus-trap-vue": "^4.0.1",
     "postcss-import": "^16.0.0",
     "postcss-url": "10.1.3",

--- a/packages/design-system/src/components/OcModal/OcModal.vue
+++ b/packages/design-system/src/components/OcModal/OcModal.vue
@@ -77,7 +77,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, ComponentPublicInstance, ref } from 'vue'
+import { defineComponent, PropType, ComponentPublicInstance } from 'vue'
 import OcButton from '../OcButton/OcButton.vue'
 import OcIcon from '../OcIcon/OcIcon.vue'
 import OcTextInput from '../OcTextInput/OcTextInput.vue'
@@ -269,12 +269,6 @@ export default defineComponent({
     }
   },
   emits: ['cancel', 'confirm', 'input'],
-  setup() {
-    const ocModalInput = ref<ComponentPublicInstance>()
-    const ocModal = ref<HTMLElement>()
-
-    return { ocModalInput, ocModal }
-  },
   data() {
     return {
       userInputValue: null
@@ -286,7 +280,10 @@ export default defineComponent({
         return this.focusTrapInitial
       }
       return () => {
-        return (this.ocModalInput?.$el || this.ocModal) as FocusTargetValueOrFalse
+        // FIXME: according to the types it's incorrect to pass this.$refs.ocModalInput
+        // but passing this.$refs.ocModalInput?.$el does not work …
+        return ((this.$refs.ocModalInput as ComponentPublicInstance as unknown as HTMLElement) ||
+          (this.$refs.ocModal as HTMLElement)) as FocusTargetValueOrFalse
       }
     },
     classes() {

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -19,7 +19,7 @@
     "design-system": "workspace:@ownclouders/design-system@*",
     "easygettext": "https://github.com/owncloud/easygettext/archive/refs/tags/v2.18.2-oc.tar.gz",
     "filesize": "^9.0.11",
-    "focus-trap": "^7.2.0",
+    "focus-trap": "7.2.0",
     "focus-trap-vue": "^4.0.1",
     "fuse.js": "6.6.2",
     "lodash-es": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,11 +346,11 @@ importers:
         specifier: ^9.0.11
         version: 9.0.11
       focus-trap:
-        specifier: ^7.2.0
-        version: 7.5.4
+        specifier: 7.2.0
+        version: 7.2.0
       focus-trap-vue:
         specifier: ^4.0.1
-        version: 4.0.3(focus-trap@7.5.4)(vue@3.3.8)
+        version: 4.0.3(focus-trap@7.2.0)(vue@3.3.8)
       fuse.js:
         specifier: 6.6.2
         version: 6.6.2
@@ -1155,7 +1155,7 @@ importers:
         specifier: ^9.0.11
         version: 9.0.11
       focus-trap:
-        specifier: ^7.2.0
+        specifier: 7.2.0
         version: 7.2.0
       focus-trap-vue:
         specifier: ^4.0.1
@@ -9156,27 +9156,20 @@ packages:
       vue: 3.3.8(typescript@5.3.3)
     dev: false
 
-  /focus-trap-vue@4.0.3(focus-trap@7.5.4)(vue@3.3.8):
+  /focus-trap-vue@4.0.3(focus-trap@7.2.0)(vue@3.3.8):
     resolution: {integrity: sha512-cIX5rybkCAlNZ4IHYJ3nCFIsipDDljJHHjtTO2IgYWkVYg7X9ipUVdab3HzYp88kmHgMwjcB71LYnXRRsF6ZqQ==}
     peerDependencies:
       focus-trap: ^7.0.0
       vue: ^3.0.0
     dependencies:
-      focus-trap: 7.5.4
+      focus-trap: 7.2.0
       vue: 3.3.8(typescript@5.3.3)
     dev: true
 
   /focus-trap@7.2.0:
     resolution: {integrity: sha512-v4wY6HDDYvzkBy4735kW5BUEuw6Yz9ABqMYLuTNbzAFPcBOGiGHwwcNVMvUz4G0kgSYh13wa/7TG3XwTeT4O/A==}
     dependencies:
-      tabbable: 6.0.1
-    dev: false
-
-  /focus-trap@7.5.4:
-    resolution: {integrity: sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==}
-    dependencies:
       tabbable: 6.2.0
-    dev: true
 
   /follow-redirects@1.15.4(debug@4.3.4):
     resolution: {integrity: sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==}
@@ -16959,13 +16952,8 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /tabbable@6.0.1:
-    resolution: {integrity: sha512-SYJSIgeyXW7EuX1ytdneO5e8jip42oHWg9xl/o3oTYhmXusZVgiA+VlPvjIN+kHii9v90AmzTZEBcsEvuAY+TA==}
-    dev: false
-
   /tabbable@6.2.0:
     resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
-    dev: true
 
   /table@6.8.1:
     resolution: {integrity: sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==}


### PR DESCRIPTION
## Description
Fixes a regression from https://github.com/owncloud/web/pull/10243 which caused some issues with the initial focus on modals.

I reverted https://github.com/owncloud/web/pull/10243/commits/7526dcaa12e9586aa3925c32fa6f38d47573c170 (which was supposed to fix it) and pinned to the version of `focus-trap` to `7.2.0` since newer versions seem to be responsible for the issue. Needs further debugging, this PR simply brings back the previous working state.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
