### PR TITLE
chore: replace easygettext with scripts from vue3 gettext

### DIFF
--- a/gettext.config.cjs
+++ b/gettext.config.cjs
@@ -1,0 +1,13 @@
+module.exports = {
+  input: {
+    path: './src',
+    include: ['**/*.js', '**/*.ts', '**/*.vue']
+  },
+  output: {
+    locales: ['bg', 'cs', 'de', 'en', 'es', 'fr', 'it', 'nl', 'ko', 'sq', 'sv', 'tr', 'zh'],
+    path: './l10n/locale',
+    potPath: '../template.pot',
+    flat: false,
+    linguas: false
+  }
+}

--- a/gettext.config.cjs
+++ b/gettext.config.cjs
@@ -4,7 +4,7 @@ module.exports = {
     include: ['**/*.js', '**/*.ts', '**/*.vue']
   },
   output: {
-    locales: ['bg', 'cs', 'de', 'en', 'es', 'fr', 'it', 'nl', 'ko', 'sq', 'sv', 'tr', 'zh'],
+    locales: ['bg', 'cs', 'de', 'en', 'es', 'fr', 'it', 'nl', 'ko', 'ru', 'sq', 'sv', 'tr', 'zh'],
     path: './l10n/locale',
     potPath: '../template.pot',
     flat: false,

--- a/packages/design-system/docs/i18n.md
+++ b/packages/design-system/docs/i18n.md
@@ -1,6 +1,6 @@
 ## Writing translations
 
-For translations we are using combination of [vue-gettext](https://github.com/Polyconseil/vue-gettext) and [easygettext](https://github.com/polyconseil/easygettext).
+For translations we are using [Vue 3 Gettext](https://jshmrtn.github.io/vue3-gettext/).
 
 ### Escaping
 

--- a/packages/design-system/l10n/.tx/config
+++ b/packages/design-system/l10n/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 
 [o:owncloud-org:p:owncloud-web:r:design-system]
-file_filter = locale/<lang>/LC_MESSAGES/app.po
+file_filter = locale/<lang>/app.po
 minimum_perc = 0
 source_file = template.pot
 source_lang = en

--- a/packages/design-system/src/components/OcEmojiPicker/OcEmojiPicker.vue
+++ b/packages/design-system/src/components/OcEmojiPicker/OcEmojiPicker.vue
@@ -25,13 +25,14 @@ export default defineComponent({
   },
   emits: ['emojiSelect', 'clickOutside'],
   setup(props, { emit }) {
-    const { $gettext, current: currentLanguage } = useGettext()
+    const language = useGettext()
+    const { $gettext } = language
     const emojiPickerRef = ref<HTMLElement>()
 
     const isLoading = ref(true)
 
     watch(
-      [() => props.theme, currentLanguage],
+      [() => props.theme, language.current],
       async () => {
         isLoading.value = true
 

--- a/packages/web-app-admin-settings/l10n/.tx/config
+++ b/packages/web-app-admin-settings/l10n/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 
 [o:owncloud-org:p:owncloud-web:r:admin-settings]
-file_filter = locale/<lang>/LC_MESSAGES/app.po
+file_filter = locale/<lang>/app.po
 minimum_perc = 0
 source_file = template.pot
 source_lang = en

--- a/packages/web-app-admin-settings/src/components/Spaces/SpacesList.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/SpacesList.vue
@@ -162,7 +162,8 @@ export default defineComponent({
   setup() {
     const router = useRouter()
     const route = useRoute()
-    const { $gettext, current: currentLanguage } = useGettext()
+    const language = useGettext()
+    const { $gettext } = language
 
     const { y: fileListHeaderY } = useFileListHeaderPosition('#admin-settings-app-bar')
     const contextMenuButtonRef = ref(undefined)
@@ -358,29 +359,29 @@ export default defineComponent({
       return managerStr
     }
     const formatDate = (date: string) => {
-      return formatDateFromJSDate(new Date(date), currentLanguage)
+      return formatDateFromJSDate(new Date(date), language.current)
     }
     const formatDateRelative = (date: string) => {
-      return formatRelativeDateFromJSDate(new Date(date), currentLanguage)
+      return formatRelativeDateFromJSDate(new Date(date), language.current)
     }
     const getTotalQuota = (space: SpaceResource) => {
       if (space.spaceQuota.total === 0) {
         return $gettext('Unrestricted')
       }
 
-      return formatFileSize(space.spaceQuota.total, currentLanguage)
+      return formatFileSize(space.spaceQuota.total, language.current)
     }
     const getUsedQuota = (space: SpaceResource) => {
       if (space.spaceQuota.used === undefined) {
         return '-'
       }
-      return formatFileSize(space.spaceQuota.used, currentLanguage)
+      return formatFileSize(space.spaceQuota.used, language.current)
     }
     const getRemainingQuota = (space: SpaceResource) => {
       if (space.spaceQuota.remaining === undefined) {
         return '-'
       }
-      return formatFileSize(space.spaceQuota.remaining, currentLanguage)
+      return formatFileSize(space.spaceQuota.remaining, language.current)
     }
     const getMemberCount = (space: SpaceResource) => {
       return (

--- a/packages/web-app-admin-settings/src/components/Users/SideBar/DetailsPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Users/SideBar/DetailsPanel.vue
@@ -109,7 +109,11 @@ export default defineComponent({
     }
   },
   setup(props) {
-    const { $gettext, current: currentLanguage } = useGettext()
+    const language = useGettext()
+    const { $gettext } = language
+    const currentLanguage = computed(() => {
+      return language.current
+    })
 
     return {
       $gettext,

--- a/packages/web-app-draw-io/l10n/.tx/config
+++ b/packages/web-app-draw-io/l10n/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 
 [o:owncloud-org:p:owncloud-web:r:draw-io]
-file_filter = locale/<lang>/LC_MESSAGES/app.po
+file_filter = locale/<lang>/app.po
 minimum_perc = 0
 source_file = template.pot
 source_lang = en

--- a/packages/web-app-external/l10n/.tx/config
+++ b/packages/web-app-external/l10n/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 
 [o:owncloud-org:p:owncloud-web:r:external]
-file_filter = locale/<lang>/LC_MESSAGES/app.po
+file_filter = locale/<lang>/app.po
 minimum_perc = 0
 source_file = template.pot
 source_lang = en

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -57,11 +57,11 @@ export default defineComponent({
   emits: ['update:applicationName'],
   setup(props, { emit }) {
     const language = useGettext()
+    const { $gettext } = language
     const { showErrorMessage } = useMessages()
     const capabilityStore = useCapabilityStore()
     const configStore = useConfigStore()
 
-    const { $gettext } = language
     const { makeRequest } = useRequest()
 
     const appNameQuery = useRouteQuery('app')
@@ -128,13 +128,11 @@ export default defineComponent({
               errorPopup(response.data?.message)
           }
 
-          const error = new Error('Error fetching app information')
-          throw error
+          throw new Error('Error fetching app information')
         }
 
         if (!response.data.app_url || !response.data.method) {
-          const error = new Error('Error in app server response')
-          throw error
+          throw new Error('Error in app server response')
         }
 
         appUrl.value = response.data.app_url

--- a/packages/web-app-files/l10n/.tx/config
+++ b/packages/web-app-files/l10n/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 
 [o:owncloud-org:p:owncloud-web:r:files]
-file_filter = locale/<lang>/LC_MESSAGES/app.po
+file_filter = locale/<lang>/app.po
 minimum_perc = 0
 source_file = template.pot
 source_lang = en

--- a/packages/web-app-files/src/components/EmbedActions/EmbedActions.vue
+++ b/packages/web-app-files/src/components/EmbedActions/EmbedActions.vue
@@ -27,7 +27,7 @@
 </template>
 
 <script lang="ts">
-import { computed, unref } from 'vue'
+import { computed, defineComponent, unref } from 'vue'
 import {
   FileAction,
   useAbility,
@@ -40,10 +40,10 @@ import { Resource } from '@ownclouders/web-client'
 import { useGettext } from 'vue3-gettext'
 import { storeToRefs } from 'pinia'
 
-export default {
+export default defineComponent({
   setup() {
     const ability = useAbility()
-    const language = useGettext()
+    const { $gettext } = useGettext()
     const { isLocationPicker, postMessage } = useEmbedMode()
     const spacesStore = useSpacesStore()
     const { currentSpace: space } = storeToRefs(spacesStore)
@@ -67,7 +67,7 @@ export default {
     const canCreatePublicLinks = computed<boolean>(() => ability.can('create-all', 'PublicLink'))
 
     const selectLabel = computed<string>(() =>
-      isLocationPicker.value ? language.$gettext('Choose') : language.$gettext('Attach as copy')
+      isLocationPicker.value ? $gettext('Choose') : $gettext('Attach as copy')
     )
 
     const emitSelect = (): void => {
@@ -93,7 +93,7 @@ export default {
       createLinkAction
     }
   }
-}
+})
 </script>
 
 <style scoped>

--- a/packages/web-app-files/src/components/SideBar/Exif/ExifPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Exif/ExifPanel.vue
@@ -53,7 +53,8 @@ export default defineComponent({
   setup() {
     const resource = inject<Ref<Resource>>('resource')
     const config = useConfigStore()
-    const { current: currentLanguage, $gettext } = useGettext()
+    const language = useGettext()
+    const { $gettext } = language
     const { showMessage } = useMessages()
     const {
       copy: copyToClipboard,
@@ -110,7 +111,7 @@ export default defineComponent({
 
     const takenDateTime = computed(() => {
       const photo = unref(resource).photo
-      return photo?.takenDateTime ? formatDateFromISO(photo.takenDateTime, currentLanguage) : '-'
+      return photo?.takenDateTime ? formatDateFromISO(photo.takenDateTime, language.current) : '-'
     })
 
     const isLocationVisible = computed(() => {

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/EditDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/EditDropdown.vue
@@ -150,6 +150,7 @@ export default defineComponent({
     const capabilityStore = useCapabilityStore()
     const capabilityRefs = storeToRefs(capabilityStore)
     const language = useGettext()
+    const { $gettext } = language
     const configStore = useConfigStore()
 
     const toggleShareDenied = (value: boolean) => {
@@ -158,7 +159,7 @@ export default defineComponent({
 
     const dropButtonTooltip = computed(() => {
       if (props.isLocked) {
-        return language.$gettext('Resource is temporarily locked, unable to manage share')
+        return $gettext('Resource is temporarily locked, unable to manage share')
       }
 
       return ''

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
@@ -199,7 +199,8 @@ export default defineComponent({
     const { showMessage, showErrorMessage } = useMessages()
     const userStore = useUserStore()
     const clientService = useClientService()
-    const { $gettext, current: currentLanguage } = useGettext()
+    const language = useGettext()
+    const { $gettext } = language
     const { dispatchModal } = useModals()
 
     const { updateShare } = useSharesStore()
@@ -214,7 +215,7 @@ export default defineComponent({
     })
 
     const shareDate = computed(() => {
-      return formatDateFromDateTime(DateTime.fromISO(props.share.createdDateTime), currentLanguage)
+      return formatDateFromDateTime(DateTime.fromISO(props.share.createdDateTime), language.current)
     })
 
     const setDenyShare = (value: boolean) => {

--- a/packages/web-app-files/src/components/SideBar/Versions/FileVersions.vue
+++ b/packages/web-app-files/src/components/SideBar/Versions/FileVersions.vue
@@ -77,7 +77,7 @@ export default defineComponent({
   },
   setup(props) {
     const clientService = useClientService()
-    const { current: currentLanguage } = useGettext()
+    const language = useGettext()
     const { downloadFile } = useDownloadFile({ clientService })
     const { updateResourceField } = useResourcesStore()
 
@@ -118,13 +118,13 @@ export default defineComponent({
       return downloadFile(unref(space), unref(resource), version.name)
     }
     const formatVersionDateRelative = (version: Resource) => {
-      return formatRelativeDateFromHTTP(version.mdate, currentLanguage)
+      return formatRelativeDateFromHTTP(version.mdate, language.current)
     }
     const formatVersionDate = (version: Resource) => {
-      return formatDateFromJSDate(new Date(version.mdate), currentLanguage)
+      return formatDateFromJSDate(new Date(version.mdate), language.current)
     }
     const formatVersionFileSize = (version: Resource) => {
-      return formatFileSize(version.size, currentLanguage)
+      return formatFileSize(version.size, language.current)
     }
 
     return {

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -226,7 +226,8 @@ export default defineComponent({
     const route = useRoute()
     const clientService = useClientService()
     const { can } = useAbility()
-    const { current: currentLanguage, $gettext } = useGettext()
+    const language = useGettext()
+    const { $gettext } = language
     const filterTerm = ref('')
     const markInstance = ref(undefined)
     const imageContentObject = ref<Record<string, { fileId: string; data: string }>>({})
@@ -357,19 +358,19 @@ export default defineComponent({
         return $gettext('Unrestricted')
       }
 
-      return formatFileSize(space.spaceQuota.total, currentLanguage)
+      return formatFileSize(space.spaceQuota.total, language.current)
     }
     const getUsedQuota = (space: SpaceResource) => {
       if (space.spaceQuota.used === undefined) {
         return '-'
       }
-      return formatFileSize(space.spaceQuota.used, currentLanguage)
+      return formatFileSize(space.spaceQuota.used, language.current)
     }
     const getRemainingQuota = (space: SpaceResource) => {
       if (space.spaceQuota.remaining === undefined) {
         return '-'
       }
-      return formatFileSize(space.spaceQuota.remaining, currentLanguage)
+      return formatFileSize(space.spaceQuota.remaining, language.current)
     }
     const getMemberCount = (space: SpaceResource) => {
       return Object.values(space.spaceRoles).flat().length

--- a/packages/web-app-importer/l10n/.tx/config
+++ b/packages/web-app-importer/l10n/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 
 [o:owncloud-org:p:owncloud-web:r:importer]
-file_filter = locale/<lang>/LC_MESSAGES/app.po
+file_filter = locale/<lang>/app.po
 minimum_perc = 0
 source_file = template.pot
 source_lang = en

--- a/packages/web-app-ocm/l10n/.tx/config
+++ b/packages/web-app-ocm/l10n/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 
 [o:owncloud-org:p:owncloud-web:r:ocm]
-file_filter = locale/<lang>/LC_MESSAGES/app.po
+file_filter = locale/<lang>/app.po
 minimum_perc = 0
 source_file = template.pot
 source_lang = en

--- a/packages/web-app-pdf-viewer/l10n/.tx/config
+++ b/packages/web-app-pdf-viewer/l10n/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 
 [o:owncloud-org:p:owncloud-web:r:pdf-viewer]
-file_filter = locale/<lang>/LC_MESSAGES/app.po
+file_filter = locale/<lang>/app.po
 minimum_perc = 0
 source_file = template.pot
 source_lang = en

--- a/packages/web-app-preview/l10n/.tx/config
+++ b/packages/web-app-preview/l10n/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 
 [o:owncloud-org:p:owncloud-web:r:preview]
-file_filter = locale/<lang>/LC_MESSAGES/app.po
+file_filter = locale/<lang>/app.po
 minimum_perc = 0
 source_file = template.pot
 source_lang = en

--- a/packages/web-app-search/l10n/.tx/config
+++ b/packages/web-app-search/l10n/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 
 [o:owncloud-org:p:owncloud-web:r:search]
-file_filter = locale/<lang>/LC_MESSAGES/app.po
+file_filter = locale/<lang>/app.po
 minimum_perc = 0
 source_file = template.pot
 source_lang = en

--- a/packages/web-app-text-editor/l10n/.tx/config
+++ b/packages/web-app-text-editor/l10n/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 
 [o:owncloud-org:p:owncloud-web:r:text-editor]
-file_filter = locale/<lang>/LC_MESSAGES/app.po
+file_filter = locale/<lang>/app.po
 minimum_perc = 0
 source_file = template.pot
 source_lang = en

--- a/packages/web-app-webfinger/l10n/.tx/config
+++ b/packages/web-app-webfinger/l10n/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 
 [o:owncloud-org:p:owncloud-web:r:webfinger]
-file_filter = locale/<lang>/LC_MESSAGES/app.po
+file_filter = locale/<lang>/app.po
 minimum_perc = 0
 source_file = template.pot
 source_lang = en

--- a/packages/web-client/l10n/.tx/config
+++ b/packages/web-client/l10n/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 
 [o:owncloud-org:p:owncloud-web:r:client]
-file_filter = locale/<lang>/LC_MESSAGES/app.po
+file_filter = locale/<lang>/app.po
 minimum_perc = 0
 source_file = template.pot
 source_lang = en

--- a/packages/web-pkg/l10n/.tx/config
+++ b/packages/web-pkg/l10n/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 
 [o:owncloud-org:p:owncloud-web:r:pkg]
-file_filter = locale/<lang>/LC_MESSAGES/app.po
+file_filter = locale/<lang>/app.po
 minimum_perc = 0
 source_file = template.pot
 source_lang = en

--- a/packages/web-pkg/src/components/CreateLinkModal.vue
+++ b/packages/web-pkg/src/components/CreateLinkModal.vue
@@ -187,7 +187,8 @@ export default defineComponent({
   emits: ['cancel', 'confirm'],
   setup(props, { expose }) {
     const clientService = useClientService()
-    const { $gettext, current: currentLanguage } = useGettext()
+    const language = useGettext()
+    const { $gettext } = language
     const passwordPolicyService = usePasswordPolicyService()
     const { isEnabled: isEmbedEnabled, postMessage } = useEmbedMode()
     const { expirationRules } = useExpirationRules()
@@ -227,14 +228,14 @@ export default defineComponent({
     const selectedExpiryDateRelative = computed(() =>
       formatRelativeDateFromDateTime(
         DateTime.fromJSDate(new Date(unref(selectedExpiry))).endOf('day'),
-        currentLanguage
+        language.current
       )
     )
 
     const selectedExpiryDate = computed(() =>
       formatRelativeDateFromDateTime(
         DateTime.fromJSDate(new Date(unref(selectedExpiry))).endOf('day'),
-        currentLanguage
+        language.current
       )
     )
 

--- a/packages/web-pkg/src/components/SideBar/Spaces/Details/SpaceDetailsMultiple.vue
+++ b/packages/web-pkg/src/components/SideBar/Spaces/Details/SpaceDetailsMultiple.vue
@@ -47,13 +47,14 @@ export default defineComponent({
     }
   },
   setup(props) {
-    const { $gettext, $ngettext, current: currentLanguage } = useGettext()
+    const language = useGettext()
+    const { $gettext, $ngettext } = language
     const totalSelectedSpaceQuotaTotal = computed(() => {
       let total = 0
       props.selectedSpaces.forEach((space) => {
         total += space.spaceQuota.total
       })
-      return formatFileSize(total, currentLanguage)
+      return formatFileSize(total, language.current)
     })
     const totalSelectedSpaceQuotaRemaining = computed(() => {
       let remaining = 0
@@ -63,7 +64,7 @@ export default defineComponent({
         }
         remaining += space.spaceQuota.remaining
       })
-      return formatFileSize(remaining, currentLanguage)
+      return formatFileSize(remaining, language.current)
     })
     const totalSelectedSpaceQuotaUsed = computed(() => {
       let used = 0
@@ -73,7 +74,7 @@ export default defineComponent({
         }
         used += space.spaceQuota.used
       })
-      return formatFileSize(used, currentLanguage)
+      return formatFileSize(used, language.current)
     })
     const totalEnabledSpaces = computed(() => {
       return props.selectedSpaces.filter((s) => !s.disabled).length

--- a/packages/web-pkg/src/components/TextEditor.vue
+++ b/packages/web-pkg/src/components/TextEditor.vue
@@ -44,7 +44,7 @@ export default defineComponent({
   },
   emits: ['update:currentContent'],
   setup(props, { emit }) {
-    const { current: currentLanguage } = useGettext()
+    const language = useGettext()
     const themeStore = useThemeStore()
     const toastUiEditorRef = ref()
     // Should not be a ref, otherwise functions like setMarkdown won't work
@@ -68,7 +68,7 @@ export default defineComponent({
         initialValue: props.currentContent,
         useCommandShortcut: false,
         hideModeSwitch: true,
-        language: currentLanguage,
+        language: language.current,
         height: '100%',
         plugins: [codeSyntaxHighlight],
         viewer: props.isReadOnly,

--- a/packages/web-pkg/src/composables/links/useExpirationRules.ts
+++ b/packages/web-pkg/src/composables/links/useExpirationRules.ts
@@ -5,9 +5,11 @@ import { useCapabilityStore } from '../piniaStores'
 
 export const useExpirationRules = () => {
   const capabilityStore = useCapabilityStore()
-  const { current: currentLanguage } = useGettext()
+  const language = useGettext()
 
-  const expirationRules = computed(() => getExpirationRules({ capabilityStore, currentLanguage }))
+  const expirationRules = computed(() =>
+    getExpirationRules({ capabilityStore, currentLanguage: language.current })
+  )
 
   return { expirationRules }
 }

--- a/packages/web-pkg/src/composables/requestHeaders/useRequestHeaders.ts
+++ b/packages/web-pkg/src/composables/requestHeaders/useRequestHeaders.ts
@@ -8,7 +8,7 @@ import { useClientService } from '../clientService'
 export const useRequestHeaders = () => {
   const authStore = useAuthStore()
   const clientService = useClientService()
-  const { current: currentLanguage } = useGettext()
+  const language = useGettext()
 
   const headers = computed<Record<string, string>>(() => {
     const auth = new Auth({
@@ -18,7 +18,7 @@ export const useRequestHeaders = () => {
     })
 
     return {
-      'Accept-Language': currentLanguage,
+      'Accept-Language': language.current,
       'Initiator-ID': clientService.initiatorId,
       'X-Request-ID': uuidV4(),
       ...auth.getHeaders()

--- a/packages/web-runtime/l10n/.tx/config
+++ b/packages/web-runtime/l10n/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 
 [o:owncloud-org:p:owncloud-web:r:core]
-file_filter = locale/<lang>/LC_MESSAGES/app.po
+file_filter = locale/<lang>/app.po
 minimum_perc = 0
 source_file = template.pot
 source_lang = en

--- a/packages/web-runtime/l10n/Makefile
+++ b/packages/web-runtime/l10n/Makefile
@@ -48,8 +48,7 @@ $(TEMPLATE_FILE):
 			export OUT_DIR=$$app/l10n; \
 		fi; \
 		mkdir -p $$OUT_DIR; \
-		export GETTEXT_APP_SOURCES=`find $$app/src -name '*.vue' -o -name '*.js' -o -name '*.ts'`; \
-		node $(NODE_MODULES)/easygettext/src/extract-cli.js --attribute v-translate --output $$OUT_DIR/template.pot $$GETTEXT_APP_SOURCES; \
+		(cd $$app && pnpm exec vue-gettext-extract --config ../../gettext.config.cjs); \
 	done;
 
 .PHONY: translations
@@ -66,7 +65,7 @@ $(OUTPUT_DIR)/translations.json:
 			export OUT_DIR=$$app/l10n; \
 		fi; \
 		mkdir -p $$OUT_DIR; \
-		gettext-compile --output $$OUT_DIR/translations.json $(patsubst %,$$OUT_DIR/locale/%/LC_MESSAGES/app.po,$(LOCALES)); \
+		(cd $$app && pnpm exec vue-gettext-compile && mv ./l10n/locale/translations.json ./l10n/translations.json); \
 	done; \
 
 .PHONY: push

--- a/packages/web-runtime/package.json
+++ b/packages/web-runtime/package.json
@@ -17,7 +17,6 @@
     "@vueuse/head": "2.0.0",
     "axios": "1.6.8",
     "design-system": "workspace:@ownclouders/design-system@*",
-    "easygettext": "https://github.com/owncloud/easygettext/archive/refs/tags/v2.18.2-oc.tar.gz",
     "filesize": "^10.1.0",
     "focus-trap": "7.2.0",
     "focus-trap-vue": "^4.0.1",

--- a/packages/web-runtime/src/components/Account/GdprExport.vue
+++ b/packages/web-runtime/src/components/Account/GdprExport.vue
@@ -55,7 +55,8 @@ export default defineComponent({
     const { showMessage, showErrorMessage } = useMessages()
     const userStore = useUserStore()
     const spacesStore = useSpacesStore()
-    const { $gettext, current: currentLanguage } = useGettext()
+    const language = useGettext()
+    const { $gettext } = language
     const clientService = useClientService()
     const { downloadFile } = useDownloadFile()
 
@@ -115,7 +116,7 @@ export default defineComponent({
     }
 
     const exportDate = computed(() => {
-      return formatDateFromJSDate(new Date(unref(exportFile).mdate), currentLanguage)
+      return formatDateFromJSDate(new Date(unref(exportFile).mdate), language.current)
     })
 
     onMounted(() => {

--- a/packages/web-runtime/src/components/Topbar/Notifications.vue
+++ b/packages/web-runtime/src/components/Topbar/Notifications.vue
@@ -101,7 +101,7 @@ export default {
     const spacesStore = useSpacesStore()
     const capabilityStore = useCapabilityStore()
     const clientService = useClientService()
-    const { current: currentLanguage } = useGettext()
+    const language = useGettext()
 
     const notifications = ref<Notification[]>([])
     const notificationsInterval = ref()
@@ -111,10 +111,10 @@ export default {
     })
 
     const formatDate = (date: string) => {
-      return formatDateFromISO(date, currentLanguage)
+      return formatDateFromISO(date, language.current)
     }
     const formatDateRelative = (date: string) => {
-      return formatRelativeDateFromISO(date, currentLanguage)
+      return formatRelativeDateFromISO(date, language.current)
     }
 
     const messageParameters = [

--- a/packages/web-runtime/src/container/sse/files.ts
+++ b/packages/web-runtime/src/container/sse/files.ts
@@ -153,13 +153,14 @@ export const onSSEItemTrashedEvent = ({
     // If initiated by current client (browser tab), action unnecessary. Web manages its own logic, return early.
     return
   }
+  const { $gettext } = language
 
   const currentFolder = resourcesStore.currentFolder
   const resourceIsCurrentFolder = currentFolder?.id === sseData.itemid
 
   if (resourceIsCurrentFolder) {
     return messageStore.showMessage({
-      title: language.$gettext(
+      title: $gettext(
         'The folder you were accessing has been removed. Please navigate to another location.'
       )
     })

--- a/packages/web-runtime/src/container/sse/shares.ts
+++ b/packages/web-runtime/src/container/sse/shares.ts
@@ -62,6 +62,8 @@ export const onSSESpaceMemberRemovedEvent = async ({
     return
   }
 
+  const { $gettext } = language
+
   spacesStore.removeSpace(removedSpace)
 
   if (
@@ -70,7 +72,7 @@ export const onSSESpaceMemberRemovedEvent = async ({
   ) {
     // Fixme: Message triggers when user membership was revoked, but still is in a group membership, which is wrong
     return messageStore.showMessage({
-      title: language.$gettext(
+      title: $gettext(
         'Your access to this space has been revoked. Please navigate to another location.'
       )
     })
@@ -219,6 +221,7 @@ export const onSSEShareRemovedEvent = async ({
     // If initiated by current client (browser tab), action unnecessary. Web manages its own logic, return early.
     return
   }
+  const { $gettext } = language
 
   if (
     isLocationSpacesActive(router, 'files-spaces-generic') &&
@@ -227,7 +230,7 @@ export const onSSEShareRemovedEvent = async ({
   ) {
     // Fixme: Message triggers when user share was revoked, but still is in a group share, which is wrong
     return messageStore.showMessage({
-      title: language.$gettext(
+      title: $gettext(
         'Your access to this share has been revoked. Please navigate to another location.'
       )
     })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1185,9 +1185,6 @@ importers:
       design-system:
         specifier: workspace:@ownclouders/design-system@*
         version: link:../design-system
-      easygettext:
-        specifier: https://github.com/owncloud/easygettext/archive/refs/tags/v2.18.2-oc.tar.gz
-        version: https://github.com/owncloud/easygettext/archive/refs/tags/v2.18.2-oc.tar.gz(typescript@5.4.5)
       filesize:
         specifier: ^10.1.0
         version: 10.1.0
@@ -3036,22 +3033,9 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/types@5.60.0':
-    resolution: {integrity: sha512-ascOuoCpNZBccFVNJRSC6rPq4EmJ2NkuoKnd6LDNyAQmdDnziAtxbCGWCbefG1CNzmDvd05zO36AmB7H8RzKPA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
   '@typescript-eslint/types@7.7.0':
     resolution: {integrity: sha512-G01YPZ1Bd2hn+KPpIbrAhEWOn5lQBrjxkzHkWvP6NucMXFtfXoevK82hzQdpfuQYuhkvFDeQYbzXCjR1z9Z03w==}
     engines: {node: ^18.18.0 || >=20.0.0}
-
-  '@typescript-eslint/typescript-estree@5.60.0':
-    resolution: {integrity: sha512-R43thAuwarC99SnvrBmh26tc7F6sPa2B3evkXp/8q954kYL6Ro56AwASYWtEEi+4j09GbiNAHqYwNNZuNlARGQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   '@typescript-eslint/typescript-estree@7.7.0':
     resolution: {integrity: sha512-8p71HQPE6CbxIBy2kWHqM1KGrC07pk6RJn40n0DSc6bMOBBREZxSDJ+BmRzc8B5OdaMh1ty3mkuWRg4sCFiDQQ==}
@@ -3067,10 +3051,6 @@ packages:
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       eslint: ^8.56.0
-
-  '@typescript-eslint/visitor-keys@5.60.0':
-    resolution: {integrity: sha512-wm9Uz71SbCyhUKgcaPRauBdTegUyY/ZWl8gLwD/i/ybJqscrrdVSFImpvUz16BLPChIeKBK5Fa9s6KDQjsjyWw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@typescript-eslint/visitor-keys@7.7.0':
     resolution: {integrity: sha512-h0WHOj8MhdhY8YWkzIF30R379y0NqyOHExI9N9KCzvmu05EgG4FumeYa3ccfKUSphyWkWQE1ybVrgz/Pbam6YA==}
@@ -3394,12 +3374,6 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
-  acorn-class-fields@0.3.7:
-    resolution: {integrity: sha512-jdUWSFce0fuADUljmExz4TWpPkxmRW/ZCPRqeeUzbGf0vFUcpQYbyq52l75qGd0oSwwtAepeL6hgb/naRgvcKQ==}
-    engines: {node: '>=4.8.2'}
-    peerDependencies:
-      acorn: ^6 || ^7 || ^8
-
   acorn-dynamic-import@4.0.0:
     resolution: {integrity: sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==}
     deprecated: This is probably built in to whatever tool you're using. If you still need it... idk
@@ -3418,30 +3392,6 @@ packages:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-
-  acorn-private-class-elements@0.2.7:
-    resolution: {integrity: sha512-+GZH2wOKNZOBI4OOPmzpo4cs6mW297sn6fgIk1dUI08jGjhAaEwvC39mN2gJAg2lmAQJ1rBkFqKWonL3Zz6PVA==}
-    engines: {node: '>=4.8.2'}
-    peerDependencies:
-      acorn: ^6.1.0 || ^7 || ^8
-
-  acorn-private-methods@0.3.3:
-    resolution: {integrity: sha512-46oeEol3YFvLSah5m9hGMlNpxDBCEkdceJgf01AjqKYTK9r6HexKs2rgSbLK81pYjZZMonhftuUReGMlbbv05w==}
-    engines: {node: '>=4.8.2'}
-    peerDependencies:
-      acorn: ^6 || ^7 || ^8
-
-  acorn-stage3@4.0.0:
-    resolution: {integrity: sha512-BR+LaADtA6GTB5prkNqWmlmCLYmkyW0whvSxdHhbupTaro2qBJ95fJDEiRLPUmiACGHPaYyeH9xmNJWdGfXRQw==}
-    engines: {node: '>=4.8.2'}
-    peerDependencies:
-      acorn: ^7.4 || ^8
-
-  acorn-static-class-features@0.2.4:
-    resolution: {integrity: sha512-5X4mpYq5J3pdndLmIB0+WtFd/mKWnNYpuTlTzj32wUu/PMmEGOiayQ5UrqgwdBNiaZBtDDh5kddpP7Yg2QaQYA==}
-    engines: {node: '>=4.8.2'}
-    peerDependencies:
-      acorn: ^6.1.0 || ^7 || ^8
 
   acorn-walk@8.2.0:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
@@ -4024,13 +3974,6 @@ packages:
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
-  cheerio-select@1.5.0:
-    resolution: {integrity: sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==}
-
-  cheerio@1.0.0-rc.10:
-    resolution: {integrity: sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==}
-    engines: {node: '>= 6'}
-
   chokidar@2.1.8:
     resolution: {integrity: sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==}
     deprecated: Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies
@@ -4449,10 +4392,6 @@ packages:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
-  css-what@5.0.1:
-    resolution: {integrity: sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==}
-    engines: {node: '>= 6'}
-
   css-what@6.1.0:
     resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
     engines: {node: '>= 6'}
@@ -4784,12 +4723,6 @@ packages:
 
   easy-table@1.2.0:
     resolution: {integrity: sha512-OFzVOv03YpvtcWGe5AayU5G2hgybsg3iqA6drU8UaoZyB9jLGMTrz9+asnLp/E+6qPh88yEI1gvyZFZ41dmgww==}
-
-  easygettext@https://github.com/owncloud/easygettext/archive/refs/tags/v2.18.2-oc.tar.gz:
-    resolution: {tarball: https://github.com/owncloud/easygettext/archive/refs/tags/v2.18.2-oc.tar.gz}
-    version: 2.16.0
-    engines: {node: '>=8'}
-    hasBin: true
 
   editorconfig@1.0.4:
     resolution: {integrity: sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==}
@@ -5300,15 +5233,6 @@ packages:
   flatted@3.2.9:
     resolution: {integrity: sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==}
 
-  flow-parser@0.153.0:
-    resolution: {integrity: sha512-qa7UODgbofQyruRWqNQ+KM5hO37CenByxhNfAztiwjBsPhWZ5AFh5g+gtLpTWPlzG7X66QdjBB9DuHNUBcaF+Q==}
-    engines: {node: '>=0.4.0'}
-
-  flow-remove-types@2.153.0:
-    resolution: {integrity: sha512-KHl0r0xH5VBMOtKmk2WJME3F4UDg+j0f/yH6lbBIGk3xKl5NTHLs+1h9murH9+KLxvVZ0ut5ydd/fx49RSqmEw==}
-    engines: {node: '>=4'}
-    hasBin: true
-
   flush-promises@1.0.2:
     resolution: {integrity: sha512-G0sYfLQERwKz4+4iOZYQEZVpOt9zQrlItIxQAAYAWpfby3gbHrx0osCHz5RLl/XoXevXk0xoN4hDFky/VV9TrA==}
 
@@ -5744,9 +5668,6 @@ packages:
 
   htmlparser2@4.1.0:
     resolution: {integrity: sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==}
-
-  htmlparser2@6.1.0:
-    resolution: {integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==}
 
   http-deceiver@1.2.7:
     resolution: {integrity: sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==}
@@ -6836,9 +6757,6 @@ packages:
     resolution: {integrity: sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  minimist@1.2.6:
-    resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
-
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -7015,10 +6933,6 @@ packages:
   node-forge@1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
     engines: {node: '>= 6.13.0'}
-
-  node-modules-regexp@1.0.0:
-    resolution: {integrity: sha512-JMaRS9L4wSRIR+6PTVEikTrq/lMGEZR43a48ETeilY0Q0iMwVnccMFrUM1k+tNzmYuIU0Vh710bCUqHX+/+ctQ==}
-    engines: {node: '>=0.10.0'}
 
   node-notifier@10.0.1:
     resolution: {integrity: sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==}
@@ -7554,10 +7468,6 @@ packages:
   pino@7.11.0:
     resolution: {integrity: sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==}
     hasBin: true
-
-  pirates@3.0.2:
-    resolution: {integrity: sha512-c5CgUJq6H2k6MJz72Ak1F5sN9n9wlSlJyEnwvpm9/y3WB4E3pHBDT2c6PEiS1vyJvq2bUxUAIu0EGf8Cx4Ic7Q==}
-    engines: {node: '>= 4'}
 
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
@@ -9292,9 +9202,6 @@ packages:
       '@swc/wasm':
         optional: true
 
-  tslib@1.14.1:
-    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
-
   tslib@2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
 
@@ -9303,12 +9210,6 @@ packages:
 
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
-
-  tsutils@3.21.0:
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
 
   tty-browserify@0.0.1:
     resolution: {integrity: sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==}
@@ -9746,9 +9647,6 @@ packages:
         optional: true
       jsdom:
         optional: true
-
-  vlq@0.2.3:
-    resolution: {integrity: sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==}
 
   vm-browserify@1.1.2:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
@@ -12144,23 +12042,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@5.60.0': {}
-
   '@typescript-eslint/types@7.7.0': {}
-
-  '@typescript-eslint/typescript-estree@5.60.0(typescript@5.4.5)':
-    dependencies:
-      '@typescript-eslint/types': 5.60.0
-      '@typescript-eslint/visitor-keys': 5.60.0
-      debug: 4.3.4(supports-color@8.1.1)
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.4.5)
-    optionalDependencies:
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@typescript-eslint/typescript-estree@7.7.0(typescript@5.4.5)':
     dependencies:
@@ -12190,11 +12072,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
-
-  '@typescript-eslint/visitor-keys@5.60.0':
-    dependencies:
-      '@typescript-eslint/types': 5.60.0
-      eslint-visitor-keys: 3.4.1
 
   '@typescript-eslint/visitor-keys@7.7.0':
     dependencies:
@@ -12678,11 +12555,6 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
-  acorn-class-fields@0.3.7(acorn@7.4.1):
-    dependencies:
-      acorn: 7.4.1
-      acorn-private-class-elements: 0.2.7(acorn@7.4.1)
-
   acorn-dynamic-import@4.0.0(acorn@6.4.2):
     dependencies:
       acorn: 6.4.2
@@ -12703,27 +12575,6 @@ snapshots:
   acorn-jsx@5.3.2(acorn@8.11.3):
     dependencies:
       acorn: 8.11.3
-
-  acorn-private-class-elements@0.2.7(acorn@7.4.1):
-    dependencies:
-      acorn: 7.4.1
-
-  acorn-private-methods@0.3.3(acorn@7.4.1):
-    dependencies:
-      acorn: 7.4.1
-      acorn-private-class-elements: 0.2.7(acorn@7.4.1)
-
-  acorn-stage3@4.0.0(acorn@7.4.1):
-    dependencies:
-      acorn: 7.4.1
-      acorn-class-fields: 0.3.7(acorn@7.4.1)
-      acorn-private-methods: 0.3.3(acorn@7.4.1)
-      acorn-static-class-features: 0.2.4(acorn@7.4.1)
-
-  acorn-static-class-features@0.2.4(acorn@7.4.1):
-    dependencies:
-      acorn: 7.4.1
-      acorn-private-class-elements: 0.2.7(acorn@7.4.1)
 
   acorn-walk@8.2.0: {}
 
@@ -13411,24 +13262,6 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
-  cheerio-select@1.5.0:
-    dependencies:
-      css-select: 4.3.0
-      css-what: 5.0.1
-      domelementtype: 2.3.0
-      domhandler: 4.3.1
-      domutils: 2.8.0
-
-  cheerio@1.0.0-rc.10:
-    dependencies:
-      cheerio-select: 1.5.0
-      dom-serializer: 1.3.2
-      domhandler: 4.3.1
-      htmlparser2: 6.1.0
-      parse5: 6.0.1
-      parse5-htmlparser2-tree-adapter: 6.0.1
-      tslib: 2.5.0
-
   chokidar@2.1.8(supports-color@6.1.0):
     dependencies:
       anymatch: 2.0.0(supports-color@6.1.0)
@@ -13937,8 +13770,6 @@ snapshots:
       mdn-data: 2.0.30
       source-map-js: 1.0.2
 
-  css-what@5.0.1: {}
-
   css-what@6.1.0: {}
 
   cssesc@3.0.0: {}
@@ -14301,25 +14132,6 @@ snapshots:
       ansi-regex: 5.0.1
     optionalDependencies:
       wcwidth: 1.0.1
-
-  easygettext@https://github.com/owncloud/easygettext/archive/refs/tags/v2.18.2-oc.tar.gz(typescript@5.4.5):
-    dependencies:
-      '@babel/core': 7.23.7
-      '@typescript-eslint/typescript-estree': 5.60.0(typescript@5.4.5)
-      acorn: 7.4.1
-      acorn-stage3: 4.0.0(acorn@7.4.1)
-      acorn-walk: 8.2.0
-      cheerio: 1.0.0-rc.10
-      estree-walker: 2.0.2
-      flow-remove-types: 2.153.0
-      minimist: 1.2.6
-      pofile: 1.1.4
-    optionalDependencies:
-      '@vue/compiler-sfc': 3.4.21
-      pug: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   editorconfig@1.0.4:
     dependencies:
@@ -15041,14 +14853,6 @@ snapshots:
 
   flatted@3.2.9: {}
 
-  flow-parser@0.153.0: {}
-
-  flow-remove-types@2.153.0:
-    dependencies:
-      flow-parser: 0.153.0
-      pirates: 3.0.2
-      vlq: 0.2.3
-
   flush-promises@1.0.2: {}
 
   flush-write-stream@1.1.1:
@@ -15524,13 +15328,6 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
       domhandler: 3.3.0
-      domutils: 2.8.0
-      entities: 2.2.0
-
-  htmlparser2@6.1.0:
-    dependencies:
-      domelementtype: 2.2.0
-      domhandler: 4.3.1
       domutils: 2.8.0
       entities: 2.2.0
 
@@ -16586,8 +16383,6 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.1
 
-  minimist@1.2.6: {}
-
   minimist@1.2.8: {}
 
   minipass-collect@1.0.2:
@@ -16758,8 +16553,6 @@ snapshots:
   node-forge@0.10.0: {}
 
   node-forge@1.3.1: {}
-
-  node-modules-regexp@1.0.0: {}
 
   node-notifier@10.0.1:
     dependencies:
@@ -17282,10 +17075,6 @@ snapshots:
       safe-stable-stringify: 2.3.1
       sonic-boom: 2.4.1
       thread-stream: 0.15.1
-
-  pirates@3.0.2:
-    dependencies:
-      node-modules-regexp: 1.0.0
 
   pirates@4.0.6: {}
 
@@ -19336,18 +19125,11 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  tslib@1.14.1: {}
-
   tslib@2.4.0: {}
 
   tslib@2.5.0: {}
 
   tslib@2.6.2: {}
-
-  tsutils@3.21.0(typescript@5.4.5):
-    dependencies:
-      tslib: 1.14.1
-      typescript: 5.4.5
 
   tty-browserify@0.0.1: {}
 
@@ -19775,8 +19557,6 @@ snapshots:
       - sugarss
       - supports-color
       - terser
-
-  vlq@0.2.3: {}
 
   vm-browserify@1.1.2: {}
 


### PR DESCRIPTION
## Description

- use vue3 gettext to extract and compile translations
- introduce gettext config which configures extraction and compilation
- drop LC_MESSAGES from path of translation files (needed due to configuration of extraction and compilation where we cannot specify path after locale)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- resolves #10249

## Motivation and Context

Get rid of dep alerts

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: macos x64
- test case 1: makefile

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [x] Maintenance (e.g. dependency updates or tooling)
