### PR TITLE
Allow generic search result items for search providers

### DIFF
--- a/packages/web-pkg/src/apps/types.ts
+++ b/packages/web-pkg/src/apps/types.ts
@@ -14,12 +14,12 @@ export interface AppReadyHookArgs {
 export interface AppNavigationItem {
   isActive?: () => boolean
   activeFor?: { name?: string; path?: string }[]
-  enabled?: () => boolean
+  enabled?: () => boolean // FIXME: Should be "isVisible"
   fillType?: string
   icon?: string
-  name?: string | (() => string)
+  name: string | (() => string)
   route?: RouteLocationRaw
-  tag?: string
+  tag?: string // FIXME: Deprecated, should be removed
   handler?: () => void
   priority?: number
 }
@@ -33,7 +33,7 @@ export interface ApplicationQuickAction {
   id?: string
   label?: (...args) => string | string
   icon?: string
-  iconFillType?: string
+  iconFillType?: IconFillType
   handler?: (...args) => Promise<void> | void
   displayed?: (...args) => boolean | boolean
 }

--- a/packages/web-pkg/src/components/Search/types.ts
+++ b/packages/web-pkg/src/components/Search/types.ts
@@ -1,8 +1,15 @@
 import { SearchResource } from '@ownclouders/web-client/src/webdav/search'
 
+export interface GenericSearchResultItem {
+  id: string
+  displayName: string
+  icon?: string
+}
+
 export interface SearchResultValue {
-  id: string | number
-  data: SearchResource
+  id: string
+  // FIXME: SearchResource is very specific for webdav search
+  data: GenericSearchResultItem | SearchResource
 }
 
 export interface SearchResult {
@@ -11,7 +18,7 @@ export interface SearchResult {
 }
 
 export interface SearchList {
-  component: unknown
+  component: unknown // Component needs to match SearchResultValue
 
   search(term: string): Promise<SearchResult>
 }

--- a/packages/web-pkg/src/components/Search/types.ts
+++ b/packages/web-pkg/src/components/Search/types.ts
@@ -1,8 +1,9 @@
 import { SearchResource } from '@ownclouders/web-client/src/webdav/search'
+import { Component } from 'vue'
 
 export interface GenericSearchResultItem {
   id: string
-  displayName: string
+  name: string
   icon?: string
 }
 
@@ -18,7 +19,7 @@ export interface SearchResult {
 }
 
 export interface SearchList {
-  component: unknown // Component needs to match SearchResultValue
+  component: Component // Component props need to match SearchResultValue data type
 
   search(term: string): Promise<SearchResult>
 }

--- a/packages/web-pkg/src/components/SideBar/types.ts
+++ b/packages/web-pkg/src/components/SideBar/types.ts
@@ -2,13 +2,13 @@ import { defineComponent } from 'vue'
 import { IconFillType } from '../../helpers/resource'
 import { Item } from '@ownclouders/web-client/src/helpers'
 
-export interface SideBarPanelContext<R, P, T extends Item> {
+export interface SideBarPanelContext<R extends Item, P extends Item, T extends Item> {
   root?: R
   parent?: P
   items?: T[]
 }
 
-export interface SideBarPanel<R, P, T extends Item> {
+export interface SideBarPanel<R extends Item, P extends Item, T extends Item> {
   name: string
   icon: string
   iconFillType?: IconFillType

--- a/packages/web-pkg/src/composables/actions/types.ts
+++ b/packages/web-pkg/src/composables/actions/types.ts
@@ -1,17 +1,18 @@
 import { Resource, SpaceResource } from '@ownclouders/web-client/src'
 import { Group, User } from '@ownclouders/web-client/src/generated'
 import { RouteLocationRaw } from 'vue-router'
+import { IconFillType } from '../../helpers'
 
 export type ActionOptions = Record<string, unknown | unknown[]>
 export interface Action<T = ActionOptions> {
   name: string
   icon: string
-  iconFillType?: string
+  iconFillType?: IconFillType
   variation?: string
   appearance?: string
   id?: string
   img?: string
-  componentType: 'button' | 'router-link'
+  componentType: 'button' | 'router-link' // FIXME: Should be determined by handler/route
   class?: string
   hasPriority?: boolean
   hideLabel?: boolean
@@ -22,7 +23,7 @@ export interface Action<T = ActionOptions> {
   ext?: string
 
   label(options?: T): string
-  isEnabled(options?: T): boolean
+  isEnabled(options?: T): boolean // FIXME: Should be isVisible
 
   // componentType: button
   handler?(options?: T): Promise<void> | void

--- a/packages/web-pkg/src/composables/piniaStores/extensionRegistry.ts
+++ b/packages/web-pkg/src/composables/piniaStores/extensionRegistry.ts
@@ -7,11 +7,12 @@ import { Item } from '@ownclouders/web-client/src/helpers'
 import { useConfigStore } from './config'
 import { FolderView } from '../../ui'
 
+export type AvailableExtensions = 'action' | 'search' | 'sidebarNav' | 'sidebarPanel' | 'folderView'
 export type ExtensionScope = 'resource' | 'user' | 'group' | string
 
 export type BaseExtension = {
   id: string
-  type: string
+  type: AvailableExtensions
   scopes?: ExtensionScope[]
 }
 

--- a/packages/web-pkg/src/composables/piniaStores/extensionRegistry.ts
+++ b/packages/web-pkg/src/composables/piniaStores/extensionRegistry.ts
@@ -6,13 +6,17 @@ import { AppNavigationItem } from '../../apps'
 import { Item } from '@ownclouders/web-client/src/helpers'
 import { useConfigStore } from './config'
 import { FolderView } from '../../ui'
+import { StringUnionOrAnyString } from '../../utils/types'
 
-export type AvailableExtensions = 'action' | 'search' | 'sidebarNav' | 'sidebarPanel' | 'folderView'
-export type ExtensionScope = 'resource' | 'user' | 'group' | string
+export type AvailableExtension = StringUnionOrAnyString<
+  'action' | 'search' | 'sidebarNav' | 'sidebarPanel' | 'folderView'
+>
+
+export type ExtensionScope = StringUnionOrAnyString<'resource' | 'user' | 'group'>
 
 export type BaseExtension = {
   id: string
-  type: AvailableExtensions
+  type: AvailableExtension
   scopes?: ExtensionScope[]
 }
 

--- a/packages/web-pkg/src/composables/piniaStores/extensionRegistry.ts
+++ b/packages/web-pkg/src/composables/piniaStores/extensionRegistry.ts
@@ -66,7 +66,7 @@ export const useExtensionRegistry = () => {
     getters: {
       requestExtensions:
         (state) =>
-        <ExtensionType extends Extension>(type: string, scopes?: string[]) => {
+        <ExtensionType extends Extension>(type: string, scopes?: ExtensionScope[]) => {
           return state.extensions
             .map((e) =>
               unref(e).filter(

--- a/packages/web-pkg/src/composables/piniaStores/extensionRegistry.ts
+++ b/packages/web-pkg/src/composables/piniaStores/extensionRegistry.ts
@@ -8,7 +8,7 @@ import { useConfigStore } from './config'
 import { FolderView } from '../../ui'
 import { StringUnionOrAnyString } from '../../utils/types'
 
-export type AvailableExtension = StringUnionOrAnyString<
+export type ExtensionType = StringUnionOrAnyString<
   'action' | 'search' | 'sidebarNav' | 'sidebarPanel' | 'folderView'
 >
 
@@ -16,7 +16,7 @@ export type ExtensionScope = StringUnionOrAnyString<'resource' | 'user' | 'group
 
 export type BaseExtension = {
   id: string
-  type: AvailableExtension
+  type: ExtensionType
   scopes?: ExtensionScope[]
 }
 

--- a/packages/web-pkg/src/utils/types.ts
+++ b/packages/web-pkg/src/utils/types.ts
@@ -1,5 +1,7 @@
 import { Ref, MaybeRef } from 'vue'
 
+export type StringUnionOrAnyString<T extends string> = T | Omit<string, T>
+
 export type ReadOnlyRef<T> = Readonly<Ref<T>>
 export type MaybeReadonlyRef<T> = MaybeRef<T> | ReadOnlyRef<T>
 

--- a/packages/web-runtime/src/container/api.ts
+++ b/packages/web-runtime/src/container/api.ts
@@ -73,6 +73,7 @@ const announceNavigationItems = (
   }
 
   const navExtensions = navigationItems.map((navItem) => ({
+    id: `app.${applicationId}.${navItem.name}`,
     type: 'sidebarNav',
     navItem,
     scopes: [`app.${applicationId}`]


### PR DESCRIPTION
## Description
Just tried writing a basic search provider while working on #10067 and realized search results were hardcoded to be webdav-specific. Figured I'd allow for a more generic approach, at least from a type perspective 🙃 