### PR TITLE
fix: handle quick link copy action in resources list on safari

### DIFF
--- a/packages/web-pkg/src/components/CreateLinkModal.vue
+++ b/packages/web-pkg/src/components/CreateLinkModal.vue
@@ -182,7 +182,7 @@ export default defineComponent({
     space: { type: Object as PropType<SpaceResource>, default: undefined },
     isQuickLink: { type: Boolean, default: false },
     callbackFn: {
-      type: Function as PropType<(result: PromiseSettledResult<Share>[]) => Promise<void> | void>,
+      type: Function as PropType<(promise: Promise<string | null>) => Promise<void> | void>,
       default: undefined
     }
   },
@@ -278,7 +278,7 @@ export default defineComponent({
       )
     }
 
-    const onConfirm = async () => {
+    const handleLinksCreation = async (): Promise<string | null> => {
       if (!unref(selectedRoleIsInternal)) {
         if (unref(passwordEnforced) && !unref(password).value) {
           password.error = $gettext('Password must not be empty')
@@ -292,11 +292,13 @@ export default defineComponent({
 
       const result = await createLinks()
 
-      const succeeded = result.filter(({ status }) => status === 'fulfilled')
+      const succeeded = result.filter(
+        ({ status }) => status === 'fulfilled'
+      ) as PromiseFulfilledResult<Share>[]
       if (succeeded.length && unref(isEmbedEnabled)) {
         postMessage<string[]>(
           'owncloud-embed:share',
-          (succeeded as PromiseFulfilledResult<Share>[]).map(({ value }) => value.url)
+          succeeded.map(({ value }) => value.url)
         )
       }
 
@@ -319,9 +321,17 @@ export default defineComponent({
         return Promise.reject()
       }
 
+      Promise.resolve(succeeded[0]?.value.url ?? null)
+    }
+
+    const onConfirm = async () => {
       if (props.callbackFn) {
-        props.callbackFn(result)
+        props.callbackFn(handleLinksCreation)
+
+        return
       }
+
+      await handleLinksCreation()
     }
 
     expose({ onConfirm })

--- a/packages/web-pkg/src/composables/clipboard/useClipboard.ts
+++ b/packages/web-pkg/src/composables/clipboard/useClipboard.ts
@@ -1,27 +1,66 @@
 import { useClipboard as _useClipboard } from '@vueuse/core'
 
 export const useClipboard = () => {
-  // doCopy creates the requested link and copies the url to the clipboard,
-  // the copy action uses the clipboard // clipboardItem api to work around the webkit limitations.
-  //
-  // https://developer.apple.com/forums/thread/691873
-  //
-  // if those apis not available (or like in firefox behind dom.events.asyncClipboard.clipboardItem)
-  // it has a fallback to the vue-use implementation.
-  //
-  // https://webkit.org/blog/10855/
-  const copyToClipboard = (quickLinkUrl: string) => {
-    if (typeof ClipboardItem && navigator?.clipboard?.write) {
-      return navigator.clipboard.write([
-        new ClipboardItem({
-          'text/plain': new Blob([quickLinkUrl], { type: 'text/plain' })
-        })
-      ])
-    } else {
-      const { copy } = _useClipboard({ legacy: true })
-      return copy(quickLinkUrl)
-    }
+  /**
+   * Copies given text into clipboard
+   *
+   * @remarks the copy action uses the clipboard // clipboardItem api to work around the webkit limitations.(https://developer.apple.com/forums/thread/691873) if those apis not available (or like in firefox behind dom.events.asyncClipboard.clipboardItem). it has a fallback to the vue-use implementation. (https://webkit.org/blog/10855/)
+   *
+   * @param quickLinkUrl If the text is supposed to be resolved via a promise, pass the promise directly and resolve it to string
+   * @returns resolves whether the text has been copied into clipboard (e.g. whether the quickLinkUrl function resolved into a string or not)
+   */
+  const copyToClipboard = (
+    quickLinkUrl: string | (() => Promise<string | null | undefined>)
+  ): Promise<boolean> => {
+    return new Promise<boolean>(async (resolve) => {
+      try {
+        if (typeof ClipboardItem && navigator?.clipboard?.write) {
+          const blob =
+            typeof quickLinkUrl === 'function'
+              ? quickLinkUrl().then((text) => {
+                  if (!text) {
+                    throw new EmptyTextError('No text received')
+                  }
+
+                  return new Blob([text], { type: 'text/plain' })
+                })
+              : new Blob([quickLinkUrl], { type: 'text/plain' })
+
+          await navigator.clipboard.write([
+            new ClipboardItem({
+              'text/plain': blob
+            })
+          ])
+
+          resolve(true)
+          return
+        }
+
+        const { copy } = _useClipboard({ legacy: true })
+        const text = typeof quickLinkUrl === 'function' ? await quickLinkUrl() : quickLinkUrl
+
+        await copy(text)
+        resolve(true)
+      } catch (error) {
+        if (error instanceof EmptyTextError) {
+          resolve(false)
+
+          return
+        }
+
+        // A real error happened
+        throw error
+      }
+    })
   }
 
   return { copyToClipboard }
+}
+
+class EmptyTextError extends Error {
+  constructor(msg) {
+    super(msg)
+
+    this.name = 'ClipboardEmptyTextError'
+  }
 }


### PR DESCRIPTION
## Description

Currently WIP. Generally speaking we need to pass any async functions happening before the clipboard write into the clipboard logic. Otherwise safari looses user context and does not consider it user action.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #9166

## Motivation and Context

Users can copy quick links on safari.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] handle link creation via modal
- [ ] handle link creation without modal
- [ ] clean up
