### PR TITLE
ci: stop running docs pipeline on stable branches (master)

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1222,7 +1222,6 @@ def documentation(ctx):
             "trigger": {
                 "ref": [
                     "refs/heads/master",
-                    "refs/heads/stable-*",
                     "refs/pull/**",
                 ],
             },


### PR DESCRIPTION
## Description
Dev docs **must** not be published from the `stable-*` branches because that overwrites changes from the `master` branch. Dev docs should always only ever reflect the current state from the `master` branch.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [x] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
