### PR TITLE
Fix keyboard nav reactivity broken after delete items in admin settings

### DIFF
--- a/changelog/unreleased/bugfix-admin-settings-keyboard-navigation
+++ b/changelog/unreleased/bugfix-admin-settings-keyboard-navigation
@@ -1,0 +1,7 @@
+Bugfix: Admin settings keyboard navigation
+
+We've fixed a bug where keyboard navigation stopped working after deleting a resource in the admin settings app.
+We also fixed a bug where initial keyboard navigation didn't work, when no resource was selected.
+
+https://github.com/owncloud/web/pull/10417
+https://github.com/owncloud/web/issues/10186

--- a/packages/web-app-admin-settings/src/components/Groups/CreateGroupModal.vue
+++ b/packages/web-app-admin-settings/src/components/Groups/CreateGroupModal.vue
@@ -17,7 +17,8 @@
 import { useGettext } from 'vue3-gettext'
 import { computed, defineComponent, ref, PropType, unref, watch } from 'vue'
 import { Group } from '@ownclouders/web-client/src/generated'
-import { MaybeRef, Modal, useClientService, useEventBus, useMessages } from '@ownclouders/web-pkg'
+import { MaybeRef, Modal, useClientService, useMessages } from '@ownclouders/web-pkg'
+import { useGroupSettingsStore } from '../../composables'
 
 export default defineComponent({
   name: 'CreateGroupModal',
@@ -28,8 +29,8 @@ export default defineComponent({
   setup(props, { emit, expose }) {
     const { $gettext } = useGettext()
     const { showMessage, showErrorMessage } = useMessages()
-    const eventBus = useEventBus()
     const clientService = useClientService()
+    const groupSettingsStore = useGroupSettingsStore()
 
     const group: MaybeRef<Group> = ref({ displayName: '' })
     const formData = ref({
@@ -62,7 +63,7 @@ export default defineComponent({
         const client = clientService.graphAuthenticated
         const response = await client.groups.createGroup(unref(group))
         showMessage({ title: $gettext('Group was created successfully') })
-        eventBus.publish('app.admin-settings.groups.add', { ...response?.data, members: [] })
+        groupSettingsStore.upsertGroup(response?.data)
       } catch (error) {
         console.error(error)
         showErrorMessage({

--- a/packages/web-app-admin-settings/src/components/Users/AddToGroupsModal.vue
+++ b/packages/web-app-admin-settings/src/components/Users/AddToGroupsModal.vue
@@ -11,13 +11,8 @@ import { defineComponent, PropType, ref, unref, watch } from 'vue'
 import { useGettext } from 'vue3-gettext'
 import { Group, User } from '@ownclouders/web-client/src/generated'
 import GroupSelect from './GroupSelect.vue'
-import {
-  useEventBus,
-  useClientService,
-  Modal,
-  useMessages,
-  useConfigStore
-} from '@ownclouders/web-pkg'
+import { useClientService, Modal, useMessages, useConfigStore } from '@ownclouders/web-pkg'
+import { useUserSettingsStore } from '../../composables/stores/userSettings'
 
 export default defineComponent({
   name: 'AddToGroupsModal',
@@ -38,8 +33,8 @@ export default defineComponent({
     const { showMessage, showErrorMessage } = useMessages()
     const clientService = useClientService()
     const configStore = useConfigStore()
-    const eventBus = useEventBus()
     const { $gettext, $ngettext } = useGettext()
+    const userSettingsStore = useUserSettingsStore()
 
     const selectedOptions = ref<Group[]>([])
     const changeSelectedGroupOption = (options: Group[]) => {
@@ -124,10 +119,10 @@ export default defineComponent({
         const usersResponse = await Promise.all(
           usersToFetch.map((userId) => client.users.getUser(userId))
         )
-        eventBus.publish(
-          'app.admin-settings.users.update',
-          usersResponse.map(({ data }) => data)
-        )
+
+        usersResponse.forEach(({ data }) => {
+          userSettingsStore.upsertUser(data)
+        })
       } catch (e) {
         console.error(e)
       }

--- a/packages/web-app-admin-settings/src/components/Users/CreateUserModal.vue
+++ b/packages/web-app-admin-settings/src/components/Users/CreateUserModal.vue
@@ -48,6 +48,7 @@ import { useGettext } from 'vue3-gettext'
 import { computed, defineComponent, ref, unref, PropType, watch } from 'vue'
 import * as EmailValidator from 'email-validator'
 import { Modal, useClientService, useEventBus, useMessages } from '@ownclouders/web-pkg'
+import { useUserSettingsStore } from '../../composables/stores/userSettings'
 
 export default defineComponent({
   name: 'CreateUserModal',
@@ -58,6 +59,7 @@ export default defineComponent({
     const eventBus = useEventBus()
     const clientService = useClientService()
     const { $gettext } = useGettext()
+    const userSettingsStore = useUserSettingsStore()
 
     const formData = ref({
       userName: {
@@ -112,7 +114,7 @@ export default defineComponent({
         const { id: createdUserId } = data
         const { data: createdUser } = await client.users.getUser(createdUserId)
         showMessage({ title: $gettext('User was created successfully') })
-        eventBus.publish('app.admin-settings.users.add', createdUser)
+        userSettingsStore.upsertUser(createdUser)
       } catch (error) {
         console.error(error)
         showErrorMessage({

--- a/packages/web-app-admin-settings/src/components/Users/LoginModal.vue
+++ b/packages/web-app-admin-settings/src/components/Users/LoginModal.vue
@@ -17,13 +17,8 @@
 import { computed, defineComponent, onMounted, PropType, ref, unref, watch } from 'vue'
 import { useGettext } from 'vue3-gettext'
 import { User } from '@ownclouders/web-client/src/generated'
-import {
-  useClientService,
-  useEventBus,
-  useUserStore,
-  Modal,
-  useMessages
-} from '@ownclouders/web-pkg'
+import { useClientService, useUserStore, Modal, useMessages } from '@ownclouders/web-pkg'
+import { useUserSettingsStore } from '../../composables/stores/userSettings'
 
 type LoginOption = {
   label: string
@@ -43,9 +38,9 @@ export default defineComponent({
   setup(props, { emit, expose }) {
     const { showMessage, showErrorMessage } = useMessages()
     const clientService = useClientService()
-    const eventBus = useEventBus()
     const { $gettext, $ngettext } = useGettext()
     const userStore = useUserStore()
+    const userSettingsStore = useUserSettingsStore()
 
     const selectedOption = ref<LoginOption>()
     const options = ref([
@@ -141,10 +136,9 @@ export default defineComponent({
           })
         )
 
-        eventBus.publish(
-          'app.admin-settings.users.update',
-          usersResponse.map(({ data }) => data)
-        )
+        usersResponse.forEach(({ data }) => {
+          userSettingsStore.upsertUser(data)
+        })
       } catch (e) {
         console.error(e)
       }

--- a/packages/web-app-admin-settings/src/components/Users/RemoveFromGroupsModal.vue
+++ b/packages/web-app-admin-settings/src/components/Users/RemoveFromGroupsModal.vue
@@ -11,7 +11,8 @@ import { defineComponent, PropType, ref, unref, watch } from 'vue'
 import { useGettext } from 'vue3-gettext'
 import { Group, User } from '@ownclouders/web-client/src/generated'
 import GroupSelect from './GroupSelect.vue'
-import { useEventBus, useClientService, Modal, useMessages } from '@ownclouders/web-pkg'
+import { useClientService, Modal, useMessages } from '@ownclouders/web-pkg'
+import { useUserSettingsStore } from '../../composables/stores/userSettings'
 
 export default defineComponent({
   name: 'RemoveFromGroupsModal',
@@ -31,8 +32,8 @@ export default defineComponent({
   setup(props, { emit, expose }) {
     const { showMessage, showErrorMessage } = useMessages()
     const clientService = useClientService()
-    const eventBus = useEventBus()
     const { $gettext, $ngettext } = useGettext()
+    const userSettingsStore = useUserSettingsStore()
 
     const selectedOptions = ref<Group[]>([])
     const changeSelectedGroupOption = (options: Group[]) => {
@@ -117,10 +118,10 @@ export default defineComponent({
         const usersResponse = await Promise.all(
           usersToFetch.map((userId) => client.users.getUser(userId))
         )
-        eventBus.publish(
-          'app.admin-settings.users.update',
-          usersResponse.map(({ data }) => data)
-        )
+
+        usersResponse.forEach(({ data }) => {
+          userSettingsStore.upsertUser(data)
+        })
       } catch (e) {
         console.error(e)
       }

--- a/packages/web-app-admin-settings/src/composables/index.ts
+++ b/packages/web-app-admin-settings/src/composables/index.ts
@@ -1,1 +1,2 @@
 export * from './actions'
+export * from './stores'

--- a/packages/web-app-admin-settings/src/composables/keyboardActions/useKeyboardTableMouseActions.ts
+++ b/packages/web-app-admin-settings/src/composables/keyboardActions/useKeyboardTableMouseActions.ts
@@ -3,11 +3,12 @@ import { eventBus } from '@ownclouders/web-pkg'
 import { KeyboardActions } from '@ownclouders/web-pkg'
 import { findIndex, find } from 'lodash-es'
 import { Resource } from '@ownclouders/web-client'
+import { Item } from '@ownclouders/web-client/src/helpers'
 
 export const useKeyboardTableMouseActions = (
   keyActions: KeyboardActions,
   paginatedResources: Ref<{ id: string }[]>,
-  selectedRows: any,
+  selectedRows: Ref<Item[]>,
   lastSelectedRowIndex: Ref<number>,
   lastSelectedRowId: Ref<string | null>
 ) => {
@@ -15,15 +16,15 @@ export const useKeyboardTableMouseActions = (
   let resourceListClickedShiftEvent
 
   const handleCtrlClickAction = (resource: Resource) => {
-    const rowIndex = findIndex(selectedRows, { id: resource.id })
+    const rowIndex = findIndex(unref(selectedRows), { id: resource.id })
     if (rowIndex >= 0) {
-      selectedRows.splice(rowIndex, 1)
+      selectedRows.value = unref(selectedRows).filter((item) => item.id != resource.id)
     } else {
-      selectedRows.push(resource)
+      unref(selectedRows).push(resource)
     }
     keyActions.resetSelectionCursor()
 
-    lastSelectedRowIndex.value = rowIndex >= 0 ? rowIndex : selectedRows.length - 1
+    lastSelectedRowIndex.value = rowIndex >= 0 ? rowIndex : unref(selectedRows).length - 1
     lastSelectedRowId.value = String(resource.id)
   }
 
@@ -47,10 +48,10 @@ export const useKeyboardTableMouseActions = (
       if (skipTargetSelection && nodeId === resource.id) {
         continue
       }
-      const selectedRowIndex = findIndex(selectedRows, { id: nodeId })
+      const selectedRowIndex = findIndex(unref(selectedRows), { id: nodeId })
       if (selectedRowIndex === -1) {
         const selectedRow = find(paginatedResources.value, { id: nodeId })
-        selectedRows.push(selectedRow)
+        unref(selectedRows).push(selectedRow)
       }
     }
 

--- a/packages/web-app-admin-settings/src/composables/stores/groupSettings.ts
+++ b/packages/web-app-admin-settings/src/composables/stores/groupSettings.ts
@@ -11,7 +11,7 @@ export const useGroupSettingsStore = defineStore('groupSettings', () => {
   }
 
   const upsertGroup = (group: Group) => {
-    const existing = unref(groups).find(({ id }) => id === group.id)
+    const existing = unref(groups).some(({ id }) => id === group.id)
     if (existing) {
       Object.assign(existing, { ...group, members: [] })
       return

--- a/packages/web-app-admin-settings/src/composables/stores/groupSettings.ts
+++ b/packages/web-app-admin-settings/src/composables/stores/groupSettings.ts
@@ -1,0 +1,51 @@
+import { defineStore } from 'pinia'
+import { ref, unref } from 'vue'
+import { Group } from '@ownclouders/web-client/src/generated'
+
+export const useGroupSettingsStore = defineStore('groupSettings', () => {
+  const groups = ref<Group[]>([])
+  const selectedGroups = ref<Group[]>([])
+
+  const setGroups = (data: Group[]) => {
+    groups.value = data
+  }
+
+  const upsertGroup = (group: Group) => {
+    const existing = unref(groups).find(({ id }) => id === group.id)
+    if (existing) {
+      Object.assign(existing, { ...group, members: [] })
+      return
+    }
+    unref(groups).push({ ...group, members: [] })
+  }
+
+  const removeGroups = (values: Group[]) => {
+    groups.value = unref(groups).filter((group) => !values.find(({ id }) => id === group.id))
+  }
+
+  const setSelectedGroups = (data: Group[]) => {
+    selectedGroups.value = data
+  }
+
+  const addSelectedGroup = (data: Group) => {
+    unref(selectedGroups).push(data)
+  }
+
+  const reset = () => {
+    groups.value = []
+    selectedGroups.value = []
+  }
+
+  return {
+    groups,
+    upsertGroup,
+    setGroups,
+    removeGroups,
+    reset,
+    selectedGroups,
+    addSelectedGroup,
+    setSelectedGroups
+  }
+})
+
+export type GroupSettingsStore = ReturnType<typeof useGroupSettingsStore>

--- a/packages/web-app-admin-settings/src/composables/stores/index.ts
+++ b/packages/web-app-admin-settings/src/composables/stores/index.ts
@@ -1,0 +1,2 @@
+export * from './groupSettings'
+export * from './spaceSettings'

--- a/packages/web-app-admin-settings/src/composables/stores/spaceSettings.ts
+++ b/packages/web-app-admin-settings/src/composables/stores/spaceSettings.ts
@@ -11,7 +11,7 @@ export const useSpaceSettingsStore = defineStore('spaceSettings', () => {
   }
 
   const upsertSpace = (space: SpaceResource) => {
-    const existing = unref(spaces).find(({ id }) => id === space.id)
+    const existing = unref(spaces).some(({ id }) => id === space.id)
     if (existing) {
       Object.assign(existing, space)
       return

--- a/packages/web-app-admin-settings/src/composables/stores/spaceSettings.ts
+++ b/packages/web-app-admin-settings/src/composables/stores/spaceSettings.ts
@@ -1,0 +1,51 @@
+import { defineStore } from 'pinia'
+import { ref, unref } from 'vue'
+import { SpaceResource } from '@ownclouders/web-client'
+
+export const useSpaceSettingsStore = defineStore('spaceSettings', () => {
+  const spaces = ref<SpaceResource[]>([])
+  const selectedSpaces = ref<SpaceResource[]>([])
+
+  const setSpaces = (data: SpaceResource[]) => {
+    spaces.value = data
+  }
+
+  const upsertSpace = (space: SpaceResource) => {
+    const existing = unref(spaces).find(({ id }) => id === space.id)
+    if (existing) {
+      Object.assign(existing, space)
+      return
+    }
+    unref(spaces).push(space)
+  }
+
+  const removeSpaces = (values: SpaceResource[]) => {
+    spaces.value = unref(spaces).filter((space) => !values.find(({ id }) => id === space.id))
+  }
+
+  const setSelectedSpaces = (data: SpaceResource[]) => {
+    selectedSpaces.value = data
+  }
+
+  const addSelectedSpace = (data: SpaceResource) => {
+    unref(selectedSpaces).push(data)
+  }
+
+  const reset = () => {
+    spaces.value = []
+    selectedSpaces.value = []
+  }
+
+  return {
+    spaces,
+    setSpaces,
+    upsertSpace,
+    removeSpaces,
+    reset,
+    selectedSpaces,
+    addSelectedSpace,
+    setSelectedSpaces
+  }
+})
+
+export type SpaceSettingsStore = ReturnType<typeof useSpaceSettingsStore>

--- a/packages/web-app-admin-settings/src/composables/stores/userSettings.ts
+++ b/packages/web-app-admin-settings/src/composables/stores/userSettings.ts
@@ -1,0 +1,51 @@
+import { defineStore } from 'pinia'
+import { ref, unref } from 'vue'
+import { User } from '@ownclouders/web-client/src/generated'
+
+export const useUserSettingsStore = defineStore('userSettings', () => {
+  const users = ref<User[]>([])
+  const selectedUsers = ref<User[]>([])
+
+  const setUsers = (data: User[]) => {
+    users.value = data
+  }
+
+  const upsertUser = (user: User) => {
+    const existing = unref(users).find(({ id }) => id === user.id)
+    if (existing) {
+      Object.assign(existing, user)
+      return
+    }
+    unref(users).push(user)
+  }
+
+  const removeUsers = (values: User[]) => {
+    users.value = unref(users).filter((user) => !values.find(({ id }) => id === user.id))
+  }
+
+  const setSelectedUsers = (data: User[]) => {
+    selectedUsers.value = data
+  }
+
+  const addSelectedUser = (data: User) => {
+    unref(selectedUsers).push(data)
+  }
+
+  const reset = () => {
+    users.value = []
+    selectedUsers.value = []
+  }
+
+  return {
+    users,
+    setUsers,
+    upsertUser,
+    removeUsers,
+    reset,
+    selectedUsers,
+    addSelectedUser,
+    setSelectedUsers
+  }
+})
+
+export type UserSettingsStore = ReturnType<typeof useUserSettingsStore>

--- a/packages/web-app-admin-settings/src/composables/stores/userSettings.ts
+++ b/packages/web-app-admin-settings/src/composables/stores/userSettings.ts
@@ -11,7 +11,7 @@ export const useUserSettingsStore = defineStore('userSettings', () => {
   }
 
   const upsertUser = (user: User) => {
-    const existing = unref(users).find(({ id }) => id === user.id)
+    const existing = unref(users).some(({ id }) => id === user.id)
     if (existing) {
       Object.assign(existing, user)
       return

--- a/packages/web-app-admin-settings/tests/unit/components/Groups/CreateGroupModal.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Groups/CreateGroupModal.spec.ts
@@ -9,6 +9,7 @@ import {
 import { mock } from 'vitest-mock-extended'
 import { AxiosResponse } from 'axios'
 import { Modal, eventBus, useMessages } from '@ownclouders/web-pkg'
+import { useGroupSettingsStore } from '../../../../src/composables'
 
 describe('CreateGroupModal', () => {
   describe('computed method "isFormInvalid"', () => {
@@ -80,12 +81,12 @@ describe('CreateGroupModal', () => {
         mockAxiosResolve({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
       )
 
-      const eventSpy = vi.spyOn(eventBus, 'publish')
       await wrapper.vm.onConfirm()
 
       const { showMessage } = useMessages()
       expect(showMessage).toHaveBeenCalled()
-      expect(eventSpy).toHaveBeenCalled()
+      const { upsertGroup } = useGroupSettingsStore()
+      expect(upsertGroup).toHaveBeenCalled()
     })
 
     it('should show message on error', async () => {
@@ -100,12 +101,12 @@ describe('CreateGroupModal', () => {
       mocks.$clientService.graphAuthenticated.groups.createGroup.mockRejectedValue(
         mockAxiosResolve({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
       )
-      const eventSpy = vi.spyOn(eventBus, 'publish')
       await wrapper.vm.onConfirm()
 
       const { showErrorMessage } = useMessages()
       expect(showErrorMessage).toHaveBeenCalled()
-      expect(eventSpy).not.toHaveBeenCalled()
+      const { upsertGroup } = useGroupSettingsStore()
+      expect(upsertGroup).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/web-app-admin-settings/tests/unit/components/Groups/GroupsList.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Groups/GroupsList.spec.ts
@@ -2,6 +2,7 @@ import GroupsList from '../../../../src/components/Groups/GroupsList.vue'
 import { defaultComponentMocks, defaultPlugins, mount, shallowMount } from 'web-test-helpers'
 import { displayPositionedDropdown, eventBus, queryItemAsString } from '@ownclouders/web-pkg'
 import { SideBarEventTopics } from '@ownclouders/web-pkg'
+import { useGroupSettingsStore } from '../../../../src/composables'
 
 const getGroupMocks = () => [
   { id: '1', members: [] },
@@ -56,36 +57,74 @@ describe('GroupsList', () => {
       ).toEqual([])
     })
   })
-  it('emits events on row click', () => {
-    const groups = getGroupMocks()
-    const { wrapper } = getWrapper({ props: { groups } })
-    wrapper.vm.rowClicked([groups[0]])
-    expect(wrapper.emitted('toggleSelectGroup')).toBeTruthy()
-  })
   it('should show the context menu on right click', async () => {
     const groups = getGroupMocks()
     const spyDisplayPositionedDropdown = vi.mocked(displayPositionedDropdown)
-    const { wrapper } = getWrapper({ mountType: mount, props: { groups } })
+    const { wrapper } = getWrapper({ mountType: mount, groups })
     await wrapper.find(`[data-item-id="${groups[0].id}"]`).trigger('contextmenu')
     expect(spyDisplayPositionedDropdown).toHaveBeenCalledTimes(1)
   })
   it('should show the context menu on context menu button click', async () => {
     const groups = getGroupMocks()
     const spyDisplayPositionedDropdown = vi.mocked(displayPositionedDropdown)
-    const { wrapper } = getWrapper({ mountType: mount, props: { groups } })
+    const { wrapper } = getWrapper({ mountType: mount, groups })
     await wrapper.find('.groups-table-btn-action-dropdown').trigger('click')
     expect(spyDisplayPositionedDropdown).toHaveBeenCalledTimes(1)
   })
   it('should show the group details on details button click', async () => {
     const groups = getGroupMocks()
     const eventBusSpy = vi.spyOn(eventBus, 'publish')
-    const { wrapper } = getWrapper({ mountType: mount, props: { groups } })
+    const { wrapper } = getWrapper({ mountType: mount, groups })
     await wrapper.find('.groups-table-btn-details').trigger('click')
     expect(eventBusSpy).toHaveBeenCalledWith(SideBarEventTopics.open)
   })
+  describe('toggle selection', () => {
+    describe('selectGroups method', () => {
+      it('selects all groups', async () => {
+        const groups = getGroupMocks()
+        const { wrapper } = getWrapper({ mountType: shallowMount, groups })
+        wrapper.vm.selectGroups(groups)
+        const { setSelectedGroups } = useGroupSettingsStore()
+        expect(setSelectedGroups).toHaveBeenCalledWith(groups)
+      })
+    })
+    describe('selectGroup method', () => {
+      it('selects a group', async () => {
+        const groups = getGroupMocks()
+        const { wrapper } = getWrapper({ mountType: shallowMount, groups: [groups[0]] })
+        wrapper.vm.selectGroup(groups[0])
+        const { addSelectedGroup } = useGroupSettingsStore()
+        expect(addSelectedGroup).toHaveBeenCalledWith(groups[0])
+      })
+      it('de-selects a selected group', async () => {
+        const groups = getGroupMocks()
+        const { wrapper } = getWrapper({
+          mountType: shallowMount,
+          groups: [groups[0]],
+          selectedGroups: [groups[0]]
+        })
+        wrapper.vm.selectGroup(groups[0])
+        const { setSelectedGroups } = useGroupSettingsStore()
+        expect(setSelectedGroups).toHaveBeenCalledWith([])
+      })
+    })
+    describe('unselectAllGroups method', () => {
+      it('de-selects all selected groups', async () => {
+        const groups = getGroupMocks()
+        const { wrapper } = getWrapper({
+          mountType: shallowMount,
+          groups: [groups[0]],
+          selectedGroups: [groups[0]]
+        })
+        wrapper.vm.unselectAllGroups()
+        const { setSelectedGroups } = useGroupSettingsStore()
+        expect(setSelectedGroups).toHaveBeenCalledWith([])
+      })
+    })
+  })
 })
 
-function getWrapper({ mountType = shallowMount, props = {} } = {}) {
+function getWrapper({ mountType = shallowMount, groups = [], selectedGroups = [] } = {}) {
   vi.mocked(queryItemAsString).mockImplementationOnce(() => '1')
   vi.mocked(queryItemAsString).mockImplementationOnce(() => '100')
   const mocks = defaultComponentMocks()
@@ -93,13 +132,16 @@ function getWrapper({ mountType = shallowMount, props = {} } = {}) {
   return {
     wrapper: mountType(GroupsList, {
       props: {
-        groups: [],
-        selectedGroups: [],
-        headerPosition: 0,
-        ...props
+        headerPosition: 0
       },
       global: {
-        plugins: [...defaultPlugins()],
+        plugins: [
+          ...defaultPlugins({
+            piniaOptions: {
+              groupSettingsStore: { groups, selectedGroups }
+            }
+          })
+        ],
         mocks,
         provide: mocks,
         stubs: {

--- a/packages/web-app-admin-settings/tests/unit/components/Groups/GroupsList.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Groups/GroupsList.spec.ts
@@ -80,7 +80,7 @@ describe('GroupsList', () => {
   })
   describe('toggle selection', () => {
     describe('selectGroups method', () => {
-      it('selects all groups', async () => {
+      it('selects all groups', () => {
         const groups = getGroupMocks()
         const { wrapper } = getWrapper({ mountType: shallowMount, groups })
         wrapper.vm.selectGroups(groups)
@@ -89,14 +89,14 @@ describe('GroupsList', () => {
       })
     })
     describe('selectGroup method', () => {
-      it('selects a group', async () => {
+      it('selects a group', () => {
         const groups = getGroupMocks()
         const { wrapper } = getWrapper({ mountType: shallowMount, groups: [groups[0]] })
         wrapper.vm.selectGroup(groups[0])
         const { addSelectedGroup } = useGroupSettingsStore()
         expect(addSelectedGroup).toHaveBeenCalledWith(groups[0])
       })
-      it('de-selects a selected group', async () => {
+      it('de-selects a selected group', () => {
         const groups = getGroupMocks()
         const { wrapper } = getWrapper({
           mountType: shallowMount,
@@ -109,7 +109,7 @@ describe('GroupsList', () => {
       })
     })
     describe('unselectAllGroups method', () => {
-      it('de-selects all selected groups', async () => {
+      it('de-selects all selected groups', () => {
         const groups = getGroupMocks()
         const { wrapper } = getWrapper({
           mountType: shallowMount,

--- a/packages/web-app-admin-settings/tests/unit/components/Spaces/SpacesList.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Spaces/SpacesList.spec.ts
@@ -122,7 +122,7 @@ describe('SpacesList', () => {
   })
   describe('toggle selection', () => {
     describe('selectSpaces method', () => {
-      it('selects all spaces', async () => {
+      it('selects all spaces', () => {
         const spaces = [
           mock<SpaceResource>({ id: '1', name: 'Some Space' }),
           mock<SpaceResource>({ id: '2', name: 'Some other Space' })
@@ -133,7 +133,7 @@ describe('SpacesList', () => {
         expect(setSelectedSpaces).toHaveBeenCalledWith(spaces)
       })
     })
-    describe('selectSpace method', () => {
+    describe('selectSpace ', () => {
       it('selects a space', async () => {
         const spaces = [mock<SpaceResource>({ id: '1', name: 'Some Space' })]
         const { wrapper } = getWrapper({ mountType: shallowMount, spaces })
@@ -141,7 +141,7 @@ describe('SpacesList', () => {
         const { addSelectedSpace } = useSpaceSettingsStore()
         expect(addSelectedSpace).toHaveBeenCalledWith(spaces[0])
       })
-      it('de-selects a selected space', async () => {
+      it('de-selects a selected space', () => {
         const spaces = [mock<SpaceResource>({ id: '1', name: 'Some Space' })]
         const { wrapper } = getWrapper({ mountType: shallowMount, spaces, selectedSpaces: spaces })
         wrapper.vm.selectSpace(spaces[0])
@@ -150,7 +150,7 @@ describe('SpacesList', () => {
       })
     })
     describe('unselectAllSpaces method', () => {
-      it('de-selects all selected spaces', async () => {
+      it('de-selects all selected spaces', () => {
         const spaces = [mock<SpaceResource>({ id: '1', name: 'Some Space' })]
         const { wrapper } = getWrapper({ mountType: shallowMount, spaces })
         wrapper.vm.unselectAllSpaces()

--- a/packages/web-app-admin-settings/tests/unit/components/Spaces/__snapshots__/SpacesList.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/components/Spaces/__snapshots__/SpacesList.spec.ts.snap
@@ -84,6 +84,32 @@ exports[`SpacesList > should render all spaces in a table 1`] = `
             </button></div>
         </td>
       </tr>
+      <tr tabindex="-1" class="oc-tbody-tr oc-tbody-tr-2" data-item-id="2" draggable="false">
+        <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-select oc-pl-s">
+          <oc-checkbox-stub id="oc-checkbox-3" disabled="false" modelvalue="false" option="[object Object]" label="Select 2 Another space" hidelabel="true" size="large" outline="false" class="oc-ml-s"></oc-checkbox-stub>
+        </td>
+        <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-icon"><span class="oc-icon oc-icon-m oc-icon-passive"><!----></span></td>
+        <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-name mark-element"><span class="spaces-table-space-name" data-test-space-name="2 Another space">2 Another space</span></td>
+        <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-manager">user1, user2... +1</td>
+        <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-members">5</td>
+        <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-totalQuota">2 GB</td>
+        <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-usedQuota">500 MB</td>
+        <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-remainingQuota">1.5 GB</td>
+        <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-mdate"><span tabindex="0"></span></td>
+        <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-status"><span class="oc-flex oc-flex-middle"><span class="oc-icon oc-icon-m oc-icon-passive oc-mr-s"><!----></span><span>Disabled</span></span></td>
+        <td class="oc-table-cell oc-table-cell-align-right oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-actions oc-pr-s">
+          <div class="spaces-list-actions"><button type="button" aria-label="Show details" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw spaces-table-btn-details">
+              <!--v-if-->
+              <!-- @slot Content of the button --> <span class="oc-icon oc-icon-m oc-icon-passive"><!----></span>
+            </button> <button type="button" aria-label="Show context menu" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw spaces-table-btn-action-dropdown" id="context-menu-trigger-2">
+              <!--v-if-->
+              <!-- @slot Content of the button --> <span class="oc-icon oc-icon-m oc-icon-passive"><!----></span>
+              <div id="context-menu-drop-2" class="oc-drop oc-box-shadow-medium oc-rounded oc-overflow-hidden">
+                <div class="oc-card oc-card-body oc-background-secondary oc-p-s"></div>
+              </div>
+            </button></div>
+        </td>
+      </tr>
     </tbody>
     <tfoot class="oc-table-footer">
       <tr class="oc-table-footer-row">
@@ -91,7 +117,7 @@ exports[`SpacesList > should render all spaces in a table 1`] = `
           <!-- @slot Footer of the table -->
           <!--v-if-->
           <div class="oc-text-nowrap oc-text-center oc-width-1-1 oc-my-s">
-            <p class="oc-text-muted">1 spaces in total</p>
+            <p class="oc-text-muted">2 spaces in total</p>
             <!--v-if-->
           </div>
         </td>

--- a/packages/web-app-admin-settings/tests/unit/components/Users/AddToGroupsModal.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/AddToGroupsModal.spec.ts
@@ -7,7 +7,7 @@ import {
 } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
 import { Group, User } from '@ownclouders/web-client/src/generated'
-import { Modal, eventBus, useMessages } from '@ownclouders/web-pkg'
+import { Modal, useMessages } from '@ownclouders/web-pkg'
 import { useUserSettingsStore } from '../../../../src/composables/stores/userSettings'
 
 describe('AddToGroupsModal', () => {
@@ -27,7 +27,6 @@ describe('AddToGroupsModal', () => {
       )
 
       wrapper.vm.selectedOptions = groups
-      const eventSpy = vi.spyOn(eventBus, 'publish')
 
       await wrapper.vm.onConfirm()
       const { showMessage } = useMessages()

--- a/packages/web-app-admin-settings/tests/unit/components/Users/AddToGroupsModal.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/AddToGroupsModal.spec.ts
@@ -8,6 +8,7 @@ import {
 import { mock } from 'vitest-mock-extended'
 import { Group, User } from '@ownclouders/web-client/src/generated'
 import { Modal, eventBus, useMessages } from '@ownclouders/web-pkg'
+import { useUserSettingsStore } from '../../../../src/composables/stores/userSettings'
 
 describe('AddToGroupsModal', () => {
   it('renders the input', () => {
@@ -31,7 +32,8 @@ describe('AddToGroupsModal', () => {
       await wrapper.vm.onConfirm()
       const { showMessage } = useMessages()
       expect(showMessage).toHaveBeenCalled()
-      expect(eventSpy).toHaveBeenCalled()
+      const { upsertUser } = useUserSettingsStore()
+      expect(upsertUser).toHaveBeenCalledTimes(users.length)
     })
 
     it('should show message on error', async () => {
@@ -44,12 +46,12 @@ describe('AddToGroupsModal', () => {
       mocks.$clientService.graphAuthenticated.users.getUser.mockRejectedValue(new Error(''))
 
       wrapper.vm.selectedOptions = groups
-      const eventSpy = vi.spyOn(eventBus, 'publish')
 
       await wrapper.vm.onConfirm()
       const { showErrorMessage } = useMessages()
       expect(showErrorMessage).toHaveBeenCalled()
-      expect(eventSpy).not.toHaveBeenCalled()
+      const { upsertUser } = useUserSettingsStore()
+      expect(upsertUser).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/web-app-admin-settings/tests/unit/components/Users/CreateUserModal.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/CreateUserModal.spec.ts
@@ -9,6 +9,7 @@ import {
 import { mock } from 'vitest-mock-extended'
 import { AxiosResponse } from 'axios'
 import { Modal, eventBus, useMessages } from '@ownclouders/web-pkg'
+import { useUserSettingsStore } from '../../../../src/composables/stores/userSettings'
 
 describe('CreateUserModal', () => {
   describe('computed method "isFormInvalid"', () => {
@@ -146,12 +147,12 @@ describe('CreateUserModal', () => {
         mockAxiosResolve({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
       )
 
-      const eventSpy = vi.spyOn(eventBus, 'publish')
       await wrapper.vm.onConfirm()
 
+      const { upsertUser } = useUserSettingsStore()
+      expect(upsertUser).toHaveBeenCalled()
       const { showMessage } = useMessages()
       expect(showMessage).toHaveBeenCalled()
-      expect(eventSpy).toHaveBeenCalled()
     })
 
     it('should show message on error', async () => {

--- a/packages/web-app-admin-settings/tests/unit/components/Users/LoginModal.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/LoginModal.spec.ts
@@ -7,8 +7,9 @@ import {
 } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
 import { User } from '@ownclouders/web-client/src/generated'
-import { Modal, eventBus, useMessages } from '@ownclouders/web-pkg'
+import { Modal, useMessages } from '@ownclouders/web-pkg'
 import { OcSelect } from 'design-system/src/components'
+import { useUserSettingsStore } from '../../../../src/composables/stores/userSettings'
 
 describe('LoginModal', () => {
   it('renders the input including two options', () => {
@@ -32,12 +33,11 @@ describe('LoginModal', () => {
         mockAxiosResolve({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
       )
 
-      const eventSpy = vi.spyOn(eventBus, 'publish')
-
       await wrapper.vm.onConfirm()
       const { showMessage } = useMessages()
       expect(showMessage).toHaveBeenCalled()
-      expect(eventSpy).toHaveBeenCalled()
+      const { upsertUser } = useUserSettingsStore()
+      expect(upsertUser).toHaveBeenCalledTimes(users.length)
       expect(mocks.$clientService.graphAuthenticated.users.editUser).toHaveBeenCalledTimes(
         users.length
       )

--- a/packages/web-app-admin-settings/tests/unit/components/Users/RemoveFromGroupsModal.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/RemoveFromGroupsModal.spec.ts
@@ -8,6 +8,7 @@ import {
 import { mock } from 'vitest-mock-extended'
 import { Group, User } from '@ownclouders/web-client/src/generated'
 import { Modal, eventBus, useMessages } from '@ownclouders/web-pkg'
+import { useUserSettingsStore } from '../../../../src/composables/stores/userSettings'
 
 describe('RemoveFromGroupsModal', () => {
   it('renders the input', () => {
@@ -29,12 +30,12 @@ describe('RemoveFromGroupsModal', () => {
       )
 
       wrapper.vm.selectedOptions = groups
-      const eventSpy = vi.spyOn(eventBus, 'publish')
 
       await wrapper.vm.onConfirm()
       const { showMessage } = useMessages()
       expect(showMessage).toHaveBeenCalled()
-      expect(eventSpy).toHaveBeenCalled()
+      const { upsertUser } = useUserSettingsStore()
+      expect(upsertUser).toHaveBeenCalledTimes(users.length)
     })
 
     it('should show message on error', async () => {
@@ -55,7 +56,8 @@ describe('RemoveFromGroupsModal', () => {
       await wrapper.vm.onConfirm()
       const { showErrorMessage } = useMessages()
       expect(showErrorMessage).toHaveBeenCalled()
-      expect(eventSpy).not.toHaveBeenCalled()
+      const { upsertUser } = useUserSettingsStore()
+      expect(upsertUser).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/web-app-admin-settings/tests/unit/components/Users/RemoveFromGroupsModal.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/RemoveFromGroupsModal.spec.ts
@@ -7,7 +7,7 @@ import {
 } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
 import { Group, User } from '@ownclouders/web-client/src/generated'
-import { Modal, eventBus, useMessages } from '@ownclouders/web-pkg'
+import { Modal, useMessages } from '@ownclouders/web-pkg'
 import { useUserSettingsStore } from '../../../../src/composables/stores/userSettings'
 
 describe('RemoveFromGroupsModal', () => {
@@ -51,7 +51,6 @@ describe('RemoveFromGroupsModal', () => {
       mocks.$clientService.graphAuthenticated.users.getUser.mockRejectedValue(new Error(''))
 
       wrapper.vm.selectedOptions = groups
-      const eventSpy = vi.spyOn(eventBus, 'publish')
 
       await wrapper.vm.onConfirm()
       const { showErrorMessage } = useMessages()

--- a/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/EditPanel.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/EditPanel.spec.ts
@@ -198,7 +198,8 @@ function getWrapper({
           memberOf: selectedGroups
         },
         roles: [{ id: '1', displayName: 'admin' }],
-        groups
+        groups,
+        applicationId: '1'
       },
       global: {
         mocks,

--- a/packages/web-app-admin-settings/tests/unit/components/Users/UsersList.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/UsersList.spec.ts
@@ -2,6 +2,7 @@ import UsersList from '../../../../src/components/Users/UsersList.vue'
 import { defaultComponentMocks, defaultPlugins, mount, shallowMount } from 'web-test-helpers'
 import { displayPositionedDropdown, eventBus, queryItemAsString } from '@ownclouders/web-pkg'
 import { SideBarEventTopics } from '@ownclouders/web-pkg'
+import { useUserSettingsStore } from '../../../../src/composables/stores/userSettings'
 
 const getUserMocks = () => [{ id: '1', displayName: 'jan' }]
 vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
@@ -14,19 +15,15 @@ describe('UsersList', () => {
   describe('computed method "allUsersSelected"', () => {
     it('should be true if all users are selected', () => {
       const { wrapper } = getWrapper({
-        props: {
-          users: getUserMocks(),
-          selectedUsers: getUserMocks()
-        }
+        users: getUserMocks(),
+        selectedUsers: getUserMocks()
       })
       expect(wrapper.vm.allUsersSelected).toBeTruthy()
     })
     it('should be false if not every user is selected', () => {
       const { wrapper } = getWrapper({
-        props: {
-          users: getUserMocks(),
-          selectedUsers: []
-        }
+        users: getUserMocks(),
+        selectedUsers: []
       })
       expect(wrapper.vm.allUsersSelected).toBeFalsy()
     })
@@ -87,51 +84,87 @@ describe('UsersList', () => {
       ])
     })
   })
-  it('emits events on row click', () => {
-    const users = getUserMocks()
-    const { wrapper } = getWrapper({ props: { users } })
-    wrapper.vm.rowClicked([users[0]])
-    expect(wrapper.emitted('toggleSelectUser')).toBeTruthy()
-  })
   it('should show the context menu on right click', async () => {
     const users = getUserMocks()
     const spyDisplayPositionedDropdown = vi.mocked(displayPositionedDropdown)
-    const { wrapper } = getWrapper({ mountType: mount, props: { users } })
+    const { wrapper } = getWrapper({ mountType: mount, users })
     await wrapper.find(`[data-item-id="${users[0].id}"]`).trigger('contextmenu')
     expect(spyDisplayPositionedDropdown).toHaveBeenCalledTimes(1)
   })
   it('should show the context menu on context menu button click', async () => {
     const users = getUserMocks()
     const spyDisplayPositionedDropdown = vi.mocked(displayPositionedDropdown)
-    const { wrapper } = getWrapper({ mountType: mount, props: { users } })
+    const { wrapper } = getWrapper({ mountType: mount, users })
     await wrapper.find('.users-table-btn-action-dropdown').trigger('click')
     expect(spyDisplayPositionedDropdown).toHaveBeenCalledTimes(1)
   })
   it('should show the user details on details button click', async () => {
     const users = getUserMocks()
     const eventBusSpy = vi.spyOn(eventBus, 'publish')
-    const { wrapper } = getWrapper({ mountType: mount, props: { users } })
+    const { wrapper } = getWrapper({ mountType: mount, users })
     await wrapper.find('.users-table-btn-details').trigger('click')
     expect(eventBusSpy).toHaveBeenCalledWith(SideBarEventTopics.open)
   })
   it('should show the user edit panel on edit button click', async () => {
     const users = getUserMocks()
     const eventBusSpy = vi.spyOn(eventBus, 'publish')
-    const { wrapper } = getWrapper({ mountType: mount, props: { users } })
+    const { wrapper } = getWrapper({ mountType: mount, users })
     await wrapper.find('.users-table-btn-edit').trigger('click')
     expect(eventBusSpy).toHaveBeenCalledWith(SideBarEventTopics.openWithPanel, 'EditPanel')
   })
+  describe('toggle selection', () => {
+    describe('selectUsers method', () => {
+      it('selects all users', async () => {
+        const users = getUserMocks()
+        const { wrapper } = getWrapper({ mountType: shallowMount, users })
+        wrapper.vm.selectUsers(users)
+        const { setSelectedUsers } = useUserSettingsStore()
+        expect(setSelectedUsers).toHaveBeenCalledWith(users)
+      })
+    })
+    describe('selectUsers method', () => {
+      it('selects a user', async () => {
+        const users = getUserMocks()
+        const { wrapper } = getWrapper({ mountType: shallowMount, users: [users[0]] })
+        wrapper.vm.selectUser(users[0])
+        const { addSelectedUser } = useUserSettingsStore()
+        expect(addSelectedUser).toHaveBeenCalledWith(users[0])
+      })
+      it('de-selects a selected user', async () => {
+        const users = getUserMocks()
+        const { wrapper } = getWrapper({
+          mountType: shallowMount,
+          users: [users[0]],
+          selectedUsers: [users[0]]
+        })
+        wrapper.vm.selectUser(users[0])
+        const { setSelectedUsers } = useUserSettingsStore()
+        expect(setSelectedUsers).toHaveBeenCalledWith([])
+      })
+    })
+    describe('unselectAllUsers method', () => {
+      it('de-selects all selected users', async () => {
+        const users = getUserMocks()
+        const { wrapper } = getWrapper({
+          mountType: shallowMount,
+          users: [users[0]],
+          selectedUsers: [users[0]]
+        })
+        wrapper.vm.unselectAllUsers()
+        const { setSelectedUsers } = useUserSettingsStore()
+        expect(setSelectedUsers).toHaveBeenCalledWith([])
+      })
+    })
+  })
 })
 
-function getWrapper({ mountType = shallowMount, props = {} } = {}) {
+function getWrapper({ mountType = shallowMount, users = [], selectedUsers = [] } = {}) {
   vi.mocked(queryItemAsString).mockImplementationOnce(() => '1')
   vi.mocked(queryItemAsString).mockImplementationOnce(() => '100')
   const mocks = defaultComponentMocks()
   return {
     wrapper: mountType(UsersList, {
       props: {
-        users: [],
-        selectedUsers: [],
         roles: [
           {
             displayName: 'Admin',
@@ -150,11 +183,16 @@ function getWrapper({ mountType = shallowMount, props = {} } = {}) {
             id: '4'
           }
         ],
-        headerPosition: 0,
-        ...props
+        headerPosition: 0
       },
       global: {
-        plugins: [...defaultPlugins()],
+        plugins: [
+          ...defaultPlugins({
+            piniaOptions: {
+              userSettingsStore: { users, selectedUsers }
+            }
+          })
+        ],
         mocks,
         provide: mocks,
         stubs: {

--- a/packages/web-app-admin-settings/tests/unit/components/Users/UsersList.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/UsersList.spec.ts
@@ -114,7 +114,7 @@ describe('UsersList', () => {
   })
   describe('toggle selection', () => {
     describe('selectUsers method', () => {
-      it('selects all users', async () => {
+      it('selects all users', () => {
         const users = getUserMocks()
         const { wrapper } = getWrapper({ mountType: shallowMount, users })
         wrapper.vm.selectUsers(users)
@@ -123,14 +123,14 @@ describe('UsersList', () => {
       })
     })
     describe('selectUsers method', () => {
-      it('selects a user', async () => {
+      it('selects a user', () => {
         const users = getUserMocks()
         const { wrapper } = getWrapper({ mountType: shallowMount, users: [users[0]] })
         wrapper.vm.selectUser(users[0])
         const { addSelectedUser } = useUserSettingsStore()
         expect(addSelectedUser).toHaveBeenCalledWith(users[0])
       })
-      it('de-selects a selected user', async () => {
+      it('de-selects a selected user', () => {
         const users = getUserMocks()
         const { wrapper } = getWrapper({
           mountType: shallowMount,
@@ -143,7 +143,7 @@ describe('UsersList', () => {
       })
     })
     describe('unselectAllUsers method', () => {
-      it('de-selects all selected users', async () => {
+      it('de-selects all selected users', () => {
         const users = getUserMocks()
         const { wrapper } = getWrapper({
           mountType: shallowMount,

--- a/packages/web-app-admin-settings/tests/unit/composables/actions/groups/useGroupActionsDelete.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/composables/actions/groups/useGroupActionsDelete.spec.ts
@@ -2,8 +2,8 @@ import { useGroupActionsDelete } from '../../../../../src/composables/actions/gr
 import { mock } from 'vitest-mock-extended'
 import { unref } from 'vue'
 import { Group } from '@ownclouders/web-client/src/generated'
-import { eventBus } from '@ownclouders/web-pkg'
 import { defaultComponentMocks, getComposableWrapper } from 'web-test-helpers'
+import { useGroupSettingsStore } from '../../../../../src/composables'
 
 describe('useGroupActionsDelete', () => {
   describe('method "isVisible"', () => {
@@ -32,26 +32,26 @@ describe('useGroupActionsDelete', () => {
   })
   describe('method "deleteGroups"', () => {
     it('should successfully delete all given gropups and reload the groups list', () => {
-      const eventSpy = vi.spyOn(eventBus, 'publish')
       getWrapper({
         setup: async ({ deleteGroups }, { clientService }) => {
           const group = mock<Group>({ id: '1' })
           await deleteGroups([group])
           expect(clientService.graphAuthenticated.groups.deleteGroup).toHaveBeenCalledWith(group.id)
-          expect(eventSpy).toHaveBeenCalledWith('app.admin-settings.list.load')
+          const { removeGroups } = useGroupSettingsStore()
+          expect(removeGroups).toHaveBeenCalled()
         }
       })
     })
     it('should handle errors', () => {
       vi.spyOn(console, 'error').mockImplementation(() => undefined)
-      const eventSpy = vi.spyOn(eventBus, 'publish')
       getWrapper({
         setup: async ({ deleteGroups }, { clientService }) => {
           clientService.graphAuthenticated.groups.deleteGroup.mockRejectedValue({})
           const group = mock<Group>({ id: '1' })
           await deleteGroups([group])
           expect(clientService.graphAuthenticated.groups.deleteGroup).toHaveBeenCalledWith(group.id)
-          expect(eventSpy).toHaveBeenCalledWith('app.admin-settings.list.load')
+          const { removeGroups } = useGroupSettingsStore()
+          expect(removeGroups).toHaveBeenCalled()
         }
       })
     })

--- a/packages/web-app-admin-settings/tests/unit/composables/actions/users/useUserActionsDelete.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/composables/actions/users/useUserActionsDelete.spec.ts
@@ -2,8 +2,9 @@ import { useUserActionsDelete } from '../../../../../src/composables/actions/use
 import { mock } from 'vitest-mock-extended'
 import { unref } from 'vue'
 import { User } from '@ownclouders/web-client/src/generated'
-import { eventBus, useCapabilityStore } from '@ownclouders/web-pkg'
+import { useCapabilityStore } from '@ownclouders/web-pkg'
 import { defaultComponentMocks, getComposableWrapper, writable } from 'web-test-helpers'
+import { useUserSettingsStore } from '../../../../../src/composables/stores/userSettings'
 
 describe('useUserActionsDelete', () => {
   describe('method "isVisible"', () => {
@@ -27,26 +28,26 @@ describe('useUserActionsDelete', () => {
   })
   describe('method "deleteUsers"', () => {
     it('should successfully delete all given users and reload the users list', () => {
-      const eventSpy = vi.spyOn(eventBus, 'publish')
       getWrapper({
         setup: async ({ deleteUsers }, { clientService }) => {
           const user = mock<User>({ id: '1' })
           await deleteUsers([user])
           expect(clientService.graphAuthenticated.users.deleteUser).toHaveBeenCalledWith(user.id)
-          expect(eventSpy).toHaveBeenCalledWith('app.admin-settings.list.load')
+          const { removeUsers } = useUserSettingsStore()
+          expect(removeUsers).toHaveBeenCalled()
         }
       })
     })
     it('should handle errors', () => {
       vi.spyOn(console, 'error').mockImplementation(() => undefined)
-      const eventSpy = vi.spyOn(eventBus, 'publish')
       getWrapper({
         setup: async ({ deleteUsers }, { clientService }) => {
           clientService.graphAuthenticated.users.deleteUser.mockRejectedValue({})
           const user = mock<User>({ id: '1' })
           await deleteUsers([user])
           expect(clientService.graphAuthenticated.users.deleteUser).toHaveBeenCalledWith(user.id)
-          expect(eventSpy).toHaveBeenCalledWith('app.admin-settings.list.load')
+          const { removeUsers } = useUserSettingsStore()
+          expect(removeUsers).toHaveBeenCalled()
         }
       })
     })

--- a/packages/web-app-admin-settings/tests/unit/views/Groups.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/views/Groups.spec.ts
@@ -1,9 +1,8 @@
 import Groups from '../../../src/views/Groups.vue'
-import { mockAxiosResolve, mockAxiosReject } from 'web-test-helpers/src/mocks'
-import { mock, mockDeep } from 'vitest-mock-extended'
-import { ClientService, eventBus, useMessages } from '@ownclouders/web-pkg'
+import { mockAxiosResolve } from 'web-test-helpers/src/mocks'
+import { mockDeep } from 'vitest-mock-extended'
+import { ClientService } from '@ownclouders/web-pkg'
 import { defaultComponentMocks, defaultPlugins, mount } from 'web-test-helpers'
-import { Group } from '@ownclouders/web-client/src/generated'
 
 const selectors = { batchActionsStub: 'batch-actions-stub' }
 const getClientServiceMock = () => {
@@ -19,45 +18,9 @@ vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
 }))
 
 describe('Groups view', () => {
-  describe('method "onEditGroup"', () => {
-    it('should emit event on success', async () => {
-      const clientService = getClientServiceMock()
-      clientService.graphAuthenticated.groups.editGroup.mockResolvedValue(mockAxiosResolve())
-      clientService.graphAuthenticated.groups.getGroup.mockResolvedValue(
-        mockAxiosResolve({ id: '1', displayName: 'administrators' })
-      )
-      const { wrapper } = getWrapper({ clientService })
-
-      const editGroup = {
-        id: '1',
-        name: 'administrators'
-      }
-
-      const busStub = vi.spyOn(eventBus, 'publish')
-      await wrapper.vm.loadResourcesTask.last
-
-      const updatedGroup = await wrapper.vm.onEditGroup(editGroup)
-
-      expect(updatedGroup.id).toEqual('1')
-      expect(updatedGroup.displayName).toEqual('administrators')
-      expect(busStub).toHaveBeenCalled()
-    })
-
-    it('should show message on error', async () => {
-      vi.spyOn(console, 'error').mockImplementation(() => undefined)
-      const clientService = getClientServiceMock()
-      clientService.graphAuthenticated.groups.editGroup.mockImplementation(() => mockAxiosReject())
-      const { wrapper } = getWrapper({ clientService })
-      await wrapper.vm.onEditGroup({})
-
-      const { showErrorMessage } = useMessages()
-      expect(showErrorMessage).toHaveBeenCalled()
-    })
-  })
-
   describe('computed method "sideBarAvailablePanels"', () => {
     describe('EditPanel', () => {
-      it('should be available when one group is selected', () => {
+      it('should be available when one group is selected', async () => {
         const { wrapper } = getWrapper()
         expect(
           wrapper.vm.sideBarAvailablePanels
@@ -101,29 +64,37 @@ describe('Groups view', () => {
       expect(wrapper.find(selectors.batchActionsStub).exists()).toBeFalsy()
     })
     it('display when one group selected', async () => {
-      const { wrapper } = getWrapper()
+      const { wrapper } = getWrapper({ selectedGroups: [{ id: '1' }] })
       await wrapper.vm.loadResourcesTask.last
-      wrapper.vm.toggleSelectGroup({ id: '1' })
       await wrapper.vm.$nextTick()
       expect(wrapper.find(selectors.batchActionsStub).exists()).toBeTruthy()
     })
     it('display when more than one groups selected', async () => {
-      const { wrapper } = getWrapper()
+      const { wrapper } = getWrapper({ selectedGroups: [{ id: '1' }, { id: '2' }] })
       await wrapper.vm.loadResourcesTask.last
-      wrapper.vm.selectGroups([mock<Group>({ groupTypes: [] }), mock<Group>({ groupTypes: [] })])
       await wrapper.vm.$nextTick()
       expect(wrapper.find(selectors.batchActionsStub).exists()).toBeTruthy()
     })
   })
 })
 
-function getWrapper({ clientService = getClientServiceMock() } = {}) {
+function getWrapper({
+  clientService = getClientServiceMock(),
+  groups = [],
+  selectedGroups = []
+} = {}) {
   const mocks = { ...defaultComponentMocks(), $clientService: clientService }
 
   return {
     wrapper: mount(Groups, {
       global: {
-        plugins: [...defaultPlugins()],
+        plugins: [
+          ...defaultPlugins({
+            piniaOptions: {
+              groupSettingsStore: { groups, selectedGroups }
+            }
+          })
+        ],
         mocks,
         provide: mocks,
         stubs: {

--- a/packages/web-app-admin-settings/tests/unit/views/Users.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/views/Users.spec.ts
@@ -176,7 +176,6 @@ describe('Users view', () => {
         selectedUsers: [{ id: '1' }, { id: '2' }]
       })
       await wrapper.vm.loadResourcesTask.last
-      wrapper.vm.selectUsers([mock<User>(), mock<User>()])
       await wrapper.vm.$nextTick()
       expect(wrapper.find('batch-actions-stub').exists()).toBeTruthy()
     })

--- a/packages/web-app-admin-settings/tests/unit/views/Users.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/views/Users.spec.ts
@@ -1,15 +1,6 @@
 import Users from '../../../src/views/Users.vue'
-import {
-  ItemFilter,
-  OptionsConfig,
-  UserAction,
-  eventBus,
-  useAppDefaults,
-  useMessages,
-  useSpacesStore
-} from '@ownclouders/web-pkg'
+import { ItemFilter, OptionsConfig, UserAction, useAppDefaults } from '@ownclouders/web-pkg'
 import { mock, mockDeep } from 'vitest-mock-extended'
-import { mockAxiosResolve, mockAxiosReject } from 'web-test-helpers/src/mocks'
 import { defaultComponentMocks, defaultPlugins, mount, shallowMount } from 'web-test-helpers'
 import { AxiosResponse } from 'axios'
 import { ClientService, queryItemAsString } from '@ownclouders/web-pkg'
@@ -108,7 +99,7 @@ const selectors = {
 describe('Users view', () => {
   describe('list view', () => {
     it('renders list initially', async () => {
-      const { wrapper } = getMountedWrapper({ mountType: mount })
+      const { wrapper } = getMountedWrapper({ mountType: mount, users: [getDefaultUser()] })
       await wrapper.vm.loadResourcesTask.last
       expect(wrapper.html()).toMatchSnapshot()
     })
@@ -137,119 +128,6 @@ describe('Users view', () => {
       })
       const createUserButton = wrapper.find(selectors.createUserButton)
       expect(createUserButton.exists()).toBeFalsy()
-    })
-  })
-
-  describe('method "onEditUser"', () => {
-    it('should emit event on success', async () => {
-      const editUser = {
-        appRoleAssignments: [
-          {
-            appRoleId: '2',
-            resourceId: 'some-graph-app-id',
-            principalId: '1'
-          }
-        ],
-        displayName: 'administrator',
-        id: '1',
-        mail: 'administrator@example.org',
-        memberOf: [
-          {
-            displayName: 'admins',
-            id: '1'
-          }
-        ],
-        drive: {
-          id: '1',
-          name: 'admin',
-          quota: {
-            total: 1000000000
-          }
-        },
-        passwordProfile: {
-          password: 'administrator'
-        }
-      }
-
-      const clientService = getClientService()
-      clientService.graphAuthenticated.users.editUser.mockResolvedValue(mockAxiosResolve())
-      clientService.graphAuthenticated.users.createUserAppRoleAssignment.mockResolvedValue(
-        mockAxiosResolve()
-      )
-      clientService.graphAuthenticated.groups.addMember.mockResolvedValue(mockAxiosResolve())
-      clientService.graphAuthenticated.drives.updateDrive.mockResolvedValue(
-        mockAxiosResolve({
-          id: '1',
-          name: 'admin',
-          quota: { remaining: 1000000000, state: 'normal', total: 1000000000, used: 0 }
-        })
-      )
-      clientService.graphAuthenticated.users.getUser.mockResolvedValue(
-        mockAxiosResolve({
-          appRoleAssignments: [
-            {
-              appRoleId: '2',
-              id: '1',
-              principalId: '1',
-              principalType: 'User',
-              resourceDisplayName: 'ownCloud Infinite Scale',
-              resourceId: 'some-graph-app-id'
-            }
-          ],
-          displayName: 'administrator',
-          drive: {
-            id: '1',
-            name: 'admin',
-            quota: { remaining: 1000000000, state: 'normal', total: 1000000000, used: 0 }
-          },
-          id: '1',
-          mail: 'administrator@example.org',
-          memberOf: [
-            {
-              displayName: 'admins',
-              id: '1'
-            }
-          ],
-          onPremisesSamAccountName: 'admin',
-          surname: 'Admin'
-        })
-      )
-
-      const { wrapper } = getMountedWrapper({ clientService })
-
-      const busStub = vi.spyOn(eventBus, 'publish')
-
-      await wrapper.vm.loadResourcesTask.last
-
-      const userToUpDate = wrapper.vm.users.find((user) => user.id === '1')
-      const updatedUser = await wrapper.vm.onEditUser({ user: userToUpDate, editUser })
-
-      expect(updatedUser.id).toEqual('1')
-      expect(updatedUser.displayName).toEqual('administrator')
-      expect(updatedUser.mail).toEqual('administrator@example.org')
-      expect(updatedUser.appRoleAssignments[0].appRoleId).toEqual('2')
-      expect(updatedUser.drive.quota.total).toEqual(1000000000)
-      expect(updatedUser.memberOf[0].id).toEqual('1')
-
-      expect(busStub).toHaveBeenCalled()
-      const spacesStore = useSpacesStore()
-      expect(spacesStore.updateSpaceField).toHaveBeenCalled()
-    })
-
-    it('should show message on error', async () => {
-      vi.spyOn(console, 'error').mockImplementation(() => undefined)
-      const clientService = getClientService()
-      clientService.graphAuthenticated.users.editUser.mockImplementation(() => mockAxiosReject())
-      const { wrapper } = getMountedWrapper({ clientService })
-
-      await wrapper.vm.loadResourcesTask.last
-      await wrapper.vm.onEditUser({
-        user: {},
-        editUser: {}
-      })
-
-      const { showErrorMessage } = useMessages()
-      expect(showErrorMessage).toHaveBeenCalled()
     })
   })
 
@@ -287,14 +165,16 @@ describe('Users view', () => {
       expect(wrapper.find('batch-actions-stub').exists()).toBeFalsy()
     })
     it('display when one user selected', async () => {
-      const { wrapper } = getMountedWrapper({ mountType: mount })
+      const { wrapper } = getMountedWrapper({ mountType: mount, selectedUsers: [{ id: '1' }] })
       await wrapper.vm.loadResourcesTask.last
-      wrapper.vm.toggleSelectUser(getDefaultUser())
       await wrapper.vm.$nextTick()
       expect(wrapper.find('batch-actions-stub').exists()).toBeTruthy()
     })
     it('display when more than one users selected', async () => {
-      const { wrapper } = getMountedWrapper({ mountType: mount })
+      const { wrapper } = getMountedWrapper({
+        mountType: mount,
+        selectedUsers: [{ id: '1' }, { id: '2' }]
+      })
       await wrapper.vm.loadResourcesTask.last
       wrapper.vm.selectUsers([mock<User>(), mock<User>()])
       await wrapper.vm.$nextTick()
@@ -393,7 +273,9 @@ function getMountedWrapper({
   groupFilterQuery = null,
   roleFilterQuery = null,
   options = {},
-  createUserActionEnabled = true
+  createUserActionEnabled = true,
+  users = [],
+  selectedUsers = []
 }: {
   mountType?: typeof shallowMount | typeof mount
   clientService?: ReturnType<typeof mockDeep<ClientService>>
@@ -402,6 +284,8 @@ function getMountedWrapper({
   roleFilterQuery?: string
   options?: OptionsConfig
   createUserActionEnabled?: boolean
+  users?: User[]
+  selectedUsers?: User[]
 } = {}) {
   vi.mocked(queryItemAsString).mockImplementationOnce(() => displayNameFilterQuery)
   vi.mocked(queryItemAsString).mockImplementationOnce(() => groupFilterQuery)
@@ -427,7 +311,11 @@ function getMountedWrapper({
       global: {
         plugins: [
           ...defaultPlugins({
-            piniaOptions: { userState: { user }, configState: { options } }
+            piniaOptions: {
+              userState: { user },
+              configState: { options },
+              userSettingsStore: { users, selectedUsers }
+            }
           })
         ],
         mocks,

--- a/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Spaces.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Spaces.spec.ts.snap
@@ -17,7 +17,7 @@ exports[`Spaces view > loading states > should render spaces list after loading 
         </div>
       </div>
       <div>
-        <spaces-list-stub spaces="[object Object]" selectedspaces="" class=""></spaces-list-stub>
+        <spaces-list-stub class=""></spaces-list-stub>
       </div>
     </div>
     <!--v-if-->

--- a/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Users.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Users.spec.ts.snap
@@ -118,37 +118,11 @@ exports[`Users view > list view > renders list initially 1`] = `
             </thead>
             <tbody class="has-item-context-menu">
               <tr tabindex="-1" class="oc-tbody-tr oc-tbody-tr-1" data-item-id="1" draggable="false">
-                <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-select oc-pl-s"><span class="oc-ml-s"><input id="oc-checkbox-2" type="checkbox" name="checkbox" class="oc-checkbox oc-rounded oc-checkbox-l" value="undefined"> <label for="oc-checkbox-2" class="oc-invisible-sr oc-cursor-pointer">Select Admin</label></span></td>
+                <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-select oc-pl-s"><span class="oc-ml-s"><input id="oc-checkbox-2" type="checkbox" name="checkbox" class="oc-checkbox oc-rounded oc-checkbox-l" value="[object Object]"> <label for="oc-checkbox-2" class="oc-invisible-sr oc-cursor-pointer">Select Admin</label></span></td>
                 <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-avatar">
                   <avatar-image width="32" userid="1" user-name="Admin"></avatar-image>
                 </td>
-                <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-onPremisesSamAccountName">function(...a) {
-                  let r = v(t);
-                  r.called = !0, r.callCount++, r.calls.push(a);
-                  let i = r.next.shift();
-                  if (i) {
-                  r.results.push(i);
-                  let [s, l] = i;
-                  if (s === "ok")
-                  return l;
-                  throw l;
-                  }
-                  let o, c = "ok";
-                  if (r.impl)
-                  try {
-                  new.target ? o = Reflect.construct(r.impl, a, new.target) : o = r.impl.apply(this, a), c = "ok";
-                  } catch (s) {
-                  throw o = s, c = "error", r.results.push([c, s]), s;
-                  }
-                  let x = [c, o];
-                  if (b(o)) {
-                  let s = o.then((l) => x[1] = l).catch((l) => {
-                  throw x[0] = "error", x[1] = l, l;
-                  });
-                  Object.assign(s, o), o = s;
-                  }
-                  return r.results.push(x), o;
-                  }</td>
+                <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-onPremisesSamAccountName"></td>
                 <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-displayName mark-element">Admin</td>
                 <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-mail">admin@example.org</td>
                 <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-role">Admin</td>

--- a/packages/web-test-helpers/src/mocks/pinia.ts
+++ b/packages/web-test-helpers/src/mocks/pinia.ts
@@ -1,6 +1,6 @@
 import { createTestingPinia } from '@pinia/testing'
 import defaultTheme from '../../../web-runtime/themes/owncloud/theme.json'
-import { User } from '../../../web-client/src/generated'
+import { User, Group } from '../../../web-client/src/generated'
 import { Message, Modal, WebThemeType } from '../../../web-pkg/src/composables/piniaStores'
 import { Capabilities } from '../../../web-client/src/ocs'
 import { mock } from 'vitest-mock-extended'
@@ -32,6 +32,18 @@ export type PiniaMockOptions = {
   }
   messagesState?: { messages?: Message[] }
   modalsState?: { modals?: Modal[] }
+  spaceSettingsStore?: {
+    spaces?: SpaceResource[]
+    selectedSpaces?: SpaceResource[]
+  }
+  groupSettingsStore?: {
+    groups?: Group[]
+    selectedGroups?: Group[]
+  }
+  userSettingsStore?: {
+    users?: User[]
+    selectedUsers?: User[]
+  }
   resourcesStore?: {
     resources?: Resource[]
     currentFolder?: Resource
@@ -58,6 +70,9 @@ export function createMockStore({
   messagesState = {},
   modalsState = {},
   resourcesStore = {},
+  userSettingsStore = {},
+  groupSettingsStore = {},
+  spaceSettingsStore = {},
   sharesState = {},
   spacesState = {},
   userState = {},
@@ -105,7 +120,10 @@ export function createMockStore({
       },
       resources: { resources: [], ...resourcesStore },
       shares: { shares: [], ...sharesState },
-      spaces: { spaces: [], spaceMembers: [], ...spacesState },
+      spaces: { spaces: [], spaceMembers: [], ...spacesState, ...spaceSettingsStore },
+      userSettings: { users: [], selectedUsers: [], ...userSettingsStore },
+      groupSettings: { groups: [], selectedGroups: [], ...groupSettingsStore },
+      spaceSettings: { spaces: [], selectedSpaces: [], ...spaceSettingsStore },
       user: { user: { ...mock<User>({ id: '1' }), ...(userState?.user && { ...userState.user }) } },
       capabilities: {
         isInitialized: capabilityState?.isInitialized ? capabilityState.isInitialized : true,


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
We've fixed a bug where keyboard navigation stopped working after deleting a resource in the admin settings app.
We also fixed a bug where initial keyboard navigation didn't work, when no resource was selected.

This has been archived to add respective stores of the available  user, space, group resources. Due to this change decluttering was also possible:
- move the edit/save methods to the responsible components instead bubbling up to the view component
- remove excessive code paths to handle events 



## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10186

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
