### PR TITLE
[tests-only] remove share access details tests and add e2e coverage

### DIFF
--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -8,48 +8,53 @@ Level-3 headings should be used for the references to the relevant issues. Inclu
 
 Other free text and markdown formatting can be used elsewhere in the document if needed. But if you want to explain something about the issue, then please post that in the issue itself.
 
-
 ### [Exit page re-appears in loop when logged in user is deleted](https://github.com/owncloud/web/issues/4677)
--   [webUILogin/openidLogin.feature:50](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/openidLogin.feature#L50)
--   [webUILogin/openidLogin.feature:60](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/openidLogin.feature#L60)
 
-### [Share additional info](https://github.com/owncloud/ocis/issues/1253)
--   [webUISharingInternalUsersShareWithPage/shareWithUsers.feature:115](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingInternalUsersShareWithPage/shareWithUsers.feature#L115)
-
-### [Different path for shares inside folder](https://github.com/owncloud/ocis/issues/1231)
+- [webUILogin/openidLogin.feature:50](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/openidLogin.feature#L50)
+- [webUILogin/openidLogin.feature:60](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/openidLogin.feature#L60)
 
 ### [Conflict / overwrite issues with TUS](https://github.com/owncloud/ocis/issues/1294)
--   [webUIUpload/uploadFileGreaterThanQuotaSize.feature:11](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature#L11)
+
+- [webUIUpload/uploadFileGreaterThanQuotaSize.feature:11](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature#L11)
 
 ### [restoring a file deleted from a received shared folder is not possible](https://github.com/owncloud/ocis/issues/1124)
--   [webUITrashbinRestore/trashbinRestore.feature:176](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature#L176)
+
+- [webUITrashbinRestore/trashbinRestore.feature:176](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature#L176)
 
 ### [Deletion of a recursive folder from trashbin is not possible](https://github.com/owncloud/product/issues/188)
--   [webUITrashbinDelete/trashbinDelete.feature:51](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITrashbinDelete/trashbinDelete.feature#L51)
--   [webUITrashbinDelete/trashbinDelete.feature:65](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITrashbinDelete/trashbinDelete.feature#L65)
+
+- [webUITrashbinDelete/trashbinDelete.feature:51](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITrashbinDelete/trashbinDelete.feature#L51)
+- [webUITrashbinDelete/trashbinDelete.feature:65](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITrashbinDelete/trashbinDelete.feature#L65)
 
 ### [Saving public share is not possible](https://github.com/owncloud/web/issues/5321)
--   [webUISharingPublicManagement/shareByPublicLink.feature:24](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature#L24)
+
+- [webUISharingPublicManagement/shareByPublicLink.feature:24](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature#L24)
 
 ### [Uploading folders does not work in files-drop](https://github.com/owncloud/web/issues/2443)
--   [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:263](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L263)
+
+- [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:263](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L263)
 
 ### [Resources cannot be locked under ocis](https://github.com/owncloud/ocis/issues/1284)
--   [webUIWebdavLockProtection/delete.feature:33](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIWebdavLockProtection/delete.feature#L33)
--   [webUIWebdavLockProtection/delete.feature:34](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIWebdavLockProtection/delete.feature#L34)
--   [webUIWebdavLockProtection/move.feature:36](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIWebdavLockProtection/move.feature#L36)
--   [webUIWebdavLockProtection/move.feature:37](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIWebdavLockProtection/move.feature#L37)
--   [webUIWebdavLockProtection/upload.feature:32](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIWebdavLockProtection/upload.feature#L32)
+
+- [webUIWebdavLockProtection/delete.feature:33](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIWebdavLockProtection/delete.feature#L33)
+- [webUIWebdavLockProtection/delete.feature:34](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIWebdavLockProtection/delete.feature#L34)
+- [webUIWebdavLockProtection/move.feature:36](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIWebdavLockProtection/move.feature#L36)
+- [webUIWebdavLockProtection/move.feature:37](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIWebdavLockProtection/move.feature#L37)
+- [webUIWebdavLockProtection/upload.feature:32](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIWebdavLockProtection/upload.feature#L32)
 
 ### [Resources cannot be locked under ocis](https://github.com/owncloud/ocis/issues/1284)
--   [webUIWebdavLockProtection/upload.feature:33](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIWebdavLockProtection/upload.feature#L33)
+
+- [webUIWebdavLockProtection/upload.feature:33](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIWebdavLockProtection/upload.feature#L33)
 
 ### [Writing to locked files/folders give only a generic error message](https://github.com/owncloud/web/issues/5741)
--   [webUIWebdavLockProtection/upload.feature:32](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIWebdavLockProtection/upload.feature#L32)
--   [webUIWebdavLockProtection/upload.feature:33](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIWebdavLockProtection/upload.feature#L33)
+
+- [webUIWebdavLockProtection/upload.feature:32](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIWebdavLockProtection/upload.feature#L32)
+- [webUIWebdavLockProtection/upload.feature:33](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIWebdavLockProtection/upload.feature#L33)
 
 ### [empty subfolder inside a folder to be uploaded is not created on the server](https://github.com/owncloud/web/issues/6348)
--   [webUIUpload/upload.feature:43](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/upload.feature#L43)
+
+- [webUIUpload/upload.feature:43](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/upload.feature#L43)
 
 ### [PROPFIND to sub-folder of a shared resources with same name gives 404](https://github.com/owncloud/ocis/issues/3859)
--   [webUISharingAcceptShares/acceptShares.feature:73](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature#L73)
+
+- [webUISharingAcceptShares/acceptShares.feature:73](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature#L73)

--- a/tests/acceptance/features/webUISharingInternalUsersShareWithPage/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsersShareWithPage/shareWithUsers.feature
@@ -102,28 +102,6 @@ Feature: Shares in share-with pages
     And the user browses to the shared-with-me page in declined shares view
     Then the unshared elements should be in declined state on the webUI
 
-  @issue-ocis-1328
-  Scenario Outline: collaborators list contains additional info when enabled
-    Given the setting "user_additional_info_field" of app "core" has been set to "<additional-info-field>" in the server
-    And user "Alice" has created folder "simple-folder" in the server
-    And user "Alice" has shared folder "simple-folder" with user "Brian" in the server
-    When user "Alice" has logged in using the webUI
-    And the user opens the share dialog for folder "simple-folder" using the webUI
-    Then user "Brian Murphy" should be listed with additional info "<additional-info-result>" in the collaborators list on the webUI
-    Examples:
-      | additional-info-field | additional-info-result |
-      | id                    | Brian                  |
-      | email                 | brian@example.org      |
-
-  @issue-ocis-1328
-  Scenario: collaborators list does not contain additional info when disabled
-    Given the setting "user_additional_info_field" of app "core" has been set to "" in the server
-    And user "Alice" has created folder "simple-folder" in the server
-    And user "Alice" has shared folder "simple-folder" with user "Brian" in the server
-    When user "Alice" has logged in using the webUI
-    And the user opens the share dialog for folder "simple-folder" using the webUI
-    Then user "Brian Murphy" should be listed without additional info in the collaborators list on the webUI
-
 
   Scenario: share a file with another internal user via collaborators quick action
     Given user "Alice" has created folder "simple-folder" in the server

--- a/tests/e2e/cucumber/features/smoke/shares/share.feature
+++ b/tests/e2e/cucumber/features/smoke/shares/share.feature
@@ -6,11 +6,11 @@ Feature: share
       | Alice |
       | Brian |
     And "Brian" logs in
-    # disabling auto accepting to check accepting share
-    And "Brian" disables auto-accepting using API
 
   Scenario: folder
-    Given "Alice" logs in
+    # disabling auto accepting to check accepting share
+    Given "Brian" disables auto-accepting using API
+    And "Alice" logs in
     And "Alice" creates the following folder in personal space using API
       | name                   |
       | folder_to_shared       |
@@ -29,15 +29,15 @@ Feature: share
 
     And "Brian" opens the "files" app
     And "Brian" navigates to the shared with me page
-    And "Brian" enables the sync for the following share
+    And "Brian" enables the sync for the following shares
       | name                   |
       | folder_to_shared       |
       | folder_to_customShared |
     Then "Brian" should not see a sync status for the folder "shared_folder"
-    When "Brian" enables the sync for the following share from the context menu
+    When "Brian" enables the sync for the following share using the context menu
       | name          |
       | shared_folder |
-    And "Brian" disables the sync for all shares using the context menu
+    And "Brian" disables the sync for the following share using the context menu
       | name          |
       | shared_folder |
     And "Brian" renames the following resource
@@ -95,18 +95,7 @@ Feature: share
 
     And "Brian" opens the "files" app
     And "Brian" navigates to the shared with me page
-    Then "Brian" should not see a sync status for the file "shareToBrian.txt"
-    When "Brian" enables the sync for the following share
-      | name             |
-      | shareToBrian.txt |
-      | shareToBrian.md  |
-      | testavatar.jpeg  |
-      | simple.pdf       |
-    Then "Brian" should not see a sync status for the file "sharedFile.txt"
-    When "Brian" enables the sync for the following share from the context menu
-      | name           |
-      | sharedFile.txt |
-    And "Brian" disables the sync for all shares using the context menu
+    And "Brian" disables the sync for the following share
       | name           |
       | sharedFile.txt |
     And "Brian" edits the following resources
@@ -157,13 +146,15 @@ Feature: share
 
     # set expirationDate to existing share
     And "Alice" sets the expiration date of share "mainFolder" of user "Brian" to "+5 days"
+    And "Alice" checks the following access details of share "mainFolder" for user "Brian"
+      | Name            | Brian Murphy      |
+      | Additional info | brian@example.org |
+      | Type            | User              |
     And "Alice" sets the expiration date of share "myfolder" of group "sales" to "+3 days"
+    And "Alice" checks the following access details of share "myfolder" for group "sales"
+      | Name            | sales department |
+      | Type            | Group            |
     And  "Alice" logs out
 
     And "Brian" navigates to the shared with me page
-    And "Brian" enables the sync for the following share
-      | name       |
-      | new.txt    |
-      | myfolder   |
-      | mainFolder |
     And "Brian" logs out

--- a/tests/e2e/cucumber/steps/ui/shares.ts
+++ b/tests/e2e/cucumber/steps/ui/shares.ts
@@ -148,7 +148,7 @@ When(
 )
 
 When(
-  '{string} enables the sync for the following share(s) from the context menu',
+  '{string} enables the sync for the following share(s) using the context menu',
   async function (this: World, stepUser: string, stepTable: DataTable): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const shareObject = new objects.applicationFiles.Share({ page })
@@ -169,7 +169,7 @@ When(
 )
 
 When(
-  '{string} disables the sync for all shares using the context menu',
+  '{string} disables the sync for the following share(s) using the context menu',
   async function (this: World, stepUser: string, stepTable: DataTable): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const shareObject = new objects.applicationFiles.Share({ page })
@@ -209,12 +209,11 @@ When(
 )
 
 When(
-  /"([^"]*)" (should|should not) see a sync status for the (folder|file) "([^"]*)"?$/,
+  /"([^"]*)" (should|should not) see a sync status for the (?:folder|file) "([^"]*)"?$/,
   async function (
     this: World,
     stepUser: string,
     condition: string,
-    _: string,
     resource: string
   ): Promise<void> {
     const shouldSee = condition === 'should'
@@ -245,12 +244,11 @@ Then(
 )
 
 When(
-  /^"([^"]*)" (grants|denies) access to the following resources(s)? for (group|user) "([^"]*)" using the sidebar panel?$/,
+  /^"([^"]*)" (grants|denies) access to the following resources(?:s)? for (group|user) "([^"]*)" using the sidebar panel?$/,
   async function (
     this: World,
     stepUser: string,
     actionType: string,
-    _: unknown,
     collaboratorType: 'user' | 'group',
     collaborator: string,
     stepTable: DataTable
@@ -297,5 +295,33 @@ When(
       } as ICollaborator,
       expirationDate
     })
+  }
+)
+
+When(
+  /^"([^"]*)" checks the following access details of share "([^"]*)" for (user|group) "([^"]*)"$/,
+  async function (
+    this: World,
+    stepUser: string,
+    resource: string,
+    collaboratorType: string,
+    collaboratorName: string,
+    stepTable: DataTable
+  ): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const shareObject = new objects.applicationFiles.Share({ page })
+    const expectedDetails = stepTable.rowsHash()
+    const actualDetails = await shareObject.getAccessDetails({
+      resource,
+      collaborator: {
+        collaborator:
+          collaboratorType === 'group'
+            ? this.usersEnvironment.getGroup({ key: collaboratorName })
+            : this.usersEnvironment.getUser({ key: collaboratorName }),
+        type: collaboratorType
+      } as ICollaborator
+    })
+
+    expect(actualDetails).toMatchObject(expectedDetails)
   }
 )

--- a/tests/e2e/support/objects/app-files/share/actions.ts
+++ b/tests/e2e/support/objects/app-files/share/actions.ts
@@ -1,6 +1,6 @@
 import { Page, expect } from '@playwright/test'
 import util from 'util'
-import Collaborator, { ICollaborator } from './collaborator'
+import Collaborator, { ICollaborator, IAccessDetails } from './collaborator'
 import { sidebar } from '../utils'
 import { clickResource } from '../resource/actions'
 import { clearCurrentPopup, createLinkArgs } from '../link/actions'
@@ -274,4 +274,15 @@ export const addExpirationDate = async (args: {
     ),
     Collaborator.setExpirationDateForCollaborator({ page, collaborator, expirationDate })
   ])
+}
+
+export const getAccessDetails = async (args: {
+  page: Page
+  resource: string
+  collaborator: Omit<ICollaborator, 'role'>
+}): Promise<IAccessDetails> => {
+  const { page, resource, collaborator } = args
+  await openSharingPanel(page, resource)
+
+  return Collaborator.getAccessDetails(page, collaborator)
 }

--- a/tests/e2e/support/objects/app-files/share/index.ts
+++ b/tests/e2e/support/objects/app-files/share/index.ts
@@ -2,7 +2,7 @@ import { Page } from '@playwright/test'
 import * as po from './actions'
 import { resourceIsNotOpenable, isAcceptedSharePresent, resourceIsSynced } from './utils'
 import { createLinkArgs } from '../link/actions'
-import { ICollaborator } from './collaborator'
+import { ICollaborator, IAccessDetails } from './collaborator'
 export class Share {
   #page: Page
 
@@ -85,5 +85,18 @@ export class Share {
     const startUrl = this.#page.url()
     await po.addExpirationDate({ resource, collaborator, expirationDate, page: this.#page })
     await this.#page.goto(startUrl)
+  }
+
+  async getAccessDetails({
+    resource,
+    collaborator
+  }: {
+    resource: string
+    collaborator: Omit<ICollaborator, 'role'>
+  }): Promise<IAccessDetails> {
+    const startUrl = this.#page.url()
+    const accessDetails = await po.getAccessDetails({ resource, collaborator, page: this.#page })
+    await this.#page.goto(startUrl)
+    return accessDetails
   }
 }


### PR DESCRIPTION
## Description
Removed acceptance tests that checks the share access details and added the coverage in e2e

## Related Issue
- https://github.com/owncloud/web/issues/10259


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
