### PR TITLE
refactor: adjust building share resources after server changes

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=024e02be95f4808cc907795b44a4cb2ef96a3ca6
+OCIS_COMMITID=5484a4a6eda1c9520e645b2119920ab76b88d1ef
 OCIS_BRANCH=master

--- a/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
+++ b/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
@@ -227,7 +227,7 @@ export default defineComponent({
 
   computed: {
     displayedFields() {
-      return ['name', 'syncEnabled', 'owner', 'sdate', 'sharedWith']
+      return ['name', 'syncEnabled', 'sharedBy', 'sdate', 'sharedWith']
     },
     countFiles() {
       return this.items.filter((s) => s.type !== 'folder').length

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -68,7 +68,10 @@
             <span v-text="sharedByDisplayNames" />
           </td>
         </tr>
-        <tr v-if="ownerDisplayName" data-testid="ownerDisplayName">
+        <tr
+          v-if="ownerDisplayName && ownerDisplayName !== sharedByDisplayNames"
+          data-testid="ownerDisplayName"
+        >
           <th scope="col" class="oc-pr-s oc-font-semibold" v-text="$gettext('Owner')" />
           <td>
             <p class="oc-m-rm">

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -65,7 +65,7 @@
         <tr v-if="showSharedBy" data-testid="shared-by">
           <th scope="col" class="oc-pr-s oc-font-semibold" v-text="$gettext('Shared by')" />
           <td>
-            <span v-text="sharedByDisplayName" />
+            <span v-text="sharedByDisplayNames" />
           </td>
         </tr>
         <tr v-if="ownerDisplayName" data-testid="ownerDisplayName">
@@ -302,7 +302,7 @@ export default defineComponent({
       )
     },
     showSharedBy() {
-      return this.showShares && !this.ownedByCurrentUser && this.sharedByDisplayName
+      return this.showShares && !this.ownedByCurrentUser && this.sharedByDisplayNames
     },
     showSharedVia() {
       return this.showShares && this.sharedAncestor
@@ -352,16 +352,16 @@ export default defineComponent({
       )
     },
     ownedByCurrentUser() {
-      return this.resource.owner?.id === this.user?.onPremisesSamAccountName
+      return this.resource.owner?.id === this.user?.id
     },
     shareIndicators() {
       return getIndicators({ resource: this.resource, ancestorMetaData: this.ancestorMetaData })
     },
-    sharedByDisplayName() {
+    sharedByDisplayNames() {
       if (!isShareResource(this.resource)) {
         return ''
       }
-      return this.resource.sharedBy?.displayName
+      return this.resource.sharedBy?.map(({ displayName }) => displayName).join(', ')
     }
   },
   methods: {

--- a/packages/web-app-files/src/views/shares/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithMe.vue
@@ -190,7 +190,9 @@ export default defineComponent({
 
       const selectedSharedBy = queryItemAsString(unref(selectedSharedByQuery))?.split('+')
       if (selectedSharedBy?.length) {
-        result = result.filter(({ owner }) => selectedSharedBy.includes(owner.id))
+        result = result.filter(({ sharedBy }) =>
+          sharedBy.some(({ id }) => selectedSharedBy.includes(id))
+        )
       }
 
       if (unref(filterTerm).trim()) {

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.ts
@@ -115,7 +115,7 @@ describe('Details SideBar Panel', () => {
     it('shows if the resource is a share from another user', () => {
       const resource = getResourceMock({
         shareTypes: [ShareTypes.user.value],
-        sharedBy: { id: '1', displayName: 'Marie' }
+        sharedBy: [{ id: '1', displayName: 'Marie' }]
       })
       const { wrapper } = createWrapper({
         resource,

--- a/packages/web-app-files/tests/unit/views/shares/SharedWithMe.spec.ts
+++ b/packages/web-app-files/tests/unit/views/shares/SharedWithMe.spec.ts
@@ -100,11 +100,11 @@ describe('SharedWithMe view', () => {
         const { wrapper } = getMountedWrapper({
           files: [
             mock<IncomingShareResource>({
-              sharedBy: collaborator1,
+              sharedBy: [collaborator1],
               shareTypes: [ShareTypes.user.value]
             }),
             mock<IncomingShareResource>({
-              sharedBy: collaborator2,
+              sharedBy: [collaborator2],
               shareTypes: [ShareTypes.user.value]
             })
           ]

--- a/packages/web-client/src/generated/api.ts
+++ b/packages/web-client/src/generated/api.ts
@@ -834,6 +834,18 @@ export interface DriveItem {
      * @memberof DriveItem
      */
     'video'?: Video;
+    /**
+     * Indicates if the item is synchronized with the underlying storage provider. Read-only.
+     * @type {boolean}
+     * @memberof DriveItem
+     */
+    '@client.synchronize'?: boolean;
+    /**
+     * Properties or facets (see UI.Facet) annotated with this term will not be rendered if the annotation evaluates to true. Users can set this to hide permissons.
+     * @type {boolean}
+     * @memberof DriveItem
+     */
+    '@UI.Hidden'?: boolean;
 }
 /**
  * 
@@ -1629,17 +1641,11 @@ export interface Permission {
      */
     '@libre.graph.permissions.actions'?: Array<string>;
     /**
-     * Indicates if the item is synchronized with the underlying storage provider. Read-only.
-     * @type {boolean}
+     * 
+     * @type {SharingInvitation}
      * @memberof Permission
      */
-    '@client.synchronize'?: boolean;
-    /**
-     * Properties or facets (see UI.Facet) annotated with this term will not be rendered if the annotation evaluates to true. Users can set this to hide permissons.
-     * @type {boolean}
-     * @memberof Permission
-     */
-    '@ui.hidden'?: boolean;
+    'invitation'?: SharingInvitation;
 }
 /**
  * The photo resource provides photo and camera properties, for example, EXIF metadata, on a driveItem. 
@@ -1842,12 +1848,6 @@ export interface RemoteItem {
      */
     'parentReference'?: ItemReference;
     /**
-     * 
-     * @type {Shared}
-     * @memberof RemoteItem
-     */
-    'shared'?: Shared;
-    /**
      * The set of permissions for the item. Read-only. Nullable.
      * @type {Array<Permission>}
      * @memberof RemoteItem
@@ -1898,35 +1898,17 @@ export interface SharePointIdentitySet {
     'group'?: Identity;
 }
 /**
- * 
+ * invitation-related data items 
  * @export
- * @interface Shared
+ * @interface SharingInvitation
  */
-export interface Shared {
+export interface SharingInvitation {
     /**
      * 
      * @type {IdentitySet}
-     * @memberof Shared
+     * @memberof SharingInvitation
      */
-    'owner'?: IdentitySet;
-    /**
-     * Indicates the scope of how the item is shared: anonymous, organization, or users. Read-only.
-     * @type {string}
-     * @memberof Shared
-     */
-    'scope'?: string;
-    /**
-     * 
-     * @type {IdentitySet}
-     * @memberof Shared
-     */
-    'sharedBy'?: IdentitySet;
-    /**
-     * The UTC date and time when the item was shared. Read-only.
-     * @type {string}
-     * @memberof Shared
-     */
-    'sharedDateTime'?: string;
+    'invitedBy'?: IdentitySet;
 }
 /**
  * The `SharingLink` resource groups link-related data items into a single structure.  If a `permission` resource has a non-null `sharingLink` facet, the permission represents a sharing link (as opposed to permissions granted to a person or group). 
@@ -2461,7 +2443,7 @@ export class ApplicationsApi extends BaseAPI {
 export const DriveItemApiAxiosParamCreator = function (configuration?: Configuration) {
     return {
         /**
-         * Delete a DriveItem by using its ID.  Deleting items using this method moves the items to the recycle bin instead of permanently deleting the item.  Mounted shares in the share jail are unmounted. The `@client.synchronize` property of the `remoteItem` in the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint will change to false. 
+         * Delete a DriveItem by using its ID.  Deleting items using this method moves the items to the recycle bin instead of permanently deleting the item.  Mounted shares in the share jail are unmounted. The `@client.synchronize` property of the `driveItem` in the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint will change to false. 
          * @summary Delete a DriveItem.
          * @param {string} driveId key: id of drive
          * @param {string} itemId key: id of item
@@ -2509,7 +2491,7 @@ export const DriveItemApiFp = function(configuration?: Configuration) {
     const localVarAxiosParamCreator = DriveItemApiAxiosParamCreator(configuration)
     return {
         /**
-         * Delete a DriveItem by using its ID.  Deleting items using this method moves the items to the recycle bin instead of permanently deleting the item.  Mounted shares in the share jail are unmounted. The `@client.synchronize` property of the `remoteItem` in the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint will change to false. 
+         * Delete a DriveItem by using its ID.  Deleting items using this method moves the items to the recycle bin instead of permanently deleting the item.  Mounted shares in the share jail are unmounted. The `@client.synchronize` property of the `driveItem` in the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint will change to false. 
          * @summary Delete a DriveItem.
          * @param {string} driveId key: id of drive
          * @param {string} itemId key: id of item
@@ -2531,7 +2513,7 @@ export const DriveItemApiFactory = function (configuration?: Configuration, base
     const localVarFp = DriveItemApiFp(configuration)
     return {
         /**
-         * Delete a DriveItem by using its ID.  Deleting items using this method moves the items to the recycle bin instead of permanently deleting the item.  Mounted shares in the share jail are unmounted. The `@client.synchronize` property of the `remoteItem` in the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint will change to false. 
+         * Delete a DriveItem by using its ID.  Deleting items using this method moves the items to the recycle bin instead of permanently deleting the item.  Mounted shares in the share jail are unmounted. The `@client.synchronize` property of the `driveItem` in the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint will change to false. 
          * @summary Delete a DriveItem.
          * @param {string} driveId key: id of drive
          * @param {string} itemId key: id of item
@@ -2552,7 +2534,7 @@ export const DriveItemApiFactory = function (configuration?: Configuration, base
  */
 export class DriveItemApi extends BaseAPI {
     /**
-     * Delete a DriveItem by using its ID.  Deleting items using this method moves the items to the recycle bin instead of permanently deleting the item.  Mounted shares in the share jail are unmounted. The `@client.synchronize` property of the `remoteItem` in the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint will change to false. 
+     * Delete a DriveItem by using its ID.  Deleting items using this method moves the items to the recycle bin instead of permanently deleting the item.  Mounted shares in the share jail are unmounted. The `@client.synchronize` property of the `driveItem` in the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint will change to false. 
      * @summary Delete a DriveItem.
      * @param {string} driveId key: id of drive
      * @param {string} itemId key: id of item
@@ -3704,7 +3686,7 @@ export class DrivesPermissionsApi extends BaseAPI {
 export const DrivesRootApiAxiosParamCreator = function (configuration?: Configuration) {
     return {
         /**
-         * You can use the root childrens endpoint to mount a remoteItem in the share jail. The `@client.synchronize` property of the `remoteItem` in the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint will change to true. 
+         * You can use the root childrens endpoint to mount a remoteItem in the share jail. The `@client.synchronize` property of the `driveItem` in the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint will change to true. 
          * @summary Create a drive item
          * @param {string} driveId key: id of drive
          * @param {DriveItem} [driveItem] In the request body, provide a JSON object with the following parameters. For mounting a share the necessary remoteItem id and permission id can be taken from the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint.
@@ -3786,7 +3768,7 @@ export const DrivesRootApiFp = function(configuration?: Configuration) {
     const localVarAxiosParamCreator = DrivesRootApiAxiosParamCreator(configuration)
     return {
         /**
-         * You can use the root childrens endpoint to mount a remoteItem in the share jail. The `@client.synchronize` property of the `remoteItem` in the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint will change to true. 
+         * You can use the root childrens endpoint to mount a remoteItem in the share jail. The `@client.synchronize` property of the `driveItem` in the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint will change to true. 
          * @summary Create a drive item
          * @param {string} driveId key: id of drive
          * @param {DriveItem} [driveItem] In the request body, provide a JSON object with the following parameters. For mounting a share the necessary remoteItem id and permission id can be taken from the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint.
@@ -3819,7 +3801,7 @@ export const DrivesRootApiFactory = function (configuration?: Configuration, bas
     const localVarFp = DrivesRootApiFp(configuration)
     return {
         /**
-         * You can use the root childrens endpoint to mount a remoteItem in the share jail. The `@client.synchronize` property of the `remoteItem` in the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint will change to true. 
+         * You can use the root childrens endpoint to mount a remoteItem in the share jail. The `@client.synchronize` property of the `driveItem` in the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint will change to true. 
          * @summary Create a drive item
          * @param {string} driveId key: id of drive
          * @param {DriveItem} [driveItem] In the request body, provide a JSON object with the following parameters. For mounting a share the necessary remoteItem id and permission id can be taken from the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint.
@@ -3850,7 +3832,7 @@ export const DrivesRootApiFactory = function (configuration?: Configuration, bas
  */
 export class DrivesRootApi extends BaseAPI {
     /**
-     * You can use the root childrens endpoint to mount a remoteItem in the share jail. The `@client.synchronize` property of the `remoteItem` in the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint will change to true. 
+     * You can use the root childrens endpoint to mount a remoteItem in the share jail. The `@client.synchronize` property of the `driveItem` in the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint will change to true. 
      * @summary Create a drive item
      * @param {string} driveId key: id of drive
      * @param {DriveItem} [driveItem] In the request body, provide a JSON object with the following parameters. For mounting a share the necessary remoteItem id and permission id can be taken from the [sharedWithMe](#/me.drive/ListSharedWithMe) endpoint.

--- a/packages/web-client/src/helpers/resource/types.ts
+++ b/packages/web-client/src/helpers/resource/types.ts
@@ -69,15 +69,15 @@ export interface Resource {
   spaceReadmeData?: any
   mimeType?: string
   isFolder?: boolean
-  sdate?: string
+  sdate?: string // FIXME: move to `ShareResource`
   mdate?: string
   indicators?: any[]
   size?: number | string // FIXME
   permissions?: string
   starred?: boolean
   etag?: string
-  shareId?: string
-  shareRoot?: string
+  shareId?: string // FIXME: this originates from the old OCS api, should be removed in the future
+  shareRoot?: string // FIXME: this originates from the old OCS api, should be removed in the future
   shareTypes?: number[]
   privateLink?: string
   description?: string

--- a/packages/web-client/src/helpers/share/types.ts
+++ b/packages/web-client/src/helpers/share/types.ts
@@ -21,7 +21,7 @@ export enum GraphSharePermission {
 
 export interface ShareResource extends Resource {
   sharedWith: Array<{ shareType: number } & Identity>
-  sharedBy: Identity
+  sharedBy: Identity[]
   outgoing: boolean
 }
 export interface OutgoingShareResource extends ShareResource {}

--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -1056,7 +1056,7 @@ export default defineComponent({
         resource.type === 'folder' ? this.$gettext('folder') : this.$gettext('file')
       return this.$gettext('This %{ resourceType } is owned by %{ ownerName }', {
         resourceType,
-        ownerName: resource.owner.displayName
+        ownerName: resource.owner?.displayName || ''
       })
     },
     getOwnerAvatarItems(resource: Resource) {
@@ -1066,10 +1066,10 @@ export default defineComponent({
 
       return [
         {
-          displayName: resource.owner.displayName,
-          name: resource.owner.displayName,
+          displayName: resource.owner?.displayName,
+          name: resource.owner?.displayName,
           shareType: ShareTypes.user.value,
-          username: resource.owner.id
+          username: resource.owner?.id
         }
       ]
     },

--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -173,13 +173,13 @@
         v-text="formatDateRelative(item.ddate)"
       />
     </template>
-    <template #owner="{ item }">
+    <template #sharedBy="{ item }">
       <oc-button appearance="raw-inverse" variation="passive" @click="openSharingSidebar(item)">
         <oc-avatars
           class="resource-table-people"
-          :items="getOwnerAvatarItems(item)"
+          :items="getSharedByAvatarItems(item)"
           :is-tooltip-displayed="true"
-          :accessible-description="getOwnerAvatarDescription(item)"
+          :accessible-description="getSharedByAvatarDescription(item)"
         />
       </oc-button>
     </template>
@@ -670,8 +670,7 @@ export default defineComponent({
               }
             : {},
           {
-            // FIXME: confusing naming. what do we want here, file or share owner?
-            name: 'owner',
+            name: 'sharedBy',
             title: this.$gettext('Shared by'),
             type: 'slot',
             alignH: 'right',
@@ -1051,27 +1050,29 @@ export default defineComponent({
         linkCount: linkCount.toString()
       })
     },
-    getOwnerAvatarDescription(resource: Resource) {
+    getSharedByAvatarDescription(resource: Resource) {
+      if (!isShareResource(resource)) {
+        return ''
+      }
+
       const resourceType =
         resource.type === 'folder' ? this.$gettext('folder') : this.$gettext('file')
-      return this.$gettext('This %{ resourceType } is owned by %{ ownerName }', {
+      return this.$gettext('This %{ resourceType } is shared by %{ user }', {
         resourceType,
-        ownerName: resource.owner?.displayName || ''
+        user: resource.sharedBy.map(({ displayName }) => displayName).join(', ')
       })
     },
-    getOwnerAvatarItems(resource: Resource) {
+    getSharedByAvatarItems(resource: Resource) {
       if (!isShareResource(resource)) {
         return []
       }
 
-      return [
-        {
-          displayName: resource.owner?.displayName,
-          name: resource.owner?.displayName,
-          shareType: ShareTypes.user.value,
-          username: resource.owner?.id
-        }
-      ]
+      return resource.sharedBy.map((s) => ({
+        displayName: s.displayName,
+        name: s.displayName,
+        shareType: ShareTypes.user.value,
+        username: s.id
+      }))
     },
     getSharedWithAvatarItems(resource: Resource) {
       if (!isShareResource(resource)) {
@@ -1238,8 +1239,8 @@ export default defineComponent({
   .oc-table-data-cell-size,
   .oc-table-header-cell-sharedWith,
   .oc-table-data-cell-sharedWith,
-  .oc-table-header-cell-owner,
-  .oc-table-data-cell-owner,
+  .oc-table-header-cell-sharedBy,
+  .oc-table-data-cell-sharedBy,
   .oc-table-header-cell-status,
   .oc-table-data-cell-status {
     display: none;
@@ -1262,8 +1263,8 @@ export default defineComponent({
     }
   }
 
-  .oc-table-header-cell-owner,
-  .oc-table-data-cell-owner,
+  .oc-table-header-cell-sharedBy,
+  .oc-table-data-cell-sharedBy,
   .oc-table-header-cell-tags,
   .oc-table-data-cell-tags,
   .oc-table-header-cell-indicators,
@@ -1285,8 +1286,8 @@ export default defineComponent({
     .oc-table-data-cell-size,
     .oc-table-header-cell-sharedWith,
     .oc-table-data-cell-sharedWith,
-    .oc-table-header-cell-owner,
-    .oc-table-data-cell-owner,
+    .oc-table-header-cell-sharedBy,
+    .oc-table-data-cell-sharedBy,
     .oc-table-header-cell-status,
     .oc-table-data-cell-status {
       display: none;
@@ -1309,8 +1310,8 @@ export default defineComponent({
       }
     }
 
-    .oc-table-header-cell-owner,
-    .oc-table-data-cell-owner,
+    .oc-table-header-cell-sharedBy,
+    .oc-table-data-cell-sharedBy,
     .oc-table-header-cell-tags,
     .oc-table-data-cell-tags,
     .oc-table-header-cell-indicators,
@@ -1324,9 +1325,9 @@ export default defineComponent({
   }
 }
 
-// shared with me: on tablets hide shared with column and display owner column instead
-#files-shared-with-me-view .files-table .oc-table-header-cell-owner,
-#files-shared-with-me-view .files-table .oc-table-data-cell-owner {
+// shared with me: on tablets hide shared with column and display sharedBy column instead
+#files-shared-with-me-view .files-table .oc-table-header-cell-sharedBy,
+#files-shared-with-me-view .files-table .oc-table-data-cell-sharedBy {
   @media only screen and (min-width: 640px) {
     display: table-cell;
   }

--- a/packages/web-pkg/tests/unit/components/FilesList/ResourceTable.spec.ts
+++ b/packages/web-pkg/tests/unit/components/FilesList/ResourceTable.spec.ts
@@ -1,6 +1,6 @@
 import { DateTime } from 'luxon'
 import ResourceTable from '../../../../src/components/FilesList/ResourceTable.vue'
-import { extractDomSelector, Resource } from '@ownclouders/web-client/src/helpers'
+import { extractDomSelector, Resource, ShareTypes } from '@ownclouders/web-client/src/helpers'
 import { defaultPlugins, mount } from 'web-test-helpers'
 import { CapabilityStore } from '../../../../src/composables/piniaStores'
 import { displayPositionedDropdown } from '../../../../src/helpers/contextMenuDropdown'
@@ -8,6 +8,7 @@ import { eventBus } from '../../../../src/services/eventBus'
 import { SideBarEventTopics } from '../../../../src/composables/sideBar'
 import { mock } from 'vitest-mock-extended'
 import { computed } from 'vue'
+import { Identity } from '@ownclouders/web-client/src/generated'
 
 const mockUseEmbedMode = vi.fn().mockReturnValue({ isLocationPicker: computed(() => false) })
 
@@ -35,39 +36,37 @@ const getCurrentDate = () => {
   return DateTime.fromJSDate(new Date()).minus({ days: 1 }).toFormat('EEE, dd MMM yyyy HH:mm:ss')
 }
 
-const fields = ['name', 'size', 'mdate', 'sdate', 'ddate', 'actions', 'owner', 'sharedWith']
+const fields = ['name', 'size', 'mdate', 'sdate', 'ddate', 'actions', 'sharedBy', 'sharedWith']
 
 const sharedWith = [
   {
     id: 'bob',
-    username: 'bob',
     displayName: 'Bob',
-    avatar:
-      'https://images.unsplash.com/photo-1610216705422-caa3fcb6d158?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTB8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60'
+    shareType: ShareTypes.user.value
   },
   {
     id: 'marie',
-    username: 'marie',
     displayName: 'Marie',
-    avatar:
-      'https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60'
+    shareType: ShareTypes.user.value
   },
   {
     id: 'john',
-    username: 'john',
-    displayName: 'John Richards Emperor of long names'
+    displayName: 'John Richards Emperor of long names',
+    shareType: ShareTypes.user.value
   }
-]
+] as Array<{ shareType: number } & Identity>
 
-const owner = [
+const owner = {
+  id: 'bob',
+  displayName: 'Bob'
+} as Resource['owner']
+
+const sharedBy = [
   {
     id: 'bob',
-    username: 'bob',
-    displayName: 'Bob',
-    avatar:
-      'https://images.unsplash.com/photo-1610216705422-caa3fcb6d158?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTB8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60'
+    displayName: 'Bob'
   }
-]
+] as Identity[]
 
 const indicators = [
   {
@@ -102,6 +101,7 @@ const resourcesWithAllFields = [
     sdate: getCurrentDate(),
     ddate: getCurrentDate(),
     owner,
+    sharedBy,
     sharedWith,
     shareTypes: [],
     syncEnabled: true,
@@ -121,6 +121,7 @@ const resourcesWithAllFields = [
     mdate: getCurrentDate(),
     sdate: getCurrentDate(),
     ddate: getCurrentDate(),
+    sharedBy,
     sharedWith,
     shareTypes: [],
     owner,
@@ -139,6 +140,7 @@ const resourcesWithAllFields = [
     mdate: getCurrentDate(),
     sdate: getCurrentDate(),
     ddate: getCurrentDate(),
+    sharedBy,
     sharedWith,
     shareTypes: [],
     owner,
@@ -156,6 +158,7 @@ const resourcesWithAllFields = [
     mdate: getCurrentDate(),
     sdate: getCurrentDate(),
     ddate: getCurrentDate(),
+    sharedBy,
     sharedWith,
     shareTypes: [],
     tags: [],
@@ -180,6 +183,7 @@ const processingResourcesWithAllFields = [
     mdate: getCurrentDate(),
     sdate: getCurrentDate(),
     ddate: getCurrentDate(),
+    sharedBy,
     owner,
     sharedWith,
     canRename: vi.fn,
@@ -199,6 +203,7 @@ const processingResourcesWithAllFields = [
     mdate: getCurrentDate(),
     sdate: getCurrentDate(),
     ddate: getCurrentDate(),
+    sharedBy,
     sharedWith,
     owner,
     canRename: vi.fn,

--- a/tests/acceptance/pageObjects/sharedWithMePage.js
+++ b/tests/acceptance/pageObjects/sharedWithMePage.js
@@ -124,7 +124,7 @@ module.exports = {
   elements: {
     shareOwnerName: {
       selector:
-        '//td[contains(@class,"oc-table-data-cell-owner")]//span[@data-test-user-name="%s"]',
+        '//td[contains(@class,"oc-table-data-cell-sharedBy")]//span[@data-test-user-name="%s"]',
       locateStrategy: 'xpath'
     },
     syncEnabled: {
@@ -135,7 +135,7 @@ module.exports = {
       // ugly hack: oc-avatar has a parent div.oc-avatars, which is also matched by `contains(@class, 'oc-avatar')`.
       // to solve this we try matching on the class surrounded by blanks, which is not matching the oc-avatars anymore.
       selector:
-        "//td[contains(@class,'oc-table-data-cell-owner')]//span[contains(concat(' ', normalize-space(@class), ' '), ' oc-avatar ')]",
+        "//td[contains(@class,'oc-table-data-cell-sharedBy')]//span[contains(concat(' ', normalize-space(@class), ' '), ' oc-avatar ')]",
       locateStrategy: 'xpath'
     },
     shareStatusActionOnFileRow: {


### PR DESCRIPTION
## Description
Bumps the libre graph client and adjusts the way how share resources are built due to recent API changes (see https://github.com/owncloud/ocis/pull/8322). Multiple shares for the same resource are now being returned as one drive item including multiple permissions. That means no more duplicated resources in the files list.

The `shareId` and the `shareRoot` on a `Resource` are now somewhat misleading, since a resource can hold multiple "shares" (= permissions). We still need those props to be able to resolve into the share jail, but we should remove this in the future.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/10418

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
