### PR TITLE
[tests-only][full-ci]bump `ocis stable-5.0` commit

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=cf04cf7880d3c210d03df219d363ae6910f6157a
-OCIS_BRANCH=stable-5.0
+OCIS_COMMITID=024e02be95f4808cc907795b44a4cb2ef96a3ca6
+OCIS_BRANCH=master


### PR DESCRIPTION
### Description
Bump latest `ocis stable-5.0` commit to web

### Related Issue:
https://github.com/owncloud/QA/issues/841