### PR TITLE
Restructure GDPR export / turn into dedicated section on accounts page

### DIFF
--- a/packages/web-runtime/src/components/Account/GdprExport.vue
+++ b/packages/web-runtime/src/components/Account/GdprExport.vue
@@ -1,31 +1,38 @@
 <template>
-  <span v-if="loading">
-    <oc-spinner />
-  </span>
-  <span v-else-if="exportInProgress" class="oc-flex oc-flex-middle" data-testid="export-in-process">
-    <oc-icon name="time" fill-type="line" size="small" class="oc-mr-s" />
-    <span v-text="$gettext('Export is being processed. This can take up to 24 hours.')" />
-  </span>
-  <div v-else>
-    <oc-button
-      appearance="raw"
-      variation="primary"
-      data-testid="request-export-btn"
-      @click="requestExport"
+  <div class="oc-mb-l">
+    <p v-text="$gettext('Request a personal data export according to §20 GDPR.')" />
+    <span v-if="loading">
+      <oc-spinner />
+    </span>
+    <span
+      v-else-if="exportInProgress"
+      class="oc-flex oc-flex-middle"
+      data-testid="export-in-process"
     >
-      <span v-text="$gettext('Request new export')" />
-    </oc-button>
-    <div v-if="exportFile" class="oc-flex oc-flex-middle">
+      <oc-icon name="time" fill-type="line" size="small" class="oc-mr-s" />
+      <span v-text="$gettext('Export is being processed. This can take up to 24 hours.')" />
+    </span>
+    <div v-else class="oc-flex">
       <oc-button
-        appearance="raw"
+        appearance="outline"
+        variation="primary"
+        data-testid="request-export-btn"
+        class="oc-mr-s"
+        @click="requestExport"
+      >
+        <span v-text="$gettext('Request new export')" />
+      </oc-button>
+      <oc-button
+        v-if="exportFile"
+        appearance="outline"
         variation="primary"
         data-testid="download-export-btn"
         @click="downloadExport"
       >
         <oc-icon name="download" fill-type="line" size="small" />
-        <span v-text="$gettext('Download export')" />
+        <span v-text="$gettext('Download latest export')" />
+        <span v-text="`(${exportDate})`" />
       </oc-button>
-      <span class="oc-ml-s" v-text="`(${exportDate})`" />
     </div>
   </div>
 </template>

--- a/packages/web-runtime/src/pages/account.vue
+++ b/packages/web-runtime/src/pages/account.vue
@@ -65,12 +65,6 @@
             </oc-button>
           </dd>
         </div>
-        <div v-if="showGdprExport" class="account-page-gdpr-export oc-mb oc-width-1-2@s">
-          <dt class="oc-text-normal oc-text-muted" v-text="$gettext('GDPR export')" />
-          <dd data-testid="gdpr-export">
-            <gdpr-export />
-          </dd>
-        </div>
         <div v-if="showChangePassword" class="account-page-password oc-mb oc-width-1-2@s">
           <dt class="oc-text-normal oc-text-muted" v-text="$gettext('Password')" />
           <dd data-testid="password">
@@ -85,6 +79,13 @@
           </dd>
         </div>
       </dl>
+    </div>
+    <div v-if="showGdprExport" class="account-page-gdpr-export oc-width-1-1">
+      <h2 class="oc-text-bold oc-mb" v-text="$gettext('GDPR')" />
+      <dt class="oc-text-normal oc-text-muted" v-text="$gettext('GDPR export')" />
+      <dd data-testid="gdpr-export">
+        <gdpr-export />
+      </dd>
     </div>
     <div>
       <div class="oc-flex oc-width-1-1">

--- a/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.ts.snap
+++ b/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.ts.snap
@@ -25,7 +25,6 @@ exports[`account page > account information section > displays basic user inform
     </dd>
   </div>
   <!--v-if-->
-  <!--v-if-->
 </dl>"
 `;
 
@@ -36,6 +35,7 @@ exports[`account page > header section > edit url button > should be displayed i
 exports[`account page > public link context > should render a limited view 1`] = `
 "<main data-v-f2ac0579="" id="account" class="oc-height-1-1 oc-m">
   <h1 data-v-f2ac0579="" id="account-page-title" class="oc-page-title oc-m-rm oc-invisible-sr">Some Title</h1>
+  <!--v-if-->
   <!--v-if-->
   <div data-v-f2ac0579="">
     <div data-v-f2ac0579="" class="oc-flex oc-width-1-1">


### PR DESCRIPTION
## Description
Supersedes stale #8851 and drops unrelated changes

Colorful borders only to make changes more obvious. As discussed with @kulmann the buttons shouldn't be filled-primary since it's not _the_ main action on the page

<img width="1552" alt="Screenshot 2024-02-02 at 08 59 59" src="https://github.com/owncloud/web/assets/16822008/a41b7563-7787-48fb-8d4b-b99de56bd304">
