### PR TITLE
[tests-only] test(e2e): create and download file having comma

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=5484a4a6eda1c9520e645b2119920ab76b88d1ef
+OCIS_COMMITID=d87f5b031634eb60a1033fc6fb57eed732398eb5
 OCIS_BRANCH=master

--- a/tests/acceptance/features/webUICreateFilesFolders/createFile.feature
+++ b/tests/acceptance/features/webUICreateFilesFolders/createFile.feature
@@ -14,9 +14,3 @@ Feature: create files
     When the user tries to create a file with already existing name "lorem.txt" using the webUI
     Then the error message "lorem.txt already exists" should be displayed on the webUI dialog prompt
     And the create file button should be disabled
-
-
-  Scenario: create file with name that contains commas
-    When the user creates a file with the name "sample,1.txt" using the webUI
-    And the user browses to the files page
-    Then file "sample,1.txt" should be listed on the webUI

--- a/tests/acceptance/features/webUIFiles/download.feature
+++ b/tests/acceptance/features/webUIFiles/download.feature
@@ -19,10 +19,3 @@ Feature: download files
     And the user reloads the current page of the webUI
     Then file "lorem.txt" should not be listed on the webUI
     And as "Alice" file "lorem.txt" should not exist in the server
-
-
-  Scenario: download file with comma in the filename
-    Given user "Alice" has created file "sample,1.txt" in the server
-    And user "Alice" has logged in using the webUI
-    When the user downloads file "sample,1.txt" using the webUI
-    Then no message should be displayed on the webUI

--- a/tests/e2e/cucumber/features/smoke/upload.feature
+++ b/tests/e2e/cucumber/features/smoke/upload.feature
@@ -21,6 +21,7 @@ Feature: Upload
       | new-lorem-big.txt | txtFile | new lorem big file  |
       | lorem.txt         | txtFile | lorem file          |
       | textfile.txt      | txtFile | some random content |
+      | comma,.txt        | txtFile | comma               |
     When "Alice" uploads the following resources
       | resource          | option    |
       | new-lorem-big.txt | replace   |
@@ -37,6 +38,10 @@ Feature: Upload
     And "Alice" tries to upload the following resource
       | resource      | error            |
       | lorem-big.txt | Not enough quota |
+    And "Alice" downloads the following public link resources using the sidebar panel
+      | resource   | type   |
+      | comma,.txt | file   |
+      | PARENT     | folder |
   #  currently upload folder feature is not available in playwright
   #  And "Alice" uploads the following resources
   #    | resource |

--- a/tests/e2e/cucumber/features/smoke/upload.feature
+++ b/tests/e2e/cucumber/features/smoke/upload.feature
@@ -21,6 +21,7 @@ Feature: Upload
       | new-lorem-big.txt | txtFile | new lorem big file  |
       | lorem.txt         | txtFile | lorem file          |
       | textfile.txt      | txtFile | some random content |
+      # Coverage for bug: https://github.com/owncloud/ocis/issues/8361
       | comma,.txt        | txtFile | comma               |
     When "Alice" uploads the following resources
       | resource          | option    |
@@ -38,10 +39,11 @@ Feature: Upload
     And "Alice" tries to upload the following resource
       | resource      | error            |
       | lorem-big.txt | Not enough quota |
-    And "Alice" downloads the following public link resources using the sidebar panel
+    And "Alice" downloads the following resources using the sidebar panel
       | resource   | type   |
-      | comma,.txt | file   |
       | PARENT     | folder |
+      # Coverage for bug: https://github.com/owncloud/ocis/issues/8361
+      | comma,.txt | file   |
   #  currently upload folder feature is not available in playwright
   #  And "Alice" uploads the following resources
   #    | resource |


### PR DESCRIPTION
## Description
Added e2e test to create and download a file containing comma in its name.
Removed these acceptance tests:
https://github.com/owncloud/web/blob/59b5bbe6d77af2a530a224abd351f738d2237966/tests/acceptance/features/webUICreateFilesFolders/createFile.feature#L19-L22
and https://github.com/owncloud/web/blob/59b5bbe6d77af2a530a224abd351f738d2237966/tests/acceptance/features/webUIFiles/download.feature#L24-L28

## Related Issue
Coverage for:
- https://github.com/owncloud/ocis/issues/8361

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
- [ ] require ocis bump
