### PR TITLE
chore: improve types in tests in preparation for Vue 3.4

### DIFF
--- a/packages/design-system/config/docs.config.js
+++ b/packages/design-system/config/docs.config.js
@@ -205,7 +205,9 @@ module.exports = {
     '**/*.test.js',
     '**/*.test.jsx',
     '**/*.spec.js',
-    '**/*.spec.jsx'
+    '**/*.spec.jsx',
+    '**/*.spec.ts',
+    '**/*.spec.tsx'
   ],
   styleguideDir: '../dist/docs',
   printServerInstructions() {},

--- a/packages/design-system/src/components/OcDrop/OcDrop.spec.ts
+++ b/packages/design-system/src/components/OcDrop/OcDrop.spec.ts
@@ -30,7 +30,7 @@ describe('OcDrop', () => {
 
     for (let i = 0; i < 5; i++) {
       const id = `custom-drop-id-${i}`
-      const wrapper = shallowMount(Drop as any, {
+      const wrapper = shallowMount(Drop, {
         props: {
           dropId: id
         }
@@ -57,18 +57,18 @@ describe('OcDrop', () => {
       'auto-start',
       'auto-end'
     ].forEach((pos) => {
-      expect((Drop as any).props.position.validator(pos)).toBeTruthy()
+      expect(Drop.props.position.validator(pos)).toBeTruthy()
     })
 
-    expect((Drop as any).props.position.validator('unknown')).toBeFalsy()
+    expect(Drop.props.position.validator('unknown')).toBeFalsy()
   })
 
   it('handles mode prop', () => {
     ;['click', 'hover'].forEach((pos) => {
-      expect((Drop as any).props.mode.validator(pos)).toBeTruthy()
+      expect(Drop.props.mode.validator(pos)).toBeTruthy()
     })
 
-    expect((Drop as any).props.mode.validator('unknown')).toBeFalsy()
+    expect(Drop.props.mode.validator('unknown')).toBeFalsy()
   })
 
   it.each(['xsmall', 'small', 'medium', 'large', 'xlarge', 'xxlarge', 'remove'])(

--- a/packages/design-system/src/components/OcRecipient/OcRecipient.spec.ts
+++ b/packages/design-system/src/components/OcRecipient/OcRecipient.spec.ts
@@ -1,6 +1,7 @@
 import { defaultPlugins, shallowMount } from 'web-test-helpers'
 
-import Recipient, { Recipient as RecipientType } from './OcRecipient.vue'
+import Recipient from './OcRecipient.vue'
+import { Recipient as RecipientType } from './types'
 
 describe('OcRecipient', () => {
   /**

--- a/packages/design-system/src/components/OcRecipient/OcRecipient.spec.ts
+++ b/packages/design-system/src/components/OcRecipient/OcRecipient.spec.ts
@@ -1,6 +1,6 @@
 import { defaultPlugins, shallowMount } from 'web-test-helpers'
 
-import Recipient from './OcRecipient.vue'
+import Recipient, { Recipient as RecipientType } from './OcRecipient.vue'
 
 describe('OcRecipient', () => {
   /**
@@ -91,7 +91,7 @@ describe('OcRecipient', () => {
       { name: 'Alice', icon: { name: 'person', label: { long: 'Long label' } } }
     ],
     ['icon label is empty', { name: 'Alice', icon: { name: 'Alice', label: '' } }]
-  ])('throws an error if %s', (def, prop) => {
+  ])('throws an error if %s', (def, prop: RecipientType) => {
     expect(() => shallowMount(Recipient, { props: { recipient: prop } })).toThrow(
       `Recipient ${def}`
     )

--- a/packages/design-system/src/components/OcRecipient/OcRecipient.vue
+++ b/packages/design-system/src/components/OcRecipient/OcRecipient.vue
@@ -38,17 +38,7 @@ import { defineComponent, PropType } from 'vue'
 import OcAvatar from '../OcAvatar/OcAvatar.vue'
 import OcIcon from '../OcIcon/OcIcon.vue'
 import OcSpinner from '../OcSpinner/OcSpinner.vue'
-
-export type Recipient = {
-  name: string
-  icon?: {
-    name: string
-    label: string
-  }
-  isLoadingAvatar?: boolean
-  hasAvatar?: boolean
-  avatar?: string
-}
+import { Recipient } from './types'
 
 export default defineComponent({
   name: 'OcRecipient',

--- a/packages/design-system/src/components/OcRecipient/types.ts
+++ b/packages/design-system/src/components/OcRecipient/types.ts
@@ -1,0 +1,10 @@
+export type Recipient = {
+  name: string
+  icon?: {
+    name: string
+    label: string
+  }
+  isLoadingAvatar?: boolean
+  hasAvatar?: boolean
+  avatar?: string
+}

--- a/packages/design-system/src/components/OcSelect/OcSelect.spec.ts
+++ b/packages/design-system/src/components/OcSelect/OcSelect.spec.ts
@@ -18,7 +18,10 @@ describe('OcSelect', () => {
   it('passes the options to the vue-select component', () => {
     const options = [{ label: 'label1' }, { label: 'label2' }]
     const wrapper = getWrapper({ options })
-    expect(wrapper.findComponent<any>(selectors.ocSelect).props('options')).toEqual(options)
+    expect(
+      // options is just passed through, so it does not exist as prop on OcSelect, hence we need the any cast
+      wrapper.findComponent<typeof OcSelect>(selectors.ocSelect).props('options' as any)
+    ).toEqual(options)
   })
   it('shows ocSpinner component when loading', () => {
     const wrapper = getWrapper({ loading: true })

--- a/packages/design-system/src/components/OcStatusIndicators/OcStatusIndicators.spec.ts
+++ b/packages/design-system/src/components/OcStatusIndicators/OcStatusIndicators.spec.ts
@@ -14,6 +14,7 @@ const indicator = {
   id: 'testid',
   label: 'testlabel',
   type: 'testtype',
+  icon: 'icon',
   handler: vi.fn()
 }
 describe('OcStatusIndicators', () => {

--- a/packages/design-system/src/composables/useIsVisible/index.spec.ts
+++ b/packages/design-system/src/composables/useIsVisible/index.spec.ts
@@ -35,7 +35,7 @@ const createWrapper = (options = {}) =>
       <div ref="target">{{ isVisible }}</div>
       </div>`,
     setup: () => {
-      const target = ref()
+      const target = ref<HTMLElement>()
       const { isVisible } = useIsVisible({ ...options, target })
 
       return {
@@ -60,7 +60,7 @@ describe('useIsVisible', () => {
   it('is visible by default if browser does not support IntersectionObserver', () => {
     disableIntersectionObserver()
     const wrapper = createWrapper()
-    expect(wrapper.vm.$refs.target.innerHTML).toBe('true')
+    expect((wrapper.vm.$refs.target as any).innerHTML).toBe('true')
   })
 
   it('observes the target', async () => {
@@ -76,11 +76,11 @@ describe('useIsVisible', () => {
     const wrapper = createWrapper()
 
     await nextTick()
-    expect(wrapper.vm.$refs.target.innerHTML).toBe('false')
+    expect((wrapper.vm.$refs.target as any).innerHTML).toBe('false')
 
     observerCallback([{ isIntersecting: true }])
     await nextTick()
-    expect(wrapper.vm.$refs.target.innerHTML).toBe('true')
+    expect((wrapper.vm.$refs.target as any).innerHTML).toBe('true')
     expect(observerMock.unobserve).toHaveBeenCalledTimes(1)
   })
 
@@ -89,11 +89,11 @@ describe('useIsVisible', () => {
     const wrapper = createWrapper({ mode: 'showHide' })
 
     await nextTick()
-    expect(wrapper.vm.$refs.target.innerHTML).toBe('false')
+    expect((wrapper.vm.$refs.target as any).innerHTML).toBe('false')
 
     observerCallback([{ isIntersecting: true }])
     await nextTick()
-    expect(wrapper.vm.$refs.target.innerHTML).toBe('true')
+    expect((wrapper.vm.$refs.target as any).innerHTML).toBe('true')
     expect(observerMock.unobserve).toHaveBeenCalledTimes(0)
   })
 

--- a/packages/web-app-admin-settings/tests/unit/components/AppTemplate.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/AppTemplate.spec.ts
@@ -6,9 +6,10 @@ import {
   RouteLocation,
   shallowMount
 } from 'web-test-helpers'
-import { eventBus } from '@ownclouders/web-pkg'
+import { eventBus, SideBar } from '@ownclouders/web-pkg'
 import { SideBarEventTopics } from '@ownclouders/web-pkg'
 import { mock } from 'vitest-mock-extended'
+import { OcBreadcrumb } from 'design-system/src/components'
 
 const stubSelectors = {
   ocBreadcrumb: 'oc-breadcrumb-stub',
@@ -81,10 +82,9 @@ describe('AppTemplate', () => {
         const { wrapper } = getWrapper({
           props: { breadcrumbs: [{ text: 'Administration Settings' }, { text: 'Users' }] }
         })
-        expect(wrapper.findComponent<any>(stubSelectors.ocBreadcrumb).props().items).toEqual([
-          { text: 'Administration Settings' },
-          { text: 'Users' }
-        ])
+        expect(
+          wrapper.findComponent<typeof OcBreadcrumb>(stubSelectors.ocBreadcrumb).props().items
+        ).toEqual([{ text: 'Administration Settings' }, { text: 'Users' }])
       })
       it('does not show in mobile view', () => {
         const { wrapper } = getWrapper({ isMobileWidth: true })
@@ -99,12 +99,12 @@ describe('AppTemplate', () => {
             sideBarAvailablePanels: [{ app: 'DetailsPanel' }]
           }
         })
-        expect(wrapper.findComponent<any>(stubSelectors.sideBar).props().activePanel).toEqual(
-          'DetailsPanel'
-        )
-        expect(wrapper.findComponent<any>(stubSelectors.sideBar).props().availablePanels).toEqual([
-          { app: 'DetailsPanel' }
-        ])
+        expect(
+          wrapper.findComponent<typeof SideBar>(stubSelectors.sideBar).props().activePanel
+        ).toEqual('DetailsPanel')
+        expect(
+          wrapper.findComponent<typeof SideBar>(stubSelectors.sideBar).props().availablePanels
+        ).toEqual([{ app: 'DetailsPanel' }])
       })
     })
   })

--- a/packages/web-app-admin-settings/tests/unit/components/Groups/ContextActions.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Groups/ContextActions.spec.ts
@@ -67,7 +67,9 @@ function getWrapper() {
   return {
     wrapper: mount(ContextActions, {
       props: {
-        items: [mock<Resource>()]
+        actionOptions: {
+          resources: [mock<Resource>()]
+        }
       },
       global: {
         stubs: { 'action-menu-item': true },

--- a/packages/web-app-admin-settings/tests/unit/components/Groups/SideBar/DetailsPanel.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Groups/SideBar/DetailsPanel.spec.ts
@@ -67,6 +67,7 @@ function getWrapper({ propsData = {} } = {}) {
   return {
     wrapper: mount(DetailsPanel, {
       props: {
+        groups: [],
         ...propsData
       },
       global: {

--- a/packages/web-app-admin-settings/tests/unit/components/Groups/SideBar/EditPanel.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Groups/SideBar/EditPanel.spec.ts
@@ -11,7 +11,7 @@ describe('EditPanel', () => {
   describe('method "revertChanges"', () => {
     it('should revert changes on property editGroup', () => {
       const { wrapper } = getWrapper()
-      wrapper.vm.editGroup.dispayName = 'users'
+      wrapper.vm.editGroup.displayName = 'users'
       wrapper.vm.revertChanges()
       expect(wrapper.vm.editGroup.displayName).toEqual('group')
     })

--- a/packages/web-app-admin-settings/tests/unit/components/Groups/SideBar/MembersPanel.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Groups/SideBar/MembersPanel.spec.ts
@@ -2,6 +2,7 @@ import MembersPanel from '../../../../../src/components/Groups/SideBar/MembersPa
 import { defaultPlugins, shallowMount } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
 import { Group } from '@ownclouders/web-client/src/generated'
+import MembersRoleSection from '../../../../../src/components/Groups/SideBar/MembersRoleSection.vue'
 
 const groupMock = mock<Group>({
   id: '1',
@@ -23,7 +24,8 @@ describe('MembersPanel', () => {
     await wrapper.vm.$nextTick
     expect(wrapper.findAll(selectors.membersRolePanelStub).length).toBe(1)
     expect(
-      wrapper.findComponent<any>(selectors.membersRolePanelStub).props().groupMembers[0].displayName
+      wrapper.findComponent<typeof MembersRoleSection>(selectors.membersRolePanelStub).props()
+        .groupMembers[0].displayName
     ).toEqual('Albert Einstein')
   })
   it('should display an empty result if no matching members found', async () => {

--- a/packages/web-app-admin-settings/tests/unit/components/Spaces/ContextActions.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Spaces/ContextActions.spec.ts
@@ -1,6 +1,6 @@
 import { defaultComponentMocks, defaultPlugins, defaultStubs, mount } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
-import { Resource } from '@ownclouders/web-client/src/helpers'
+import { SpaceResource } from '@ownclouders/web-client/src/helpers'
 import ContextActions from '../../../../src/components/Spaces/ContextActions.vue'
 import {
   Action,
@@ -54,7 +54,7 @@ function getWrapper() {
     mocks,
     wrapper: mount(ContextActions, {
       props: {
-        items: [mock<Resource>()]
+        items: [mock<SpaceResource>()]
       },
       global: {
         mocks,

--- a/packages/web-app-admin-settings/tests/unit/components/Spaces/SideBar/MembersPanel.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Spaces/SideBar/MembersPanel.spec.ts
@@ -2,6 +2,7 @@ import MembersPanel from '../../../../../src/components/Spaces/SideBar/MembersPa
 import { defaultPlugins, shallowMount } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
 import { SpaceResource } from '@ownclouders/web-client/src/helpers'
+import MembersRoleSection from '../../../../../src/components/Spaces/SideBar/MembersRoleSection.vue'
 
 const spaceMock = mock<SpaceResource>({
   spaceRoles: {
@@ -30,7 +31,8 @@ describe('MembersPanel', () => {
     await wrapper.vm.$nextTick
     expect(wrapper.findAll(selectors.membersRolePanelStub).length).toBe(1)
     expect(
-      wrapper.findComponent<any>(selectors.membersRolePanelStub).props().members[0].displayName
+      wrapper.findComponent<typeof MembersRoleSection>(selectors.membersRolePanelStub).props()
+        .members[0].displayName
     ).toEqual(userToFilterFor.displayName)
   })
   it('should display an empty result if no matching members found', async () => {

--- a/packages/web-app-admin-settings/tests/unit/components/Spaces/SpacesList.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Spaces/SpacesList.spec.ts
@@ -1,9 +1,11 @@
 import SpacesList from '../../../../src/components/Spaces/SpacesList.vue'
 import { defaultComponentMocks, defaultPlugins, mount, shallowMount } from 'web-test-helpers'
-import { eventBus, queryItemAsString } from '@ownclouders/web-pkg'
+import { SortDir, eventBus, queryItemAsString } from '@ownclouders/web-pkg'
 import { displayPositionedDropdown } from '@ownclouders/web-pkg'
 import { SideBarEventTopics } from '@ownclouders/web-pkg'
 import { nextTick } from 'vue'
+import { OcTable } from 'design-system/src/components'
+import { SpaceResource } from '@ownclouders/web-client'
 
 const spaceMocks = [
   {
@@ -67,14 +69,20 @@ describe('SpacesList', () => {
       const { wrapper } = getWrapper({ mountType: shallowMount, spaces: spaceMocks })
       wrapper.vm.sortBy = prop
       await wrapper.vm.$nextTick()
-      expect(wrapper.findComponent<any>(selectors.ocTableStub).props().data[0].id).toBe(
-        spaceMocks[0].id
-      )
-      wrapper.vm.sortDir = 'desc'
+      expect(
+        (
+          wrapper.findComponent<typeof OcTable>(selectors.ocTableStub).props()
+            .data[0] as SpaceResource
+        ).id
+      ).toBe(spaceMocks[0].id)
+      wrapper.vm.sortDir = SortDir.Desc
       await wrapper.vm.$nextTick()
-      expect(wrapper.findComponent<any>(selectors.ocTableStub).props().data[0].id).toBe(
-        spaceMocks[1].id
-      )
+      expect(
+        (
+          wrapper.findComponent<typeof OcTable>(selectors.ocTableStub).props()
+            .data[0] as SpaceResource
+        ).id
+      ).toBe(spaceMocks[1].id)
     }
   )
   it('should set the sort parameters accordingly when calling "handleSort"', () => {

--- a/packages/web-app-admin-settings/tests/unit/components/Users/LoginModal.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/LoginModal.spec.ts
@@ -8,6 +8,7 @@ import {
 import { mock } from 'vitest-mock-extended'
 import { User } from '@ownclouders/web-client/src/generated'
 import { Modal, eventBus, useMessages } from '@ownclouders/web-pkg'
+import { OcSelect } from 'design-system/src/components'
 
 describe('LoginModal', () => {
   it('renders the input including two options', () => {
@@ -16,7 +17,9 @@ describe('LoginModal', () => {
   })
   it('shows a warning when the current user is being selected', () => {
     const { wrapper } = getWrapper([mock<User>({ id: '1' })])
-    expect(wrapper.findComponent<any>('oc-select-stub').props('warningMessage')).toBeDefined()
+    expect(
+      wrapper.findComponent<typeof OcSelect>('oc-select-stub').props('warningMessage')
+    ).toBeDefined()
   })
   describe('method "onConfirm"', () => {
     it('updates the login for all given users', async () => {

--- a/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/DetailsPanel.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/DetailsPanel.spec.ts
@@ -1,5 +1,5 @@
 import DetailsPanel from '../../../../../src/components/Users/SideBar/DetailsPanel.vue'
-import { defaultPlugins, shallowMount } from 'web-test-helpers'
+import { PartialComponentProps, defaultPlugins, shallowMount } from 'web-test-helpers'
 
 const defaultUser = { displayName: 'user', memberOf: [] }
 
@@ -54,10 +54,14 @@ describe('DetailsPanel', () => {
   })
 })
 
-function getWrapper({ props = {} } = {}) {
+function getWrapper({ props }: { props: PartialComponentProps<typeof DetailsPanel> }) {
   return {
     wrapper: shallowMount(DetailsPanel, {
-      props: { ...props },
+      props: {
+        users: [],
+        roles: [],
+        ...props
+      },
       global: {
         plugins: [...defaultPlugins()]
       }

--- a/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/EditPanel.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/EditPanel.spec.ts
@@ -9,6 +9,7 @@ import { mock } from 'vitest-mock-extended'
 import { Group } from '@ownclouders/web-client/src/generated'
 import { AxiosResponse } from 'axios'
 import { CapabilityStore } from '@ownclouders/web-pkg'
+import GroupSelect from '../../../../../src/components/Users/GroupSelect.vue'
 
 const availableGroupOptions = [
   mock<Group>({ id: '1', displayName: 'group1', groupTypes: [] }),
@@ -26,9 +27,11 @@ describe('EditPanel', () => {
   it('filters selected groups when passing the options to the GroupSelect component', () => {
     const { wrapper } = getWrapper({ selectedGroups: [availableGroupOptions[0]] })
     const selectedGroups = wrapper
-      .findComponent<any>(selectors.groupSelectStub)
+      .findComponent<typeof GroupSelect>(selectors.groupSelectStub)
       .props('selectedGroups')
-    const groupOptions = wrapper.findComponent<any>(selectors.groupSelectStub).props('groupOptions')
+    const groupOptions = wrapper
+      .findComponent<typeof GroupSelect>(selectors.groupSelectStub)
+      .props('groupOptions')
     expect(selectedGroups.length).toBe(1)
     expect(selectedGroups[0].id).toEqual(availableGroupOptions[0].id)
     expect(groupOptions.length).toBe(1)
@@ -157,15 +160,17 @@ describe('EditPanel', () => {
   describe('group select', () => {
     it('takes all available groups', () => {
       const { wrapper } = getWrapper()
-      expect(wrapper.findComponent<any>('group-select-stub').props('groupOptions').length).toBe(
-        availableGroupOptions.length
-      )
+      expect(
+        wrapper.findComponent<typeof GroupSelect>('group-select-stub').props('groupOptions').length
+      ).toBe(availableGroupOptions.length)
     })
     it('filters out read-only groups', () => {
       const { wrapper } = getWrapper({
         groups: [mock<Group>({ id: '1', displayName: 'group1', groupTypes: ['ReadOnly'] })]
       })
-      expect(wrapper.findComponent<any>('group-select-stub').props('groupOptions').length).toBe(0)
+      expect(
+        wrapper.findComponent<typeof GroupSelect>('group-select-stub').props('groupOptions').length
+      ).toBe(0)
     })
   })
 })

--- a/packages/web-app-admin-settings/tests/unit/views/Users.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/views/Users.spec.ts
@@ -243,6 +243,7 @@ describe('Users view', () => {
 
       await wrapper.vm.loadResourcesTask.last
       await wrapper.vm.onEditUser({
+        user: {},
         editUser: {}
       })
 

--- a/packages/web-app-external/tests/unit/app.spec.ts
+++ b/packages/web-app-external/tests/unit/app.spec.ts
@@ -87,7 +87,9 @@ function createShallowMountWrapper(makeRequest = vi.fn().mockResolvedValue({ sta
   return {
     wrapper: shallowMount(App, {
       props: {
-        resource: mock<Resource>()
+        space: null,
+        resource: mock<Resource>(),
+        isReadOnly: false
       },
       global: {
         plugins: [

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/RecipientContainer.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/RecipientContainer.vue
@@ -21,7 +21,7 @@
 import { avatarUrl } from '../../../../../helpers/user'
 import { ShareTypes } from '@ownclouders/web-client/src/helpers/share'
 import { defineComponent } from 'vue'
-import { Recipient } from 'design-system/src/components/OcRecipient/OcRecipient.vue'
+import { Recipient } from 'design-system/src/components/OcRecipient/types'
 import { useCapabilityStore, useConfigStore } from '@ownclouders/web-pkg'
 import { storeToRefs } from 'pinia'
 

--- a/packages/web-app-files/src/views/Favorites.vue
+++ b/packages/web-app-files/src/views/Favorites.vue
@@ -153,7 +153,7 @@ export default defineComponent({
 
     onBeforeUnmount(() => {
       visibilityObserver.disconnect()
-      eventBus.unsubscribe('app.files.list.removeFromFavorites', loadResourcesEventToken)
+      eventBus.unsubscribe('app.files.list.removeFromFavorites', unref(loadResourcesEventToken))
     })
 
     return {

--- a/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.ts
+++ b/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.ts
@@ -17,6 +17,7 @@ import { RouteLocation } from 'vue-router'
 import { useExtensionRegistry } from '@ownclouders/web-pkg'
 import { useExtensionRegistryMock } from 'web-test-helpers/src/mocks/useExtensionRegistryMock'
 import { ref } from 'vue'
+import { OcButton } from 'design-system/src/components'
 
 vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
   ...(await importOriginal<any>()),
@@ -42,15 +43,23 @@ describe('CreateAndUpload component', () => {
   describe('action buttons', () => {
     it('should show and be enabled if file creation is possible', () => {
       const { wrapper } = getWrapper()
-      expect(wrapper.findComponent<any>(elSelector.uploadBtn).props().disabled).toBeFalsy()
-      expect(wrapper.findComponent<any>(elSelector.newFolderBtn).props().disabled).toBeFalsy()
+      expect(
+        wrapper.findComponent<typeof OcButton>(elSelector.uploadBtn).props().disabled
+      ).toBeFalsy()
+      expect(
+        wrapper.findComponent<typeof OcButton>(elSelector.newFolderBtn).props().disabled
+      ).toBeFalsy()
       expect(wrapper.html()).toMatchSnapshot()
     })
     it('should be disabled if file creation is not possible', () => {
       const currentFolder = mock<Resource>({ canUpload: () => false })
       const { wrapper } = getWrapper({ currentFolder, createActions: [] })
-      expect(wrapper.findComponent<any>(elSelector.uploadBtn).props().disabled).toBeTruthy()
-      expect(wrapper.findComponent<any>(elSelector.newFolderBtn).props().disabled).toBeTruthy()
+      expect(
+        wrapper.findComponent<typeof OcButton>(elSelector.uploadBtn).props().disabled
+      ).toBeTruthy()
+      expect(
+        wrapper.findComponent<typeof OcButton>(elSelector.newFolderBtn).props().disabled
+      ).toBeTruthy()
     })
     it('should not be visible if file creation is not possible on a public page', () => {
       const currentFolder = mock<Resource>({ canUpload: () => false })
@@ -188,7 +197,7 @@ function getWrapper({
 
   return {
     mocks,
-    wrapper: shallowMount(CreateAndUpload as any, {
+    wrapper: shallowMount(CreateAndUpload, {
       data: () => ({ newFileAction }),
       props: { space: space as any, item, itemId },
       global: {

--- a/packages/web-app-files/tests/unit/components/AppBar/Upload/ResourceUpload.spec.ts
+++ b/packages/web-app-files/tests/unit/components/AppBar/Upload/ResourceUpload.spec.ts
@@ -2,6 +2,7 @@ import { mockDeep } from 'vitest-mock-extended'
 import ResourceUpload from 'web-app-files/src/components/AppBar/Upload/ResourceUpload.vue'
 import { defaultComponentMocks, defaultPlugins, defaultStubs, mount } from 'web-test-helpers'
 import { UppyService } from '@ownclouders/web-pkg'
+import { OcButton } from 'design-system/src/components'
 
 describe('Resource Upload Component', () => {
   describe('file upload', () => {
@@ -42,7 +43,7 @@ describe('Resource Upload Component', () => {
     const uppyService = mockDeep<UppyService>()
     uppyService.isRemoteUploadInProgress.mockReturnValue(true)
     const { wrapper } = getWrapper({ isFolder: true }, uppyService)
-    expect(wrapper.findComponent<any>('button').props('disabled')).toBeTruthy()
+    expect(wrapper.findComponent<typeof OcButton>('button').props('disabled')).toBeTruthy()
   })
 })
 

--- a/packages/web-app-files/tests/unit/components/FilesList/NotFoundMessage.spec.ts
+++ b/packages/web-app-files/tests/unit/components/FilesList/NotFoundMessage.spec.ts
@@ -4,6 +4,7 @@ import { PublicSpaceResource, SpaceResource, Resource } from '@ownclouders/web-c
 import { MockProxy, mock } from 'vitest-mock-extended'
 import { join } from 'path'
 import { defaultComponentMocks, defaultPlugins, shallowMount } from 'web-test-helpers'
+import { OcButton } from 'design-system/src/components'
 
 const selectors = {
   homeButton: '#files-list-not-found-button-go-home',
@@ -40,7 +41,7 @@ describe('NotFoundMessage', () => {
 
     it('should have property route to personal space', () => {
       const { wrapper } = getWrapper(space, spacesLocation)
-      const homeButton = wrapper.findComponent<any>(selectors.homeButton)
+      const homeButton = wrapper.findComponent<typeof OcButton>(selectors.homeButton)
 
       expect(homeButton.props().to.name).toBe(spacesLocation.name)
       expect(homeButton.props().to.params.driveAliasAndItem).toBe('personal')
@@ -76,7 +77,7 @@ describe('NotFoundMessage', () => {
 
     it('should have property route to files public list', () => {
       const { wrapper } = getWrapper(space, publicLocation)
-      const reloadLinkButton = wrapper.findComponent<any>(selectors.reloadLinkButton)
+      const reloadLinkButton = wrapper.findComponent<typeof OcButton>(selectors.reloadLinkButton)
 
       expect(reloadLinkButton.props().to.name).toBe(publicLocation.name)
       expect(reloadLinkButton.props().to.params.driveAliasAndItem).toBe(

--- a/packages/web-app-files/tests/unit/components/FilesList/QuickActions.spec.ts
+++ b/packages/web-app-files/tests/unit/components/FilesList/QuickActions.spec.ts
@@ -5,6 +5,7 @@ import { useExtensionRegistry } from '@ownclouders/web-pkg'
 import { mock } from 'vitest-mock-extended'
 import { ref } from 'vue'
 import { useExtensionRegistryMock } from 'web-test-helpers/src/mocks/useExtensionRegistryMock'
+import { Resource } from '@ownclouders/web-client'
 
 vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
   ...(await importOriginal<any>()),
@@ -31,11 +32,12 @@ const quicklinkAction = {
 }
 
 const testItem = {
+  id: '1',
   icon: 'file',
   name: 'lorem.txt',
   path: '/lorem.txt',
   size: '12220'
-}
+} as Resource
 
 describe('QuickActions', () => {
   describe('when multiple actions are provided', () => {

--- a/packages/web-app-files/tests/unit/components/FilesList/ResourceDetails.spec.ts
+++ b/packages/web-app-files/tests/unit/components/FilesList/ResourceDetails.spec.ts
@@ -2,7 +2,7 @@ import { defaultComponentMocks, defaultPlugins, mount, RouteLocation } from 'web
 import ResourceDetails from '../../../../src/components/FilesList/ResourceDetails.vue'
 import { mock } from 'vitest-mock-extended'
 import { useFileActions } from '@ownclouders/web-pkg'
-import { SpaceResource } from '@ownclouders/web-client'
+import { Resource, SpaceResource } from '@ownclouders/web-client'
 import { useRouteQuery } from '@ownclouders/web-pkg'
 import { ref } from 'vue'
 
@@ -49,18 +49,18 @@ describe('ResourceDetails component', () => {
     mocks.$clientService.webdav.listFileVersions.mockResolvedValue([])
 
     const file = {
-      id: 0,
+      id: '0',
       name: 'image.jpg',
+      path: '/',
       size: 24064,
       mdate: 'Wed, 21 Oct 2015 07:28:00 GMT',
       mimeType: 'image/jpg',
       isFolder,
-      owner: [
-        {
-          username: 'admin'
-        }
-      ]
-    }
+      owner: {
+        id: '1',
+        displayName: 'admin'
+      }
+    } as Resource
     const space = mock<SpaceResource>()
 
     return {

--- a/packages/web-app-files/tests/unit/components/FilesList/__snapshots__/ResourceDetails.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/FilesList/__snapshots__/ResourceDetails.spec.ts.snap
@@ -29,7 +29,14 @@ exports[`ResourceDetails component > renders resource details correctly 1`] = `
           <!--v-if-->
           <!--v-if-->
           <!--v-if-->
-          <!--v-if-->
+          <tr data-v-5080a6a4="" data-testid="ownerDisplayName">
+            <th data-v-5080a6a4="" scope="col" class="oc-pr-s oc-font-semibold">Owner</th>
+            <td data-v-5080a6a4="">
+              <p data-v-5080a6a4="" class="oc-m-rm">admin
+                <!--v-if-->
+              </p>
+            </td>
+          </tr>
           <tr data-v-5080a6a4="" data-testid="sizeInfo">
             <th data-v-5080a6a4="" scope="col" class="oc-pr-s oc-font-semibold">Size</th>
             <td data-v-5080a6a4="">24 kB</td>

--- a/packages/web-app-files/tests/unit/components/FilesList/__snapshots__/ResourceDetails.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/FilesList/__snapshots__/ResourceDetails.spec.ts.snap
@@ -32,9 +32,7 @@ exports[`ResourceDetails component > renders resource details correctly 1`] = `
           <tr data-v-5080a6a4="" data-testid="ownerDisplayName">
             <th data-v-5080a6a4="" scope="col" class="oc-pr-s oc-font-semibold">Owner</th>
             <td data-v-5080a6a4="">
-              <p data-v-5080a6a4="" class="oc-m-rm">admin
-                <!--v-if-->
-              </p>
+              <p data-v-5080a6a4="" class="oc-m-rm">admin <span data-v-5080a6a4="" data-msgid="(me)" data-current-language="en">(me)</span></p>
             </td>
           </tr>
           <tr data-v-5080a6a4="" data-testid="sizeInfo">

--- a/packages/web-app-files/tests/unit/components/Modals/SetLinkPasswordModal.spec.ts
+++ b/packages/web-app-files/tests/unit/components/Modals/SetLinkPasswordModal.spec.ts
@@ -2,6 +2,7 @@ import { mock } from 'vitest-mock-extended'
 import SetLinkPasswordModal from '../../../../src/components/Modals/SetLinkPasswordModal.vue'
 import { defaultComponentMocks, defaultPlugins, shallowMount } from 'web-test-helpers'
 import { Modal, useMessages, useSharesStore } from '@ownclouders/web-pkg'
+import { Share } from '@ownclouders/web-client/src/helpers'
 
 describe('SetLinkPasswordModal', () => {
   it('should render a text input field for the password', () => {
@@ -31,7 +32,7 @@ describe('SetLinkPasswordModal', () => {
   })
 })
 
-function getWrapper({ link = {} } = {}) {
+function getWrapper() {
   const mocks = { ...defaultComponentMocks() }
 
   return {
@@ -39,7 +40,7 @@ function getWrapper({ link = {} } = {}) {
     wrapper: shallowMount(SetLinkPasswordModal, {
       props: {
         modal: mock<Modal>(),
-        link
+        link: mock<Share>()
       },
       global: {
         plugins: [...defaultPlugins()],

--- a/packages/web-app-files/tests/unit/components/Search/List.spec.ts
+++ b/packages/web-app-files/tests/unit/components/Search/List.spec.ts
@@ -6,7 +6,7 @@ import { useResourcesViewDefaultsMock } from 'web-app-files/tests/mocks/useResou
 import { createRouter, createMemoryHistory } from 'vue-router'
 
 import { defaultComponentMocks, defaultPlugins, mockAxiosResolve } from 'web-test-helpers/src'
-import { queryItemAsString, useResourcesStore } from '@ownclouders/web-pkg'
+import { AppBar, ItemFilter, queryItemAsString, useResourcesStore } from '@ownclouders/web-pkg'
 import { ref } from 'vue'
 import { Resource } from '@ownclouders/web-client/src'
 import { mock } from 'vitest-mock-extended'
@@ -85,13 +85,13 @@ describe('List component', () => {
   describe('breadcrumbs', () => {
     it('show "Search" when no search term given', () => {
       const { wrapper } = getWrapper()
-      const appBar = wrapper.findComponent<any>('app-bar-stub')
+      const appBar = wrapper.findComponent<typeof AppBar>('app-bar-stub')
       expect(appBar.props('breadcrumbs')[0].text).toEqual('Search')
     })
     it('include the search term if given', () => {
       const searchTerm = 'term'
       const { wrapper } = getWrapper({ searchTerm })
-      const appBar = wrapper.findComponent<any>('app-bar-stub')
+      const appBar = wrapper.findComponent<typeof AppBar>('app-bar-stub')
       expect(appBar.props('breadcrumbs')[0].text).toEqual(`Search results for "${searchTerm}"`)
     })
   })
@@ -109,9 +109,9 @@ describe('List component', () => {
         const { wrapper } = getWrapper({ availableTags: [tag] })
         await wrapper.vm.loadAvailableTagsTask.last
         expect(wrapper.find(selectors.tagFilter).exists()).toBeTruthy()
-        expect(wrapper.findComponent<any>(selectors.tagFilter).props('items')).toEqual([
-          { label: tag, id: tag }
-        ])
+        expect(
+          wrapper.findComponent<typeof ItemFilter>(selectors.tagFilter).props('items')
+        ).toEqual([{ label: tag, id: tag }])
       })
       it('should set initial filter when tags are given via query param', async () => {
         const searchTerm = 'term'
@@ -163,9 +163,9 @@ describe('List component', () => {
         await wrapper.vm.loadAvailableTagsTask.last
 
         expect(wrapper.find(selectors.lastModifiedFilter).exists()).toBeTruthy()
-        expect(wrapper.findComponent<any>(selectors.lastModifiedFilter).props('items')).toEqual(
-          expectation
-        )
+        expect(
+          wrapper.findComponent<typeof ItemFilter>(selectors.lastModifiedFilter).props('items')
+        ).toEqual(expectation)
       })
       it('should set initial filter when last modified is given via query param', async () => {
         const searchTerm = 'Screenshot'

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/RecipientContainer.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/RecipientContainer.spec.ts
@@ -33,7 +33,7 @@ describe('InviteCollaborator RecipientContainer', () => {
   it('emits an event if deselect button is clicked', async () => {
     const recipient = getRecipient()
     const { wrapper } = getMountedWrapper(recipient, true)
-    const spyOnDeselect = wrapper.vm.deselect.mockImplementation()
+    const spyOnDeselect = (wrapper.vm.deselect as any).mockImplementation()
     const button = wrapper.find('.files-share-invite-recipient-btn-remove')
     await button.trigger('click')
     expect(spyOnDeselect).toHaveBeenCalledTimes(1)

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileLinks.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileLinks.spec.ts
@@ -11,6 +11,7 @@ import {
   useFileActionsCreateLink
 } from '@ownclouders/web-pkg'
 import { computed } from 'vue'
+import DetailsAndEdit from '../../../../../src/components/SideBar/Shares/Links/DetailsAndEdit.vue'
 
 const defaultLinksList = [
   {
@@ -136,7 +137,9 @@ describe('FileLinks', () => {
         shareType: ShareTypes.link.value
       }
       const { wrapper } = getWrapper({ resource, abilities: [], links: [viewerLink] })
-      const detailsAndEdit = wrapper.findComponent<any>(linkListItemDetailsAndEdit)
+      const detailsAndEdit = wrapper.findComponent<typeof DetailsAndEdit>(
+        linkListItemDetailsAndEdit
+      )
       const isModifiable = detailsAndEdit.props('isModifiable')
       expect(isModifiable).toBeFalsy()
     })
@@ -152,11 +155,13 @@ describe('FileLinks', () => {
         shareType: ShareTypes.link.value
       }
       const { wrapper } = getWrapper({ resource, abilities: [], links: [internalLink] })
-      const detailsAndEdit = wrapper.findComponent<any>(linkListItemDetailsAndEdit)
+      const detailsAndEdit = wrapper.findComponent<typeof DetailsAndEdit>(
+        linkListItemDetailsAndEdit
+      )
       const availableRoleOptions = detailsAndEdit.props('availableRoleOptions')
       const isModifiable = detailsAndEdit.props('isModifiable')
       expect(availableRoleOptions.length).toBe(1)
-      expect(availableRoleOptions[0].permissions()).toEqual([SharePermissions.internal])
+      expect(availableRoleOptions[0].permissions(false)).toEqual([SharePermissions.internal])
       expect(isModifiable).toBeTruthy()
     })
   })

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
@@ -13,6 +13,7 @@ import {
   RouteLocation
 } from 'web-test-helpers'
 import { CapabilityStore, useResourcesStore, useSharesStore } from '@ownclouders/web-pkg'
+import CollaboratorListItem from '../../../../../src/components/SideBar/Shares/Collaborators/ListItem.vue'
 
 const getCollaborator = () => ({
   shareType: 0,
@@ -82,7 +83,9 @@ describe('FileShares', () => {
         .spyOn((FileShares as any).methods, '$_ocCollaborators_deleteShare_trigger')
         .mockImplementation(() => undefined)
       const { wrapper } = getWrapper({ collaborators })
-      ;(wrapper.findComponent<any>('collaborator-list-item-stub').vm as any).$emit('onDelete')
+      ;(
+        wrapper.findComponent<typeof CollaboratorListItem>('collaborator-list-item-stub').vm as any
+      ).$emit('onDelete')
       await wrapper.vm.$nextTick()
       expect(spyOnCollaboratorDeleteTrigger).toHaveBeenCalledTimes(1)
     })
@@ -92,7 +95,9 @@ describe('FileShares', () => {
         '/somePath': { id: indirectCollaborator.itemSource }
       }
       const { wrapper } = getWrapper({ collaborators: [indirectCollaborator], ancestorMetaData })
-      const listItemStub = wrapper.findComponent<any>('collaborator-list-item-stub')
+      const listItemStub = wrapper.findComponent<typeof CollaboratorListItem>(
+        'collaborator-list-item-stub'
+      )
       expect(listItemStub.props('sharedParentRoute')).toBeTruthy()
       expect(listItemStub.props('modifiable')).toBeFalsy()
     })

--- a/packages/web-app-files/tests/unit/components/SideBar/TagsSelect.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/TagsSelect.spec.ts
@@ -21,7 +21,7 @@ describe('Tag Select', () => {
 
     const { wrapper } = createWrapper(resource, clientService)
     await wrapper.vm.loadAvailableTagsTask.last
-    expect(wrapper.findComponent<any>('vue-select-stub').props('options')).toEqual([
+    expect((wrapper.findComponent<any>('vue-select-stub').props() as any).options).toEqual([
       { label: 'a' },
       { label: 'b' },
       { label: 'c' }
@@ -108,7 +108,7 @@ describe('Tag Select', () => {
     const resource = mock<Resource>({ tags: ['a'] })
     const eventStub = vi.spyOn(eventBus, 'publish')
     const { wrapper } = createWrapper(resource, clientService)
-    wrapper.vm.selectedTags.push('b')
+    wrapper.vm.selectedTags.push({ label: 'b' })
     await wrapper.vm.save(wrapper.vm.selectedTags)
     expect(assignTagsStub).toHaveBeenCalled()
     expect(eventStub).not.toHaveBeenCalled()

--- a/packages/web-app-files/tests/unit/components/Spaces/SpaceHeader.spec.ts
+++ b/packages/web-app-files/tests/unit/components/Spaces/SpaceHeader.spec.ts
@@ -1,7 +1,7 @@
 import { ref } from 'vue'
 import SpaceHeader from 'web-app-files/src/components/Spaces/SpaceHeader.vue'
 import { Drive } from '@ownclouders/web-client/src/generated'
-import { buildSpace } from '@ownclouders/web-client/src/helpers'
+import { SpaceResource, buildSpace } from '@ownclouders/web-client/src/helpers'
 import { defaultPlugins, mount, defaultComponentMocks } from 'web-test-helpers'
 
 describe('SpaceHeader', () => {
@@ -41,7 +41,7 @@ describe('SpaceHeader', () => {
   })
 })
 
-function getWrapper({ space = {}, isSideBarOpen = false, isMobileWidth = false }) {
+function getWrapper({ space = {} as SpaceResource, isSideBarOpen = false, isMobileWidth = false }) {
   const mocks = defaultComponentMocks()
   mocks.$previewService.loadPreview.mockResolvedValue('blob:image')
   return mount(SpaceHeader, {

--- a/packages/web-app-files/tests/unit/views/shares/SharedViaLink.spec.ts
+++ b/packages/web-app-files/tests/unit/views/shares/SharedViaLink.spec.ts
@@ -11,6 +11,7 @@ import {
   defaultStubs,
   RouteLocation
 } from 'web-test-helpers'
+import { ResourceTable } from '@ownclouders/web-pkg'
 
 vi.mock('web-app-files/src/composables')
 vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
@@ -42,9 +43,9 @@ describe('SharedViaLink view', () => {
       const { wrapper } = getMountedWrapper({ files: mockedFiles })
       expect(wrapper.find('.no-content-message').exists()).toBeFalsy()
       expect(wrapper.find('resource-table-stub').exists()).toBeTruthy()
-      expect(wrapper.findComponent<any>('resource-table-stub').props().resources.length).toEqual(
-        mockedFiles.length
-      )
+      expect(
+        wrapper.findComponent<typeof ResourceTable>('resource-table-stub').props().resources.length
+      ).toEqual(mockedFiles.length)
     })
   })
 })

--- a/packages/web-app-files/tests/unit/views/shares/SharedWithMe.spec.ts
+++ b/packages/web-app-files/tests/unit/views/shares/SharedWithMe.spec.ts
@@ -4,7 +4,8 @@ import {
   queryItemAsString,
   InlineFilterOption,
   useSort,
-  useOpenWithDefaultApp
+  useOpenWithDefaultApp,
+  ItemFilter
 } from '@ownclouders/web-pkg'
 import { useResourcesViewDefaultsMock } from 'web-app-files/tests/mocks/useResourcesViewDefaultsMock'
 import { ref } from 'vue'
@@ -13,6 +14,7 @@ import { useSortMock } from 'web-app-files/tests/mocks/useSortMock'
 import { mock } from 'vitest-mock-extended'
 import { defaultPlugins, mount, defaultComponentMocks } from 'web-test-helpers'
 import { ShareTypes, IncomingShareResource } from '@ownclouders/web-client/src/helpers'
+import SharedWithMeSection from '../../../../src/components/Shares/SharedWithMeSection.vue'
 
 vi.mock('web-app-files/src/composables/resourcesViewDefaults')
 vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
@@ -64,18 +66,22 @@ describe('SharedWithMe view', () => {
       it('shows all visible shares', () => {
         const { wrapper } = getMountedWrapper()
         expect(wrapper.findAll('shared-with-me-section-stub').length).toBe(1)
-        expect(wrapper.findComponent<any>('shared-with-me-section-stub').props('title')).toEqual(
-          'Shares'
-        )
+        expect(
+          wrapper
+            .findComponent<typeof SharedWithMeSection>('shared-with-me-section-stub')
+            .props('title')
+        ).toEqual('Shares')
       })
       it('shows all hidden shares', async () => {
         const { wrapper } = getMountedWrapper()
         wrapper.vm.setAreHiddenFilesShown(mock<InlineFilterOption>({ name: 'hidden' }))
         await wrapper.vm.$nextTick()
         expect(wrapper.findAll('shared-with-me-section-stub').length).toBe(1)
-        expect(wrapper.findComponent<any>('shared-with-me-section-stub').props('title')).toEqual(
-          'Hidden Shares'
-        )
+        expect(
+          wrapper
+            .findComponent<typeof SharedWithMeSection>('shared-with-me-section-stub')
+            .props('title')
+        ).toEqual('Hidden Shares')
       })
     })
     describe('share type', () => {
@@ -88,7 +94,9 @@ describe('SharedWithMe view', () => {
             mock<IncomingShareResource>({ shareTypes: [shareType2.value] })
           ]
         })
-        const filterItems = wrapper.findComponent<any>('.share-type-filter').props('items')
+        const filterItems = wrapper
+          .findComponent<typeof ItemFilter>('.share-type-filter')
+          .props('items')
         expect(wrapper.find('.share-type-filter').exists()).toBeTruthy()
         expect(filterItems).toEqual([shareType1, shareType2])
       })
@@ -109,7 +117,9 @@ describe('SharedWithMe view', () => {
             })
           ]
         })
-        const filterItems = wrapper.findComponent<any>('.shared-by-filter').props('items')
+        const filterItems = wrapper
+          .findComponent<typeof ItemFilter>('.shared-by-filter')
+          .props('items')
         expect(wrapper.find('.shared-by-filter').exists()).toBeTruthy()
         expect(filterItems).toEqual([collaborator1, collaborator2])
       })

--- a/packages/web-app-files/tests/unit/views/shares/SharedWithOthers.spec.ts
+++ b/packages/web-app-files/tests/unit/views/shares/SharedWithOthers.spec.ts
@@ -8,6 +8,7 @@ import { Resource } from '@ownclouders/web-client'
 import { defaultPlugins, mount, defaultComponentMocks } from 'web-test-helpers'
 import { ShareResource, ShareTypes } from '@ownclouders/web-client/src/helpers'
 import { useSortMock } from '../../../mocks/useSortMock'
+import { ResourceTable } from '@ownclouders/web-pkg'
 
 vi.mock('web-app-files/src/composables')
 vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
@@ -42,9 +43,9 @@ describe('SharedWithOthers view', () => {
       const { wrapper } = getMountedWrapper({ files: mockedFiles })
       expect(wrapper.find('.no-content-message').exists()).toBeFalsy()
       expect(wrapper.find('resource-table-stub').exists()).toBeTruthy()
-      expect(wrapper.findComponent<any>('resource-table-stub').props().resources.length).toEqual(
-        mockedFiles.length
-      )
+      expect(
+        wrapper.findComponent<typeof ResourceTable>('resource-table-stub').props().resources.length
+      ).toEqual(mockedFiles.length)
     })
   })
   describe('filter', () => {

--- a/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
@@ -9,9 +9,10 @@ import {
   mount,
   defaultComponentMocks,
   defaultStubs,
-  RouteLocation
+  RouteLocation,
+  ComponentProps
 } from 'web-test-helpers'
-import { useBreadcrumbsFromPath, useExtensionRegistry } from '@ownclouders/web-pkg'
+import { AppBar, useBreadcrumbsFromPath, useExtensionRegistry } from '@ownclouders/web-pkg'
 import { useBreadcrumbsFromPathMock } from '../../../mocks/useBreadcrumbsFromPathMock'
 import { useExtensionRegistryMock } from 'web-test-helpers/src/mocks/useExtensionRegistryMock'
 import { h } from 'vue'
@@ -99,7 +100,7 @@ describe('GenericSpace view', () => {
         isOwner: () => driveType === 'personal'
       }
       const { wrapper } = getMountedWrapper({ files: [mockDeep<Resource>()], props: { space } })
-      expect(wrapper.findComponent<any>('app-bar-stub').props().breadcrumbs.length).toBe(
+      expect(wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs.length).toBe(
         expectedItems
       )
     })
@@ -110,10 +111,12 @@ describe('GenericSpace view', () => {
         props: { item: `/${folderName}` },
         breadcrumbsFromPath: [{ text: folderName }]
       })
-      expect(wrapper.findComponent<any>('app-bar-stub').props().breadcrumbs.length).toBe(2)
-      expect(wrapper.findComponent<any>('app-bar-stub').props().breadcrumbs[1].text).toEqual(
-        folderName
+      expect(wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs.length).toBe(
+        2
       )
+      expect(
+        wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs[1].text
+      ).toEqual(folderName)
     })
     it('omit the "page"-query of the current route', () => {
       const currentRoute = { name: 'files-spaces-generic', path: '/', query: { page: '2' } }
@@ -122,8 +125,9 @@ describe('GenericSpace view', () => {
         props: { item: 'someFolder' },
         currentRoute
       })
-      const breadCrumbItem = wrapper.findComponent<any>('app-bar-stub').props().breadcrumbs[0]
-      expect(breadCrumbItem.to.query.page).toBeUndefined()
+      const breadCrumbItem = wrapper.findComponent<typeof AppBar>('app-bar-stub').props()
+        .breadcrumbs[0]
+      expect((breadCrumbItem.to as RouteLocation).query.page).toBeUndefined()
     })
   })
   describe('loader task', () => {
@@ -197,12 +201,12 @@ describe('GenericSpace view', () => {
             ...mock<Resource>()
           },
           files: [{ ...mock<Resource>(), isFolder: false }],
-          space: {
-            id: 1,
+          space: mock<SpaceResource>({
+            id: '1',
             getDriveAliasAndItem: vi.fn(),
             name: 'Personal space',
             driveType: 'public'
-          }
+          })
         })
         expect(wrapper.find('resource-details-stub').exists()).toBeTruthy()
       })
@@ -276,7 +280,12 @@ function getMountedWrapper({
   currentRoute = { name: 'files-spaces-generic', path: '/' },
   currentFolder = mock<Resource>(),
   runningOnEos = false,
-  space = { id: 1, getDriveAliasAndItem: vi.fn(), name: 'Personal space', driveType: '' },
+  space = mock<SpaceResource>({
+    id: '1',
+    getDriveAliasAndItem: vi.fn(),
+    name: 'Personal space',
+    driveType: ''
+  }),
   breadcrumbsFromPath = [],
   stubs = {}
 } = {}) {
@@ -319,9 +328,10 @@ function getMountedWrapper({
     ...(mocks && mocks)
   }
 
-  const propsData = {
+  const propsData: ComponentProps<typeof GenericSpace> = {
     space,
     item: '/',
+    itemId: undefined,
     ...props
   }
 

--- a/packages/web-app-files/tests/unit/views/spaces/GenericTrash.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/GenericTrash.spec.ts
@@ -10,8 +10,11 @@ import {
   mount,
   defaultComponentMocks,
   defaultStubs,
-  RouteLocation
+  RouteLocation,
+  PartialComponentProps,
+  ComponentProps
 } from 'web-test-helpers'
+import { AppBar } from '@ownclouders/web-pkg'
 
 vi.mock('web-app-files/src/composables')
 
@@ -26,16 +29,16 @@ describe('GenericTrash view', () => {
   })
   it('shows the personal space breadcrumb', () => {
     const { wrapper } = getMountedWrapper()
-    expect(wrapper.findComponent<any>('app-bar-stub').props().breadcrumbs[1].text).toEqual(
-      'Personal space'
-    )
+    expect(
+      wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs[1].text
+    ).toEqual('Personal space')
   })
   it('shows the project space breadcrumb', () => {
     const space = mock<SpaceResource>({ driveType: 'project' })
     const { wrapper } = getMountedWrapper({ props: { space } })
-    expect(wrapper.findComponent<any>('app-bar-stub').props().breadcrumbs[1].text).toEqual(
-      space.name
-    )
+    expect(
+      wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs[1].text
+    ).toEqual(space.name)
   })
   describe('different files view states', () => {
     it('shows the loading spinner during loading', () => {
@@ -55,7 +58,12 @@ describe('GenericTrash view', () => {
   })
 })
 
-function getMountedWrapper({ mocks = {}, props = {}, files = [], loading = false } = {}) {
+function getMountedWrapper({
+  mocks = {},
+  props = {} as PartialComponentProps<typeof GenericTrash>,
+  files = [],
+  loading = false
+} = {}) {
   vi.mocked(useResourcesViewDefaults).mockImplementation(() =>
     useResourcesViewDefaultsMock({
       paginatedResources: ref(files),
@@ -68,8 +76,8 @@ function getMountedWrapper({ mocks = {}, props = {}, files = [], loading = false
     }),
     ...(mocks && mocks)
   }
-  const propsData = {
-    space: { id: 1, getDriveAliasAndItem: vi.fn(), name: 'Personal space' },
+  const propsData: ComponentProps<typeof GenericTrash> = {
+    space: mock<SpaceResource>({ id: '1', getDriveAliasAndItem: vi.fn(), name: 'Personal space' }),
     ...props
   }
   return {

--- a/packages/web-app-text-editor/tests/unit/app.spec.ts
+++ b/packages/web-app-text-editor/tests/unit/app.spec.ts
@@ -1,6 +1,4 @@
-import { Resource } from '@ownclouders/web-client/src'
-import { AppConfigObject } from '@ownclouders/web-pkg'
-import { mount } from 'web-test-helpers'
+import { PartialComponentProps, mount } from 'web-test-helpers'
 import App from '../../src/App.vue'
 
 vi.mock('@ownclouders/web-pkg')
@@ -14,10 +12,16 @@ describe('Text editor app', () => {
   })
 })
 
-function getWrapper(props: { applicationConfig: AppConfigObject; resource?: Resource }) {
+function getWrapper(props: PartialComponentProps<typeof App>) {
   return {
     wrapper: mount(App, {
-      props
+      props: {
+        applicationConfig: {},
+        currentContent: '',
+        isReadOnly: false,
+        resource: undefined,
+        ...props
+      }
     })
   }
 }

--- a/packages/web-pkg/tests/unit/components/AppBar/AppBar.spec.ts
+++ b/packages/web-pkg/tests/unit/components/AppBar/AppBar.spec.ts
@@ -10,6 +10,8 @@ import {
 } from 'web-test-helpers'
 import { ArchiverService } from '../../../../src/services'
 import { FolderView } from '../../../../src/ui/types'
+import { ViewOptions } from '../../../../src'
+import { OcBreadcrumb } from 'design-system/src/components'
 
 const selectors = {
   ocBreadcrumbStub: 'oc-breadcrumb-stub',
@@ -43,9 +45,9 @@ describe('AppBar component', () => {
       it('if given, by default without breadcrumbsContextActionsItems', () => {
         const { wrapper } = getShallowWrapper([], {}, { breadcrumbs: breadcrumbItems })
         expect(wrapper.find(selectors.ocBreadcrumbStub).exists()).toBeTruthy()
-        expect(wrapper.findComponent<any>(selectors.ocBreadcrumbStub).props('items')).toEqual(
-          breadcrumbItems
-        )
+        expect(
+          wrapper.findComponent<typeof OcBreadcrumb>(selectors.ocBreadcrumbStub).props('items')
+        ).toEqual(breadcrumbItems)
       })
       it('if given, with breadcrumbsContextActionsItems if allowed on last breadcrumb item', () => {
         const { wrapper } = getShallowWrapper(
@@ -54,10 +56,9 @@ describe('AppBar component', () => {
           { breadcrumbs: [...breadcrumbItems, breadCrumbItemWithContextActionAllowed] }
         )
         expect(wrapper.find(selectors.ocBreadcrumbStub).exists()).toBeTruthy()
-        expect(wrapper.findComponent<any>(selectors.ocBreadcrumbStub).props('items')).toEqual([
-          ...breadcrumbItems,
-          breadCrumbItemWithContextActionAllowed
-        ])
+        expect(
+          wrapper.findComponent<typeof OcBreadcrumb>(selectors.ocBreadcrumbStub).props('items')
+        ).toEqual([...breadcrumbItems, breadCrumbItemWithContextActionAllowed])
       })
       it('not if no breadcrumb items given', () => {
         const { wrapper } = getShallowWrapper([], {}, { breadcrumbs: [] })
@@ -114,9 +115,9 @@ describe('AppBar component', () => {
       it('passes viewModes array to ViewOptions', () => {
         const viewModes = [mock<FolderView>]
         const { wrapper } = getShallowWrapper([], {}, { hasViewOptions: true, viewModes })
-        expect(wrapper.findComponent<any>(selectors.viewOptionsStub).props('viewModes')).toEqual(
-          viewModes
-        )
+        expect(
+          wrapper.findComponent<typeof ViewOptions>(selectors.viewOptionsStub).props('viewModes')
+        ).toEqual(viewModes)
       })
     })
     it('if given, with content in the actions slot', () => {

--- a/packages/web-pkg/tests/unit/components/BatchActions.spec.ts
+++ b/packages/web-pkg/tests/unit/components/BatchActions.spec.ts
@@ -1,7 +1,8 @@
-import { defaultPlugins, mount } from 'web-test-helpers'
+import { PartialComponentProps, defaultPlugins, mount } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
 import { Resource } from '@ownclouders/web-client/src/helpers'
 import BatchActions from '../../../src/components/BatchActions.vue'
+import { Action, ActionMenuItem } from '../../../src'
 
 const selectors = {
   actionMenuItemStub: 'action-menu-item-stub',
@@ -16,7 +17,7 @@ describe('BatchActions', () => {
     })
 
     it('render enabled actions', () => {
-      const actions = [{}]
+      const actions = [{} as Action]
       const { wrapper } = getWrapper({ props: { actions } })
       expect(wrapper.findAll(selectors.actionMenuItemStub).length).toBe(actions.length)
     })
@@ -27,19 +28,26 @@ describe('BatchActions', () => {
       expect(wrapper.find(selectors.batchActionsSquashed).exists()).toBeTruthy()
     })
     it('correctly tells the action item component to show tooltips when limited screen space is available', () => {
-      const { wrapper } = getWrapper({ props: { actions: [{}], limitedScreenSpace: true } })
+      const { wrapper } = getWrapper({
+        props: { actions: [{} as Action], limitedScreenSpace: true }
+      })
       expect(
-        wrapper.findComponent<any>(selectors.actionMenuItemStub).props().showTooltip
+        wrapper.findComponent<typeof ActionMenuItem>(selectors.actionMenuItemStub).props()
+          .showTooltip
       ).toBeTruthy()
     })
   })
 })
 
-function getWrapper({ props = {} } = {}) {
+function getWrapper(
+  { props }: { props?: PartialComponentProps<typeof BatchActions> } = { props: {} }
+) {
   return {
     wrapper: mount(BatchActions, {
       props: {
         items: [mock<Resource>()],
+        actions: [],
+        actionOptions: {},
         ...props
       },
       global: {

--- a/packages/web-pkg/tests/unit/components/ContextActions/ActionMenuItem.spec.ts
+++ b/packages/web-pkg/tests/unit/components/ContextActions/ActionMenuItem.spec.ts
@@ -91,6 +91,7 @@ function getWrapper(action, items = [], appearance = null, mountType = shallowMo
     wrapper: mountType(ActionMenuItem, {
       props: {
         action,
+        actionOptions: {},
         items,
         ...(appearance && { appearance })
       },

--- a/packages/web-pkg/tests/unit/components/CreateLinkModal.spec.ts
+++ b/packages/web-pkg/tests/unit/components/CreateLinkModal.spec.ts
@@ -237,7 +237,8 @@ function getWrapper({
       props: {
         resources,
         isQuickLink,
-        callbackFn
+        callbackFn,
+        modal: undefined
       },
       global: {
         plugins: [

--- a/packages/web-pkg/tests/unit/components/CreateShortcutModal.spec.ts
+++ b/packages/web-pkg/tests/unit/components/CreateShortcutModal.spec.ts
@@ -16,7 +16,7 @@ describe('CreateShortcutModal', () => {
   describe('method "onConfirm"', () => {
     it('should show message on success', async () => {
       const { wrapper } = getWrapper()
-      await wrapper.vm.onConfirm('https://owncloud.com', 'owncloud.url')
+      await wrapper.vm.onConfirm()
 
       const { upsertResource } = useResourcesStore()
       expect(upsertResource).toHaveBeenCalled()
@@ -26,7 +26,7 @@ describe('CreateShortcutModal', () => {
     it('should show error message on fail', async () => {
       console.error = vi.fn()
       const { wrapper } = getWrapper({ rejectPutFileContents: true })
-      await wrapper.vm.onConfirm('https://owncloud.com', 'owncloud.url')
+      await wrapper.vm.onConfirm()
 
       const { upsertResource } = useResourcesStore()
       expect(upsertResource).not.toHaveBeenCalled()
@@ -79,7 +79,8 @@ function getWrapper({ rejectPutFileContents = false, rejectSearch = false } = {}
     mocks,
     wrapper: shallowMount(CreateShortcutModal, {
       props: {
-        space: mock<SpaceResource>()
+        space: mock<SpaceResource>(),
+        modal: undefined
       },
       global: {
         plugins: [

--- a/packages/web-pkg/tests/unit/components/FilesList/ResourceIcon.spec.ts
+++ b/packages/web-pkg/tests/unit/components/FilesList/ResourceIcon.spec.ts
@@ -59,14 +59,14 @@ function match(resource: Partial<Resource>, additionalText?: string) {
 
 function getWrapper({ resource, size }: { resource: Partial<Resource>; size: string }) {
   return {
-    wrapper: shallowMount(ResourceIcon as any, {
+    wrapper: shallowMount(ResourceIcon, {
       global: {
         provide: {
           [resourceIconMappingInjectionKey]: resourceIconMapping
         }
       },
       props: {
-        resource,
+        resource: resource as Resource,
         size
       }
     })

--- a/packages/web-pkg/tests/unit/components/FilesList/ResourceListItem.spec.ts
+++ b/packages/web-pkg/tests/unit/components/FilesList/ResourceListItem.spec.ts
@@ -1,5 +1,6 @@
 import { defaultPlugins, mount } from 'web-test-helpers'
 import ResourceListItem from '../../../../src/components/FilesList/ResourceListItem.vue'
+import { Resource } from '@ownclouders/web-client'
 
 const fileResource = {
   name: 'forest.jpg',
@@ -8,20 +9,20 @@ const fileResource = {
   type: 'file',
   isFolder: false,
   extension: 'jpg'
-}
+} as Resource
 const folderResource = {
   name: 'Documents',
   path: '',
   type: 'folder',
   isFolder: true
-}
+} as Resource
 const fileResourceWithoutParentFoldername = {
   name: 'example.pdf',
   path: 'example.pdf',
   type: 'file',
   isFolder: false,
   extension: 'pdf'
-}
+} as Resource
 
 describe('OcResource', () => {
   it("doesn't emit a click if the resource is a folder", () => {

--- a/packages/web-pkg/tests/unit/components/FilesList/ResourceTable.spec.ts
+++ b/packages/web-pkg/tests/unit/components/FilesList/ResourceTable.spec.ts
@@ -1,6 +1,12 @@
 import { DateTime } from 'luxon'
 import ResourceTable from '../../../../src/components/FilesList/ResourceTable.vue'
-import { extractDomSelector, Resource, ShareTypes } from '@ownclouders/web-client/src/helpers'
+import {
+  extractDomSelector,
+  IncomingShareResource,
+  Resource,
+  ShareTypes,
+  SpaceResource
+} from '@ownclouders/web-client/src/helpers'
 import { defaultPlugins, mount } from 'web-test-helpers'
 import { CapabilityStore } from '../../../../src/composables/piniaStores'
 import { displayPositionedDropdown } from '../../../../src/helpers/contextMenuDropdown'
@@ -103,9 +109,13 @@ const resourcesWithAllFields = [
     owner,
     sharedBy,
     sharedWith,
-    shareTypes: [],
+    hidden: false,
     syncEnabled: true,
-    canRename: vi.fn,
+    outgoing: false,
+    shareRoles: [],
+    sharePermissions: [],
+    shareTypes: [],
+    canRename: vi.fn(),
     getDomSelector: () => extractDomSelector('forest')
   },
   {
@@ -121,11 +131,16 @@ const resourcesWithAllFields = [
     mdate: getCurrentDate(),
     sdate: getCurrentDate(),
     ddate: getCurrentDate(),
+    owner,
     sharedBy,
     sharedWith,
+    hidden: false,
+    syncEnabled: true,
+    outgoing: false,
+    shareRoles: [],
+    sharePermissions: [],
     shareTypes: [],
-    owner,
-    canRename: vi.fn,
+    canRename: vi.fn(),
     getDomSelector: () => extractDomSelector('notes')
   },
   {
@@ -140,11 +155,16 @@ const resourcesWithAllFields = [
     mdate: getCurrentDate(),
     sdate: getCurrentDate(),
     ddate: getCurrentDate(),
+    owner,
     sharedBy,
     sharedWith,
+    hidden: false,
+    syncEnabled: true,
+    outgoing: false,
+    shareRoles: [],
+    sharePermissions: [],
     shareTypes: [],
-    owner,
-    canRename: vi.fn,
+    canRename: vi.fn(),
     getDomSelector: () => extractDomSelector('documents')
   },
   {
@@ -158,15 +178,20 @@ const resourcesWithAllFields = [
     mdate: getCurrentDate(),
     sdate: getCurrentDate(),
     ddate: getCurrentDate(),
+    owner,
     sharedBy,
     sharedWith,
+    hidden: false,
+    syncEnabled: true,
+    outgoing: false,
+    shareRoles: [],
+    sharePermissions: [],
     shareTypes: [],
     tags: [],
-    owner,
-    canRename: vi.fn,
+    canRename: vi.fn(),
     getDomSelector: () => extractDomSelector('another-one==')
   }
-]
+] as IncomingShareResource[]
 
 const processingResourcesWithAllFields = [
   {
@@ -183,10 +208,16 @@ const processingResourcesWithAllFields = [
     mdate: getCurrentDate(),
     sdate: getCurrentDate(),
     ddate: getCurrentDate(),
-    sharedBy,
     owner,
+    sharedBy,
     sharedWith,
-    canRename: vi.fn,
+    hidden: false,
+    syncEnabled: true,
+    outgoing: false,
+    shareRoles: [],
+    sharePermissions: [],
+    shareTypes: [],
+    canRename: vi.fn(),
     getDomSelector: () => extractDomSelector('forest'),
     processing: true
   },
@@ -203,14 +234,20 @@ const processingResourcesWithAllFields = [
     mdate: getCurrentDate(),
     sdate: getCurrentDate(),
     ddate: getCurrentDate(),
+    owner,
     sharedBy,
     sharedWith,
-    owner,
-    canRename: vi.fn,
+    hidden: false,
+    syncEnabled: true,
+    outgoing: false,
+    shareRoles: [],
+    sharePermissions: [],
+    shareTypes: [],
+    canRename: vi.fn(),
     getDomSelector: () => extractDomSelector('notes'),
     processing: true
   }
-]
+] as IncomingShareResource[]
 
 describe('ResourceTable', () => {
   it('displays all known fields of the resources', () => {
@@ -475,9 +512,9 @@ function getMountedWrapper({
         ],
         selection: [],
         hover: false,
-        space: {
+        space: mock<SpaceResource>({
           getDriveAliasAndItem: vi.fn()
-        },
+        }),
         ...props
       },
       global: {

--- a/packages/web-pkg/tests/unit/components/Filters/ItemFilterInline.spec.ts
+++ b/packages/web-pkg/tests/unit/components/Filters/ItemFilterInline.spec.ts
@@ -1,6 +1,11 @@
 import ItemFilterInline from '../../../../src/components/Filters/ItemFilterInline.vue'
 import { InlineFilterOption } from '../../../../src/components/Filters/types'
-import { defaultComponentMocks, defaultPlugins, mount } from 'web-test-helpers'
+import {
+  defaultComponentMocks,
+  defaultPlugins,
+  mount,
+  PartialComponentProps
+} from 'web-test-helpers'
 import { queryItemAsString } from '../../../../src/composables/appDefaults'
 import { mock } from 'vitest-mock-extended'
 
@@ -50,7 +55,13 @@ describe('ItemFilterInline', () => {
   })
 })
 
-function getWrapper({ props = {}, initialQuery = '' } = {}) {
+function getWrapper({
+  props = {},
+  initialQuery = ''
+}: {
+  props?: PartialComponentProps<typeof ItemFilterInline>
+  initialQuery?: string
+} = {}) {
   vi.mocked(queryItemAsString).mockImplementation(() => initialQuery)
   const mocks = defaultComponentMocks()
   return {
@@ -58,6 +69,7 @@ function getWrapper({ props = {}, initialQuery = '' } = {}) {
     wrapper: mount(ItemFilterInline, {
       props: {
         filterName: 'InlineFilter',
+        filterOptions: [],
         ...props
       },
       global: {

--- a/packages/web-pkg/tests/unit/components/ItemFilter.spec.ts
+++ b/packages/web-pkg/tests/unit/components/ItemFilter.spec.ts
@@ -1,6 +1,7 @@
 import ItemFilter from '../../../src/components/ItemFilter.vue'
 import { defaultComponentMocks, defaultPlugins, mount } from 'web-test-helpers'
 import { queryItemAsString } from '../../../src/composables/appDefaults'
+import { OcCheckbox } from 'design-system/src/components'
 
 vi.mock('../../../src/composables/appDefaults')
 
@@ -57,11 +58,15 @@ describe('ItemFilter', () => {
       expect(wrapper.emitted('selectionChange')).toBeFalsy()
       let selectionChangeEmits = 0
       for (const item of wrapper.findAll(selectors.filterListItem)) {
-        expect(item.findComponent<any>(selectors.checkboxStub).props('modelValue')).toBeFalsy()
+        expect(
+          item.findComponent<typeof OcCheckbox>(selectors.checkboxStub).props('modelValue')
+        ).toBeFalsy()
         await item.trigger('click')
         selectionChangeEmits += 1
         expect(wrapper.emitted('selectionChange').length).toBe(selectionChangeEmits)
-        expect(item.findComponent<any>(selectors.checkboxStub).props('modelValue')).toBeTruthy()
+        expect(
+          item.findComponent<typeof OcCheckbox>(selectors.checkboxStub).props('modelValue')
+        ).toBeTruthy()
       }
       expect(wrapper.vm.selectedItems.length).toBe(wrapper.findAll(selectors.filterListItem).length)
     })
@@ -83,7 +88,9 @@ describe('ItemFilter', () => {
       await item.trigger('click')
       await item.trigger('click')
       expect(wrapper.emitted('selectionChange').length).toBe(2)
-      expect(item.findComponent<any>(selectors.checkboxStub).props('modelValue')).toBeFalsy()
+      expect(
+        item.findComponent<typeof OcCheckbox>(selectors.checkboxStub).props('modelValue')
+      ).toBeFalsy()
       expect(wrapper.vm.selectedItems.length).toBe(0)
     })
     it('clears the selection when the clear-button is being clicked', async () => {
@@ -92,7 +99,9 @@ describe('ItemFilter', () => {
       await item.trigger('click')
       await wrapper.find(selectors.clearBtn).trigger('click')
       expect(wrapper.emitted('selectionChange').length).toBe(2)
-      expect(item.findComponent<any>(selectors.checkboxStub).props('modelValue')).toBeFalsy()
+      expect(
+        item.findComponent<typeof OcCheckbox>(selectors.checkboxStub).props('modelValue')
+      ).toBeFalsy()
       expect(wrapper.vm.selectedItems.length).toBe(0)
     })
   })

--- a/packages/web-pkg/tests/unit/components/LoadingIndicator.spec.ts
+++ b/packages/web-pkg/tests/unit/components/LoadingIndicator.spec.ts
@@ -2,6 +2,7 @@ import LoadingIndicator from '../../../src/components/LoadingIndicator.vue'
 import { defaultPlugins, shallowMount } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
 import { LoadingService } from '../../../src/services'
+import { OcProgress } from 'design-system/src/components'
 
 const selectors = {
   loadingIndicator: '#oc-loading-indicator',
@@ -20,11 +21,15 @@ describe('LoadingIndicator', () => {
   describe('indeterminate', () => {
     it('progress bar should be in indeterminate when no progress given', () => {
       const { wrapper } = getWrapper({ isLoading: true })
-      expect(wrapper.findComponent<any>(selectors.progressStub).props('indeterminate')).toBeTruthy()
+      expect(
+        wrapper.findComponent<typeof OcProgress>(selectors.progressStub).props('indeterminate')
+      ).toBeTruthy()
     })
     it('progress bar should not be in indeterminate when progress given', () => {
       const { wrapper } = getWrapper({ isLoading: true, currentProgress: 50 })
-      expect(wrapper.findComponent<any>(selectors.progressStub).props('indeterminate')).toBeFalsy()
+      expect(
+        wrapper.findComponent<typeof OcProgress>(selectors.progressStub).props('indeterminate')
+      ).toBeFalsy()
     })
   })
 })

--- a/packages/web-pkg/tests/unit/components/Modals/ResourceConflictModal.spec.ts
+++ b/packages/web-pkg/tests/unit/components/Modals/ResourceConflictModal.spec.ts
@@ -68,7 +68,7 @@ function getWrapper({ props = {} } = {}) {
     wrapper: shallowMount(ResourceConflictModal, {
       props: {
         modal: mock<Modal>(),
-        resource: mock<Resource>,
+        resource: mock<Resource>(),
         conflictCount: 1,
         callbackFn: () => ({}),
         ...props

--- a/packages/web-pkg/tests/unit/components/SearchBarFilter.spec.ts
+++ b/packages/web-pkg/tests/unit/components/SearchBarFilter.spec.ts
@@ -1,6 +1,7 @@
 import { useRouteQuery } from '../../../src/composables/router/useRouteQuery'
 import SearchBarFilter from '../../../src/components/SearchBarFilter.vue'
 import { defaultComponentMocks, defaultPlugins, shallowMount } from 'web-test-helpers'
+import { OcFilterChip } from 'design-system/src/components'
 
 vi.mock('../../../src/composables/router/useRouteQuery')
 
@@ -11,17 +12,23 @@ const selectors = {
 describe('SearchBarFilter', () => {
   it('shows "All files" as default option', () => {
     const { wrapper } = getWrapper({ currentFolderAvailable: true })
-    const filterLabel = wrapper.findComponent<any>(selectors.filterChipStub).props('filterLabel')
+    const filterLabel = wrapper
+      .findComponent<typeof OcFilterChip>(selectors.filterChipStub)
+      .props('filterLabel')
     expect(filterLabel).toBe('All files')
   })
   it('shows "All files" as current option if no Current folder available', () => {
     const { wrapper } = getWrapper()
-    const filterLabel = wrapper.findComponent<any>(selectors.filterChipStub).props('filterLabel')
+    const filterLabel = wrapper
+      .findComponent<typeof OcFilterChip>(selectors.filterChipStub)
+      .props('filterLabel')
     expect(filterLabel).toBe('All files')
   })
   it('shows "Current folder" as current option if given via scope', () => {
     const { wrapper } = getWrapper({ useScope: 'true' })
-    const filterLabel = wrapper.findComponent<any>(selectors.filterChipStub).props('filterLabel')
+    const filterLabel = wrapper
+      .findComponent<typeof OcFilterChip>(selectors.filterChipStub)
+      .props('filterLabel')
     expect(filterLabel).toBe('Current folder')
   })
 })

--- a/packages/web-pkg/tests/unit/components/SpaceQuota.spec.ts
+++ b/packages/web-pkg/tests/unit/components/SpaceQuota.spec.ts
@@ -1,3 +1,4 @@
+import { OcProgress } from 'design-system/src/components'
 import { SpaceQuota } from '../../../src/components'
 import { defaultPlugins, shallowMount } from 'web-test-helpers'
 
@@ -14,7 +15,7 @@ describe('SpaceQuota component', () => {
     { state: 'exceeded', expectedVariation: 'danger' }
   ])('renders the progress variant correctly', (dataSet) => {
     const { wrapper } = getWrapper({ total: 10, used: 1, state: dataSet.state })
-    const progressBar = wrapper.findComponent<any>('.space-quota oc-progress-stub')
+    const progressBar = wrapper.findComponent<typeof OcProgress>('.space-quota oc-progress-stub')
     expect(progressBar.exists()).toBeTruthy()
     expect(progressBar.props().variation).toBe(dataSet.expectedVariation)
   })

--- a/packages/web-pkg/tests/unit/components/Spaces/QuotaModal.spec.ts
+++ b/packages/web-pkg/tests/unit/components/Spaces/QuotaModal.spec.ts
@@ -7,6 +7,7 @@ import {
   mockAxiosResolve
 } from 'web-test-helpers'
 import { useMessages, useSpacesStore } from '../../../../src/composables/piniaStores'
+import { SpaceResource } from '@ownclouders/web-client'
 
 describe('QuotaModal', () => {
   describe('method "editQuota"', () => {
@@ -52,6 +53,7 @@ function getWrapper() {
     mocks,
     wrapper: mount(QuotaModal, {
       props: {
+        modal: undefined,
         spaces: [
           {
             id: '1fe58d8b-aa69-4c22-baf7-97dd57479f22',
@@ -61,7 +63,7 @@ function getWrapper() {
               total: 10000000000,
               used: 164
             }
-          }
+          } as SpaceResource
         ]
       },
       global: {

--- a/packages/web-pkg/tests/unit/components/ViewOptions.spec.ts
+++ b/packages/web-pkg/tests/unit/components/ViewOptions.spec.ts
@@ -1,5 +1,11 @@
 import { ref, unref } from 'vue'
-import { defaultPlugins, defaultComponentMocks, mount, RouteLocation } from 'web-test-helpers'
+import {
+  defaultPlugins,
+  defaultComponentMocks,
+  mount,
+  RouteLocation,
+  PartialComponentProps
+} from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
 import ViewOptions from '../../../src/components/ViewOptions.vue'
 import {
@@ -9,6 +15,7 @@ import {
   useRouteQueryPersisted
 } from '../../../src/composables'
 import { FolderView } from '../../../src'
+import { OcPageSize, OcSwitch } from 'design-system/src/components'
 
 vi.mock('../../../src/composables/router', async (importOriginal) => ({
   ...(await importOriginal<any>()),
@@ -33,7 +40,9 @@ describe('ViewOptions component', () => {
     it('sets the correct initial files page limit', () => {
       const perPage = '100'
       const { wrapper } = getWrapper({ perPage })
-      expect(wrapper.findComponent<any>(selectors.pageSizeSelect).props().selected).toBe(perPage)
+      expect(
+        wrapper.findComponent<typeof OcPageSize>(selectors.pageSizeSelect).props().selected
+      ).toBe(perPage)
     })
     it('sets the correct files page limit', () => {
       const perPage = '100'
@@ -65,10 +74,9 @@ describe('ViewOptions component', () => {
     })
     it('toggles the setting to show/hide hidden files', () => {
       const { wrapper } = getWrapper()
-      ;(wrapper.findComponent<any>(selectors.hiddenFilesSwitch).vm as any).$emit(
-        'update:checked',
-        false
-      )
+      wrapper
+        .findComponent<typeof OcSwitch>(selectors.hiddenFilesSwitch)
+        .vm.$emit('update:checked', false)
 
       const { setAreHiddenFilesShown } = useResourcesStore()
       expect(setAreHiddenFilesShown).toHaveBeenCalled()
@@ -81,10 +89,9 @@ describe('ViewOptions component', () => {
     })
     it('toggles the setting to show/hide file extensions', () => {
       const { wrapper } = getWrapper()
-      ;(wrapper.findComponent<any>(selectors.fileExtensionsSwitch).vm as any).$emit(
-        'update:checked',
-        false
-      )
+      wrapper
+        .findComponent<typeof OcSwitch>(selectors.fileExtensionsSwitch)
+        .vm.$emit('update:checked', false)
 
       const { setAreFileExtensionsShown } = useResourcesStore()
       expect(setAreFileExtensionsShown).toHaveBeenCalled()
@@ -134,6 +141,12 @@ function getWrapper({
   tileSize = '1',
   props = {},
   currentPage = '1'
+}: {
+  perPage?: string
+  viewMode?: string
+  tileSize?: string
+  props?: PartialComponentProps<typeof ViewOptions>
+  currentPage?: string
 } = {}) {
   vi.mocked(useRouteQueryPersisted).mockImplementationOnce(() => ref(perPage))
   vi.mocked(useRouteQueryPersisted).mockImplementationOnce(() => ref(viewMode))
@@ -148,7 +161,10 @@ function getWrapper({
   return {
     mocks,
     wrapper: mount(ViewOptions, {
-      props: { ...props },
+      props: {
+        perPageStoragePrefix: '',
+        ...props
+      },
       global: {
         mocks,
         provide: mocks,

--- a/packages/web-pkg/tests/unit/composables/folderLink/useFolderLink.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/folderLink/useFolderLink.spec.ts
@@ -1,6 +1,6 @@
 import { defaultComponentMocks, getComposableWrapper } from 'web-test-helpers'
 import { CapabilityStore, useFolderLink } from '../../../../src/composables'
-import { SpaceResource } from '@ownclouders/web-client'
+import { Resource, SpaceResource } from '@ownclouders/web-client'
 
 describe('useFolderLink', () => {
   it('getFolderLink should return the correct folder link', () => {
@@ -43,7 +43,7 @@ describe('useFolderLink', () => {
       const resource = {
         path: '/my-folder',
         storageId: '1'
-      }
+      } as Resource
 
       const wrapper = createWrapper()
       const parentFolderName = wrapper.vm.getParentFolderName(resource)
@@ -53,7 +53,7 @@ describe('useFolderLink', () => {
       const resource = {
         path: '/my-folder',
         storageId: '2'
-      }
+      } as Resource
 
       const wrapper = createWrapper()
       const parentFolderName = wrapper.vm.getParentFolderName(resource)
@@ -65,7 +65,7 @@ describe('useFolderLink', () => {
         shareRoot: '/My share',
         shareId: '1',
         isShareRoot: () => true
-      }
+      } as Resource
 
       const wrapper = createWrapper()
       const parentFolderName = wrapper.vm.getParentFolderName(resource)
@@ -76,7 +76,7 @@ describe('useFolderLink', () => {
         path: '/My share/test.txt',
         shareRoot: '/My share',
         shareId: '1'
-      }
+      } as Resource
 
       const wrapper = createWrapper()
       const parentFolderName = wrapper.vm.getParentFolderName(resource)

--- a/packages/web-runtime/tests/unit/components/Avatar.spec.ts
+++ b/packages/web-runtime/tests/unit/components/Avatar.spec.ts
@@ -4,6 +4,7 @@ import { mock, mockDeep } from 'vitest-mock-extended'
 import { CapabilityStore, ClientService } from '@ownclouders/web-pkg'
 import { AxiosResponse } from 'axios'
 import { nextTick } from 'vue'
+import { OcAvatar } from 'design-system/src/components'
 
 const propsData = {
   userName: 'admin',
@@ -49,7 +50,7 @@ describe('Avatar component', () => {
     })
     it('should set props on oc-avatar component', () => {
       const { wrapper } = getShallowWrapper()
-      const avatar = wrapper.findComponent<any>(ocAvatar)
+      const avatar = wrapper.findComponent<typeof OcAvatar>(ocAvatar)
 
       expect(avatar.props().width).toEqual(propsData.width)
       expect(avatar.props().userName).toEqual(propsData.userName)
@@ -58,7 +59,7 @@ describe('Avatar component', () => {
     describe('when an avatar is not found', () => {
       it('should set empty string to src prop on oc-avatar component', () => {
         const { wrapper } = getShallowWrapper()
-        const avatar = wrapper.findComponent<any>(ocAvatar)
+        const avatar = wrapper.findComponent<typeof OcAvatar>(ocAvatar)
         expect(avatar.props().src).toEqual('')
       })
     })
@@ -80,7 +81,7 @@ describe('Avatar component', () => {
         await nextTick()
         await nextTick()
         await nextTick()
-        const avatar = wrapper.findComponent<any>(ocAvatar)
+        const avatar = wrapper.findComponent<typeof OcAvatar>(ocAvatar)
         expect(avatar.props().src).toEqual(blob)
       })
     })

--- a/packages/web-runtime/tests/unit/components/Topbar/Notifications.spec.ts
+++ b/packages/web-runtime/tests/unit/components/Topbar/Notifications.spec.ts
@@ -4,6 +4,7 @@ import { mock, mockDeep } from 'vitest-mock-extended'
 import { defaultComponentMocks, defaultPlugins, shallowMount } from 'web-test-helpers'
 import { OwnCloudSdk } from '@ownclouders/web-client/src/types'
 import { SpaceResource } from '@ownclouders/web-client'
+import { RouterLink, RouteLocationNamedRaw, RouteLocationNormalizedLoaded } from 'vue-router'
 
 const selectors = {
   notificationBellStub: 'notification-bell-stub',
@@ -155,11 +156,13 @@ describe('Notification component', () => {
         await wrapper.vm.fetchNotificationsTask.last
         wrapper.vm.showDrop()
         await wrapper.vm.$nextTick()
-        const routerLink = wrapper.findComponent<any>(
+        const routerLink = wrapper.findComponent<typeof RouterLink>(
           `${selectors.notificationItem} router-link-stub`
         )
-        expect(routerLink.props('to').name).toEqual('files-shares-with-me')
-        expect(routerLink.props('to').query).toEqual({
+        expect((routerLink.props('to') as RouteLocationNamedRaw).name).toEqual(
+          'files-shares-with-me'
+        )
+        expect((routerLink.props('to') as RouteLocationNamedRaw).query).toEqual({
           scrollTo: notification.messageRichParameters.share.id
         })
       })
@@ -182,10 +185,10 @@ describe('Notification component', () => {
         await wrapper.vm.fetchNotificationsTask.last
         wrapper.vm.showDrop()
         await wrapper.vm.$nextTick()
-        const routerLink = wrapper.findComponent<any>(
+        const routerLink = wrapper.findComponent<typeof RouterLink>(
           `${selectors.notificationItem} router-link-stub`
         )
-        expect(routerLink.props('to').params).toEqual({
+        expect((routerLink.props('to') as RouteLocationNormalizedLoaded).params).toEqual({
           driveAliasAndItem: 'driveAlias'
         })
       })

--- a/packages/web-runtime/tests/unit/components/UploadInfo.spec.ts
+++ b/packages/web-runtime/tests/unit/components/UploadInfo.spec.ts
@@ -1,5 +1,6 @@
 import UploadInfo from '../../../src/components/UploadInfo.vue'
 import { defaultPlugins, shallowMount, defaultComponentMocks } from 'web-test-helpers'
+import { ResourceListItem } from '@ownclouders/web-pkg'
 
 const selectors = {
   overlay: '#upload-info',
@@ -190,7 +191,7 @@ describe('UploadInfo component', () => {
 
       const info = wrapper.find(selectors.info.items)
       expect(info.exists()).toBeTruthy()
-      const resourceStub = wrapper.findComponent<any>(
+      const resourceStub = wrapper.findComponent<typeof ResourceListItem>(
         `${selectors.info.item} resource-list-item-stub`
       )
       expect(resourceStub.props().isResourceClickable).toBeTruthy()

--- a/packages/web-runtime/tests/unit/pages/account.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/account.spec.ts
@@ -9,7 +9,7 @@ import {
 import { mock } from 'vitest-mock-extended'
 import { AxiosResponse } from 'axios'
 import { useMessages, useResourcesStore } from '@ownclouders/web-pkg'
-import { SettingsBundle, SettingsValue } from 'web-runtime/src/helpers/settings'
+import { LanguageOption, SettingsBundle, SettingsValue } from 'web-runtime/src/helpers/settings'
 import { User } from '@ownclouders/web-client/src/generated'
 
 const $route = {
@@ -216,7 +216,7 @@ describe('account page', () => {
       mocks.$clientService.graphAuthenticated.users.editMe.mockResolvedValueOnce(
         mockAxiosResolve({})
       )
-      await wrapper.vm.updateSelectedLanguage('en')
+      await wrapper.vm.updateSelectedLanguage({ value: 'en' } as LanguageOption)
       const { showMessage } = useMessages()
       expect(showMessage).toHaveBeenCalled()
     })
@@ -232,7 +232,7 @@ describe('account page', () => {
       mocks.$clientService.graphAuthenticated.users.editMe.mockImplementation(() =>
         mockAxiosReject('err')
       )
-      await wrapper.vm.updateSelectedLanguage('en')
+      await wrapper.vm.updateSelectedLanguage({ value: 'en' } as LanguageOption)
       const { showErrorMessage } = useMessages()
       expect(showErrorMessage).toHaveBeenCalled()
     })

--- a/packages/web-test-helpers/src/helpers.ts
+++ b/packages/web-test-helpers/src/helpers.ts
@@ -3,13 +3,14 @@ import { defineComponent, nextTick } from 'vue'
 import { defaultPlugins, DefaultPluginsOptions } from './defaultPlugins'
 import { createRouter as _createRouter } from '../../web-runtime/src/router'
 import { createMemoryHistory, RouterOptions } from 'vue-router'
+import { DefinedComponent } from '@vue/test-utils/dist/types'
 
 export { mount, shallowMount } from '@vue/test-utils'
 
 vi.spyOn(console, 'warn').mockImplementation(() => undefined)
 
 export const getComposableWrapper = <T>(
-  setup: any,
+  setup: (...args: any[]) => T,
   {
     mocks = undefined,
     provide = undefined,
@@ -60,3 +61,6 @@ export const nextTicks = async (amount: number) => {
     await nextTick()
   }
 }
+
+export type ComponentProps<T extends DefinedComponent> = InstanceType<T>['$props']
+export type PartialComponentProps<T extends DefinedComponent> = Partial<ComponentProps<T>>


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Improve types in tests, so the Vue 3.4 update will be easier.

## Motivation and Context
Types in Vue 3.4 seem to have improved a lot, they allow type checking/auto completion for `wrapper.vm` or on `wrapper.props`. For that to work, we need to use proper types when using `findComponent`. Otherwise types will be missing and cause a lot of errors.

I've bumped Vue locally, fixed (basically) all type issues and commited just the fixes - as we still have runtime issues with Vue 3.4. After this has been merged, we can focus on the runtime issues when actually bumping Vue and keep the PR more focused.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
