### PR TITLE
[tests-only] Removed scenario related to folder upload from old web UI test

### DIFF
--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -21,10 +21,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 
 - [webUISharingPublicManagement/shareByPublicLink.feature:24](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicManagement/shareByPublicLink.feature#L24)
 
-### [Uploading folders does not work in files-drop](https://github.com/owncloud/web/issues/2443)
-
-- [webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature:263](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature#L263)
-
 ### [Resources cannot be locked under ocis](https://github.com/owncloud/ocis/issues/1284)
 
 - [webUIWebdavLockProtection/delete.feature:33](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIWebdavLockProtection/delete.feature#L33)

--- a/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature
+++ b/tests/acceptance/features/webUISharingPublicDifferentRoles/shareByPublicLinkDifferentRoles.feature
@@ -259,15 +259,6 @@ Feature: Share by public link with different roles
     And as "Alice" the content of "simple-folder/'single'quotes.txt" in the server should be the same as the content of local file "'single'quotes.txt"
     And as "Alice" the content of "simple-folder/new-lorem.txt" in the server should be the same as the content of local file "new-lorem.txt"
 
-  @issue-2443
-  Scenario: creating a public link with "Uploader" role makes it possible to upload a folder
-    Given user "Alice" has shared folder "simple-folder" with link with "create" permissions in the server
-    When the public uses the webUI to access the last public link created by user "Alice" in a new session
-    And the public uploads folder "FOLDER" in files-drop page
-    Then the following files should be listed on the files-drop page:
-      | FOLDER |
-    And as "Alice" folder "simple-folder/FOLDER" should exist in the server
-
   @issue-ocis-723
   Scenario: creating a public link with "Uploader" role makes it possible to create files through files-drop page even with password set
     Given user "Alice" has shared folder "simple-folder" with link with "create" permissions and password "#Passw0rd" in the server

--- a/tests/e2e/cucumber/features/smoke/shares/link.feature
+++ b/tests/e2e/cucumber/features/smoke/shares/link.feature
@@ -45,6 +45,10 @@ Feature: link
       | lorem.txt     | lorem_new.txt    |
       | textfile.txt  | textfile_new.txt |
       | new-lorem.txt | test.txt         |
+#    currently upload folder feature is not available in playwright
+#    And "Anonymous" uploads the following resources in public link page
+#      | resource              |
+#      | filesForUpload/PARENT |
     And "Alice" removes the public link named "myPublicLink" of resource "folderPublic"
     And "Anonymous" should not be able to open the old link "myPublicLink"
     And "Alice" logs out


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Removed a bug demonstration test scenario related to issue https://github.com/owncloud/web/issues/2443 from the web UI test and added a step for uploading folder in public link share. As the folder upload is not available in playwright, the step for E2E test is added and is commented for now.
The test is also done manually and the issue doesn't occur in the latest master branch.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/web/issues/10259

## Screenshots (if appropriate):
Result from manual test.

[Screencast from 02-14-2024 11:33:42 AM.webm](https://github.com/owncloud/web/assets/83579989/ab629237-07a2-495c-a3c9-d77ea123e37f)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
