### PR TITLE
fix: public link download in authenticated context

### DIFF
--- a/changelog/unreleased/bugfix-public-link-file-download
+++ b/changelog/unreleased/bugfix-public-link-file-download
@@ -1,0 +1,6 @@
+Bugfix: Public link file download
+
+We've fixed a bug where the download of a file from a public link was not working when the user had logged in already. The download only worked if no user was logged in.
+
+https://github.com/owncloud/web/issues/10473
+https://github.com/owncloud/web/pull/10494

--- a/tests/e2e/cucumber/features/smoke/shares/link.feature
+++ b/tests/e2e/cucumber/features/smoke/shares/link.feature
@@ -42,6 +42,10 @@ Feature: link
       | lorem.txt     | lorem_new.txt    |
       | textfile.txt  | textfile_new.txt |
       | new-lorem.txt | test.txt         |
+    #    currently upload folder feature is not available in playwright
+    #    And "Anonymous" uploads the following resources in public link page
+    #      | resource              |
+    #      | filesForUpload/PARENT |
     And "Alice" removes the public link named "myPublicLink" of resource "folderPublic"
     And "Anonymous" should not be able to open the old link "myPublicLink"
     And "Alice" logs out
@@ -69,6 +73,7 @@ Feature: link
     Given "Admin" creates following user using API
       | id    |
       | Brian |
+      | Carol |
     And "Alice" logs in
     And "Alice" creates the following resources
       | resource     | type   |
@@ -97,9 +102,14 @@ Feature: link
     And "Alice" creates a public link for the resource "testavatar.jpg" with password "%public%" using the sidebar panel
     And "Alice" renames the most recently created public link of resource "testavatar.jpg" to "imageLink"
     And "Alice" logs out
+
+    # authenticated user with access to resources. should be redirected to shares with me page
     And "Brian" logs in
     When "Brian" opens the public link "folderLink"
     And "Brian" unlocks the public link with password "%public%"
+    And "Brian" downloads the following public link resources using the sidebar panel
+      | resource         | type |
+      | shareToBrian.txt | file |
     And "Brian" uploads the following resources
       | resource  |
       | lorem.txt |
@@ -120,6 +130,32 @@ Feature: link
     Then "Brian" is in a image-viewer
     And "Brian" closes the file viewer
     And "Brian" logs out
+
+    # authenticated user without access to resources. should be redirected to the public links page
+    And "Carol" logs in
+    When "Carol" opens the public link "folderLink"
+    And "Carol" unlocks the public link with password "%public%"
+    # https://github.com/owncloud/web/issues/10473
+    And "Carol" downloads the following public link resources using the sidebar panel
+      | resource  | type |
+      | lorem.txt | file |
+    When "Carol" opens the public link "textLink"
+    And "Carol" unlocks the public link with password "%public%"
+    Then "Carol" is in a text-editor
+    And "Carol" closes the file viewer
+    When "Carol" opens the public link "markdownLink"
+    And "Carol" unlocks the public link with password "%public%"
+    Then "Carol" is in a text-editor
+    And "Carol" closes the file viewer
+    When "Carol" opens the public link "pdfLink"
+    And "Carol" unlocks the public link with password "%public%"
+    Then "Carol" is in a pdf-viewer
+    And "Carol" closes the file viewer
+    When "Carol" opens the public link "imageLink"
+    And "Carol" unlocks the public link with password "%public%"
+    Then "Carol" is in a image-viewer
+    And "Carol" closes the file viewer
+    And "Carol" logs out
 
 
   Scenario: add banned password for public link
@@ -148,4 +184,3 @@ Feature: link
     And "Anonymous" opens the public link "myPublicLink"
     And "Anonymous" unlocks the public link with password "%copied_password%"
     And "Alice" logs out
-    


### PR DESCRIPTION
## Description
Fixes a bug where file downloads via public links that were opened in an authenticated context failed.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/10473

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
