### PR TITLE
[test-only] rewrite copy/move tests

### DIFF
--- a/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIDeleteFilesFolders/deleteFilesFolders.feature
@@ -6,38 +6,6 @@ Feature: deleting files and folders
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files in the server
 
-  @smokeTest @ocisSmokeTest @disablePreviews
-  Scenario: Delete files & folders one by one and check its existence after page reload
-    Given user "Alice" has created folder "simple-empty-folder" in the server
-    And user "Alice" has created folder "simple-folder" in the server
-    And user "Alice" has created file "lorem.txt" in the server
-    And user "Alice" has created file "lorem-big.txt" in the server
-    And user "Alice" has created folder "strängé नेपाली folder" in the server
-    And user "Alice" has created file "strängé filename (duplicate #2 &).txt" in the server
-    And user "Alice" has created file "sample,1.txt" in the server
-    And user "Alice" has created folder "Sample,Folder,With,Comma" in the server
-    And user "Alice" has logged in using the webUI
-    When the user deletes the following elements using the webUI
-      | name                                  |
-      | simple-folder                         |
-      | lorem.txt                             |
-      | strängé नेपाली folder                 |
-      | strängé filename (duplicate #2 &).txt |
-      | sample,1.txt                          |
-      | Sample,Folder,With,Comma              |
-    Then as "Alice" folder "simple-folder" should not exist in the server
-    And as "Alice" file "lorem.txt" should not exist in the server
-    And as "Alice" folder "strängé नेपाली folder" should not exist in the server
-    And as "Alice" file "strängé filename (duplicate #2 &).txt" should not exist in the server
-    And as "Alice" file "sample,1.txt" should not exist in the server
-    And as "Alice" folder "Sample,Folder,With,Comma" should not exist in the server
-    And no message should be displayed on the webUI
-    And the deleted elements should not be listed on the webUI
-    But folder "simple-empty-folder" should be listed on the webUI
-    And file "lorem-big.txt" should be listed on the webUI
-    And file "strängé नेपाली folder" should not be listed on the webUI
-    But the deleted elements should not be listed on the webUI after a page reload
-
 
   Scenario Outline: Delete a file with problematic characters
     Given user "Alice" has created file <file_name> in the server
@@ -52,61 +20,6 @@ Feature: deleting files and folders
       | "\"double\" quotes" |
       | "question?"         |
       | "&and#hash"         |
-
-
-  @ocis-reva-issue-106 @ocis-reve-issue-442 @skipOnOC10 @issue-4582
-  Scenario: Delete all except for a few files at once
-    Given user "Alice" has uploaded file "data.zip" to "data.zip" in the server
-    And user "Alice" has created file "lorem.txt" in the server
-    And user "Alice" has created file "fileToDelete.txt" in the server
-    And user "Alice" has created folder "folderToDelete" in the server
-    And user "Alice" has created folder "simple-folder" in the server
-    And user "Alice" has logged in using the webUI
-    When the user marks all files for batch action using the webUI
-    And the user unmarks these files for batch action using the webUI
-      | name          |
-      | lorem.txt     |
-      | simple-folder |
-    And the user batch deletes the marked files using the webUI
-    Then as "Alice" file "lorem.txt" should exist in the server
-    And as "Alice" folder "simple-folder" should exist in the server
-    And folder "simple-folder" should be listed on the webUI
-    And file "lorem.txt" should be listed on the webUI
-    But as "Alice" file "data.zip" should not exist in the server
-    And as "Alice" file "fileToDelete.txt" should not exist in the server
-    And as "Alice" folder "folderToDelete" should not exist in the server
-    And file "data.zip" should not be listed on the webUI
-    And the count of files and folders shown on the webUI should be 2
-    And no message should be displayed on the webUI
-
-
-  Scenario: Delete the last file in a folder
-    Given user "Alice" has created file "zzzz-must-be-last-file-in-folder.txt" in the server
-    And user "Alice" has logged in using the webUI
-    When the user deletes file "zzzz-must-be-last-file-in-folder.txt" using the webUI
-    Then as "Alice" file "zzzz-must-be-last-file-in-folder.txt" should not exist in the server
-    And file "zzzz-must-be-last-file-in-folder.txt" should not be listed on the webUI
-    And no message should be displayed on the webUI
-
-
-  Scenario: delete a file on a public share
-    Given user "Alice" has created folder "simple-folder" in the server
-    And user "Alice" has created file "simple-folder/lorem.txt" in the server
-    And user "Alice" has created folder "simple-folder/simple-empty-folder" in the server
-    And user "Alice" has created folder "simple-folder/strängé filename (duplicate #2 &).txt" in the server
-    And user "Alice" has shared folder "simple-folder" with link with "read, update, create, delete" permissions in the server
-    When the public uses the webUI to access the last public link created by user "Alice" in a new session
-    And the user deletes the following elements using the webUI
-      | name                                  |
-      | simple-empty-folder                   |
-      | lorem.txt                             |
-      | strängé filename (duplicate #2 &).txt |
-    Then as "Alice" file "simple-folder/lorem.txt" should not exist in the server
-    And as "Alice" folder "simple-folder/simple-empty-folder" should not exist in the server
-    And as "Alice" file "simple-folder/strängé filename (duplicate #2 &).txt" should not exist in the server
-    And the deleted elements should not be listed on the webUI
-    And no message should be displayed on the webUI
-    And the deleted elements should not be listed on the webUI after a page reload
 
 
   Scenario: delete a file on a public share with problematic characters
@@ -142,61 +55,6 @@ Feature: deleting files and folders
       | question?       |
       | &and#hash       |
 
-  @issue-4582
-  Scenario: Delete multiple files at once on a public share
-    Given user "Alice" has created folder "simple-folder" in the server
-    And user "Alice" has created file "simple-folder/data.zip" in the server
-    And user "Alice" has created file "simple-folder/lorem.txt" in the server
-    And user "Alice" has created file "simple-folder/simple-empty-folder" in the server
-    And user "Alice" has shared folder "simple-folder" with link with "read, update, create, delete" permissions in the server
-    When the public uses the webUI to access the last public link created by user "Alice" in a new session
-    And the user batch deletes these files using the webUI
-      | name                |
-      | data.zip            |
-      | lorem.txt           |
-      | simple-empty-folder |
-    Then as "Alice" file "simple-folder/data.zip" should not exist in the server
-    And as "Alice" file "simple-folder/lorem.txt" should not exist in the server
-    And as "Alice" folder "simple-folder/simple-empty-folder" should not exist in the server
-    And the deleted elements should not be listed on the webUI
-    And the deleted elements should not be listed on the webUI after a page reload
-
-  @issue-5435
-  Scenario: Delete a file and folder from shared with me page
-    Given user "Brian" has been created with default attributes and without skeleton files in the server
-    And user "Brian" has created folder "simple-folder" in the server
-    And user "Brian" has created file "lorem.txt" in the server
-    And user "Brian" has shared folder "simple-folder" with user "Alice" in the server
-    And user "Brian" has shared file "lorem.txt" with user "Alice" in the server
-    And user "Alice" has logged in using the webUI
-    And the user has browsed to the shared-with-me page
-    When the user unshares folder "simple-folder" using the webUI
-    And the user unshares file "lorem.txt" using the webUI
-    Then as "Alice" folder "simple-folder" should not exist in the server
-    And as "Alice" file "lorem.txt" should not exist in the server
-    And no message should be displayed on the webUI
-
-
-  Scenario: Try to delete file and folder that used to exist but does not anymore
-    Given user "Alice" has created folder "simple-folder" in the server
-    And user "Alice" has created file "lorem.txt" in the server
-    # user logs in first and deletes the files/folders using the API requests (demanded by the scenario)
-    # so that the steps are organized as follows
-    And user "Alice" has logged in using the webUI
-    And the following files have been deleted by user "Alice" in the server
-      | name          |
-      | lorem.txt     |
-      | simple-folder |
-    When the user deletes file "lorem.txt" using the webUI
-    Then the "error" message with header 'Failed to delete "lorem.txt"' should be displayed on the webUI
-    When the user clears all error message from the webUI
-    And the user deletes folder "simple-folder" using the webUI
-    Then the "error" message with header 'Failed to delete "simple-folder"' should be displayed on the webUI
-    When the user reloads the current page of the webUI
-    Then file "lorem.txt" should not be listed on the webUI
-    And folder "simple-folder" should not be listed on the webUI
-    And as "Alice" file "lorem.txt" should not exist in the server
-    And as "Alice" folder "simple-folder" should not exist in the server
 
 
   Scenario: Delete folder with dot in the name

--- a/tests/acceptance/features/webUIFilesCopy/copy.feature
+++ b/tests/acceptance/features/webUIFilesCopy/copy.feature
@@ -7,52 +7,6 @@ Feature: copy files and folders
     Given the administrator has set the default folder for received shares to "Shares" in the server
     And user "Alice" has been created with default attributes and without skeleton files in the server
 
-  @smokeTest @ocisSmokeTest @skipOnIphoneResolution
-  Scenario: copy a file and a folder into a folder
-    Given user "Alice" has uploaded file "data.zip" to "data.zip" in the server
-    And user "Alice" has created folder "simple-empty-folder" in the server
-    And user "Alice" has created folder "simple-folder" in the server
-    And user "Alice" has created folder "strängé नेपाली folder empty" in the server
-    And user "Alice" has logged in using the webUI
-    And the user reloads the current page of the webUI
-    When the user copies file "data.zip" into folder "simple-empty-folder" using the webUI
-    Then breadcrumb for folder "simple-empty-folder" should be displayed on the webUI
-    And file "data.zip" should be listed on the webUI
-    When the user browses to the files page
-    And the user copies folder "simple-folder" into folder "strängé नेपाली folder empty" using the webUI
-    Then breadcrumb for folder "strängé नेपाली folder empty" should be displayed on the webUI
-    And folder "simple-folder" should be listed on the webUI
-
-
-  Scenario: copy a file into a folder where a file with the same name already exists
-    Given user "Alice" has created file "strängé filename (duplicate #2 &).txt" in the server
-    And user "Alice" has created folder "strängé नेपाली folder" in the server
-    And user "Alice" has created file "strängé नेपाली folder/strängé filename (duplicate #2 &).txt" in the server
-    And user "Alice" has logged in using the webUI
-    And the user has browsed to the personal page
-    When the user tries to copy file "strängé filename (duplicate #2 &).txt" into folder "strängé नेपाली folder" using the webUI
-    Then the "modal error" message with header 'File with name "strängé filename (duplicate #2 &).txt" already exists.' should be displayed on the webUI
-
-  @smokeTest @ocisSmokeTest @skipOnIphoneResolution
-  Scenario: Copy multiple files at once
-    Given user "Alice" has uploaded file "data.zip" to "data.zip" in the server
-    And user "Alice" has uploaded file "lorem.txt" to "lorem.txt" in the server
-    And user "Alice" has uploaded file "new-data.zip" to "testapp.zip" in the server
-    And user "Alice" has created folder "simple-empty-folder" in the server
-    And user "Alice" has logged in using the webUI
-    And the user has reloaded the current page of the webUI
-    When the user batch copies these files into folder "simple-empty-folder" using the webUI
-      | file_name   |
-      | data.zip    |
-      | lorem.txt   |
-      | testapp.zip |
-    Then breadcrumb for folder "simple-empty-folder" should be displayed on the webUI
-    And the following files should be listed on the webUI
-      | file_name   |
-      | data.zip    |
-      | lorem.txt   |
-      | testapp.zip |
-
 
   Scenario Outline: copy a file into a folder (problematic characters)
     Given user "Alice" has uploaded file "lorem.txt" to "lorem.txt" in the server
@@ -83,24 +37,3 @@ Feature: copy files and folders
     And file "data.zip" should be listed on the webUI
     And as "Alice" file "simple-folder/simple-empty-folder/data.zip" should exist in the server
     And as "Alice" file "simple-folder/data.zip" should exist in the server
-
-
-  Scenario: copy a folder into the same folder
-    Given user "Alice" has created folder "simple-empty-folder" in the server
-    And user "Alice" has logged in using the webUI
-    When the user tries to copy folder "simple-empty-folder" into folder "simple-empty-folder" using the webUI
-    Then the "error" message with header "You can't paste the selected file at this location because you can't paste an item into itself." should be displayed on the webUI
-    And the user clears all error message from the webUI
-    And as "Alice" file "simple-empty-folder/simple-empty-folder" should not exist in the server
-
-
-  Scenario: copy a folder into another folder with same name
-    Given user "Alice" has created folder "simple-empty-folder" in the server
-    And user "Alice" has created folder "folder with space" in the server
-    And user "Alice" has created folder "folder with space/simple-empty-folder" in the server
-    And user "Alice" has logged in using the webUI
-    When the user copies folder "simple-empty-folder" into folder "folder with space/simple-empty-folder" using the webUI
-    Then breadcrumb for folder "folder with space" should be displayed on the webUI
-    And folder "simple-empty-folder" should be listed on the webUI
-    And as "Alice" folder "folder with space/simple-empty-folder/simple-empty-folder" should exist in the server
-    And as "Alice" folder "simple-empty-folder" should exist in the server

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -16,55 +16,6 @@ Feature: move files
     Then the error message 'The name cannot contain "/"' should be displayed on the webUI dialog prompt
     And file "lorem.txt" should be listed on the webUI
 
-  @smokeTest @ocisSmokeTest @skipOnIphoneResolution
-  Scenario: move a file into a folder
-    Given user "Alice" has logged in using the webUI
-    And user "Alice" has uploaded file "data.tar.gz" to "data.tar.gz" in the server
-    And user "Alice" has uploaded file "strängé filename (duplicate #2 &).txt" to "strängé filename (duplicate #2 &).txt" in the server
-    And user "Alice" has created folder "strängé नेपाली folder empty" in the server
-    And the user has reloaded the current page of the webUI
-    When the user moves file "lorem.txt" into folder "simple-folder" using the webUI
-    Then breadcrumb for folder "simple-folder" should be displayed on the webUI
-    And file "lorem.txt" should be listed on the webUI
-    When the user browses to the files page
-    And the user moves file "data.tar.gz" into folder "strängé नेपाली folder empty" using the webUI
-    Then breadcrumb for folder "strängé नेपाली folder empty" should be displayed on the webUI
-    And file "data.tar.gz" should be listed on the webUI
-    When the user browses to the files page
-    And the user moves file "strängé filename (duplicate #2 &).txt" into folder "strängé नेपाली folder empty" using the webUI
-    Then breadcrumb for folder "strängé नेपाली folder empty" should be displayed on the webUI
-    And file "strängé filename (duplicate #2 &).txt" should be listed on the webUI
-    When the user browses to the files page
-    Then file "lorem.txt" should not be listed on the webUI
-    And file "data.tar.gz" should not be listed on the webUI
-    And file "strängé filename (duplicate #2 &).txt" should not be listed on the webUI
-
-
-  Scenario: move a file into a folder where a file with the same name already exists
-    Given user "Alice" has logged in using the webUI
-    And user "Alice" has uploaded file "lorem.txt" to "simple-folder/lorem.txt" in the server
-    And the user has browsed to the personal page
-    When the user tries to move file "lorem.txt" into folder "simple-folder" using the webUI
-    Then the "modal error" message with header 'File with name "lorem.txt" already exists.' should be displayed on the webUI
-
-  @smokeTest @ocisSmokeTest @disablePreviews @skipOnIphoneResolution
-  Scenario: Move multiple files at once
-    Given user "Alice" has logged in using the webUI
-    And user "Alice" has uploaded file "data.zip" to "data.zip" in the server
-    And user "Alice" has uploaded file "data.zip" to "testapp.zip" in the server
-    And the user has reloaded the current page of the webUI
-    When the user batch moves these files into folder "simple-folder" using the webUI
-      | file_name   |
-      | data.zip    |
-      | lorem.txt   |
-      | testapp.zip |
-    Then breadcrumb for folder "simple-folder" should be displayed on the webUI
-    And the following files should be listed on the webUI
-      | file_name   |
-      | data.zip    |
-      | lorem.txt   |
-      | testapp.zip |
-
 
   Scenario Outline: move a file into a folder (problematic characters)
     Given user "Alice" has logged in using the webUI
@@ -92,4 +43,3 @@ Feature: move files
     And file "data.zip" should be listed on the webUI
     And as "Alice" file "simple-folder/simple-empty-folder/data.zip" should exist in the server
     But as "Alice" file "simple-folder/data.zip" should not exist in the server
-

--- a/tests/e2e/cucumber/features/smoke/copyMove.feature
+++ b/tests/e2e/cucumber/features/smoke/copyMove.feature
@@ -150,3 +150,49 @@ Feature: Copy
       | Sub1            |
       | Sub2            |
     And "Alice" logs out
+
+
+  Scenario: Copy and move resources with same name in personal space
+    Given "Admin" creates following user using API
+      | id    |
+      | Alice |
+    And "Alice" logs in
+    And "Alice" creates the following folders in personal space using API
+      | name         |
+      | sub          |
+      | folder1      |
+      | sub/folder1  |
+      | sub1/folder1 |
+    And "Alice" creates the following files into personal space using API
+      | pathToFile                | content                 |
+      | example1.txt              | personal space location |
+      | folder1/example1.txt      | folder1 location        |
+      | sub/folder1/example1.txt  | sub/folder1 location    |
+      | sub1/folder1/example1.txt | sub1/folder1 location   |
+    And "Alice" opens the "files" app
+
+    # copy and move file
+    When "Alice" copies the following resource using sidebar-panel
+      | resource     | to      | option    |
+      | example1.txt | folder1 | keep both |
+    # issue https://github.com/owncloud/web/issues/10515
+    # | example1.txt | folder1 | replace   |
+    And "Alice" moves the following resource using sidebar-panel
+      | resource     | to          | option    |
+      | example1.txt | sub/folder1 | keep both |
+    # issue https://github.com/owncloud/web/issues/10515
+    # | folder1/example1.txt | sub/folder1 | replace   |
+
+    # copy and move folder
+    And "Alice" copies the following resource using sidebar-panel
+      | resource | to  | option    |
+      | folder1  | sub | keep both |
+    # issue https://github.com/owncloud/web/issues/10515
+    # | folder1  | sub | replace |
+    And "Alice" moves the following resource using sidebar-panel
+      | resource | to  | option    |
+      | folder1  | sub | keep both |
+    # issue https://github.com/owncloud/web/issues/10515
+    # | sub1/folder1  | sub | replace |
+    And "Alice" logs out
+    

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -142,11 +142,12 @@ When(
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const resourceObject = new objects.applicationFiles.Resource({ page })
 
-    for (const { resource, to } of stepTable.hashes()) {
+    for (const { resource, to, option } of stepTable.hashes()) {
       await resourceObject[actionType === 'copies' ? 'copy' : 'move']({
         resource,
         newLocation: to,
-        method
+        method,
+        option: option
       })
     }
   }

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -739,7 +739,7 @@ export const pasteResource = async (args: moveOrCopyResourceArgs): Promise<void>
         (resp) =>
           resp.url().endsWith(resource) &&
           resp.status() === 201 &&
-          resp.request().method() === (action === 'copy' ? 'COPY' : 'MOVE')
+          resp.request().method() === action.toUpperCase()
       ),
       option === 'replace'
         ? page.locator(actionSecondaryConfirmationButton).click()
@@ -891,7 +891,7 @@ export const moveOrCopyResource = async (args: moveOrCopyResourceArgs): Promise<
           (resp) =>
             resp.url().endsWith(resource) &&
             resp.status() === 201 &&
-            resp.request().method() === (action === 'copy' ? 'COPY' : 'MOVE')
+            resp.request().method() === action.toUpperCase()
         ),
         page.keyboard.press('Control+v')
       ])

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -115,6 +115,7 @@ const emptyTrashbinButtonSelector = '.oc-files-actions-empty-trash-bin-trigger'
 const resourceLockIcon =
   '//*[@data-test-resource-name="%s"]/ancestor::tr//td//span[contains(@class, "oc-resource-icon-status-badge-inner")]'
 const sharesNavigationButtonSelector = '.oc-sidebar-nav [data-nav-name="files-shares"]'
+const keepBothButton = '.oc-modal-body-actions-confirm'
 
 export const clickResource = async ({
   page,
@@ -707,16 +708,15 @@ export interface moveOrCopyResourceArgs {
   newLocation: string
   action: 'copy' | 'move'
   method: string
+  option?: string
 }
 
 export interface moveOrCopyMultipleResourceArgs extends Omit<moveOrCopyResourceArgs, 'resource'> {
   resources: string[]
 }
 
-export const pasteResource = async (
-  args: Omit<moveOrCopyResourceArgs, 'action'>
-): Promise<void> => {
-  const { page, resource, newLocation, method } = args
+export const pasteResource = async (args: moveOrCopyResourceArgs): Promise<void> => {
+  const { page, resource, newLocation, action, method, option } = args
 
   await page.locator(breadcrumbRoot).click()
   const newLocationPath = newLocation.split('/')
@@ -733,11 +733,24 @@ export const pasteResource = async (
   } else {
     await page.locator(pasteButton).click()
   }
-
-  await waitForResources({
-    page,
-    names: [resource]
-  })
+  if (option) {
+    await Promise.all([
+      page.waitForResponse(
+        (resp) =>
+          resp.url().endsWith(resource) &&
+          resp.status() === 201 &&
+          resp.request().method() === (action === 'copy' ? 'COPY' : 'MOVE')
+      ),
+      option === 'replace'
+        ? page.locator(actionSecondaryConfirmationButton).click()
+        : page.locator(keepBothButton).click()
+    ])
+  } else {
+    await waitForResources({
+      page,
+      names: [resource]
+    })
+  }
 }
 
 export const moveOrCopyMultipleResources = async (
@@ -832,7 +845,7 @@ export const moveOrCopyMultipleResources = async (
 }
 
 export const moveOrCopyResource = async (args: moveOrCopyResourceArgs): Promise<void> => {
-  const { page, resource, newLocation, action, method } = args
+  const { page, resource, newLocation, action, method, option } = args
   const { dir: resourceDir, base: resourceBase } = path.parse(resource)
 
   if (resourceDir) {
@@ -843,13 +856,13 @@ export const moveOrCopyResource = async (args: moveOrCopyResourceArgs): Promise<
     case 'dropdown-menu': {
       await page.locator(util.format(resourceNameSelector, resourceBase)).click({ button: 'right' })
       await page.locator(util.format(filesContextMenuAction, action)).click()
-      await pasteResource({ page, resource: resourceBase, newLocation, method })
+      await pasteResource({ page, resource: resourceBase, newLocation, action, method, option })
       break
     }
     case 'batch-action': {
       await page.locator(util.format(checkBox, resourceBase)).click()
       await page.locator(util.format(filesBatchAction, action)).click()
-      await pasteResource({ page, resource: resourceBase, newLocation, method })
+      await pasteResource({ page, resource: resourceBase, newLocation, action, method, option })
       break
     }
     case 'sidebar-panel': {
@@ -858,7 +871,7 @@ export const moveOrCopyResource = async (args: moveOrCopyResourceArgs): Promise<
 
       const actionButtonType = action === 'copy' ? 'Copy' : 'Cut'
       await page.locator(util.format(sideBarActionButton, actionButtonType)).click()
-      await pasteResource({ page, resource: resourceBase, newLocation, method })
+      await pasteResource({ page, resource: resourceBase, newLocation, action, method, option })
       break
     }
     case 'keyboard': {


### PR DESCRIPTION
part of #10259 

- [x] deleted UI test
- [x] created new e2e when user copies or moves file/folder with same name (using `replace` and `keep both` options)
- [x] found bug #10515 