### PR TITLE
[test-only][full-ci] added e2e test to delete and restore file inside a shared folder

### DIFF
--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -13,10 +13,6 @@ Other free text and markdown formatting can be used elsewhere in the document if
 - [webUILogin/openidLogin.feature:50](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/openidLogin.feature#L50)
 - [webUILogin/openidLogin.feature:60](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/openidLogin.feature#L60)
 
-### [restoring a file deleted from a received shared folder is not possible](https://github.com/owncloud/ocis/issues/1124)
-
-- [webUITrashbinRestore/trashbinRestore.feature:176](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature#L176)
-
 ### [empty subfolder inside a folder to be uploaded is not created on the server](https://github.com/owncloud/web/issues/6348)
 
 - [webUIUpload/upload.feature:36](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/upload.feature#L36)

--- a/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/webUITrashbinRestore/trashbinRestore.feature
@@ -172,23 +172,6 @@ Feature: Restore deleted files/folders
     Then folder "lorem.txt" should be listed on the webUI
     And file "lorem.txt" should not be listed on the webUI
 
-  @issue-ocis-1124
-  Scenario: delete and restore a file inside a received shared folder
-    Given the administrator has set the default folder for received shares to "Shares" in the server
-    And user "Carol" has been created with default attributes and without skeleton files in the server
-    And user "Carol" has created folder "folder-to-share" in the server
-    And user "Carol" has uploaded file with content "does-not-matter" to "folder-to-share/fileToShare.txt" in the server
-    And user "Carol" has shared folder "folder-to-share" with user "Alice" in the server
-    And the user has reloaded the current page of the webUI
-    When the user opens folder "Shares" using the webUI
-    And the user opens folder "folder-to-share" using the webUI
-    And the user deletes file "fileToShare.txt" using the webUI
-    And the user browses to the trashbin page
-    Then as "Alice" file "fileToShare.txt" should exist in the trashbin in the server
-    When the user restores file "…/folder-to-share/fileToShare.txt" from the trashbin using the webUI
-    Then the "success" message with header "fileToShare.txt was restored successfully" should be displayed on the webUI
-    And as "Alice" file "/Shares/folder-to-share/fileToShare.txt" should exist in the server
-
   @issue-1502
   Scenario: Delete and restore folders with dot in the name
     Given user "Alice" has created the following folders in the server

--- a/tests/e2e/cucumber/features/smoke/trashbinDelete.feature
+++ b/tests/e2e/cucumber/features/smoke/trashbinDelete.feature
@@ -3,14 +3,16 @@ Feature: Trashbin delete
   I want to delete files and folders from the trashbin
   So that I can control my trashbin space and which files are kept in that space
 
-
-  Scenario: delete files and folders from trashbin
-    Given "Admin" logs in
-    And "Admin" creates following user using API
+  Background:
+    Given "Admin" creates following user using API
       | id    |
       | Alice |
+      | Brian |
     And "Alice" logs in
-    And "Alice" creates the following resources
+
+
+  Scenario: delete files and folders from trashbin
+    Given "Alice" creates the following resources
       | resource     | type   |
       | FOLDER       | folder |
       | PARENT/CHILD | folder |
@@ -37,4 +39,45 @@ Feature: Trashbin delete
       | lorem.txt |
       | PARENT    |
     And "Alice" empties the trashbin
+    And "Alice" logs out
+
+
+  Scenario: delete and restore a file inside a received shared folder
+    Given "Alice" creates the following resources
+      | resource      | type   |
+      | folderToShare | folder |
+    And "Alice" uploads the following resource
+      | resource  | to            |
+      | lorem.txt | folderToShare |
+    And "Alice" shares the following resource using the sidebar panel
+      | resource      | recipient | type | role     | resourceType |
+      | folderToShare | Brian     | user | Can edit | folder       |
+    And "Brian" logs in
+    And "Brian" navigates to the shared with me page
+    And "Brian" opens folder "folderToShare"
+    When "Brian" deletes the following resources using the sidebar panel
+      | resource  |
+      | lorem.txt |
+    And "Brian" navigates to the trashbin
+    Then following resources should not be displayed in the trashbin for user "Brian"
+      | resource                |
+      | folderToShare/lorem.txt |
+    And "Alice" navigates to the trashbin
+    And following resources should be displayed in the trashbin for user "Alice"
+      | resource                |
+      | folderToShare/lorem.txt |
+    And "Alice" restores the following resource from trashbin
+      | resource                |
+      | folderToShare/lorem.txt |
+    And "Alice" opens the "files" app
+    And "Alice" opens folder "folderToShare"
+    And following resources should be displayed in the files list for user "Alice"
+      | resource  |
+      | lorem.txt |
+    And "Brian" navigates to the shared with me page
+    And "Brian" opens folder "folderToShare"
+    And following resources should be displayed in the files list for user "Brian"
+      | resource  |
+      | lorem.txt |
+    And "Brian" logs out
     And "Alice" logs out

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -298,6 +298,19 @@ Then(
   }
 )
 
+Then(
+  '{string} restores the following resource from trashbin',
+  async function (this: World, stepUser: string, stepTable: DataTable): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const resourceObject = new objects.applicationFiles.Resource({ page })
+    for (const info of stepTable.hashes()) {
+      const message = await resourceObject.restoreTrashBin({ resource: info.resource })
+      const paths = info.resource.split('/')
+      expect(message).toBe(`${paths[paths.length - 1]} was restored successfully`)
+    }
+  }
+)
+
 When(
   /^"([^"]*)" searches "([^"]*)" using the global search(?: and the "([^"]*)" filter)?( and presses enter)?$/,
   async function (
@@ -320,7 +333,7 @@ When(
 )
 
 Then(
-  /^following resources (should|should not) be displayed in the (search list|files list|Shares) for user "([^"]*)"$/,
+  /^following resources (should|should not) be displayed in the (search list|files list|Shares|trashbin) for user "([^"]*)"$/,
   async function (
     this: World,
     actionType: string,

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -1346,7 +1346,7 @@ export const searchResourceGlobalSearch = async (
   }
 }
 
-export type displayedResourceType = 'search list' | 'files list'
+export type displayedResourceType = 'search list' | 'files list' | 'Shares' | 'trashbin'
 
 export interface getDisplayedResourcesArgs {
   keyword: displayedResourceType
@@ -1377,6 +1377,18 @@ export const getDisplayedResourcesFromFilesList = async (page): Promise<string[]
 export const getDisplayedResourcesFromShares = async (page): Promise<string[]> => {
   const files = []
   await page.locator(sharesNavigationButtonSelector).click()
+  const result = await page.locator('[data-test-resource-path]')
+
+  const count = await result.count()
+  for (let i = 0; i < count; i++) {
+    files.push(await result.nth(i).getAttribute('data-test-resource-name'))
+  }
+
+  return files
+}
+
+export const getDisplayedResourcesFromTrashbin = async (page): Promise<string[]> => {
+  const files = []
   const result = await page.locator('[data-test-resource-path]')
 
   const count = await result.count()

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -183,14 +183,17 @@ export class Resource {
   }
 
   getDisplayedResources(args: Omit<po.getDisplayedResourcesArgs, 'page'>): Promise<string[]> {
-    if (args.keyword === 'files list') {
-      return po.getDisplayedResourcesFromFilesList(this.#page)
-    } else if (args.keyword === 'search list') {
-      return po.getDisplayedResourcesFromSearch(this.#page)
-    } else if (args.keyword === 'Shares') {
-      return po.getDisplayedResourcesFromShares(this.#page)
-    } else {
-      throw new Error('Unknown keyword')
+    switch (args.keyword) {
+      case 'files list':
+        return po.getDisplayedResourcesFromFilesList(this.#page)
+      case 'search list':
+        return po.getDisplayedResourcesFromSearch(this.#page)
+      case 'Shares':
+        return po.getDisplayedResourcesFromShares(this.#page)
+      case 'trashbin':
+        return po.getDisplayedResourcesFromTrashbin(this.#page)
+      default:
+        throw new Error('Unknown keyword')
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
In this PR,
- removed test scenario from webUI acceptance test related to delete and restore file from shared folder
- added E2E test to delete and restore file from shared folder

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/web/issues/10259

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
