### PR TITLE
feat: adjust tile sizes

### DIFF
--- a/changelog/unreleased/enhancement-tile-sizes
+++ b/changelog/unreleased/enhancement-tile-sizes
@@ -1,0 +1,8 @@
+Enhancement: Tile sizes
+
+We've adjusted the tile sizes to have a bigger base size and smaller stepping from one tile size to the next.
+In addition to that the default tile size has been changed to the second stepping, so that initially both
+space tiles and file/folder tiles have a sufficient size for reading longer names.
+
+https://github.com/owncloud/web/issues/10018
+https://github.com/owncloud/web/pull/10558

--- a/packages/design-system/src/tokens/ods/size.yaml
+++ b/packages/design-system/src/tokens/ods/size.yaml
@@ -24,6 +24,6 @@ size:
     value: 14px
   tiles:
     resize-step:
-      value: 9rem
+      value: 6rem
     default:
-      value: 9rem
+      value: 10rem

--- a/packages/web-pkg/src/components/ViewOptions.vue
+++ b/packages/web-pkg/src/components/ViewOptions.vue
@@ -77,7 +77,7 @@
             v-model="viewSizeCurrent"
             type="range"
             :min="1"
-            :max="FolderViewModeConstants.tilesSizeMax"
+            :max="viewSizeMax"
             class="oc-range"
             data-testid="files-tiles-size-slider"
           />
@@ -99,7 +99,8 @@ import {
   PaginationConstants,
   FolderViewModeConstants,
   useRouteName,
-  useResourcesStore
+  useResourcesStore,
+  useViewSizeMax
 } from '../composables'
 import { FolderView } from '../ui/types'
 import { storeToRefs } from 'pinia'
@@ -192,10 +193,13 @@ export default defineComponent({
       { immediate: true, deep: true }
     )
 
+    const viewSizeMax = useViewSizeMax()
+
     return {
       FolderViewModeConstants,
       viewModeCurrent: viewModeQuery,
       viewSizeCurrent: viewSizeQuery,
+      viewSizeMax,
       itemsPerPageCurrent: itemsPerPageQuery,
       queryParamsLoading,
       queryItemAsString,

--- a/packages/web-pkg/src/components/ViewOptions.vue
+++ b/packages/web-pkg/src/components/ViewOptions.vue
@@ -76,8 +76,8 @@
             id="tiles-size-slider"
             v-model="viewSizeCurrent"
             type="range"
-            min="1"
-            max="6"
+            :min="1"
+            :max="FolderViewModeConstants.tilesSizeMax"
             class="oc-range"
             data-testid="files-tiles-size-slider"
           />

--- a/packages/web-pkg/src/composables/viewMode/constants.ts
+++ b/packages/web-pkg/src/composables/viewMode/constants.ts
@@ -7,6 +7,6 @@ export const FolderViewModeConstants = {
   },
   defaultModeName: 'resource-table',
   queryName: 'view-mode',
-  tilesSizeDefault: 1,
+  tilesSizeDefault: 2,
   tilesSizeQueryName: 'tiles-size'
 } as const

--- a/packages/web-pkg/src/composables/viewMode/constants.ts
+++ b/packages/web-pkg/src/composables/viewMode/constants.ts
@@ -8,5 +8,6 @@ export const FolderViewModeConstants = {
   defaultModeName: 'resource-table',
   queryName: 'view-mode',
   tilesSizeDefault: 2,
+  tilesSizeMax: 6,
   tilesSizeQueryName: 'tiles-size'
 } as const

--- a/packages/web-pkg/src/composables/viewMode/useTileSize.ts
+++ b/packages/web-pkg/src/composables/viewMode/useTileSize.ts
@@ -1,9 +1,6 @@
-import { useViewSize } from './useViewMode'
-import { computed, onMounted, ref, unref } from 'vue'
+import { onMounted, ref, unref } from 'vue'
 
 export const useTileSize = () => {
-  const viewSize = useViewSize(null)
-
   const themeVarToPixels = (value: string) => {
     if (!value.endsWith('rem') && !value.endsWith('px')) {
       return 0
@@ -23,16 +20,17 @@ export const useTileSize = () => {
     baseSizePixels.value = themeVarToPixels(styles.getPropertyValue('--oc-size-tiles-default'))
     stepSizePixels.value = themeVarToPixels(styles.getPropertyValue('--oc-size-tiles-resize-step'))
   })
-  const tileSizePixels = computed(() => {
-    return unref(baseSizePixels) + (unref(viewSize) - 1) * unref(stepSizePixels)
-  })
-  const tileSizeRem = computed(() => {
+
+  const calculateTileSizePixels = (viewSize: number) => {
+    return unref(baseSizePixels) + (viewSize - 1) * unref(stepSizePixels)
+  }
+  const calculateTileSizeRem = (viewSize: number) => {
     const fontSize = parseFloat(getComputedStyle(document.documentElement).fontSize)
-    return unref(tileSizePixels) / fontSize
-  })
+    return calculateTileSizePixels(viewSize) / fontSize
+  }
 
   return {
-    tileSizePixels,
-    tileSizeRem
+    calculateTileSizePixels,
+    calculateTileSizeRem
   }
 }

--- a/packages/web-pkg/src/composables/viewMode/useViewMode.ts
+++ b/packages/web-pkg/src/composables/viewMode/useViewMode.ts
@@ -1,4 +1,4 @@
-import { computed, ComputedRef, unref } from 'vue'
+import { computed, ComputedRef, ref, Ref, unref } from 'vue'
 import { queryItemAsString } from '../appDefaults'
 import { useRouteQueryPersisted } from '../router'
 import { FolderViewModeConstants } from './constants'
@@ -25,4 +25,10 @@ export function useViewSize(options: ComputedRef<string>): ComputedRef<number> {
     defaultValue: FolderViewModeConstants.tilesSizeDefault.toString()
   })
   return computed(() => parseInt(queryItemAsString(unref(viewModeSize))))
+}
+
+// doesn't need to be persisted anywhere. Gets re-calculated when the ResourceTiles component gets mounted.
+const viewSizeMax = ref<number>(FolderViewModeConstants.tilesSizeMax)
+export function useViewSizeMax(): Ref<number> {
+  return viewSizeMax
 }

--- a/packages/web-pkg/tests/unit/components/FilesList/ResourceTiles.spec.ts
+++ b/packages/web-pkg/tests/unit/components/FilesList/ResourceTiles.spec.ts
@@ -7,7 +7,7 @@ import { mock } from 'vitest-mock-extended'
 vi.mock('../../../../src/composables/viewMode', async (importOriginal) => ({
   ...(await importOriginal<any>()),
   useTileSize: vi.fn().mockReturnValue({
-    tileSizePixels: 100
+    calculateTileSizePixels: vi.fn().mockImplementation((viewSize: number) => 100 * viewSize)
   })
 }))
 
@@ -134,8 +134,9 @@ describe('ResourceTiles component', () => {
     { viewSize: 4, expected: 'xxlarge' },
     { viewSize: 5, expected: 'xxxlarge' },
     { viewSize: 6, expected: 'xxxlarge' }
-  ])('passes the "viewSize" to the OcTile component', (data) => {
+  ])('passes the "viewSize" to the OcTile component', async (data) => {
     const { wrapper } = getWrapper({ resources: spacesResources, viewSize: data.viewSize })
+    await wrapper.vm.$nextTick()
     expect(wrapper.find('resource-tile-stub').attributes('resourceiconsize')).toEqual(data.expected)
   })
 
@@ -143,6 +144,7 @@ describe('ResourceTiles component', () => {
     return {
       wrapper: mount(ResourceTiles, {
         props: {
+          viewSize: 1,
           ...props
         },
         slots: {

--- a/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTiles.spec.ts.snap
+++ b/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTiles.spec.ts.snap
@@ -19,21 +19,11 @@ exports[`ResourceTiles component > renders an array of spaces correctly 1`] = `
     <li data-v-67d39700="" class="oc-tiles-item has-item-context-menu">
       <resource-tile-stub data-v-67d39700="" resource="[object Object]" isresourceselected="false" isextensiondisplayed="true" resourceiconsize="xlarge" draggable="false" resourceroute="[object Object]"></resource-tile-stub>
     </li>
-    <li data-v-67d39700="" class="ghost-tile" aria-hidden="true">
-      <div data-v-67d39700="">1</div>
-    </li>
-    <li data-v-67d39700="" class="ghost-tile" aria-hidden="true">
-      <div data-v-67d39700="">1</div>
-    </li>
-    <li data-v-67d39700="" class="ghost-tile" aria-hidden="true">
-      <div data-v-67d39700="">1</div>
-    </li>
-    <li data-v-67d39700="" class="ghost-tile" aria-hidden="true">
-      <div data-v-67d39700="">1</div>
-    </li>
-    <li data-v-67d39700="" class="ghost-tile" aria-hidden="true">
-      <div data-v-67d39700="">1</div>
-    </li>
+    <li data-v-67d39700="" class="ghost-tile" aria-hidden="true"></li>
+    <li data-v-67d39700="" class="ghost-tile" aria-hidden="true"></li>
+    <li data-v-67d39700="" class="ghost-tile" aria-hidden="true"></li>
+    <li data-v-67d39700="" class="ghost-tile" aria-hidden="true"></li>
+    <li data-v-67d39700="" class="ghost-tile" aria-hidden="true"></li>
   </oc-list>
   <!--v-if-->
   <div data-v-67d39700="" class="oc-tiles-footer"></div>

--- a/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTiles.spec.ts.snap
+++ b/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTiles.spec.ts.snap
@@ -20,19 +20,19 @@ exports[`ResourceTiles component > renders an array of spaces correctly 1`] = `
       <resource-tile-stub data-v-67d39700="" resource="[object Object]" isresourceselected="false" isextensiondisplayed="true" resourceiconsize="xlarge" draggable="false" resourceroute="[object Object]"></resource-tile-stub>
     </li>
     <li data-v-67d39700="" class="ghost-tile" aria-hidden="true">
-      <div data-v-67d39700="">1</div>
+      <div data-v-67d39700="">2</div>
     </li>
     <li data-v-67d39700="" class="ghost-tile" aria-hidden="true">
-      <div data-v-67d39700="">1</div>
+      <div data-v-67d39700="">2</div>
     </li>
     <li data-v-67d39700="" class="ghost-tile" aria-hidden="true">
-      <div data-v-67d39700="">1</div>
+      <div data-v-67d39700="">2</div>
     </li>
     <li data-v-67d39700="" class="ghost-tile" aria-hidden="true">
-      <div data-v-67d39700="">1</div>
+      <div data-v-67d39700="">2</div>
     </li>
     <li data-v-67d39700="" class="ghost-tile" aria-hidden="true">
-      <div data-v-67d39700="">1</div>
+      <div data-v-67d39700="">2</div>
     </li>
   </oc-list>
   <!--v-if-->

--- a/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTiles.spec.ts.snap
+++ b/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTiles.spec.ts.snap
@@ -20,19 +20,19 @@ exports[`ResourceTiles component > renders an array of spaces correctly 1`] = `
       <resource-tile-stub data-v-67d39700="" resource="[object Object]" isresourceselected="false" isextensiondisplayed="true" resourceiconsize="xlarge" draggable="false" resourceroute="[object Object]"></resource-tile-stub>
     </li>
     <li data-v-67d39700="" class="ghost-tile" aria-hidden="true">
-      <div data-v-67d39700="">2</div>
+      <div data-v-67d39700="">1</div>
     </li>
     <li data-v-67d39700="" class="ghost-tile" aria-hidden="true">
-      <div data-v-67d39700="">2</div>
+      <div data-v-67d39700="">1</div>
     </li>
     <li data-v-67d39700="" class="ghost-tile" aria-hidden="true">
-      <div data-v-67d39700="">2</div>
+      <div data-v-67d39700="">1</div>
     </li>
     <li data-v-67d39700="" class="ghost-tile" aria-hidden="true">
-      <div data-v-67d39700="">2</div>
+      <div data-v-67d39700="">1</div>
     </li>
     <li data-v-67d39700="" class="ghost-tile" aria-hidden="true">
-      <div data-v-67d39700="">2</div>
+      <div data-v-67d39700="">1</div>
     </li>
   </oc-list>
   <!--v-if-->


### PR DESCRIPTION
## Description
Played around with tile sizes... stepping from one tile size to the next was too big.

Previously we had 9rem as base tile size and added 9rem for every step in the tile size slider.
Now we have 10rem as base tile size and add 6rem for every step in the tile size slider.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/10018
- Fixes https://github.com/owncloud/web/issues/10564

## Screenshots:

### new default tile size (the second stepping, slighty smaller than before: now 16rem, before 18rem)
<img width="1796" alt="Screenshot 2024-03-07 at 09 17 59" src="https://github.com/owncloud/web/assets/3532843/24d0d0c3-d422-42eb-85ef-bf2fe05109aa">
<img width="1865" alt="Screenshot 2024-03-07 at 09 25 03" src="https://github.com/owncloud/web/assets/3532843/f90b302f-9f2b-4e22-9d09-442ad7e98e9f">

### new smallest tile size (the first stepping, slightly bigger than before: now 10rem, before 9rem)
<img width="1796" alt="Screenshot 2024-03-07 at 09 18 03" src="https://github.com/owncloud/web/assets/3532843/5397b758-8f75-4672-9483-935f29e86240">
<img width="1624" alt="Screenshot 2024-03-07 at 09 19 20" src="https://github.com/owncloud/web/assets/3532843/b2ce9c43-d990-41cc-92bd-9eb6c98ae7dd">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
