### PR TITLE
[tests-only] override lint rules for tests/e2e

### DIFF
--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -77,7 +77,7 @@ To run a particular test, simply add the feature file and line number to the tes
 
 Various options are available via ENV variables, e.g.
 
-- `BASIC_AUTH=true` use basic authorization for api requests. 
+- `BASIC_AUTH=true` use basic authorization for api requests.
 - `RETRY=n` to retry failures `n` times
 - `SLOW_MO=n` to slow the execution time by `n` milliseconds
 - `TIMEOUT=n` to set tests to timeout after `n` milliseconds
@@ -98,6 +98,22 @@ To then open e.g. the tracing from the `REPORT_DIR`, run
 ```shell
 $ npx playwright show-trace path/to/file.zip
 ```
+
+#### Lint E2E Test Code
+
+Run the following command to find out the lint issues early in the test codes:
+
+```shell
+$ pnpm lint
+```
+
+And to fix the lint problems run the following command:
+
+```shell
+$ pnpm lint --fix
+```
+
+If the lint problems are not fixed by `--fix` option, we have to manually fix the code.
 
 ### Acceptance Tests (Nightwatch)
 

--- a/tests/e2e/.eslintrc.json
+++ b/tests/e2e/.eslintrc.json
@@ -1,0 +1,29 @@
+{
+  "extends": "@ownclouders",
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@typescript-eslint/recommended-requiring-type-checking",
+        "plugin:@typescript-eslint/recommended"
+      ],
+      "parserOptions": {
+        "project": ["./tsconfig.json"] // for TypeScript files
+      },
+      "rules": {
+        "@typescript-eslint/await-thenable": "error",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-unsafe-member-access": "off",
+        "@typescript-eslint/no-unsafe-argument": "off",
+        "@typescript-eslint/no-unsafe-call": "off",
+        "@typescript-eslint/no-unsafe-return": "off",
+        "@typescript-eslint/restrict-template-expressions": "off",
+        "@typescript-eslint/restrict-plus-operands": "off",
+        "@typescript-eslint/no-unnecessary-type-assertion": "off"
+      }
+    }
+  ]
+}

--- a/tests/e2e/cucumber/steps/ui/public.ts
+++ b/tests/e2e/cucumber/steps/ui/public.ts
@@ -61,7 +61,7 @@ Then(
   /^"([^"]*)" is in a (text-editor|pdf-viewer|image-viewer)$/,
   async function (this: World, stepUser: string, fileViewerType: string): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
-    const fileViewerLocator = await editor.fileViewerLocator({ page, fileViewerType })
+    const fileViewerLocator = editor.fileViewerLocator({ page, fileViewerType })
     await expect(fileViewerLocator).toBeVisible()
   }
 )

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -7,7 +7,8 @@ import { config } from '../../../config'
 import {
   createResourceTypes,
   displayedResourceType,
-  shortcutType
+  shortcutType,
+  ActionViaType
 } from '../../../support/objects/app-files/resource/actions'
 import { Public } from '../../../support/objects/app-files/page/public'
 import { Resource } from '../../../support/objects/app-files'
@@ -442,15 +443,23 @@ export const processDownload = async (
   for (const folder of Object.keys(downloadInfo)) {
     files = downloadInfo[folder]
     parentFolder = folder !== 'undefined' ? folder : null
+
+    let via: ActionViaType = 'SINGLE_SHARE_VIEW'
+    switch (actionType) {
+      case 'batch action':
+        via = 'BATCH_ACTION'
+        break
+      case 'sidebar panel':
+        via = 'SIDEBAR_PANEL'
+        break
+      default:
+        break
+    }
+
     downloads = await pageObject.download({
       folder: parentFolder,
       resources: files,
-      via:
-        actionType === 'batch action'
-          ? 'BATCH_ACTION'
-          : actionType === 'sidebar panel'
-            ? 'SIDEBAR_PANEL'
-            : 'SINGLE_SHARE_VIEW'
+      via
     })
 
     downloads.forEach((download) => {
@@ -757,7 +766,7 @@ Then(
   async function (this: World, stepUser: string, file: string, actionType: string) {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const resourceObject = new objects.applicationFiles.Resource({ page })
-    const lockLocator = await resourceObject.getLockLocator({ resource: file })
+    const lockLocator = resourceObject.getLockLocator({ resource: file })
 
     actionType === 'should'
       ? await expect(lockLocator).toBeVisible()

--- a/tests/e2e/cucumber/steps/ui/spaces.ts
+++ b/tests/e2e/cucumber/steps/ui/spaces.ts
@@ -223,7 +223,7 @@ When(
 )
 
 When(
-  '{string} downloads the space {string}',
+  /^"([^"]*)" downloads the space (?:"[^"]*")$/,
   async function (this: World, stepUser: string): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const spacesObject = new objects.applicationFiles.Spaces({ page })

--- a/tests/e2e/cucumber/steps/ui/spaces.ts
+++ b/tests/e2e/cucumber/steps/ui/spaces.ts
@@ -224,7 +224,7 @@ When(
 
 When(
   '{string} downloads the space {string}',
-  async function (this: World, stepUser: string, space: string): Promise<void> {
+  async function (this: World, stepUser: string): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const spacesObject = new objects.applicationFiles.Spaces({ page })
     const downloadedResource = await spacesObject.downloadSpace()

--- a/tests/e2e/support/objects/app-files/link/actions.ts
+++ b/tests/e2e/support/objects/app-files/link/actions.ts
@@ -233,8 +233,8 @@ export const showOrHidePassword = async (args): Promise<void> => {
   const { page, showOrHide } = args
   await page.locator(showOrHidePasswordButton).click()
   showOrHide === 'reveals'
-    ? expect(page.locator(editPublicLinkInput)).toHaveAttribute('type', 'text')
-    : expect(page.locator(editPublicLinkInput)).toHaveAttribute('type', 'password')
+    ? await expect(page.locator(editPublicLinkInput)).toHaveAttribute('type', 'text')
+    : await expect(page.locator(editPublicLinkInput)).toHaveAttribute('type', 'password')
 }
 
 export const copyEnteredPassword = async (page: Page): Promise<void> => {

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -193,7 +193,7 @@ export const createSpaceFromSelection = async ({
 }): Promise<Space> => {
   await selectOrDeselectResources({
     page,
-    resources: resources.map((r) => ({ name: r }) as resourceArgs),
+    resources: resources.map((r) => ({ name: r }) as resourceArgs), // prettier-ignore
     select: true
   })
   await page.locator(util.format(resourceNameSelector, resources[0])).click({ button: 'right' })
@@ -594,11 +594,13 @@ interface resourceArgs {
   type?: string
 }
 
+export type ActionViaType = 'SIDEBAR_PANEL' | 'BATCH_ACTION' | 'SINGLE_SHARE_VIEW'
+
 export interface downloadResourcesArgs {
   page: Page
   resources: resourceArgs[]
   folder?: string
-  via: 'SIDEBAR_PANEL' | 'BATCH_ACTION' | 'SINGLE_SHARE_VIEW'
+  via: ActionViaType
 }
 
 export const downloadResources = async (args: downloadResourcesArgs): Promise<Download[]> => {
@@ -1008,7 +1010,7 @@ export interface deleteResourceArgs {
   page: Page
   resourcesWithInfo: resourceArgs[]
   folder?: string
-  via: 'SIDEBAR_PANEL' | 'BATCH_ACTION'
+  via: ActionViaType
 }
 
 export const deleteResource = async (args: deleteResourceArgs): Promise<void> => {
@@ -1705,7 +1707,7 @@ export interface expectFileToBeLockedArgs {
   resource: string
 }
 
-export const getLockLocator = async (args: expectFileToBeLockedArgs): Promise<Locator> => {
+export const getLockLocator = (args: expectFileToBeLockedArgs): Locator => {
   const { page, resource } = args
   return page.locator(util.format(resourceLockIcon, resource))
 }

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -287,7 +287,7 @@ export class Resource {
     await po.openShotcut({ page: this.#page, name: name, url: url })
   }
 
-  async getLockLocator(args: Omit<po.expectFileToBeLockedArgs, 'page'>): Promise<Locator> {
+  getLockLocator(args: Omit<po.expectFileToBeLockedArgs, 'page'>): Locator {
     return po.getLockLocator({ ...args, page: this.#page })
   }
 }

--- a/tests/e2e/support/objects/app-files/utils/editor.ts
+++ b/tests/e2e/support/objects/app-files/utils/editor.ts
@@ -20,13 +20,13 @@ export const save = async (page: Page): Promise<unknown> => {
   ])
 }
 
-export const fileViewerLocator = async ({
+export const fileViewerLocator = ({
   page,
   fileViewerType
 }: {
   page: Page
   fileViewerType: string
-}): Promise<Locator> => {
+}): Locator => {
   switch (fileViewerType) {
     case 'text-editor':
       return page.locator(texEditor)


### PR DESCRIPTION
## Description
To prevent mistakes like see here https://github.com/owncloud/web/pull/10553 (which caused tests to be flaky), I have implemented override config for e2e tests with customized rules for `tests/e2e`. With this, we can have separate rules defined for the e2e test code.

## Related Issue

## Motivation and Context

## How Has This Been Tested?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
