### PR TITLE
[test-only]check that image is open

### DIFF
--- a/tests/e2e/cucumber/features/shares/link.feature
+++ b/tests/e2e/cucumber/features/shares/link.feature
@@ -45,10 +45,10 @@ Feature: link
       | lorem.txt     | lorem_new.txt    |
       | textfile.txt  | textfile_new.txt |
       | new-lorem.txt | test.txt         |
-#    currently upload folder feature is not available in playwright
-#    And "Anonymous" uploads the following resources in public link page
-#      | resource              |
-#      | filesForUpload/PARENT |
+    #    currently upload folder feature is not available in playwright
+    #    And "Anonymous" uploads the following resources in public link page
+    #      | resource              |
+    #      | filesForUpload/PARENT |
     And "Alice" removes the public link named "myPublicLink" of resource "folderPublic"
     And "Anonymous" should not be able to open the old link "myPublicLink"
     And "Alice" logs out
@@ -149,6 +149,7 @@ Feature: link
       | simple.pdf | file |
     When "Brian" opens the public link "imageLink"
     And "Brian" unlocks the public link with password "%public%"
+    # https://github.com/owncloud/ocis/issues/8602
     Then "Brian" is in a image-viewer
     And "Brian" closes the file viewer
     And "Brian" downloads the following public link resources using the single share view
@@ -184,6 +185,7 @@ Feature: link
       | simple.pdf | file |
     When "Carol" opens the public link "imageLink"
     And "Carol" unlocks the public link with password "%public%"
+    # https://github.com/owncloud/ocis/issues/8602
     Then "Carol" is in a image-viewer
     And "Carol" closes the file viewer
     And "Carol" downloads the following public link resources using the single share view

--- a/tests/e2e/support/objects/app-files/utils/editor.ts
+++ b/tests/e2e/support/objects/app-files/utils/editor.ts
@@ -4,7 +4,7 @@ const closeTextEditorOrViewerButton = '#app-top-bar-close'
 const saveTextEditorOrViewerButton = '#app-save-action'
 const texEditor = '#text-editor'
 const pdfViewer = '#pdf-viewer'
-const imageViewer = '.preview-controls-action-bar'
+const imageViewer = '.stage'
 
 export const close = (page: Page): Promise<unknown> => {
   return Promise.all([

--- a/tests/e2e/support/objects/app-files/utils/editor.ts
+++ b/tests/e2e/support/objects/app-files/utils/editor.ts
@@ -4,7 +4,7 @@ const closeTextEditorOrViewerButton = '#app-top-bar-close'
 const saveTextEditorOrViewerButton = '#app-save-action'
 const texEditor = '#text-editor'
 const pdfViewer = '#pdf-viewer'
-const imageViewer = '#preview'
+const imageViewer = '.preview-controls-action-bar'
 
 export const close = (page: Page): Promise<unknown> => {
   return Promise.all([


### PR DESCRIPTION
related https://github.com/owncloud/ocis/issues/8602

we had test for this bug but unfortunately the test didn't expect an error

the image viewer was open, but the image did not appear<img width="2001" alt="Screenshot 2024-03-07 at 17 39 25" src="https://github.com/owncloud/web/assets/84779829/3e5dab9a-6b79-46e6-813e-01ad5740e5fd">


I'm wait locators now
<img width="512" alt="image" src="https://github.com/owncloud/web/assets/84779829/f886c254-01aa-43a7-90ab-558e95925db3">

we can check the response, but sometimes that doesn't give us a 100% guarantee that everything works. Example, openning broken pdf file: 
<img width="1943" alt="image" src="https://github.com/owncloud/web/assets/84779829/8e343cef-53d0-4139-a712-eaa71514551e">

for txt or md files we can check content(ctr+c and evaluate clickboard) but it dificult when user viewer
