### PR TITLE
refactor: make expand on user and group listings optional

### DIFF
--- a/packages/web-app-admin-settings/src/views/Groups.vue
+++ b/packages/web-app-admin-settings/src/views/Groups.vue
@@ -96,7 +96,9 @@ export default defineComponent({
     const createGroupAction = computed(() => unref(createGroupActions)[0])
 
     const loadResourcesTask = useTask(function* (signal) {
-      const response = yield clientService.graphAuthenticated.groups.listGroups('displayName')
+      const response = yield clientService.graphAuthenticated.groups.listGroups('displayName', [
+        'members'
+      ])
       groupSettingsStore.setGroups(response.data.value || [])
     })
 

--- a/packages/web-app-admin-settings/src/views/Users.vue
+++ b/packages/web-app-admin-settings/src/views/Users.vue
@@ -230,7 +230,10 @@ export default defineComponent({
     let editQuotaActionEventToken: string
 
     const loadGroupsTask = useTask(function* (signal) {
-      const groupsResponse = yield clientService.graphAuthenticated.groups.listGroups('displayName')
+      const groupsResponse = yield clientService.graphAuthenticated.groups.listGroups(
+        'displayName',
+        ['members']
+      )
       groups.value = groupsResponse.data.value
     })
 
@@ -268,7 +271,8 @@ export default defineComponent({
 
       const usersResponse = yield clientService.graphAuthenticated.users.listUsers(
         'displayName',
-        filter
+        filter,
+        ['appRoleAssignments']
       )
       userSettingsStore.setUsers(usersResponse.data.value || [])
     })

--- a/packages/web-app-admin-settings/tests/unit/views/Users.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/views/Users.spec.ts
@@ -196,7 +196,8 @@ describe('Users view', () => {
         expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenNthCalledWith(
           2,
           'displayName',
-          "(memberOf/any(m:m/id eq '1'))"
+          "(memberOf/any(m:m/id eq '1'))",
+          ['appRoleAssignments']
         )
       })
       it('does filter initially if group ids are given via query param', async () => {
@@ -210,7 +211,8 @@ describe('Users view', () => {
         await wrapper.vm.loadResourcesTask.last
         expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenCalledWith(
           'displayName',
-          "(memberOf/any(m:m/id eq '1') or memberOf/any(m:m/id eq '2'))"
+          "(memberOf/any(m:m/id eq '1') or memberOf/any(m:m/id eq '2'))",
+          ['appRoleAssignments']
         )
       })
     })
@@ -228,7 +230,8 @@ describe('Users view', () => {
         expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenNthCalledWith(
           2,
           'displayName',
-          "(appRoleAssignments/any(m:m/appRoleId eq '1'))"
+          "(appRoleAssignments/any(m:m/appRoleId eq '1'))",
+          ['appRoleAssignments']
         )
       })
       it('does filter initially if role ids are given via query param', async () => {
@@ -242,7 +245,8 @@ describe('Users view', () => {
         await wrapper.vm.loadResourcesTask.last
         expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenCalledWith(
           'displayName',
-          "(appRoleAssignments/any(m:m/appRoleId eq '1') or appRoleAssignments/any(m:m/appRoleId eq '2'))"
+          "(appRoleAssignments/any(m:m/appRoleId eq '1') or appRoleAssignments/any(m:m/appRoleId eq '2'))",
+          ['appRoleAssignments']
         )
       })
     })
@@ -258,7 +262,8 @@ describe('Users view', () => {
         await wrapper.vm.loadResourcesTask.last
         expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenCalledWith(
           'displayName',
-          "contains(displayName,'Albert')"
+          "contains(displayName,'Albert')",
+          ['appRoleAssignments']
         )
       })
     })

--- a/packages/web-client/src/graph.ts
+++ b/packages/web-client/src/graph.ts
@@ -59,7 +59,12 @@ export interface Graph {
     changeOwnPassword: (currentPassword: string, newPassword: string) => AxiosPromise<void>
     editUser: (userId: string, user: User) => AxiosPromise<User>
     deleteUser: (userId: string) => AxiosPromise<void>
-    listUsers: (orderBy?: string, filter?: string) => AxiosPromise<CollectionOfUser>
+    listUsers: (
+      orderBy?: string,
+      filter?: string,
+      expand?: Array<'drive' | 'drives' | 'memberOf' | 'appRoleAssignments'>,
+      search?: string
+    ) => AxiosPromise<CollectionOfUser>
     createUserAppRoleAssignment: (
       userId: string,
       appRoleAssignment: AppRoleAssignment
@@ -70,7 +75,11 @@ export interface Graph {
     ) => AxiosPromise<void>
   }
   groups: {
-    listGroups: (orderBy?: string) => AxiosPromise<CollectionOfGroup>
+    listGroups: (
+      orderBy?: string,
+      expand?: Array<'members'>,
+      search?: string
+    ) => AxiosPromise<CollectionOfGroup>
     createGroup: (group: Group) => AxiosPromise<Group>
     getGroup: (groupId: string) => AxiosPromise<Group>
     editGroup: (groupId: string, group: Group) => AxiosPromise<void>
@@ -157,13 +166,18 @@ export const graph = (baseURI: string, axiosClient: AxiosInstance): Graph => {
         meChangepasswordApiFactory.changeOwnPassword({ currentPassword, newPassword }),
       editUser: (userId: string, user: User) => userApiFactory.updateUser(userId, user),
       deleteUser: (userId: string) => userApiFactory.deleteUser(userId),
-      listUsers: (orderBy?: any, filter?: string) =>
+      listUsers: (
+        orderBy?: any,
+        filter?: string,
+        expand?: Array<'drive' | 'drives' | 'memberOf' | 'appRoleAssignments'>,
+        search: string = ''
+      ) =>
         usersApiFactory.listUsers(
-          '',
+          search,
           filter,
-          new Set<any>([orderBy]),
-          new Set<any>([]),
-          new Set<any>(['appRoleAssignments'])
+          orderBy ? new Set<any>([orderBy]) : null,
+          null,
+          expand ? new Set<any>(expand) : null
         ),
       createUserAppRoleAssignment: (userId: string, appRoleAssignment: AppRoleAssignment) =>
         userAppRoleAssignmentApiFactory.userCreateAppRoleAssignments(userId, appRoleAssignment),
@@ -176,12 +190,12 @@ export const graph = (baseURI: string, axiosClient: AxiosInstance): Graph => {
       getGroup: (groupId: string) =>
         groupApiFactory.getGroup(groupId, new Set<any>([]), new Set<any>(['members'])),
       deleteGroup: (groupId: string) => groupApiFactory.deleteGroup(groupId),
-      listGroups: (orderBy?: any) =>
+      listGroups: (orderBy?: any, expand?: Array<'members'>, search: string = '') =>
         groupsApiFactory.listGroups(
-          '',
-          new Set<any>([orderBy]),
-          new Set<any>([]),
-          new Set<any>(['members'])
+          search,
+          orderBy ? new Set<any>([orderBy]) : null,
+          null,
+          expand ? new Set<any>(expand) : null
         ),
       addMember: (groupId: string, userId: string, server: string) =>
         groupApiFactory.addMember(groupId, { '@odata.id': `${server}graph/v1.0/users/${userId}` }),


### PR DESCRIPTION
## Description
The endpoints for listing users and groups will be used for fetching potential sharees in the future. Regular users (non-admins) are not allowed to expand these requests though, hence we need to make the expand option optional.

To be honest, our current wrapper of the Graph SDK just feels like useless boilerplate since we're basically re-implementing it 1:1 (with the exception of some parts that were left out or are set to default - which bites us here e.g.). IMO we should either drop this wrapper or make it somewhat useful.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/10418

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
