### PR TITLE
fix: reading hidden state property of shares

### DIFF
--- a/packages/web-client/src/helpers/share/functionsNG.ts
+++ b/packages/web-client/src/helpers/share/functionsNG.ts
@@ -113,7 +113,7 @@ export function buildIncomingShareResource({
     type: !!driveItem.folder ? 'folder' : 'file',
     mimeType: driveItem.file?.mimeType || 'httpd/unix-directory',
     syncEnabled: driveItem['@client.synchronize'],
-    hidden: driveItem['@ui.hidden'],
+    hidden: driveItem['@UI.Hidden'],
     shareRoles,
     sharePermissions,
     outgoing: false,


### PR DESCRIPTION
## Description
Fixes reading the hidden state property of shares, which caused shares to never be displayed in a hidden state. This is a regression of the recent sharing NG implementations.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10542

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
