### PR TITLE
[tests-only][full-ci] removed webUI test and added e2e test to upload folder containing empty sub-folder

### DIFF
--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -12,7 +12,3 @@ Other free text and markdown formatting can be used elsewhere in the document if
 
 - [webUILogin/openidLogin.feature:50](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/openidLogin.feature#L50)
 - [webUILogin/openidLogin.feature:60](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/openidLogin.feature#L60)
-
-### [empty subfolder inside a folder to be uploaded is not created on the server](https://github.com/owncloud/web/issues/6348)
-
-- [webUIUpload/upload.feature:36](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/upload.feature#L36)

--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -32,19 +32,6 @@ Feature: File Upload
     And as "Alice" the content of "CUSTOM/sub1/new-lorem.txt" in the server should be the same as the content of local file "CUSTOM/sub1/new-lorem.txt"
     And as "Alice" the content of "CUSTOM/sub2/sub3/new-lorem.txt" in the server should be the same as the content of local file "CUSTOM/sub2/sub3/new-lorem.txt"
 
-
-  Scenario: simple upload of a folder that does not exist before with empty sub-folders
-    Given a folder "CUSTOM" has been created with the following files in separate sub-folders in the middleware
-      | subFolder      | file |
-      | sub4           |      |
-      | sub5/sub6/sub7 |      |
-    When the user uploads folder "CUSTOM" using the webUI
-    Then no message should be displayed on the webUI
-    And folder "CUSTOM" should be listed on the webUI
-    And as "Alice" folder "CUSTOM" should exist in the server
-    And as "Alice" folder "CUSTOM/sub4" should exist in the server
-    And as "Alice" folder "CUSTOM/sub5/sub6/sub7" should exist in the server
-
   @smokeTest @ocisSmokeTest
   Scenario: simple upload of a folder with subfolders that does not exist before
     When the user uploads folder "PARENT" using the webUI

--- a/tests/e2e/cucumber/features/smoke/upload.feature
+++ b/tests/e2e/cucumber/features/smoke/upload.feature
@@ -33,9 +33,9 @@ Feature: Upload
       | PARENT/parent.txt  | txtFile | some text    |
       | PARENT/example.txt | txtFile | example text |
     And "Alice" uploads the following resources via drag-n-drop
-        | resource       |
-        | simple.pdf     |
-        | testavatar.jpg |
+      | resource       |
+      | simple.pdf     |
+      | testavatar.jpg |
     And "Alice" tries to upload the following resource
       | resource      | error            |
       | lorem-big.txt | Not enough quota |
@@ -44,10 +44,13 @@ Feature: Upload
       | PARENT     | folder |
       # Coverage for bug: https://github.com/owncloud/ocis/issues/8361
       | comma,.txt | file   |
-  #  currently upload folder feature is not available in playwright
-  #  And "Alice" uploads the following resources
-  #    | resource |
-  #    | PARENT   |
+
+    # https://github.com/owncloud/web/issues/6348
+    # Note: uploading folder with empty sub-folder should be done manually
+    # currently upload folder feature is not available in playwright
+    # And "Alice" uploads the following resources
+    #  | resource |
+    #  | FOLDER   |
     And "Alice" logs out
 
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
In this PR,
- removed webUI test related to uploading folder with empty sub-folder
- added a e2e step to uploading folder with empty sub-folder

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/web/issues/10259

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
