### PR TITLE
[tests-only][full-ci]Cache latest ocis commit on nightly

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2400,14 +2400,15 @@ def e2eTestsOnKeycloak(ctx):
     }]
 
 def getOcislatestCommitId(ctx):
-    repo_path = "https://raw.githubusercontent.com/owncloud/ocis-php-sdk/%s" % ctx.build.commit
+    web_repo_path = "https://raw.githubusercontent.com/owncloud/web/%s" % ctx.build.commit
     return [
         {
             "name": "get-ocis-latest-commit-id",
             "image": OC_CI_ALPINE,
             "commands": [
-                "curl -o .drone.env %s/.drone.env" % repo_path,
-                "curl -o get-latest-ocis-commit-id.sh %s/tests/drone/get-latest-ocis-commit-id.sh" % repo_path,
+                "curl -o .drone.env %s/.drone.env" % web_repo_path,
+                "curl -o get-latest-ocis-commit-id.sh %s/tests/drone/get-latest-ocis-commit-id.sh" % web_repo_path,
+                "ls -al",
                 ". ./.drone.env",
                 "bash get-latest-ocis-commit-id.sh",
             ],

--- a/.drone.star
+++ b/.drone.star
@@ -40,7 +40,7 @@ dir = {
     "federated": "/var/www/owncloud/federated",
     "server": "/var/www/owncloud/server",
     "web": "/var/www/owncloud/web",
-    "ocis": "/var/www/owncloud/ocis-build",
+    "ocis": "/var/www/owncloud/ocis",
     "commentsFile": "/var/www/owncloud/web/comments.file",
     "app": "/srv/app",
     "config": "/srv/config",
@@ -523,6 +523,8 @@ def buildCacheWeb(ctx):
                      },
                      "commands": [
                          "make dist",
+                         "pwd",
+                         "ls -al",
                      ],
                  }] +
                  rebuildBuildArtifactCache(ctx, "web-dist", "dist"),
@@ -683,7 +685,7 @@ def e2eTests(ctx):
                 setupServerConfigureWeb(params["logLevel"])
 
         if ctx.build.event != "cron":
-            steps += restoreBuildArtifactCache(ctx, "ocis-build", "ocis")
+            steps += restoreBuildArtifactCache(ctx, "ocis", "ocis")
         else:
             steps += restoreOcisCache()
 
@@ -820,7 +822,7 @@ def acceptance(ctx):
                         services = browserService(alternateSuiteName, browser) + middlewareService()
 
                         if ctx.build.event != "cron":
-                            steps += restoreBuildArtifactCache(ctx, "ocis-build", "ocis")
+                            steps += restoreBuildArtifactCache(ctx, "ocis", "ocis")
                         else:
                             steps += restoreOcisCache()
 
@@ -961,6 +963,8 @@ def installPnpm():
             'npm install --silent --global --force "$(jq -r ".packageManager" < package.json)"',
             "pnpm config set store-dir ./.pnpm-store",
             "pnpm install",
+            "pwd",
+            "ls -al",
         ],
     }]
 
@@ -1264,6 +1268,7 @@ def ocisService(type, tika_enabled = False, enforce_password_public_link = False
             "detach": True,
             "environment": environment,
             "commands": [
+                "pwd",
                 "cd %s" % dir["ocis"],
                 "mkdir -p %s" % dir["ocisRevaDataRoot"],
                 "mkdir -p /srv/app/tmp/ocis/storage/users/",
@@ -1389,7 +1394,7 @@ def cacheOcisPipeline(ctx):
     if ctx.build.event != "cron":
         steps = getOcislatestCommitId(ctx) + \
                 buildOcis() + \
-                rebuildBuildArtifactCache(ctx, "ocis-build", "ocis")
+                rebuildBuildArtifactCache(ctx, "ocis", "ocis")
     else:
         steps = checkForExistingOcisCache(ctx) + \
                 buildOcis() + \
@@ -1439,9 +1444,6 @@ def buildOcis():
             "image": OC_CI_GOLANG,
             "commands": [
                 "source .drone.env",
-                "cd $GOPATH/src",
-                "mkdir -p github.com/owncloud",
-                "cd github.com/owncloud",
                 "git clone -b $OCIS_BRANCH --single-branch %s" % ocis_repo_url,
                 "cd ocis",
                 "git checkout $OCIS_COMMITID",
@@ -1453,20 +1455,22 @@ def buildOcis():
             "image": OC_CI_NODEJS,
             "commands": [
                 # we cannot use the $GOPATH here because of different base image
-                "cd /go/src/github.com/owncloud/ocis/",
+                "cd ocis",
                 "retry -t 3 'make ci-node-generate'",
             ],
-            "volumes": go_step_volumes,
         },
         {
             "name": "build-ocis",
             "image": OC_CI_GOLANG,
             "commands": [
                 "source .drone.env",
-                "cd $GOPATH/src/github.com/owncloud/ocis/ocis",
+                "cd ocis/ocis",
                 "retry -t 3 'make build'",
-                "mkdir -p %s/$OCIS_COMMITID" % dir["base"],
-                "cp bin/ocis %s/$OCIS_COMMITID" % dir["base"],
+                "cp bin/ocis %s" % dir["base"],
+                "pwd",
+                "cd %s" % dir["base"],
+                "ls -al",
+                "pwd",
             ],
             "volumes": go_step_volumes,
         },
@@ -1480,7 +1484,7 @@ def cacheOcis():
         "commands": [
             ". ./.drone.env",
             "mc alias set s3 $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY",
-            "mc cp -r -a %s/$OCIS_COMMITID/ocis s3/$CACHE_BUCKET/ocis-build/$OCIS_COMMITID" % dir["base"],
+            "mc cp -r -a %s s3/$CACHE_BUCKET/ocis-build/$OCIS_COMMITID" % dir["ocis"],
             "mc ls --recursive s3/$CACHE_BUCKET/ocis-build",
         ],
     }]
@@ -2408,6 +2412,7 @@ def getOcislatestCommitId(ctx):
             "commands": [
                 "curl -o .drone.env %s/.drone.env" % web_repo_path,
                 "curl -o get-latest-ocis-commit-id.sh %s/tests/drone/get-latest-ocis-commit-id.sh" % web_repo_path,
+                "pwd",
                 "ls -al",
                 ". ./.drone.env",
                 "bash get-latest-ocis-commit-id.sh",

--- a/.drone.star
+++ b/.drone.star
@@ -682,7 +682,7 @@ def e2eTests(ctx):
                 restoreBuildArtifactCache(ctx, "web-dist", "dist") + \
                 setupServerConfigureWeb(params["logLevel"])
 
-        if ctx.build.event == "cron":
+        if ctx.build.event != "cron":
             steps += restoreBuildArtifactCache(ctx, "ocis-build", "ocis")
         else:
             steps += restoreOcisCache()
@@ -819,7 +819,7 @@ def acceptance(ctx):
 
                         services = browserService(alternateSuiteName, browser) + middlewareService()
 
-                        if ctx.build.event == "cron":
+                        if ctx.build.event != "cron":
                             steps += restoreBuildArtifactCache(ctx, "ocis-build", "ocis")
                         else:
                             steps += restoreOcisCache()
@@ -1386,7 +1386,7 @@ def runWebuiAcceptanceTests(ctx, suite, alternateSuiteName, filterTags, extraEnv
 def cacheOcisPipeline(ctx):
     steps = []
 
-    if ctx.build.event == "cron":
+    if ctx.build.event != "cron":
         steps = getOcislatestCommitId(ctx) + \
                 buildOcis() + \
                 rebuildBuildArtifactCache(ctx, "ocis-build", "ocis")
@@ -2411,10 +2411,5 @@ def getOcislatestCommitId(ctx):
                 ". ./.drone.env",
                 "bash get-latest-ocis-commit-id.sh",
             ],
-            "when": {
-                "event": [
-                    "cron",
-                ],
-            },
         },
     ]

--- a/tests/drone/get-latest-ocis-commit-id.sh
+++ b/tests/drone/get-latest-ocis-commit-id.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+. .drone.env
+
+echo "$OCIS_BRANCH"
+# Run git ls-remote to get the latest commit ID
+latest_commit_id=$(git ls-remote https://github.com/owncloud/ocis.git "refs/heads/$OCIS_BRANCH" | cut -f 1)
+
+# Specify the path to the drone.env file
+env_file="././.drone.env"
+
+if [[ "$OCIS_BRANCH" == "master" ]] || [["$OCIS_BRANCH" == "stable-5.0"]]; then
+  # Update the OCIS_COMMITID in the drone.env file
+  sed -i "s/^OCIS_COMMITID=.*/OCIS_COMMITID=$latest_commit_id/" "$env_file"
+  cat $env_file
+else
+  echo "Invalid branch $1"
+  exit 78
+fi

--- a/tests/drone/get-latest-ocis-commit-id.sh
+++ b/tests/drone/get-latest-ocis-commit-id.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-. .drone.env
+source .drone.env
 
 echo "$OCIS_BRANCH"
 # Run git ls-remote to get the latest commit ID
 latest_commit_id=$(git ls-remote https://github.com/owncloud/ocis.git "refs/heads/$OCIS_BRANCH" | cut -f 1)
 
 # Specify the path to the drone.env file
-env_file="././.drone.env"
+env_file="./.drone.env"
 
 if [[ "$OCIS_BRANCH" == "master" ]] || [["$OCIS_BRANCH" == "stable-5.0"]]; then
   # Update the OCIS_COMMITID in the drone.env file


### PR DESCRIPTION
## Description
This PR makes changes on building ocis cache on nightly. After this PR merged, on nightly run, it fetch latest ocis commit id from master for web master  

## Related Issue
- Part of https://github.com/owncloud/web/issues/10559

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
