### PR TITLE
[tests-only][full-ci] forward port removed webUI test and added e2e test to upload folder containing empty sub-folder

### DIFF
--- a/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
+++ b/tests/acceptance/expected-failures-with-ocis-server-ocis-storage.md
@@ -12,7 +12,3 @@ Other free text and markdown formatting can be used elsewhere in the document if
 
 - [webUILogin/openidLogin.feature:50](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/openidLogin.feature#L50)
 - [webUILogin/openidLogin.feature:60](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUILogin/openidLogin.feature#L60)
-
-### [empty subfolder inside a folder to be uploaded is not created on the server](https://github.com/owncloud/web/issues/6348)
-
-- [webUIUpload/upload.feature:36](https://github.com/owncloud/web/blob/master/tests/acceptance/features/webUIUpload/upload.feature#L36)

--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -32,19 +32,6 @@ Feature: File Upload
     And as "Alice" the content of "CUSTOM/sub1/new-lorem.txt" in the server should be the same as the content of local file "CUSTOM/sub1/new-lorem.txt"
     And as "Alice" the content of "CUSTOM/sub2/sub3/new-lorem.txt" in the server should be the same as the content of local file "CUSTOM/sub2/sub3/new-lorem.txt"
 
-
-  Scenario: simple upload of a folder that does not exist before with empty sub-folders
-    Given a folder "CUSTOM" has been created with the following files in separate sub-folders in the middleware
-      | subFolder      | file |
-      | sub4           |      |
-      | sub5/sub6/sub7 |      |
-    When the user uploads folder "CUSTOM" using the webUI
-    Then no message should be displayed on the webUI
-    And folder "CUSTOM" should be listed on the webUI
-    And as "Alice" folder "CUSTOM" should exist in the server
-    And as "Alice" folder "CUSTOM/sub4" should exist in the server
-    And as "Alice" folder "CUSTOM/sub5/sub6/sub7" should exist in the server
-
   @smokeTest @ocisSmokeTest
   Scenario: simple upload of a folder with subfolders that does not exist before
     When the user uploads folder "PARENT" using the webUI

--- a/tests/e2e/cucumber/features/smoke/upload.feature
+++ b/tests/e2e/cucumber/features/smoke/upload.feature
@@ -33,9 +33,9 @@ Feature: Upload
       | PARENT/parent.txt  | txtFile | some text    |
       | PARENT/example.txt | txtFile | example text |
     And "Alice" uploads the following resources via drag-n-drop
-        | resource       |
-        | simple.pdf     |
-        | testavatar.jpg |
+      | resource       |
+      | simple.pdf     |
+      | testavatar.jpg |
     And "Alice" tries to upload the following resource
       | resource      | error            |
       | lorem-big.txt | Not enough quota |
@@ -44,10 +44,13 @@ Feature: Upload
       | PARENT     | folder |
       # Coverage for bug: https://github.com/owncloud/ocis/issues/8361
       | comma,.txt | file   |
-  #  currently upload folder feature is not available in playwright
-  #  And "Alice" uploads the following resources
-  #    | resource |
-  #    | PARENT   |
+
+    # https://github.com/owncloud/web/issues/6348
+    # Note: uploading folder with empty sub-folder should be done manually
+    # currently upload folder feature is not available in playwright
+    # And "Alice" uploads the following resources
+    #  | resource |
+    #  | FOLDER   |
     And "Alice" logs out
 
 


### PR DESCRIPTION
This PR forward ports: https://github.com/owncloud/web/pull/10574