### PR TITLE
[tests-only] fix drag-n-drop upload

### DIFF
--- a/tests/e2e/cucumber/features/smoke/upload.feature
+++ b/tests/e2e/cucumber/features/smoke/upload.feature
@@ -11,7 +11,7 @@ Feature: Upload
     And "Alice" logs in
     And "Admin" opens the "admin-settings" app
     And "Admin" navigates to the users management page
-    When "Admin" changes the quota of the user "Alice" to "0.00001" using the sidebar panel
+    When "Admin" changes the quota of the user "Alice" to "0.00008" using the sidebar panel
     And "Alice" opens the "files" app
 
 

--- a/tests/e2e/support/utils/dragDrop.ts
+++ b/tests/e2e/support/utils/dragDrop.ts
@@ -8,13 +8,13 @@ interface File {
 
 interface FileBuffer {
   name: string
-  buffer: Buffer
+  bufferString: string
 }
 
 export const dragDropFiles = async (page: Page, resources: File[], targetSelector: string) => {
   const files = resources.map((file) => ({
     name: file.name,
-    buffer: readFileSync(file.path)
+    bufferString: JSON.stringify(Array.from(readFileSync(file.path)))
   }))
 
   await page.evaluate(
@@ -23,7 +23,9 @@ export const dragDropFiles = async (page: Page, resources: File[], targetSelecto
       const dt = new DataTransfer()
 
       for (const file of files) {
-        dt.items.add(new File([file.buffer.toString()], file.name))
+        const buffer = Buffer.from(JSON.parse(file.bufferString))
+        const blob = new Blob([buffer])
+        dt.items.add(new File([blob], file.name))
       }
 
       dropArea.dispatchEvent(new DragEvent('drop', { dataTransfer: dt }))


### PR DESCRIPTION
## Description
Drag-n-drop upload was not uploading the file with the correct data which caused the files to be corrupted and the respective file viewer could not open the file. This PR has a fix for that.

## Related Issue

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
