### PR TITLE
fix: replacing folders

### DIFF
--- a/changelog/unreleased/bugfix-folder-replace
+++ b/changelog/unreleased/bugfix-folder-replace
@@ -1,0 +1,6 @@
+Bugfix: Folder replace
+
+The "Replace" conflict option, which previously didn't work at all when trying to copy/move a folder, has been fixed.
+
+https://github.com/owncloud/web/issues/10515
+https://github.com/owncloud/web/pull/10597

--- a/packages/web-app-files/src/helpers/resource/actions/transfer.ts
+++ b/packages/web-app-files/src/helpers/resource/actions/transfer.ts
@@ -11,6 +11,7 @@ import {
 } from '@ownclouders/web-pkg'
 
 import { TransferType } from '.'
+import { Ref, unref } from 'vue'
 
 export class ResourceTransfer extends ConflictDialog {
   constructor(
@@ -18,6 +19,7 @@ export class ResourceTransfer extends ConflictDialog {
     private resourcesToMove: Resource[],
     private targetSpace: SpaceResource,
     private targetFolder: Resource,
+    private currentFolder: Ref<Resource>,
     private clientService: ClientService,
     private loadingService: LoadingService,
     createModal: (modal: object) => void,
@@ -141,10 +143,19 @@ export class ResourceTransfer extends ConflictDialog {
   }
 
   // This is for an edge case if a user moves a subfolder with the same name as the parent folder into the parent of the parent folder (which is not possible because of the backend)
-  public isOverwritingParentFolder(resource, targetFolder, targetFolderResources) {
+  public isOverwritingParentFolder(
+    resource: Resource,
+    targetFolder: Resource,
+    targetFolderResources: Resource[]
+  ) {
     if (resource.type !== 'folder') {
       return false
     }
+
+    if (targetFolder.path === unref(this.currentFolder)?.path) {
+      return false
+    }
+
     const folderName = basename(resource.path)
     const newPath = join(targetFolder.path, folderName)
     return targetFolderResources.some((resource) => resource.path === newPath)

--- a/packages/web-app-files/src/store/actions.ts
+++ b/packages/web-app-files/src/store/actions.ts
@@ -22,6 +22,7 @@ import { ClientService, LoadingTaskCallbackArguments } from '@ownclouders/web-pk
 import { Language } from 'vue3-gettext'
 import { eventBus } from '@ownclouders/web-pkg'
 import { AncestorMetaData } from '@ownclouders/web-pkg'
+import { computed } from 'vue'
 
 const allowSharePermissions = (getters) => {
   return (
@@ -95,6 +96,7 @@ export default {
       resources,
       targetSpace,
       context.state.currentFolder,
+      computed(() => context.state.currentFolder),
       clientService,
       loadingService,
       createModal,

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -649,6 +649,7 @@ export default defineComponent({
         selected,
         this.space,
         targetFolder,
+        this.currentFolder,
         this.$clientService,
         this.$loadingService,
         this.createModal,

--- a/packages/web-app-files/tests/unit/helpers/resource/resourcesTransfer.spec.ts
+++ b/packages/web-app-files/tests/unit/helpers/resource/resourcesTransfer.spec.ts
@@ -5,6 +5,7 @@ import { mock, mockDeep, mockReset } from 'jest-mock-extended'
 import { buildSpace, Resource } from '@ownclouders/web-client/src/helpers'
 import { ListFilesResult } from '@ownclouders/web-client/src/webdav/listFiles'
 import { Drive } from '@ownclouders/web-client/src/generated'
+import { computed } from 'vue'
 
 const clientServiceMock = mockDeep<ClientService>()
 const loadingServiceMock = mock<LoadingService>({
@@ -62,6 +63,7 @@ describe('resourcesTransfer', () => {
       resourcesToMove,
       targetSpace,
       resourcesToMove[0],
+      computed(() => mock<Resource>()),
       clientServiceMock,
       loadingServiceMock,
       jest.fn(),
@@ -91,6 +93,7 @@ describe('resourcesTransfer', () => {
           resourcesToMove,
           targetSpace,
           targetFolder,
+          computed(() => mock<Resource>()),
           clientServiceMock,
           loadingServiceMock,
           jest.fn(),
@@ -131,6 +134,7 @@ describe('resourcesTransfer', () => {
       resourcesToMove,
       targetSpace,
       resourcesToMove[0],
+      computed(() => mock<Resource>()),
       clientServiceMock,
       loadingServiceMock,
       jest.fn(),
@@ -161,6 +165,7 @@ describe('resourcesTransfer', () => {
       resourcesToMove,
       targetSpace,
       resourcesToMove[0],
+      computed(() => mock<Resource>()),
       clientServiceMock,
       loadingServiceMock,
       jest.fn(),


### PR DESCRIPTION
## Description
Fixes the "Replace" conflict option when copying/moving a folder.

The mechanism of `isOverwritingParentFolder` falsely prevented this though it should only care about the edge case scenario when moving a sub-folder with the same name as the current folder's parent folder into the parent (via breadcrumbs). This needs an additional check if the current folder differs from the target location.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10515

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
