### PR TITLE
fix: downloading incoming shared files

### DIFF
--- a/packages/web-client/src/helpers/share/functionsNG.ts
+++ b/packages/web-client/src/helpers/share/functionsNG.ts
@@ -1,6 +1,6 @@
 import { extractDomSelector, extractExtensionFromFile, extractStorageId } from '../resource'
 import { ShareTypes } from './type'
-import { SHARE_JAIL_ID, buildWebDavSpacesPath } from '../space'
+import { buildWebDavSpacesPath } from '../space'
 import { DriveItem, Identity, UnifiedRoleDefinition, User } from '../../generated'
 import { GraphSharePermission, IncomingShareResource, OutgoingShareResource } from './types'
 import { urlJoin } from '../../utils'
@@ -104,7 +104,7 @@ export function buildIncomingShareResource({
     sdate: driveItem.lastModifiedDateTime, // FIXME: share date is missing in API
     indicators: [],
     tags: [],
-    webDavPath: buildWebDavSpacesPath([SHARE_JAIL_ID, driveItem.id].join('!'), '/'),
+    webDavPath: buildWebDavSpacesPath(driveItem.id, '/'),
     sharedBy,
     owner: driveItem.remoteItem.createdBy?.user,
     sharedWith,


### PR DESCRIPTION
## Description
Fixes downloading incoming shared files, which was broken since the switch to sharing NG. Apparently the server now includes the share jail id in a drive item's id, hence Web must not prepend it manually anymore.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/8618

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
