### PR TITLE
fix: space notification links

### DIFF
--- a/changelog/unreleased/bugfix-space-notification-links
+++ b/changelog/unreleased/bugfix-space-notification-links
@@ -1,0 +1,6 @@
+Bugfix: Space notification links
+
+Links for incoming new space notifications have been fixed. We also made sure links are being removed if a user has been removed from a space and the space had been loaded before.
+
+https://github.com/owncloud/web/issues/10397
+https://github.com/owncloud/web/pull/10603


### PR DESCRIPTION
## Description
Fixes links for incoming space notifications if the user has been added to a new space. Also makes sure links are being removed if a user has been removed from a space and the space had been loaded before.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10397

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
