### PR TITLE
refactor: remove usage of sdk for notifications

### DIFF
--- a/packages/web-app-ocm/src/views/ConnectionsPanel.vue
+++ b/packages/web-app-ocm/src/views/ConnectionsPanel.vue
@@ -154,7 +154,7 @@ export default defineComponent({
 
     const deleteConnection = async (user) => {
       try {
-        await clientService.httpAuthenticated.delete('/sciencemesh/delete-accepted-user', {
+        await clientService.httpAuthenticated.delete('/sciencemesh/delete-accepted-user', null, {
           params: {
             user_id: user.user_id,
             idp: user.idp

--- a/packages/web-pkg/src/http/client.ts
+++ b/packages/web-pkg/src/http/client.ts
@@ -20,9 +20,10 @@ export class HttpClient {
 
   public async delete<T = any, D = any, S extends z.Schema | T = T>(
     url: string,
+    data?: D,
     config?: RequestConfig<D, S>
   ) {
-    return await this.internalRequest('delete', url, config)
+    return await this.internalRequestWithData('delete', url, data, config)
   }
 
   public get<T = unknown, D = any, S extends z.Schema | T = T>(
@@ -107,7 +108,7 @@ export class HttpClient {
   }
 
   private async internalRequestWithData<T = any, D = any, S extends z.Schema | T = T>(
-    method: 'post' | 'put' | 'patch',
+    method: 'post' | 'put' | 'patch' | 'delete',
     url: string,
     data: D,
     config: RequestConfig<D, S>

--- a/packages/web-pkg/tests/unit/http/client.spec.ts
+++ b/packages/web-pkg/tests/unit/http/client.spec.ts
@@ -35,7 +35,7 @@ describe('HttpClient', () => {
       const { data: typedResponse } = await client.delete<Schema>('/foo')
       typedResponse.someProperty
 
-      const { data: schemaResponse } = await client.delete('/foo', { schema })
+      const { data: schemaResponse } = await client.delete('/foo', null, { schema })
       schemaResponse.someProperty
     }
 

--- a/packages/web-runtime/src/helpers/notifications.ts
+++ b/packages/web-runtime/src/helpers/notifications.ts
@@ -1,12 +1,5 @@
 import { RouteLocationNamedRaw } from 'vue-router'
 
-export interface NotificationAction {
-  label: string
-  link: string
-  type: string
-  primary: boolean
-}
-
 export interface Notification {
   notification_id: string
   app: string
@@ -19,7 +12,6 @@ export interface Notification {
   object_type?: string
   object_id?: string
   link?: string
-  actions?: NotificationAction[]
   computedMessage?: string
   computedLink?: RouteLocationNamedRaw
 }

--- a/tests/e2e/support/objects/runtime/application.ts
+++ b/tests/e2e/support/objects/runtime/application.ts
@@ -32,7 +32,7 @@ export class Application {
     await Promise.all([
       this.#page.waitForResponse(
         (resp) =>
-          resp.url().endsWith('notifications?format=json') &&
+          resp.url().endsWith('notifications') &&
           resp.status() === 200 &&
           resp.request().method() === 'GET'
       ),


### PR DESCRIPTION
## Description
Removes the usage of the ownCloud SDK for notifications since it's deprecated and we want to get rid of it. Also removes some old oC10 related code such as `actions` for notifications.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/9709

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
