### PR TITLE
refactor: remove usage of sdk for file version urls

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Versions/FileVersions.vue
+++ b/packages/web-app-files/src/components/SideBar/Versions/FileVersions.vue
@@ -142,7 +142,7 @@ export default defineComponent({
       fetchVersionsTask.perform()
     }
     const downloadVersion = (version: Resource) => {
-      return downloadFile(unref(resource), version.name)
+      return downloadFile(unref(space), unref(resource), version.name)
     }
     const formatVersionDateRelative = (version: Resource) => {
       return formatRelativeDateFromHTTP(version.mdate, currentLanguage)

--- a/packages/web-app-preview/src/App.vue
+++ b/packages/web-app-preview/src/App.vue
@@ -171,6 +171,9 @@ export default defineComponent({
 
     const { activeFiles, currentFileContext, closed } = appDefaults
 
+    const fileId = computed(() => unref(unref(currentFileContext).itemId))
+    const space = computed(() => unref(unref(currentFileContext).space))
+
     const isFullScreenModeActivated = ref(false)
     const toggleFullscreenMode = () => {
       const activateFullscreen = !unref(isFullScreenModeActivated)
@@ -236,10 +239,10 @@ export default defineComponent({
     const isFileContentLoading = ref(true)
 
     const triggerActiveFileDownload = () => {
-      if (isFileContentLoading.value) {
+      if (unref(isFileContentLoading)) {
         return
       }
-      downloadFile(activeFilteredFile.value)
+      downloadFile(unref(space), unref(activeFilteredFile))
     }
 
     const fileActions: Action<ActionOptions>[] = [
@@ -274,8 +277,6 @@ export default defineComponent({
       { immediate: true }
     )
 
-    const fileId = computed(() => unref(unref(currentFileContext).itemId))
-    const space = computed(() => unref(unref(currentFileContext).space))
     const { selectedResources } = useSelectedResources()
     watch(activeFilteredFile, (file) => {
       selectedResources.value = [file]

--- a/packages/web-client/src/webdav/getFileUrl.ts
+++ b/packages/web-client/src/webdav/getFileUrl.ts
@@ -18,12 +18,12 @@ export const GetFileUrlFactory = (
         disposition = 'attachment',
         signUrlTimeout = 86400,
         version = null,
-        preflightHeadRequest = false
+        doHeadRequest = false
       }: {
         disposition?: 'inline' | 'attachment'
         signUrlTimeout?: number
         version?: string
-        preflightHeadRequest?: boolean
+        doHeadRequest?: boolean
       }
     ): Promise<string> {
       const inlineDisposition = disposition === 'inline'
@@ -39,7 +39,7 @@ export const GetFileUrlFactory = (
           ? dav.getFileUrl(urlJoin('meta', resource.fileId, 'v', version))
           : dav.getFileUrl(webDavPath)
 
-        if (user && preflightHeadRequest) {
+        if (user && doHeadRequest) {
           await clientService.httpAuthenticated.head(downloadURL)
         }
 

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadFile.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadFile.ts
@@ -18,8 +18,8 @@ export const useFileActionsDownloadFile = () => {
   const isFilesAppActive = useIsFilesAppActive()
   const isSearchActive = useIsSearchActive()
   const { downloadFile } = useDownloadFile()
-  const handler = ({ resources }: FileActionOptions) => {
-    downloadFile(resources[0])
+  const handler = ({ space, resources }: FileActionOptions) => {
+    downloadFile(space, resources[0])
   }
 
   const actions = computed((): FileAction[] => [

--- a/packages/web-pkg/src/composables/download/useDownloadFile.ts
+++ b/packages/web-pkg/src/composables/download/useDownloadFile.ts
@@ -2,65 +2,33 @@ import { useClientService } from '../clientService'
 import { triggerDownloadWithFilename } from '../../../src/helpers'
 import { useGettext } from 'vue3-gettext'
 import { ClientService } from '../../services'
-import { useAuthStore, useMessages, useCapabilityStore } from '../piniaStores'
+import { useMessages } from '../piniaStores'
+import { Resource, SpaceResource } from '@ownclouders/web-client'
 
 export interface DownloadFileOptions {
   clientService?: ClientService
 }
 
 export const useDownloadFile = (options?: DownloadFileOptions) => {
-  const authStore = useAuthStore()
   const { showErrorMessage } = useMessages()
-  const capabilityStore = useCapabilityStore()
   const clientService = options?.clientService || useClientService()
   const { $gettext } = useGettext()
 
-  const downloadFile = async (file, version = null) => {
-    const { owncloudSdk: client } = clientService
-
-    // public links have a pre-signed download url
-    if (file.downloadURL) {
-      try {
-        triggerDownloadWithFilename(file.downloadURL, file.name)
-      } catch (e) {
-        console.error(e)
-        showErrorMessage({
-          title: $gettext('Download failed'),
-          desc: $gettext('File could not be located'),
-          errors: [e]
-        })
-      }
-      return
+  const downloadFile = async (space: SpaceResource, file: Resource, version: string = null) => {
+    try {
+      const url = await clientService.webdav.getFileUrl(space, file, {
+        version,
+        preflightHeadRequest: true
+      })
+      triggerDownloadWithFilename(url, file.name)
+    } catch (e) {
+      console.error(e)
+      showErrorMessage({
+        title: $gettext('Download failed'),
+        desc: $gettext('File could not be located'),
+        errors: [e]
+      })
     }
-
-    // construct the download url
-    const url =
-      version === null
-        ? `${client.helpers._davPath}${file.webDavPath}`
-        : client.fileVersions.getFileVersionUrl(file.fileId, version)
-
-    // download with signing enabled
-    if (authStore.userContextReady && capabilityStore.supportUrlSigning) {
-      const httpClient = clientService.httpAuthenticated
-      try {
-        const response = await httpClient.head(url)
-        if (response.status === 200) {
-          const signedUrl = await client.signUrl(url)
-          triggerDownloadWithFilename(signedUrl, file.name)
-          return
-        }
-      } catch (e) {
-        console.error(e)
-        showErrorMessage({
-          title: $gettext('Download failed'),
-          desc: $gettext('File could not be located'),
-          errors: [e]
-        })
-      }
-      return
-    }
-
-    triggerDownloadWithFilename(url, file.name)
   }
 
   return {

--- a/packages/web-pkg/src/composables/download/useDownloadFile.ts
+++ b/packages/web-pkg/src/composables/download/useDownloadFile.ts
@@ -18,7 +18,7 @@ export const useDownloadFile = (options?: DownloadFileOptions) => {
     try {
       const url = await clientService.webdav.getFileUrl(space, file, {
         version,
-        preflightHeadRequest: true
+        doHeadRequest: true
       })
       triggerDownloadWithFilename(url, file.name)
     } catch (e) {

--- a/packages/web-runtime/src/components/Account/GdprExport.vue
+++ b/packages/web-runtime/src/components/Account/GdprExport.vue
@@ -111,7 +111,7 @@ export default defineComponent({
       }
     }
     const downloadExport = () => {
-      return downloadFile(unref(exportFile))
+      return downloadFile(spacesStore.personalSpace, unref(exportFile))
     }
 
     const exportDate = computed(() => {


### PR DESCRIPTION
## Description
Removes the usage of the ownCloud SDK for file versions URLs since it's deprecated and we want to get rid of it. This could be achieved quite simple as nearly all the logic we had in `useDownloadFile` is already present in `getFileUrl` of our webdav implementation.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/9709

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
