### PR TITLE
refactor: handle favorites via our webdav implementation instead of sdk

### DIFF
--- a/packages/web-app-files/src/services/folder/loaderFavorites.ts
+++ b/packages/web-app-files/src/services/folder/loaderFavorites.ts
@@ -1,7 +1,6 @@
 import { FolderLoader, FolderLoaderTask, TaskContext } from '../folder'
 import { Router } from 'vue-router'
 import { useTask } from 'vue-concurrency'
-import { DavProperties } from '@ownclouders/web-client/src/webdav/constants'
 import { buildResource } from '@ownclouders/web-client/src/helpers'
 import { isLocationCommonActive } from '@ownclouders/web-pkg'
 
@@ -15,36 +14,16 @@ export class FolderLoaderFavorites implements FolderLoader {
   }
 
   public getTask(context: TaskContext): FolderLoaderTask {
-    const {
-      userStore,
-      resourcesStore,
-      clientService: { owncloudSdk: client }
-    } = context
+    const { resourcesStore, clientService } = context
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     return useTask(function* (signal1, signal2) {
       resourcesStore.clearResourceList()
       resourcesStore.setAncestorMetaData({})
 
-      // favorite implementation is going to change soon, so we are not implementing it
-      // as a proper factory in our new WebDAV client for now
-      const legacyPropertyNames = DavProperties.Default.map((propertyName) => {
-        const prefix = DavProperties.DavNamespace.includes(propertyName)
-          ? '{DAV:}'
-          : '{http://owncloud.org/ns}'
+      let resources = yield clientService.webdav.listFavoriteFiles()
 
-        return `${prefix}${propertyName}`
-      })
-
-      let resources = yield client.files.getFavoriteFiles(legacyPropertyNames)
-      resources = resources.map((f) => {
-        const resource = buildResource(f)
-        // info: in oc10 we have no storageId in resources. All resources are mounted into the personal space.
-        if (!resource.storageId) {
-          resource.storageId = userStore.user.onPremisesSamAccountName
-        }
-        return resource
-      })
+      resources = resources.map(buildResource)
       resourcesStore.initResourceList({ currentFolder: null, resources })
       resourcesStore.loadIndicators('/')
     })

--- a/packages/web-client/src/webdav/client/builders.ts
+++ b/packages/web-client/src/webdav/client/builders.ts
@@ -3,16 +3,37 @@ import { DavProperties, DavPropertyValue } from '../constants'
 import { SpaceResource, isPublicSpaceResource } from '../../helpers'
 import { Headers } from 'webdav'
 
-export const buildPropFindBody = (
-  properties: DavPropertyValue[] = [],
-  { pattern, limit = 0 }: { pattern?: string; limit?: number } = {}
-): string => {
-  const bodyType = pattern ? 'oc:search-files' : 'd:propfind'
-  const props = properties.reduce<Record<string, string>>((acc, val) => {
-    const davNamespace = DavProperties.DavNamespace.includes(val)
-    acc[davNamespace ? `d:${val}` : `oc:${val}`] = ''
+const getNamespacedDavProps = (obj: Partial<Record<DavPropertyValue, unknown>>) => {
+  return Object.keys(obj).reduce<Record<string, string>>((acc, val) => {
+    const davNamespace = DavProperties.DavNamespace.includes(val as DavPropertyValue)
+    acc[davNamespace ? `d:${val}` : `oc:${val}`] = obj[val] || ''
     return acc
   }, {})
+}
+
+export const buildPropFindBody = (
+  properties: DavPropertyValue[] = [],
+  {
+    pattern,
+    filterRules,
+    limit = 0
+  }: {
+    pattern?: string
+    filterRules?: Partial<Record<DavPropertyValue, unknown>>
+    limit?: number
+  } = {}
+): string => {
+  let bodyType = 'd:propfind'
+  if (pattern) {
+    bodyType = 'oc:search-files'
+  }
+
+  if (filterRules) {
+    bodyType = 'oc:filter-files'
+  }
+
+  const object = properties.reduce((obj, item) => Object.assign(obj, { [item]: null }), {})
+  const props = getNamespacedDavProps(object)
 
   const xmlObj = {
     [bodyType]: {
@@ -21,6 +42,9 @@ export const buildPropFindBody = (
       '@@xmlns:oc': 'http://owncloud.org/ns',
       ...(pattern && {
         'oc:search': { 'oc:pattern': pattern, 'oc:limit': limit }
+      }),
+      ...(filterRules && {
+        'oc:filter-rules': getNamespacedDavProps(filterRules)
       })
     }
   }
@@ -38,15 +62,9 @@ export const buildPropFindBody = (
 export const buildPropPatchBody = (
   properties: Partial<Record<DavPropertyValue, unknown>>
 ): string => {
-  const props = Object.keys(properties).reduce<Record<string, string>>((acc, val) => {
-    const davNamespace = DavProperties.DavNamespace.includes(val as DavPropertyValue)
-    acc[davNamespace ? `d:${val}` : `oc:${val}`] = properties[val]
-    return acc
-  }, {})
-
   const xmlObj = {
     'd:propertyupdate': {
-      'd:set': { 'd:prop': props },
+      'd:set': { 'd:prop': getNamespacedDavProps(properties) },
       '@@xmlns:d': 'DAV:',
       '@@xmlns:oc': 'http://owncloud.org/ns'
     }

--- a/packages/web-client/src/webdav/client/builders.ts
+++ b/packages/web-client/src/webdav/client/builders.ts
@@ -35,6 +35,33 @@ export const buildPropFindBody = (
   return builder.build(xmlObj)
 }
 
+export const buildPropPatchBody = (
+  properties: Partial<Record<DavPropertyValue, unknown>>
+): string => {
+  const props = Object.keys(properties).reduce<Record<string, string>>((acc, val) => {
+    const davNamespace = DavProperties.DavNamespace.includes(val as DavPropertyValue)
+    acc[davNamespace ? `d:${val}` : `oc:${val}`] = properties[val]
+    return acc
+  }, {})
+
+  const xmlObj = {
+    'd:propertyupdate': {
+      'd:set': { 'd:prop': props },
+      '@@xmlns:d': 'DAV:',
+      '@@xmlns:oc': 'http://owncloud.org/ns'
+    }
+  }
+
+  const builder = new XMLBuilder({
+    format: true,
+    ignoreAttributes: false,
+    attributeNamePrefix: '@@',
+    suppressEmptyNode: true
+  })
+
+  return builder.build(xmlObj)
+}
+
 export const buildPublicLinkAuthHeader = (password: string) => {
   return 'Basic ' + Buffer.from('public:' + password).toString('base64')
 }

--- a/packages/web-client/src/webdav/client/dav.ts
+++ b/packages/web-client/src/webdav/client/dav.ts
@@ -9,7 +9,7 @@ import {
 import { v4 as uuidV4 } from 'uuid'
 import { encodePath, urlJoin } from '../../utils'
 import { DavMethod, DavPropertyValue } from '../constants'
-import { buildPropFindBody } from './builders'
+import { buildPropFindBody, buildPropPatchBody } from './builders'
 import { parseError, parseMultiStatus, parseTusHeaders } from './parsers'
 import { WebDavResponseResource } from '../../helpers'
 import { HttpError } from '../../errors'
@@ -144,6 +144,15 @@ export class DAV {
 
   public delete(path: string, { headers = {} }: { headers?: Headers } = {}) {
     return this.request(DavMethod.delete, path, { headers })
+  }
+
+  public propPatch(
+    path: string,
+    properties: Partial<Record<DavPropertyValue, unknown>>,
+    { headers = {} }: { headers?: Headers } = {}
+  ) {
+    const body = buildPropPatchBody(properties)
+    return this.request(DavMethod.proppatch, path, { body, headers })
   }
 
   public getFileUrl(path: string) {

--- a/packages/web-client/src/webdav/client/dav.ts
+++ b/packages/web-client/src/webdav/client/dav.ts
@@ -65,21 +65,24 @@ export class DAV {
     return body
   }
 
-  public async search(
-    pattern: string,
+  public async report(
     path: string,
     {
+      pattern = '',
+      filterRules = null,
       limit = 30,
       properties,
       headers = {}
     }: {
+      pattern?: string
+      filterRules?: Partial<Record<DavPropertyValue, unknown>>
       limit?: number
       properties?: DavPropertyValue[]
       headers?: Headers
     } = {}
   ) {
     const { body, result } = await this.request(DavMethod.report, path, {
-      body: buildPropFindBody(properties, { pattern, limit }),
+      body: buildPropFindBody(properties, { pattern, filterRules, limit }),
       headers
     })
 

--- a/packages/web-client/src/webdav/index.ts
+++ b/packages/web-client/src/webdav/index.ts
@@ -17,6 +17,8 @@ import { GetPathForFileIdFactory } from './getPathForFileId'
 import { DAV } from './client/dav'
 import { ListFileVersionsFactory } from './listFileVersions'
 import { ListFilesByIdFactory } from './listFilesById'
+import { SetFavoriteFactory } from './setFavorite'
+import { ListFavoriteFilesFactory } from './listFavoriteFiles'
 
 export * from './constants'
 export * from './types'
@@ -61,6 +63,9 @@ export const webdav = (options: WebDavOptions): WebDAV => {
 
   const { search } = SearchFactory(dav, options)
 
+  const { listFavoriteFiles } = ListFavoriteFilesFactory(dav, options)
+  const { setFavorite } = SetFavoriteFactory(dav, options)
+
   return {
     copyFiles,
     createFolder,
@@ -79,6 +84,8 @@ export const webdav = (options: WebDavOptions): WebDAV => {
     putFileContents,
     revokeUrl,
     clearTrashBin,
-    search
+    search,
+    listFavoriteFiles,
+    setFavorite
   }
 }

--- a/packages/web-client/src/webdav/listFavoriteFiles.ts
+++ b/packages/web-client/src/webdav/listFavoriteFiles.ts
@@ -1,0 +1,19 @@
+import { urlJoin } from '../utils'
+import { WebDavOptions } from './types'
+import { DAV, buildAuthHeader } from './client'
+import { unref } from 'vue'
+import { DavProperties } from './constants'
+
+export const ListFavoriteFilesFactory = (dav: DAV, { accessToken, user }: WebDavOptions) => {
+  return {
+    listFavoriteFiles({ davProperties = DavProperties.Default } = {}) {
+      const headers = buildAuthHeader(unref(accessToken))
+
+      return dav.report(urlJoin('files', unref(user).onPremisesSamAccountName), {
+        headers,
+        properties: davProperties,
+        filterRules: { favorite: 1 }
+      })
+    }
+  }
+}

--- a/packages/web-client/src/webdav/search.ts
+++ b/packages/web-client/src/webdav/search.ts
@@ -26,7 +26,8 @@ export const SearchFactory = (dav: DAV, { accessToken }: WebDavOptions) => {
     ): Promise<SearchResult> {
       const path = '/spaces/'
       const headers = buildAuthHeader(unref(accessToken))
-      const { range, results } = await dav.search(term, path, {
+      const { range, results } = await dav.report(path, {
+        pattern: term,
         limit: searchLimit,
         properties: davProperties,
         headers

--- a/packages/web-client/src/webdav/setFavorite.ts
+++ b/packages/web-client/src/webdav/setFavorite.ts
@@ -1,0 +1,17 @@
+import { urlJoin } from '../utils'
+import { SpaceResource } from '../helpers'
+import { WebDavOptions } from './types'
+import { DAV, buildAuthHeader } from './client'
+import { unref } from 'vue'
+import { DavProperty } from './constants'
+
+export const SetFavoriteFactory = (dav: DAV, { accessToken }: WebDavOptions) => {
+  return {
+    setFavorite(space: SpaceResource, { path }: { path: string }, value: unknown) {
+      const headers = buildAuthHeader(unref(accessToken), space)
+      const properties = { [DavProperty.IsFavorite]: value ? 'true' : 'false' }
+
+      return dav.propPatch(urlJoin(space.webDavPath, path), properties, { headers })
+    }
+  }
+}

--- a/packages/web-client/src/webdav/types.ts
+++ b/packages/web-client/src/webdav/types.ts
@@ -19,6 +19,8 @@ import { Capabilities } from '../ocs'
 import { Ref } from 'vue'
 import { ListFilesByIdFactory } from './listFilesById'
 import { User } from '../generated'
+import { SetFavoriteFactory } from './setFavorite'
+import { ListFavoriteFilesFactory } from './listFavoriteFiles'
 
 export interface WebDavOptions {
   sdk: OwnCloudSdk
@@ -49,4 +51,6 @@ export interface WebDAV {
   restoreFileVersion: ReturnType<typeof RestoreFileVersionFactory>['restoreFileVersion']
   clearTrashBin: ReturnType<typeof ClearTrashBinFactory>['clearTrashBin']
   search: ReturnType<typeof SearchFactory>['search']
+  listFavoriteFiles: ReturnType<typeof ListFavoriteFilesFactory>['listFavoriteFiles']
+  setFavorite: ReturnType<typeof SetFavoriteFactory>['setFavorite']
 }

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsFavorite.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsFavorite.ts
@@ -19,10 +19,10 @@ export const useFileActionsFavorite = () => {
   const resourcesStore = useResourcesStore()
   const eventBus = useEventBus()
 
-  const handler = async ({ resources }: FileActionOptions) => {
+  const handler = async ({ space, resources }: FileActionOptions) => {
     try {
       const newValue = !resources[0].starred
-      await clientService.owncloudSdk.files.favorite(resources[0].webDavPath, newValue)
+      await clientService.webdav.setFavorite(space, resources[0], newValue)
 
       resourcesStore.updateResourceField({ id: resources[0].id, field: 'starred', value: newValue })
       if (!newValue) {


### PR DESCRIPTION
## Description
Handle favorites (listing and marking) via our webdav implementation instead of using the SDK. Also adds the possibility to do a `proppatch` and to use `filterRules` via a `report` request via our webdav implementation.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/9709

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
