### PR TITLE
refactor: move url signing to web-client package

### DIFF
--- a/packages/web-app-files/src/helpers/user/avatarUrl.ts
+++ b/packages/web-app-files/src/helpers/user/avatarUrl.ts
@@ -23,12 +23,7 @@ export const avatarUrl = async (options: AvatarUrlOptions, cached = false): Prom
     throw new Error(statusText)
   }
 
-  const { owncloudSdk } = options.clientService
-  if (!owncloudSdk || typeof owncloudSdk.signUrl !== 'function') {
-    return url
-  }
-
-  return owncloudSdk.signUrl(url)
+  return options.clientService.ocsUserContext.signUrl(url)
 }
 
 const cacheFactory = async (options: AvatarUrlOptions): Promise<string> => {

--- a/packages/web-app-files/tests/unit/helpers/user/avatarUrl.spec.ts
+++ b/packages/web-app-files/tests/unit/helpers/user/avatarUrl.spec.ts
@@ -17,29 +17,20 @@ describe('avatarUrl', () => {
     defaultOptions.clientService.httpAuthenticated.head.mockResolvedValue({
       status: 200
     } as AxiosResponse)
-    defaultOptions.clientService.owncloudSdk.signUrl.mockRejectedValue(new Error('error'))
+    defaultOptions.clientService.ocsUserContext.signUrl.mockRejectedValue(new Error('error'))
     const avatarUrlPromise = avatarUrl(defaultOptions)
     await expect(avatarUrlPromise).rejects.toThrow(new Error('error'))
     expect(defaultOptions.clientService.httpAuthenticated.head).toHaveBeenCalledWith(
       buildUrl(defaultOptions)
     )
   })
-  it('returns an unsigned url', async () => {
-    const defaultOptions = getDefaultOptions()
-    defaultOptions.clientService.owncloudSdk = null
-    defaultOptions.clientService.httpAuthenticated.head.mockResolvedValue({
-      status: 200
-    } as AxiosResponse)
-    const avatarUrlPromise = avatarUrl(defaultOptions)
-    await expect(avatarUrlPromise).resolves.toBe(buildUrl(defaultOptions))
-  })
   it('returns a signed url', async () => {
     const defaultOptions = getDefaultOptions()
     defaultOptions.clientService.httpAuthenticated.head.mockResolvedValue({
       status: 200
     } as AxiosResponse)
-    defaultOptions.clientService.owncloudSdk.signUrl.mockImplementation((url) => {
-      return `${url}?signed=true`
+    defaultOptions.clientService.ocsUserContext.signUrl.mockImplementation((url) => {
+      return Promise.resolve(`${url}?signed=true`)
     })
     const avatarUrlPromise = avatarUrl(defaultOptions)
     await expect(avatarUrlPromise).resolves.toBe(`${buildUrl(defaultOptions)}?signed=true`)
@@ -49,7 +40,9 @@ describe('avatarUrl', () => {
     defaultOptions.clientService.httpAuthenticated.head.mockResolvedValue({
       status: 200
     } as AxiosResponse)
-    defaultOptions.clientService.owncloudSdk.signUrl.mockImplementation((url) => url)
+    defaultOptions.clientService.ocsUserContext.signUrl.mockImplementation((url) =>
+      Promise.resolve(url)
+    )
 
     const avatarUrlPromiseUncached = avatarUrl(defaultOptions, true)
     await expect(avatarUrlPromiseUncached).resolves.toBe(buildUrl(defaultOptions))

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -24,6 +24,7 @@
     "luxon": "3.2.1",
     "@microsoft/fetch-event-source": "^2.0.1",
     "webdav": "5.3.1",
+    "xml-js": "^1.6.11",
     "zod": "3.22.4"
   }
 }

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -1,6 +1,8 @@
 import { AxiosInstance } from 'axios'
 import { graph, Graph } from './graph'
 import { ocs, OCS } from './ocs'
+import { User } from './generated'
+import { Ref } from 'vue'
 
 export type { Graph } from './graph'
 export type { OCS } from './ocs'
@@ -16,9 +18,9 @@ interface Client {
   ocs: OCS
 }
 
-export const client = (baseURI: string, axiosClient: AxiosInstance): Client => {
+export const client = (baseURI: string, axiosClient: AxiosInstance, user: Ref<User>): Client => {
   return {
     graph: graph(baseURI, axiosClient),
-    ocs: ocs(baseURI, axiosClient)
+    ocs: ocs(baseURI, axiosClient, user)
   }
 }

--- a/packages/web-client/src/ocs/index.ts
+++ b/packages/web-client/src/ocs/index.ts
@@ -1,22 +1,31 @@
 import { Capabilities, GetCapabilitiesFactory } from './capabilities'
 import { AxiosInstance } from 'axios'
+import { UrlSign } from './urlSign'
+import { Ref } from 'vue'
+import { User } from '../generated'
 
 export type { Capabilities } from './capabilities'
 
 export interface OCS {
   getCapabilities: () => Promise<Capabilities>
+  signUrl: (url: string) => Promise<string>
 }
 
-export const ocs = (baseURI: string, axiosClient: AxiosInstance): OCS => {
+export const ocs = (baseURI: string, axiosClient: AxiosInstance, user: Ref<User>): OCS => {
   const url = new URL(baseURI)
   url.pathname = [...url.pathname.split('/'), 'ocs', 'v1.php'].filter(Boolean).join('/')
   const ocsV1BaseURI = url.href
 
   const capabilitiesFactory = GetCapabilitiesFactory(ocsV1BaseURI, axiosClient)
 
+  const urlSign = new UrlSign({ baseURI, axiosClient, user })
+
   return {
     getCapabilities: () => {
       return capabilitiesFactory.getCapabilities()
+    },
+    signUrl: (url: string) => {
+      return urlSign.signUrl(url)
     }
   }
 }

--- a/packages/web-client/src/ocs/urlSign.ts
+++ b/packages/web-client/src/ocs/urlSign.ts
@@ -1,0 +1,76 @@
+import { AxiosInstance } from 'axios'
+import { urlJoin } from '../utils'
+import convert from 'xml-js'
+import { User } from '../generated'
+import { Ref, unref } from 'vue'
+import { pbkdf2Sync } from 'crypto'
+
+export interface UrlSignOptions {
+  axiosClient: AxiosInstance
+  baseURI: string
+  user: Ref<User>
+}
+
+export class UrlSign {
+  private axiosClient: AxiosInstance
+  private baseURI: string
+  private user: Ref<User>
+
+  private signingKey: string
+
+  private ALGORITHM = 'sha512'
+  private TTL = 1200
+  private HASH_LENGTH = 32
+  private ITERATION_COUNT = 10000
+
+  constructor({ axiosClient, baseURI, user }: UrlSignOptions) {
+    this.axiosClient = axiosClient
+    this.baseURI = baseURI
+    this.user = user
+  }
+
+  public async signUrl(url: string) {
+    const signedUrl = new URL(url)
+    signedUrl.searchParams.set('OC-Credential', unref(this.user).onPremisesSamAccountName)
+    signedUrl.searchParams.set('OC-Date', new Date().toISOString())
+    signedUrl.searchParams.set('OC-Expires', this.TTL.toString())
+    signedUrl.searchParams.set('OC-Verb', 'GET')
+
+    const hashedKey = await this.createHashedKey(signedUrl.toString())
+
+    signedUrl.searchParams.set('OC-Algo', `PBKDF2/${this.ITERATION_COUNT}-SHA512`)
+    signedUrl.searchParams.set('OC-Signature', hashedKey)
+
+    return signedUrl.toString()
+  }
+
+  private async getSignKey() {
+    if (this.signingKey) {
+      return this.signingKey
+    }
+
+    const data = await this.axiosClient.get(
+      urlJoin(this.baseURI, 'ocs/v1.php/cloud/user/signing-key'),
+      {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+      }
+    )
+
+    const parsedXML = convert.xml2js(data.data, { compact: true }) as any
+    this.signingKey = parsedXML.ocs.data['signing-key']._text
+    return this.signingKey
+  }
+
+  private async createHashedKey(url: string) {
+    const signignKey = await this.getSignKey()
+    const hashedKey = pbkdf2Sync(
+      url,
+      signignKey,
+      this.ITERATION_COUNT,
+      this.HASH_LENGTH,
+      this.ALGORITHM
+    )
+
+    return hashedKey.toString('hex')
+  }
+}

--- a/packages/web-client/src/webdav/getFileUrl.ts
+++ b/packages/web-client/src/webdav/getFileUrl.ts
@@ -8,7 +8,7 @@ import { DAV } from './client'
 export const GetFileUrlFactory = (
   dav: DAV,
   getFileContentsFactory: ReturnType<typeof GetFileContentsFactory>,
-  { sdk, capabilities, clientService, user }: WebDavOptions
+  { capabilities, clientService, user }: WebDavOptions
 ) => {
   return {
     async getFileUrl(
@@ -39,13 +39,13 @@ export const GetFileUrlFactory = (
           ? dav.getFileUrl(urlJoin('meta', resource.fileId, 'v', version))
           : dav.getFileUrl(webDavPath)
 
-        if (user && doHeadRequest) {
+        if (unref(user) && doHeadRequest) {
           await clientService.httpAuthenticated.head(downloadURL)
         }
 
         // sign url
-        if (isUrlSigningEnabled) {
-          downloadURL = await sdk.signUrl(downloadURL, signUrlTimeout)
+        if (isUrlSigningEnabled && unref(user)) {
+          downloadURL = await clientService.ocsUserContext.signUrl(downloadURL, signUrlTimeout)
         } else {
           signed = false
         }

--- a/packages/web-pkg/src/services/archiver.ts
+++ b/packages/web-pkg/src/services/archiver.ts
@@ -66,7 +66,7 @@ export class ArchiverService {
 
     const url = options.publicToken
       ? downloadUrl
-      : await this.clientService.owncloudSdk.signUrl(downloadUrl)
+      : await this.clientService.ocsUserContext.signUrl(downloadUrl)
 
     try {
       const response = await this.clientService.httpUnAuthenticated.get<ArrayBuffer>(url, {

--- a/packages/web-pkg/src/services/client/client.ts
+++ b/packages/web-pkg/src/services/client/client.ts
@@ -8,7 +8,8 @@ import { OwnCloudSdk } from '@ownclouders/web-client/src/types'
 import { Language } from 'vue3-gettext'
 import { FetchEventSourceInit } from '@microsoft/fetch-event-source'
 import { sse } from '@ownclouders/web-client/src/sse'
-import { AuthStore, ConfigStore } from '../../composables'
+import { AuthStore, ConfigStore, UserStore } from '../../composables'
+import { computed } from 'vue'
 
 interface OcClient {
   token: string
@@ -53,12 +54,14 @@ export interface ClientServiceOptions {
   configStore: ConfigStore
   language: Language
   authStore: AuthStore
+  userStore: UserStore
 }
 
 export class ClientService {
   private configStore: ConfigStore
   private language: Language
   private authStore: AuthStore
+  private userStore: UserStore
 
   private httpAuthenticatedClient: HttpClient
   private httpUnAuthenticatedClient: HttpClient
@@ -73,6 +76,7 @@ export class ClientService {
     this.configStore = options.configStore
     this.language = options.language
     this.authStore = options.authStore
+    this.userStore = options.userStore
   }
 
   public get httpAuthenticated(): _HttpClient {
@@ -139,7 +143,8 @@ export class ClientService {
   private getOcsClient(authParams: AuthParameters): OcClient {
     const { graph, ocs } = client(
       this.configStore.serverUrl,
-      createAxiosInstance(authParams, this.currentLanguage)
+      createAxiosInstance(authParams, this.currentLanguage),
+      computed(() => this.userStore.user)
     )
     return {
       token: this.authStore.accessToken,

--- a/packages/web-pkg/tests/unit/services/archiver.spec.ts
+++ b/packages/web-pkg/tests/unit/services/archiver.spec.ts
@@ -13,7 +13,7 @@ const getArchiverServiceInstance = (capabilities: Ref<ArchiverCapability[]>) => 
     data: new ArrayBuffer(8),
     headers: { 'content-disposition': 'filename="download.tar"' }
   } as unknown as AxiosResponse)
-  clientServiceMock.owncloudSdk.signUrl.mockImplementation((url) => url)
+  clientServiceMock.ocsUserContext.signUrl.mockImplementation((url) => Promise.resolve(url))
 
   return new ArchiverService(clientServiceMock, serverUrl, capabilities)
 }

--- a/packages/web-pkg/tests/unit/services/client.spec.ts
+++ b/packages/web-pkg/tests/unit/services/client.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '../../../src/http'
-import { ClientService, useAuthStore, useConfigStore } from '../../../src/'
+import { ClientService, useAuthStore, useConfigStore, useUserStore } from '../../../src/'
 import { Language } from 'vue3-gettext'
 import { Graph, OCS, client as _client } from '@ownclouders/web-client'
 import { createTestingPinia, writable } from 'web-test-helpers'
@@ -12,13 +12,15 @@ const serverUrl = 'someUrl'
 const getClientServiceMock = () => {
   const authStore = useAuthStore()
   const configStore = useConfigStore()
+  const userStore = useUserStore()
   writable(configStore).serverUrl = serverUrl
 
   return {
     clientService: new ClientService({
       configStore,
       language: language as Language,
-      authStore
+      authStore,
+      userStore
     }),
     authStore
   }
@@ -88,7 +90,7 @@ describe('ClientService', () => {
     })
     const { clientService, authStore } = getClientServiceMock()
     const client = clientService.graphAuthenticated
-    expect(_client).toHaveBeenCalledWith(serverUrl, expect.anything())
+    expect(_client).toHaveBeenCalledWith(serverUrl, expect.anything(), expect.anything())
     expect(_client).toHaveBeenCalledTimes(1)
     expect(graphClient).toEqual(client)
     // test re-instantiation on token and language change
@@ -108,7 +110,7 @@ describe('ClientService', () => {
     })
     const { clientService, authStore } = getClientServiceMock()
     const client = clientService.ocsUserContext
-    expect(_client).toHaveBeenCalledWith(serverUrl, expect.anything())
+    expect(_client).toHaveBeenCalledWith(serverUrl, expect.anything(), expect.anything())
     expect(_client).toHaveBeenCalledTimes(1)
     expect(ocsClient).toEqual(client)
     // test re-instantiation on token and language change
@@ -128,7 +130,7 @@ describe('ClientService', () => {
     })
     const { clientService, authStore } = getClientServiceMock()
     const client = clientService.ocsPublicLinkContext()
-    expect(_client).toHaveBeenCalledWith(serverUrl, expect.anything())
+    expect(_client).toHaveBeenCalledWith(serverUrl, expect.anything(), expect.anything())
     expect(_client).toHaveBeenCalledTimes(1)
     expect(ocsClient).toEqual(client)
     // test re-instantiation on token and language change

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -402,7 +402,8 @@ export const announceClientService = ({
   const clientService = new ClientService({
     configStore,
     language: app.config.globalProperties.$language,
-    authStore
+    authStore,
+    userStore
   })
   app.config.globalProperties.$client = sdk
   app.config.globalProperties.$clientService = clientService

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -940,6 +940,9 @@ importers:
       webdav:
         specifier: 5.3.1
         version: 5.3.1
+      xml-js:
+        specifier: ^1.6.11
+        version: 1.6.11
       zod:
         specifier: 3.22.4
         version: 3.22.4


### PR DESCRIPTION
## Description
Moves the URL signing to the OCS client inside our `web-client` package. This allows us to get rid of the implementation in the owncloud SDK.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/9709

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
