### PR TITLE
feat: make full text search default

### DIFF
--- a/changelog/unreleased/enhancement-full-text-search-default
+++ b/changelog/unreleased/enhancement-full-text-search-default
@@ -1,0 +1,6 @@
+Enhancement: Full text search default
+
+Full text search is now enabled by default when searching for files if the server supports it.
+
+https://github.com/owncloud/web/issues/10534
+https://github.com/owncloud/web/pull/10626

--- a/packages/web-app-files/tests/unit/components/Search/List.spec.ts
+++ b/packages/web-app-files/tests/unit/components/Search/List.spec.ts
@@ -25,7 +25,7 @@ const selectors = {
   resourceTableStub: 'resource-table-stub',
   tagFilter: '.files-search-filter-tags',
   lastModifiedFilter: '.files-search-filter-last-modified',
-  fullTextFilter: '.files-search-filter-full-text',
+  titleOnlyFilter: '.files-search-filter-title-only',
   filter: '.files-search-result-filter'
 }
 
@@ -66,7 +66,7 @@ describe('List component', () => {
         name: 'files-common-search',
         query: merge(
           {
-            q_fullText: 'q_fullText',
+            q_titleOnly: 'q_titleOnly',
             q_tags: 'q_tags',
             q_lastModified: 'q_lastModified',
             useScope: 'useScope'
@@ -123,7 +123,7 @@ describe('List component', () => {
         })
         await wrapper.vm.loadAvailableTagsTask.last
         expect(wrapper.emitted('search')[0][0]).toEqual(
-          `name:"*${searchTerm}*" AND tag:("${availableTags[0]}" OR "${availableTags[1]}")`
+          `(name:"*${searchTerm}*" OR content:"${searchTerm}") AND tag:("${availableTags[0]}" OR "${availableTags[1]}")`
         )
       })
     })
@@ -176,25 +176,29 @@ describe('List component', () => {
         })
         await wrapper.vm.loadAvailableTagsTask.last
         expect(wrapper.emitted('search')[0][0]).toEqual(
-          `name:"*${searchTerm}*" AND mtime:"${lastModifiedFilterQuery}"`
+          `(name:"*${searchTerm}*" OR content:"${searchTerm}") AND mtime:${lastModifiedFilterQuery}`
         )
       })
     })
 
-    describe('fullText', () => {
+    describe('titleOnly', () => {
       it('should render filter if enabled via capabilities', () => {
         const { wrapper } = getWrapper({ fullTextSearchEnabled: true })
-        expect(wrapper.find(selectors.fullTextFilter).exists()).toBeTruthy()
+        expect(wrapper.find(selectors.titleOnlyFilter).exists()).toBeTruthy()
       })
-      it('should set initial filter when fullText is set active via query param', async () => {
+      it('should not render filter if not enabled via capabilities', () => {
+        const { wrapper } = getWrapper({ fullTextSearchEnabled: false })
+        expect(wrapper.find(selectors.titleOnlyFilter).exists()).toBeFalsy()
+      })
+      it('should set initial filter when titleOnly is set active via query param', async () => {
         const searchTerm = 'term'
         const { wrapper } = getWrapper({
           searchTerm,
-          fullTextFilterQuery: 'true',
+          titleOnlyFilterQuery: 'true',
           fullTextSearchEnabled: true
         })
         await wrapper.vm.loadAvailableTagsTask.last
-        expect(wrapper.emitted('search')[0][0]).toEqual(`content:"${searchTerm}"`)
+        expect(wrapper.emitted('search')[0][0]).toEqual(`name:"*${searchTerm}*"`)
       })
     })
   })
@@ -205,14 +209,14 @@ function getWrapper({
   resources = [],
   searchTerm = '',
   tagFilterQuery = null,
-  fullTextFilterQuery = null,
-  fullTextSearchEnabled = false,
+  titleOnlyFilterQuery = null,
+  fullTextSearchEnabled = true,
   availableLastModifiedValues = {},
   lastModifiedFilterQuery = null,
   mocks = {}
 } = {}) {
   vi.mocked(queryItemAsString).mockImplementationOnce(() => searchTerm)
-  vi.mocked(queryItemAsString).mockImplementationOnce(() => fullTextFilterQuery)
+  vi.mocked(queryItemAsString).mockImplementationOnce(() => titleOnlyFilterQuery)
   vi.mocked(queryItemAsString).mockImplementationOnce(() => tagFilterQuery)
   vi.mocked(queryItemAsString).mockImplementationOnce(() => lastModifiedFilterQuery)
 

--- a/packages/web-pkg/src/router/common.ts
+++ b/packages/web-pkg/src/router/common.ts
@@ -32,7 +32,7 @@ export const buildRoutes = (components: RouteComponents): RouteRecordRaw[] => [
             'provider',
             'q_tags',
             'q_lastModified',
-            'q_fullText',
+            'q_titleOnly',
             'q_mediaType',
             'scope',
             'useScope'

--- a/tests/e2e/cucumber/features/search/fullTextSearch.feature
+++ b/tests/e2e/cucumber/features/search/fullTextSearch.feature
@@ -77,8 +77,7 @@ Feature: Search
       | fileToShare.txt               |
       | spaceFolder/spaceTextfile.txt |
 
-    When "Brian" enables the option to search in file content
-    And "Brian" searches "Cheers" using the global search and the "all files" filter and presses enter
+    When "Brian" searches "Cheers" using the global search and the "all files" filter and presses enter
     Then following resources should be displayed in the files list for user "Brian"
       | resource                      |
       | textfile.txt                  |

--- a/tests/e2e/cucumber/features/search/search.feature
+++ b/tests/e2e/cucumber/features/search/search.feature
@@ -104,6 +104,7 @@ Feature: Search
 
     # search difficult names
     When "Alice" searches "strängéनेपालीName" using the global search and the "all files" filter and presses enter
+    And "Alice" enables the option to search title only
     Then following resources should be displayed in the files list for user "Alice"
       | strängéनेपालीName |
 
@@ -171,6 +172,7 @@ Feature: Search
       | mediaTest.zip | I'm a Archive  |
     When "Alice" opens the "files" app
     And "Alice" searches "mediaTest" using the global search and the "all files" filter and presses enter
+    And "Alice" enables the option to search title only
     And "Alice" selects mediaType "Document" from the search result filter chip
     Then following resources should be displayed in the files list for user "Alice"
       | resource      |
@@ -223,6 +225,7 @@ Feature: Search
     And "Alice" opens the "files" app
     When "Alice" opens folder "mainFolder"
     And "Alice" searches "mediaTest" using the global search and the "current folder" filter and presses enter
+    And "Alice" enables the option to search title only
     And "Alice" selects lastModified "last 30 days" from the search result filter chip
     Then following resources should be displayed in the files list for user "Alice"
       | resource                 |

--- a/tests/e2e/cucumber/steps/ui/search.ts
+++ b/tests/e2e/cucumber/steps/ui/search.ts
@@ -23,11 +23,11 @@ When(
 )
 
 When(
-  /^"([^"]*)" (enable|disable)s the option to search in file content?$/,
+  /^"([^"]*)" (enable|disable)s the option to search title only?$/,
   async function (this: World, stepUser: string, enableOrDisable: string): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const searchObject = new objects.applicationFiles.Search({ page })
-    await searchObject.toggleSearchInFileContent({ enableOrDisable })
+    await searchObject.toggleSearchTitleOnly({ enableOrDisable })
   }
 )
 When(

--- a/tests/e2e/support/objects/app-files/search/actions.ts
+++ b/tests/e2e/support/objects/app-files/search/actions.ts
@@ -11,10 +11,10 @@ const mediaTypeOutside = '.files-search-result-filter'
 const clearFilterSelector = '.item-filter-%s .oc-filter-chip-clear'
 const lastModifiedFilterSelector = '.item-filter-lastModified'
 const lastModifiedFilterItem = '[data-test-value="%s"]'
-const enableSearchInFileContentSelector =
-  '//div[contains(@class,"files-search-filter-full-text")]//button[contains(@class,"oc-filter-chip-button")]'
-const disableSearchInFileContentSelector =
-  '//div[contains(@class,"files-search-filter-full-text")]//button[contains(@class,"oc-filter-chip-clear")]'
+const enableSearchTitleOnlySelector =
+  '//div[contains(@class,"files-search-filter-title-only")]//button[contains(@class,"oc-filter-chip-button")]'
+const disableSearchTitleOnlySelector =
+  '//div[contains(@class,"files-search-filter-title-only")]//button[contains(@class,"oc-filter-chip-clear")]'
 
 export const getSearchResultMessage = ({ page }: { page: Page }): Promise<string> => {
   return page.locator(searchResultMessageSelector).innerText()
@@ -80,7 +80,7 @@ export const clearFilter = async ({
   await page.locator(util.format(clearFilterSelector, filter)).click()
 }
 
-export const toggleSearchInFileContent = async ({
+export const toggleSearchTitleOnly = async ({
   enableOrDisable,
   page
 }: {
@@ -88,8 +88,6 @@ export const toggleSearchInFileContent = async ({
   page: Page
 }): Promise<void> => {
   const selector =
-    enableOrDisable === 'enable'
-      ? enableSearchInFileContentSelector
-      : disableSearchInFileContentSelector
+    enableOrDisable === 'enable' ? enableSearchTitleOnlySelector : disableSearchTitleOnlySelector
   await page.locator(selector).click()
 }

--- a/tests/e2e/support/objects/app-files/search/index.ts
+++ b/tests/e2e/support/objects/app-files/search/index.ts
@@ -28,7 +28,7 @@ export class Search {
     await po.clearFilter({ page: this.#page, filter: string })
   }
 
-  async toggleSearchInFileContent({ enableOrDisable: string }): Promise<void> {
-    await po.toggleSearchInFileContent({ enableOrDisable: string, page: this.#page })
+  async toggleSearchTitleOnly({ enableOrDisable: string }): Promise<void> {
+    await po.toggleSearchTitleOnly({ enableOrDisable: string, page: this.#page })
   }
 }


### PR DESCRIPTION
## Description
Enables full text search as default if the server supports it.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10534

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
