### PR TITLE
fix: active share nav item after closing editors

### DIFF
--- a/packages/web-pkg/src/composables/driveResolver/useDriveResolver.ts
+++ b/packages/web-pkg/src/composables/driveResolver/useDriveResolver.ts
@@ -57,7 +57,10 @@ export const useDriveResolver = (options: DriveResolverOptions = {}): DriveResol
 
   // clean up global state as the watchers aren't triggered anymore when navigating away
   onUnmounted(() => {
-    spacesStore.setCurrentSpace(null)
+    const driveAliasAndItem = unref(options.driveAliasAndItem)
+    if (!driveAliasAndItem?.startsWith('personal/') && !driveAliasAndItem?.startsWith('project/')) {
+      spacesStore.setCurrentSpace(null)
+    }
   })
 
   watch(


### PR DESCRIPTION

## Description
Fixes an issue where the share nav item would be wrongly marked as active after closing a file viewer/editor in the personal space. This happened because the `currentSpace` had been reset as soon as the `useDriveResolver` composable got unmounted. This must not happen in personal or project spaces though.

Regression from https://github.com/owncloud/web/pull/10452

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10615

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
