### PR TITLE
fix: disable download for unsynced shares

### DIFF
--- a/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadArchive.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadArchive.ts
@@ -8,6 +8,7 @@ import { useIsFilesAppActive } from '../helpers'
 import path from 'path'
 import first from 'lodash-es/first'
 import {
+  isIncomingShareResource,
   isProjectSpaceResource,
   isPublicSpaceResource,
   Resource
@@ -127,6 +128,9 @@ export const useFileActionsDownloadArchive = () => {
             return false
           }
           if (isProjectSpaceResource(resources[0]) && resources[0].disabled) {
+            return false
+          }
+          if (isIncomingShareResource(resources[0]) && !resources[0].syncEnabled) {
             return false
           }
           if (

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadFile.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadFile.ts
@@ -11,6 +11,7 @@ import { useIsSearchActive } from '../helpers'
 import { computed, unref } from 'vue'
 import { useGettext } from 'vue3-gettext'
 import { useDownloadFile } from '../../download'
+import { isIncomingShareResource } from '@ownclouders/web-client/src/helpers'
 
 export const useFileActionsDownloadFile = () => {
   const router = useRouter()
@@ -48,6 +49,9 @@ export const useFileActionsDownloadFile = () => {
           return false
         }
         if (resources[0].isFolder) {
+          return false
+        }
+        if (isIncomingShareResource(resources[0]) && !resources[0].syncEnabled) {
           return false
         }
         return resources[0].canDownload()


### PR DESCRIPTION
## Description
Disables the download for unsynced shares as we currently don't support this. It will be possible some day in the future though.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10622

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
