### PR TITLE
fix: re-clicking the spaces nav item

### DIFF
--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -413,11 +413,11 @@ export default defineComponent({
 
     const displayThumbnails = computed(() => configStore.options.displayThumbnails)
 
-    const rowMounted = (space) => {
+    const rowMounted = (space: SpaceResource) => {
       loadPreview(space)
     }
 
-    const loadPreview = async (space) => {
+    const loadPreview = async (space: SpaceResource) => {
       if (!unref(displayThumbnails) || !space.spaceImageData) {
         return
       }
@@ -450,7 +450,8 @@ export default defineComponent({
     }
 
     const folderView = computed(() => {
-      return unref(viewModes).find((v) => v.name === unref(viewMode))
+      const viewModeName = unref(viewMode) || FolderViewModeConstants.name.tiles
+      return unref(viewModes).find((v) => v.name === viewModeName)
     })
 
     return {


### PR DESCRIPTION
## Description
Fixes errors when re-clicking the "Spaces" nav item when the user is already on that page. The issue existed because the `viewMode` is `undefined` for a short moment on navigation change. This seems to happen because of the asynchronous behaviour of the `useRouteQuery` composable.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10639

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
