### PR TITLE
fix: scope when clicking "Show n results"

### DIFF
--- a/changelog/unreleased/bugfix-scope-loss-search-results
+++ b/changelog/unreleased/bugfix-scope-loss-search-results
@@ -1,0 +1,6 @@
+Bugfix: Scope loss when showing search results
+
+Clicking "Show n results" in the search preview no longer loses the search scope.
+
+https://github.com/owncloud/web/issues/10634
+https://github.com/owncloud/web/pull/10653


### PR DESCRIPTION
## Description
Prevents the search scope from getting lost when clicking "Show n results" in the search preview.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10634

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

