### PR TITLE
[test-only] Prevent caching ocis repo directory

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1303,7 +1303,6 @@ def checkForExistingOcisCache(ctx):
                 "curl -o check-oCIS-cache.sh %s/tests/drone/check-oCIS-cache.sh" % web_repo_path,
                 ". ./.drone.env",
                 "mc alias set s3 $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY",
-                "mc rm --recursive --force s3/$CACHE_BUCKET/ocis-build/ae74e77c4656b9b5fa6af3386a15d10bad49e759",
                 "mc ls --recursive s3/$CACHE_BUCKET/ocis-build",
                 "bash check-oCIS-cache.sh",
             ],
@@ -1478,7 +1477,7 @@ def cacheOcis():
         "commands": [
             ". ./.drone.env",
             "mc alias set s3 $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY",
-            "mc cp -r -a %s/ocis s3/$CACHE_BUCKET/ocis-build/$OCIS_COMMITID" % dir["web"],
+            "mc cp -a %s/ocis s3/$CACHE_BUCKET/ocis-build/$OCIS_COMMITID" % dir["web"],
             "mc ls --recursive s3/$CACHE_BUCKET/ocis-build",
         ],
     }]

--- a/.drone.star
+++ b/.drone.star
@@ -256,7 +256,6 @@ def Diff(li1, li2):
     return li_dif
 
 def main(ctx):
-    return cacheOcisPipeline(ctx)
     uiSuitesCheck = checkTestSuites()
     if (uiSuitesCheck == False):
         print("Errors detected. Review messages above.")
@@ -1393,7 +1392,9 @@ def cacheOcisPipeline(ctx):
                 buildOcis() + \
                 rebuildBuildArtifactCache(ctx, "ocis", "ocis")
     else:
-        steps = checkForExistingOcisCache(ctx)
+        steps = checkForExistingOcisCache(ctx) + \
+                buildOcis() + \
+                cacheOcis()
     return [{
         "kind": "pipeline",
         "type": "docker",
@@ -1437,8 +1438,12 @@ def buildOcis():
             "image": OC_CI_GOLANG,
             "commands": [
                 "source .drone.env",
-                "git clone -b $OCIS_BRANCH --single-branch %s ocis_repo" % ocis_repo_url,
-                "cd ocis_repo",
+                # NOTE: it is important to not start repo name with ocis*
+                # because we copy ocis binary to root workspace
+                # and upload binary <workspace>/ocis to cache bucket.
+                # This prevents accidental upload of ocis repo to the cache
+                "git clone -b $OCIS_BRANCH --single-branch %s repo_ocis" % ocis_repo_url,
+                "cd repo_ocis",
                 "git checkout $OCIS_COMMITID",
             ],
             "volumes": go_step_volumes,
@@ -1447,7 +1452,7 @@ def buildOcis():
             "name": "generate-ocis",
             "image": OC_CI_NODEJS,
             "commands": [
-                "cd ocis_repo",
+                "cd repo_ocis",
                 "retry -t 3 'make ci-node-generate'",
             ],
             "volumes": go_step_volumes,
@@ -1457,7 +1462,7 @@ def buildOcis():
             "image": OC_CI_GOLANG,
             "commands": [
                 "source .drone.env",
-                "cd ocis_repo/ocis",
+                "cd repo_ocis/ocis",
                 "retry -t 3 'make build'",
                 "cp bin/ocis %s" % dir["web"],
             ],

--- a/.drone.star
+++ b/.drone.star
@@ -256,6 +256,7 @@ def Diff(li1, li2):
     return li_dif
 
 def main(ctx):
+    return cacheOcisPipeline(ctx)
     uiSuitesCheck = checkTestSuites()
     if (uiSuitesCheck == False):
         print("Errors detected. Review messages above.")
@@ -1303,6 +1304,7 @@ def checkForExistingOcisCache(ctx):
                 "curl -o check-oCIS-cache.sh %s/tests/drone/check-oCIS-cache.sh" % web_repo_path,
                 ". ./.drone.env",
                 "mc alias set s3 $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY",
+                "mc rm --recursive --force s3/$CACHE_BUCKET/ocis-build/ae74e77c4656b9b5fa6af3386a15d10bad49e759",
                 "mc ls --recursive s3/$CACHE_BUCKET/ocis-build",
                 "bash check-oCIS-cache.sh",
             ],
@@ -1391,9 +1393,7 @@ def cacheOcisPipeline(ctx):
                 buildOcis() + \
                 rebuildBuildArtifactCache(ctx, "ocis", "ocis")
     else:
-        steps = checkForExistingOcisCache(ctx) + \
-                buildOcis() + \
-                cacheOcis()
+        steps = checkForExistingOcisCache(ctx)
     return [{
         "kind": "pipeline",
         "type": "docker",


### PR DESCRIPTION
**Problem:**
Command `mc cp -r -a %s/ocis s3/$CACHE_BUCKET/ocis-build/$OCIS_COMMITID` also copied the `ocis_repo` to the cache bucket.

To prevent this, I have renamed the ocis repo to not start with `ocis*`

INFO: The cache was not there and was rebuilt in this PR https://drone.owncloud.com/owncloud/web/43535/7/1

Fixes https://github.com/owncloud/web/issues/10651