### PR TITLE
[full-ci][tests-only] fix ocis cache

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1454,7 +1454,7 @@ def cacheOcis():
         "commands": [
             ". ./.drone.env",
             "mc alias set s3 $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY",
-            "mc cp -a %s/ocis s3/$CACHE_BUCKET/ocis-build/$OCIS_COMMITID" % dir["web"],
+            "mc cp -a %s/ocis s3/$CACHE_BUCKET/ocis-build/$OCIS_COMMITID/" % dir["web"],
             "mc ls --recursive s3/$CACHE_BUCKET/ocis-build",
         ],
     }]


### PR DESCRIPTION
## Description
`mc cp -a %s/ocis s3/$CACHE_BUCKET/ocis-build/$OCIS_COMMITID` was caching ocis binary as `$OCIS_COMMITID` but not `$OCIS_COMMITID/ocis`. This cause the cache restore failure in pipelines. e.g. https://drone.owncloud.com/owncloud/web/43614/11/8

## Related Issue


## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
