### PR TITLE
[test-only] fix drag-n-drop flaky test

### DIFF
--- a/tests/e2e/support/utils/dragDrop.ts
+++ b/tests/e2e/support/utils/dragDrop.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs'
-import { Page } from '@playwright/test'
+import { Page, expect } from '@playwright/test'
 
 interface File {
   name: string
@@ -16,6 +16,8 @@ export const dragDropFiles = async (page: Page, resources: File[], targetSelecto
     name: file.name,
     bufferString: JSON.stringify(Array.from(readFileSync(file.path)))
   }))
+  // waiting to files view
+  await expect(page.locator('#new-file-menu-btn')).toBeVisible()
 
   await page.evaluate(
     ([files, targetSelector]: [FileBuffer[], string]) => {


### PR DESCRIPTION
in the ocis CI test https://github.com/owncloud/web/blob/master/tests/e2e/cucumber/features/spaces/publicLink.feature#L3 is flaky. 
see here: https://drone.owncloud.com/owncloud/ocis/33234/67/9

my guess is that the upload starts before the page opens. Now I'm waiting that button `New` is available on the page, after that start uploading