### PR TITLE
[tests-only] move element visibility check from helpers

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=352d60a931cb793c5be92dc52891f0a589d639d6
+OCIS_COMMITID=18b5b4ea8d52b1f00f0bd390dffd65e2fd4af5ab
 OCIS_BRANCH=master

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -544,6 +544,8 @@ export const tryToUploadResource = async (args: uploadResourceArgs): Promise<voi
 export const dropUploadFiles = async (args: uploadResourceArgs): Promise<void> => {
   const { page, resources } = args
 
+  // waiting to files view
+  await page.locator(addNewResourceButton).waitFor()
   await dragDropFiles(page, resources, filesView)
 
   await page.locator(uploadInfoCloseButton).click()

--- a/tests/e2e/support/utils/dragDrop.ts
+++ b/tests/e2e/support/utils/dragDrop.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs'
-import { Page, expect } from '@playwright/test'
+import { Page } from '@playwright/test'
 
 interface File {
   name: string
@@ -16,8 +16,6 @@ export const dragDropFiles = async (page: Page, resources: File[], targetSelecto
     name: file.name,
     bufferString: JSON.stringify(Array.from(readFileSync(file.path)))
   }))
-  // waiting to files view
-  await expect(page.locator('#new-file-menu-btn')).toBeVisible()
 
   await page.evaluate(
     ([files, targetSelector]: [FileBuffer[], string]) => {


### PR DESCRIPTION
## Description
Let's not use the page specific code in the helpers as much as possible. This should let us use the helpers anywhere

Refactor of https://github.com/owncloud/web/pull/10676

## Related Issue

## Motivation and Context

## How Has This Been Tested?


## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

