### PR TITLE
fix: capitalization of banned password error message

### DIFF
--- a/packages/web-app-files/src/components/Modals/SetLinkPasswordModal.vue
+++ b/packages/web-app-files/src/components/Modals/SetLinkPasswordModal.vue
@@ -19,6 +19,7 @@
 <script lang="ts">
 import { defineComponent, ref, unref, PropType } from 'vue'
 import { useGettext } from 'vue3-gettext'
+import { upperFirst } from 'lodash-es'
 import {
   Modal,
   useClientService,
@@ -65,7 +66,8 @@ export default defineComponent({
       } catch (e) {
         // Human-readable error message is provided, for example when password is on banned list
         if (e.response?.status === 400) {
-          errorMessage.value = $gettext(e.response.data.error.message)
+          const errorMsg = e.response.data.error.message
+          errorMessage.value = $gettext(upperFirst(errorMsg))
           return Promise.reject()
         }
 

--- a/packages/web-pkg/src/components/CreateLinkModal.vue
+++ b/packages/web-pkg/src/components/CreateLinkModal.vue
@@ -141,6 +141,7 @@
 <script lang="ts">
 import { DateTime } from 'luxon'
 import { v4 as uuidV4 } from 'uuid'
+import { upperFirst } from 'lodash-es'
 import { useGettext } from 'vue3-gettext'
 import { computed, defineComponent, PropType, ref, reactive, unref, onMounted } from 'vue'
 import {
@@ -280,7 +281,9 @@ export default defineComponent({
             console.error(e)
             // Human-readable error message is provided, for example when password is on banned list
             if (e.response?.status === 400) {
-              userFacingErrors.push(e.response.data.error)
+              const error = e.response.data.error
+              error.message = upperFirst(error.message)
+              userFacingErrors.push(error)
             }
           })
       }

--- a/tests/e2e/cucumber/features/shares/link.feature
+++ b/tests/e2e/cucumber/features/shares/link.feature
@@ -234,17 +234,15 @@ Feature: link
       | resource  | password |
       | lorem.txt | %public% |
     When "Alice" tries to sets a new password "ownCloud-1" of the public link named "Link" of resource "lorem.txt"
-    # https://github.com/owncloud/ocis/issues/8624
     Then "Alice" should see an error message
       """
-      unfortunately, your password is commonly used. please pick a harder-to-guess password for your safety
+      Unfortunately, your password is commonly used. please pick a harder-to-guess password for your safety
       """
     And "Alice" closes the public link password dialog box
     When "Alice" tries to sets a new password "ownCloud-1" of the public link named "Link" of resource "lorem.txt"
-    # https://github.com/owncloud/ocis/issues/8624
     Then "Alice" should see an error message
       """
-      unfortunately, your password is commonly used. please pick a harder-to-guess password for your safety
+      Unfortunately, your password is commonly used. please pick a harder-to-guess password for your safety
       """
     And "Alice" reveals the password of the public link
     And "Alice" hides the password of the public link


### PR DESCRIPTION
## Description
Regression of https://github.com/owncloud/web/pull/10433.

With sharing NG, the server doesn't capitalize the first letter of the banned password error message (or error messages in general). Therefore we need to capitalize it manually until we have a better solution (error codes? translations via server?).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/10418

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
