### PR TITLE
fix: missing password modal on link type change

### DIFF
--- a/packages/web-app-files/src/components/Modals/SetLinkPasswordModal.vue
+++ b/packages/web-app-files/src/components/Modals/SetLinkPasswordModal.vue
@@ -34,7 +34,11 @@ export default defineComponent({
     modal: { type: Object as PropType<Modal>, required: true },
     space: { type: Object as PropType<SpaceResource>, required: true },
     resource: { type: Object as PropType<Resource>, required: true },
-    link: { type: Object as PropType<LinkShare>, required: true }
+    link: { type: Object as PropType<LinkShare>, required: true },
+    callbackFn: {
+      type: Function as PropType<() => void>,
+      default: undefined
+    }
   },
   emits: ['confirm', 'update:confirmDisabled'],
   setup(props, { expose }) {
@@ -61,6 +65,10 @@ export default defineComponent({
           linkShare: props.link,
           options: { password: unref(password) }
         })
+        if (props.callbackFn) {
+          props.callbackFn()
+          return
+        }
         showMessage({ title: $gettext('Link was updated successfully') })
       } catch (e) {
         // Human-readable error message is provided, for example when password is on banned list

--- a/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
@@ -130,7 +130,6 @@ import { LinkShare } from '@ownclouders/web-client/src/helpers/share'
 import DetailsAndEdit from './Links/DetailsAndEdit.vue'
 import NameAndCopy from './Links/NameAndCopy.vue'
 import CreateQuickLink from './Links/CreateQuickLink.vue'
-import SetLinkPasswordModal from '../../Modals/SetLinkPasswordModal.vue'
 import { Resource, SpaceResource } from '@ownclouders/web-client/src/helpers'
 import { isLocationSharesActive, useSharesStore } from '@ownclouders/web-pkg'
 import { useGettext } from 'vue3-gettext'
@@ -231,11 +230,6 @@ export default defineComponent({
       linkShare: LinkShare
       password?: string
     }) => {
-      if (password !== undefined && !canDeletePublicLinkPassword(linkShare)) {
-        showPasswordModal(linkShare)
-        return
-      }
-
       try {
         await updateLink({
           clientService,
@@ -257,18 +251,6 @@ export default defineComponent({
           errors: [e]
         })
       }
-    }
-
-    const showPasswordModal = (linkShare: LinkShare) => {
-      dispatchModal({
-        title: $gettext('Set password'),
-        customComponent: SetLinkPasswordModal,
-        customComponentAttrs: () => ({
-          space: unref(space),
-          resource: unref(resource),
-          link: linkShare
-        })
-      })
     }
 
     return {


### PR DESCRIPTION
## Description
Fixes an issue where the password modal was missing when link passwords are enforced and the type of a link changes from internal (or viewer for admins) to anything other.

This was a bit tricky because we first need to add the password to a link and then update its role. The most elegant way of doing this (at least what I found) was by adding a callback function to the password modal component.

Regression of https://github.com/owncloud/web/pull/10433.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10418

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
