### PR TITLE
fix: missing translations for share roles

### DIFF
--- a/packages/web-runtime/src/helpers/additionalTranslations.ts
+++ b/packages/web-runtime/src/helpers/additionalTranslations.ts
@@ -18,5 +18,16 @@ export const additionalTranslations = {
   ocsErrorPasswordOnBannedList: $gettext(
     'Unfortunately, your password is commonly used. please pick a harder-to-guess password for your safety'
   ),
-  openAppFromSmartBanner: $gettext('OPEN')
+  openAppFromSmartBanner: $gettext('OPEN'),
+  shareRoleDescriptionViewer: $gettext('View and download.'),
+  shareRoleDescriptionEditor: $gettext('View, download, upload, edit, add and delete.'),
+  shareRoleDescriptionFileEditor: $gettext('View, download and edit.'),
+  shareRoleDescriptionUploader: $gettext('View, download and upload.'),
+  shareRoleDescriptionManager: $gettext(
+    'View, download, upload, edit, add, delete and manage members.'
+  ),
+  shareRoleLabelViewer: $gettext('Can view'),
+  shareRoleLabelEditor: $gettext('Can edit'),
+  shareRoleLabelUploader: $gettext('Can upload'),
+  shareRoleLabelManager: $gettext('Can manage')
 }


### PR DESCRIPTION
## Description
Share role labels and descriptions are now coming from the server, hence we need to wrap them manually via `gettext` in our additional translations for them to appear in Transifex (as least for now until we have a better way of handling this).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/10418

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
