### PR TITLE
refactor: remove shares panel separation for details query

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
@@ -2,24 +2,19 @@
   <div>
     <oc-loader v-if="sharesLoading" :aria-label="$gettext('Loading list of shares')" />
     <template v-else>
-      <space-members
-        v-if="showSpaceMembers"
-        ref="peopleShares"
-        class="oc-background-highlight oc-p-m oc-mb-s"
-      />
-      <file-shares v-else ref="peopleShares" class="oc-background-highlight oc-p-m oc-mb-s" />
-      <file-links v-if="showLinks" ref="linkShares" class="oc-background-highlight oc-p-m" />
+      <space-members v-if="showSpaceMembers" class="oc-background-highlight oc-p-m oc-mb-s" />
+      <file-shares v-else class="oc-background-highlight oc-p-m oc-mb-s" />
+      <file-links v-if="showLinks" class="oc-background-highlight oc-p-m" />
     </template>
   </div>
 </template>
 
 <script lang="ts">
-import { ComponentPublicInstance, defineComponent, inject, Ref } from 'vue'
+import { defineComponent } from 'vue'
 import FileLinks from './FileLinks.vue'
 import FileShares from './FileShares.vue'
 import SpaceMembers from './SpaceMembers.vue'
 import { useSharesStore } from '@ownclouders/web-pkg'
-import { Resource } from '@ownclouders/web-client'
 import { storeToRefs } from 'pinia'
 
 export default defineComponent({
@@ -39,31 +34,7 @@ export default defineComponent({
     const { loading: sharesLoading } = storeToRefs(sharesStore)
 
     return {
-      sharesLoading,
-      resource: inject<Ref<Resource>>('resource'),
-      activePanel: inject<String>('activePanel')
-    }
-  },
-  watch: {
-    sharesLoading: {
-      handler: function (sharesLoading, old) {
-        // FIXME: !old can be removed as soon as https://github.com/owncloud/web/issues/7621 has been fixed
-        if (!this.activePanel || !old) {
-          return
-        }
-        this.$nextTick(() => {
-          const [panelName, ref] = this.activePanel.split('#')
-
-          if (!ref || !this.$refs[ref]) {
-            return
-          }
-          this.$emit('scrollToElement', {
-            element: (this.$refs[ref] as ComponentPublicInstance).$el,
-            panelName
-          })
-        })
-      },
-      immediate: true
+      sharesLoading
     }
   }
 })


### PR DESCRIPTION
## Description
Removes the shares panel separation between people and link shares when using the `details` query param. It's not needed and didn't work before anyway.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/10418

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
