### PR TITLE
refactor: space member loading

### DIFF
--- a/packages/web-app-files/src/components/Spaces/SpaceHeader.vue
+++ b/packages/web-app-files/src/components/Spaces/SpaceHeader.vue
@@ -94,7 +94,6 @@ import {
   useClientService,
   usePreviewService,
   ProcessorType,
-  useSpacesStore,
   useResourcesStore,
   TextEditor
 } from '@ownclouders/web-pkg'
@@ -128,7 +127,6 @@ export default defineComponent({
     const clientService = useClientService()
     const { getFileContents, getFileInfo } = clientService.webdav
     const previewService = usePreviewService()
-    const spacesStore = useSpacesStore()
     const resourcesStore = useResourcesStore()
 
     const markdownContainerRef = ref(null)
@@ -238,7 +236,7 @@ export default defineComponent({
     )
 
     const memberCount = computed(() => {
-      return spacesStore.spaceMembers.length
+      return Object.values(props.space.spaceRoles).flat().length
     })
     const memberCountString = computed(() => {
       return $ngettext('%{count} member', '%{count} members', unref(memberCount), {

--- a/packages/web-pkg/src/components/SideBar/FileSideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/FileSideBar.vue
@@ -315,9 +315,11 @@ export default defineComponent({
       sharesStore.setCollaboratorShares(loadedCollaboratorShares)
       sharesStore.setLinkShares(loadedLinkShares)
 
-      if (isProjectSpaceResource(resource)) {
-        // FIXME: do we need this?
-        spacesStore.setSpaceMembers(sharesStore.collaboratorShares)
+      if (isProjectSpaceResource(props.space)) {
+        yield spacesStore.loadSpaceMembers({
+          graphClient: clientService.graphAuthenticated,
+          space: props.space
+        })
       }
 
       sharesStore.setLoading(false)

--- a/packages/web-pkg/src/composables/driveResolver/useDriveResolver.ts
+++ b/packages/web-pkg/src/composables/driveResolver/useDriveResolver.ts
@@ -141,11 +141,6 @@ export const useDriveResolver = (options: DriveResolverOptions = {}): DriveResol
     space,
     (s: SpaceResource) => {
       spacesStore.setCurrentSpace(s)
-      if (!s || ['public', 'share', 'personal', 'mountpoint'].includes(s.driveType)) {
-        return
-      }
-      // FIXME: move loading to FileSideBar.vue
-      spacesStore.loadSpaceMembers({ graphClient: clientService.graphAuthenticated, space: s })
     },
     { immediate: true }
   )

--- a/packages/web-pkg/tests/unit/composables/driveResolver/useDriveResolver.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/driveResolver/useDriveResolver.spec.ts
@@ -3,7 +3,6 @@ import { ref, unref } from 'vue'
 import { mock, mockDeep } from 'vitest-mock-extended'
 import { isShareSpaceResource, SpaceResource } from '@ownclouders/web-client/src/helpers'
 import { getComposableWrapper, defaultComponentMocks, RouteLocation } from 'web-test-helpers'
-import { useSpacesStore } from '../../../../src/composables/piniaStores'
 
 describe('useDriveResolver', () => {
   it('should be valid', () => {
@@ -106,36 +105,6 @@ describe('useDriveResolver', () => {
         })
         expect(unref(space)).toEqual(spaceMock)
         expect(unref(item)).toEqual(resourcePath)
-      },
-      {
-        mocks,
-        provide: mocks,
-        pluginOptions: { piniaOptions: { spacesState: { spaces: [spaceMock] } } }
-      }
-    )
-  })
-  it.each([
-    { driveType: 'projects', loadMembersCalls: 1 },
-    { driveType: 'public', loadMembersCalls: 0 },
-    { driveType: 'share', loadMembersCalls: 0 },
-    { driveType: 'personal', loadMembersCalls: 0 }
-  ])('loads space members for a project space', (data) => {
-    const driveAlias = `/${data.driveType}`
-    const spaceMock = mockDeep<SpaceResource>({ driveAlias, driveType: data.driveType })
-
-    const mocks = defaultComponentMocks({
-      currentRoute: mock<RouteLocation>({
-        name: 'files-spaces-generic',
-        path: '/',
-        query: { fileId: undefined }
-      })
-    })
-
-    getComposableWrapper(
-      () => {
-        useDriveResolver({ driveAliasAndItem: ref(`${driveAlias}/someFolder`) })
-        const spacesStore = useSpacesStore()
-        expect(spacesStore.loadSpaceMembers).toHaveBeenCalledTimes(data.loadMembersCalls)
       },
       {
         mocks,


### PR DESCRIPTION
## Description
Refactors space member loading so members are only being loaded when the sidebar for a resource or a space is being opened. It happened in the drive resolver before, which is a bad place to handle this.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/10418

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
