### PR TITLE
refactor: remove space share types

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/AutocompleteItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/AutocompleteItem.vue
@@ -62,16 +62,11 @@ export default {
     },
 
     isAnyUserShareType() {
-      return [ShareTypes.user.key, ShareTypes.spaceUser.key].includes(this.shareType.key)
+      return ShareTypes.user.key === this.shareType.key
     },
 
     isAnyPrimaryShareType() {
-      return [
-        ShareTypes.user.key,
-        ShareTypes.spaceUser.key,
-        ShareTypes.group.key,
-        ShareTypes.spaceGroup.key
-      ].includes(this.shareType.key)
+      return [ShareTypes.user.key, ShareTypes.group.key].includes(this.shareType.key)
     },
 
     collaboratorClass() {

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -291,12 +291,12 @@ export default defineComponent({
 
       const users = (userData.value || []).map((u) => ({
         ...u,
-        shareType: unref(resourceIsSpace) ? ShareTypes.spaceUser.value : ShareTypes.user.value
+        shareType: ShareTypes.user.value
       })) as CollaboratorAutoCompleteItem[]
 
       const groups = (groupData.value || []).map((u) => ({
         ...u,
-        shareType: unref(resourceIsSpace) ? ShareTypes.spaceGroup.value : ShareTypes.group.value
+        shareType: ShareTypes.group.value
       })) as CollaboratorAutoCompleteItem[]
 
       autocompleteResults.value = [...users, ...groups]
@@ -340,9 +340,7 @@ export default defineComponent({
       const addedShares: CollaboratorShare[] = []
 
       unref(selectedCollaborators).forEach(({ id, shareType, displayName }) => {
-        const type = [ShareTypes.group.value, ShareTypes.spaceGroup.value].includes(shareType)
-          ? 'group'
-          : 'user'
+        const type = shareType === ShareTypes.group.value ? 'group' : 'user'
 
         savePromises.push(
           saveQueue.add(async () => {

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/RecipientContainer.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/RecipientContainer.vue
@@ -54,9 +54,7 @@ export default defineComponent({
       formattedRecipient: {
         name: this.recipient.displayName,
         icon: this.getRecipientIcon(),
-        hasAvatar: [ShareTypes.user.value, ShareTypes.spaceUser.value].includes(
-          this.recipient.shareType
-        ),
+        hasAvatar: this.recipient.shareType === ShareTypes.user.value,
         isLoadingAvatar: true
       }
     }

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
@@ -118,7 +118,7 @@
         <oc-info-drop
           ref="accessDetailsDrop"
           class="share-access-details-drop"
-          v-bind="isAnySpaceShareType ? accessDetailsPropsSpace : accessDetailsProps"
+          v-bind="accessDetailsProps"
           mode="manual"
           :target="`#edit-drop-down-${editDropDownToggleId}`"
         />
@@ -185,6 +185,10 @@ export default defineComponent({
       default: false
     },
     isLocked: {
+      type: Boolean,
+      default: false
+    },
+    isSpaceShare: {
       type: Boolean,
       default: false
     }
@@ -263,11 +267,7 @@ export default defineComponent({
     },
 
     isAnyUserShareType() {
-      return [ShareTypes.user, ShareTypes.spaceUser].includes(this.shareType)
-    },
-
-    isAnySpaceShareType() {
-      return [ShareTypes.spaceUser, ShareTypes.spaceGroup].includes(this.shareType)
+      return ShareTypes.user === this.shareType
     },
 
     shareTypeText() {
@@ -345,18 +345,6 @@ export default defineComponent({
     shareOwnerDisplayName() {
       return this.share.sharedBy.displayName
     },
-    accessDetailsPropsSpace() {
-      const list = []
-
-      list.push({ text: this.$gettext('Name'), headline: true }, { text: this.shareDisplayName })
-
-      list.push({ text: this.$gettext('Type'), headline: true }, { text: this.shareTypeText })
-
-      return {
-        title: this.$gettext('Access details'),
-        list
-      }
-    },
     accessDetailsProps() {
       const list = []
 
@@ -368,10 +356,13 @@ export default defineComponent({
         { text: this.hasExpirationDate ? this.expirationDate : this.$gettext('no') }
       )
       list.push({ text: this.$gettext('Shared on'), headline: true }, { text: this.shareDate })
-      list.push(
-        { text: this.$gettext('Invited by'), headline: true },
-        { text: this.shareOwnerDisplayName }
-      )
+
+      if (!this.isSpaceShare) {
+        list.push(
+          { text: this.$gettext('Invited by'), headline: true },
+          { text: this.shareOwnerDisplayName }
+        )
+      }
 
       return {
         title: this.$gettext('Access details'),

--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -77,6 +77,7 @@
             :deniable="isSpaceMemberDeniable(collaborator)"
             :modifiable="false"
             :is-share-denied="isSpaceMemberDenied(collaborator)"
+            :is-space-share="true"
             @on-set-deny="setDenyShare"
           />
         </li>
@@ -118,7 +119,8 @@ import {
   isProjectSpaceResource,
   Resource,
   SpaceResource,
-  CollaboratorShare
+  CollaboratorShare,
+  isSpaceResource
 } from '@ownclouders/web-client/src/helpers'
 import { getSharedAncestorRoute } from '@ownclouders/web-pkg'
 
@@ -355,11 +357,9 @@ export default defineComponent({
             clientService: this.$clientService,
             space: this.space,
             resource: this.resource,
-            collaboratorShare:
-              share.shareType === ShareTypes.spaceUser.value ||
-              share.shareType === ShareTypes.spaceGroup.value
-                ? this.getDeniedSpaceMember(share)
-                : this.getDeniedShare(share),
+            collaboratorShare: isSpaceResource(this.resource)
+              ? this.getDeniedSpaceMember(share)
+              : this.getDeniedShare(share),
             loadIndicators: false
           })
           this.showMessage({

--- a/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
@@ -53,6 +53,7 @@
           <collaborator-list-item
             :share="collaborator"
             :modifiable="isModifiable(collaborator)"
+            :is-space-share="true"
             @on-delete="deleteMemberConfirm(collaborator)"
           />
         </li>

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/AutocompleteItem.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/AutocompleteItem.spec.ts
@@ -11,9 +11,7 @@ describe('AutocompleteItem component', () => {
     'displays the correct image/icon according to the shareType',
     (shareType) => {
       const { wrapper } = createWrapper({ shareType: shareType.value })
-      const isUserShareType = [ShareTypes.user.key, ShareTypes.spaceUser.key].includes(
-        shareType.key
-      )
+      const isUserShareType = shareType.key === ShareTypes.user.key
       if (isUserShareType) {
         expect(wrapper.find('avatar-image-stub').exists()).toBeTruthy()
         expect(wrapper.find('oc-avatar-item-stub').exists()).toBeFalsy()
@@ -47,15 +45,13 @@ describe('AutocompleteItem component', () => {
         'Alice Hansen'
       )
     })
-    it.each([
-      ShareTypes.user.value,
-      ShareTypes.spaceUser.value,
-      ShareTypes.group.value,
-      ShareTypes.spaceGroup.value
-    ])('hides share type for users and groups', (shareType: number) => {
-      const { wrapper } = createWrapper({ shareType })
-      expect(wrapper.find('.files-collaborators-autocomplete-share-type').exists()).toBeFalsy()
-    })
+    it.each([ShareTypes.user.value, ShareTypes.group.value])(
+      'hides share type for users and groups',
+      (shareType: number) => {
+        const { wrapper } = createWrapper({ shareType })
+        expect(wrapper.find('.files-collaborators-autocomplete-share-type').exists()).toBeFalsy()
+      }
+    )
     it('shows share type for guests', () => {
       const { wrapper } = createWrapper({ shareType: ShareTypes.guest.value })
       expect(wrapper.find('.files-collaborators-autocomplete-share-type').text()).toEqual('(Guest)')

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/ListItem.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/ListItem.spec.ts
@@ -59,15 +59,14 @@ const getShareMock = ({
 
 describe('Collaborator ListItem component', () => {
   describe('displays the correct image/icon according to the shareType', () => {
-    describe('user and spaceUser share type', () => {
-      it.each([ShareTypes.user.value, ShareTypes.spaceUser.value])(
-        'should display a users avatar',
-        (shareType) => {
-          const { wrapper } = createWrapper({ share: getShareMock({ shareType }) })
-          expect(wrapper.find(selectors.userAvatarImage).exists()).toBeTruthy()
-          expect(wrapper.find(selectors.notUserAvatar).exists()).toBeFalsy()
-        }
-      )
+    describe('user share type', () => {
+      it('should display a users avatar', () => {
+        const { wrapper } = createWrapper({
+          share: getShareMock({ shareType: ShareTypes.user.value })
+        })
+        expect(wrapper.find(selectors.userAvatarImage).exists()).toBeTruthy()
+        expect(wrapper.find(selectors.notUserAvatar).exists()).toBeFalsy()
+      })
       it('sets user info on the avatar', () => {
         const share = getShareMock()
         const { wrapper } = createWrapper({ share })
@@ -80,20 +79,19 @@ describe('Collaborator ListItem component', () => {
       })
     })
     describe('non-user share types', () => {
-      it.each(
-        ShareTypes.all.filter(
-          (shareType) => ![ShareTypes.user, ShareTypes.spaceUser].includes(shareType)
-        )
-      )('should display an oc-avatar-item for any non-user share types', (shareType) => {
-        const { wrapper } = createWrapper({ share: getShareMock({ shareType: shareType.value }) })
-        expect(wrapper.find(selectors.userAvatarImage).exists()).toBeFalsy()
-        expect(wrapper.find(selectors.notUserAvatar).exists()).toBeTruthy()
-        expect(wrapper.find(selectors.notUserAvatar).attributes().name).toEqual(shareType.key)
-      })
+      it.each(ShareTypes.all.filter((shareType) => shareType !== ShareTypes.user))(
+        'should display an oc-avatar-item for any non-user share types',
+        (shareType) => {
+          const { wrapper } = createWrapper({ share: getShareMock({ shareType: shareType.value }) })
+          expect(wrapper.find(selectors.userAvatarImage).exists()).toBeFalsy()
+          expect(wrapper.find(selectors.notUserAvatar).exists()).toBeTruthy()
+          expect(wrapper.find(selectors.notUserAvatar).attributes().name).toEqual(shareType.key)
+        }
+      )
       it('should display an oc-avatar-item for space group shares', () => {
         const { wrapper } = createWrapper({
           share: getShareMock({
-            shareType: ShareTypes.spaceGroup.value,
+            shareType: ShareTypes.group.value,
             sharedWith: { id: '1', displayName: 'someGroup' }
           })
         })
@@ -157,7 +155,7 @@ describe('Collaborator ListItem component', () => {
     it('calls "upsertSpaceMember" for space resources', async () => {
       const resource = mock<SpaceResource>({ driveType: 'project' })
       const { wrapper } = createWrapper({
-        share: getShareMock({ shareType: ShareTypes.spaceUser.value }),
+        share: getShareMock({ shareType: ShareTypes.user.value }),
         resource
       })
       wrapper.findComponent<typeof RoleDropdown>('role-dropdown-stub').vm.$emit('optionChange', {
@@ -177,7 +175,7 @@ describe('Collaborator ListItem component', () => {
         throw new Error()
       })
       wrapper.findComponent<typeof RoleDropdown>('role-dropdown-stub').vm.$emit('optionChange', {
-        share: getShareMock({ shareType: ShareTypes.spaceUser.value }),
+        share: getShareMock({ shareType: ShareTypes.user.value }),
         resource
       })
 

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/SpaceMembers.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/SpaceMembers.spec.ts
@@ -25,7 +25,7 @@ vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
 const memberMocks = [
   {
     id: '1',
-    shareType: ShareTypes.spaceUser.value,
+    shareType: ShareTypes.user.value,
     sharedWith: {
       id: 'alice',
       displayName: 'alice'
@@ -38,7 +38,7 @@ const memberMocks = [
   },
   {
     id: '2',
-    shareType: ShareTypes.spaceUser.value,
+    shareType: ShareTypes.user.value,
     sharedWith: {
       onPremisesSamAccountName: 'Einstein',
       displayName: 'einstein'
@@ -51,7 +51,7 @@ const memberMocks = [
   },
   {
     id: '3',
-    shareType: ShareTypes.spaceUser.value,
+    shareType: ShareTypes.user.value,
     sharedWith: {
       onPremisesSamAccountName: 'Marie',
       displayName: 'marie'

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/FileShares.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/FileShares.spec.ts.snap
@@ -13,16 +13,16 @@ exports[`FileShares > collaborators list > renders sharedWithLabel and sharee li
   <portal-target name="app.files.sidebar.sharing.shared-with.top" slot-props="[object Object]" multiple="true"></portal-target>
   <ul id="files-collaborators-list" class="oc-list oc-list-divider oc-overflow-hidden oc-m-rm" aria-label="Share receivers">
     <li>
-      <collaborator-list-item-stub share="[object Object]" issharedenied="false" modifiable="true" resourcename="[Function]" deniable="false" islocked="[Function]"></collaborator-list-item-stub>
+      <collaborator-list-item-stub share="[object Object]" issharedenied="false" modifiable="true" resourcename="[Function]" deniable="false" islocked="[Function]" isspaceshare="false"></collaborator-list-item-stub>
     </li>
     <li>
-      <collaborator-list-item-stub share="[object Object]" issharedenied="false" modifiable="true" resourcename="[Function]" deniable="false" islocked="[Function]"></collaborator-list-item-stub>
+      <collaborator-list-item-stub share="[object Object]" issharedenied="false" modifiable="true" resourcename="[Function]" deniable="false" islocked="[Function]" isspaceshare="false"></collaborator-list-item-stub>
     </li>
     <li>
-      <collaborator-list-item-stub share="[object Object]" issharedenied="false" modifiable="true" resourcename="[Function]" deniable="false" islocked="[Function]"></collaborator-list-item-stub>
+      <collaborator-list-item-stub share="[object Object]" issharedenied="false" modifiable="true" resourcename="[Function]" deniable="false" islocked="[Function]" isspaceshare="false"></collaborator-list-item-stub>
     </li>
     <li>
-      <collaborator-list-item-stub share="[object Object]" issharedenied="false" modifiable="true" resourcename="[Function]" deniable="false" islocked="[Function]"></collaborator-list-item-stub>
+      <collaborator-list-item-stub share="[object Object]" issharedenied="false" modifiable="true" resourcename="[Function]" deniable="false" islocked="[Function]" isspaceshare="false"></collaborator-list-item-stub>
     </li>
     <portal-target name="app.files.sidebar.sharing.shared-with.bottom" slot-props="[object Object]" multiple="true"></portal-target>
   </ul>
@@ -47,7 +47,7 @@ exports[`FileShares > current space > loads space members if a space is given an
   <portal-target name="app.files.sidebar.sharing.shared-with.top" slot-props="[object Object]" multiple="true"></portal-target>
   <ul id="files-collaborators-list" class="oc-list oc-list-divider oc-overflow-hidden oc-mb-l" aria-label="Share receivers">
     <li>
-      <collaborator-list-item-stub share="[object Object]" issharedenied="false" modifiable="false" resourcename="[Function]" deniable="false" islocked="[Function]"></collaborator-list-item-stub>
+      <collaborator-list-item-stub share="[object Object]" issharedenied="false" modifiable="false" resourcename="[Function]" deniable="false" islocked="[Function]" isspaceshare="false"></collaborator-list-item-stub>
     </li>
     <portal-target name="app.files.sidebar.sharing.shared-with.bottom" slot-props="[object Object]" multiple="true"></portal-target>
   </ul>
@@ -55,10 +55,10 @@ exports[`FileShares > current space > loads space members if a space is given an
   <h4 class="oc-text-bold oc-my-s">Space members</h4>
   <ul id="space-collaborators-list" class="oc-list oc-list-divider oc-overflow-hidden oc-m-rm" aria-label="Space members">
     <li>
-      <collaborator-list-item-stub share="[object Object]" issharedenied="false" modifiable="false" resourcename="[Function]" deniable="false" islocked="false"></collaborator-list-item-stub>
+      <collaborator-list-item-stub share="[object Object]" issharedenied="false" modifiable="false" resourcename="[Function]" deniable="false" islocked="false" isspaceshare="true"></collaborator-list-item-stub>
     </li>
     <li>
-      <collaborator-list-item-stub share="[object Object]" issharedenied="false" modifiable="false" resourcename="[Function]" deniable="false" islocked="false"></collaborator-list-item-stub>
+      <collaborator-list-item-stub share="[object Object]" issharedenied="false" modifiable="false" resourcename="[Function]" deniable="false" islocked="false" isspaceshare="true"></collaborator-list-item-stub>
     </li>
   </ul>
   <!--v-if-->

--- a/packages/web-client/src/helpers/share/functions.ts
+++ b/packages/web-client/src/helpers/share/functions.ts
@@ -229,32 +229,22 @@ export function buildCollaboratorShare({
   graphPermission,
   graphRoles,
   resourceId,
-  spaceId,
   user,
   indirect = false
 }: {
   graphPermission: Permission
   graphRoles: UnifiedRoleDefinition[]
   resourceId: string
-  spaceId: string
   user: User
   indirect?: boolean
 }): CollaboratorShare {
   const role = graphRoles.find(({ id }) => id === graphPermission.roles?.[0])
-  const isSpace = resourceId === spaceId
-
-  let shareType: number
-  if (graphPermission.grantedToV2.group) {
-    shareType = isSpace ? ShareTypes.spaceGroup.value : ShareTypes.group.value
-  } else {
-    shareType = isSpace ? ShareTypes.spaceUser.value : ShareTypes.user.value
-  }
 
   return {
     id: graphPermission.id,
     resourceId,
     indirect,
-    shareType,
+    shareType: graphPermission.grantedToV2.group ? ShareTypes.group.value : ShareTypes.user.value,
     role,
     sharedBy: { id: user.id, displayName: user.displayName },
     sharedWith: graphPermission.grantedToV2.user || graphPermission.grantedToV2.group,

--- a/packages/web-client/src/helpers/share/type.ts
+++ b/packages/web-client/src/helpers/share/type.ts
@@ -41,29 +41,12 @@ export abstract class ShareTypes {
   static readonly link = new ShareType('link', 3, $gettext('Link'), 'link')
   static readonly guest = new ShareType('guest', 4, $gettext('Guest'), 'global')
   static readonly remote = new ShareType('remote', 6, $gettext('Federated'), 'earth')
-  static readonly spaceUser = new ShareType('spaceUser', 7, $gettext('User'), 'user')
-  static readonly spaceGroup = new ShareType('spaceGroup', 8, $gettext('Group'), 'group')
 
-  static readonly individuals = [this.user, this.guest, this.remote, this.spaceUser]
-  static readonly collectives = [this.group, this.spaceGroup]
+  static readonly individuals = [this.user, this.guest, this.remote]
+  static readonly collectives = [this.group]
   static readonly unauthenticated = [this.link]
-  static readonly authenticated = [
-    this.user,
-    this.group,
-    this.guest,
-    this.remote,
-    this.spaceUser,
-    this.spaceGroup
-  ]
-  static readonly all = [
-    this.user,
-    this.group,
-    this.link,
-    this.guest,
-    this.remote,
-    this.spaceUser,
-    this.spaceGroup
-  ]
+  static readonly authenticated = [this.user, this.group, this.guest, this.remote]
+  static readonly all = [this.user, this.group, this.link, this.guest, this.remote]
 
   static isIndividual(type: ShareType): boolean {
     return this.individuals.includes(type)

--- a/packages/web-client/src/helpers/space/types.ts
+++ b/packages/web-client/src/helpers/space/types.ts
@@ -27,6 +27,10 @@ export interface SpaceResource extends Resource {
   isOwner(user: User): boolean
 }
 
+export const isSpaceResource = (resource: Resource): resource is SpaceResource => {
+  return resource?.type === 'space'
+}
+
 export interface PersonalSpaceResource extends SpaceResource {
   __personalSpaceResource?: any
 }

--- a/packages/web-pkg/src/components/SideBar/FileSideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/FileSideBar.vue
@@ -251,7 +251,6 @@ export default defineComponent({
               graphPermission,
               graphRoles: sharesStore.graphRoles,
               resourceId,
-              spaceId: getGraphItemId(props.space),
               user: userStore.user,
               indirect
             })

--- a/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
+++ b/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
@@ -182,7 +182,6 @@ export const useSharesStore = defineStore('shares', () => {
           graphPermission,
           graphRoles: unref(graphRoles),
           resourceId: resource.id,
-          spaceId: space.id,
           user: userStore.user
         })
       )
@@ -215,7 +214,6 @@ export const useSharesStore = defineStore('shares', () => {
       graphPermission: data,
       graphRoles: unref(graphRoles),
       resourceId: resource.id,
-      spaceId: space.id,
       user: userStore.user
     })
     upsertCollaboratorShare(share)

--- a/packages/web-pkg/src/composables/piniaStores/spaces.ts
+++ b/packages/web-pkg/src/composables/piniaStores/spaces.ts
@@ -206,7 +206,6 @@ export const useSpacesStore = defineStore('spaces', () => {
             graphPermission,
             graphRoles: sharesStore.graphRoles,
             resourceId: space.id,
-            spaceId: space.id,
             user: userStore.user
           })
         )


### PR DESCRIPTION
## Description
Removes the space share types `spaceUser` and `spaceGroup` because they originate from the removed OCS API and are not needed anymore. This information can easily be retrieved via the underlying resource of a share.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/10418

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
