### PR TITLE
fix: fall back to username in share autocomplete items

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/AutocompleteItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/AutocompleteItem.vue
@@ -29,13 +29,17 @@
           v-text="`(${$gettext(shareType.label)})`"
         />
       </template>
-      <div v-if="item.mail" class="files-collaborators-autocomplete-mail" v-text="`${item.mail}`" />
+      <div
+        v-if="additionalInfo"
+        class="files-collaborators-autocomplete-additionalInfo"
+        v-text="`${additionalInfo}`"
+      />
     </div>
   </div>
 </template>
 
 <script lang="ts">
-import { PropType } from 'vue'
+import { computed, PropType } from 'vue'
 import { CollaboratorAutoCompleteItem, ShareTypes } from '@ownclouders/web-client/src/helpers/share'
 
 export default {
@@ -47,7 +51,13 @@ export default {
       required: true
     }
   },
+  setup(props) {
+    const additionalInfo = computed(() => {
+      return props.item.mail || props.item.onPremisesSamAccountName
+    })
 
+    return { additionalInfo }
+  },
   computed: {
     shareType() {
       return ShareTypes.getByValue(this.item.shareType)
@@ -77,7 +87,7 @@ export default {
 </script>
 
 <style lang="scss">
-.files-collaborators-autocomplete-mail {
+.files-collaborators-autocomplete-additionalInfo {
   font-size: var(--oc-font-size-small);
 }
 </style>

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -289,17 +289,7 @@ export default defineComponent({
       )
       const { data: groupData } = yield client.groups.listGroups('displayName', null, `"${query}"`)
 
-      const users = (userData.value || []).map((u) => ({
-        ...u,
-        shareType: ShareTypes.user.value
-      })) as CollaboratorAutoCompleteItem[]
-
-      const groups = (groupData.value || []).map((u) => ({
-        ...u,
-        shareType: ShareTypes.group.value
-      })) as CollaboratorAutoCompleteItem[]
-
-      autocompleteResults.value = [...users, ...groups]
+      autocompleteResults.value = [...userData.value, ...groupData.value]
         .filter((collaborator: CollaboratorAutoCompleteItem) => {
           if (collaborator.id === userStore.user.id) {
             // filter current user
@@ -319,10 +309,10 @@ export default defineComponent({
           return true
         })
         .map((collaborator) => ({
-          id: collaborator.id,
-          displayName: collaborator.displayName,
-          shareType: collaborator.shareType,
-          mail: collaborator.mail
+          ...collaborator,
+          shareType: Object.hasOwn(collaborator, 'mail')
+            ? ShareTypes.user.value
+            : ShareTypes.group.value
         })) satisfies CollaboratorAutoCompleteItem[]
       searchInProgress.value = false
     }).restartable()

--- a/packages/web-client/src/helpers/share/types.ts
+++ b/packages/web-client/src/helpers/share/types.ts
@@ -65,4 +65,5 @@ export interface CollaboratorAutoCompleteItem {
   displayName: string
   shareType: number
   mail?: string
+  onPremisesSamAccountName?: string
 }


### PR DESCRIPTION
## Description
Since user emails are sensitive information and we can't rely on the server providing it anymore, share autocomplete items now fall back to the username (`onPremisesSamAccountName` in graph).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/ocis/issues/8726

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

