### PR TITLE
fix: apply sandbox attribute to OnlyOffice/Collabora iframe

### DIFF
--- a/changelog/unreleased/iframe-sandbox-drawio.md
+++ b/changelog/unreleased/iframe-sandbox-drawio.md
@@ -1,5 +1,5 @@
 Bugfix: Apply sandbox attribute to iframe in draw-io extension
 
-General hardening of ownCloud Web
+General hardening of ownCloud Web integration with draw.io
 
 https://github.com/owncloud/web/pull/10702

--- a/changelog/unreleased/iframe-sandbox-external.md
+++ b/changelog/unreleased/iframe-sandbox-external.md
@@ -1,0 +1,5 @@
+Bugfix: Apply sandbox attribute to iframe in app-external extension
+
+General hardening of ownCloud Web integration with OnlyOffice/Collabora
+
+https://github.com/owncloud/web/pull/10706

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -5,6 +5,7 @@
     class="oc-width-1-1 oc-height-1-1"
     :title="iFrameTitle"
     allowfullscreen
+    sandbox="allow-scripts allow-same-origin"
   />
   <div v-if="appUrl && method === 'POST' && formParameters" class="oc-height-1-1 oc-width-1-1">
     <form :action="appUrl" target="app-iframe" method="post">
@@ -18,6 +19,7 @@
       class="oc-width-1-1 oc-height-1-1"
       :title="iFrameTitle"
       allowfullscreen
+      sandbox="allow-scripts allow-same-origin"
     />
   </div>
 </template>

--- a/packages/web-app-external/tests/unit/__snapshots__/app.spec.ts.snap
+++ b/packages/web-app-external/tests/unit/__snapshots__/app.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`The app provider extension > should be able to load an iFrame via get 1`] = `
-"<iframe src="https://example.test/d12ab86/loe009157-MzBw" class="oc-width-1-1 oc-height-1-1" title="" example-app" app content area" allowfullscreen=""></iframe>
+"<iframe src="https://example.test/d12ab86/loe009157-MzBw" class="oc-width-1-1 oc-height-1-1" title="" example-app" app content area" allowfullscreen="" sandbox="allow-scripts allow-same-origin"></iframe>
 
 <!--v-if-->"
 `;
@@ -13,7 +13,7 @@ exports[`The app provider extension > should be able to load an iFrame via post 
   <form action="https://example.test/d12ab86/loe009157-MzBw" target="app-iframe" method="post"><input type="submit" class="oc-hidden" value="[object Object]">
     <div><input name="access_token" type="hidden" value="asdfsadfsadf"></div>
     <div><input name="access_token_ttl" type="hidden" value="123456"></div>
-  </form> <iframe name="app-iframe" class="oc-width-1-1 oc-height-1-1" title="" example-app" app content area" allowfullscreen=""></iframe>
+  </form> <iframe name="app-iframe" class="oc-width-1-1 oc-height-1-1" title="" example-app" app content area" allowfullscreen="" sandbox="allow-scripts allow-same-origin"></iframe>
 </div>"
 `;
 


### PR DESCRIPTION
## Description
Applying sandbox attribute to iframe in app-external extension(OnlyOffice & Collabora)
https://www.w3schools.com/tags/att_iframe_sandbox.asp

## Motivation and Context
:police_officer: 

## How Has This Been Tested?
- :hand: 
- open office file file in OnlyOffice
- see it still working properly
- :exclamation: Could not test with Collabora - not showing in docker compose setup - https://github.com/owncloud/ocis/issues/8474

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
