### PR TITLE
[tests-only][full-ci]Bump latest ocis commit on web and fix the failing tests

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=e3e0a7ae3912af84cdae51f33f946cf3c3bd25a1
+OCIS_COMMITID=581d4b417ea0ef6980da9d589634c9bd747026b8
 OCIS_BRANCH=master


### PR DESCRIPTION
### Description
This PR:
- [x] Bumps the `ocis` latest commit
- [x] Fix the failing e2e tests (should be fixed by https://github.com/owncloud/web/pull/10738)

### Related Issue:
https://github.com/owncloud/web/issues/10712