### PR TITLE
refactor: improve SpaceResource interface

### DIFF
--- a/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersPanel.vue
@@ -38,7 +38,7 @@
 </template>
 <script lang="ts">
 import { computed, defineComponent, inject, ref, watch, unref } from 'vue'
-import { Resource } from '@ownclouders/web-client/src'
+import { SpaceResource, SpaceRole } from '@ownclouders/web-client/src/helpers'
 import MembersRoleSection from './MembersRoleSection.vue'
 import Fuse from 'fuse.js'
 import Mark from 'mark.js'
@@ -48,11 +48,11 @@ export default defineComponent({
   name: 'MembersPanel',
   components: { MembersRoleSection },
   setup() {
-    const resource = inject<Resource>('resource')
+    const resource = inject<SpaceResource>('resource')
     const filterTerm = ref('')
     const markInstance = ref(null)
     const membersListRef = ref(null)
-    const filterMembers = (collection, term) => {
+    const filterMembers = (collection: Array<SpaceRole & { roleType: string }>, term: string) => {
       if (!(term || '').trim()) {
         return collection
       }

--- a/packages/web-client/src/helpers/resource/types.ts
+++ b/packages/web-client/src/helpers/resource/types.ts
@@ -32,18 +32,7 @@ export type AbilitySubjects =
 export type Ability = MongoAbility<[AbilityActions, AbilitySubjects]>
 export type AbilityRule = SubjectRawRule<AbilityActions, AbilitySubjects, any>
 
-export interface SpaceRole extends Identity {
-  kind: 'user' | 'group'
-  isMember(u: User): boolean
-}
-
-export interface SpaceRoles {
-  viewer: SpaceRole[]
-  editor: SpaceRole[]
-  manager: SpaceRole[]
-}
-
-// TODO: add more fields to the resource interface. Extend into different resource types: FileResource, FolderResource, ShareResource, IncomingShareResource, OutgoingShareResource, ...
+// FIXME: almost all of the properties are non-optional, the interface should reflect that
 export interface Resource {
   id: string
   fileId?: string
@@ -54,7 +43,6 @@ export interface Resource {
   tags?: string[]
   audio?: Audio
   location?: GeoCoordinates
-  disabled?: boolean
   path: string
   webDavPath?: string
   downloadURL?: string
@@ -64,15 +52,11 @@ export interface Resource {
   locked?: boolean
   lockOwnerName?: string
   lockTime?: string
-  spaceRoles?: SpaceRoles
-  spaceQuota?: any
-  spaceImageData?: any
-  spaceReadmeData?: any
   mimeType?: string
   isFolder?: boolean
   sdate?: string // FIXME: move to `ShareResource`
   mdate?: string
-  indicators?: any[]
+  indicators?: any[] // FIXME: add type
   size?: number | string // FIXME
   permissions?: string
   starred?: boolean
@@ -81,10 +65,6 @@ export interface Resource {
   shareRoot?: string // FIXME: this originates from the old OCS api, should be removed in the future
   shareTypes?: number[]
   privateLink?: string
-  description?: string
-  driveType?: 'mountpoint' | 'personal' | 'project' | 'share' | 'public' | (string & unknown)
-  driveAlias?: string
-  matchingSpace?: any
   owner?: Identity
   extension?: string
   ddate?: string
@@ -92,26 +72,19 @@ export interface Resource {
   canCreate?(): boolean
   canUpload?({ user }: { user?: User }): boolean
   canDownload?(): boolean
-  canShare?({ user, ability }?: { user?: User; ability?: Ability }): boolean
-  canRename?({ user }?: { user?: User; ability?: Ability }): boolean
-  canBeDeleted?({ user }?: { user?: User; ability?: Ability }): boolean
+  canShare?(args?: { user?: User; ability?: Ability }): boolean
+  canRename?(args?: { user?: User; ability?: Ability }): boolean
+  canBeDeleted?(args?: { user?: User; ability?: Ability }): boolean
   canBeRestored?(): boolean
   canDeny?(): boolean
-  canEditDescription?({ user }: { user?: User; ability?: Ability }): boolean
-  canRestore?({ user }: { user?: User; ability?: any }): boolean
-  canDisable?({ user }: { user?: User; ability?: any }): boolean
-  canEditImage?({ user }: { user?: User }): boolean
-  canEditReadme?({ user }: { user?: User }): boolean
   canRemoveFromTrashbin?({ user }: { user?: User }): boolean
-
-  canEditSpaceQuota?(): boolean
   canEditTags?(): boolean
+
+  getDomSelector?(): string
 
   isReceivedShare?(): boolean
   isShareRoot?(): boolean
   isMounted?(): boolean
-
-  getDomSelector?(): string
 }
 
 // These interfaces have empty (unused) __${type}SpaceResource properties which are only

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -1,11 +1,13 @@
 import { User } from '../../generated'
-import { extractDomSelector, extractNodeId, Resource, SpaceRole } from '../resource'
+import { extractDomSelector, extractNodeId, Resource } from '../resource'
 import {
   PublicSpaceResource,
   ShareSpaceResource,
   SpaceResource,
   SHARE_JAIL_ID,
-  OCM_PROVIDER_ID
+  OCM_PROVIDER_ID,
+  SpaceRoles,
+  SpaceRole
 } from './types'
 
 import { DavProperty } from '../../webdav/constants'
@@ -88,7 +90,7 @@ export function buildShareSpaceResource({
   shareName: string
   serverUrl: string
 }): ShareSpaceResource {
-  let id
+  let id: string
   if (driveAliasPrefix === 'ocm-share') {
     id = `${OCM_PROVIDER_ID}$${shareId}!${shareId}`
   } else {
@@ -121,7 +123,7 @@ export function buildSpace(
 ): SpaceResource {
   let spaceImageData: DriveItem, spaceReadmeData: DriveItem
   let disabled = false
-  const spaceRoles: Resource['spaceRoles'] = { viewer: [], editor: [], manager: [] }
+  const spaceRoles: SpaceRoles = { viewer: [], editor: [], manager: [] }
 
   if (data.special) {
     spaceImageData = data.special.find((el) => el.specialFolder.name === 'image')
@@ -202,9 +204,7 @@ export function buildSpace(
     starred: false,
     etag: '',
     shareId: data.shareId?.toString(),
-    shareTypes: (function () {
-      return []
-    })(),
+    shareTypes: [],
     privateLink: '',
     downloadURL: '',
     owner: data.owner?.user,

--- a/packages/web-client/src/helpers/space/types.ts
+++ b/packages/web-client/src/helpers/space/types.ts
@@ -6,20 +6,45 @@
 // ```
 // because in the else block resource gets the type never. If this is changed in a later TypeScript version
 // or all types get different members, the underscored props can be removed.
-import { DriveItem } from '@ownclouders/web-client/src/generated'
-import { Resource } from '../resource'
-import { User } from '../../generated'
+import { DriveItem, Identity, Quota, User } from '@ownclouders/web-client/src/generated'
+import { Ability, Resource } from '../resource'
 
 export const SHARE_JAIL_ID = 'a0ca6a90-a365-4782-871e-d44447bbc668'
 export const OCM_PROVIDER_ID = '89f37a33-858b-45fa-8890-a1f2b27d90e1'
 
+export interface SpaceRole extends Identity {
+  kind: 'user' | 'group'
+  isMember(u: User): boolean
+}
+
+export interface SpaceRoles {
+  viewer: SpaceRole[]
+  editor: SpaceRole[]
+  manager: SpaceRole[]
+}
+
 export interface SpaceResource extends Resource {
-  disabled?: boolean
-  webDavTrashPath: string
+  description: string
+  disabled: boolean
+  driveAlias: string
+  driveType: 'mountpoint' | 'personal' | 'project' | 'share' | 'public' | (string & unknown)
   root: DriveItem
+  spaceRoles: SpaceRoles
+  spaceQuota: Quota
+  spaceImageData: DriveItem
+  spaceReadmeData: DriveItem
+  webDavTrashPath: string
+
+  canDisable(args?: { user?: User; ability?: Ability }): boolean
+  canEditDescription(args?: { user?: User; ability?: Ability }): boolean
+  canEditImage(args?: { user?: User }): boolean
+  canEditReadme(args?: { user?: User }): boolean
+  canRestore(args?: { user?: User; ability?: Ability }): boolean
+
   getWebDavUrl({ path }: { path: string }): string
   getWebDavTrashUrl({ path }: { path: string }): string
   getDriveAliasAndItem(resource: Resource): string
+
   isViewer(user: User): boolean
   isEditor(user: User): boolean
   isManager(user: User): boolean
@@ -35,14 +60,14 @@ export interface PersonalSpaceResource extends SpaceResource {
   __personalSpaceResource?: any
 }
 export const isPersonalSpaceResource = (resource: Resource): resource is PersonalSpaceResource => {
-  return resource?.driveType === 'personal'
+  return (resource as SpaceResource)?.driveType === 'personal'
 }
 
 export interface ProjectSpaceResource extends SpaceResource {
   __projectSpaceResource?: any
 }
 export const isProjectSpaceResource = (resource: Resource): resource is ProjectSpaceResource => {
-  return resource?.driveType === 'project'
+  return (resource as SpaceResource)?.driveType === 'project'
 }
 
 export interface ShareSpaceResource extends SpaceResource {
@@ -50,7 +75,7 @@ export interface ShareSpaceResource extends SpaceResource {
   rename(newName: string): void
 }
 export const isShareSpaceResource = (resource: Resource): resource is ShareSpaceResource => {
-  return resource?.driveType === 'share'
+  return (resource as SpaceResource)?.driveType === 'share'
 }
 
 export interface MountPointSpaceResource extends SpaceResource {
@@ -59,7 +84,7 @@ export interface MountPointSpaceResource extends SpaceResource {
 export const isMountPointSpaceResource = (
   resource: Resource
 ): resource is MountPointSpaceResource => {
-  return resource?.driveType === 'mountpoint'
+  return (resource as SpaceResource)?.driveType === 'mountpoint'
 }
 
 export interface PublicSpaceResource extends SpaceResource {
@@ -71,5 +96,5 @@ export interface PublicSpaceResource extends SpaceResource {
   publicLinkShareOwner?: string
 }
 export const isPublicSpaceResource = (resource: Resource): resource is PublicSpaceResource => {
-  return resource?.driveType === 'public'
+  return (resource as SpaceResource)?.driveType === 'public'
 }

--- a/packages/web-pkg/src/components/FilesList/ResourceTile.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTile.vue
@@ -5,7 +5,7 @@
     :class="{
       'oc-tile-card-selected': isResourceSelected,
       'oc-tile-card-disabled': resource.processing,
-      'state-trashed': resource.disabled
+      'state-trashed': resourceDisabled
     }"
     @contextmenu="$emit('contextmenu', $event)"
   >
@@ -20,7 +20,7 @@
         <slot name="selection" :item="resource" />
       </div>
       <oc-tag
-        v-if="resource.disabled"
+        v-if="resourceDisabled"
         class="resource-disabled-indicator oc-position-absolute"
         type="span"
       >
@@ -67,8 +67,8 @@
           <slot name="contextMenu" :item="resource" />
         </div>
       </div>
-      <p v-if="resource.description" class="oc-text-left oc-my-rm oc-text-truncate">
-        <small v-text="resource.description" />
+      <p v-if="resourceDescription" class="oc-text-left oc-my-rm oc-text-truncate">
+        <small v-text="resourceDescription" />
       </p>
     </div>
   </div>
@@ -81,6 +81,7 @@ import ResourceListItem from './ResourceListItem.vue'
 import ResourceLink from './ResourceLink.vue'
 import { Resource } from '@ownclouders/web-client'
 import { useGettext } from 'vue3-gettext'
+import { isSpaceResource } from '@ownclouders/web-client/src/helpers'
 
 export default defineComponent({
   name: 'ResourceTile',
@@ -146,10 +147,23 @@ export default defineComponent({
       return null
     })
 
+    const resourceDisabled = computed(() => {
+      return isSpaceResource(props.resource) && props.resource.disabled === true
+    })
+
+    const resourceDescription = computed(() => {
+      if (isSpaceResource(props.resource)) {
+        return props.resource.description
+      }
+      return ''
+    })
+
     return {
       statusIconAttrs,
       showStatusIcon,
-      tooltipLabelIcon
+      tooltipLabelIcon,
+      resourceDisabled,
+      resourceDescription
     }
   }
 })

--- a/packages/web-pkg/src/components/Search/ResourcePreview.vue
+++ b/packages/web-pkg/src/components/Search/ResourcePreview.vue
@@ -24,7 +24,7 @@ import {
   useConfigStore,
   useResourcesStore
 } from '../../composables'
-import { Resource } from '@ownclouders/web-client/src/helpers'
+import { isSpaceResource, Resource } from '@ownclouders/web-client/src/helpers'
 import { isResourceTxtFileAlmostEmpty } from '../../helpers'
 import ResourceListItem from '../FilesList/ResourceListItem.vue'
 import { SearchResultValue } from './types'
@@ -77,7 +77,8 @@ export default defineComponent({
     const space = computed(() => getMatchingSpace(unref(resource)))
 
     const resourceDisabled = computed(() => {
-      return unref(resource).disabled === true
+      const res = unref(resource)
+      return isSpaceResource(res) && res.disabled === true
     })
 
     const resourceClicked = () => {

--- a/packages/web-pkg/src/components/SideBar/Spaces/SpaceInfo.vue
+++ b/packages/web-pkg/src/components/SideBar/Spaces/SpaceInfo.vue
@@ -18,13 +18,13 @@
 
 <script lang="ts">
 import { defineComponent, inject } from 'vue'
-import { Resource } from '@ownclouders/web-client'
+import { SpaceResource } from '@ownclouders/web-client'
 
 export default defineComponent({
   name: 'SpaceInfo',
   setup() {
     return {
-      resource: inject<Resource>('resource')
+      resource: inject<SpaceResource>('resource')
     }
   }
 })

--- a/packages/web-pkg/src/components/Spaces/QuotaModal.vue
+++ b/packages/web-pkg/src/components/Spaces/QuotaModal.vue
@@ -151,7 +151,11 @@ export default defineComponent({
           })
         }
         spacesStore.updateSpaceField({ id: space.id, field: 'spaceQuota', value: driveData.quota })
-        updateResourceField({ id: space.id, field: 'spaceQuota', value: driveData.quota })
+        updateResourceField<SpaceResource, any>({
+          id: space.id,
+          field: 'spaceQuota',
+          value: driveData.quota
+        })
       })
       const results = await Promise.allSettled<Array<unknown>>(requests)
       const succeeded = results.filter((r) => r.status === 'fulfilled')

--- a/packages/web-pkg/src/components/Spaces/QuotaModal.vue
+++ b/packages/web-pkg/src/components/Spaces/QuotaModal.vue
@@ -151,7 +151,7 @@ export default defineComponent({
           })
         }
         spacesStore.updateSpaceField({ id: space.id, field: 'spaceQuota', value: driveData.quota })
-        updateResourceField<SpaceResource, any>({
+        updateResourceField<SpaceResource>({
           id: space.id,
           field: 'spaceQuota',
           value: driveData.quota

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsDisableSync.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsDisableSync.ts
@@ -36,7 +36,7 @@ export const useFileActionsDisableSync = () => {
             const { graphAuthenticated } = clientService
             await graphAuthenticated.drives.deleteDriveItem(resource.driveId, resource.id)
 
-            updateResourceField<IncomingShareResource, any>({
+            updateResourceField<IncomingShareResource>({
               id: resource.id,
               field: 'syncEnabled',
               value: false

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsEnableSync.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsEnableSync.ts
@@ -37,7 +37,7 @@ export const useFileActionsEnableSync = () => {
               remoteItem: { id: resource.fileId }
             })
 
-            updateResourceField<IncomingShareResource, any>({
+            updateResourceField<IncomingShareResource>({
               id: resource.id,
               field: 'syncEnabled',
               value: true

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsToggleHideShare.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsToggleHideShare.ts
@@ -42,7 +42,7 @@ export const useFileActionsToggleHideShare = () => {
               }
             )
 
-            updateResourceField<IncomingShareResource, any>({
+            updateResourceField<IncomingShareResource>({
               id: resource.id,
               field: 'hidden',
               value: hidden

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditQuota.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditQuota.ts
@@ -2,7 +2,11 @@ import { computed } from 'vue'
 import { SpaceAction, SpaceActionOptions } from '../types'
 import { useGettext } from 'vue3-gettext'
 import { useAbility } from '../../ability'
-import { SpaceResource, isProjectSpaceResource } from '@ownclouders/web-client/src/helpers'
+import {
+  SpaceResource,
+  isProjectSpaceResource,
+  isSpaceResource
+} from '@ownclouders/web-client/src/helpers'
 import { QuotaModal } from '../../../components'
 import { useModals } from '../../piniaStores'
 
@@ -45,7 +49,9 @@ export const useSpaceActionsEditQuota = () => {
         if (!resources || !resources.length) {
           return false
         }
-        if (resources.some((r) => !isProjectSpaceResource(r) || r.spaceQuota === false)) {
+        if (
+          resources.some((r) => !isProjectSpaceResource(r) || (isSpaceResource(r) && !r.spaceQuota))
+        ) {
           return false
         }
         return ability.can('set-quota-all', 'Drive')

--- a/packages/web-pkg/src/composables/piniaStores/resources.ts
+++ b/packages/web-pkg/src/composables/piniaStores/resources.ts
@@ -77,16 +77,16 @@ export const useResourcesStore = defineStore('resources', () => {
     resources.value = [...other, ...values]
   }
 
-  const updateResourceField = <T extends Resource, K extends keyof Resource>({
+  const updateResourceField = <T extends Resource>({
     id,
     field,
     value
   }: {
     id: T['id']
-    field: K
-    value: T[K]
+    field: keyof T
+    value: T[keyof T]
   }) => {
-    const resource = unref(resources).find((resource) => id === resource.id)
+    const resource = unref(resources).find((resource) => id === resource.id) as T
     if (resource) {
       resource[field] = value
     }

--- a/packages/web-pkg/src/composables/piniaStores/spaces.ts
+++ b/packages/web-pkg/src/composables/piniaStores/spaces.ts
@@ -125,16 +125,16 @@ export const useSpacesStore = defineStore('spaces', () => {
     addSpaces([space])
   }
 
-  const updateSpaceField = <T extends SpaceResource, K extends keyof SpaceResource>({
+  const updateSpaceField = <T extends SpaceResource>({
     id,
     field,
     value
   }: {
     id: T['id']
-    field: K
-    value: T[K]
+    field: keyof T
+    value: T[keyof T]
   }) => {
-    const space = unref(spaces).find((space) => id === space.id)
+    const space = unref(spaces).find((space) => id === space.id) as T
     if (space) {
       space[field] = value
     }

--- a/packages/web-pkg/tests/unit/components/sidebar/FileSideBar.spec.ts
+++ b/packages/web-pkg/tests/unit/components/sidebar/FileSideBar.spec.ts
@@ -1,5 +1,5 @@
 import FileSideBar from '../../../../src/components/SideBar/FileSideBar.vue'
-import { Resource } from '@ownclouders/web-client/src/helpers'
+import { Resource, SpaceResource } from '@ownclouders/web-client/src/helpers'
 import { mock } from 'vitest-mock-extended'
 import {
   defaultComponentMocks,
@@ -47,7 +47,7 @@ describe('FileSideBar', () => {
       expect(wrapper.find(selectors.fileInfoStub).exists()).toBeFalsy()
     })
     it('should not show when selected resource is a project space', async () => {
-      const item = mock<Resource>({ path: '/someFolder', driveType: 'project' })
+      const item = mock<SpaceResource>({ path: '/someFolder', driveType: 'project' })
       const { wrapper } = createWrapper({ item })
       wrapper.vm.loadedResource = item
       await wrapper.vm.$nextTick()
@@ -56,7 +56,7 @@ describe('FileSideBar', () => {
   })
   describe('space info header', () => {
     it('should show when one project space resource selected', async () => {
-      const item = mock<Resource>({ path: '/someFolder', driveType: 'project' })
+      const item = mock<SpaceResource>({ path: '/someFolder', driveType: 'project' })
       const { wrapper } = createWrapper({ item })
       wrapper.vm.loadedResource = item
       await wrapper.vm.$nextTick()

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsCreateLink.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsCreateLink.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../../../src/composables/piniaStores'
 import { defaultComponentMocks, getComposableWrapper } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
-import { Resource } from '@ownclouders/web-client'
+import { Resource, SpaceResource } from '@ownclouders/web-client'
 import { SharingLinkType } from '@ownclouders/web-client/src/generated'
 import { useLinkTypes } from '../../../../../src/composables/links/useLinkTypes'
 
@@ -37,7 +37,7 @@ describe('useFileActionsCreateLink', () => {
       getWrapper({
         setup: ({ actions }) => {
           const resources = [
-            mock<Resource>({ canShare: () => true, disabled: true, driveType: 'project' })
+            mock<SpaceResource>({ canShare: () => true, disabled: true, driveType: 'project' })
           ]
           expect(unref(actions)[0].isVisible({ space: null, resources })).toBeFalsy()
         }

--- a/packages/web-runtime/src/components/Topbar/UserMenu.vue
+++ b/packages/web-runtime/src/components/Topbar/UserMenu.vue
@@ -210,7 +210,7 @@ export default defineComponent({
       })
     },
     personalStorageDetailsLabel() {
-      const total = this.quota.definition === 'none' ? 0 : this.quota.total || 0
+      const total = this.quota.total || 0
       const used = this.quota.used || 0
       return total
         ? this.$gettext('%{used} of %{total} used', {

--- a/packages/web-runtime/tests/unit/pages/resolvePublicLink.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/resolvePublicLink.spec.ts
@@ -2,7 +2,7 @@ import ResolvePublicLink from '../../../src/pages/resolvePublicLink.vue'
 import { defaultPlugins, defaultComponentMocks, shallowMount, nextTicks } from 'web-test-helpers'
 import { mockDeep } from 'vitest-mock-extended'
 import { CapabilityStore, ClientService } from '@ownclouders/web-pkg'
-import { Resource } from '@ownclouders/web-client'
+import { SpaceResource } from '@ownclouders/web-client'
 import { authService } from 'web-runtime/src/services/auth'
 import { useLoadTokenInfo } from '../../../src/composables/tokenInfo'
 import { Task } from 'vue-concurrency'
@@ -75,7 +75,9 @@ function getWrapper({ passwordRequired = false } = {}) {
   })
 
   const $clientService = mockDeep<ClientService>()
-  $clientService.webdav.getFileInfo.mockResolvedValue(mockDeep<Resource>({ driveType: 'public' }))
+  $clientService.webdav.getFileInfo.mockResolvedValue(
+    mockDeep<SpaceResource>({ driveType: 'public' })
+  )
   const mocks = { ...defaultComponentMocks(), $clientService }
 
   const capabilities = {


### PR DESCRIPTION
## Description
Improves the `SpaceResource` interface by moving all space relevant properties from the `Resource` interface to there as well as by making them non-optional. This allows us for better distinction between the both.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- fixes https://github.com/owncloud/web/issues/10681

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
