### PR TITLE
fix: sharing for non-admin users

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -289,8 +289,18 @@ export default defineComponent({
       )
       const { data: groupData } = yield client.groups.listGroups('displayName', null, `"${query}"`)
 
-      autocompleteResults.value = [...userData.value, ...groupData.value]
-        .filter((collaborator: CollaboratorAutoCompleteItem) => {
+      const users = (userData.value || []).map((u) => ({
+        ...u,
+        shareType: ShareTypes.user.value
+      })) as CollaboratorAutoCompleteItem[]
+
+      const groups = (groupData.value || []).map((u) => ({
+        ...u,
+        shareType: ShareTypes.group.value
+      })) as CollaboratorAutoCompleteItem[]
+
+      autocompleteResults.value = [...users, ...groups].filter(
+        (collaborator: CollaboratorAutoCompleteItem) => {
           if (collaborator.id === userStore.user.id) {
             // filter current user
             return false
@@ -307,13 +317,8 @@ export default defineComponent({
           announcement.value = $gettext('Person was added')
 
           return true
-        })
-        .map((collaborator) => ({
-          ...collaborator,
-          shareType: Object.hasOwn(collaborator, 'mail')
-            ? ShareTypes.user.value
-            : ShareTypes.group.value
-        })) satisfies CollaboratorAutoCompleteItem[]
+        }
+      )
       searchInProgress.value = false
     }).restartable()
 


### PR DESCRIPTION
## Description
Since the server doesn't send any information other than `id` and `displayName` for non-admins when querying users, we need to change the way how to distinguish between users and groups. This basically undos the simplified approach done via PR #10703 as it doesn't work anymore.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10712

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
