### PR TITLE
fix: hide link shares on "Shared with others" page

### DIFF
--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -174,7 +174,12 @@
       />
     </template>
     <template #sharedBy="{ item }">
-      <oc-button appearance="raw-inverse" variation="passive" @click="openSharingSidebar(item)">
+      <oc-button
+        appearance="raw-inverse"
+        variation="passive"
+        class="resource-table-shared-by"
+        @click="openSharingSidebar(item)"
+      >
         <oc-avatars
           class="resource-table-people"
           :items="getSharedByAvatarItems(item)"
@@ -184,7 +189,12 @@
       </oc-button>
     </template>
     <template #sharedWith="{ item }">
-      <oc-button appearance="raw-inverse" variation="passive" @click="openSharingSidebar(item)">
+      <oc-button
+        appearance="raw-inverse"
+        variation="passive"
+        class="resource-table-shared-with"
+        @click="openSharingSidebar(item)"
+      >
         <oc-avatars
           class="resource-table-people"
           :items="getSharedWithAvatarItems(item)"
@@ -1021,34 +1031,22 @@ export default defineComponent({
         resource.type === 'folder' ? this.$gettext('folder') : this.$gettext('file')
 
       const shareCount = resource.sharedWith.filter(({ shareType }) =>
-        [ShareTypes.user.value, ShareTypes.link.value].includes(shareType)
-      ).length
-      const linkCount = resource.sharedWith.filter(
-        ({ shareType }) => shareType === ShareTypes.link.value
+        ShareTypes.authenticated.includes(ShareTypes.getByValue(shareType))
       ).length
 
-      const shareText =
-        shareCount > 0
-          ? this.$ngettext(
-              'This %{ resourceType } is shared via %{ shareCount } invite',
-              'This %{ resourceType } is shared via %{ shareCount } invites',
-              shareCount
-            )
-          : ''
-      const linkText =
-        linkCount > 0
-          ? this.$ngettext(
-              'This %{ resourceType } is shared via %{ linkCount } link',
-              'This %{ resourceType } is shared via %{ linkCount } links',
-              linkCount
-            )
-          : ''
-      const description = [shareText, linkText].join(' ')
-      return this.$gettext(description, {
-        resourceType,
-        shareCount: shareCount.toString(),
-        linkCount: linkCount.toString()
-      })
+      if (!shareCount) {
+        return ''
+      }
+
+      return this.$ngettext(
+        'This %{ resourceType } is shared via %{ shareCount } invite',
+        'This %{ resourceType } is shared via %{ shareCount } invites',
+        shareCount,
+        {
+          resourceType,
+          shareCount: shareCount.toString()
+        }
+      )
     },
     getSharedByAvatarDescription(resource: Resource) {
       if (!isShareResource(resource)) {
@@ -1079,12 +1077,16 @@ export default defineComponent({
         return []
       }
 
-      return resource.sharedWith.map((s) => ({
-        displayName: s.displayName,
-        name: s.displayName,
-        shareType: s.shareType,
-        username: s.id
-      }))
+      return resource.sharedWith
+        .filter(({ shareType }) =>
+          ShareTypes.authenticated.includes(ShareTypes.getByValue(shareType))
+        )
+        .map((s) => ({
+          displayName: s.displayName,
+          name: s.displayName,
+          shareType: s.shareType,
+          username: s.id
+        }))
     }
   }
 })

--- a/packages/web-pkg/tests/unit/components/FilesList/ResourceTable.spec.ts
+++ b/packages/web-pkg/tests/unit/components/FilesList/ResourceTable.spec.ts
@@ -3,11 +3,12 @@ import ResourceTable from '../../../../src/components/FilesList/ResourceTable.vu
 import {
   extractDomSelector,
   IncomingShareResource,
+  OutgoingShareResource,
   Resource,
   ShareTypes,
   SpaceResource
 } from '@ownclouders/web-client/src/helpers'
-import { defaultPlugins, mount } from 'web-test-helpers'
+import { defaultPlugins, mount, PartialComponentProps } from 'web-test-helpers'
 import { CapabilityStore } from '../../../../src/composables/piniaStores'
 import { displayPositionedDropdown } from '../../../../src/helpers/contextMenuDropdown'
 import { eventBus } from '../../../../src/services/eventBus'
@@ -498,12 +499,36 @@ describe('ResourceTable', () => {
       })
     })
   })
+  describe('"shared with" field', () => {
+    it('only displays authenticated shares', () => {
+      const resource = mock<OutgoingShareResource>({ id: '1' })
+      resource.sharedWith = [
+        {
+          id: 'bob',
+          displayName: 'Bob',
+          shareType: ShareTypes.user.value
+        },
+        { displayName: 'Link', shareType: ShareTypes.link.value }
+      ]
+
+      const { wrapper } = getMountedWrapper({ resources: [resource] })
+
+      expect(wrapper.find('.resource-table-shared-with').exists()).toBeTruthy()
+      expect(wrapper.findAll('.resource-table-shared-with .oc-avatar').length).toBe(1)
+    })
+  })
 })
 
 function getMountedWrapper({
   props = {},
   userContextReady = true,
-  addProcessingResources = false
+  addProcessingResources = false,
+  resources = resourcesWithAllFields
+}: {
+  props?: PartialComponentProps<typeof ResourceTable>
+  userContextReady?: boolean
+  addProcessingResources?: boolean
+  resources?: Resource[]
 } = {}) {
   const capabilities = {
     files: { tags: true }
@@ -513,7 +538,7 @@ function getMountedWrapper({
     wrapper: mount(ResourceTable, {
       props: {
         resources: [
-          ...resourcesWithAllFields,
+          ...resources,
           ...(addProcessingResources ? processingResourcesWithAllFields : [])
         ],
         selection: [],


### PR DESCRIPTION
## Description
Prevents links from wrongfully showing up in the "Shared with" column on the "Shared with others" page. This page is about authenticated shares only.

No changelog needed since this is a regression from the recent sharing NG changes.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10749

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
