### PR TITLE
fix: prevent permissions from being loaded for incoming shares

### DIFF
--- a/packages/web-app-files/src/composables/extensions/useFileSideBars.ts
+++ b/packages/web-app-files/src/composables/extensions/useFileSideBars.ts
@@ -22,7 +22,7 @@ import {
   useCapabilityStore
 } from '@ownclouders/web-pkg'
 import {
-  isIncomingShareResource,
+  isPersonalSpaceResource,
   isProjectSpaceResource,
   isShareResource,
   isShareSpaceResource,
@@ -219,7 +219,7 @@ export const useSideBarPanels = () => {
             componentAttrs: () => ({
               isReadOnly: !unref(isFilesAppActive)
             }),
-            isVisible: ({ items }) => {
+            isVisible: ({ items, root }) => {
               if (items?.length !== 1) {
                 return false
               }
@@ -227,10 +227,14 @@ export const useSideBarPanels = () => {
                 // project space roots don't support versions
                 return false
               }
+
+              const userIsSpaceMember =
+                (isProjectSpaceResource(root) && root.isMember(userStore.user)) ||
+                (isPersonalSpaceResource(root) && root.isOwner(userStore.user))
+
               if (
                 isLocationTrashActive(router, 'files-trash-generic') ||
-                isLocationPublicActive(router, 'files-public-link') ||
-                isIncomingShareResource(items[0]) ||
+                !userIsSpaceMember ||
                 isSpaceResource(items[0])
               ) {
                 return false

--- a/tests/e2e/cucumber/features/shares/share.feature
+++ b/tests/e2e/cucumber/features/shares/share.feature
@@ -54,7 +54,7 @@ Feature: share
     And "Alice" uploads the following resource
       | resource          | to               | option  |
       | PARENT/simple.pdf | folder_to_shared | replace |
-    And "Brian" should not see the version of the file
+    And "Brian" should not see the version panel for the file
       | resource   | to               |
       | simple.pdf | folder_to_shared |
     And "Alice" removes following sharee

--- a/tests/e2e/cucumber/features/spaces/project.feature
+++ b/tests/e2e/cucumber/features/spaces/project.feature
@@ -106,7 +106,7 @@ Feature: spaces.personal
     And "Alice" uploads the following resource
       | resource          | to               | option  |
       | PARENT/simple.pdf | folder_to_shared | replace |
-    And "Brian" should not see the version of the file
+    And "Brian" should not see the version panel for the file
       | resource   | to               |
       | simple.pdf | folder_to_shared |
     When "Alice" deletes the following resources using the sidebar panel

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -667,6 +667,32 @@ Then(
   }
 )
 
+Then(
+  '{string} should not see the version panel for the file(s)',
+  async function (this: World, stepUser: string, stepTable: DataTable): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const resourceObject = new objects.applicationFiles.Resource({ page })
+    const fileInfo = stepTable.hashes().reduce<File[]>((acc, stepRow) => {
+      const { to, resource } = stepRow
+
+      if (!acc[to]) {
+        acc[to] = []
+      }
+
+      acc[to].push(this.filesEnvironment.getFile({ name: resource }))
+
+      return acc
+    }, [])
+
+    for (const folder of Object.keys(fileInfo)) {
+      await resourceObject.checkThatFileVersionPanelIsNotAvailable({
+        folder,
+        files: fileInfo[folder]
+      })
+    }
+  }
+)
+
 When(
   '{string} navigates to page {string} of the personal/project space files view',
   async function (this: World, stepUser: string, pageNumber: string) {

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -90,6 +90,7 @@ const tagInInputForm =
 const tagFormInput = '//*[@data-testid="tags"]//input'
 const resourcesAsTiles = '#files-view .oc-tiles'
 const fileVersionSidebar = '#oc-file-versions-sidebar'
+const versionsPanelSelect = '//*[@data-testid="sidebar-panel-versions-select"]'
 const noLinkMessage = '#web .oc-link-resolve-error-message'
 const listItemPageSelector = '//*[contains(@class,"oc-pagination-list-item-page") and text()="%s"]'
 const itemsPerPageDropDownOptionSelector =
@@ -1600,6 +1601,17 @@ export const checkThatFileVersionIsNotAvailable = async (
 
   await sidebar.openPanel({ page, name: 'versions' })
   await expect(page.locator(fileVersionSidebar)).toHaveText('No Versions available for this file')
+}
+
+export const checkThatFileVersionPanelIsNotAvailable = async (
+  args: resourceVersionArgs
+): Promise<void> => {
+  const { page, files, folder } = args
+  const fileName = files.map((file) => path.basename(file.name))
+  await clickResource({ page, path: folder })
+  await sidebar.open({ page, resource: fileName[0] })
+
+  await expect(page.locator(versionsPanelSelect)).not.toBeVisible()
 }
 
 export const expectThatPublicLinkIsDeleted = async (args): Promise<void> => {

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -257,6 +257,14 @@ export class Resource {
     await this.#page.goto(startUrl)
   }
 
+  async checkThatFileVersionPanelIsNotAvailable(
+    args: Omit<po.resourceVersionArgs, 'page'>
+  ): Promise<void> {
+    const startUrl = this.#page.url()
+    await po.checkThatFileVersionPanelIsNotAvailable({ ...args, page: this.#page })
+    await this.#page.goto(startUrl)
+  }
+
   async changePage(args: Omit<po.changePageArgs, 'page'>): Promise<void> {
     await po.changePage({ ...args, page: this.#page })
   }


### PR DESCRIPTION
## Description
Fixes an issue were permissions were loaded for and in incoming shares. Also fixes another issue where versions were loaded for files inside incoming resources. Both cases need to check if the current user is an actual member of the current space, meaning either a project space or the own personal space. All other spaces don't support loading this kind of information for "foreign" users.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10756

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
