### PR TITLE
Introduce more extension points and delete `scopes`

### DIFF
--- a/changelog/9.0.0_2024-04-16/change-extension-points
+++ b/changelog/9.0.0_2024-04-16/change-extension-points
@@ -1,4 +1,6 @@
-Enhancement: Add extensionPoint concept
+Change: Add extensionPoint concept
+
+BREAKING CHANGE for developers: The `scopes` property has been removed from the `Extension` type in favour of the new `extensionPointIds` property.
 
 The extension system now allows developers to register extension points. An extension point defines the metadata for the
 integration of a certain extension type in a certain context. Examples for extension points are render targets for
@@ -7,10 +9,11 @@ menu), etc.
 
 Extensions can now specify that they are only valid for a certain or multiple extension points. This way a file action extension
 can e.g. specify to be rendered only in the context menu, but not in the batch actions. Consequently, the extension points
-concept is the next iteration of the `scopes` concept. The `scopes` concept will most likely be removed in a future release.
+concept is the next iteration of the `scopes` concept. The `scopes` concept has been removed from the codebase.
 
 Extension points can define if users should be able to choose preferences for the extension point. E.g. for the global progress
 bar extension point, users can choose which of the available progress bar extensions should be used, since the extension point
-only allows one extension to be active. At the moment we persist the user choice in the local storage of the browser.
+only allows one extension to be active. At the moment we persist the user choice in the localStorage of the browser.
 
 https://github.com/owncloud/web/pull/10443
+https://github.com/owncloud/web/pull/10758

--- a/changelog/9.0.0_2024-04-16/change-remove-deprecated-quick-actions-extension-point
+++ b/changelog/9.0.0_2024-04-16/change-remove-deprecated-quick-actions-extension-point
@@ -1,6 +1,6 @@
 Change: Remove deprecated extension point for adding quick actions
 
-BREAKING CHANGE for developers: The old way of registering quick actions via the `quickaction` property of an app has been removed. Quick actions should be registered as extension via our extension registry. They need to be of type `action` and have the `files.quick-action` scope.
+BREAKING CHANGE for developers: The old way of registering quick actions via the `quickaction` property of an app has been removed. Quick actions should be registered as extension via our extension registry. They need to be of type `action` and have the `app.files.quick-action` extensionPointId.
 
 https://github.com/owncloud/web/pull/10102
 https://github.com/owncloud/web/pull/10223

--- a/changelog/unreleased/change-disable-opening-files-in-embed-mode
+++ b/changelog/unreleased/change-disable-opening-files-in-embed-mode
@@ -1,6 +1,6 @@
 Change: Disable opening files in embed mode
 
-We have disabled to open files in the embed mode, since opening or editing files is not in scope of the embed mode
+We have disabled to open files in the embed mode, since opening or editing files is not in scope of the embed mode.
 
 https://github.com/owncloud/web/pull/10786
 https://github.com/owncloud/web/issues/10635

--- a/changelog/unreleased/change-remove-portal-targets
+++ b/changelog/unreleased/change-remove-portal-targets
@@ -1,0 +1,9 @@
+Change: Portal target removed
+
+BREAKING CHANGE for developers: The (undocumented) portal target `app.runtime.header` is not available anymore. Please use the extension point `app.runtime.header.center` with `customComponent` extensions instead (for details see below).
+
+The portal target `app.runtime.header` has been removed in favour of a new extension point with the id `app.runtime.header.center`. The extension point
+is capable of mounting extensions of type `customComponent`. The search bar, which was previously using this portal target, was rewired into an extension. Other `portal` instances which used this portal target won't work anymore
+and need to be ported to the `customComponent` extension type instead.
+
+https://github.com/owncloud/web/pull/10758

--- a/changelog/unreleased/enhancement-search-extensions
+++ b/changelog/unreleased/enhancement-search-extensions
@@ -1,0 +1,7 @@
+Enhancement: Search providers extension point
+
+We've added a new extension point with the id `app.search.provider` and for the extensionType `search` that can be used to
+register additional search providers. All search providers that are registered for this extension point will be used
+by the global search automatically.
+
+https://github.com/owncloud/web/pull/10758

--- a/docs/extension-system/_index.md
+++ b/docs/extension-system/_index.md
@@ -134,22 +134,20 @@ You can find predefined extension point ids in the extension points section belo
 #### Extension Points
 
 There are standardized components and places where extensions are being used automatically. The following are the ones that are currently provided
-by the ownCloud Web runtime or the `files` app. If you decide to develop an extension which fulfills the type and allows the extensionPointId of the respective extension point, 
+by the ownCloud Web runtime or the `files` app. If you decide to develop an extension which fulfills the type and registers itself for the extensionPointId of the respective extension point, 
 your extension will be used automatically. 
 
-1. Left Sidebar for Navigation
-2. Any file(s) context (files app, viewer apps, editor apps)
-   1. Right sidebar. ExtensionPointId `app.files.sidebar`. Mounts extensions of type `sidebarPanel`. 
-3. Files app
-   1. Folder views for regular folders. ExtensionPointId `app.files.folder-views.folder`.
-   2. Folder views for the project spaces overview. ExtensionPointId `app.files.folder-views.project-spaces`.
-   3. Folder views for the favorites page. ExtensionPointId `app.files.folder-views.favorites`.
-   4. Right click context menu. ExtensionPointId `app.files.context-actions`.
-   5. Batch actions in the app bar above file lists. ExtensionPointId `app.files.batch-actions`.
-   6. Upload menu. ExtensionPointId `app.files.upload-menu`.
-   7. Quick actions. ExtensionPointId `app.files.quick-actions`.
-4. Search results in the search app
-5. Global progress bar for the global loading state. ExtensionPointId `app.runtime.global-progress-bar`. Mounts a single extensions of type `customComponent`.
+1. Left Sidebar for Navigation. ExtensionPointId `app.${appName}.navItems` (dynamically created for each app). Mounts extensions of type `sidebarNav`.
+2. Files app
+   1. Right sidebar. ExtensionPointId `app.files.sidebar`. Mounts extensions of type `sidebarPanel`. Used in any file(s) context (files app, file viewer apps, file editor apps)
+   2. Folder views for regular folders. ExtensionPointId `app.files.folder-views.folder`. Mounts extensions of type `folderView`.
+   3. Folder views for the project spaces overview. ExtensionPointId `app.files.folder-views.project-spaces`. Mounts extensions of type `folderView`.
+   4. Folder views for the favorites page. ExtensionPointId `app.files.folder-views.favorites`. Mounts extensions of type `folderView`.
+   5. Right click context menu. ExtensionPointId `app.files.context-actions`. Mounts extensions of type `action`.
+   6. Batch actions in the app bar above file lists. ExtensionPointId `app.files.batch-actions`. Mounts extensions of type `action`.
+   7. Upload menu. ExtensionPointId `app.files.upload-menu`. Mounts extensions of type `action`.
+   8. Quick actions. ExtensionPointId `app.files.quick-actions`. Mounts extensions of type `action`.
+3. Global progress bar for the global loading state. ExtensionPointId `app.runtime.global-progress-bar`. Mounts a single extensions of type `customComponent`. If multiple exist, the user can choose via the account page.
 
 #### User Preferences for Extensions
 

--- a/docs/extension-system/_index.md
+++ b/docs/extension-system/_index.md
@@ -148,6 +148,7 @@ your extension will be used automatically.
    7. Upload menu. ExtensionPointId `app.files.upload-menu`. Mounts extensions of type `action`.
    8. Quick actions. ExtensionPointId `app.files.quick-actions`. Mounts extensions of type `action`.
 3. Global progress bar for the global loading state. ExtensionPointId `app.runtime.global-progress-bar`. Mounts a single extensions of type `customComponent`. If multiple exist, the user can choose via the account page.
+4. Global search providers. ExtensionPointId `app.search.providers`. Utilizes extensions of type `search` as search engines for the search input in the global top bar.
 
 #### User Preferences for Extensions
 

--- a/docs/extension-system/_index.md
+++ b/docs/extension-system/_index.md
@@ -96,7 +96,7 @@ In contrast to applications, extensions usually have a rather small scope and de
 
 The globally available extension registry provided by the ownCloud Web runtime can be used to both register and query extensions. All extensions
 which are being made available via an `app` get registered in the extension registry automatically. In your custom application code you can
-then query any of the available extensions by providing a `type` string and optionally a list of `scopes`. Throughout the ownCloud Web platform
+then query any of the available extensions by providing a `type` string and optionally a list of `extensionPointIds`. Throughout the ownCloud Web platform
 and most prominently also in the `files` app we have defined some extension points which automatically use certain extensions, see the 
 `Extension Points` section below.
 
@@ -104,8 +104,8 @@ and most prominently also in the `files` app we have defined some extension poin
 
 For building an extension you can choose from the types predefined by the ownCloud Web extension system. See the full list of available extension types below.
 
-1. `ActionExtension` (type `action`) - An extension that can register `Action` items which then get shown in various places (e.g. context menus, batch actions), depending on their 
-respective scope. Most commonly used for file and folder actions (e.g. copy, rename, delete, etc.). For details, please refer to the [action docs]({{< ref "extension-types/actions.md" >}})
+1. `ActionExtension` (type `action`) - An extension that can register `Action` items which then get shown in various places (e.g. context menus, batch actions), depending on the 
+extension points defined in the extension respectively. Most commonly used for file and folder actions (e.g. copy, rename, delete, etc.). For details, please refer to the [action docs]({{< ref "extension-types/actions.md" >}})
 2. `SearchExtension` (type `search`) - An extension that can register additional search providers. For details, please refer to the [search docs]({{< ref "extension-types/search.md" >}})
 3. `SidebarNavExtension` (type `sidebarNav`) - An extension that can register additional navigation items to the left sidebar. These can be scoped to specific apps, and programmatically enabled/disabled.
 For details, please refer to the [sidebar nav docs]({{< ref "extension-types/left-sidebar-menu-item.md" >}})
@@ -134,17 +134,22 @@ You can find predefined extension point ids in the extension points section belo
 #### Extension Points
 
 There are standardized components and places where extensions are being used automatically. The following are the ones that are currently provided
-by the ownCloud Web runtime or the `files` app.
+by the ownCloud Web runtime or the `files` app. If you decide to develop an extension which fulfills the type and allows the extensionPointId of the respective extension point, 
+your extension will be used automatically. 
 
 1. Left Sidebar for Navigation
-2. Right Sidebar in any file(s) context 
-3. Folder Views in the files app 
-4. Right click context menu in the files app 
-5. Batch actions in the files app
-6. Upload menu in the files app 
-7. Quick actions in the files list of the files app
-8. Search results in the search app
-9. Global progress bar for the global loading state. Extension point id `app.runtime.global-progress-bar`. Allows to render a single custom component.
+2. Any file(s) context (files app, viewer apps, editor apps)
+   1. Right sidebar. ExtensionPointId `app.files.sidebar`. Mounts extensions of type `sidebarPanel`. 
+3. Files app
+   1. Folder views for regular folders. ExtensionPointId `app.files.folder-views.folder`.
+   2. Folder views for the project spaces overview. ExtensionPointId `app.files.folder-views.project-spaces`.
+   3. Folder views for the favorites page. ExtensionPointId `app.files.folder-views.favorites`.
+   4. Right click context menu. ExtensionPointId `app.files.context-actions`.
+   5. Batch actions in the app bar above file lists. ExtensionPointId `app.files.batch-actions`.
+   6. Upload menu. ExtensionPointId `app.files.upload-menu`.
+   7. Quick actions. ExtensionPointId `app.files.quick-actions`.
+4. Search results in the search app
+5. Global progress bar for the global loading state. ExtensionPointId `app.runtime.global-progress-bar`. Mounts a single extensions of type `customComponent`.
 
 #### User Preferences for Extensions
 

--- a/docs/extension-system/_index.md
+++ b/docs/extension-system/_index.md
@@ -12,7 +12,7 @@ geekdocCollapseSection: true
 
 ## Concepts and Building Blocks
 
-The ownCloud Web can be extended through various entry points with custom **apps** and **extensions**.
+ownCloud Web can be extended through various entry points with custom **apps** and **extensions**.
 
 ### Distinction between Apps and Extensions
 
@@ -26,6 +26,11 @@ It serves two main purposes:
 
 Both parts are optional. This means that an application can be a file editor without any custom extensions, or even contain
 no custom application code at all and only host extensions to be registered in the extension registry, or a combination of both.
+
+### Examples
+
+You can find open source examples for apps and extensions in our [curated list of ownCloud apps and extensions](https://github.com/owncloud/awesome-ocis).
+Feel free to contribute or just be inspired for your own apps or extensions.
 
 ### Apps
 
@@ -96,7 +101,7 @@ In contrast to applications, extensions usually have a rather small scope and de
 
 The globally available extension registry provided by the ownCloud Web runtime can be used to both register and query extensions. All extensions
 which are being made available via an `app` get registered in the extension registry automatically. In your custom application code you can
-then query any of the available extensions by providing a `type` string and optionally a list of `extensionPointIds`. Throughout the ownCloud Web platform
+then query any of the available extensions by providing an `extensionPoint` entity. Throughout the ownCloud Web platform
 and most prominently also in the `files` app we have defined some extension points which automatically use certain extensions, see the 
 `Extension Points` section below.
 
@@ -105,13 +110,13 @@ and most prominently also in the `files` app we have defined some extension poin
 For building an extension you can choose from the types predefined by the ownCloud Web extension system. See the full list of available extension types below.
 
 1. `ActionExtension` (type `action`) - An extension that can register `Action` items which then get shown in various places (e.g. context menus, batch actions), depending on the 
-extension points defined in the extension respectively. Most commonly used for file and folder actions (e.g. copy, rename, delete, etc.). For details, please refer to the [action docs]({{< ref "extension-types/actions.md" >}})
-2. `SearchExtension` (type `search`) - An extension that can register additional search providers. For details, please refer to the [search docs]({{< ref "extension-types/search.md" >}})
-3. `SidebarNavExtension` (type `sidebarNav`) - An extension that can register additional navigation items to the left sidebar. These can be scoped to specific apps, and programmatically enabled/disabled.
-For details, please refer to the [sidebar nav docs]({{< ref "extension-types/left-sidebar-menu-item.md" >}})
-4. `SidebarPanelExtension`, (type `sidebarPanel`) - An extension that can register panels to the right sidebar. For details, please refer to the [sidebar panel docs]({{< ref "extension-types/right-sidebar-panels.md" >}})
-5. `FolderViewExtension` (type `folderView`) - An extension that can register additional ways of displaying the content of a folder (resources, so spaces, folders or files) to the user.
-For details, please refer to the [folder view docs]({{< ref "extension-types/folder-view.md" >}})
+extension points referenced in the extension respectively. Most commonly used for file and folder actions (e.g. copy, rename, delete, etc.). For details, please refer to the [action docs]({{< ref "extension-types/actions.md" >}}).
+2. `SearchExtension` (type `search`) - An extension that can register additional search providers. For details, please refer to the [search docs]({{< ref "extension-types/search.md" >}}).
+3. `SidebarNavExtension` (type `sidebarNav`) - An extension that can register additional navigation items for the left sidebar. These can be scoped to specific apps, and programmatically enabled/disabled.
+For details, please refer to the [sidebar nav docs]({{< ref "extension-types/left-sidebar-menu-item.md" >}}).
+4. `SidebarPanelExtension`, (type `sidebarPanel`) - An extension that can register panels for the right sidebar. For details, please refer to the [sidebar panel docs]({{< ref "extension-types/right-sidebar-panels.md" >}}).
+5. `FolderViewExtension` (type `folderView`) - An extension that can register additional ways of displaying the content of a folder (resources like spaces, folders or files) to the user.
+For details, please refer to the [folder view docs]({{< ref "extension-types/folder-view.md" >}}).
 6. `CustomComponentExtension` (type `customComponent`) - An extension that can register a custom component for a render target. For details, please refer to the
 [custom component docs]({{< ref "extension-types/custom-components.md" >}})
 
@@ -120,7 +125,7 @@ that an important extension type is missing and would be beneficial for the plat
 
 #### Extension Base Configuration
 
-Any extension is required to define at least an `id` and a `type`.
+Any extension is required to define at least an `id` and a `type` in order to fulfill the generic `Extension` interface.
 
 The `id` is supposed to be unique throughout the ownCloud Web ecosystem. In order to keep `id`s readable for humans we didn't want to enforce uniqueness through e.g. uuids. 
 Instead, we chose to use dot-formatted namespaces like e.g. `com.github.owncloud.web.files.search`. We'd like to encourage you to follow the same format for your own extensions.
@@ -133,13 +138,16 @@ You can find predefined extension point ids in the extension points section belo
 
 #### Extension Points
 
-There are standardized components and places where extensions are being used automatically. The following are the ones that are currently provided
-by the ownCloud Web runtime or the `files` app. If you decide to develop an extension which fulfills the type and registers itself for the extensionPointId of the respective extension point, 
-your extension will be used automatically. 
+There are standardized components and places where extensions are being used automatically. The following ones are currently provided by the ownCloud Web runtime or 
+the `files` app. If you decide to develop an extension which fulfills the type and registers itself for the extensionPointId of the respective extension point, 
+your extension will be used automatically.
 
 1. Left Sidebar for Navigation. ExtensionPointId `app.${appName}.navItems` (dynamically created for each app). Mounts extensions of type `sidebarNav`.
-2. Files app
-   1. Right sidebar. ExtensionPointId `app.files.sidebar`. Mounts extensions of type `sidebarPanel`. Used in any file(s) context (files app, file viewer apps, file editor apps)
+2. Global top bar
+   1. Center area. ExtensionPointId `app.runtime.header.center`. Mounts extensions of type `customComponent`.
+   2. Progress bar for the global loading state. ExtensionPointId `app.runtime.global-progress-bar`. Mounts a single extensions of type `customComponent`. If multiple exist, the user can choose via the account page.
+3. Files app
+   1. Right sidebar. ExtensionPointId `app.files.sidebar`. Mounts extensions of type `sidebarPanel`. Used in any file(s) context (files app, file viewer apps, file editor apps).
    2. Folder views for regular folders. ExtensionPointId `app.files.folder-views.folder`. Mounts extensions of type `folderView`.
    3. Folder views for the project spaces overview. ExtensionPointId `app.files.folder-views.project-spaces`. Mounts extensions of type `folderView`.
    4. Folder views for the favorites page. ExtensionPointId `app.files.folder-views.favorites`. Mounts extensions of type `folderView`.
@@ -147,7 +155,6 @@ your extension will be used automatically.
    6. Batch actions in the app bar above file lists. ExtensionPointId `app.files.batch-actions`. Mounts extensions of type `action`.
    7. Upload menu. ExtensionPointId `app.files.upload-menu`. Mounts extensions of type `action`.
    8. Quick actions. ExtensionPointId `app.files.quick-actions`. Mounts extensions of type `action`.
-3. Global progress bar for the global loading state. ExtensionPointId `app.runtime.global-progress-bar`. Mounts a single extensions of type `customComponent`. If multiple exist, the user can choose via the account page.
 4. Global search providers. ExtensionPointId `app.search.providers`. Utilizes extensions of type `search` as search engines for the search input in the global top bar.
 
 #### User Preferences for Extensions
@@ -158,7 +165,7 @@ The user can then select one out of all the extensions which have been registere
 
 ### Helpful packages
 
-We currently offer two packages that can be integrated into your app, providing useful utilities and types.
+We currently offer the following packages that can be integrated into your app, providing useful utilities and types.
 
-- `web-client` - This package serves as an abstraction layer between the server APIs and an app or extension. It converts API data into objects with helpful types and utilities. For details, please refer to the package's [README.md](https://github.com/owncloud/web/blob/master/packages/web-client/README.md).
+- `web-client` - This package serves as an abstraction layer between the server APIs and an app or extension. It converts raw API data into objects with helpful types and utilities. For details, please refer to the package's [README.md](https://github.com/owncloud/web/blob/master/packages/web-client/README.md).
 - `web-pkg` - This package provides utilities, most importantly a variety of components and composables, that can be useful when developing apps and extensions. For details, please refer to the package's [README.md](https://github.com/owncloud/web/blob/master/packages/web-pkg/README.md).

--- a/docs/extension-system/extension-types/actions.md
+++ b/docs/extension-system/extension-types/actions.md
@@ -16,18 +16,18 @@ Actions are one of the possible extension types. Registered actions get rendered
 
 ### Configuration
 
-This is what the ActionExtension interface looks like:
+This is what the `ActionExtension` interface looks like:
 
 ```typescript
 interface ActionExtension {
   id: string
   type: 'action'
-  scopes?: ExtensionScope[]
+  extensionPointIds?: string[]
   action: Action // Please check the Action section below
 }
 ```
 
-For `id`, `type`, and `scopes`, please see [extension base section]({{< ref "../_index.md#extension-base-configuration" >}}) in top level docs.
+For `id`, `type`, and `extensionPointIds`, please see [extension base section]({{< ref "../_index.md#extension-base-configuration" >}}) in top level docs.
 
 #### Action
 

--- a/docs/extension-system/extension-types/custom-components.md
+++ b/docs/extension-system/extension-types/custom-components.md
@@ -22,9 +22,9 @@ Here's what it looks like:
 
 ```typescript
 interface CustomComponentExtension {
-  id: string,
-  type: 'customComponent',
-  extensionPointIds: string[],
+  id: string
+  type: 'customComponent'
+  extensionPointIds?: string[]
   content: Slot | Component
 }
 ```

--- a/docs/extension-system/extension-types/folder-view.md
+++ b/docs/extension-system/extension-types/folder-view.md
@@ -19,13 +19,13 @@ This is what the FolderViewExtension interface looks like:
 ```typescript
 interface FolderViewExtension {
   id: string
-  scopes?: ExtensionScope[]
   type: 'folderView'
+  extensionPointIds?: string[]
   folderView: FolderView // See FolderView section below
 }
 ```
 
-For `id`, `type`, and `scopes`, please see [extension base section]({{< ref "../_index.md#extension-base-configuration" >}}) in top level docs.
+For `id`, `type`, and `extensionPointIds`, please see [extension base section]({{< ref "../_index.md#extension-base-configuration" >}}) in top level docs.
 
 #### FolderView
 

--- a/docs/extension-system/extension-types/left-sidebar-menu-item.md
+++ b/docs/extension-system/extension-types/left-sidebar-menu-item.md
@@ -23,13 +23,13 @@ It looks like this:
 interface SidebarNavExtension {
     id: string
     type: 'sidebarNav'
-    scopes?: ExtensionScope[]
+    extensionPointIds?: string[]
     navItem: AppNavigationItem // Please check the AppNavigationItem section below
     }
 }
 ```
 
-For `id`, `type`, and `scopes`, please see [extension base section]({{< ref "../_index.md#extension-base-configuration" >}}) in top level docs.
+For `id`, `type`, and `extensionPointIds`, please see [extension base section]({{< ref "../_index.md#extension-base-configuration" >}}) in top level docs.
 
 #### AppNavigationItem
 

--- a/docs/extension-system/extension-types/right-sidebar-panels.md
+++ b/docs/extension-system/extension-types/right-sidebar-panels.md
@@ -29,12 +29,12 @@ It can be found below:
 interface SidebarPanelExtension<R extends Item, P extends Item, T extends Item> {
   id: string
   type: 'sidebarPanel'
-  scopes?: ExtensionScope[]
+  extensionPointIds?: string[]
   panel: SideBarPanel<R, P, T> // Please check the SideBarPanel section below
 }
 ```
 
-For `id`, `type`, and `scopes`, please see [extension base section]({{< ref "../_index.md#extension-base-configuration" >}}) in the top level docs.
+For `id`, `type`, and `extensionPointIds`, please see [extension base section]({{< ref "../_index.md#extension-base-configuration" >}}) in the top level docs.
 
 The `panel` object configures the actual sidebar panel. It consists of different properties and functions, where all the functions get called with a
 `SideBarPanelContext` entity from the integrating extension points.

--- a/docs/extension-system/extension-types/search.md
+++ b/docs/extension-system/extension-types/search.md
@@ -23,7 +23,7 @@ An example of a search extension configuration can be found below:
 interface SearchExtension {
   id: string
   type: 'search'
-  scopes?: ExtensionScope[]
+  extensionPointIds?: string[]
   searchProvider: {
     id: string
     available: boolean
@@ -34,7 +34,7 @@ interface SearchExtension {
 }
 ```
 
-For `id`, `type`, and `scopes`, please see [extension base section]({{< ref "../_index.md#extension-base-configuration" >}}) in top level docs.
+For `id`, `type`, and `extensionPointIds`, please see [extension base section]({{< ref "../_index.md#extension-base-configuration" >}}) in top level docs.
 
 The `searchProvider` object configures the actual provider. It consist of the following:
 

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
   "engines": {
     "node": ">=18"
   },
-  "packageManager": "pnpm@9.0.6",
+  "packageManager": "pnpm@9.1.1",
   "volta": {
     "node": "18.19.0"
   },

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -228,7 +228,7 @@ import { ActionExtension, useExtensionRegistry } from '@ownclouders/web-pkg'
 import { Action, ResourceIcon } from '@ownclouders/web-pkg'
 import { v4 as uuidv4 } from 'uuid'
 import { storeToRefs } from 'pinia'
-import { uploadMenuExtensionPointId } from '../../extensionPoints'
+import { uploadMenuExtensionPoint } from '../../extensionPoints'
 
 export default defineComponent({
   components: {
@@ -320,8 +320,8 @@ export default defineComponent({
     const extensionActions = computed(() => {
       return [
         ...extensionRegistry
-          .requestExtensions<ActionExtension>('action', {
-            extensionPointIds: [uploadMenuExtensionPointId]
+          .requestExtensions<ActionExtension>({
+            extensionPoint: uploadMenuExtensionPoint
           })
           .map((e) => e.action)
       ].filter((e) => e.isVisible())

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -228,6 +228,7 @@ import { ActionExtension, useExtensionRegistry } from '@ownclouders/web-pkg'
 import { Action, ResourceIcon } from '@ownclouders/web-pkg'
 import { v4 as uuidv4 } from 'uuid'
 import { storeToRefs } from 'pinia'
+import { uploadMenuExtensionPointId } from '../../extensionPoints'
 
 export default defineComponent({
   components: {
@@ -319,7 +320,9 @@ export default defineComponent({
     const extensionActions = computed(() => {
       return [
         ...extensionRegistry
-          .requestExtensions<ActionExtension>('action', { scopes: ['upload-menu'] })
+          .requestExtensions<ActionExtension>('action', {
+            extensionPointIds: [uploadMenuExtensionPointId]
+          })
           .map((e) => e.action)
       ].filter((e) => e.isVisible())
     })

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -224,7 +224,7 @@ import { useService, useUpload, UppyService, UploadResult } from '@ownclouders/w
 import { HandleUpload } from 'web-app-files/src/HandleUpload'
 import { useRoute } from 'vue-router'
 import { useGettext } from 'vue3-gettext'
-import { ActionExtension, useExtensionRegistry } from '@ownclouders/web-pkg'
+import { useExtensionRegistry } from '@ownclouders/web-pkg'
 import { Action, ResourceIcon } from '@ownclouders/web-pkg'
 import { v4 as uuidv4 } from 'uuid'
 import { storeToRefs } from 'pinia'
@@ -319,11 +319,7 @@ export default defineComponent({
     const extensionRegistry = useExtensionRegistry()
     const extensionActions = computed(() => {
       return [
-        ...extensionRegistry
-          .requestExtensions<ActionExtension>({
-            extensionPoint: uploadMenuExtensionPoint
-          })
-          .map((e) => e.action)
+        ...extensionRegistry.requestExtensions(uploadMenuExtensionPoint).map((e) => e.action)
       ].filter((e) => e.isVisible())
     })
 

--- a/packages/web-app-files/src/components/FilesList/QuickActions.vue
+++ b/packages/web-app-files/src/components/FilesList/QuickActions.vue
@@ -17,7 +17,7 @@
 
 <script lang="ts">
 import { computed, defineComponent, PropType } from 'vue'
-import { ActionExtension, useEmbedMode, useExtensionRegistry } from '@ownclouders/web-pkg'
+import { useEmbedMode, useExtensionRegistry } from '@ownclouders/web-pkg'
 import { Resource, SpaceResource } from '@ownclouders/web-client'
 import { unref } from 'vue'
 import { quickActionsExtensionPoint } from '../../extensionPoints'
@@ -40,9 +40,7 @@ export default defineComponent({
 
     const filteredActions = computed(() => {
       return unref(extensionRegistry)
-        .requestExtensions<ActionExtension>({
-          extensionPoint: quickActionsExtensionPoint
-        })
+        .requestExtensions(quickActionsExtensionPoint)
         .map((e) => e.action)
         .filter(({ isVisible }) => isVisible({ space: props.space, resources: [props.item] }))
     })

--- a/packages/web-app-files/src/components/FilesList/QuickActions.vue
+++ b/packages/web-app-files/src/components/FilesList/QuickActions.vue
@@ -20,6 +20,7 @@ import { computed, defineComponent, PropType } from 'vue'
 import { ActionExtension, useEmbedMode, useExtensionRegistry } from '@ownclouders/web-pkg'
 import { Resource, SpaceResource } from '@ownclouders/web-client'
 import { unref } from 'vue'
+import { quickActionsExtensionPointId } from '../../extensionPoints'
 
 export default defineComponent({
   name: 'QuickActions',
@@ -39,7 +40,9 @@ export default defineComponent({
 
     const filteredActions = computed(() => {
       return unref(extensionRegistry)
-        .requestExtensions<ActionExtension>('action', { scopes: ['resource.quick-action'] })
+        .requestExtensions<ActionExtension>('action', {
+          extensionPointIds: [quickActionsExtensionPointId]
+        })
         .map((e) => e.action)
         .filter(({ isVisible }) => isVisible({ space: props.space, resources: [props.item] }))
     })

--- a/packages/web-app-files/src/components/FilesList/QuickActions.vue
+++ b/packages/web-app-files/src/components/FilesList/QuickActions.vue
@@ -20,7 +20,7 @@ import { computed, defineComponent, PropType } from 'vue'
 import { ActionExtension, useEmbedMode, useExtensionRegistry } from '@ownclouders/web-pkg'
 import { Resource, SpaceResource } from '@ownclouders/web-client'
 import { unref } from 'vue'
-import { quickActionsExtensionPointId } from '../../extensionPoints'
+import { quickActionsExtensionPoint } from '../../extensionPoints'
 
 export default defineComponent({
   name: 'QuickActions',
@@ -40,8 +40,8 @@ export default defineComponent({
 
     const filteredActions = computed(() => {
       return unref(extensionRegistry)
-        .requestExtensions<ActionExtension>('action', {
-          extensionPointIds: [quickActionsExtensionPointId]
+        .requestExtensions<ActionExtension>({
+          extensionPoint: quickActionsExtensionPoint
         })
         .map((e) => e.action)
         .filter(({ isVisible }) => isVisible({ space: props.space, resources: [props.item] }))

--- a/packages/web-app-files/src/composables/extensions/useFileSideBars.ts
+++ b/packages/web-app-files/src/composables/extensions/useFileSideBars.ts
@@ -31,10 +31,10 @@ import {
 } from '@ownclouders/web-client'
 import { Resource } from '@ownclouders/web-client'
 import { useGettext } from 'vue3-gettext'
-import { computed, unref } from 'vue'
+import { unref } from 'vue'
 import { fileSideBarExtensionPoint } from '../../extensionPoints'
 
-export const useSideBarPanels = () => {
+export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resource, Resource>[] => {
   const router = useRouter()
   const capabilityStore = useCapabilityStore()
   const { $gettext } = useGettext()
@@ -42,308 +42,304 @@ export const useSideBarPanels = () => {
   const { isPersonalSpaceRoot } = useGetMatchingSpace()
   const userStore = useUserStore()
 
-  return computed(
-    () =>
-      [
-        {
-          id: 'com.github.owncloud.web.files.sidebar-panel.no-selection',
-          type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPoint.id],
-          panel: {
-            name: 'no-selection',
-            icon: 'questionnaire-line',
-            title: () => $gettext('Details'),
-            component: NoSelection,
-            isRoot: () => true,
-            isVisible: ({ parent, items }) => {
-              if (isLocationTrashActive(router, 'files-trash-overview')) {
-                // trash overview has its own "no selection" panel
-                return false
-              }
-              if (isLocationSpacesActive(router, 'files-spaces-projects')) {
-                // project spaces overview has its own "no selection" panel
-                return false
-              }
-              if (items?.length > 0) {
-                return false
-              }
-              // empty selection in a project space root shows a "details" panel for the space itself
-              return !isProjectSpaceResource(parent)
-            }
+  return [
+    {
+      id: 'com.github.owncloud.web.files.sidebar-panel.no-selection',
+      type: 'sidebarPanel',
+      extensionPointIds: [fileSideBarExtensionPoint.id],
+      panel: {
+        name: 'no-selection',
+        icon: 'questionnaire-line',
+        title: () => $gettext('Details'),
+        component: NoSelection,
+        isRoot: () => true,
+        isVisible: ({ parent, items }) => {
+          if (isLocationTrashActive(router, 'files-trash-overview')) {
+            // trash overview has its own "no selection" panel
+            return false
           }
-        },
-        {
-          id: 'com.github.owncloud.web.files.sidebar-panel.trash-no-selection',
-          type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPoint.id],
-          panel: {
-            name: 'no-selection',
-            icon: 'questionnaire-line',
-            title: () => $gettext('Details'),
-            component: TrashNoSelection,
-            isRoot: () => true,
-            isVisible: () => {
-              return isLocationTrashActive(router, 'files-trash-overview')
-            }
+          if (isLocationSpacesActive(router, 'files-spaces-projects')) {
+            // project spaces overview has its own "no selection" panel
+            return false
           }
-        },
-        {
-          id: 'com.github.owncloud.web.files.sidebar-panel.details-single-selection',
-          type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPoint.id],
-          panel: {
-            name: 'details',
-            icon: 'questionnaire-line',
-            title: () => $gettext('Details'),
-            component: FileDetails,
-            componentAttrs: ({ items }) => ({
-              previewEnabled: unref(isFilesAppActive),
-              tagsEnabled:
-                !isPersonalSpaceRoot(items[0]) &&
-                !isLocationTrashActive(router, 'files-trash-generic'),
-              versionsEnabled: !isLocationTrashActive(router, 'files-trash-generic')
-            }),
-            isRoot: () => true,
-            isVisible: ({ items }) => {
-              if (items?.length !== 1) {
-                return false
-              }
-              // project spaces have their own "details" panel
-              return !isProjectSpaceResource(items[0])
-            }
+          if (items?.length > 0) {
+            return false
           }
-        },
-        {
-          id: 'com.github.owncloud.web.files.sidebar-panel.details-multi-selection',
-          type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPoint.id],
-          panel: {
-            name: 'details-multiple',
-            icon: 'questionnaire-line',
-            title: () => $gettext('Details'),
-            component: FileDetailsMultiple,
-            componentAttrs: () => ({
-              get showSpaceCount() {
-                return (
-                  !isLocationSpacesActive(router, 'files-spaces-generic') &&
-                  !isLocationSharesActive(router, 'files-shares-with-me') &&
-                  !isLocationTrashActive(router, 'files-trash-generic')
-                )
-              }
-            }),
-            isRoot: () => true,
-            isVisible: ({ items }) => {
-              if (isLocationSpacesActive(router, 'files-spaces-projects')) {
-                // project spaces overview has its own "no selection" panel
-                return false
-              }
-              return items?.length > 1
-            }
-          }
-        },
-        {
-          id: 'com.github.owncloud.web.files.sidebar-panel.actions',
-          type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPoint.id],
-          panel: {
-            name: 'actions',
-            icon: 'slideshow-3',
-            title: () => $gettext('Actions'),
-            component: FileActions,
-            isRoot: () => false,
-            isVisible: ({ items }) => {
-              if (items?.length !== 1) {
-                return false
-              }
-              if (isPersonalSpaceRoot(items[0])) {
-                // actions panel is not available on the personal space root for now ;-)
-                return false
-              }
-              // project spaces have their own "actions" panel
-              return !isProjectSpaceResource(items[0])
-            }
-          }
-        },
-        {
-          id: 'com.github.owncloud.web.files.sidebar-panel.sharing',
-          type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPoint.id],
-          panel: {
-            name: 'sharing',
-            icon: 'user-add',
-            iconFillType: 'line',
-            title: () => $gettext('Shares'),
-            component: SharesPanel,
-            componentAttrs: () => ({
-              showSpaceMembers: false,
-              get showLinks() {
-                return capabilityStore.sharingPublicEnabled
-              }
-            }),
-            isVisible: ({ items, root }) => {
-              if (items?.length !== 1) {
-                return false
-              }
-              if (isProjectSpaceResource(items[0])) {
-                // project space roots have their own "sharing" panel (= space members)
-                return false
-              }
-              if (isPersonalSpaceRoot(items[0])) {
-                // sharing panel is not available on the personal space root
-                return false
-              }
-              if (isShareResource(items[0])) {
-                return false
-              }
-              if (isShareSpaceResource(root)) {
-                return false
-              }
-              if (
-                isLocationTrashActive(router, 'files-trash-generic') ||
-                isLocationPublicActive(router, 'files-public-link')
-              ) {
-                return false
-              }
-              return capabilityStore.sharingApiEnabled
-            }
-          }
-        },
-        {
-          id: 'com.github.owncloud.web.files.sidebar-panel.versions',
-          type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPoint.id],
-          panel: {
-            name: 'versions',
-            icon: 'git-branch',
-            title: () => $gettext('Versions'),
-            component: FileVersions,
-            componentAttrs: () => ({
-              isReadOnly: !unref(isFilesAppActive)
-            }),
-            isVisible: ({ items, root }) => {
-              if (items?.length !== 1) {
-                return false
-              }
-              if (isProjectSpaceResource(items[0])) {
-                // project space roots don't support versions
-                return false
-              }
-
-              const userIsSpaceMember =
-                (isProjectSpaceResource(root) && root.isMember(userStore.user)) ||
-                (isPersonalSpaceResource(root) && root.isOwner(userStore.user))
-
-              if (
-                isLocationTrashActive(router, 'files-trash-generic') ||
-                !userIsSpaceMember ||
-                isSpaceResource(items[0])
-              ) {
-                return false
-              }
-              return items[0].type !== 'folder'
-            }
-          }
-        },
-        {
-          id: 'com.github.owncloud.web.files.sidebar-panel.projects.no-selection',
-          type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPoint.id],
-          panel: {
-            name: 'no-selection',
-            icon: 'questionnaire-line',
-            title: () => $gettext('Details'),
-            component: SpaceNoSelection,
-            isRoot: () => true,
-            isVisible: ({ items }) => {
-              if (!isLocationSpacesActive(router, 'files-spaces-projects')) {
-                // only for project spaces overview
-                return false
-              }
-              return items?.length === 0
-            }
-          }
-        },
-        {
-          id: 'com.github.owncloud.web.files.sidebar-panel.projects.details-single-selection',
-          type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPoint.id],
-          panel: {
-            name: 'details-space',
-            icon: 'questionnaire-line',
-            title: () => $gettext('Details'),
-            component: SpaceDetails,
-            isRoot: () => true,
-            isVisible: ({ items }) => {
-              return items?.length === 1 && isProjectSpaceResource(items[0])
-            }
-          }
-        },
-        {
-          id: 'com.github.owncloud.web.files.sidebar-panel.projects.details-multi-selection',
-          type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPoint.id],
-          panel: {
-            name: 'details-space-multiple',
-            icon: 'questionnaire-line',
-            title: () => $gettext('Details'),
-            component: SpaceDetailsMultiple,
-            componentAttrs: ({ items }) => ({
-              selectedSpaces: items
-            }),
-            isRoot: () => true,
-            isVisible: ({ items }) => {
-              return items?.length > 1 && isLocationSpacesActive(router, 'files-spaces-projects')
-            }
-          }
-        },
-        {
-          id: 'com.github.owncloud.web.files.sidebar-panel.projects.actions',
-          type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPoint.id],
-          panel: {
-            name: 'space-actions',
-            icon: 'slideshow-3',
-            title: () => $gettext('Actions'),
-            component: SpaceActions,
-            isVisible: ({ items }) => {
-              if (items?.length !== 1) {
-                return false
-              }
-              if (!isProjectSpaceResource(items[0])) {
-                return false
-              }
-              if (
-                !isLocationSpacesActive(router, 'files-spaces-projects') &&
-                !isLocationSpacesActive(router, 'files-spaces-generic')
-              ) {
-                return false
-              }
-              return [...items[0].spaceRoles.manager, ...items[0].spaceRoles.editor].some(
-                (role) => role.id === userStore.user.id
-              )
-            }
-          }
-        },
-        {
-          id: 'com.github.owncloud.web.files.sidebar-panel.projects.sharing',
-          type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPoint.id],
-          panel: {
-            name: 'space-share',
-            icon: 'group',
-            title: () => $gettext('Members'),
-            component: SharesPanel,
-            componentAttrs: () => ({
-              showSpaceMembers: true,
-              get showLinks() {
-                return capabilityStore.sharingPublicEnabled
-              }
-            }),
-            isVisible: ({ items }) => {
-              return items?.length === 1 && isProjectSpaceResource(items[0])
-            }
-          }
+          // empty selection in a project space root shows a "details" panel for the space itself
+          return !isProjectSpaceResource(parent)
         }
-      ] satisfies SidebarPanelExtension<SpaceResource, Resource, Resource>[]
-  )
+      }
+    },
+    {
+      id: 'com.github.owncloud.web.files.sidebar-panel.trash-no-selection',
+      type: 'sidebarPanel',
+      extensionPointIds: [fileSideBarExtensionPoint.id],
+      panel: {
+        name: 'no-selection',
+        icon: 'questionnaire-line',
+        title: () => $gettext('Details'),
+        component: TrashNoSelection,
+        isRoot: () => true,
+        isVisible: () => {
+          return isLocationTrashActive(router, 'files-trash-overview')
+        }
+      }
+    },
+    {
+      id: 'com.github.owncloud.web.files.sidebar-panel.details-single-selection',
+      type: 'sidebarPanel',
+      extensionPointIds: [fileSideBarExtensionPoint.id],
+      panel: {
+        name: 'details',
+        icon: 'questionnaire-line',
+        title: () => $gettext('Details'),
+        component: FileDetails,
+        componentAttrs: ({ items }) => ({
+          previewEnabled: unref(isFilesAppActive),
+          tagsEnabled:
+            !isPersonalSpaceRoot(items[0]) && !isLocationTrashActive(router, 'files-trash-generic'),
+          versionsEnabled: !isLocationTrashActive(router, 'files-trash-generic')
+        }),
+        isRoot: () => true,
+        isVisible: ({ items }) => {
+          if (items?.length !== 1) {
+            return false
+          }
+          // project spaces have their own "details" panel
+          return !isProjectSpaceResource(items[0])
+        }
+      }
+    },
+    {
+      id: 'com.github.owncloud.web.files.sidebar-panel.details-multi-selection',
+      type: 'sidebarPanel',
+      extensionPointIds: [fileSideBarExtensionPoint.id],
+      panel: {
+        name: 'details-multiple',
+        icon: 'questionnaire-line',
+        title: () => $gettext('Details'),
+        component: FileDetailsMultiple,
+        componentAttrs: () => ({
+          get showSpaceCount() {
+            return (
+              !isLocationSpacesActive(router, 'files-spaces-generic') &&
+              !isLocationSharesActive(router, 'files-shares-with-me') &&
+              !isLocationTrashActive(router, 'files-trash-generic')
+            )
+          }
+        }),
+        isRoot: () => true,
+        isVisible: ({ items }) => {
+          if (isLocationSpacesActive(router, 'files-spaces-projects')) {
+            // project spaces overview has its own "no selection" panel
+            return false
+          }
+          return items?.length > 1
+        }
+      }
+    },
+    {
+      id: 'com.github.owncloud.web.files.sidebar-panel.actions',
+      type: 'sidebarPanel',
+      extensionPointIds: [fileSideBarExtensionPoint.id],
+      panel: {
+        name: 'actions',
+        icon: 'slideshow-3',
+        title: () => $gettext('Actions'),
+        component: FileActions,
+        isRoot: () => false,
+        isVisible: ({ items }) => {
+          if (items?.length !== 1) {
+            return false
+          }
+          if (isPersonalSpaceRoot(items[0])) {
+            // actions panel is not available on the personal space root for now ;-)
+            return false
+          }
+          // project spaces have their own "actions" panel
+          return !isProjectSpaceResource(items[0])
+        }
+      }
+    },
+    {
+      id: 'com.github.owncloud.web.files.sidebar-panel.sharing',
+      type: 'sidebarPanel',
+      extensionPointIds: [fileSideBarExtensionPoint.id],
+      panel: {
+        name: 'sharing',
+        icon: 'user-add',
+        iconFillType: 'line',
+        title: () => $gettext('Shares'),
+        component: SharesPanel,
+        componentAttrs: () => ({
+          showSpaceMembers: false,
+          get showLinks() {
+            return capabilityStore.sharingPublicEnabled
+          }
+        }),
+        isVisible: ({ items, root }) => {
+          if (items?.length !== 1) {
+            return false
+          }
+          if (isProjectSpaceResource(items[0])) {
+            // project space roots have their own "sharing" panel (= space members)
+            return false
+          }
+          if (isPersonalSpaceRoot(items[0])) {
+            // sharing panel is not available on the personal space root
+            return false
+          }
+          if (isShareResource(items[0])) {
+            return false
+          }
+          if (isShareSpaceResource(root)) {
+            return false
+          }
+          if (
+            isLocationTrashActive(router, 'files-trash-generic') ||
+            isLocationPublicActive(router, 'files-public-link')
+          ) {
+            return false
+          }
+          return capabilityStore.sharingApiEnabled
+        }
+      }
+    },
+    {
+      id: 'com.github.owncloud.web.files.sidebar-panel.versions',
+      type: 'sidebarPanel',
+      extensionPointIds: [fileSideBarExtensionPoint.id],
+      panel: {
+        name: 'versions',
+        icon: 'git-branch',
+        title: () => $gettext('Versions'),
+        component: FileVersions,
+        componentAttrs: () => ({
+          isReadOnly: !unref(isFilesAppActive)
+        }),
+        isVisible: ({ items, root }) => {
+          if (items?.length !== 1) {
+            return false
+          }
+          if (isProjectSpaceResource(items[0])) {
+            // project space roots don't support versions
+            return false
+          }
+
+          const userIsSpaceMember =
+            (isProjectSpaceResource(root) && root.isMember(userStore.user)) ||
+            (isPersonalSpaceResource(root) && root.isOwner(userStore.user))
+
+          if (
+            isLocationTrashActive(router, 'files-trash-generic') ||
+            !userIsSpaceMember ||
+            isSpaceResource(items[0])
+          ) {
+            return false
+          }
+          return items[0].type !== 'folder'
+        }
+      }
+    },
+    {
+      id: 'com.github.owncloud.web.files.sidebar-panel.projects.no-selection',
+      type: 'sidebarPanel',
+      extensionPointIds: [fileSideBarExtensionPoint.id],
+      panel: {
+        name: 'no-selection',
+        icon: 'questionnaire-line',
+        title: () => $gettext('Details'),
+        component: SpaceNoSelection,
+        isRoot: () => true,
+        isVisible: ({ items }) => {
+          if (!isLocationSpacesActive(router, 'files-spaces-projects')) {
+            // only for project spaces overview
+            return false
+          }
+          return items?.length === 0
+        }
+      }
+    },
+    {
+      id: 'com.github.owncloud.web.files.sidebar-panel.projects.details-single-selection',
+      type: 'sidebarPanel',
+      extensionPointIds: [fileSideBarExtensionPoint.id],
+      panel: {
+        name: 'details-space',
+        icon: 'questionnaire-line',
+        title: () => $gettext('Details'),
+        component: SpaceDetails,
+        isRoot: () => true,
+        isVisible: ({ items }) => {
+          return items?.length === 1 && isProjectSpaceResource(items[0])
+        }
+      }
+    },
+    {
+      id: 'com.github.owncloud.web.files.sidebar-panel.projects.details-multi-selection',
+      type: 'sidebarPanel',
+      extensionPointIds: [fileSideBarExtensionPoint.id],
+      panel: {
+        name: 'details-space-multiple',
+        icon: 'questionnaire-line',
+        title: () => $gettext('Details'),
+        component: SpaceDetailsMultiple,
+        componentAttrs: ({ items }) => ({
+          selectedSpaces: items
+        }),
+        isRoot: () => true,
+        isVisible: ({ items }) => {
+          return items?.length > 1 && isLocationSpacesActive(router, 'files-spaces-projects')
+        }
+      }
+    },
+    {
+      id: 'com.github.owncloud.web.files.sidebar-panel.projects.actions',
+      type: 'sidebarPanel',
+      extensionPointIds: [fileSideBarExtensionPoint.id],
+      panel: {
+        name: 'space-actions',
+        icon: 'slideshow-3',
+        title: () => $gettext('Actions'),
+        component: SpaceActions,
+        isVisible: ({ items }) => {
+          if (items?.length !== 1) {
+            return false
+          }
+          if (!isProjectSpaceResource(items[0])) {
+            return false
+          }
+          if (
+            !isLocationSpacesActive(router, 'files-spaces-projects') &&
+            !isLocationSpacesActive(router, 'files-spaces-generic')
+          ) {
+            return false
+          }
+          return [...items[0].spaceRoles.manager, ...items[0].spaceRoles.editor].some(
+            (role) => role.id === userStore.user.id
+          )
+        }
+      }
+    },
+    {
+      id: 'com.github.owncloud.web.files.sidebar-panel.projects.sharing',
+      type: 'sidebarPanel',
+      extensionPointIds: [fileSideBarExtensionPoint.id],
+      panel: {
+        name: 'space-share',
+        icon: 'group',
+        title: () => $gettext('Members'),
+        component: SharesPanel,
+        componentAttrs: () => ({
+          showSpaceMembers: true,
+          get showLinks() {
+            return capabilityStore.sharingPublicEnabled
+          }
+        }),
+        isVisible: ({ items }) => {
+          return items?.length === 1 && isProjectSpaceResource(items[0])
+        }
+      }
+    }
+  ]
 }

--- a/packages/web-app-files/src/composables/extensions/useFileSideBars.ts
+++ b/packages/web-app-files/src/composables/extensions/useFileSideBars.ts
@@ -32,7 +32,7 @@ import {
 import { Resource } from '@ownclouders/web-client'
 import { useGettext } from 'vue3-gettext'
 import { computed, unref } from 'vue'
-import { fileSideBarExtensionPointId } from '../../extensionPoints'
+import { fileSideBarExtensionPoint } from '../../extensionPoints'
 
 export const useSideBarPanels = () => {
   const router = useRouter()
@@ -48,7 +48,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.no-selection',
           type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPointId],
+          extensionPointIds: [fileSideBarExtensionPoint.id],
           panel: {
             name: 'no-selection',
             icon: 'questionnaire-line',
@@ -75,7 +75,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.trash-no-selection',
           type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPointId],
+          extensionPointIds: [fileSideBarExtensionPoint.id],
           panel: {
             name: 'no-selection',
             icon: 'questionnaire-line',
@@ -90,7 +90,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.details-single-selection',
           type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPointId],
+          extensionPointIds: [fileSideBarExtensionPoint.id],
           panel: {
             name: 'details',
             icon: 'questionnaire-line',
@@ -116,7 +116,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.details-multi-selection',
           type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPointId],
+          extensionPointIds: [fileSideBarExtensionPoint.id],
           panel: {
             name: 'details-multiple',
             icon: 'questionnaire-line',
@@ -144,7 +144,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.actions',
           type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPointId],
+          extensionPointIds: [fileSideBarExtensionPoint.id],
           panel: {
             name: 'actions',
             icon: 'slideshow-3',
@@ -167,7 +167,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.sharing',
           type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPointId],
+          extensionPointIds: [fileSideBarExtensionPoint.id],
           panel: {
             name: 'sharing',
             icon: 'user-add',
@@ -211,7 +211,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.versions',
           type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPointId],
+          extensionPointIds: [fileSideBarExtensionPoint.id],
           panel: {
             name: 'versions',
             icon: 'git-branch',
@@ -247,7 +247,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.projects.no-selection',
           type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPointId],
+          extensionPointIds: [fileSideBarExtensionPoint.id],
           panel: {
             name: 'no-selection',
             icon: 'questionnaire-line',
@@ -266,7 +266,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.projects.details-single-selection',
           type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPointId],
+          extensionPointIds: [fileSideBarExtensionPoint.id],
           panel: {
             name: 'details-space',
             icon: 'questionnaire-line',
@@ -281,7 +281,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.projects.details-multi-selection',
           type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPointId],
+          extensionPointIds: [fileSideBarExtensionPoint.id],
           panel: {
             name: 'details-space-multiple',
             icon: 'questionnaire-line',
@@ -299,7 +299,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.projects.actions',
           type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPointId],
+          extensionPointIds: [fileSideBarExtensionPoint.id],
           panel: {
             name: 'space-actions',
             icon: 'slideshow-3',
@@ -327,7 +327,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.projects.sharing',
           type: 'sidebarPanel',
-          extensionPointIds: [fileSideBarExtensionPointId],
+          extensionPointIds: [fileSideBarExtensionPoint.id],
           panel: {
             name: 'space-share',
             icon: 'group',

--- a/packages/web-app-files/src/composables/extensions/useFileSideBars.ts
+++ b/packages/web-app-files/src/composables/extensions/useFileSideBars.ts
@@ -32,6 +32,7 @@ import {
 import { Resource } from '@ownclouders/web-client'
 import { useGettext } from 'vue3-gettext'
 import { computed, unref } from 'vue'
+import { fileSideBarExtensionPointId } from '../../extensionPoints'
 
 export const useSideBarPanels = () => {
   const router = useRouter()
@@ -47,7 +48,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.no-selection',
           type: 'sidebarPanel',
-          scopes: ['resource'],
+          extensionPointIds: [fileSideBarExtensionPointId],
           panel: {
             name: 'no-selection',
             icon: 'questionnaire-line',
@@ -74,7 +75,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.trash-no-selection',
           type: 'sidebarPanel',
-          scopes: ['resource'],
+          extensionPointIds: [fileSideBarExtensionPointId],
           panel: {
             name: 'no-selection',
             icon: 'questionnaire-line',
@@ -89,7 +90,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.details-single-selection',
           type: 'sidebarPanel',
-          scopes: ['resource'],
+          extensionPointIds: [fileSideBarExtensionPointId],
           panel: {
             name: 'details',
             icon: 'questionnaire-line',
@@ -115,7 +116,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.details-multi-selection',
           type: 'sidebarPanel',
-          scopes: ['resource'],
+          extensionPointIds: [fileSideBarExtensionPointId],
           panel: {
             name: 'details-multiple',
             icon: 'questionnaire-line',
@@ -143,7 +144,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.actions',
           type: 'sidebarPanel',
-          scopes: ['resource'],
+          extensionPointIds: [fileSideBarExtensionPointId],
           panel: {
             name: 'actions',
             icon: 'slideshow-3',
@@ -166,7 +167,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.sharing',
           type: 'sidebarPanel',
-          scopes: ['resource'],
+          extensionPointIds: [fileSideBarExtensionPointId],
           panel: {
             name: 'sharing',
             icon: 'user-add',
@@ -210,7 +211,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.versions',
           type: 'sidebarPanel',
-          scopes: ['resource'],
+          extensionPointIds: [fileSideBarExtensionPointId],
           panel: {
             name: 'versions',
             icon: 'git-branch',
@@ -246,7 +247,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.projects.no-selection',
           type: 'sidebarPanel',
-          scopes: ['resource'],
+          extensionPointIds: [fileSideBarExtensionPointId],
           panel: {
             name: 'no-selection',
             icon: 'questionnaire-line',
@@ -265,7 +266,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.projects.details-single-selection',
           type: 'sidebarPanel',
-          scopes: ['resource'],
+          extensionPointIds: [fileSideBarExtensionPointId],
           panel: {
             name: 'details-space',
             icon: 'questionnaire-line',
@@ -280,7 +281,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.projects.details-multi-selection',
           type: 'sidebarPanel',
-          scopes: ['resource'],
+          extensionPointIds: [fileSideBarExtensionPointId],
           panel: {
             name: 'details-space-multiple',
             icon: 'questionnaire-line',
@@ -298,7 +299,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.projects.actions',
           type: 'sidebarPanel',
-          scopes: ['resource'],
+          extensionPointIds: [fileSideBarExtensionPointId],
           panel: {
             name: 'space-actions',
             icon: 'slideshow-3',
@@ -326,7 +327,7 @@ export const useSideBarPanels = () => {
         {
           id: 'com.github.owncloud.web.files.sidebar-panel.projects.sharing',
           type: 'sidebarPanel',
-          scopes: ['resource'],
+          extensionPointIds: [fileSideBarExtensionPointId],
           panel: {
             name: 'space-share',
             icon: 'group',

--- a/packages/web-app-files/src/composables/extensions/useFolderViews.ts
+++ b/packages/web-app-files/src/composables/extensions/useFolderViews.ts
@@ -1,9 +1,9 @@
 import { FolderViewExtension, ResourceTable, ResourceTiles } from '@ownclouders/web-pkg'
 import { useGettext } from 'vue3-gettext'
 import {
-  folderViewsFavorites,
-  folderViewsFolder,
-  folderViewsProjectSpaces
+  folderViewsFavoritesExtensionPoint,
+  folderViewsFolderExtensionPoint,
+  folderViewsProjectSpacesExtensionPoint
 } from '../../extensionPoints'
 
 export const useFolderViews = (): FolderViewExtension[] => {
@@ -13,7 +13,11 @@ export const useFolderViews = (): FolderViewExtension[] => {
     {
       id: 'com.github.owncloud.web.files.folder-view.resource-table',
       type: 'folderView',
-      extensionPointIds: [folderViewsFolder, folderViewsProjectSpaces, folderViewsFavorites],
+      extensionPointIds: [
+        folderViewsFolderExtensionPoint.id,
+        folderViewsProjectSpacesExtensionPoint.id,
+        folderViewsFavoritesExtensionPoint.id
+      ],
       folderView: {
         name: 'resource-table',
         label: $gettext('Switch to default table view'),
@@ -27,7 +31,7 @@ export const useFolderViews = (): FolderViewExtension[] => {
     {
       id: 'com.github.owncloud.web.files.folder-view.resource-table-condensed',
       type: 'folderView',
-      extensionPointIds: [folderViewsFolder],
+      extensionPointIds: [folderViewsFolderExtensionPoint.id],
       folderView: {
         name: 'resource-table-condensed',
         label: $gettext('Switch to condensed table view'),
@@ -41,7 +45,11 @@ export const useFolderViews = (): FolderViewExtension[] => {
     {
       id: 'com.github.owncloud.web.files.folder-view.resource-tiles',
       type: 'folderView',
-      extensionPointIds: [folderViewsFolder, folderViewsProjectSpaces, folderViewsFavorites],
+      extensionPointIds: [
+        folderViewsFolderExtensionPoint.id,
+        folderViewsProjectSpacesExtensionPoint.id,
+        folderViewsFavoritesExtensionPoint.id
+      ],
       folderView: {
         name: 'resource-tiles',
         label: $gettext('Switch to tiles view'),

--- a/packages/web-app-files/src/composables/extensions/useFolderViews.ts
+++ b/packages/web-app-files/src/composables/extensions/useFolderViews.ts
@@ -1,6 +1,10 @@
-import { FolderViewExtension } from '@ownclouders/web-pkg'
+import { FolderViewExtension, ResourceTable, ResourceTiles } from '@ownclouders/web-pkg'
 import { useGettext } from 'vue3-gettext'
-import { ResourceTable, ResourceTiles } from '@ownclouders/web-pkg'
+import {
+  folderViewsFavorites,
+  folderViewsFolder,
+  folderViewsProjectSpaces
+} from '../../extensionPoints'
 
 export const useFolderViews = (): FolderViewExtension[] => {
   const { $gettext } = useGettext()
@@ -9,7 +13,7 @@ export const useFolderViews = (): FolderViewExtension[] => {
     {
       id: 'com.github.owncloud.web.files.folder-view.resource-table',
       type: 'folderView',
-      scopes: ['resource', 'space', 'favorite'],
+      extensionPointIds: [folderViewsFolder, folderViewsProjectSpaces, folderViewsFavorites],
       folderView: {
         name: 'resource-table',
         label: $gettext('Switch to default table view'),
@@ -23,7 +27,7 @@ export const useFolderViews = (): FolderViewExtension[] => {
     {
       id: 'com.github.owncloud.web.files.folder-view.resource-table-condensed',
       type: 'folderView',
-      scopes: ['resource'],
+      extensionPointIds: [folderViewsFolder],
       folderView: {
         name: 'resource-table-condensed',
         label: $gettext('Switch to condensed table view'),
@@ -37,7 +41,7 @@ export const useFolderViews = (): FolderViewExtension[] => {
     {
       id: 'com.github.owncloud.web.files.folder-view.resource-tiles',
       type: 'folderView',
-      scopes: ['resource', 'space', 'favorite'],
+      extensionPointIds: [folderViewsFolder, folderViewsProjectSpaces, folderViewsFavorites],
       folderView: {
         name: 'resource-tiles',
         label: $gettext('Switch to tiles view'),

--- a/packages/web-app-files/src/extensionPoints.ts
+++ b/packages/web-app-files/src/extensionPoints.ts
@@ -12,7 +12,7 @@ export const uploadMenuExtensionPoint: ExtensionPoint<ActionExtension> = {
   multiple: true
 }
 export const quickActionsExtensionPoint: ExtensionPoint<ActionExtension> = {
-  id: 'global.files.quick-actions',
+  id: 'app.files.quick-actions',
   extensionType: 'action',
   multiple: true
 }

--- a/packages/web-app-files/src/extensionPoints.ts
+++ b/packages/web-app-files/src/extensionPoints.ts
@@ -12,22 +12,22 @@ export const uploadMenuExtensionPoint: ExtensionPoint<ActionExtension> = {
   multiple: true
 }
 export const quickActionsExtensionPoint: ExtensionPoint<ActionExtension> = {
-  id: 'app.files.quick-actions',
+  id: 'global.files.quick-actions',
   extensionType: 'action',
   multiple: true
 }
 export const batchActionsExtensionPoint: ExtensionPoint<ActionExtension> = {
-  id: 'app.files.batch-actions',
+  id: 'global.files.batch-actions',
   extensionType: 'action',
   multiple: true
 }
 export const contextActionsExtensionPoint: ExtensionPoint<ActionExtension> = {
-  id: 'app.files.context-actions',
+  id: 'global.files.context-actions',
   extensionType: 'action',
   multiple: true
 }
 export const fileSideBarExtensionPoint: ExtensionPoint<SidebarPanelExtension<any, any, any>> = {
-  id: 'app.files.sidebar',
+  id: 'global.files.sidebar',
   extensionType: 'sidebarPanel',
   multiple: true
 }

--- a/packages/web-app-files/src/extensionPoints.ts
+++ b/packages/web-app-files/src/extensionPoints.ts
@@ -1,55 +1,55 @@
 import { ExtensionPoint } from '@ownclouders/web-pkg'
 import { computed } from 'vue'
 
-export const uploadMenuExtensionPointId = 'app.files.upload-menu'
-export const quickActionsExtensionPointId = 'app.files.quick-actions'
-export const batchActionsExtensionPointId = 'app.files.batch-actions'
-export const contextActionsExtensionPointId = 'app.files.context-actions'
-export const fileSideBarExtensionPointId = 'app.files.sidebar'
-export const folderViewsFolder = 'app.files.folder-views.folder'
-export const folderViewsFavorites = 'app.files.folder-views.favorites'
-export const folderViewsProjectSpaces = 'app.files.folder-views.project-spaces'
+export const uploadMenuExtensionPoint: ExtensionPoint = {
+  id: 'app.files.upload-menu',
+  extensionType: 'action',
+  multiple: true
+}
+export const quickActionsExtensionPoint: ExtensionPoint = {
+  id: 'app.files.quick-actions',
+  extensionType: 'action',
+  multiple: true
+}
+export const batchActionsExtensionPoint: ExtensionPoint = {
+  id: 'app.files.batch-actions',
+  extensionType: 'action',
+  multiple: true
+}
+export const contextActionsExtensionPoint: ExtensionPoint = {
+  id: 'app.files.context-actions',
+  extensionType: 'action',
+  multiple: true
+}
+export const fileSideBarExtensionPoint: ExtensionPoint = {
+  id: 'app.files.sidebar',
+  extensionType: 'sidebarPanel',
+  multiple: true
+}
+export const folderViewsFolderExtensionPoint: ExtensionPoint = {
+  id: 'app.files.folder-views.folder',
+  extensionType: 'folderView'
+}
+export const folderViewsFavoritesExtensionPoint: ExtensionPoint = {
+  id: 'app.files.folder-views.favorites',
+  extensionType: 'folderView'
+}
+export const folderViewsProjectSpacesExtensionPoint: ExtensionPoint = {
+  id: 'app.files.folder-views.project-spaces',
+  extensionType: 'folderView'
+}
 
 export const extensionPoints = () => {
   return computed<ExtensionPoint[]>(() => {
     return [
-      {
-        id: uploadMenuExtensionPointId,
-        extensionType: 'action',
-        multiple: true
-      },
-      {
-        id: quickActionsExtensionPointId,
-        extensionType: 'action',
-        multiple: true
-      },
-      {
-        id: batchActionsExtensionPointId,
-        extensionType: 'action',
-        multiple: true
-      },
-      {
-        id: contextActionsExtensionPointId,
-        extensionType: 'action',
-        multiple: true
-      },
-      {
-        id: fileSideBarExtensionPointId,
-        extensionType: 'sidebarPanel',
-        multiple: true
-      },
-      {
-        id: folderViewsFolder,
-        extensionType: 'folderView'
-      },
-      {
-        id: folderViewsFavorites,
-        extensionType: 'folderView'
-      },
-      {
-        id: folderViewsProjectSpaces,
-        extensionType: 'folderView'
-      }
+      uploadMenuExtensionPoint,
+      quickActionsExtensionPoint,
+      batchActionsExtensionPoint,
+      contextActionsExtensionPoint,
+      fileSideBarExtensionPoint,
+      folderViewsFolderExtensionPoint,
+      folderViewsFavoritesExtensionPoint,
+      folderViewsProjectSpacesExtensionPoint
     ]
   })
 }

--- a/packages/web-app-files/src/extensionPoints.ts
+++ b/packages/web-app-files/src/extensionPoints.ts
@@ -1,46 +1,51 @@
-import { ExtensionPoint } from '@ownclouders/web-pkg'
+import {
+  ActionExtension,
+  ExtensionPoint,
+  FolderViewExtension,
+  SidebarPanelExtension
+} from '@ownclouders/web-pkg'
 import { computed } from 'vue'
 
-export const uploadMenuExtensionPoint: ExtensionPoint = {
+export const uploadMenuExtensionPoint: ExtensionPoint<ActionExtension> = {
   id: 'app.files.upload-menu',
   extensionType: 'action',
   multiple: true
 }
-export const quickActionsExtensionPoint: ExtensionPoint = {
+export const quickActionsExtensionPoint: ExtensionPoint<ActionExtension> = {
   id: 'app.files.quick-actions',
   extensionType: 'action',
   multiple: true
 }
-export const batchActionsExtensionPoint: ExtensionPoint = {
+export const batchActionsExtensionPoint: ExtensionPoint<ActionExtension> = {
   id: 'app.files.batch-actions',
   extensionType: 'action',
   multiple: true
 }
-export const contextActionsExtensionPoint: ExtensionPoint = {
+export const contextActionsExtensionPoint: ExtensionPoint<ActionExtension> = {
   id: 'app.files.context-actions',
   extensionType: 'action',
   multiple: true
 }
-export const fileSideBarExtensionPoint: ExtensionPoint = {
+export const fileSideBarExtensionPoint: ExtensionPoint<SidebarPanelExtension<any, any, any>> = {
   id: 'app.files.sidebar',
   extensionType: 'sidebarPanel',
   multiple: true
 }
-export const folderViewsFolderExtensionPoint: ExtensionPoint = {
+export const folderViewsFolderExtensionPoint: ExtensionPoint<FolderViewExtension> = {
   id: 'app.files.folder-views.folder',
   extensionType: 'folderView'
 }
-export const folderViewsFavoritesExtensionPoint: ExtensionPoint = {
+export const folderViewsFavoritesExtensionPoint: ExtensionPoint<FolderViewExtension> = {
   id: 'app.files.folder-views.favorites',
   extensionType: 'folderView'
 }
-export const folderViewsProjectSpacesExtensionPoint: ExtensionPoint = {
+export const folderViewsProjectSpacesExtensionPoint: ExtensionPoint<FolderViewExtension> = {
   id: 'app.files.folder-views.project-spaces',
   extensionType: 'folderView'
 }
 
 export const extensionPoints = () => {
-  return computed<ExtensionPoint[]>(() => {
+  return computed<ExtensionPoint<any>[]>(() => {
     return [
       uploadMenuExtensionPoint,
       quickActionsExtensionPoint,

--- a/packages/web-app-files/src/extensionPoints.ts
+++ b/packages/web-app-files/src/extensionPoints.ts
@@ -1,0 +1,55 @@
+import { ExtensionPoint } from '@ownclouders/web-pkg'
+import { computed } from 'vue'
+
+export const uploadMenuExtensionPointId = 'app.files.upload-menu'
+export const quickActionsExtensionPointId = 'app.files.quick-actions'
+export const batchActionsExtensionPointId = 'app.files.batch-actions'
+export const contextActionsExtensionPointId = 'app.files.context-actions'
+export const fileSideBarExtensionPointId = 'app.files.sidebar'
+export const folderViewsFolder = 'app.files.folder-views.folder'
+export const folderViewsFavorites = 'app.files.folder-views.favorites'
+export const folderViewsProjectSpaces = 'app.files.folder-views.project-spaces'
+
+export const extensionPoints = () => {
+  return computed<ExtensionPoint[]>(() => {
+    return [
+      {
+        id: uploadMenuExtensionPointId,
+        extensionType: 'action',
+        multiple: true
+      },
+      {
+        id: quickActionsExtensionPointId,
+        extensionType: 'action',
+        multiple: true
+      },
+      {
+        id: batchActionsExtensionPointId,
+        extensionType: 'action',
+        multiple: true
+      },
+      {
+        id: contextActionsExtensionPointId,
+        extensionType: 'action',
+        multiple: true
+      },
+      {
+        id: fileSideBarExtensionPointId,
+        extensionType: 'sidebarPanel',
+        multiple: true
+      },
+      {
+        id: folderViewsFolder,
+        extensionType: 'folderView'
+      },
+      {
+        id: folderViewsFavorites,
+        extensionType: 'folderView'
+      },
+      {
+        id: folderViewsProjectSpaces,
+        extensionType: 'folderView'
+      }
+    ]
+  })
+}

--- a/packages/web-app-files/src/extensions.ts
+++ b/packages/web-app-files/src/extensions.ts
@@ -1,15 +1,16 @@
 import {
   Extension,
-  useRouter,
-  useSearch,
-  useFileActionsShowShares,
+  useCapabilityStore,
   useFileActionsCopyQuickLink,
-  useCapabilityStore
+  useFileActionsShowShares,
+  useRouter,
+  useSearch
 } from '@ownclouders/web-pkg'
 import { computed, unref } from 'vue'
 import { SDKSearch } from './search'
 import { useSideBarPanels } from './composables/extensions/useFileSideBars'
 import { useFolderViews } from './composables/extensions/useFolderViews'
+import { quickActionsExtensionPointId } from './extensionPoints'
 
 export const extensions = () => {
   const capabilityStore = useCapabilityStore()
@@ -34,13 +35,13 @@ export const extensions = () => {
         },
         {
           id: 'com.github.owncloud.web.files.quick-action.collaborator',
-          scopes: ['resource', 'resource.quick-action'],
+          extensionPointIds: [quickActionsExtensionPointId],
           type: 'action',
           action: unref(showSharesActions)[0]
         },
         {
           id: 'com.github.owncloud.web.files.quick-action.quicklink',
-          scopes: ['resource', 'resource.quick-action'],
+          extensionPointIds: [quickActionsExtensionPointId],
           type: 'action',
           action: unref(quickLinkActions)[0]
         }

--- a/packages/web-app-files/src/extensions.ts
+++ b/packages/web-app-files/src/extensions.ts
@@ -10,7 +10,7 @@ import { computed, unref } from 'vue'
 import { SDKSearch } from './search'
 import { useSideBarPanels } from './composables/extensions/useFileSideBars'
 import { useFolderViews } from './composables/extensions/useFolderViews'
-import { quickActionsExtensionPointId } from './extensionPoints'
+import { quickActionsExtensionPoint } from './extensionPoints'
 
 export const extensions = () => {
   const capabilityStore = useCapabilityStore()
@@ -35,13 +35,13 @@ export const extensions = () => {
         },
         {
           id: 'com.github.owncloud.web.files.quick-action.collaborator',
-          extensionPointIds: [quickActionsExtensionPointId],
+          extensionPointIds: [quickActionsExtensionPoint.id],
           type: 'action',
           action: unref(showSharesActions)[0]
         },
         {
           id: 'com.github.owncloud.web.files.quick-action.quicklink',
-          extensionPointIds: [quickActionsExtensionPointId],
+          extensionPointIds: [quickActionsExtensionPoint.id],
           type: 'action',
           action: unref(quickLinkActions)[0]
         }

--- a/packages/web-app-files/src/extensions.ts
+++ b/packages/web-app-files/src/extensions.ts
@@ -20,31 +20,29 @@ export const extensions = () => {
   const { actions: showSharesActions } = useFileActionsShowShares()
   const { actions: quickLinkActions } = useFileActionsCopyQuickLink()
 
-  const panels = useSideBarPanels()
-  const folderViews = useFolderViews()
+  const folderViewExtensions = useFolderViews()
+  const sideBarPanelExtensions = useSideBarPanels()
 
-  return computed(
-    () =>
-      [
-        ...folderViews,
-        ...unref(panels),
-        {
-          id: 'com.github.owncloud.web.files.search',
-          type: 'search',
-          searchProvider: new SDKSearch(capabilityStore, router, searchFunction)
-        },
-        {
-          id: 'com.github.owncloud.web.files.quick-action.collaborator',
-          extensionPointIds: [quickActionsExtensionPoint.id],
-          type: 'action',
-          action: unref(showSharesActions)[0]
-        },
-        {
-          id: 'com.github.owncloud.web.files.quick-action.quicklink',
-          extensionPointIds: [quickActionsExtensionPoint.id],
-          type: 'action',
-          action: unref(quickLinkActions)[0]
-        }
-      ] satisfies Extension[]
-  )
+  return computed<Extension[]>(() => [
+    ...folderViewExtensions,
+    ...sideBarPanelExtensions,
+    {
+      id: 'com.github.owncloud.web.files.search',
+      extensionPointIds: ['app.search.provider'],
+      type: 'search',
+      searchProvider: new SDKSearch(capabilityStore, router, searchFunction)
+    },
+    {
+      id: 'com.github.owncloud.web.files.quick-action.collaborator',
+      extensionPointIds: [quickActionsExtensionPoint.id],
+      type: 'action',
+      action: unref(showSharesActions)[0]
+    },
+    {
+      id: 'com.github.owncloud.web.files.quick-action.quicklink',
+      extensionPointIds: [quickActionsExtensionPoint.id],
+      type: 'action',
+      action: unref(quickLinkActions)[0]
+    }
+  ])
 }

--- a/packages/web-app-files/src/index.ts
+++ b/packages/web-app-files/src/index.ts
@@ -36,8 +36,7 @@ const appInfo: ApplicationInformation = {
   icon: 'resource-type-folder',
   color: 'var(--oc-color-swatch-primary-muted)',
   isFileEditor: false,
-  extensions: [],
-  extensionPoints: []
+  extensions: []
 }
 
 export const navItems = (context: ComponentCustomProperties): AppNavigationItem[] => {

--- a/packages/web-app-files/src/index.ts
+++ b/packages/web-app-files/src/index.ts
@@ -23,6 +23,7 @@ import { AppNavigationItem } from '@ownclouders/web-pkg'
 import SearchResults from '../../web-app-search/src/views/List.vue'
 import { isPersonalSpaceResource, isShareSpaceResource } from '@ownclouders/web-client'
 import { ComponentCustomProperties } from 'vue'
+import { extensionPoints } from './extensionPoints'
 
 // just a dummy function to trick gettext tools
 function $gettext(msg: string) {
@@ -35,7 +36,8 @@ const appInfo: ApplicationInformation = {
   icon: 'resource-type-folder',
   color: 'var(--oc-color-swatch-primary-muted)',
   isFileEditor: false,
-  extensions: []
+  extensions: [],
+  extensionPoints: []
 }
 
 export const navItems = (context: ComponentCustomProperties): AppNavigationItem[] => {
@@ -158,7 +160,8 @@ export default defineWebApplication({
       }),
       navItems,
       translations,
-      extensions: extensions()
+      extensions: extensions(),
+      extensionPoints: extensionPoints()
     }
   }
 })

--- a/packages/web-app-files/src/views/Favorites.vue
+++ b/packages/web-app-files/src/views/Favorites.vue
@@ -98,7 +98,7 @@ import FilesViewWrapper from '../components/FilesViewWrapper.vue'
 import { useResourcesViewDefaults } from '../composables'
 import { useFileActions } from '@ownclouders/web-pkg'
 import { storeToRefs } from 'pinia'
-import { folderViewsFavorites } from '../extensionPoints'
+import { folderViewsFavoritesExtensionPoint } from '../extensionPoints'
 
 const visibilityObserver = new VisibilityObserver()
 
@@ -131,8 +131,8 @@ export default defineComponent({
     const viewModes = computed(() => {
       return [
         ...extensionRegistry
-          .requestExtensions<FolderViewExtension>('folderView', {
-            extensionPointIds: [folderViewsFavorites]
+          .requestExtensions<FolderViewExtension>({
+            extensionPoint: folderViewsFavoritesExtensionPoint
           })
           .map((e) => e.folderView)
       ]

--- a/packages/web-app-files/src/views/Favorites.vue
+++ b/packages/web-app-files/src/views/Favorites.vue
@@ -68,7 +68,8 @@ import {
   defineComponent,
   onBeforeUnmount,
   onMounted,
-  ref
+  ref,
+  unref
 } from 'vue'
 import { debounce } from 'lodash-es'
 
@@ -97,7 +98,7 @@ import FilesViewWrapper from '../components/FilesViewWrapper.vue'
 import { useResourcesViewDefaults } from '../composables'
 import { useFileActions } from '@ownclouders/web-pkg'
 import { storeToRefs } from 'pinia'
-import { unref } from 'vue'
+import { folderViewsFavorites } from '../extensionPoints'
 
 const visibilityObserver = new VisibilityObserver()
 
@@ -130,7 +131,9 @@ export default defineComponent({
     const viewModes = computed(() => {
       return [
         ...extensionRegistry
-          .requestExtensions<FolderViewExtension>('folderView', { scopes: ['favorite'] })
+          .requestExtensions<FolderViewExtension>('folderView', {
+            extensionPointIds: [folderViewsFavorites]
+          })
           .map((e) => e.folderView)
       ]
     })

--- a/packages/web-app-files/src/views/Favorites.vue
+++ b/packages/web-app-files/src/views/Favorites.vue
@@ -75,7 +75,6 @@ import { debounce } from 'lodash-es'
 
 import { Resource } from '@ownclouders/web-client'
 import {
-  FolderViewExtension,
   VisibilityObserver,
   useExtensionRegistry,
   useConfigStore,
@@ -131,9 +130,7 @@ export default defineComponent({
     const viewModes = computed(() => {
       return [
         ...extensionRegistry
-          .requestExtensions<FolderViewExtension>({
-            extensionPoint: folderViewsFavoritesExtensionPoint
-          })
+          .requestExtensions(folderViewsFavoritesExtensionPoint)
           .map((e) => e.folderView)
       ]
     })

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -146,7 +146,6 @@ import {
 } from '@ownclouders/web-client'
 
 import {
-  FolderViewExtension,
   ProcessorType,
   ResourceTransfer,
   TransferType,
@@ -274,9 +273,7 @@ export default defineComponent({
     const viewModes = computed(() => {
       return [
         ...extensionRegistry
-          .requestExtensions<FolderViewExtension>({
-            extensionPoint: folderViewsFolderExtensionPoint
-          })
+          .requestExtensions(folderViewsFolderExtensionPoint)
           .map((e) => e.folderView)
       ]
     })

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -203,7 +203,7 @@ import {
 } from 'web-app-files/src/composables/keyboardActions'
 import { storeToRefs } from 'pinia'
 import { ComponentPublicInstance } from 'vue'
-import { folderViewsFolder } from '../../extensionPoints'
+import { folderViewsFolderExtensionPoint } from '../../extensionPoints'
 
 const visibilityObserver = new VisibilityObserver()
 
@@ -274,8 +274,8 @@ export default defineComponent({
     const viewModes = computed(() => {
       return [
         ...extensionRegistry
-          .requestExtensions<FolderViewExtension>('folderView', {
-            extensionPointIds: [folderViewsFolder]
+          .requestExtensions<FolderViewExtension>({
+            extensionPoint: folderViewsFolderExtensionPoint
           })
           .map((e) => e.folderView)
       ]

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -203,6 +203,7 @@ import {
 } from 'web-app-files/src/composables/keyboardActions'
 import { storeToRefs } from 'pinia'
 import { ComponentPublicInstance } from 'vue'
+import { folderViewsFolder } from '../../extensionPoints'
 
 const visibilityObserver = new VisibilityObserver()
 
@@ -273,7 +274,9 @@ export default defineComponent({
     const viewModes = computed(() => {
       return [
         ...extensionRegistry
-          .requestExtensions<FolderViewExtension>('folderView', { scopes: ['resource'] })
+          .requestExtensions<FolderViewExtension>('folderView', {
+            extensionPointIds: [folderViewsFolder]
+          })
           .map((e) => e.folderView)
       ]
     })

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -205,7 +205,7 @@ import {
 } from 'web-app-files/src/composables/keyboardActions'
 import { orderBy } from 'lodash-es'
 import { useResourcesViewDefaults } from '../../composables'
-import { folderViewsProjectSpaces } from '../../extensionPoints'
+import { folderViewsProjectSpacesExtensionPoint } from '../../extensionPoints'
 
 export default defineComponent({
   components: {
@@ -326,8 +326,8 @@ export default defineComponent({
     const viewModes = computed(() => {
       return [
         ...extensionRegistry
-          .requestExtensions<FolderViewExtension>('folderView', {
-            extensionPointIds: [folderViewsProjectSpaces]
+          .requestExtensions<FolderViewExtension>({
+            extensionPoint: folderViewsProjectSpacesExtensionPoint
           })
           .map((e) => e.folderView)
       ]

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -205,6 +205,7 @@ import {
 } from 'web-app-files/src/composables/keyboardActions'
 import { orderBy } from 'lodash-es'
 import { useResourcesViewDefaults } from '../../composables'
+import { folderViewsProjectSpaces } from '../../extensionPoints'
 
 export default defineComponent({
   components: {
@@ -325,7 +326,9 @@ export default defineComponent({
     const viewModes = computed(() => {
       return [
         ...extensionRegistry
-          .requestExtensions<FolderViewExtension>('folderView', { scopes: ['space'] })
+          .requestExtensions<FolderViewExtension>('folderView', {
+            extensionPointIds: [folderViewsProjectSpaces]
+          })
           .map((e) => e.folderView)
       ]
     })

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -159,7 +159,6 @@ import {
   useConfigStore,
   useResourcesStore,
   useSpacesStore,
-  FolderViewExtension,
   useExtensionRegistry
 } from '@ownclouders/web-pkg'
 
@@ -326,9 +325,7 @@ export default defineComponent({
     const viewModes = computed(() => {
       return [
         ...extensionRegistry
-          .requestExtensions<FolderViewExtension>({
-            extensionPoint: folderViewsProjectSpacesExtensionPoint
-          })
+          .requestExtensions(folderViewsProjectSpacesExtensionPoint)
           .map((e) => e.folderView)
       ]
     })

--- a/packages/web-app-files/tests/unit/components/FilesList/QuickActions.spec.ts
+++ b/packages/web-app-files/tests/unit/components/FilesList/QuickActions.spec.ts
@@ -5,6 +5,7 @@ import { useExtensionRegistry } from '@ownclouders/web-pkg'
 import { mock } from 'vitest-mock-extended'
 import { ref } from 'vue'
 import { Resource } from '@ownclouders/web-client'
+import { quickActionsExtensionPointId } from '../../../../src/extensionPoints'
 
 vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
   ...(await importOriginal<any>()),
@@ -20,7 +21,7 @@ const collaboratorAction = {
   label: () => 'Add people'
 }
 
-const quicklinkAction = {
+const quickLinkAction = {
   isVisible: vi.fn(() => false),
   handler: vi.fn(),
   icon: 'link-add',
@@ -89,8 +90,14 @@ function getWrapper({ embedModeEnabled = false } = {}) {
 
   const { requestExtensions } = useExtensionRegistry()
   vi.mocked(requestExtensions).mockReturnValue([
-    mock<ActionExtension>({ scopes: ['resource.quick-action'], action: collaboratorAction }),
-    mock<ActionExtension>({ scopes: ['resource.quick-action'], action: quicklinkAction })
+    mock<ActionExtension>({
+      extensionPointIds: [quickActionsExtensionPointId],
+      action: collaboratorAction
+    }),
+    mock<ActionExtension>({
+      extensionPointIds: [quickActionsExtensionPointId],
+      action: quickLinkAction
+    })
   ])
 
   return {

--- a/packages/web-app-files/tests/unit/components/FilesList/QuickActions.spec.ts
+++ b/packages/web-app-files/tests/unit/components/FilesList/QuickActions.spec.ts
@@ -5,7 +5,7 @@ import { useExtensionRegistry } from '@ownclouders/web-pkg'
 import { mock } from 'vitest-mock-extended'
 import { ref } from 'vue'
 import { Resource } from '@ownclouders/web-client'
-import { quickActionsExtensionPointId } from '../../../../src/extensionPoints'
+import { quickActionsExtensionPoint } from '../../../../src/extensionPoints'
 
 vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
   ...(await importOriginal<any>()),
@@ -91,11 +91,11 @@ function getWrapper({ embedModeEnabled = false } = {}) {
   const { requestExtensions } = useExtensionRegistry()
   vi.mocked(requestExtensions).mockReturnValue([
     mock<ActionExtension>({
-      extensionPointIds: [quickActionsExtensionPointId],
+      extensionPointIds: [quickActionsExtensionPoint.id],
       action: collaboratorAction
     }),
     mock<ActionExtension>({
-      extensionPointIds: [quickActionsExtensionPointId],
+      extensionPointIds: [quickActionsExtensionPoint.id],
       action: quickLinkAction
     })
   ])

--- a/packages/web-app-files/tests/unit/views/Favorites.spec.ts
+++ b/packages/web-app-files/tests/unit/views/Favorites.spec.ts
@@ -6,7 +6,7 @@ import { mockDeep, mock } from 'vitest-mock-extended'
 import { Resource } from '@ownclouders/web-client'
 import { defaultPlugins, defaultStubs, mount, defaultComponentMocks } from 'web-test-helpers'
 import { RouteLocation } from 'vue-router'
-import { Extension, useExtensionRegistry } from '@ownclouders/web-pkg'
+import { FolderViewExtension, useExtensionRegistry } from '@ownclouders/web-pkg'
 import {
   folderViewsFavoritesExtensionPoint,
   folderViewsFolderExtensionPoint,
@@ -79,7 +79,7 @@ function getMountedWrapper({
         component: h('div', { class: 'resource-table' })
       }
     }
-  ] satisfies Extension[]
+  ] satisfies FolderViewExtension[]
   const { requestExtensions } = useExtensionRegistry()
   vi.mocked(requestExtensions).mockReturnValue(extensions)
 

--- a/packages/web-app-files/tests/unit/views/Favorites.spec.ts
+++ b/packages/web-app-files/tests/unit/views/Favorites.spec.ts
@@ -7,6 +7,11 @@ import { Resource } from '@ownclouders/web-client'
 import { defaultPlugins, defaultStubs, mount, defaultComponentMocks } from 'web-test-helpers'
 import { RouteLocation } from 'vue-router'
 import { Extension, useExtensionRegistry } from '@ownclouders/web-pkg'
+import {
+  folderViewsFavorites,
+  folderViewsFolder,
+  folderViewsProjectSpaces
+} from '../../../src/extensionPoints'
 
 vi.mock('web-app-files/src/composables')
 vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
@@ -59,7 +64,7 @@ function getMountedWrapper({
     {
       id: 'com.github.owncloud.web.files.folder-view.resource-table',
       type: 'folderView',
-      scopes: ['resource', 'space', 'favorite'],
+      extensionPointIds: [folderViewsFolder, folderViewsProjectSpaces, folderViewsFavorites],
       folderView: {
         name: 'resource-table',
         label: 'Switch to default view',

--- a/packages/web-app-files/tests/unit/views/Favorites.spec.ts
+++ b/packages/web-app-files/tests/unit/views/Favorites.spec.ts
@@ -8,9 +8,9 @@ import { defaultPlugins, defaultStubs, mount, defaultComponentMocks } from 'web-
 import { RouteLocation } from 'vue-router'
 import { Extension, useExtensionRegistry } from '@ownclouders/web-pkg'
 import {
-  folderViewsFavorites,
-  folderViewsFolder,
-  folderViewsProjectSpaces
+  folderViewsFavoritesExtensionPoint,
+  folderViewsFolderExtensionPoint,
+  folderViewsProjectSpacesExtensionPoint
 } from '../../../src/extensionPoints'
 
 vi.mock('web-app-files/src/composables')
@@ -64,7 +64,11 @@ function getMountedWrapper({
     {
       id: 'com.github.owncloud.web.files.folder-view.resource-table',
       type: 'folderView',
-      extensionPointIds: [folderViewsFolder, folderViewsProjectSpaces, folderViewsFavorites],
+      extensionPointIds: [
+        folderViewsFolderExtensionPoint.id,
+        folderViewsProjectSpacesExtensionPoint.id,
+        folderViewsFavoritesExtensionPoint.id
+      ],
       folderView: {
         name: 'resource-table',
         label: 'Switch to default view',

--- a/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
@@ -22,6 +22,11 @@ import {
 import { useBreadcrumbsFromPathMock } from '../../../mocks/useBreadcrumbsFromPathMock'
 import { h } from 'vue'
 import { BreadcrumbItem } from 'design-system/src/components/OcBreadcrumb/types'
+import {
+  folderViewsFavorites,
+  folderViewsFolder,
+  folderViewsProjectSpaces
+} from '../../../../src/extensionPoints'
 
 const mockCreateFolder = vi.fn()
 const mockUseEmbedMode = vi.fn().mockReturnValue({ isEnabled: computed(() => false) })
@@ -325,7 +330,7 @@ function getMountedWrapper({
     {
       id: 'com.github.owncloud.web.files.folder-view.resource-table',
       type: 'folderView',
-      scopes: ['resource', 'space', 'favorite'],
+      extensionPointIds: [folderViewsFolder, folderViewsProjectSpaces, folderViewsFavorites],
       folderView: {
         name: 'resource-table',
         label: 'Switch to default view',

--- a/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
@@ -15,7 +15,7 @@ import {
 } from 'web-test-helpers'
 import {
   AppBar,
-  Extension,
+  FolderViewExtension,
   useBreadcrumbsFromPath,
   useExtensionRegistry
 } from '@ownclouders/web-pkg'
@@ -345,7 +345,7 @@ function getMountedWrapper({
         component: h('div', { class: 'resource-table' })
       }
     }
-  ] satisfies Extension[]
+  ] satisfies FolderViewExtension[]
   const { requestExtensions } = useExtensionRegistry()
   vi.mocked(requestExtensions).mockReturnValue(extensions)
 

--- a/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
@@ -23,9 +23,9 @@ import { useBreadcrumbsFromPathMock } from '../../../mocks/useBreadcrumbsFromPat
 import { h } from 'vue'
 import { BreadcrumbItem } from 'design-system/src/components/OcBreadcrumb/types'
 import {
-  folderViewsFavorites,
-  folderViewsFolder,
-  folderViewsProjectSpaces
+  folderViewsFavoritesExtensionPoint,
+  folderViewsFolderExtensionPoint,
+  folderViewsProjectSpacesExtensionPoint
 } from '../../../../src/extensionPoints'
 
 const mockCreateFolder = vi.fn()
@@ -330,7 +330,11 @@ function getMountedWrapper({
     {
       id: 'com.github.owncloud.web.files.folder-view.resource-table',
       type: 'folderView',
-      extensionPointIds: [folderViewsFolder, folderViewsProjectSpaces, folderViewsFavorites],
+      extensionPointIds: [
+        folderViewsFolderExtensionPoint.id,
+        folderViewsProjectSpacesExtensionPoint.id,
+        folderViewsFavoritesExtensionPoint.id
+      ],
       folderView: {
         name: 'resource-table',
         label: 'Switch to default view',

--- a/packages/web-app-files/tests/unit/views/spaces/Projects.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/Projects.spec.ts
@@ -17,9 +17,9 @@ import {
 } from 'web-test-helpers'
 import { AbilityRule, SpaceResource } from '@ownclouders/web-client'
 import {
-  folderViewsFavorites,
-  folderViewsFolder,
-  folderViewsProjectSpaces
+  folderViewsFavoritesExtensionPoint,
+  folderViewsFolderExtensionPoint,
+  folderViewsProjectSpacesExtensionPoint
 } from '../../../../src/extensionPoints'
 
 vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
@@ -121,7 +121,11 @@ function getMountedWrapper({
     {
       id: 'com.github.owncloud.web.files.folder-view.resource-table',
       type: 'folderView',
-      extensionPointIds: [folderViewsFolder, folderViewsProjectSpaces, folderViewsFavorites],
+      extensionPointIds: [
+        folderViewsFolderExtensionPoint.id,
+        folderViewsProjectSpacesExtensionPoint.id,
+        folderViewsFavoritesExtensionPoint.id
+      ],
       folderView: {
         name: 'resource-table',
         label: 'Switch to default view',

--- a/packages/web-app-files/tests/unit/views/spaces/Projects.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/Projects.spec.ts
@@ -5,7 +5,7 @@ import {
   queryItemAsString,
   useFileActionsDelete,
   useExtensionRegistry,
-  Extension
+  FolderViewExtension
 } from '@ownclouders/web-pkg'
 
 import {
@@ -136,7 +136,7 @@ function getMountedWrapper({
         component: h('div', { class: 'resource-table' })
       }
     }
-  ] satisfies Extension[]
+  ] satisfies FolderViewExtension[]
   const { requestExtensions } = useExtensionRegistry()
   vi.mocked(requestExtensions).mockReturnValue(extensions)
 

--- a/packages/web-app-files/tests/unit/views/spaces/Projects.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/Projects.spec.ts
@@ -16,6 +16,11 @@ import {
   RouteLocation
 } from 'web-test-helpers'
 import { AbilityRule, SpaceResource } from '@ownclouders/web-client'
+import {
+  folderViewsFavorites,
+  folderViewsFolder,
+  folderViewsProjectSpaces
+} from '../../../../src/extensionPoints'
 
 vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
   ...(await importOriginal<any>()),
@@ -116,7 +121,7 @@ function getMountedWrapper({
     {
       id: 'com.github.owncloud.web.files.folder-view.resource-table',
       type: 'folderView',
-      scopes: ['resource', 'space', 'favorite'],
+      extensionPointIds: [folderViewsFolder, folderViewsProjectSpaces, folderViewsFavorites],
       folderView: {
         name: 'resource-table',
         label: 'Switch to default view',

--- a/packages/web-app-importer/src/extensions.ts
+++ b/packages/web-app-importer/src/extensions.ts
@@ -123,7 +123,7 @@ export const extensions = ({ applicationConfig }: ApplicationSetupOptions) => {
         {
           id: 'com.github.owncloud.web.import-file',
           type: 'action',
-          scopes: ['resource', 'upload-menu'],
+          extensionPointIds: ['app.files.upload-menu'],
           action: {
             name: 'import-files',
             icon: 'cloud',

--- a/packages/web-app-importer/src/extensions.ts
+++ b/packages/web-app-importer/src/extensions.ts
@@ -117,35 +117,32 @@ export const extensions = ({ applicationConfig }: ApplicationSetupOptions) => {
     }
   }
 
-  return computed(
-    () =>
-      [
-        {
-          id: 'com.github.owncloud.web.import-file',
-          type: 'action',
-          extensionPointIds: ['app.files.upload-menu'],
-          action: {
-            name: 'import-files',
-            icon: 'cloud',
-            handler,
-            label: () => $gettext('Import'),
-            isVisible: () => {
-              if (!companionUrl) {
-                return false
-              }
-
-              if (authStore.publicLinkContextReady) {
-                return false
-              }
-
-              return unref(canUpload) && supportedClouds.length
-            },
-            isDisabled: () => !!Object.keys(uppyService.getCurrentUploads()).length,
-            disabledTooltip: () => $gettext('Please wait until all imports have finished'),
-            componentType: 'button',
-            class: 'oc-files-actions-import'
+  return computed<Extension[]>(() => [
+    {
+      id: 'com.github.owncloud.web.import-file',
+      type: 'action',
+      extensionPointIds: ['app.files.upload-menu'],
+      action: {
+        name: 'import-files',
+        icon: 'cloud',
+        handler,
+        label: () => $gettext('Import'),
+        isVisible: () => {
+          if (!companionUrl) {
+            return false
           }
-        }
-      ] satisfies Extension[]
-  )
+
+          if (authStore.publicLinkContextReady) {
+            return false
+          }
+
+          return unref(canUpload) && supportedClouds.length
+        },
+        isDisabled: () => !!Object.keys(uppyService.getCurrentUploads()).length,
+        disabledTooltip: () => $gettext('Please wait until all imports have finished'),
+        componentType: 'button',
+        class: 'oc-files-actions-import'
+      }
+    }
+  ])
 }

--- a/packages/web-app-importer/tests/unit/extensions.spec.ts
+++ b/packages/web-app-importer/tests/unit/extensions.spec.ts
@@ -3,11 +3,11 @@ import { unref } from 'vue'
 import { Resource } from '@ownclouders/web-client'
 import { mock, mockDeep } from 'vitest-mock-extended'
 import { extensions } from '../../src/extensions'
-import { ApplicationSetupOptions, UppyService } from '@ownclouders/web-pkg'
+import { ActionExtension, ApplicationSetupOptions, UppyService } from '@ownclouders/web-pkg'
 
 const getAction = (opts: ApplicationSetupOptions) => {
-  const { action } = unref(extensions(opts))[0]
-  return action
+  const importFileExtension = unref(extensions(opts))[0] as ActionExtension
+  return importFileExtension.action
 }
 
 describe('useFileActionsImport', () => {
@@ -16,7 +16,7 @@ describe('useFileActionsImport', () => {
       getWrapper({
         currentFolder: mock<Resource>({ canUpload: () => true }),
         setup: () => {
-          const action = unref(extensions({ applicationConfig: {} }))[0].action
+          const action = getAction({ applicationConfig: {} })
           expect(action.isVisible()).toBeFalsy()
         }
       })
@@ -52,14 +52,12 @@ describe('useFileActionsImport', () => {
       getWrapper({
         currentFolder: mock<Resource>({ canUpload: () => true }),
         setup: () => {
-          const action = unref(
-            extensions({
-              applicationConfig: {
-                companionUrl: 'companionUrl',
-                supportedClouds: []
-              }
-            })
-          )[0].action
+          const action = getAction({
+            applicationConfig: {
+              companionUrl: 'companionUrl',
+              supportedClouds: []
+            }
+          })
           expect(action.isVisible()).toBeFalsy()
         }
       })

--- a/packages/web-app-ocm/src/extensions.ts
+++ b/packages/web-app-ocm/src/extensions.ts
@@ -52,13 +52,17 @@ export const extensions = () => {
         {
           id: 'com.github.owncloud.web.open-file-remote',
           type: 'action',
-          scopes: ['resource', 'resource.context-menu'],
+          extensionPointIds: ['app.files.context-actions'],
           action: {
             name: 'open-file-remote',
+            category: 'actions',
             icon: 'remote-control',
             handler,
             label: () => $gettext('Open remotely'),
             isVisible: ({ resources }: FileActionOptions) => {
+              if (!resources?.length) {
+                return false
+              }
               return (
                 configStore.options.ocm.openRemotely &&
                 resources[0]?.storageId?.startsWith(OCM_PROVIDER_ID)

--- a/packages/web-app-ocm/src/extensions.ts
+++ b/packages/web-app-ocm/src/extensions.ts
@@ -50,7 +50,7 @@ export const extensions = () => {
     {
       id: 'com.github.owncloud.web.open-file-remote',
       type: 'action',
-      extensionPointIds: ['app.files.context-actions'],
+      extensionPointIds: ['global.files.context-actions'],
       action: {
         name: 'open-file-remote',
         category: 'actions',

--- a/packages/web-app-ocm/src/extensions.ts
+++ b/packages/web-app-ocm/src/extensions.ts
@@ -46,32 +46,29 @@ export const extensions = () => {
     }
   }
 
-  return computed(
-    () =>
-      [
-        {
-          id: 'com.github.owncloud.web.open-file-remote',
-          type: 'action',
-          extensionPointIds: ['app.files.context-actions'],
-          action: {
-            name: 'open-file-remote',
-            category: 'actions',
-            icon: 'remote-control',
-            handler,
-            label: () => $gettext('Open remotely'),
-            isVisible: ({ resources }: FileActionOptions) => {
-              if (!resources?.length) {
-                return false
-              }
-              return (
-                configStore.options.ocm.openRemotely &&
-                resources[0]?.storageId?.startsWith(OCM_PROVIDER_ID)
-              )
-            },
-            componentType: 'button',
-            class: 'oc-files-actions-open-file-remote'
+  return computed<Extension[]>(() => [
+    {
+      id: 'com.github.owncloud.web.open-file-remote',
+      type: 'action',
+      extensionPointIds: ['app.files.context-actions'],
+      action: {
+        name: 'open-file-remote',
+        category: 'actions',
+        icon: 'remote-control',
+        handler,
+        label: () => $gettext('Open remotely'),
+        isVisible: ({ resources }: FileActionOptions) => {
+          if (!resources?.length) {
+            return false
           }
-        }
-      ] satisfies Extension[]
-  )
+          return (
+            configStore.options.ocm.openRemotely &&
+            resources[0]?.storageId?.startsWith(OCM_PROVIDER_ID)
+          )
+        },
+        componentType: 'button',
+        class: 'oc-files-actions-open-file-remote'
+      }
+    }
+  ])
 }

--- a/packages/web-app-search/src/composables/useAvailableProviders.ts
+++ b/packages/web-app-search/src/composables/useAvailableProviders.ts
@@ -4,11 +4,9 @@ import { computed, Ref } from 'vue'
 export const useAvailableProviders = (): Ref<SearchProvider[]> => {
   const extensionRegistry = useExtensionRegistry()
 
-  const availableProviders = computed(() => {
+  return computed(() => {
     return extensionRegistry
-      .requestExtensions<SearchExtension>('search')
+      .requestExtensions<SearchExtension>({ extensionType: 'search' })
       .map(({ searchProvider }) => searchProvider)
   })
-
-  return availableProviders
 }

--- a/packages/web-app-search/src/composables/useAvailableProviders.ts
+++ b/packages/web-app-search/src/composables/useAvailableProviders.ts
@@ -1,12 +1,13 @@
-import { SearchExtension, SearchProvider, useExtensionRegistry } from '@ownclouders/web-pkg'
+import { SearchProvider, useExtensionRegistry } from '@ownclouders/web-pkg'
 import { computed, Ref } from 'vue'
+import { searchProviderExtensionPoint } from '../extensionPoints'
 
 export const useAvailableProviders = (): Ref<SearchProvider[]> => {
   const extensionRegistry = useExtensionRegistry()
 
   return computed(() => {
     return extensionRegistry
-      .requestExtensions<SearchExtension>({ extensionType: 'search' })
+      .requestExtensions(searchProviderExtensionPoint)
       .map(({ searchProvider }) => searchProvider)
   })
 }

--- a/packages/web-app-search/src/extensionPoints.ts
+++ b/packages/web-app-search/src/extensionPoints.ts
@@ -1,0 +1,14 @@
+import { ExtensionPoint, SearchExtension } from '@ownclouders/web-pkg'
+import { computed } from 'vue'
+
+export const searchProviderExtensionPoint: ExtensionPoint<SearchExtension> = {
+  id: 'app.search.provider',
+  extensionType: 'search',
+  multiple: true
+}
+
+export const extensionPoints = () => {
+  return computed<ExtensionPoint<any>[]>(() => {
+    return [searchProviderExtensionPoint]
+  })
+}

--- a/packages/web-app-search/src/extensions.ts
+++ b/packages/web-app-search/src/extensions.ts
@@ -1,0 +1,16 @@
+import { computed } from 'vue'
+import { CustomComponentExtension, Extension } from '@ownclouders/web-pkg'
+import SearchBar from './portals/SearchBar.vue'
+
+const searchBarExtension: CustomComponentExtension = {
+  id: 'com.github.owncloud.web.search.search-bar',
+  type: 'customComponent',
+  extensionPointIds: ['app.runtime.header.center'],
+  content: SearchBar
+}
+
+export const extensions = () => {
+  return computed<Extension[]>(() => {
+    return [searchBarExtension]
+  })
+}

--- a/packages/web-app-search/src/index.ts
+++ b/packages/web-app-search/src/index.ts
@@ -1,48 +1,49 @@
-import SearchBar from './portals/SearchBar.vue'
 import App from './App.vue'
 import List from './views/List.vue'
-import { Component } from 'vue'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import translations from '../l10n/translations.json'
+import { ApplicationInformation, defineWebApplication } from '@ownclouders/web-pkg'
+import { extensions } from './extensions'
+import { extensionPoints } from './extensionPoints'
 
 // just a dummy function to trick gettext tools
 const $gettext = (msg: string) => {
   return msg
 }
 
-export default {
-  appInfo: {
-    name: $gettext('Search'),
-    id: 'search',
-    icon: 'folder'
-  },
-  routes: [
-    {
-      name: 'search',
-      path: '/',
-      component: App,
-      children: [
-        {
-          name: 'provider-list',
-          path: 'list/:page?',
-          component: List,
-          meta: {
-            authContext: 'user',
-            contextQueryItems: ['term', 'provider']
-          }
-        }
-      ]
-    }
-  ],
-  translations,
-  mounted({
-    portal
-  }: {
-    portal: {
-      open: (toApp: string, toPortal: string, order: number, components: Component[]) => void
-    }
-  }): void {
-    portal.open('runtime', 'header', 1, [SearchBar])
-  }
+const appInfo: ApplicationInformation = {
+  name: $gettext('Search'),
+  id: 'search',
+  icon: 'folder',
+  isFileEditor: false
 }
+
+export default defineWebApplication({
+  setup() {
+    return {
+      appInfo,
+      routes: [
+        {
+          name: 'search',
+          path: '/',
+          component: App,
+          children: [
+            {
+              name: 'provider-list',
+              path: 'list/:page?',
+              component: List,
+              meta: {
+                authContext: 'user',
+                contextQueryItems: ['term', 'provider']
+              }
+            }
+          ]
+        }
+      ],
+      translations,
+      extensions: extensions(),
+      extensionPoints: extensionPoints()
+    }
+  }
+})

--- a/packages/web-pkg/src/apps/types.ts
+++ b/packages/web-pkg/src/apps/types.ts
@@ -94,7 +94,7 @@ export interface ClassicApplicationScript {
   navItems?: ((args: ComponentCustomProperties) => AppNavigationItem[]) | AppNavigationItem[]
   translations?: ApplicationTranslations
   extensions?: Ref<Extension[]>
-  extensionPoints?: Ref<ExtensionPoint[]>
+  extensionPoints?: Ref<ExtensionPoint<any>[]>
   initialize?: () => void
   ready?: (args: AppReadyHookArgs) => Promise<void> | void
   mounted?: (args: AppReadyHookArgs) => void

--- a/packages/web-pkg/src/apps/types.ts
+++ b/packages/web-pkg/src/apps/types.ts
@@ -1,6 +1,6 @@
 import { App, ComponentCustomProperties, Ref } from 'vue'
 import { RouteLocationRaw, Router, RouteRecordRaw } from 'vue-router'
-import { Extension } from '../composables/piniaStores'
+import { Extension, ExtensionPoint } from '../composables/piniaStores'
 import { IconFillType } from '../helpers'
 import { Resource, SpaceResource } from '@ownclouders/web-client'
 
@@ -94,6 +94,7 @@ export interface ClassicApplicationScript {
   navItems?: ((args: ComponentCustomProperties) => AppNavigationItem[]) | AppNavigationItem[]
   translations?: ApplicationTranslations
   extensions?: Ref<Extension[]>
+  extensionPoints?: Ref<ExtensionPoint[]>
   initialize?: () => void
   ready?: (args: AppReadyHookArgs) => Promise<void> | void
   mounted?: (args: AppReadyHookArgs) => void

--- a/packages/web-pkg/src/components/AppBar/AppBar.vue
+++ b/packages/web-pkg/src/components/AppBar/AppBar.vue
@@ -211,8 +211,8 @@ export default defineComponent({
       }
 
       const actionExtensions = requestExtensions<ActionExtension>({
-        extensionType: 'action',
-        extensionPointIds: ['app.files.batch-actions']
+        id: 'app.files.batch-actions',
+        extensionType: 'action'
       })
       if (actionExtensions.length) {
         actions = [...actions, ...actionExtensions.map((e) => e.action)]

--- a/packages/web-pkg/src/components/AppBar/AppBar.vue
+++ b/packages/web-pkg/src/components/AppBar/AppBar.vue
@@ -210,7 +210,8 @@ export default defineComponent({
         ] as FileAction[]
       }
 
-      const actionExtensions = requestExtensions<ActionExtension>('action', {
+      const actionExtensions = requestExtensions<ActionExtension>({
+        extensionType: 'action',
         extensionPointIds: ['app.files.batch-actions']
       })
       if (actionExtensions.length) {

--- a/packages/web-pkg/src/components/AppBar/AppBar.vue
+++ b/packages/web-pkg/src/components/AppBar/AppBar.vue
@@ -91,7 +91,9 @@ import {
   useRouteMeta,
   useSpacesStore,
   useRouter,
-  FolderViewModeConstants
+  FolderViewModeConstants,
+  useExtensionRegistry,
+  ActionExtension
 } from '../../composables'
 import { BreadcrumbItem } from 'design-system/src/components/OcBreadcrumb/types'
 import { useActiveLocation } from '../../composables'
@@ -151,6 +153,7 @@ export default defineComponent({
     const { $gettext } = useGettext()
     const { can } = useAbility()
     const router = useRouter()
+    const { requestExtensions } = useExtensionRegistry()
 
     const resourcesStore = useResourcesStore()
     const { selectedResources } = storeToRefs(resourcesStore)
@@ -205,6 +208,13 @@ export default defineComponent({
           ...unref(deleteSpaceActions),
           ...unref(disableSpaceActions)
         ] as FileAction[]
+      }
+
+      const actionExtensions = requestExtensions<ActionExtension>('action', {
+        extensionPointIds: ['app.files.batch-actions']
+      })
+      if (actionExtensions.length) {
+        actions = [...actions, ...actionExtensions.map((e) => e.action)]
       }
 
       return actions.filter((item) =>

--- a/packages/web-pkg/src/components/AppBar/AppBar.vue
+++ b/packages/web-pkg/src/components/AppBar/AppBar.vue
@@ -211,7 +211,7 @@ export default defineComponent({
       }
 
       const actionExtensions = requestExtensions<ActionExtension>({
-        id: 'app.files.batch-actions',
+        id: 'global.files.batch-actions',
         extensionType: 'action'
       })
       if (actionExtensions.length) {

--- a/packages/web-pkg/src/components/ContextActions/ContextActionMenu.vue
+++ b/packages/web-pkg/src/components/ContextActions/ContextActionMenu.vue
@@ -23,7 +23,7 @@
 <script lang="ts">
 import { defineComponent, PropType } from 'vue'
 import ActionMenuItem from './ActionMenuItem.vue'
-import { Action, ActionOptions } from '../../composables/actions'
+import { Action, ActionOptions } from '../../composables'
 
 type MenuSection = {
   name: string

--- a/packages/web-pkg/src/components/CustomComponentTarget.vue
+++ b/packages/web-pkg/src/components/CustomComponentTarget.vue
@@ -19,7 +19,7 @@ export default defineComponent({
   name: 'CustomComponentTarget',
   props: {
     extensionPoint: {
-      type: Object as PropType<ExtensionPoint>,
+      type: Object as PropType<ExtensionPoint<CustomComponentExtension>>,
       required: true
     }
   },
@@ -28,9 +28,7 @@ export default defineComponent({
     const extensionPreferences = useExtensionPreferencesStore()
 
     const allExtensions = computed(() => {
-      return extensionRegistry.requestExtensions<CustomComponentExtension>({
-        extensionPoint: props.extensionPoint
-      })
+      return extensionRegistry.requestExtensions(props.extensionPoint)
     })
 
     const defaultExtensionIds = extensionPreferences.extractDefaultExtensionIds(

--- a/packages/web-pkg/src/components/CustomComponentTarget.vue
+++ b/packages/web-pkg/src/components/CustomComponentTarget.vue
@@ -28,8 +28,8 @@ export default defineComponent({
     const extensionPreferences = useExtensionPreferencesStore()
 
     const allExtensions = computed(() => {
-      return extensionRegistry.requestExtensions<CustomComponentExtension>('customComponent', {
-        extensionPointIds: [props.extensionPoint.id]
+      return extensionRegistry.requestExtensions<CustomComponentExtension>({
+        extensionPoint: props.extensionPoint
       })
     })
 

--- a/packages/web-pkg/src/components/FilesList/ContextActions.vue
+++ b/packages/web-pkg/src/components/FilesList/ContextActions.vue
@@ -71,14 +71,16 @@ export default defineComponent({
     const extensionRegistry = useExtensionRegistry()
     const extensionsContextActions = computed(() => {
       return extensionRegistry
-        .requestExtensions<ActionExtension>('action', {
+        .requestExtensions<ActionExtension>({
+          extensionType: 'action',
           extensionPointIds: ['app.files.context-actions']
         })
         .map((e) => e.action)
     })
     const extensionsBatchActions = computed(() => {
       return extensionRegistry
-        .requestExtensions<ActionExtension>('action', {
+        .requestExtensions<ActionExtension>({
+          extensionType: 'action',
           extensionPointIds: ['app.files.batch-actions']
         })
         .map((e) => e.action)

--- a/packages/web-pkg/src/components/FilesList/ContextActions.vue
+++ b/packages/web-pkg/src/components/FilesList/ContextActions.vue
@@ -72,7 +72,7 @@ export default defineComponent({
     const extensionsContextActions = computed(() => {
       return extensionRegistry
         .requestExtensions<ActionExtension>({
-          id: 'app.files.context-actions',
+          id: 'global.files.context-actions',
           extensionType: 'action'
         })
         .map((e) => e.action)
@@ -80,7 +80,7 @@ export default defineComponent({
     const extensionsBatchActions = computed(() => {
       return extensionRegistry
         .requestExtensions<ActionExtension>({
-          id: 'app.files.batch-actions',
+          id: 'global.files.batch-actions',
           extensionType: 'action'
         })
         .map((e) => e.action)

--- a/packages/web-pkg/src/components/FilesList/ContextActions.vue
+++ b/packages/web-pkg/src/components/FilesList/ContextActions.vue
@@ -72,16 +72,16 @@ export default defineComponent({
     const extensionsContextActions = computed(() => {
       return extensionRegistry
         .requestExtensions<ActionExtension>({
-          extensionType: 'action',
-          extensionPointIds: ['app.files.context-actions']
+          id: 'app.files.context-actions',
+          extensionType: 'action'
         })
         .map((e) => e.action)
     })
     const extensionsBatchActions = computed(() => {
       return extensionRegistry
         .requestExtensions<ActionExtension>({
-          extensionType: 'action',
-          extensionPointIds: ['app.files.batch-actions']
+          id: 'app.files.batch-actions',
+          extensionType: 'action'
         })
         .map((e) => e.action)
     })

--- a/packages/web-pkg/src/components/SideBar/FileSideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/FileSideBar.vue
@@ -185,7 +185,7 @@ export default defineComponent({
       extensionRegistry
         .requestExtensions<SidebarPanelExtension<SpaceResource, Resource, Resource>>(
           'sidebarPanel',
-          { scopes: ['resource'] }
+          { extensionPointIds: ['app.files.sidebar'] }
         )
         .map((e) => e.panel)
     )
@@ -279,10 +279,10 @@ export default defineComponent({
         delete ancestorDataWithoutRoot['/']
       }
 
-      const chachedIds = [...collaboratorCache, ...linkCache].map(({ resourceId }) => resourceId)
+      const cachedIds = [...collaboratorCache, ...linkCache].map(({ resourceId }) => resourceId)
       const ancestorIds = Object.values(ancestorDataWithoutRoot)
         .map(({ id }) => id)
-        .filter((id) => id !== resource.id && !chachedIds.includes(id))
+        .filter((id) => id !== resource.id && !cachedIds.includes(id))
 
       const queue = new PQueue({
         concurrency: configStore.options.concurrentRequests.shares.list

--- a/packages/web-pkg/src/components/SideBar/FileSideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/FileSideBar.vue
@@ -184,8 +184,8 @@ export default defineComponent({
     const availablePanels = computed(() =>
       extensionRegistry
         .requestExtensions<SidebarPanelExtension<SpaceResource, Resource, Resource>>({
-          extensionType: 'sidebarPanel',
-          extensionPointIds: ['app.files.sidebar']
+          id: 'app.files.sidebar',
+          extensionType: 'sidebarPanel'
         })
         .map((e) => e.panel)
     )

--- a/packages/web-pkg/src/components/SideBar/FileSideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/FileSideBar.vue
@@ -183,10 +183,10 @@ export default defineComponent({
 
     const availablePanels = computed(() =>
       extensionRegistry
-        .requestExtensions<SidebarPanelExtension<SpaceResource, Resource, Resource>>(
-          'sidebarPanel',
-          { extensionPointIds: ['app.files.sidebar'] }
-        )
+        .requestExtensions<SidebarPanelExtension<SpaceResource, Resource, Resource>>({
+          extensionType: 'sidebarPanel',
+          extensionPointIds: ['app.files.sidebar']
+        })
         .map((e) => e.panel)
     )
 

--- a/packages/web-pkg/src/components/SideBar/FileSideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/FileSideBar.vue
@@ -184,7 +184,7 @@ export default defineComponent({
     const availablePanels = computed(() =>
       extensionRegistry
         .requestExtensions<SidebarPanelExtension<SpaceResource, Resource, Resource>>({
-          id: 'app.files.sidebar',
+          id: 'global.files.sidebar',
           extensionType: 'sidebarPanel'
         })
         .map((e) => e.panel)

--- a/packages/web-pkg/src/composables/actions/types.ts
+++ b/packages/web-pkg/src/composables/actions/types.ts
@@ -2,11 +2,12 @@ import { Resource, SpaceResource } from '@ownclouders/web-client'
 import { Group, User } from '@ownclouders/web-client/graph/generated'
 import { RouteLocationRaw } from 'vue-router'
 import { IconFillType } from '../../helpers'
+import { StringUnionOrAnyString } from '../../utils'
 
 export type ActionOptions = Record<string, unknown | unknown[]>
 export interface Action<T = ActionOptions> {
   name: string
-  category?: 'context' | 'share' | 'actions' | 'sidebar'
+  category?: StringUnionOrAnyString<'context' | 'share' | 'actions' | 'sidebar'>
   icon: string
   iconFillType?: IconFillType
   variation?: string

--- a/packages/web-pkg/src/composables/actions/types.ts
+++ b/packages/web-pkg/src/composables/actions/types.ts
@@ -6,6 +6,7 @@ import { IconFillType } from '../../helpers'
 export type ActionOptions = Record<string, unknown | unknown[]>
 export interface Action<T = ActionOptions> {
   name: string
+  category?: 'context' | 'share' | 'actions' | 'sidebar'
   icon: string
   iconFillType?: IconFillType
   variation?: string

--- a/packages/web-pkg/src/composables/piniaStores/extensionRegistry/extensionPreferences.ts
+++ b/packages/web-pkg/src/composables/piniaStores/extensionRegistry/extensionPreferences.ts
@@ -29,7 +29,7 @@ export const useExtensionPreferencesStore = defineStore('extensionPreferences', 
     }
   }
   const extractDefaultExtensionIds = (
-    extensionPoint: ExtensionPoint,
+    extensionPoint: ExtensionPoint<Extension>,
     extensions: Extension[]
   ): string[] => {
     if (extensionPoint.multiple) {

--- a/packages/web-pkg/src/composables/piniaStores/extensionRegistry/extensionRegistry.ts
+++ b/packages/web-pkg/src/composables/piniaStores/extensionRegistry/extensionRegistry.ts
@@ -27,9 +27,6 @@ export const useExtensionRegistry = defineStore('extensionRegistry', () => {
   }
 
   const extensionPoints = ref<Ref<ExtensionPoint<Extension>[]>[]>([])
-  const registerExtensionPoint = <T extends Extension>(e: ExtensionPoint<T>) => {
-    extensionPoints.value.push(ref([e]))
-  }
   const registerExtensionPoints = <T extends Extension>(e: Ref<ExtensionPoint<T>[]>) => {
     extensionPoints.value.push(e)
   }
@@ -57,7 +54,6 @@ export const useExtensionRegistry = defineStore('extensionRegistry', () => {
     registerExtensions,
     requestExtensions,
     extensionPoints,
-    registerExtensionPoint,
     registerExtensionPoints,
     getExtensionPoints
   }

--- a/packages/web-pkg/src/composables/piniaStores/extensionRegistry/extensionRegistry.ts
+++ b/packages/web-pkg/src/composables/piniaStores/extensionRegistry/extensionRegistry.ts
@@ -39,13 +39,16 @@ export const useExtensionRegistry = defineStore('extensionRegistry', () => {
   }
   const getExtensionPoints = <T extends ExtensionPoint>(
     options: {
-      type?: ExtensionType
+      extensionType?: ExtensionType
     } = {}
   ) => {
     return unref(extensionPoints).flatMap(
       (e) =>
         unref(e).filter((e) => {
-          if (Object.hasOwn(options, 'type') && e.type !== options.type) {
+          if (
+            Object.hasOwn(options, 'extensionType') &&
+            e.extensionType !== options.extensionType
+          ) {
             return false
           }
           return true

--- a/packages/web-pkg/src/composables/piniaStores/extensionRegistry/extensionRegistry.ts
+++ b/packages/web-pkg/src/composables/piniaStores/extensionRegistry/extensionRegistry.ts
@@ -30,8 +30,11 @@ export const useExtensionRegistry = defineStore('extensionRegistry', () => {
     ) as T[]
   }
 
-  const extensionPoints = ref<ExtensionPoint[]>([])
+  const extensionPoints = ref<Ref<ExtensionPoint[]>[]>([])
   const registerExtensionPoint = (e: ExtensionPoint) => {
+    extensionPoints.value.push(ref([e]))
+  }
+  const registerExtensionPoints = (e: Ref<ExtensionPoint[]>) => {
     extensionPoints.value.push(e)
   }
   const getExtensionPoints = <T extends ExtensionPoint>(
@@ -39,12 +42,15 @@ export const useExtensionRegistry = defineStore('extensionRegistry', () => {
       type?: ExtensionType
     } = {}
   ) => {
-    return unref(extensionPoints).filter((e) => {
-      if (Object.hasOwn(options, 'type') && e.type !== options.type) {
-        return false
-      }
-      return true
-    }) as T[]
+    return unref(extensionPoints).flatMap(
+      (e) =>
+        unref(e).filter((e) => {
+          if (Object.hasOwn(options, 'type') && e.type !== options.type) {
+            return false
+          }
+          return true
+        }) as T[]
+    )
   }
 
   return {
@@ -53,6 +59,7 @@ export const useExtensionRegistry = defineStore('extensionRegistry', () => {
     requestExtensions,
     extensionPoints,
     registerExtensionPoint,
+    registerExtensionPoints,
     getExtensionPoints
   }
 })

--- a/packages/web-pkg/src/composables/piniaStores/extensionRegistry/extensionRegistry.ts
+++ b/packages/web-pkg/src/composables/piniaStores/extensionRegistry/extensionRegistry.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref, Ref, unref } from 'vue'
 import { useConfigStore } from '../config'
-import { Extension, ExtensionPoint, ExtensionScope, ExtensionType } from './types'
+import { Extension, ExtensionPoint, ExtensionType } from './types'
 
 export const useExtensionRegistry = defineStore('extensionRegistry', () => {
   const configStore = useConfigStore()
@@ -14,7 +14,6 @@ export const useExtensionRegistry = defineStore('extensionRegistry', () => {
   const requestExtensions = <T extends Extension>(
     type: ExtensionType,
     options?: {
-      scopes?: ExtensionScope[]
       extensionPointIds?: string[]
     }
   ) => {
@@ -23,7 +22,6 @@ export const useExtensionRegistry = defineStore('extensionRegistry', () => {
         (e) =>
           e.type === type &&
           !configStore.options.disabledExtensions.includes(e.id) &&
-          (!options?.scopes || e.scopes?.some((s) => options?.scopes.includes(s))) &&
           (!options?.extensionPointIds ||
             e.extensionPointIds?.some((id) => options?.extensionPointIds.includes(id)))
       )

--- a/packages/web-pkg/src/composables/piniaStores/extensionRegistry/types.ts
+++ b/packages/web-pkg/src/composables/piniaStores/extensionRegistry/types.ts
@@ -10,13 +10,10 @@ export type ExtensionType = StringUnionOrAnyString<
   'action' | 'customComponent' | 'folderView' | 'search' | 'sidebarNav' | 'sidebarPanel'
 >
 
-export type ExtensionScope = StringUnionOrAnyString<'resource' | 'user' | 'group'>
-
 export type BaseExtension = {
   id: string
   type: ExtensionType
   extensionPointIds?: string[]
-  scopes?: ExtensionScope[] // TODO: deprecated
   userPreference?: {
     optionLabel?: string
   }

--- a/packages/web-pkg/src/composables/piniaStores/extensionRegistry/types.ts
+++ b/packages/web-pkg/src/composables/piniaStores/extensionRegistry/types.ts
@@ -10,7 +10,7 @@ export type ExtensionType = StringUnionOrAnyString<
   'action' | 'customComponent' | 'folderView' | 'search' | 'sidebarNav' | 'sidebarPanel'
 >
 
-export type BaseExtension = {
+export type Extension = {
   id: string
   type: ExtensionType
   extensionPointIds?: string[]
@@ -19,46 +19,38 @@ export type BaseExtension = {
   }
 }
 
-export interface ActionExtension extends BaseExtension {
+export interface ActionExtension extends Extension {
   type: 'action'
   action: Action
 }
 
-export interface SearchExtension extends BaseExtension {
+export interface SearchExtension extends Extension {
   type: 'search'
   searchProvider: SearchProvider
 }
 
-export interface SidebarNavExtension extends BaseExtension {
+export interface SidebarNavExtension extends Extension {
   type: 'sidebarNav'
   navItem: AppNavigationItem
 }
 
 export interface SidebarPanelExtension<R extends Item, P extends Item, T extends Item>
-  extends BaseExtension {
+  extends Extension {
   type: 'sidebarPanel'
   panel: SideBarPanel<R, P, T>
 }
 
-export interface FolderViewExtension extends BaseExtension {
+export interface FolderViewExtension extends Extension {
   type: 'folderView'
   folderView: FolderView
 }
 
-export interface CustomComponentExtension extends BaseExtension {
+export interface CustomComponentExtension extends Extension {
   type: 'customComponent'
   content: Slot | Component
 }
 
-export type Extension =
-  | ActionExtension
-  | SearchExtension
-  | SidebarNavExtension
-  | SidebarPanelExtension<Item, Item, Item>
-  | FolderViewExtension
-  | CustomComponentExtension
-
-export type ExtensionPoint = {
+export type ExtensionPoint<T extends Extension> = {
   id: string
   extensionType: ExtensionType
   multiple?: boolean

--- a/packages/web-pkg/src/composables/piniaStores/extensionRegistry/types.ts
+++ b/packages/web-pkg/src/composables/piniaStores/extensionRegistry/types.ts
@@ -7,7 +7,7 @@ import { Component, Slot } from 'vue'
 import { StringUnionOrAnyString } from '../../../utils'
 
 export type ExtensionType = StringUnionOrAnyString<
-  'action' | 'search' | 'sidebarNav' | 'sidebarPanel' | 'folderView' | 'customComponent'
+  'action' | 'customComponent' | 'folderView' | 'search' | 'sidebarNav' | 'sidebarPanel'
 >
 
 export type ExtensionScope = StringUnionOrAnyString<'resource' | 'user' | 'group'>
@@ -63,7 +63,7 @@ export type Extension =
 
 export type ExtensionPoint = {
   id: string
-  type: ExtensionType
+  extensionType: ExtensionType
   multiple?: boolean
   defaultExtensionId?: string
   userPreference?: {

--- a/packages/web-pkg/tests/unit/components/AppBar/AppBar.spec.ts
+++ b/packages/web-pkg/tests/unit/components/AppBar/AppBar.spec.ts
@@ -11,7 +11,7 @@ import {
 } from 'web-test-helpers'
 import { ArchiverService } from '../../../../src/services'
 import { FolderView } from '../../../../src/ui/types'
-import { ViewOptions } from '../../../../src'
+import { useExtensionRegistry, ViewOptions } from '../../../../src'
 import { OcBreadcrumb } from 'design-system/src/components'
 
 const selectors = {
@@ -147,6 +147,15 @@ function getShallowWrapper(
   }),
   isMobileWidth = false
 ) {
+  const plugins = defaultPlugins({
+    piniaOptions: {
+      resourcesStore: { resources: selected, selectedIds: selected.map(({ id }) => id) }
+    }
+  })
+
+  const { requestExtensions } = useExtensionRegistry()
+  vi.mocked(requestExtensions).mockReturnValue([])
+
   const mocks = {
     ...defaultComponentMocks({
       currentRoute
@@ -160,13 +169,7 @@ function getShallowWrapper(
       props: { ...props, space: mock<SpaceResource>() },
       slots,
       global: {
-        plugins: [
-          ...defaultPlugins({
-            piniaOptions: {
-              resourcesStore: { resources: selected, selectedIds: selected.map(({ id }) => id) }
-            }
-          })
-        ],
+        plugins,
         provide: { ...mocks, isMobileWidth: ref(isMobileWidth) },
         mocks
       }

--- a/packages/web-pkg/tests/unit/components/CustomComponentTarget.spec.ts
+++ b/packages/web-pkg/tests/unit/components/CustomComponentTarget.spec.ts
@@ -16,12 +16,12 @@ const selectors = {
 }
 
 describe('CustomComponentTarget', () => {
-  const mockExtensionPointSingle = mock<ExtensionPoint>({
+  const mockExtensionPointSingle = mock<ExtensionPoint<Extension>>({
     id: 'dummy-extension-point-single',
     extensionType: 'customComponent',
     multiple: false
   })
-  const mockExtensionPointMulti = mock<ExtensionPoint>({
+  const mockExtensionPointMulti = mock<ExtensionPoint<Extension>>({
     id: 'dummy-extension-point-multi',
     extensionType: 'customComponent',
     multiple: true
@@ -92,7 +92,7 @@ function getWrapper({
   extensions,
   preference
 }: {
-  extensionPoint: ExtensionPoint
+  extensionPoint: ExtensionPoint<Extension>
   extensions: Extension[]
   preference?: ExtensionPreferenceItem
 }) {

--- a/packages/web-pkg/tests/unit/components/CustomComponentTarget.spec.ts
+++ b/packages/web-pkg/tests/unit/components/CustomComponentTarget.spec.ts
@@ -18,12 +18,12 @@ const selectors = {
 describe('CustomComponentTarget', () => {
   const mockExtensionPointSingle = mock<ExtensionPoint>({
     id: 'dummy-extension-point-single',
-    type: 'customComponent',
+    extensionType: 'customComponent',
     multiple: false
   })
   const mockExtensionPointMulti = mock<ExtensionPoint>({
     id: 'dummy-extension-point-multi',
-    type: 'customComponent',
+    extensionType: 'customComponent',
     multiple: true
   })
 

--- a/packages/web-pkg/tests/unit/composables/piniaStores/extensionRegistry/extensionPreferences.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/piniaStores/extensionRegistry/extensionPreferences.spec.ts
@@ -66,7 +66,7 @@ describe('useExtensionPreferencesStore', () => {
       it('returns all provided extension ids', () => {
         getWrapper({
           setup: (instance) => {
-            const extensionPoint = mock<ExtensionPoint>({
+            const extensionPoint = mock<ExtensionPoint<Extension>>({
               id: 'extension-point-id',
               multiple: true
             })
@@ -83,7 +83,7 @@ describe('useExtensionPreferencesStore', () => {
       it('returns the default extension id from the extension point', () => {
         getWrapper({
           setup: (instance) => {
-            const extensionPoint = mock<ExtensionPoint>({
+            const extensionPoint = mock<ExtensionPoint<Extension>>({
               id: 'extension-point-id',
               multiple: false,
               defaultExtensionId: 'foo-1'
@@ -95,7 +95,7 @@ describe('useExtensionPreferencesStore', () => {
       it('returns an empty array if the extension point has no default extension id', () => {
         getWrapper({
           setup: (instance) => {
-            const extensionPoint = mock<ExtensionPoint>({
+            const extensionPoint = mock<ExtensionPoint<Extension>>({
               id: 'extension-point-id',
               multiple: false,
               defaultExtensionId: undefined

--- a/packages/web-pkg/tests/unit/composables/piniaStores/extensionRegistry/extensionRegistry.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/piniaStores/extensionRegistry/extensionRegistry.spec.ts
@@ -94,14 +94,14 @@ describe('useExtensionRegistry', () => {
       it('if no matching extension points are found', () => {
         const extensionPoint = mock<ExtensionPoint>({
           id: 'foo-1',
-          type: 'customComponent'
+          extensionType: 'customComponent'
         })
 
         getWrapper({
           setup: (instance) => {
             instance.registerExtensionPoint(extensionPoint)
 
-            const result = instance.getExtensionPoints({ type: 'customComponent' })
+            const result = instance.getExtensionPoints({ extensionType: 'customComponent' })
             expect(result.length).toBe(1)
           }
         })
@@ -112,15 +112,15 @@ describe('useExtensionRegistry', () => {
       const extensionPoints = [
         mock<ExtensionPoint>({
           id: 'foo-1',
-          type: 'customComponent'
+          extensionType: 'customComponent'
         }),
         mock<ExtensionPoint>({
           id: 'foo-2',
-          type: 'sidebarPanel'
+          extensionType: 'sidebarPanel'
         }),
         mock<ExtensionPoint>({
           id: ' foo-3',
-          type: 'customComponent'
+          extensionType: 'customComponent'
         })
       ]
 
@@ -128,10 +128,10 @@ describe('useExtensionRegistry', () => {
         setup: (instance) => {
           extensionPoints.forEach((ep) => instance.registerExtensionPoint(ep))
 
-          const result1 = instance.getExtensionPoints({ type: 'customComponent' })
+          const result1 = instance.getExtensionPoints({ extensionType: 'customComponent' })
           expect(result1.map((ep) => ep.id)).toEqual([extensionPoints[0].id, extensionPoints[2].id])
 
-          const result2 = instance.getExtensionPoints({ type: 'sidebarPanel' })
+          const result2 = instance.getExtensionPoints({ extensionType: 'sidebarPanel' })
           expect(result2.map((ep) => ep.id)).toEqual([extensionPoints[1].id])
         }
       })

--- a/packages/web-pkg/tests/unit/composables/piniaStores/extensionRegistry/extensionRegistry.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/piniaStores/extensionRegistry/extensionRegistry.spec.ts
@@ -10,11 +10,20 @@ describe('useExtensionRegistry', () => {
   })
 
   describe('register and request extensions', () => {
+    describe('querying extensions throws an error', () => {
+      it('if neither extensionType nor extensionPoint are provided', () => {
+        getWrapper({
+          setup: (instance) => {
+            expect(() => instance.requestExtensions({})).toThrowError()
+          }
+        })
+      })
+    })
     describe('querying extensions has an empty result', () => {
       it('if no extensions are registered', () => {
         getWrapper({
           setup: (instance) => {
-            const result = instance.requestExtensions('customComponent')
+            const result = instance.requestExtensions({ extensionType: 'customComponent' })
             expect(result.length).toBe(0)
           }
         })
@@ -34,15 +43,17 @@ describe('useExtensionRegistry', () => {
           setup: (instance) => {
             instance.registerExtensions(extensions)
 
-            const result1 = instance.requestExtensions('sidebarPanel')
+            const result1 = instance.requestExtensions({ extensionType: 'sidebarPanel' })
             expect(result1.length).toBe(0)
 
-            const result2 = instance.requestExtensions('sidebarPanel', {
+            const result2 = instance.requestExtensions({
+              extensionType: 'sidebarPanel',
               extensionPointIds: ['some-other-extension-point-id']
             })
             expect(result2.length).toBe(0)
 
-            const result3 = instance.requestExtensions('customComponent', {
+            const result3 = instance.requestExtensions({
+              extensionType: 'customComponent',
               extensionPointIds: ['some-other-extension-point-id']
             })
             expect(result3.length).toBe(0)
@@ -68,10 +79,11 @@ describe('useExtensionRegistry', () => {
         setup: (instance) => {
           instance.registerExtensions(extensions)
 
-          const resultPlain = instance.requestExtensions('customComponent')
+          const resultPlain = instance.requestExtensions({ extensionType: 'customComponent' })
           expect(resultPlain.map((e) => e.id)).toEqual(extensionIds)
 
-          const resultWithExtensionPoint = instance.requestExtensions('customComponent', {
+          const resultWithExtensionPoint = instance.requestExtensions({
+            extensionType: 'customComponent',
             extensionPointIds: [extensionPointId, 'unknown-extension-point-id']
           })
           expect(resultWithExtensionPoint.map((e) => e.id)).toEqual(extensionIds)

--- a/packages/web-pkg/tests/unit/composables/piniaStores/extensionRegistry/extensionRegistry.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/piniaStores/extensionRegistry/extensionRegistry.spec.ts
@@ -1,4 +1,11 @@
-import { Extension, ExtensionPoint, useExtensionRegistry } from '../../../../../src'
+import {
+  ActionExtension,
+  CustomComponentExtension,
+  Extension,
+  ExtensionPoint,
+  SidebarPanelExtension,
+  useExtensionRegistry
+} from '../../../../../src'
 import { getComposableWrapper } from 'web-test-helpers'
 import { createPinia, setActivePinia } from 'pinia'
 import { computed } from 'vue'
@@ -11,10 +18,27 @@ describe('useExtensionRegistry', () => {
 
   describe('register and request extensions', () => {
     describe('querying extensions throws an error', () => {
-      it('if neither extensionType nor extensionPoint are provided', () => {
+      it('if the extensionPoint has no id', () => {
         getWrapper({
           setup: (instance) => {
-            expect(() => instance.requestExtensions({})).toThrowError()
+            const extensionPointMock: ExtensionPoint<ActionExtension> = mock<
+              ExtensionPoint<ActionExtension>
+            >({
+              id: '',
+              extensionType: 'action'
+            })
+            expect(() => instance.requestExtensions(extensionPointMock)).toThrowError()
+          }
+        })
+      })
+      it('if the extensionPoint has no extensionType', () => {
+        getWrapper({
+          setup: (instance) => {
+            const extensionPointMock: ExtensionPoint<any> = mock<ExtensionPoint<any>>({
+              id: 'some.unique.id',
+              extensionType: ''
+            })
+            expect(() => instance.requestExtensions(extensionPointMock)).toThrowError()
           }
         })
       })
@@ -23,18 +47,30 @@ describe('useExtensionRegistry', () => {
       it('if no extensions are registered', () => {
         getWrapper({
           setup: (instance) => {
-            const result = instance.requestExtensions({ extensionType: 'customComponent' })
+            const extensionPointMock: ExtensionPoint<CustomComponentExtension> = mock<
+              ExtensionPoint<CustomComponentExtension>
+            >({
+              id: 'some.unique.id',
+              extensionType: 'customComponent'
+            })
+            const result = instance.requestExtensions(extensionPointMock)
             expect(result.length).toBe(0)
           }
         })
       })
       it('if no matching extensions are found', () => {
-        const extensions = computed(() =>
+        const extensionPoint: ExtensionPoint<CustomComponentExtension> = mock<
+          ExtensionPoint<CustomComponentExtension>
+        >({
+          id: 'extension-point-id',
+          extensionType: 'customComponent'
+        })
+        const extensions = computed<Extension[]>(() =>
           ['foo-1', 'foo-2'].map((id) =>
             mock<Extension>({
               id,
               type: 'customComponent',
-              extensionPointIds: ['extension-point-id']
+              extensionPointIds: [extensionPoint.id]
             })
           )
         )
@@ -43,50 +79,56 @@ describe('useExtensionRegistry', () => {
           setup: (instance) => {
             instance.registerExtensions(extensions)
 
-            const result1 = instance.requestExtensions({ extensionType: 'sidebarPanel' })
+            const extensionPointWrongType: ExtensionPoint<SidebarPanelExtension<any, any, any>> =
+              mock<ExtensionPoint<SidebarPanelExtension<any, any, any>>>({
+                id: 'extension-point-id',
+                extensionType: 'sidebarPanel'
+              })
+            const result1 = instance.requestExtensions(extensionPointWrongType)
             expect(result1.length).toBe(0)
 
-            const result2 = instance.requestExtensions({
-              extensionType: 'sidebarPanel',
-              extensionPointIds: ['some-other-extension-point-id']
+            const extensionPointWrongId: ExtensionPoint<CustomComponentExtension> = mock<
+              ExtensionPoint<CustomComponentExtension>
+            >({
+              id: 'some-other-extension-point-id',
+              extensionType: 'customComponent'
             })
+            const result2 = instance.requestExtensions(extensionPointWrongId)
             expect(result2.length).toBe(0)
-
-            const result3 = instance.requestExtensions({
-              extensionType: 'customComponent',
-              extensionPointIds: ['some-other-extension-point-id']
-            })
-            expect(result3.length).toBe(0)
           }
         })
       })
     })
 
-    it('can query extensions by type and extension point id', () => {
-      const extensionPointId = 'extension-point-id'
+    it('can query extensions by extension point', () => {
+      const extensionPoint: ExtensionPoint<CustomComponentExtension> = mock<
+        ExtensionPoint<CustomComponentExtension>
+      >({
+        id: 'extension-point-id',
+        extensionType: 'customComponent'
+      })
       const extensionIds = ['foo-1', 'foo-2', 'foo-3']
-      const extensions = computed(() =>
-        extensionIds.map((id) =>
+      const extensions = computed(() => [
+        ...extensionIds.map((id) =>
           mock<Extension>({
             id,
             type: 'customComponent',
-            extensionPointIds: [extensionPointId]
+            extensionPointIds: [extensionPoint.id]
           })
-        )
-      )
+        ),
+        mock<Extension>({
+          id: 'foo-4',
+          type: 'customComponent',
+          extensionPointIds: ['some-other-extension-point-id']
+        })
+      ])
 
       getWrapper({
         setup: (instance) => {
           instance.registerExtensions(extensions)
 
-          const resultPlain = instance.requestExtensions({ extensionType: 'customComponent' })
-          expect(resultPlain.map((e) => e.id)).toEqual(extensionIds)
-
-          const resultWithExtensionPoint = instance.requestExtensions({
-            extensionType: 'customComponent',
-            extensionPointIds: [extensionPointId, 'unknown-extension-point-id']
-          })
-          expect(resultWithExtensionPoint.map((e) => e.id)).toEqual(extensionIds)
+          const result = instance.requestExtensions(extensionPoint)
+          expect(result.map((e) => e.id)).toEqual(extensionIds)
         }
       })
     })
@@ -104,7 +146,7 @@ describe('useExtensionRegistry', () => {
       })
 
       it('if no matching extension points are found', () => {
-        const extensionPoint = mock<ExtensionPoint>({
+        const extensionPoint = mock<ExtensionPoint<Extension>>({
           id: 'foo-1',
           extensionType: 'customComponent'
         })
@@ -122,15 +164,15 @@ describe('useExtensionRegistry', () => {
 
     it('can query extension points by type', () => {
       const extensionPoints = [
-        mock<ExtensionPoint>({
+        mock<ExtensionPoint<CustomComponentExtension>>({
           id: 'foo-1',
           extensionType: 'customComponent'
         }),
-        mock<ExtensionPoint>({
+        mock<ExtensionPoint<SidebarPanelExtension<any, any, any>>>({
           id: 'foo-2',
           extensionType: 'sidebarPanel'
         }),
-        mock<ExtensionPoint>({
+        mock<ExtensionPoint<CustomComponentExtension>>({
           id: ' foo-3',
           extensionType: 'customComponent'
         })

--- a/packages/web-runtime/src/components/Account/ExtensionPreference.vue
+++ b/packages/web-runtime/src/components/Account/ExtensionPreference.vue
@@ -37,8 +37,8 @@ export default defineComponent({
     const extensionPreferences = useExtensionPreferencesStore()
 
     const allExtensions = computed<Extension[]>(() =>
-      extensionRegistry.requestExtensions<Extension>(props.extensionPoint.extensionType, {
-        extensionPointIds: [props.extensionPoint.id]
+      extensionRegistry.requestExtensions<Extension>({
+        extensionPoint: props.extensionPoint
       })
     )
     const defaultExtensionIds = computed(() => {

--- a/packages/web-runtime/src/components/Account/ExtensionPreference.vue
+++ b/packages/web-runtime/src/components/Account/ExtensionPreference.vue
@@ -37,7 +37,7 @@ export default defineComponent({
     const extensionPreferences = useExtensionPreferencesStore()
 
     const allExtensions = computed<Extension[]>(() =>
-      extensionRegistry.requestExtensions<Extension>(props.extensionPoint.type, {
+      extensionRegistry.requestExtensions<Extension>(props.extensionPoint.extensionType, {
         extensionPointIds: [props.extensionPoint.id]
       })
     )

--- a/packages/web-runtime/src/components/Account/ExtensionPreference.vue
+++ b/packages/web-runtime/src/components/Account/ExtensionPreference.vue
@@ -28,7 +28,7 @@ export default defineComponent({
   name: 'ExtensionRegistry',
   props: {
     extensionPoint: {
-      type: Object as PropType<ExtensionPoint>,
+      type: Object as PropType<ExtensionPoint<Extension>>,
       required: true
     }
   },
@@ -36,18 +36,14 @@ export default defineComponent({
     const extensionRegistry = useExtensionRegistry()
     const extensionPreferences = useExtensionPreferencesStore()
 
-    const allExtensions = computed<Extension[]>(() =>
-      extensionRegistry.requestExtensions<Extension>({
-        extensionPoint: props.extensionPoint
-      })
-    )
+    const allExtensions = computed(() => extensionRegistry.requestExtensions(props.extensionPoint))
     const defaultExtensionIds = computed(() => {
       return extensionPreferences.extractDefaultExtensionIds(
         props.extensionPoint,
         unref(allExtensions)
       )
     })
-    const extensions = computed<Extension[]>(() => {
+    const extensions = computed(() => {
       return unref(allExtensions).sort((extension1, extension2) => {
         // default extension first
         if (

--- a/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -19,7 +19,7 @@
       </router-link>
     </div>
     <div v-if="!contentOnLeftPortal" class="oc-topbar-center">
-      <portal-target name="app.runtime.header" multiple />
+      <custom-component-target :extension-point="topBarCenterExtensionPoint" />
     </div>
     <div class="oc-topbar-right oc-flex oc-flex-middle">
       <portal-target name="app.runtime.header.right" multiple />
@@ -50,6 +50,7 @@ import FeedbackLink from './FeedbackLink.vue'
 import SideBarToggle from './SideBarToggle.vue'
 import {
   ApplicationInformation,
+  CustomComponentTarget,
   useAuthStore,
   useCapabilityStore,
   useConfigStore,
@@ -59,12 +60,14 @@ import {
 } from '@ownclouders/web-pkg'
 import { isRuntimeRoute } from '../../router'
 import { MenuItem } from '../../helpers/menuItems'
+import { topBarCenterExtensionPoint } from '../../extensionPoints'
 
 type Menus = 'apps' | 'appSwitcher' | 'user'
 
 export default {
   components: {
     ApplicationsMenu,
+    CustomComponentTarget,
     FeedbackLink,
     Notifications,
     SideBarToggle,
@@ -210,7 +213,8 @@ export default {
       isEmbedModeEnabled,
       isSideBarToggleVisible,
       isSideBarToggleDisabled,
-      homeLink
+      homeLink,
+      topBarCenterExtensionPoint
     }
   },
   computed: {

--- a/packages/web-runtime/src/container/api.ts
+++ b/packages/web-runtime/src/container/api.ts
@@ -1,7 +1,13 @@
 import { RouteRecordRaw, Router } from 'vue-router'
 import clone from 'lodash-es/clone'
 import { RuntimeApi } from './types'
-import { ApiError, ExtensionRegistry, SidebarNavExtension } from '@ownclouders/web-pkg'
+import {
+  ApiError,
+  Extension,
+  ExtensionPoint,
+  ExtensionRegistry,
+  SidebarNavExtension
+} from '@ownclouders/web-pkg'
 import { isEqual, isObject, isArray, merge } from 'lodash-es'
 import { App, Component, computed, h } from 'vue'
 import { ApplicationTranslations, AppNavigationItem } from '@ownclouders/web-pkg'
@@ -77,7 +83,8 @@ const announceNavigationItems = (
     extensionType: 'sidebarNav',
     multiple: true
   }
-  extensionRegistry.registerExtensionPoint(navExtensionPoint)
+  const extensionPoints = computed<ExtensionPoint<Extension>[]>(() => [navExtensionPoint])
+  extensionRegistry.registerExtensionPoints(extensionPoints)
 
   const navExtensions = navigationItems.map((navItem) => ({
     id: `app.${applicationId}.${navItem.name}`,

--- a/packages/web-runtime/src/container/api.ts
+++ b/packages/web-runtime/src/container/api.ts
@@ -72,11 +72,18 @@ const announceNavigationItems = (
     throw new ApiError("navigationItems can't be blank")
   }
 
+  const navExtensionPoint = {
+    id: `app.${applicationId}.navItems`,
+    extensionType: 'sidebarNav',
+    multiple: true
+  }
+  extensionRegistry.registerExtensionPoint(navExtensionPoint)
+
   const navExtensions = navigationItems.map((navItem) => ({
     id: `app.${applicationId}.${navItem.name}`,
     type: 'sidebarNav',
     navItem,
-    scopes: [`app.${applicationId}`]
+    extensionPointIds: [navExtensionPoint.id]
   })) as SidebarNavExtension[]
 
   extensionRegistry.registerExtensions(computed(() => navExtensions))

--- a/packages/web-runtime/src/container/application/classic.ts
+++ b/packages/web-runtime/src/container/application/classic.ts
@@ -129,5 +129,9 @@ export const convertClassicApplication = ({
     extensionRegistry.registerExtensions(applicationScript.extensions)
   }
 
+  if (applicationScript.extensionPoints) {
+    extensionRegistry.registerExtensionPoints(applicationScript.extensionPoints)
+  }
+
   return new ClassicApplication(runtimeApi, applicationScript, app)
 }

--- a/packages/web-runtime/src/extensionPoints.ts
+++ b/packages/web-runtime/src/extensionPoints.ts
@@ -1,0 +1,14 @@
+import { CustomComponentExtension, ExtensionPoint } from '@ownclouders/web-pkg'
+import { computed } from 'vue'
+
+export const topBarCenterExtensionPoint: ExtensionPoint<CustomComponentExtension> = {
+  id: 'app.runtime.header.center',
+  extensionType: 'customComponent',
+  multiple: true
+}
+
+export const extensionPoints = () => {
+  return computed<ExtensionPoint<any>[]>(() => {
+    return [topBarCenterExtensionPoint]
+  })
+}

--- a/packages/web-runtime/src/extensionPoints.ts
+++ b/packages/web-runtime/src/extensionPoints.ts
@@ -1,4 +1,4 @@
-import { CustomComponentExtension, ExtensionPoint } from '@ownclouders/web-pkg'
+import { CustomComponentExtension, Extension, ExtensionPoint } from '@ownclouders/web-pkg'
 import { computed } from 'vue'
 
 export const topBarCenterExtensionPoint: ExtensionPoint<CustomComponentExtension> = {
@@ -8,7 +8,7 @@ export const topBarCenterExtensionPoint: ExtensionPoint<CustomComponentExtension
 }
 
 export const extensionPoints = () => {
-  return computed<ExtensionPoint<any>[]>(() => {
+  return computed<ExtensionPoint<Extension>[]>(() => {
     return [topBarCenterExtensionPoint]
   })
 }

--- a/packages/web-runtime/src/helpers/navItems.ts
+++ b/packages/web-runtime/src/helpers/navItems.ts
@@ -13,6 +13,8 @@ export const getExtensionNavItems = ({
   appId: string
 }) =>
   extensionRegistry
-    .requestExtensions<SidebarNavExtension>('sidebarNav', { scopes: [`app.${appId}`] })
+    .requestExtensions<SidebarNavExtension>('sidebarNav', {
+      extensionPointIds: [`app.${appId}.navItems`]
+    })
     .map(({ navItem }) => navItem)
     .filter((n) => !Object.hasOwn(n, 'isVisible') || n.isVisible())

--- a/packages/web-runtime/src/helpers/navItems.ts
+++ b/packages/web-runtime/src/helpers/navItems.ts
@@ -13,7 +13,8 @@ export const getExtensionNavItems = ({
   appId: string
 }) =>
   extensionRegistry
-    .requestExtensions<SidebarNavExtension>('sidebarNav', {
+    .requestExtensions<SidebarNavExtension>({
+      extensionType: 'sidebarNav',
       extensionPointIds: [`app.${appId}.navItems`]
     })
     .map(({ navItem }) => navItem)

--- a/packages/web-runtime/src/helpers/navItems.ts
+++ b/packages/web-runtime/src/helpers/navItems.ts
@@ -14,8 +14,8 @@ export const getExtensionNavItems = ({
 }) =>
   extensionRegistry
     .requestExtensions<SidebarNavExtension>({
-      extensionType: 'sidebarNav',
-      extensionPointIds: [`app.${appId}.navItems`]
+      id: `app.${appId}.navItems`,
+      extensionType: 'sidebarNav'
     })
     .map(({ navItem }) => navItem)
     .filter((n) => !Object.hasOwn(n, 'isVisible') || n.isVisible())

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -44,6 +44,7 @@ import Avatar from './components/Avatar.vue'
 import focusMixin from './mixins/focusMixin'
 import { ArchiverService } from '@ownclouders/web-pkg'
 import { UnifiedRoleDefinition } from '@ownclouders/web-client/graph/generated'
+import { extensionPoints } from './extensionPoints'
 
 export const bootstrapApp = async (configurationPath: string): Promise<void> => {
   const pinia = createPinia()
@@ -62,6 +63,8 @@ export const bootstrapApp = async (configurationPath: string): Promise<void> => 
     messagesStore,
     sharesStore
   } = announcePiniaStores()
+
+  extensionRegistry.registerExtensionPoints(extensionPoints())
 
   app.provide('$router', router)
 

--- a/packages/web-runtime/src/layouts/Application.vue
+++ b/packages/web-runtime/src/layouts/Application.vue
@@ -190,7 +190,7 @@ export default defineComponent({
     extensionRegistry.registerExtensions(toRef([defaultProgressBarExtension] satisfies Extension[]))
     const progressBarExtensionPoint: ExtensionPoint = {
       id: progressBarExtensionPointId,
-      type: 'customComponent',
+      extensionType: 'customComponent',
       multiple: false,
       defaultExtensionId: defaultProgressBarExtension.id,
       userPreference: {

--- a/packages/web-runtime/src/layouts/Application.vue
+++ b/packages/web-runtime/src/layouts/Application.vue
@@ -188,7 +188,7 @@ export default defineComponent({
       }
     }
     extensionRegistry.registerExtensions(toRef([defaultProgressBarExtension] satisfies Extension[]))
-    const progressBarExtensionPoint: ExtensionPoint = {
+    const progressBarExtensionPoint: ExtensionPoint<CustomComponentExtension> = {
       id: progressBarExtensionPointId,
       extensionType: 'customComponent',
       multiple: false,

--- a/packages/web-runtime/src/layouts/Application.vue
+++ b/packages/web-runtime/src/layouts/Application.vue
@@ -197,7 +197,8 @@ export default defineComponent({
         label: $gettext('Global progress bar')
       }
     }
-    extensionRegistry.registerExtensionPoint(progressBarExtensionPoint)
+    const extensionPoints = computed<ExtensionPoint<Extension>[]>(() => [progressBarExtensionPoint])
+    extensionRegistry.registerExtensionPoints(extensionPoints)
 
     return {
       apps,

--- a/packages/web-runtime/src/pages/account.vue
+++ b/packages/web-runtime/src/pages/account.vue
@@ -184,8 +184,6 @@ import EditPasswordModal from '../components/EditPasswordModal.vue'
 import { SettingsBundle, LanguageOption, SettingsValue } from '../helpers/settings'
 import { computed, defineComponent, onMounted, unref, ref } from 'vue'
 import {
-  Extension,
-  ExtensionPoint,
   useAuthStore,
   useCapabilityStore,
   useClientService,
@@ -461,18 +459,16 @@ export default defineComponent({
 
     const extensionRegistry = useExtensionRegistry()
     const extensionPointsWithUserPreferences = computed(() => {
-      return extensionRegistry
-        .getExtensionPoints<ExtensionPoint<Extension>>()
-        .filter((extensionPoint) => {
-          if (
-            !Object.hasOwn(extensionPoint, 'userPreference') ||
-            isEmpty(extensionPoint.userPreference)
-          ) {
-            return false
-          }
-          const extensions = extensionRegistry.requestExtensions(extensionPoint)
-          return !!extensions.length
-        })
+      return extensionRegistry.getExtensionPoints().filter((extensionPoint) => {
+        if (
+          !Object.hasOwn(extensionPoint, 'userPreference') ||
+          isEmpty(extensionPoint.userPreference)
+        ) {
+          return false
+        }
+        const extensions = extensionRegistry.requestExtensions(extensionPoint)
+        return !!extensions.length
+      })
     })
 
     onMounted(async () => {

--- a/packages/web-runtime/src/pages/account.vue
+++ b/packages/web-runtime/src/pages/account.vue
@@ -469,8 +469,8 @@ export default defineComponent({
           ) {
             return false
           }
-          const extensions = extensionRegistry.requestExtensions(extensionPoint.extensionType, {
-            extensionPointIds: [extensionPoint.id]
+          const extensions = extensionRegistry.requestExtensions({
+            extensionPoint
           })
           return !!extensions.length
         })

--- a/packages/web-runtime/src/pages/account.vue
+++ b/packages/web-runtime/src/pages/account.vue
@@ -184,6 +184,7 @@ import EditPasswordModal from '../components/EditPasswordModal.vue'
 import { SettingsBundle, LanguageOption, SettingsValue } from '../helpers/settings'
 import { computed, defineComponent, onMounted, unref, ref } from 'vue'
 import {
+  Extension,
   ExtensionPoint,
   useAuthStore,
   useCapabilityStore,
@@ -461,17 +462,15 @@ export default defineComponent({
     const extensionRegistry = useExtensionRegistry()
     const extensionPointsWithUserPreferences = computed(() => {
       return extensionRegistry
-        .getExtensionPoints<ExtensionPoint>()
-        .filter((extensionPoint: ExtensionPoint) => {
+        .getExtensionPoints<ExtensionPoint<Extension>>()
+        .filter((extensionPoint) => {
           if (
             !Object.hasOwn(extensionPoint, 'userPreference') ||
             isEmpty(extensionPoint.userPreference)
           ) {
             return false
           }
-          const extensions = extensionRegistry.requestExtensions({
-            extensionPoint
-          })
+          const extensions = extensionRegistry.requestExtensions(extensionPoint)
           return !!extensions.length
         })
     })

--- a/packages/web-runtime/src/pages/account.vue
+++ b/packages/web-runtime/src/pages/account.vue
@@ -469,7 +469,7 @@ export default defineComponent({
           ) {
             return false
           }
-          const extensions = extensionRegistry.requestExtensions(extensionPoint.type, {
+          const extensions = extensionRegistry.requestExtensions(extensionPoint.extensionType, {
             extensionPointIds: [extensionPoint.id]
           })
           return !!extensions.length

--- a/packages/web-runtime/tests/unit/components/Account/ExtensionPreference.spec.ts
+++ b/packages/web-runtime/tests/unit/components/Account/ExtensionPreference.spec.ts
@@ -18,7 +18,7 @@ describe('ExtensionPreference component', () => {
   })
 
   it('renders a dropdown for an extension point', () => {
-    const extensionPoint = mock<ExtensionPoint>({
+    const extensionPoint = mock<ExtensionPoint<Extension>>({
       id: 'test-extension-point',
       multiple: false
     })
@@ -27,7 +27,7 @@ describe('ExtensionPreference component', () => {
   })
 
   describe('extensionPoint with multiple=false', () => {
-    const extensionPoint = mock<ExtensionPoint>({
+    const extensionPoint = mock<ExtensionPoint<Extension>>({
       id: 'test-extension-point',
       multiple: false,
       defaultExtensionId: 'foo-2'
@@ -87,7 +87,7 @@ function getWrapper({
   extensionPoint,
   extensions = []
 }: {
-  extensionPoint: ExtensionPoint
+  extensionPoint: ExtensionPoint<Extension>
   extensions?: Extension[]
 }) {
   const plugins = defaultPlugins({

--- a/packages/web-runtime/tests/unit/pages/account.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/account.spec.ts
@@ -229,7 +229,7 @@ describe('account page', () => {
     })
 
     it('should be hidden if an extension point only has 1 or less extensions', async () => {
-      const extensionPointMock = mock<ExtensionPoint>({
+      const extensionPointMock = mock<ExtensionPoint<Extension>>({
         userPreference: {
           label: 'example-extension-point'
         }
@@ -243,7 +243,7 @@ describe('account page', () => {
     })
 
     it('should be visible if an extension point has at least 2 extensions', async () => {
-      const extensionPoint = mock<ExtensionPoint>({
+      const extensionPoint = mock<ExtensionPoint<Extension>>({
         id: 'test-extension-point',
         multiple: false,
         defaultExtensionId: 'foo-2',
@@ -298,7 +298,7 @@ function getWrapper({
   spaces?: SpaceResource[]
   isPublicLinkContext?: boolean
   isUserContext?: boolean
-  extensionPoints?: ExtensionPoint[]
+  extensionPoints?: ExtensionPoint<Extension>[]
   extensions?: Extension[]
 } = {}) {
   const plugins = defaultPlugins({


### PR DESCRIPTION
## Description
This PR introduces more extension points, allows registering extension points through app bootstrapping and gets rid of the `scopes` property on the `Extension` type.

All of the changes are "under the hood", if anything is different in the UI now it's a bug in the PR.

## Motivation and Context
Offer extension points throughout our platform so that extension developers can easily hook their extensions into existing extension points.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
