### PR TITLE
[tests-only][full-ci]Bump latest `ocis` commit to `web` master

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=581d4b417ea0ef6980da9d589634c9bd747026b8
+OCIS_COMMITID=e253ad0a298b05d70c6a2c2b81ab72310b8ab529
 OCIS_BRANCH=master


### PR DESCRIPTION
### Description
This PR bumps latest `ocis-master` commit to `web-master`.

### Related Issue:
https://github.com/owncloud/QA/issues/848