### PR TITLE
Bump stable-5.0 latests ocis commit to web stable-8.0

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=d5acebe08a5d0a5cc0bd2844d7dadce9f4d116b6
+OCIS_COMMITID=436757fd8dd0d1ee67429cfa0cf957659e87af20
 OCIS_BRANCH=stable-5.0


### PR DESCRIPTION
### Description
This PR bumps latest `ocis stable-5.0` commit to `web stable-8.0`.

### Related Issue:
https://github.com/owncloud/QA/issues/848