### PR TITLE
fix: flickering loading indicator on batch delete

### DIFF
--- a/changelog/unreleased/bugfix-flickering-loading-indicator
+++ b/changelog/unreleased/bugfix-flickering-loading-indicator
@@ -1,0 +1,7 @@
+Bugfix: Flickering loading indicator
+
+The flickering loading indicator when batch deleting a lot of files has been fixed.
+
+We also added a request limit that stops the network from being overrun with concurrent requests.
+
+https://github.com/owncloud/web/pull/10763


### PR DESCRIPTION
## Description
Fixes the flickering loading indicator when batch deleting a bunch of files. Since delete operations are running in parallel, using the `setProgress` method for the loading indicator won't work. This is only suited for serial requests.

Also adds a concurrent request limit via pqueue. This stops the network from being overrun with concurrent requests.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/enterprise/issues/6425

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
