### PR TITLE
refactor: remove available shares roles hack 

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=e253ad0a298b05d70c6a2c2b81ab72310b8ab529
+OCIS_COMMITID=fad37db840c5ca768fb29dfba208e9146514ad42
 OCIS_BRANCH=master

--- a/packages/web-pkg/src/components/SideBar/FileSideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/FileSideBar.vue
@@ -227,26 +227,10 @@ export default defineComponent({
         data = response.data
       }
 
-      let availableRoles =
-        sharesStore.graphRoles.filter(
-          (r) =>
-            data['@libre.graph.permissions.roles.allowedValues']?.map(({ id }) => id).includes(r.id)
-        ) || []
-
-      // FIXME server bug, remove when https://github.com/owncloud/ocis/issues/8331 is resolved
-      if (resource.isFolder) {
-        availableRoles = availableRoles.filter(
-          ({ id }) => id !== '2d00ce52-1fc2-4dbc-8b95-a73b73395f5a'
-        )
-      } else {
-        availableRoles = availableRoles.filter(
-          ({ id }) =>
-            id !== 'fb6c3e19-e378-47e5-b277-9732f9de6e21' &&
-            id !== '1c996275-f1c9-4e71-abdf-a42f6495e960'
-        )
-      }
-
-      availableShareRoles.value = availableRoles
+      const allowedValues = data['@libre.graph.permissions.roles.allowedValues']
+      availableShareRoles.value =
+        sharesStore.graphRoles.filter((r) => allowedValues?.map(({ id }) => id).includes(r.id)) ||
+        []
 
       const permissions = data.value || []
 


### PR DESCRIPTION
## Description
Removes the hack for computing all available share roles since the [server issue](https://github.com/owncloud/ocis/issues/8331) regarding this has been fixed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10769

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
