### PR TITLE
enhancement: configurable share role icons

### DIFF
--- a/changelog/unreleased/enhancement-themeable-sharing-role-icon
+++ b/changelog/unreleased/enhancement-themeable-sharing-role-icon
@@ -1,0 +1,7 @@
+Enhancement: Ability to theme sharing role icons
+
+We've added the ability to theme the sharing role icons.
+This is useful for custom themes that want to customize the look of the sharing role dropdown.
+
+https://github.com/owncloud/web/pull/10801
+https://github.com/owncloud/ocis/issues/8844

--- a/docs/theming/_index.md
+++ b/docs/theming/_index.md
@@ -389,7 +389,7 @@ A full template for your custom theme is provided below, and you can use the ins
       "imprint": "",
       "privacy": ""
     },
-    "roles": {
+    "shareRoles": {
       "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5": {
         "name": "UnifiedRoleViewer",
         "iconName": "eye"

--- a/docs/theming/_index.md
+++ b/docs/theming/_index.md
@@ -61,7 +61,7 @@ The structure of a valid `common` section is outlined below:
     "imprint": "",
     "privacy": ""
   }, 
-  "roles": {}
+  "shareRoles": {}
 }
 ```
 

--- a/docs/theming/_index.md
+++ b/docs/theming/_index.md
@@ -60,7 +60,8 @@ The structure of a valid `common` section is outlined below:
     "accessDeniedHelp": "",
     "imprint": "",
     "privacy": ""
-  }
+  }, 
+  "roles": {}
 }
 ```
 
@@ -387,6 +388,40 @@ A full template for your custom theme is provided below, and you can use the ins
       "accessDeniedHelp": "",
       "imprint": "",
       "privacy": ""
+    },
+    "roles": {
+      "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5": {
+        "name": "UnifiedRoleViewer",
+        "iconName": "eye"
+      },
+      "a8d5fe5e-96e3-418d-825b-534dbdf22b99": {
+        "label": "UnifiedRoleSpaceViewer",
+        "iconName": "eye"
+      },
+      "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a": {
+        "label": "UnifiedRoleFileEditor",
+        "iconName": "pencil"
+      },
+      "fb6c3e19-e378-47e5-b277-9732f9de6e21": {
+        "label": "UnifiedRoleEditor",
+        "iconName": "pencil"
+      },
+      "58c63c02-1d89-4572-916a-870abc5a1b7d": {
+        "label": "UnifiedRoleSpaceEditor",
+        "iconName": "pencil"
+      },
+      "312c0871-5ef7-4b3a-85b6-0e4074c64049": {
+        "label": "UnifiedRoleManager",
+        "iconName": "user-star"
+      },
+      "1c996275-f1c9-4e71-abdf-a42f6495e960": {
+        "label": "UnifiedRoleUploader",
+        "iconName": "pencil"
+      },
+      "aa97fe03-7980-45ac-9e50-b325749fd7e6": {
+        "label": "UnifiedRoleSecureView",
+        "iconName": "shield"
+      }
     }
   },
   "clients": {

--- a/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
+++ b/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
@@ -2,7 +2,6 @@ import {
   CollaboratorShare,
   LinkShare,
   Share,
-  GraphShareRoleIdMap,
   ShareRole,
   ShareTypes,
   isProjectSpaceResource,
@@ -20,6 +19,7 @@ import {
   UpdateShareOptions
 } from './types'
 import { useResourcesStore } from '../resources'
+import { useThemeStore } from '../theme'
 import { Permission, UnifiedRoleDefinition } from '@ownclouders/web-client/graph/generated'
 import { useUserStore } from '../user'
 import { buildLinkShare, buildCollaboratorShare } from '@ownclouders/web-client'
@@ -27,25 +27,16 @@ import { buildLinkShare, buildCollaboratorShare } from '@ownclouders/web-client'
 export const useSharesStore = defineStore('shares', () => {
   const resourcesStore = useResourcesStore()
   const userStore = useUserStore()
-
+  const { getRoleIcon: getThemeRoleIcon } = useThemeStore()
   const loading = ref(false)
   const collaboratorShares = ref<CollaboratorShare[]>([]) as Ref<CollaboratorShare[]>
   const linkShares = ref<LinkShare[]>([]) as Ref<LinkShare[]>
   const graphRoles = ref<ShareRole[]>([]) as Ref<ShareRole[]>
 
   const setGraphRoles = (values: UnifiedRoleDefinition[]) => {
-    const ShareRoleIconMap = {
-      [GraphShareRoleIdMap.Viewer]: 'eye',
-      [GraphShareRoleIdMap.SpaceViewer]: 'eye',
-      [GraphShareRoleIdMap.FileEditor]: 'pencil',
-      [GraphShareRoleIdMap.FolderEditor]: 'pencil',
-      [GraphShareRoleIdMap.SpaceEditor]: 'pencil',
-      [GraphShareRoleIdMap.SpaceManager]: 'user-star'
-    }
-
     graphRoles.value = values.map((v) => ({
       ...v,
-      icon: ShareRoleIconMap[v.id] || 'user'
+      icon: getThemeRoleIcon(v)
     }))
   }
 

--- a/packages/web-pkg/src/composables/piniaStores/theme.ts
+++ b/packages/web-pkg/src/composables/piniaStores/theme.ts
@@ -24,7 +24,7 @@ const CommonSection = z.object({
     imprint: z.string(),
     privacy: z.string()
   }),
-  roles: z.record(
+  shareRoles: z.record(
     z.string(),
     z.object({
       iconName: z.string()
@@ -148,7 +148,7 @@ export const useThemeStore = defineStore('theme', () => {
   }
 
   const getRoleIcon = (role: ShareRole) => {
-    return unref(currentTheme).common?.roles[role.id]?.iconName || 'user'
+    return unref(currentTheme).common?.shareRoles[role.id]?.iconName || 'user'
   }
 
   return {

--- a/packages/web-pkg/src/composables/piniaStores/theme.ts
+++ b/packages/web-pkg/src/composables/piniaStores/theme.ts
@@ -4,6 +4,7 @@ import { computed, ref, unref } from 'vue'
 import { useLocalStorage, usePreferredDark } from '@vueuse/core'
 import { z } from 'zod'
 import { applyCustomProp } from 'design-system/src/'
+import { ShareRole } from '@ownclouders/web-client'
 
 const AppBanner = z.object({
   title: z.string().optional(),
@@ -22,7 +23,13 @@ const CommonSection = z.object({
     accessDeniedHelp: z.string(),
     imprint: z.string(),
     privacy: z.string()
-  })
+  }),
+  roles: z.record(
+    z.string(),
+    z.object({
+      iconName: z.string()
+    })
+  )
 })
 
 const DesignTokens = z.object({
@@ -140,12 +147,17 @@ export const useThemeStore = defineStore('theme', () => {
     })
   }
 
+  const getRoleIcon = (role: ShareRole) => {
+    return unref(currentTheme).common?.roles[role.id]?.iconName || 'user'
+  }
+
   return {
     availableThemes,
     currentTheme,
     initializeThemes,
     setAndApplyTheme,
     setAutoSystemTheme,
-    isCurrentThemeAutoSystem
+    isCurrentThemeAutoSystem,
+    getRoleIcon
   }
 })

--- a/packages/web-runtime/themes/owncloud/theme.json
+++ b/packages/web-runtime/themes/owncloud/theme.json
@@ -8,7 +8,7 @@
       "imprint": "",
       "privacy": ""
     },
-    "roles": {
+    "shareRoles": {
       "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5": {
         "name": "UnifiedRoleViewer",
         "iconName": "eye"

--- a/packages/web-runtime/themes/owncloud/theme.json
+++ b/packages/web-runtime/themes/owncloud/theme.json
@@ -35,7 +35,7 @@
       },
       "1c996275-f1c9-4e71-abdf-a42f6495e960": {
         "label": "UnifiedRoleUploader",
-        "iconName": "pencil"
+        "iconName": "upload"
       },
       "aa97fe03-7980-45ac-9e50-b325749fd7e6": {
         "label": "UnifiedRoleSecureView",

--- a/packages/web-runtime/themes/owncloud/theme.json
+++ b/packages/web-runtime/themes/owncloud/theme.json
@@ -7,6 +7,40 @@
       "accessDeniedHelp": "",
       "imprint": "",
       "privacy": ""
+    },
+    "roles": {
+      "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5": {
+        "name": "UnifiedRoleViewer",
+        "iconName": "eye"
+      },
+      "a8d5fe5e-96e3-418d-825b-534dbdf22b99": {
+        "label": "UnifiedRoleSpaceViewer",
+        "iconName": "eye"
+      },
+      "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a": {
+        "label": "UnifiedRoleFileEditor",
+        "iconName": "pencil"
+      },
+      "fb6c3e19-e378-47e5-b277-9732f9de6e21": {
+        "label": "UnifiedRoleEditor",
+        "iconName": "pencil"
+      },
+      "58c63c02-1d89-4572-916a-870abc5a1b7d": {
+        "label": "UnifiedRoleSpaceEditor",
+        "iconName": "pencil"
+      },
+      "312c0871-5ef7-4b3a-85b6-0e4074c64049": {
+        "label": "UnifiedRoleManager",
+        "iconName": "user-star"
+      },
+      "1c996275-f1c9-4e71-abdf-a42f6495e960": {
+        "label": "UnifiedRoleUploader",
+        "iconName": "pencil"
+      },
+      "aa97fe03-7980-45ac-9e50-b325749fd7e6": {
+        "label": "UnifiedRoleSecureView",
+        "iconName": "shield"
+      }
     }
   },
   "clients": {


### PR DESCRIPTION
## Description
Introduce themeable sharing role icons which are used in the sidebar sharing dialog.

## Related Issue
- Fixes https://github.com/owncloud/web/pull/10801
- Fixes https://github.com/owncloud/web/issues/10777

## Motivation and Context
give the individual user the ability to customize the look of the sharing role dropdown

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- missing unit tests

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)