### PR TITLE
[test-only] fix flaky test: 403 while creating space

### DIFF
--- a/tests/e2e/cucumber/features/smoke/urlJourneys.feature
+++ b/tests/e2e/cucumber/features/smoke/urlJourneys.feature
@@ -6,6 +6,9 @@ Feature: web can be navigated through urls
       | id    |
       | Alice |
       | Brian |
+    And "Admin" assigns following roles to the users using API
+      | id    | role        |
+      | Alice | Space Admin |
     And "Alice" logs in
     And "Alice" creates the following folders in personal space using API
       | name   |
@@ -20,9 +23,6 @@ Feature: web can be navigated through urls
     And "Alice" creates the following files into personal space using API
       | pathToFile | content     |
       | lorem.txt  | new content |
-    And "Admin" assigns following roles to the users using API
-      | id    | role        |
-      | Alice | Space Admin |
     And "Alice" creates the following project space using API
       | name        | id     |
       | Development | team.1 |


### PR DESCRIPTION
common issue where user after assign Space Admin role tries to create space and get 403 error
https://drone.owncloud.com/owncloud/web/44075/12/13
https://drone.owncloud.com/owncloud/ocis/33844/51/10

Fixes https://github.com/owncloud/ocis/issues/8883