### PR TITLE
[tests-only][full-ci] add e2e test coverage for filename with hash

### DIFF
--- a/tests/e2e/cucumber/features/smoke/upload.feature
+++ b/tests/e2e/cucumber/features/smoke/upload.feature
@@ -23,6 +23,9 @@ Feature: Upload
       | textfile.txt      | txtFile | some random content |
       # Coverage for bug: https://github.com/owncloud/ocis/issues/8361
       | comma,.txt        | txtFile | comma               |
+      # Coverage for bug: https://github.com/owncloud/web/issues/10810
+      | test#file.txt     | txtFile | some content        |
+      | test#folder       | folder  |                     |
     When "Alice" uploads the following resources
       | resource          | option    |
       | new-lorem-big.txt | replace   |
@@ -40,10 +43,13 @@ Feature: Upload
       | resource      | error            |
       | lorem-big.txt | Not enough quota |
     And "Alice" downloads the following resources using the sidebar panel
-      | resource   | type   |
-      | PARENT     | folder |
+      | resource      | type   |
+      | PARENT        | folder |
       # Coverage for bug: https://github.com/owncloud/ocis/issues/8361
-      | comma,.txt | file   |
+      | comma,.txt    | file   |
+      # Coverage for bug: https://github.com/owncloud/web/issues/10810
+      | test#file.txt | file   |
+      | test#folder   | folder |
 
     # https://github.com/owncloud/web/issues/6348
     # Note: uploading folder with empty sub-folder should be done manually


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds the steps for downloading file/folder with hash `#` in their name. When user tries to download file/folder with hash in its name, then the download fails with 404 error on `ocis 5.0.2`.

Test coverage for issue https://github.com/owncloud/web/issues/10810

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
