### PR TITLE
fix: download of files with special chars

### DIFF
--- a/changelog/unreleased/bugfix-download-files-special-chars
+++ b/changelog/unreleased/bugfix-download-files-special-chars
@@ -1,0 +1,6 @@
+Bugfix: Download files with special chars in name
+
+We've fixed a bug where having a `#` in the filename resulted in requests going to cut off urls.
+
+https://github.com/owncloud/web/issues/10810
+https://github.com/owncloud/web/pull/10813

--- a/packages/web-pkg/src/composables/download/useDownloadFile.ts
+++ b/packages/web-pkg/src/composables/download/useDownloadFile.ts
@@ -2,11 +2,12 @@ import { unref } from 'vue'
 import { usePublicLinkContext } from '../authContext'
 import { useClientService } from '../clientService'
 import { useStore } from '../store'
-import { triggerDownloadWithFilename } from '../../../src/helpers'
+import { triggerDownloadWithFilename } from '../../helpers'
 import { useGettext } from 'vue3-gettext'
 import { useCapabilityCoreSupportUrlSigning } from '../capability'
 import { Store } from 'vuex'
 import { ClientService } from '../../services'
+import { encodePath } from '../../utils'
 
 export interface DownloadFileOptions {
   store?: Store<any>
@@ -42,7 +43,7 @@ export const useDownloadFile = (options?: DownloadFileOptions) => {
     // construct the download url
     const url =
       version === null
-        ? `${client.helpers._davPath}${file.webDavPath}`
+        ? `${client.helpers._davPath}${encodePath(file.webDavPath)}`
         : client.fileVersions.getFileVersionUrl(file.fileId, version)
 
     // download with signing enabled


### PR DESCRIPTION
## Description
Fixes downloads of files with special chars, especially `#` in the filename by encoding the webdav path.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/10810

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)