### PR TITLE
[full-ci] [tests-only] Remove old acceptance/add e2e test to edit password of public link

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=5d41175b12cdd20a8142624d207b6aadc9190360
+OCIS_COMMITID=08c6f41fc8a965b1a1dc83045b673ce1bdfc000e
 OCIS_BRANCH=stable-5.0

--- a/tests/acceptance/features/webUISharingPublicBasic/publicLinkEdit.feature
+++ b/tests/acceptance/features/webUISharingPublicBasic/publicLinkEdit.feature
@@ -20,34 +20,6 @@ Feature: Edit public link shares
     And the public uses the webUI to access the last public link created by user "Alice" with password "#Passw0rd" in a new session
     Then file "lorem.txt" should be listed on the webUI
 
-
-  Scenario: user edits the password of an already existing public link
-    Given user "Alice" has created folder "simple-folder" in the server
-    And user "Alice" has created file "simple-folder/lorem.txt" in the server
-    And user "Alice" has created a public link with following settings in the server
-      | path        | simple-folder                |
-      | name        | Public-link                  |
-      | permissions | read, update, create, delete |
-      | password    | #Passw0rd                    |
-    And user "Alice" has logged in using the webUI
-    When the user tries to edit the public link named "Public-link" of folder "simple-folder" changing the password to "#Passw0rd123"
-    And the public uses the webUI to access the last public link created by user "Alice" with password "#Passw0rd123" in a new session
-    Then file "lorem.txt" should be listed on the webUI
-
-  @issue-3830
-  Scenario: user edits the password of an already existing public link and tries to access with old password
-    Given user "Alice" has created folder "simple-folder" in the server
-    And user "Alice" has shared folder "simple-folder" with link with "read, update, create, delete" permissions and password "#Passw0rd" in the server
-    And user "Alice" has created a public link with following settings in the server
-      | path        | simple-folder                |
-      | name        | Public-link                  |
-      | permissions | read, update, create, delete |
-      | password    | #Passw0rd                    |
-    And user "Alice" has logged in using the webUI
-    When the user tries to edit the public link named "Public-link" of folder "simple-folder" changing the password to "#Passw0rd123"
-    And the public uses the webUI to access the last public link created by user "Alice" with password "#Passw0rd" in a new session
-    Then the public should not get access to the publicly shared file
-
   @issue-ocis-reva-292
   Scenario: user edits the permission of an already existing public link from read-write to read
     Given user "Alice" has created folder "simple-folder" in the server

--- a/tests/acceptance/features/webUISharingPublicManagement/sharingPublicSession.feature
+++ b/tests/acceptance/features/webUISharingPublicManagement/sharingPublicSession.feature
@@ -30,30 +30,3 @@ Feature: Session storage for public link
     When the public uses the webUI to access the last public link created by user "Alice" with password "#Passw0rd" in a new session
     And the user closes the text editor using the webUI
     Then file "lorem.txt" should be listed on the webUI as single share
-
-
-  Scenario: Public link author changes the password when the public is in public link files page session (folder share)
-    Given user "Alice" has created folder "simple-folder" in the server
-    And user "Alice" has created file "simple-folder/lorem.txt" in the server
-    And user "Alice" has shared folder "simple-folder" with link with "read" permissions and password "#Passw0rd" in the server
-    When the public uses the webUI to access the last public link created by user "Alice" with password "#Passw0rd" in a new session
-    Then file "lorem.txt" should be listed on the webUI
-    And user "Alice" changes the password of last public link  to "#Passw0rd123" using the Sharing API in the server
-    When the user reloads the current page of the webUI
-    Then the password input for the public link should appear on the webUI
-    When the user accesses the public link with password "#Passw0rd123" using the webUI
-    Then file "lorem.txt" should be listed on the webUI
-
-
-  @skipOnOC10
-  Scenario: Public link author changes the password when the public is in public link files page session (file share)
-    Given user "Alice" has created file "lorem.txt" in the server
-    And user "Alice" has shared folder "lorem.txt" with link with "read" permissions and password "#Passw0rd" in the server
-    When the public uses the webUI to access the last public link created by user "Alice" with password "#Passw0rd" in a new session
-    And the user closes the text editor using the webUI
-    Then file "lorem.txt" should be listed on the webUI as single share
-    And user "Alice" changes the password of last public link  to "#Passw0rd123" using the Sharing API in the server
-    When the user reloads the current page of the webUI
-    Then the password input for the public link should appear on the webUI
-    When the user accesses the public link with password "#Passw0rd123" using the webUI
-    Then file "lorem.txt" should be listed on the webUI as single share

--- a/tests/e2e/cucumber/features/shares/link.feature
+++ b/tests/e2e/cucumber/features/shares/link.feature
@@ -256,3 +256,27 @@ Feature: link
     And "Anonymous" opens the public link "Link"
     And "Anonymous" unlocks the public link with password "%copied_password%"
     And "Alice" logs out
+
+
+  Scenario: edit password of the public link
+    When "Alice" logs in
+    And "Alice" creates the following folders in personal space using API
+      | name         |
+      | folderPublic |
+    And "Alice" creates the following files into personal space using API
+      | pathToFile             | content     |
+      | folderPublic/lorem.txt | lorem ipsum |
+    And "Alice" opens the "files" app
+    And "Alice" creates a public link creates a public link of following resource using the sidebar panel
+      | resource     | role     | password |
+      | folderPublic | Can edit | %public% |
+    And "Alice" renames the most recently created public link of resource "folderPublic" to "myPublicLink"
+    When "Anonymous" opens the public link "myPublicLink"
+    And "Anonymous" unlocks the public link with password "%public%"
+    And "Alice" changes the password of the public link named "myPublicLink" of resource "folderPublic" to "new-strongPass1"
+    And "Anonymous" refreshes the old link
+    And "Anonymous" unlocks the public link with password "new-strongPass1"
+    And "Anonymous" downloads the following public link resources using the sidebar panel
+      | resource  | type |
+      | lorem.txt | file |
+    And "Alice" logs out


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR removes the old acceptance test for editing the password of the public link and adds the E2E test. Also, bumps the oCIS stable-5.0 commit id to the latest.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/web/issues/10259
- Related to https://github.com/owncloud/QA/issues/849

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
