### PR TITLE
fix: add missing share date

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
@@ -198,7 +198,7 @@ export default defineComponent({
     const { showMessage, showErrorMessage } = useMessages()
     const userStore = useUserStore()
     const clientService = useClientService()
-    const { $gettext } = useGettext()
+    const { $gettext, current: currentLanguage } = useGettext()
     const { dispatchModal } = useModals()
 
     const { updateShare } = useSharesStore()
@@ -210,6 +210,10 @@ export default defineComponent({
       return queryItemAsString(props.sharedParentRoute?.params?.driveAliasAndItem)
         .split('/')
         .pop()
+    })
+
+    const shareDate = computed(() => {
+      return formatDateFromDateTime(DateTime.fromISO(props.share.createdDateTime), currentLanguage)
     })
 
     const setDenyShare = (value) => {
@@ -238,6 +242,7 @@ export default defineComponent({
       user,
       clientService,
       sharedParentDir,
+      shareDate,
       setDenyShare,
       showNotifyShareModal,
       showMessage,
@@ -333,14 +338,6 @@ export default defineComponent({
 
     editDropDownToggleId() {
       return uuid.v4()
-    },
-    shareDate() {
-      return ''
-      // FIXME
-      // return formatDateFromDateTime(
-      //   DateTime.fromSeconds(parseInt(this.share.permission.)),
-      //   this.$language.current
-      // )
     },
     shareOwnerDisplayName() {
       return this.share.sharedBy.displayName

--- a/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
@@ -179,7 +179,7 @@ export default defineComponent({
     const directLinks = computed(() =>
       unref(linkShares)
         .filter((l) => !l.indirect && !l.isQuickLink)
-        .sort((a: any, b: any) => b.stime - a.stime) // FIXME: share date not yet available
+        .sort((a, b) => b.createdDateTime.localeCompare(a.createdDateTime))
         .map((share) => {
           return { ...share, key: 'direct-link-' + share.id }
         })
@@ -187,7 +187,7 @@ export default defineComponent({
     const indirectLinks = computed(() =>
       unref(linkShares)
         .filter((l) => l.indirect)
-        .sort((a: any, b: any) => b.stime - a.stime) // FIXME: share date not yet available
+        .sort((a, b) => b.createdDateTime.localeCompare(a.createdDateTime))
         .map((share) => {
           return { ...share, key: 'indirect-link-' + share.id }
         })

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/ListItem.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/ListItem.spec.ts
@@ -55,7 +55,8 @@ const getShareMock = ({
   role: mock<ShareRole>({ description: '', displayName: '' }),
   resourceId: '1',
   indirect: false,
-  expirationDateTime: expirationDateTime || ''
+  expirationDateTime: expirationDateTime || '',
+  createdDateTime: '2024-01-01'
 })
 
 describe('Collaborator ListItem component', () => {

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileLinks.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileLinks.spec.ts
@@ -19,6 +19,7 @@ const defaultLinksList = [
     id: '1',
     indirect: false,
     shareType: ShareTypes.link.value,
+    createdDateTime: '2020-01-01',
     displayName: 'public link 1',
     webUrl: ' some-link-1'
   },
@@ -26,6 +27,7 @@ const defaultLinksList = [
     id: '2',
     indirect: true,
     shareType: ShareTypes.link.value,
+    createdDateTime: '2020-01-01',
     displayName: 'public link 2',
     webUrl: ' some-link-2'
   }
@@ -70,7 +72,11 @@ describe('FileLinks', () => {
       })
 
       describe('collapsing', () => {
-        const link = mock<LinkShare>({ indirect: false, isQuickLink: false })
+        const link = mock<LinkShare>({
+          indirect: false,
+          isQuickLink: false,
+          createdDateTime: '2020-01-01'
+        })
 
         it('shows all links if showAllOnLoad config is set', () => {
           const links = [link, link, link, link]

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
@@ -34,7 +34,8 @@ const getCollaborator = (): CollaboratorShare => ({
   role: mock<ShareRole>(),
   resourceId: uuidV4(),
   indirect: false,
-  shareType: ShareTypes.user.value
+  shareType: ShareTypes.user.value,
+  createdDateTime: '2024-01-01'
 })
 
 describe('FileShares', () => {

--- a/packages/web-client/src/graph/generated/api.ts
+++ b/packages/web-client/src/graph/generated/api.ts
@@ -1616,6 +1616,12 @@ export interface Permission {
      */
     'expirationDateTime'?: string | null;
     /**
+     * An optional creation date. Libregraph only.
+     * @type {string}
+     * @memberof Permission
+     */
+    'createdDateTime'?: string | null;
+    /**
      * 
      * @type {SharePointIdentitySet}
      * @memberof Permission
@@ -2561,6 +2567,44 @@ export const DriveItemApiAxiosParamCreator = function (configuration?: Configura
             };
         },
         /**
+         * Get a DriveItem by using its ID. 
+         * @summary Get a DriveItem.
+         * @param {string} driveId key: id of drive
+         * @param {string} itemId key: id of item
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getDriveItem: async (driveId: string, itemId: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'driveId' is not null or undefined
+            assertParamExists('getDriveItem', 'driveId', driveId)
+            // verify required parameter 'itemId' is not null or undefined
+            assertParamExists('getDriveItem', 'itemId', itemId)
+            const localVarPath = `/v1beta1/drives/{drive-id}/items/{item-id}`
+                .replace(`{${"drive-id"}}`, encodeURIComponent(String(driveId)))
+                .replace(`{${"item-id"}}`, encodeURIComponent(String(itemId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * Update a DriveItem.  The request body must include a JSON object with the properties to update. Only the properties that are provided will be updated.  Currently it supports updating the following properties:  * `@UI.Hidden` - Hides the item from the UI. 
          * @summary Update a DriveItem.
          * @param {string} driveId key: id of drive
@@ -2627,6 +2671,18 @@ export const DriveItemApiFp = function(configuration?: Configuration) {
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
+         * Get a DriveItem by using its ID. 
+         * @summary Get a DriveItem.
+         * @param {string} driveId key: id of drive
+         * @param {string} itemId key: id of item
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getDriveItem(driveId: string, itemId: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<DriveItem>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getDriveItem(driveId, itemId, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
          * Update a DriveItem.  The request body must include a JSON object with the properties to update. Only the properties that are provided will be updated.  Currently it supports updating the following properties:  * `@UI.Hidden` - Hides the item from the UI. 
          * @summary Update a DriveItem.
          * @param {string} driveId key: id of drive
@@ -2635,7 +2691,7 @@ export const DriveItemApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async updateDriveItem(driveId: string, itemId: string, driveItem: DriveItem, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+        async updateDriveItem(driveId: string, itemId: string, driveItem: DriveItem, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<DriveItem>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.updateDriveItem(driveId, itemId, driveItem, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
@@ -2661,6 +2717,17 @@ export const DriveItemApiFactory = function (configuration?: Configuration, base
             return localVarFp.deleteDriveItem(driveId, itemId, options).then((request) => request(axios, basePath));
         },
         /**
+         * Get a DriveItem by using its ID. 
+         * @summary Get a DriveItem.
+         * @param {string} driveId key: id of drive
+         * @param {string} itemId key: id of item
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getDriveItem(driveId: string, itemId: string, options?: any): AxiosPromise<DriveItem> {
+            return localVarFp.getDriveItem(driveId, itemId, options).then((request) => request(axios, basePath));
+        },
+        /**
          * Update a DriveItem.  The request body must include a JSON object with the properties to update. Only the properties that are provided will be updated.  Currently it supports updating the following properties:  * `@UI.Hidden` - Hides the item from the UI. 
          * @summary Update a DriveItem.
          * @param {string} driveId key: id of drive
@@ -2669,7 +2736,7 @@ export const DriveItemApiFactory = function (configuration?: Configuration, base
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateDriveItem(driveId: string, itemId: string, driveItem: DriveItem, options?: any): AxiosPromise<void> {
+        updateDriveItem(driveId: string, itemId: string, driveItem: DriveItem, options?: any): AxiosPromise<DriveItem> {
             return localVarFp.updateDriveItem(driveId, itemId, driveItem, options).then((request) => request(axios, basePath));
         },
     };
@@ -2693,6 +2760,19 @@ export class DriveItemApi extends BaseAPI {
      */
     public deleteDriveItem(driveId: string, itemId: string, options?: AxiosRequestConfig) {
         return DriveItemApiFp(this.configuration).deleteDriveItem(driveId, itemId, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Get a DriveItem by using its ID. 
+     * @summary Get a DriveItem.
+     * @param {string} driveId key: id of drive
+     * @param {string} itemId key: id of item
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DriveItemApi
+     */
+    public getDriveItem(driveId: string, itemId: string, options?: AxiosRequestConfig) {
+        return DriveItemApiFp(this.configuration).getDriveItem(driveId, itemId, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/packages/web-client/src/graph/index.ts
+++ b/packages/web-client/src/graph/index.ts
@@ -61,7 +61,11 @@ export interface Graph {
     disableDrive: (id: string) => AxiosPromise<void>
     deleteDrive: (id: string) => AxiosPromise<void>
     deleteDriveItem: (driveId: string, itemId: string) => AxiosPromise<void>
-    updateDriveItem: (driveId: string, itemId: string, driveItem: DriveItem) => AxiosPromise<void>
+    updateDriveItem: (
+      driveId: string,
+      itemId: string,
+      driveItem: DriveItem
+    ) => AxiosPromise<DriveItem>
     createDriveItem: (driveId: string, driveItem: DriveItem) => AxiosPromise<DriveItem>
   }
   users: {

--- a/packages/web-client/src/helpers/resource/types.ts
+++ b/packages/web-client/src/helpers/resource/types.ts
@@ -67,7 +67,6 @@ export interface Resource {
   lockTime?: string
   mimeType?: string
   isFolder?: boolean
-  sdate?: string // FIXME: move to `ShareResource`
   mdate?: string
   indicators?: ResourceIndicator[]
   size?: number | string // FIXME

--- a/packages/web-client/src/helpers/share/functions.ts
+++ b/packages/web-client/src/helpers/share/functions.ts
@@ -122,7 +122,7 @@ export function buildIncomingShareResource({
     fileId: driveItem.remoteItem.id,
     storageId,
     parentFolderId: driveItem.parentReference?.id,
-    sdate: driveItem.lastModifiedDateTime, // FIXME: share date is missing in API
+    sdate: driveItem.remoteItem.permissions[0].createdDateTime,
     indicators: [],
     tags: [],
     webDavPath: buildWebDavSpacesPath(driveItem.id, '/'),
@@ -175,7 +175,7 @@ export function buildOutgoingShareResource({
     fileId: driveItem.id,
     storageId,
     parentFolderId: driveItem.parentReference?.id,
-    sdate: driveItem.lastModifiedDateTime, // FIXME: share date is missing in API
+    sdate: driveItem.permissions[0].createdDateTime,
     indicators: [],
     tags: [],
     webDavPath: buildWebDavSpacesPath(storageId, path),
@@ -251,6 +251,7 @@ export function buildCollaboratorShare({
     permissions: (graphPermission['@libre.graph.permissions.actions']
       ? graphPermission['@libre.graph.permissions.actions']
       : role.rolePermissions.flatMap((p) => p.allowedResourceActions)) as GraphSharePermission[],
+    createdDateTime: graphPermission.createdDateTime,
     expirationDateTime: graphPermission.expirationDateTime
   }
 }
@@ -273,6 +274,7 @@ export function buildLinkShare({
     shareType: ShareTypes.link.value,
     sharedBy: { id: user.id, displayName: user.displayName },
     hasPassword: graphPermission.hasPassword,
+    createdDateTime: graphPermission.createdDateTime,
     expirationDateTime: graphPermission.expirationDateTime,
     displayName: graphPermission.link['@libre.graph.displayName'],
     isQuickLink: graphPermission.link['@libre.graph.quickLink'],

--- a/packages/web-client/src/helpers/share/types.ts
+++ b/packages/web-client/src/helpers/share/types.ts
@@ -19,6 +19,7 @@ export enum GraphSharePermission {
 export interface ShareResource extends Resource {
   sharedWith: Array<{ shareType: number } & Identity>
   sharedBy: Identity[]
+  sdate: string
   outgoing: boolean
   driveId: string
 }
@@ -42,6 +43,7 @@ export interface Share {
   indirect: boolean
   sharedBy: Identity
   shareType: number
+  createdDateTime: string
   expirationDateTime?: string
 }
 

--- a/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
+++ b/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
@@ -104,8 +104,7 @@ export const useSharesStore = defineStore('shares', () => {
       return
     }
 
-    // FIXME: use push as soon as we have a share date
-    unref(linkShares).unshift(share)
+    unref(linkShares).push(share)
   }
 
   const removeLinkShare = (share: LinkShare) => {

--- a/packages/web-pkg/tests/unit/composables/sort/useSort.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/sort/useSort.spec.ts
@@ -33,15 +33,15 @@ describe('useSort', () => {
 
   describe('sorting resources', () => {
     const resources: Resource[] = [
-      { id: '1', name: 'c.png', path: '', webDavPath: '', sdate: '2' },
-      { id: '2', name: 'Dir4', path: '', webDavPath: '', sdate: '4', type: 'folder' },
-      { id: '3', name: 'a.png', path: '', webDavPath: '', sdate: '3' },
-      { id: '4', name: 'A.png', path: '', webDavPath: '', sdate: '6' },
-      { id: '5', name: 'dir2', path: '', webDavPath: '', sdate: '7', type: 'folder' },
-      { id: '6', name: 'b.png', path: '', webDavPath: '', sdate: '1' },
-      { id: '7', name: 'Dir1', path: '', webDavPath: '', sdate: '5', type: 'folder' },
-      { id: '8', name: 'dir11', path: '', webDavPath: '', sdate: '8', type: 'folder' },
-      { id: '9', name: 'dir3', path: '', webDavPath: '', sdate: '9', type: 'folder' }
+      { id: '1', name: 'c.png', path: '', webDavPath: '', mdate: '2' },
+      { id: '2', name: 'Dir4', path: '', webDavPath: '', mdate: '4', type: 'folder' },
+      { id: '3', name: 'a.png', path: '', webDavPath: '', mdate: '3' },
+      { id: '4', name: 'A.png', path: '', webDavPath: '', mdate: '6' },
+      { id: '5', name: 'dir2', path: '', webDavPath: '', mdate: '7', type: 'folder' },
+      { id: '6', name: 'b.png', path: '', webDavPath: '', mdate: '1' },
+      { id: '7', name: 'Dir1', path: '', webDavPath: '', mdate: '5', type: 'folder' },
+      { id: '8', name: 'dir11', path: '', webDavPath: '', mdate: '8', type: 'folder' },
+      { id: '9', name: 'dir3', path: '', webDavPath: '', mdate: '9', type: 'folder' }
     ]
 
     it('sorts resources by name', () => {
@@ -55,7 +55,7 @@ describe('useSort', () => {
               sortable: true
             },
             {
-              name: 'sdate',
+              name: 'mdate',
               sortable: true
             }
           ],


### PR DESCRIPTION
## Description
Adds the missing share date for incoming share resources as well as listed shares in the right sidebar.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10778

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
