### PR TITLE
[tests-only][full-ci]bump latest ocis commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=dadc78d4ffc16a97d4e8ce5a342f82bc3f454787
+OCIS_COMMITID=bf1d18951ed898a7aea4503842b6a6233070b520
 OCIS_BRANCH=master

--- a/.drone.star
+++ b/.drone.star
@@ -1222,6 +1222,9 @@ def ocisService(type, tika_enabled = False, enforce_password_public_link = False
         "FRONTEND_SEARCH_MIN_LENGTH": "2",
         "FRONTEND_OCS_ENABLE_DENIALS": True,
         "OCIS_PASSWORD_POLICY_BANNED_PASSWORDS_LIST": "%s/tests/drone/banned-passwords.txt" % dir["web"],
+        "PROXY_CSP_CONFIG_FILE_LOCATION": "%s/tests/drone/csp.yaml" % dir["web"],
+        "COLLABORA_DOMAIN": "${COLLABORA_DOMAIN:-collabora:9980}",
+        "ONLYOFFICE_DOMAIN": "${ONLYOFFICE_DOMAIN:-onlyoffice:443}",
     }
     if type == "keycloak":
         environment["PROXY_AUTOPROVISION_ACCOUNTS"] = "true"

--- a/.drone.star
+++ b/.drone.star
@@ -1223,8 +1223,6 @@ def ocisService(type, tika_enabled = False, enforce_password_public_link = False
         "FRONTEND_OCS_ENABLE_DENIALS": True,
         "OCIS_PASSWORD_POLICY_BANNED_PASSWORDS_LIST": "%s/tests/drone/banned-passwords.txt" % dir["web"],
         "PROXY_CSP_CONFIG_FILE_LOCATION": "%s/tests/drone/csp.yaml" % dir["web"],
-        "COLLABORA_DOMAIN": "${COLLABORA_DOMAIN:-collabora:9980}",
-        "ONLYOFFICE_DOMAIN": "${ONLYOFFICE_DOMAIN:-onlyoffice:443}",
     }
     if type == "keycloak":
         environment["PROXY_AUTOPROVISION_ACCOUNTS"] = "true"
@@ -1238,6 +1236,7 @@ def ocisService(type, tika_enabled = False, enforce_password_public_link = False
         environment["OCIS_EXCLUDE_RUN_SERVICES"] = "idp"
         environment["GRAPH_ASSIGN_DEFAULT_USER_ROLE"] = "false"
         environment["GRAPH_USERNAME_MATCH"] = "none"
+        environment["KEYCLOAK_DOMAIN"] = "keycloak:8443"
 
     if type == "app-provider":
         environment["GATEWAY_GRPC_ADDR"] = "0.0.0.0:9142"
@@ -1245,6 +1244,8 @@ def ocisService(type, tika_enabled = False, enforce_password_public_link = False
         environment["MICRO_REGISTRY_ADDRESS"] = "0.0.0.0:9233"
         environment["NATS_NATS_HOST"] = "0.0.0.0"
         environment["NATS_NATS_PORT"] = 9233
+        environment["COLLABORA_DOMAIN"] = "collabora:9980"
+        environment["ONLYOFFICE_DOMAIN"] = "onlyoffice:443"
     else:
         environment["WEB_UI_CONFIG_FILE"] = "%s" % dir["ocisConfig"]
 

--- a/tests/drone/csp.yaml
+++ b/tests/drone/csp.yaml
@@ -3,6 +3,7 @@ directives:
     - '''self'''
   connect-src:
     - '''self'''
+    - 'https://${KEYCLOAK_DOMAIN:-keycloak:8443}/'
   default-src:
     - '''none'''
   font-src:
@@ -14,14 +15,12 @@ directives:
     - 'https://embed.diagrams.net/'
     - 'https://${ONLYOFFICE_DOMAIN:-onlyoffice:443}/'
     - 'https://${COLLABORA_DOMAIN:-collabora:9980}/'
-    - 'https://${KEYCLOAK_DOMAIN:-keycloak:8443}/'
   img-src:
     - '''self'''
     - 'data:'
     - 'blob:'
     - 'https://${ONLYOFFICE_DOMAIN:-onlyoffice:443}/'
     - 'https://${COLLABORA_DOMAIN:-collabora:9980}/'
-    - 'https://${KEYCLOAK_DOMAIN:-keycloak:8443}/'
   manifest-src:
     - '''self'''
   media-src:

--- a/tests/drone/csp.yaml
+++ b/tests/drone/csp.yaml
@@ -1,0 +1,37 @@
+directives:
+  child-src:
+    - '''self'''
+  connect-src:
+    - '''self'''
+  default-src:
+    - '''none'''
+  font-src:
+    - '''self'''
+  frame-ancestors:
+    - '''none'''
+  frame-src:
+    - '''self'''
+    - 'https://embed.diagrams.net/'
+    - 'https://${ONLYOFFICE_DOMAIN:-onlyoffice:443}/'
+    - 'https://${COLLABORA_DOMAIN:-collabora:9980}/'
+    - 'https://${KEYCLOAK_DOMAIN:-keycloak:8443}/'
+  img-src:
+    - '''self'''
+    - 'data:'
+    - 'blob:'
+    - 'https://${ONLYOFFICE_DOMAIN:-onlyoffice:443}/'
+    - 'https://${COLLABORA_DOMAIN:-collabora:9980}/'
+    - 'https://${KEYCLOAK_DOMAIN:-keycloak:8443}/'
+  manifest-src:
+    - '''self'''
+  media-src:
+    - '''self'''
+  object-src:
+    - '''self'''
+    - 'blob:'
+  script-src:
+    - '''self'''
+    - '''unsafe-inline'''
+  style-src:
+    - '''self'''
+    - '''unsafe-inline'''


### PR DESCRIPTION
### Description
With this PR https://github.com/owncloud/ocis/pull/8777 CSP headers and other security related headers were added to http responses due to which the app providers and keycloak related e2e tests were failing. This PR adds an env `PROXY_CSP_CONFIG_FILE_LOCATION` which specifies path to `csp.yaml` file which specifies the domains for keycloak and app providers.

This PR also bumps latest ocis commit id.
Part of: https://github.com/owncloud/QA/issues/849

Fixes https://github.com/owncloud/web/issues/10860, fixes https://github.com/owncloud/web/issues/10857