### PR TITLE
fix: remove unused sidebar events

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
@@ -28,7 +28,6 @@ export default defineComponent({
     showSpaceMembers: { type: Boolean, default: false },
     showLinks: { type: Boolean, default: false }
   },
-  emits: ['scrollToElement'],
   setup() {
     const sharesStore = useSharesStore()
     const { loading: sharesLoading } = storeToRefs(sharesStore)

--- a/packages/web-pkg/src/components/SideBar/FileSideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/FileSideBar.vue
@@ -11,9 +11,6 @@
     :loading="isLoading"
     v-bind="$attrs"
     data-custom-key-bindings-disabled="true"
-    @before-unmount="destroySideBar"
-    @mounted="focusSideBar"
-    @file-changed="focusSideBar"
     @select-panel="setActiveSideBarPanel"
     @close="closeSideBar"
   >
@@ -151,19 +148,8 @@ export default defineComponent({
     const closeSideBar = () => {
       eventBus.publish(SideBarEventTopics.close)
     }
-    const setActiveSideBarPanel = (panelName) => {
+    const setActiveSideBarPanel = (panelName: string) => {
       eventBus.publish(SideBarEventTopics.setActivePanel, panelName)
-    }
-    const focusSideBar = (component, event) => {
-      component.focus({
-        from: document.activeElement,
-        to: component.sidebar?.$el,
-        revert: event === 'beforeUnmount'
-      })
-    }
-    const destroySideBar = (component, event) => {
-      focusSideBar(component, event)
-      eventBus.publish(SideBarEventTopics.close)
     }
     const isFileHeaderVisible = computed(() => {
       return (
@@ -433,8 +419,6 @@ export default defineComponent({
       loadedResource,
       setActiveSideBarPanel,
       closeSideBar,
-      destroySideBar,
-      focusSideBar,
       panelContext,
       availablePanels,
       isFileHeaderVisible,

--- a/packages/web-pkg/src/components/SideBar/SideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/SideBar.vue
@@ -64,7 +64,6 @@
               <component
                 :is="panel.component"
                 v-bind="panel.componentAttrs?.(panelContext) || {}"
-                @scroll-to-element="scrollToElement"
               />
             </slot>
           </div>
@@ -194,22 +193,6 @@ export default defineComponent({
     hiddenObserver.disconnect()
   },
   methods: {
-    scrollToElement({ element, panelName }) {
-      const sideBarPanelBodyEl = document.getElementsByClassName(
-        `sidebar-panel__body-${panelName}`
-      )[0]
-
-      const sideBarPanelPadding = Number(
-        window.getComputedStyle(sideBarPanelBodyEl).getPropertyValue('padding')?.split('px')[0]
-      )
-
-      sideBarPanelBodyEl.scrollTo(
-        0,
-        element.getBoundingClientRect().y -
-          sideBarPanelBodyEl.getBoundingClientRect().y -
-          sideBarPanelPadding
-      )
-    },
     setSidebarPanel(panel: string) {
       this.$emit('selectPanel', panel)
     },


### PR DESCRIPTION
## Description
Removes the unused sidebar event `scrollToElement` (which was never emitted) as well as some broken Vue lifecycle hooks from the right sidebar.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
