### PR TITLE
[tests-only] [full-ci] Bump ocis stable-5.0 latest commit id to web stable-8.0

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=08c6f41fc8a965b1a1dc83045b673ce1bdfc000e
+OCIS_COMMITID=af437186fc424e746dc723daf6acc18ee5c58504
 OCIS_BRANCH=stable-5.0


### PR DESCRIPTION
## Description
Bump ocis stable-5.0 commit id.

## Related Issue
- Part of https://github.com/owncloud/QA/issues/849