### PR TITLE
fix: idp logout issues

### DIFF
--- a/changelog/unreleased/bugfix-idp-logout-issues
+++ b/changelog/unreleased/bugfix-idp-logout-issues
@@ -1,0 +1,5 @@
+Bugfix: IDP logout issues
+
+Falsely showing the logout page after opening ownCloud Web with an expired token has been fixed.
+
+https://github.com/owncloud/web/pull/10881

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -252,14 +252,10 @@ export class AuthService {
       })
     }
     if (isUserContextRequired(this.router, route) || isIdpContextRequired(this.router, route)) {
-      // defines a number of seconds after a token expired.
-      // if that threshold surpasses we assume a regular token expiry instead of an auth error.
-      // as a result, the user will be logged out.
-      const TOKEN_EXPIRY_THRESHOLD = 5
-
       const user = await this.userManager.getUser()
-      if (user?.expires_in && user.expires_in < -TOKEN_EXPIRY_THRESHOLD) {
-        return this.logoutUser()
+      if (user?.expires_in !== undefined && user.expires_in < 0) {
+        // token expired, simply return and let the regular auth flow do its thing
+        return
       }
 
       await this.userManager.removeUser('authError')


### PR DESCRIPTION
## Description
Fixes falsely showing the logout page after opening ownCloud Web with an expired token. The issue seemed to be related to the fact that we manually logged out the user after token expiry, whereas the correct way is to let the IDP auth flow handle this. There is no need for a custom implementation on our side.

Also removes the threshold because it doesn't really make sense IMO. Either the token is expired, or it's still valid.

## Related Issue
- refs https://github.com/owncloud/enterprise/issues/6639
- refs https://github.com/owncloud/enterprise/issues/6560
- refs https://github.com/owncloud/enterprise/issues/6627

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
