### PR TITLE
fix: local docker compose setup not working with app-providers

### DIFF
--- a/dev/docker/ocis/csp.yaml
+++ b/dev/docker/ocis/csp.yaml
@@ -1,0 +1,37 @@
+directives:
+  child-src:
+    - '''self'''
+  connect-src:
+    - '''self'''
+  default-src:
+    - '''none'''
+  font-src:
+    - '''self'''
+  frame-ancestors:
+    - '''none'''
+  frame-src:
+    - '''self'''
+    - 'https://embed.diagrams.net/'
+    # In contrast to bash and docker the default is given after the | character
+    - 'https://${ONLYOFFICE_DOMAIN|host.docker.internal:9981}/'
+    - 'https://${COLLABORA_DOMAIN|host.docker.internal:9980}/'
+  img-src:
+    - '''self'''
+    - 'data:'
+    - 'blob:'
+    # In contrast to bash and docker the default is given after the | character
+    - 'https://${ONLYOFFICE_DOMAIN|host.docker.internal:9981}/'
+    - 'https://${COLLABORA_DOMAIN|host.docker.internal:9980}/'
+  manifest-src:
+    - '''self'''
+  media-src:
+    - '''self'''
+  object-src:
+    - '''self'''
+    - 'blob:'
+  script-src:
+    - '''self'''
+    - '''unsafe-inline'''
+  style-src:
+    - '''self'''
+    - '''unsafe-inline'''

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,9 @@ services:
       # make the registry available to the app provider containers
       MICRO_REGISTRY: 'nats-js-kv'
       MICRO_REGISTRY_ADDRESS: 0.0.0.0:9233
+      PROXY_CSP_CONFIG_FILE_LOCATION: /etc/ocis/csp.yaml
+      ONLYOFFICE_DOMAIN: host.docker.internal:9981
+      COLLABORA_DOMAIN: host.docker.internal:9980
     labels:
       traefik.enable: true
       traefik.http.routers.ocis.tls: true
@@ -101,6 +104,7 @@ services:
       # workaround: https://github.com/owncloud/ocis/issues/5108
       traefik.http.routers.ocis.middlewares: cors
     volumes:
+      - ./dev/docker/ocis/csp.yaml:/etc/ocis/csp.yaml
       - ./dev/docker/ocis/password-policy-banned-passwords.txt:/etc/ocis/password-policy-banned-passwords.txt
       - ./dev/docker/ocis.idp.config.yaml:/etc/ocis/idp.yaml
       - ./dev/docker/ocis-ca:/var/lib/ocis/proxy
@@ -395,7 +399,6 @@ volumes:
   uppy_companion_datadir:
   ocis-config:
   ocis-federated-config:
-
 
 networks:
   traefik:


### PR DESCRIPTION
## Description
local docker-compose setup was not working with app-providers due to security policies. This PR has a fix for that

Similar to: https://github.com/owncloud/web/pull/10856, https://github.com/owncloud/ocis/pull/9025 due to https://github.com/owncloud/ocis/pull/8777

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/9084

## How Has This Been Tested?
- :computer: 


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
