### PR TITLE
[full-ci] [tests-only] Fixed failure in lock test

### DIFF
--- a/tests/e2e/cucumber/features/app-provider/lock.feature
+++ b/tests/e2e/cucumber/features/app-provider/lock.feature
@@ -34,7 +34,7 @@ Feature: lock
 
     # checking that user cannot delete or change share of the locked file
     # https://github.com/owncloud/web/issues/10507
-    And "Alice" should not be able to manage share for file "test.odt" with user "Brian"
+    And "Alice" should not be able to manage share of a file "test.odt" for user "Brian"
 
     # checking that sharing and creating link of the locked file is possible
     And "Alice" creates a public link of following resource using the sidebar panel
@@ -48,7 +48,7 @@ Feature: lock
     When "Brian" closes the file viewer
     Then "Alice" should get "file-unlocked" SSE event
     And for "Alice" file "test.odt" should not be locked
-    And "Alice" should be able to manage share for file "test.odt" with user "Brian"
+    And "Alice" should be able to manage share of a file "test.odt" for user "Brian"
 
     And "Brian" logs out
     And "Alice" logs out

--- a/tests/e2e/cucumber/features/app-provider/lock.feature
+++ b/tests/e2e/cucumber/features/app-provider/lock.feature
@@ -34,7 +34,7 @@ Feature: lock
 
     # checking that user cannot delete or change share of the locked file
     # https://github.com/owncloud/web/issues/10507
-    And "Alice" should not be able to manage share with user "Brian"
+    And "Alice" should not be able to manage share for file "test.odt" with user "Brian"
 
     # checking that sharing and creating link of the locked file is possible
     And "Alice" creates a public link of following resource using the sidebar panel
@@ -48,7 +48,7 @@ Feature: lock
     When "Brian" closes the file viewer
     Then "Alice" should get "file-unlocked" SSE event
     And for "Alice" file "test.odt" should not be locked
-    And "Alice" should be able to manage share with user "Brian"
+    And "Alice" should be able to manage share for file "test.odt" with user "Brian"
 
     And "Brian" logs out
     And "Alice" logs out

--- a/tests/e2e/cucumber/features/app-provider/lock.feature
+++ b/tests/e2e/cucumber/features/app-provider/lock.feature
@@ -23,7 +23,7 @@ Feature: lock
     When "Brian" opens the following file in Collabora
       | resource |
       | test.odt |
-    Then "Brian" should see the content "some content" in editor "OnlyOffice"
+    Then "Brian" should see the content "some content" in editor "Collabora"
 
     # file-locked
     And "Alice" should get "file-locked" SSE event

--- a/tests/e2e/cucumber/steps/ui/shares.ts
+++ b/tests/e2e/cucumber/steps/ui/shares.ts
@@ -323,7 +323,7 @@ Then(
 )
 
 Then(
-  /^"([^"]*)" (should|should not) be able to manage share for file "([^"]*)" with user "([^"]*)"$/,
+  /^"([^"]*)" (should|should not) be able to manage share of a file "([^"]*)" for user "([^"]*)"$/,
   async function (
     this: World,
     stepUser: any,

--- a/tests/e2e/cucumber/steps/ui/shares.ts
+++ b/tests/e2e/cucumber/steps/ui/shares.ts
@@ -323,11 +323,12 @@ Then(
 )
 
 Then(
-  /^"([^"]*)" (should|should not) be able to manage share with user "([^"]*)"$/,
+  /^"([^"]*)" (should|should not) be able to manage share for file "([^"]*)" with user "([^"]*)"$/,
   async function (
     this: World,
     stepUser: any,
     actionType: string,
+    resource: string,
     recipient: string
   ): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
@@ -338,6 +339,8 @@ Then(
     const changeShare = shareObject.changeShareLocator(
       this.usersEnvironment.getUser({ key: recipient })
     )
+
+    await shareObject.openSharingPanel(resource)
 
     if (actionType === 'should') {
       await expect(changeRole).not.toBeDisabled()

--- a/tests/e2e/support/objects/app-files/share/index.ts
+++ b/tests/e2e/support/objects/app-files/share/index.ts
@@ -112,4 +112,8 @@ export class Share {
   changeShareLocator(recipient: User): Locator {
     return po.changeRoleLocator({ page: this.#page, recipient })
   }
+
+  async openSharingPanel(resource): Promise<void> {
+    await po.openSharingPanel(this.#page, resource)
+  }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
The file is opened with `Collabora` and `then` step is checked with `OnlyOffice` so the selector of `OnlyOffice` is not found in `collabora` editor. 
The failure arose after this PR https://github.com/owncloud/web/pull/10873 .

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10880

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

