### PR TITLE
feat: make unsynced shares accessible

### DIFF
--- a/packages/web-app-files/src/components/Search/List.vue
+++ b/packages/web-app-files/src/components/Search/List.vue
@@ -421,10 +421,10 @@ export default defineComponent({
       ]
     })
 
-    const resourceDomSelector = ({ id, shareId }: Resource) => {
+    const resourceDomSelector = ({ id, remoteItemId }: Resource) => {
       let selectorStr = id.toString()
-      if (shareId) {
-        selectorStr += shareId
+      if (remoteItemId) {
+        selectorStr += remoteItemId
       }
       return extractDomSelector(selectorStr)
     }

--- a/packages/web-app-files/src/services/folder/loaderSpace.ts
+++ b/packages/web-app-files/src/services/folder/loaderSpace.ts
@@ -62,7 +62,7 @@ export class FolderLoaderSpace implements FolderLoader {
             // FIXME: it would be cleaner to fetch the driveItem as soon as graph api is capable of it
             currentFolder = {
               ...currentFolder,
-              id: space.shareId,
+              id: space.id,
               syncEnabled: true,
               canShare: () => false
             } as IncomingShareResource
@@ -87,8 +87,8 @@ export class FolderLoaderSpace implements FolderLoader {
         }
 
         // TODO: remove when server returns share id for federated shares in propfind response
-        if (space.shareId) {
-          resources.forEach((r) => (r.shareId = space.shareId))
+        if (isShareSpaceResource(space)) {
+          resources.forEach((r) => (r.remoteItemId = space.id))
         }
 
         resourcesStore.initResourceList({ currentFolder, resources })

--- a/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.ts
+++ b/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.ts
@@ -97,7 +97,7 @@ describe('CreateAndUpload component', () => {
       const { wrapper, mocks } = getWrapper({
         clipboardResources: [
           mock<Resource>({
-            shareRoot: undefined
+            remoteItemPath: undefined
           })
         ]
       })

--- a/packages/web-client/src/helpers/resource/functions.ts
+++ b/packages/web-client/src/helpers/resource/functions.ts
@@ -129,8 +129,8 @@ export function buildResource(resource: WebDavResponseResource): Resource {
     shareTypes,
     privateLink: resource.props[DavProperty.PrivateLink],
     downloadURL: resource.props[DavProperty.DownloadURL],
-    shareId: resource.props[DavProperty.ShareId],
-    shareRoot: resource.props[DavProperty.ShareRoot],
+    remoteItemId: resource.props[DavProperty.RemoteItemId],
+    remoteItemPath: resource.props[DavProperty.ShareRoot],
     owner: {
       id: resource.props[DavProperty.OwnerId],
       displayName: resource.props[DavProperty.OwnerDisplayName]

--- a/packages/web-client/src/helpers/resource/types.ts
+++ b/packages/web-client/src/helpers/resource/types.ts
@@ -73,13 +73,15 @@ export interface Resource {
   permissions?: string
   starred?: boolean
   etag?: string
-  shareId?: string // FIXME: this originates from the old OCS api, should be removed in the future
-  shareRoot?: string // FIXME: this originates from the old OCS api, should be removed in the future
   shareTypes?: number[]
   privateLink?: string
   owner?: Identity
   extension?: string
   ddate?: string
+
+  // necessary for incoming share resources and resources inside shares
+  remoteItemId?: string
+  remoteItemPath?: string
 
   canCreate?(): boolean
   canUpload?({ user }: { user?: User }): boolean

--- a/packages/web-client/src/helpers/share/functions.ts
+++ b/packages/web-client/src/helpers/share/functions.ts
@@ -115,7 +115,7 @@ export function buildIncomingShareResource({
 
   const resource: IncomingShareResource = {
     id: driveItem.id,
-    shareId: driveItem.remoteItem.id,
+    remoteItemId: driveItem.remoteItem.id,
     driveId: driveItem.parentReference?.driveId,
     path: '/',
     name: resourceName,
@@ -168,7 +168,6 @@ export function buildOutgoingShareResource({
 
   const resource: OutgoingShareResource = {
     id: driveItem.id,
-    shareId: driveItem.permissions[0].id,
     driveId: driveItem.parentReference?.driveId,
     path,
     name: driveItem.name,

--- a/packages/web-client/src/helpers/share/functions.ts
+++ b/packages/web-client/src/helpers/share/functions.ts
@@ -115,7 +115,7 @@ export function buildIncomingShareResource({
 
   const resource: IncomingShareResource = {
     id: driveItem.id,
-    shareId: driveItem.remoteItem.permissions[0].id,
+    shareId: driveItem.remoteItem.id,
     driveId: driveItem.parentReference?.driveId,
     path: '/',
     name: resourceName,
@@ -125,7 +125,7 @@ export function buildIncomingShareResource({
     sdate: driveItem.remoteItem.permissions[0].createdDateTime,
     indicators: [],
     tags: [],
-    webDavPath: buildWebDavSpacesPath(driveItem.id, '/'),
+    webDavPath: buildWebDavSpacesPath(driveItem.remoteItem.id, '/'),
     sharedBy,
     owner: driveItem.remoteItem.createdBy?.user,
     sharedWith,

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -94,7 +94,6 @@ export function buildShareSpaceResource({
     driveAlias: `${driveAliasPrefix}/${shareName}`,
     driveType: 'share',
     name: shareName,
-    shareId: id,
     serverUrl
   }) as ShareSpaceResource
   space.rename = (newName: string) => {
@@ -108,7 +107,6 @@ export function buildSpace(
   data: Drive & {
     path?: string
     serverUrl?: string
-    shareId?: string | number
     webDavPath?: string
     webDavTrashPath?: string
   }
@@ -195,7 +193,6 @@ export function buildSpace(
     permissions: '',
     starred: false,
     etag: '',
-    shareId: data.shareId?.toString(),
     shareTypes: [] as number[],
     privateLink: '',
     downloadURL: '',
@@ -282,7 +279,7 @@ export function buildSpace(
     isOwner({ id }: User): boolean {
       return id === this.owner?.id
     }
-  }
+  } satisfies SpaceResource
   Object.defineProperty(s, 'nodeId', {
     get() {
       return extractNodeId(this.id)

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -4,8 +4,6 @@ import {
   PublicSpaceResource,
   ShareSpaceResource,
   SpaceResource,
-  SHARE_JAIL_ID,
-  OCM_PROVIDER_ID,
   SpaceRoles,
   SpaceRole
 } from './types'
@@ -82,28 +80,21 @@ export function buildPublicSpaceResource(
 
 export function buildShareSpaceResource({
   driveAliasPrefix,
-  shareId,
+  id,
   shareName,
   serverUrl
 }: {
   driveAliasPrefix: 'share' | 'ocm-share'
-  shareId: string | number
+  id: string
   shareName: string
   serverUrl: string
 }): ShareSpaceResource {
-  let id: string
-  if (driveAliasPrefix === 'ocm-share') {
-    id = `${OCM_PROVIDER_ID}$${shareId}!${shareId}`
-  } else {
-    id = [SHARE_JAIL_ID, shareId].join('!')
-  }
-
   const space = buildSpace({
     id,
     driveAlias: `${driveAliasPrefix}/${shareName}`,
     driveType: 'share',
     name: shareName,
-    shareId,
+    shareId: id,
     serverUrl
   }) as ShareSpaceResource
   space.rename = (newName: string) => {

--- a/packages/web-client/src/helpers/space/types.ts
+++ b/packages/web-client/src/helpers/space/types.ts
@@ -9,7 +9,6 @@
 import { DriveItem, Identity, Quota, User } from '@ownclouders/web-client/graph/generated'
 import { Ability, Resource } from '../resource'
 
-export const SHARE_JAIL_ID = 'a0ca6a90-a365-4782-871e-d44447bbc668'
 export const OCM_PROVIDER_ID = '89f37a33-858b-45fa-8890-a1f2b27d90e1'
 
 export interface SpaceRole extends Identity {

--- a/packages/web-client/src/helpers/space/types.ts
+++ b/packages/web-client/src/helpers/space/types.ts
@@ -9,6 +9,7 @@
 import { DriveItem, Identity, Quota, User } from '@ownclouders/web-client/graph/generated'
 import { Ability, Resource } from '../resource'
 
+export const SHARE_JAIL_ID = 'a0ca6a90-a365-4782-871e-d44447bbc668'
 export const OCM_PROVIDER_ID = '89f37a33-858b-45fa-8890-a1f2b27d90e1'
 
 export interface SpaceRole extends Identity {

--- a/packages/web-client/src/webdav/constants/dav.ts
+++ b/packages/web-client/src/webdav/constants/dav.ts
@@ -73,6 +73,7 @@ const DavPropertyMapping = {
   DownloadURL: defString('downloadURL' as const),
   Highlights: defString('highlights' as const),
   MetaPathForUser: defString('meta-path-for-user' as const),
+  RemoteItemId: defString('remote-item-id' as const),
 
   ShareId: defString('shareid' as const),
   ShareRoot: defString('shareroot' as const),

--- a/packages/web-client/src/webdav/constants/dav.ts
+++ b/packages/web-client/src/webdav/constants/dav.ts
@@ -116,7 +116,7 @@ export abstract class DavProperties {
     DavProperty.ActiveLock,
     DavProperty.OwnerId,
     DavProperty.OwnerDisplayName,
-    DavProperty.ShareId,
+    DavProperty.RemoteItemId,
     DavProperty.ShareRoot,
     DavProperty.ShareTypes,
     DavProperty.PrivateLink,

--- a/packages/web-client/src/webdav/moveFiles.ts
+++ b/packages/web-client/src/webdav/moveFiles.ts
@@ -1,4 +1,4 @@
-import { SpaceResource, isShareSpaceResource, SHARE_JAIL_ID } from '../helpers'
+import { SpaceResource } from '../helpers'
 import { WebDavOptions } from './types'
 import { DAV } from './client'
 
@@ -11,14 +11,6 @@ export const MoveFilesFactory = (dav: DAV, options: WebDavOptions) => {
       { path: targetPath }: { path: string },
       options?: { overwrite?: boolean }
     ) {
-      if (isShareSpaceResource(sourceSpace) && sourcePath === '/') {
-        return dav.move(
-          `${sourceSpace.webDavPath}/${sourcePath || ''}`,
-          `/spaces/${SHARE_JAIL_ID}!${SHARE_JAIL_ID}/${targetPath || ''}`,
-          { overwrite: options?.overwrite || false }
-        )
-      }
-
       return dav.move(
         `${sourceSpace.webDavPath}/${sourcePath || ''}`,
         `${targetSpace.webDavPath}/${targetPath || ''}`,

--- a/packages/web-client/src/webdav/search.ts
+++ b/packages/web-client/src/webdav/search.ts
@@ -29,8 +29,7 @@ export const SearchFactory = (dav: DAV, options: WebDavOptions) => {
       return {
         resources: results.map((r) => ({
           ...buildResource(r),
-          highlights: r.props[DavProperty.Highlights] || '',
-          shareId: r.props[DavProperty.RemoteItemId] || ''
+          highlights: r.props[DavProperty.Highlights] || ''
         })),
         totalResults: range ? parseInt(range?.split('/')[1]) : null
       }

--- a/packages/web-client/src/webdav/search.ts
+++ b/packages/web-client/src/webdav/search.ts
@@ -29,7 +29,8 @@ export const SearchFactory = (dav: DAV, options: WebDavOptions) => {
       return {
         resources: results.map((r) => ({
           ...buildResource(r),
-          highlights: r.props[DavProperty.Highlights] || ''
+          highlights: r.props[DavProperty.Highlights] || '',
+          shareId: r.props[DavProperty.RemoteItemId] || ''
         })),
         totalResults: range ? parseInt(range?.split('/')[1]) : null
       }

--- a/packages/web-client/tests/unit/helpers/share/functions.spec.ts
+++ b/packages/web-client/tests/unit/helpers/share/functions.spec.ts
@@ -132,7 +132,7 @@ describe('share helper functions', () => {
 
       expect(result.id).toEqual(driveItem.id)
       expect(result.fileId).toEqual(driveItem.remoteItem.id)
-      expect(result.shareId).toEqual(driveItem.remoteItem.permissions[0].id)
+      expect(result.remoteItemId).toEqual(driveItem.remoteItem.id)
       expect(result.driveId).toEqual(driveItem.parentReference.driveId)
       expect(result.parentFolderId).toEqual(driveItem.parentReference.id)
     })
@@ -177,7 +177,6 @@ describe('share helper functions', () => {
 
       expect(result.id).toEqual(driveItem.id)
       expect(result.fileId).toEqual(driveItem.id)
-      expect(result.shareId).toEqual(driveItem.permissions[0].id)
       expect(result.driveId).toEqual(driveItem.parentReference.driveId)
       expect(result.parentFolderId).toEqual(driveItem.parentReference.id)
     })

--- a/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
+++ b/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
@@ -73,7 +73,8 @@ import {
   SpaceResource,
   call,
   isPersonalSpaceResource,
-  isProjectSpaceResource
+  isProjectSpaceResource,
+  isShareSpaceResource
 } from '@ownclouders/web-client'
 import { DavPermission } from '@ownclouders/web-client/webdav'
 import { HttpError } from '@ownclouders/web-client'
@@ -221,13 +222,13 @@ export default defineComponent({
         query: {
           ...unref(currentRoute).query,
           fileId: id,
-          shareId: space.shareId,
           contextRouteName: path === '/' ? 'files-shares-with-me' : 'files-spaces-generic',
+          ...(isShareSpaceResource(space) && { shareId: space.id }),
           contextRouteParams: {
             driveAliasAndItem: dirname(driveAliasAndItem)
           } as any,
           contextRouteQuery: {
-            shareId: space.shareId
+            ...(isShareSpaceResource(space) && { shareId: space.id })
           } as any
         }
       })

--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -1041,11 +1041,6 @@ export default defineComponent({
         return false
       }
 
-      // TODO: remove as soon as unsynced shares are accessible
-      if (isIncomingShareResource(resource) && !resource.syncEnabled) {
-        return false
-      }
-
       return !this.disabledResources.includes(resource.id)
     },
     getResourceCheckboxLabel(resource: Resource) {

--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -245,7 +245,7 @@ import {
 import { useWindowSize } from '@vueuse/core'
 import { IncomingShareResource, Resource } from '@ownclouders/web-client'
 import { extractDomSelector, SpaceResource } from '@ownclouders/web-client'
-import { ShareTypes, isIncomingShareResource, isShareResource } from '@ownclouders/web-client'
+import { ShareTypes, isShareResource } from '@ownclouders/web-client'
 
 import {
   SortDir,

--- a/packages/web-pkg/src/composables/actions/files/useFileActions.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActions.ts
@@ -110,13 +110,7 @@ export const useFileActions = () => {
           }),
           img: appInfo.img,
           handler: (options) =>
-            openEditor(
-              fileExtension,
-              options.space,
-              options.resources[0],
-              EDITOR_MODE_EDIT,
-              options.space.shareId
-            ),
+            openEditor(fileExtension, options.space, options.resources[0], EDITOR_MODE_EDIT),
           isVisible: ({ resources }) => {
             if (resources.length !== 1) {
               return false
@@ -159,7 +153,7 @@ export const useFileActions = () => {
     space: SpaceResource,
     resource: Resource,
     mode: string,
-    shareId: string
+    remoteItemId: string
   ) => {
     return {
       name: appFileExtension.routeName || appFileExtension.app,
@@ -170,7 +164,7 @@ export const useFileActions = () => {
         mode
       },
       query: {
-        ...(shareId && { shareId }),
+        ...(remoteItemId && { shareId: remoteItemId }),
         ...(resource.fileId && configStore.options.routing.idBased && { fileId: resource.fileId }),
         ...(appFileExtension.app === 'external' && { app: appFileExtension.name }),
         ...routeToContextQuery(unref(router.currentRoute))
@@ -182,10 +176,10 @@ export const useFileActions = () => {
     appFileExtension: ApplicationFileExtension,
     space: SpaceResource,
     resource: Resource,
-    mode: string,
-    shareId: string = undefined
+    mode: string
   ) => {
-    const routeOpts = routeOptsHelper(appFileExtension, space, resource, mode, shareId)
+    const remoteItemId = isShareSpaceResource(space) ? space.id : undefined
+    const routeOpts = routeOptsHelper(appFileExtension, space, resource, mode, remoteItemId)
 
     if (configStore.options.openAppsInTab) {
       const path = router.resolve(routeOpts).href

--- a/packages/web-pkg/src/composables/actions/files/useFileActions.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActions.ts
@@ -1,5 +1,5 @@
 import kebabCase from 'lodash-es/kebabCase'
-import { isIncomingShareResource } from '@ownclouders/web-client'
+import { isShareSpaceResource } from '@ownclouders/web-client'
 import { routeToContextQuery } from '../../appDefaults'
 import { isLocationTrashActive } from '../../../router'
 import { computed, unref } from 'vue'
@@ -122,11 +122,7 @@ export const useFileActions = () => {
               return false
             }
 
-            if (
-              !unref(isSearchActive) &&
-              (isLocationTrashActive(router, 'files-trash-generic') ||
-                (isIncomingShareResource(resources[0]) && !resources[0].syncEnabled))
-            ) {
+            if (!unref(isSearchActive) && isLocationTrashActive(router, 'files-trash-generic')) {
               return false
             }
 

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCopyQuicklink.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCopyQuicklink.ts
@@ -1,4 +1,4 @@
-import { LinkShare, isIncomingShareResource } from '@ownclouders/web-client'
+import { LinkShare } from '@ownclouders/web-client'
 import { computed, unref } from 'vue'
 import { useClientService } from '../../clientService'
 import { useGettext } from 'vue3-gettext'
@@ -95,9 +95,6 @@ export const useFileActionsCopyQuickLink = () => {
       handler,
       isVisible: ({ space, resources }) => {
         if (resources.length !== 1) {
-          return false
-        }
-        if (isIncomingShareResource(resources[0]) && !resources[0].syncEnabled) {
           return false
         }
 

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCreateNewFile.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCreateNewFile.ts
@@ -85,7 +85,7 @@ export const useFileActionsCreateNewFile = ({ space }: { space?: SpaceResource }
 
     resourcesStore.upsertResource(resource)
 
-    return openEditor(appFileExtension, space, resource, EDITOR_MODE_CREATE, space.shareId)
+    return openEditor(appFileExtension, space, resource, EDITOR_MODE_CREATE)
   }
 
   const handler = (

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadArchive.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadArchive.ts
@@ -7,12 +7,7 @@ import {
 import { useIsFilesAppActive } from '../helpers'
 import path from 'path'
 import first from 'lodash-es/first'
-import {
-  isIncomingShareResource,
-  isProjectSpaceResource,
-  isPublicSpaceResource,
-  Resource
-} from '@ownclouders/web-client'
+import { isProjectSpaceResource, isPublicSpaceResource, Resource } from '@ownclouders/web-client'
 import { computed, unref } from 'vue'
 import { useLoadingService } from '../../loadingService'
 import { useRouter } from '../../router'
@@ -128,9 +123,6 @@ export const useFileActionsDownloadArchive = () => {
             return false
           }
           if (isProjectSpaceResource(resources[0]) && resources[0].disabled) {
-            return false
-          }
-          if (isIncomingShareResource(resources[0]) && !resources[0].syncEnabled) {
             return false
           }
           if (

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadFile.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadFile.ts
@@ -11,7 +11,6 @@ import { useIsSearchActive } from '../helpers'
 import { computed, unref } from 'vue'
 import { useGettext } from 'vue3-gettext'
 import { useDownloadFile } from '../../download'
-import { isIncomingShareResource } from '@ownclouders/web-client'
 
 export const useFileActionsDownloadFile = () => {
   const router = useRouter()
@@ -49,9 +48,6 @@ export const useFileActionsDownloadFile = () => {
           return false
         }
         if (resources[0].isFolder) {
-          return false
-        }
-        if (isIncomingShareResource(resources[0]) && !resources[0].syncEnabled) {
           return false
         }
         return resources[0].canDownload()

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsNavigate.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsNavigate.ts
@@ -5,7 +5,6 @@ import {
   isLocationPublicActive,
   isLocationTrashActive
 } from '../../../router'
-import { isIncomingShareResource } from '@ownclouders/web-client'
 import merge from 'lodash-es/merge'
 import { SpaceResource } from '@ownclouders/web-client'
 import { createFileRouteOptions } from '../../../helpers/router'
@@ -55,10 +54,6 @@ export const useFileActionsNavigate = () => {
         }
 
         if (!resources[0].isFolder || resources[0].type === 'space') {
-          return false
-        }
-
-        if (isIncomingShareResource(resources[0]) && !resources[0].syncEnabled) {
           return false
         }
 

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsRename.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsRename.ts
@@ -227,8 +227,8 @@ export const useFileActionsRename = () => {
         // FIXME: Remove this check as soon as renaming shares works as expected
         // see https://github.com/owncloud/ocis/issues/4866
         const rootShareIncluded = configStore.options.routing.fullShareOwnerPaths
-          ? resources.some((r) => r.shareRoot && r.path)
-          : resources.some((r) => r.shareId && r.path === '/')
+          ? resources.some((r) => r.remoteItemPath && r.path)
+          : resources.some((r) => r.remoteItemId && r.path === '/')
         if (rootShareIncluded) {
           return false
         }

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsShowShares.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsShowShares.ts
@@ -1,5 +1,5 @@
 import { isLocationTrashActive } from '../../../router'
-import { ShareResource, isIncomingShareResource } from '@ownclouders/web-client'
+import { ShareResource } from '@ownclouders/web-client'
 import { eventBus } from '../../../services'
 import { SideBarEventTopics } from '../../sideBar'
 import { computed, unref } from 'vue'
@@ -38,9 +38,6 @@ export const useFileActionsShowShares = () => {
           return false
         }
         if (resources.length !== 1) {
-          return false
-        }
-        if (isIncomingShareResource(resources[0]) && !resources[0].syncEnabled) {
           return false
         }
         return canShare({ space, resource: resources[0] })

--- a/packages/web-pkg/src/composables/driveResolver/useDriveResolver.ts
+++ b/packages/web-pkg/src/composables/driveResolver/useDriveResolver.ts
@@ -1,5 +1,5 @@
 import { computed, Ref, ref, unref, watch } from 'vue'
-import { buildShareSpaceResource, SpaceResource } from '@ownclouders/web-client'
+import { buildShareSpaceResource, SHARE_JAIL_ID, SpaceResource } from '@ownclouders/web-client'
 import { useRouteQuery } from '../router'
 import { useSpacesLoading } from './useSpacesLoading'
 import { queryItemAsString } from '../appDefaults'
@@ -97,9 +97,16 @@ export const useDriveResolver = (options: DriveResolverOptions = {}): DriveResol
       ) {
         const [shareName, ...item] = driveAliasAndItem.split('/').slice(1)
         const driveAliasPrefix = driveAliasAndItem.startsWith('ocm-share/') ? 'ocm-share' : 'share'
+
+        let shareIdStr = queryItemAsString(unref(shareId))
+        // keep compatibility with old share jail ids pre sharing NG
+        if (shareIdStr?.includes(':')) {
+          shareIdStr = [SHARE_JAIL_ID, shareIdStr].join('!')
+        }
+
         matchingSpace = buildShareSpaceResource({
           driveAliasPrefix,
-          id: queryItemAsString(unref(shareId)),
+          id: shareIdStr,
           shareName: unref(shareName),
           serverUrl: configStore.serverUrl
         })

--- a/packages/web-pkg/src/composables/driveResolver/useDriveResolver.ts
+++ b/packages/web-pkg/src/composables/driveResolver/useDriveResolver.ts
@@ -99,7 +99,7 @@ export const useDriveResolver = (options: DriveResolverOptions = {}): DriveResol
         const driveAliasPrefix = driveAliasAndItem.startsWith('ocm-share/') ? 'ocm-share' : 'share'
         matchingSpace = buildShareSpaceResource({
           driveAliasPrefix,
-          shareId: queryItemAsString(unref(shareId)),
+          id: queryItemAsString(unref(shareId)),
           shareName: unref(shareName),
           serverUrl: configStore.serverUrl
         })

--- a/packages/web-pkg/src/composables/folderLink/useFolderLink.ts
+++ b/packages/web-pkg/src/composables/folderLink/useFolderLink.ts
@@ -46,7 +46,7 @@ export const useFolderLink = (options: ResourceRouteResolverOptions = {}) => {
       space,
       path: dirname(resource.path)
     })
-    if ((resource.shareId && resource.path === '/') || !parentFolderAccessible) {
+    if ((resource.remoteItemId && resource.path === '/') || !parentFolderAccessible) {
       return createLocationShares('files-shares-with-me')
     }
     if (isProjectSpaceResource(resource)) {

--- a/packages/web-pkg/src/composables/resources/useGetResourceContext.ts
+++ b/packages/web-pkg/src/composables/resources/useGetResourceContext.ts
@@ -58,7 +58,7 @@ export const useGetResourceContext = () => {
 
     space = buildShareSpaceResource({
       driveAliasPrefix: resource.storageId?.startsWith(OCM_PROVIDER_ID) ? 'ocm-share' : 'share',
-      shareId: mountPoint.nodeId,
+      id: mountPoint.nodeId,
       shareName: mountPoint.name,
       serverUrl: configStore.serverUrl
     })

--- a/packages/web-pkg/src/composables/resources/useGetResourceContext.ts
+++ b/packages/web-pkg/src/composables/resources/useGetResourceContext.ts
@@ -58,7 +58,7 @@ export const useGetResourceContext = () => {
 
     space = buildShareSpaceResource({
       driveAliasPrefix: resource.storageId?.startsWith(OCM_PROVIDER_ID) ? 'ocm-share' : 'share',
-      id: mountPoint.nodeId,
+      id: mountPoint.root?.remoteItem?.id,
       shareName: mountPoint.name,
       serverUrl: configStore.serverUrl
     })

--- a/packages/web-pkg/src/composables/scrollTo/useScrollTo.ts
+++ b/packages/web-pkg/src/composables/scrollTo/useScrollTo.ts
@@ -77,7 +77,7 @@ export const useScrollTo = (): ScrollToResult => {
 
     const resource = unref(resources).find((r) => {
       if (isIncomingShareResource(r)) {
-        return r.shareId === unref(scrollTo)
+        return r.remoteItemId === unref(scrollTo)
       }
       return r.id === unref(scrollTo)
     })

--- a/packages/web-pkg/src/composables/search/useSearch.ts
+++ b/packages/web-pkg/src/composables/search/useSearch.ts
@@ -42,8 +42,8 @@ export const useSearch = () => {
           const matchingSpace = getProjectSpace(resource.parentFolderId)
           const data = (matchingSpace ? matchingSpace : resource) as SearchResource
 
-          if (configStore.options.routing.fullShareOwnerPaths && data.shareRoot) {
-            data.path = urlJoin(data.shareRoot, data.path)
+          if (configStore.options.routing.fullShareOwnerPaths && data.remoteItemPath) {
+            data.path = urlJoin(data.remoteItemPath, data.path)
           }
 
           return { id: data.id, data }

--- a/packages/web-pkg/src/composables/spaces/useGetMatchingSpace.ts
+++ b/packages/web-pkg/src/composables/spaces/useGetMatchingSpace.ts
@@ -52,8 +52,8 @@ export const useGetMatchingSpace = (options?: GetMatchingSpaceOptions) => {
         : 'share'
 
     let shareName: string
-    if (resource.shareRoot) {
-      shareName = basename(resource.shareRoot)
+    if (resource.remoteItemPath) {
+      shareName = basename(resource.remoteItemPath)
     } else if (
       unref(driveAliasAndItem)?.startsWith('share/') ||
       unref(driveAliasAndItem)?.startsWith('ocm-share/')
@@ -65,7 +65,7 @@ export const useGetMatchingSpace = (options?: GetMatchingSpaceOptions) => {
 
     return buildShareSpaceResource({
       driveAliasPrefix,
-      id: resource.shareId,
+      id: resource.remoteItemId,
       shareName,
       serverUrl: configStore.serverUrl
     })

--- a/packages/web-pkg/src/composables/spaces/useGetMatchingSpace.ts
+++ b/packages/web-pkg/src/composables/spaces/useGetMatchingSpace.ts
@@ -65,7 +65,7 @@ export const useGetMatchingSpace = (options?: GetMatchingSpaceOptions) => {
 
     return buildShareSpaceResource({
       driveAliasPrefix,
-      shareId: resource.shareId,
+      id: resource.shareId,
       shareName,
       serverUrl: configStore.serverUrl
     })

--- a/packages/web-pkg/src/helpers/router/routeOptions.ts
+++ b/packages/web-pkg/src/helpers/router/routeOptions.ts
@@ -26,7 +26,7 @@ export const createFileRouteOptions = (
       driveAliasAndItem: space.getDriveAliasAndItem({ path: target.path || '' } as Resource)
     },
     query: {
-      ...(isShareSpaceResource(space) && { shareId: space.shareId }),
+      ...(isShareSpaceResource(space) && { shareId: space.id }),
       ...(config?.options?.routing?.idBased &&
         !isUndefined(target.fileId) && { fileId: `${target.fileId}` })
     }

--- a/packages/web-pkg/tests/unit/components/AppTopBar.spec.ts
+++ b/packages/web-pkg/tests/unit/components/AppTopBar.spec.ts
@@ -12,19 +12,19 @@ import { Action } from '../../../src/composables/actions'
 describe('AppTopBar', () => {
   describe('if no resource is present', () => {
     it('renders only a close button', () => {
-      const { wrapper } = getWrapper(mock<Resource>({ path: '/test.txt', shareRoot: '/test' }))
+      const { wrapper } = getWrapper(mock<Resource>({ path: '/test.txt', remoteItemPath: '/test' }))
       expect(wrapper.html()).toMatchSnapshot()
     })
   })
   describe('if a resource is present', () => {
     it('renders a resource and no actions (if none given) and a close button', () => {
-      const { wrapper } = getWrapper(mock<Resource>({ path: '/test.txt', shareRoot: '/test' }))
+      const { wrapper } = getWrapper(mock<Resource>({ path: '/test.txt', remoteItemPath: '/test' }))
       expect(wrapper.html()).toMatchSnapshot()
     })
 
     it('renders a resource and mainActions (if given) and a close button', () => {
       const { wrapper } = getWrapper(
-        mock<Resource>({ path: '/test.txt', shareRoot: '/test' }),
+        mock<Resource>({ path: '/test.txt', remoteItemPath: '/test' }),
         [],
         [mock<Action>()]
       )
@@ -33,7 +33,7 @@ describe('AppTopBar', () => {
 
     it('renders a resource and dropdownActions (if given) and a close button', () => {
       const { wrapper } = getWrapper(
-        mock<Resource>({ path: '/test.txt', shareRoot: '/test' }),
+        mock<Resource>({ path: '/test.txt', remoteItemPath: '/test' }),
         [mock<Action>()],
         []
       )
@@ -41,7 +41,7 @@ describe('AppTopBar', () => {
     })
     it('renders a resource and dropdownActions as well as mainActions (if both are passed) and a close button', () => {
       const { wrapper } = getWrapper(
-        mock<Resource>({ path: '/test.txt', shareRoot: '/test' }),
+        mock<Resource>({ path: '/test.txt', remoteItemPath: '/test' }),
         [mock<Action>()],
         [mock<Action>()]
       )
@@ -49,7 +49,7 @@ describe('AppTopBar', () => {
     })
     it('renders a resource without file extension if areFileExtensionsShown is set to false', () => {
       const { wrapper } = getWrapper(
-        mock<Resource>({ path: '/test.txt', shareRoot: '/test' }),
+        mock<Resource>({ path: '/test.txt', remoteItemPath: '/test' }),
         [mock<Action>()],
         [mock<Action>()],
         false

--- a/packages/web-pkg/tests/unit/components/Search/ResourcePreview.spec.ts
+++ b/packages/web-pkg/tests/unit/components/Search/ResourcePreview.spec.ts
@@ -61,7 +61,7 @@ function getWrapper({
       storageId: '1',
       name: 'lorem.txt',
       path: '/',
-      shareRoot: ''
+      remoteItemPath: ''
     }
   }),
   areFileExtensionsShown = true

--- a/packages/web-pkg/tests/unit/composables/folderLink/useFolderLink.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/folderLink/useFolderLink.spec.ts
@@ -62,8 +62,8 @@ describe('useFolderLink', () => {
     it('should equal the "Shared with me" if resource is representing the root share', () => {
       const resource = {
         path: '/My share',
-        shareRoot: '/My share',
-        shareId: '1',
+        remoteItemPath: '/My share',
+        remoteItemId: '1',
         isShareRoot: () => true
       } as Resource
 
@@ -74,8 +74,8 @@ describe('useFolderLink', () => {
     it('should equal the share name if resource is representing a file or folder in the root of a share', () => {
       const resource = {
         path: '/My share/test.txt',
-        shareRoot: '/My share',
-        shareId: '1'
+        remoteItemPath: '/My share',
+        remoteItemId: '1'
       } as Resource
 
       const wrapper = createWrapper()

--- a/packages/web-pkg/tests/unit/composables/spaces/useGetMatchingSpace.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/spaces/useGetMatchingSpace.spec.ts
@@ -28,7 +28,7 @@ describe('useSpaceHelpers', () => {
     it('should return the matching share space', () => {
       getWrapper({
         setup: ({ getMatchingSpace }) => {
-          const resource = mock<Resource>({ shareRoot: '/' })
+          const resource = mock<Resource>({ remoteItemPath: '/' })
           expect(getMatchingSpace(resource).driveType).toEqual('share')
         }
       })

--- a/packages/web-runtime/src/components/Topbar/ApplicationsMenu.vue
+++ b/packages/web-runtime/src/components/Topbar/ApplicationsMenu.vue
@@ -126,7 +126,7 @@ export default defineComponent({
         ({ app, extension }) => app === item.id && extension === item.defaultExtension
       )
 
-      openEditor(appFileExtension, space, emptyResource, EDITOR_MODE_EDIT, space.shareId)
+      openEditor(appFileExtension, space, emptyResource, EDITOR_MODE_EDIT)
     }
     const getAdditionalEventBindings = (item: MenuItem) => {
       if (item?.openAsEditor) {

--- a/packages/web-runtime/src/pages/resolvePrivateLink.vue
+++ b/packages/web-runtime/src/pages/resolvePrivateLink.vue
@@ -58,12 +58,10 @@ import { unref, defineComponent, computed, onMounted, ref, Ref } from 'vue'
 import { dirname } from 'path'
 import { createFileRouteOptions, useGetResourceContext } from '@ownclouders/web-pkg'
 import { useTask } from 'vue-concurrency'
-import { isShareSpaceResource, Resource } from '@ownclouders/web-client'
+import { isShareSpaceResource, Resource, SHARE_JAIL_ID } from '@ownclouders/web-client'
 import { RouteLocationNamedRaw } from 'vue-router'
 import { useGettext } from 'vue3-gettext'
 import { DriveItem } from '@ownclouders/web-client/graph/generated'
-
-export const SHARE_JAIL_ID = 'a0ca6a90-a365-4782-871e-d44447bbc668'
 
 export default defineComponent({
   name: 'ResolvePrivateLink',

--- a/packages/web-runtime/src/pages/resolvePrivateLink.vue
+++ b/packages/web-runtime/src/pages/resolvePrivateLink.vue
@@ -124,7 +124,7 @@ export default defineComponent({
       if (isShareSpaceResource(space)) {
         sharedParentResource.value = resource
         resourceIsNestedInShare = path !== '/'
-        if (!resourceIsNestedInShare && space.shareId) {
+        if (!resourceIsNestedInShare) {
           // FIXME: get drive item by id as soon as server supports it
           const { data } = yield clientService.graphAuthenticated.drives.listSharedWithMe()
           const share = (data.value as DriveItem[]).find(
@@ -158,8 +158,7 @@ export default defineComponent({
       targetLocation.params = params
       targetLocation.query = {
         ...query,
-        scrollTo:
-          targetLocation.name === 'files-shares-with-me' ? space.shareId : unref(resource).fileId,
+        scrollTo: unref(resource).fileId,
         ...(unref(details) && { details: unref(details) }),
         ...(isHiddenShare && { 'q_share-visibility': 'hidden' }),
         ...(openWithDefault && { openWithDefaultApp: 'true' })

--- a/packages/web-runtime/src/pages/resolvePrivateLink.vue
+++ b/packages/web-runtime/src/pages/resolvePrivateLink.vue
@@ -58,10 +58,12 @@ import { unref, defineComponent, computed, onMounted, ref, Ref } from 'vue'
 import { dirname } from 'path'
 import { createFileRouteOptions, useGetResourceContext } from '@ownclouders/web-pkg'
 import { useTask } from 'vue-concurrency'
-import { isShareSpaceResource, Resource, SHARE_JAIL_ID } from '@ownclouders/web-client'
+import { isShareSpaceResource, Resource } from '@ownclouders/web-client'
 import { RouteLocationNamedRaw } from 'vue-router'
 import { useGettext } from 'vue3-gettext'
 import { DriveItem } from '@ownclouders/web-client/graph/generated'
+
+export const SHARE_JAIL_ID = 'a0ca6a90-a365-4782-871e-d44447bbc668'
 
 export default defineComponent({
   name: 'ResolvePrivateLink',

--- a/packages/web-runtime/tests/unit/pages/resolvePrivateLink.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/resolvePrivateLink.spec.ts
@@ -1,4 +1,4 @@
-import resolvePrivateLink from '../../../src/pages/resolvePrivateLink.vue'
+import resolvePrivateLink, { SHARE_JAIL_ID } from '../../../src/pages/resolvePrivateLink.vue'
 import {
   defaultPlugins,
   defaultComponentMocks,
@@ -8,7 +8,6 @@ import {
 import { mock } from 'vitest-mock-extended'
 import { queryItemAsString, useGetResourceContext } from '@ownclouders/web-pkg'
 import { Resource, SpaceResource } from '@ownclouders/web-client'
-import { SHARE_JAIL_ID } from '@ownclouders/web-client'
 import { DriveItem } from '@ownclouders/web-client/graph/generated'
 
 vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({

--- a/packages/web-runtime/tests/unit/pages/resolvePrivateLink.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/resolvePrivateLink.spec.ts
@@ -1,4 +1,4 @@
-import resolvePrivateLink, { SHARE_JAIL_ID } from '../../../src/pages/resolvePrivateLink.vue'
+import resolvePrivateLink from '../../../src/pages/resolvePrivateLink.vue'
 import {
   defaultPlugins,
   defaultComponentMocks,
@@ -7,7 +7,7 @@ import {
 } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
 import { queryItemAsString, useGetResourceContext } from '@ownclouders/web-pkg'
-import { Resource, SpaceResource } from '@ownclouders/web-client'
+import { Resource, SHARE_JAIL_ID, SpaceResource } from '@ownclouders/web-client'
 import { DriveItem } from '@ownclouders/web-client/graph/generated'
 
 vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({


### PR DESCRIPTION
## Description
Makes unsynced shares accessible. The way to make this work is by using the remote item id instead of the share jail id for opening/resolving into incoming shares.

Notable changes in the course of this:

* Renames `shareId` to `remoteItemId` and `shareRoot` to `remoteItemPath` on resources to match with the Graph terminology.
* Removes the `remoteItemId` on space resources because it only matters for share spaces, in which case this is simply the space id. That means instead of blindly going for `space.remoteItemId`, it now checks if the space is actually a share space and then uses its id.



## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9784

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
