### PR TITLE
fix: filesize requires defining return type options

### DIFF
--- a/packages/web-app-files/src/HandleUpload.ts
+++ b/packages/web-app-files/src/HandleUpload.ts
@@ -1,5 +1,5 @@
 import Uppy, { BasePlugin, UppyFile } from '@uppy/core'
-import { filesize } from 'filesize'
+import { filesize, FileSizeOptionsString } from 'filesize'
 import { basename, dirname, join } from 'path'
 import * as uuid from 'uuid'
 import { Language } from 'vue3-gettext'
@@ -245,7 +245,9 @@ export class HandleUpload extends BasePlugin {
             'There is not enough quota on %{spaceName}, you need additional %{missingSpace} to upload these files',
             {
               spaceName,
-              missingSpace: filesize((space.spaceQuota.remaining - uploadSize) * -1)
+              missingSpace: filesize<FileSizeOptionsString>(
+                (space.spaceQuota.remaining - uploadSize) * -1
+              )
             }
           )
         })

--- a/packages/web-pkg/src/components/SpaceQuota.vue
+++ b/packages/web-pkg/src/components/SpaceQuota.vue
@@ -12,7 +12,7 @@
 
 <script lang="ts">
 import { defineComponent, PropType } from 'vue'
-import { filesize } from 'filesize'
+import { filesize, FileSizeOptionsString } from 'filesize'
 import { Quota } from '@ownclouders/web-client/graph/generated'
 
 export default defineComponent({
@@ -39,10 +39,10 @@ export default defineComponent({
       })
     },
     quotaTotal() {
-      return filesize(this.spaceQuota.total)
+      return filesize<FileSizeOptionsString>(this.spaceQuota.total)
     },
     quotaUsed() {
-      return filesize(this.spaceQuota.used)
+      return filesize<FileSizeOptionsString>(this.spaceQuota.used)
     },
     quotaUsagePercent() {
       return parseFloat(((this.spaceQuota.used / this.spaceQuota.total) * 100).toFixed(2))

--- a/packages/web-runtime/src/components/Topbar/UserMenu.vue
+++ b/packages/web-runtime/src/components/Topbar/UserMenu.vue
@@ -142,7 +142,7 @@
 <script lang="ts">
 import { storeToRefs } from 'pinia'
 import { defineComponent, PropType, ComponentPublicInstance, computed, unref } from 'vue'
-import { filesize } from 'filesize'
+import { filesize, FileSizeOptionsString } from 'filesize'
 import { authService } from '../../services/auth'
 import {
   useRoute,
@@ -215,12 +215,12 @@ export default defineComponent({
       const used = this.quota.used || 0
       return total
         ? this.$gettext('%{used} of %{total} used', {
-            used: filesize(used),
-            total: filesize(total)
+            used: filesize<FileSizeOptionsString>(used),
+            total: filesize<FileSizeOptionsString>(total)
           })
         : this.$gettext('%{used} used', {
-            used: filesize(used),
-            total: filesize(total)
+            used: filesize<FileSizeOptionsString>(used),
+            total: filesize<FileSizeOptionsString>(total)
           })
     },
     limitedPersonalStorage() {


### PR DESCRIPTION
## Description
`pnpm check:types` complains about `filesize` returning the wrong type for `string` as needed by `$gettext`. Fixing it by defining return type options.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [x] Maintenance (e.g. dependency updates or tooling)
