### PR TITLE
[tests-only][full-ci] bump latest ocis stable-5.0 commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=31e1d03a3857f89efb2f8ca1e8f6fb1656bd0d6f
+OCIS_COMMITID=447967b9856867166934543a4058d8cbc5bb03c6
 OCIS_BRANCH=stable-5.0

--- a/tests/e2e/support/objects/app-files/spaces/actions.ts
+++ b/tests/e2e/support/objects/app-files/spaces/actions.ts
@@ -88,6 +88,7 @@ export interface openSpaceArgs {
 export const openSpace = async (args: openSpaceArgs): Promise<void> => {
   const { page, id } = args
   await page.locator(util.format(spaceIdSelector, id)).click()
+  await page.locator('#files-space-table').waitFor()
 }
 /**/
 

--- a/tests/e2e/support/objects/app-files/spaces/actions.ts
+++ b/tests/e2e/support/objects/app-files/spaces/actions.ts
@@ -22,6 +22,7 @@ const editSpacesDescription = '.oc-files-actions-edit-readme-content-trigger:vis
 const spacesDescriptionInputArea = '#description-input-area'
 const sideBarActions =
   '//ul[@id="oc-files-actions-sidebar"]//span[@class="oc-files-context-action-label"]'
+const spaceHeaderSelector = '.space-header'
 
 export const openActionsPanel = async (page: Page): Promise<void> => {
   await sidebar.open({ page })
@@ -88,6 +89,7 @@ export interface openSpaceArgs {
 export const openSpace = async (args: openSpaceArgs): Promise<void> => {
   const { page, id } = args
   await page.locator(util.format(spaceIdSelector, id)).click()
+  await page.locator(spaceHeaderSelector).waitFor()
 }
 /**/
 

--- a/tests/e2e/support/objects/app-files/spaces/actions.ts
+++ b/tests/e2e/support/objects/app-files/spaces/actions.ts
@@ -88,7 +88,6 @@ export interface openSpaceArgs {
 export const openSpace = async (args: openSpaceArgs): Promise<void> => {
   const { page, id } = args
   await page.locator(util.format(spaceIdSelector, id)).click()
-  await page.locator('#files-space-table').waitFor()
 }
 /**/
 


### PR DESCRIPTION
### Description
- Bump latest ocis stable commit id
- Added `waitFor()` to wait for an element after navigating to a project space

Fixes: https://github.com/owncloud/ocis/issues/9170