### PR TITLE
feat: add image and photo to dav default requested props

### DIFF
--- a/packages/web-client/src/webdav/constants/dav.ts
+++ b/packages/web-client/src/webdav/constants/dav.ts
@@ -1,4 +1,4 @@
-import { Audio, GeoCoordinates } from '../../graph/generated'
+import { Audio, GeoCoordinates, Image, Photo } from '../../graph/generated'
 
 export abstract class DavPermission {
   static readonly Shared: string = 'S'
@@ -59,6 +59,14 @@ const DavPropertyMapping = {
   Location: {
     value: 'location',
     type: null as GeoCoordinates
+  },
+  Image: {
+    value: 'image',
+    type: null as Image
+  },
+  Photo: {
+    value: 'photo',
+    type: null as Photo
   },
   ETag: defString('getetag' as const),
   MimeType: defString('getcontenttype' as const),
@@ -128,7 +136,9 @@ export abstract class DavProperties {
     DavProperty.DownloadURL,
     DavProperty.Tags,
     DavProperty.Audio,
-    DavProperty.Location
+    DavProperty.Location,
+    DavProperty.Image,
+    DavProperty.Photo
   ]
 
   static readonly PublicLink: DavPropertyValue[] = DavProperties.Default.concat([


### PR DESCRIPTION
## Description
Adding `photo` and `image` props to the by default requested dav props. This will enable us to write extensions about image and photo metadata (e.g. an `ExifPanel` for the right sidebar).

Can be merged without the ocis and reva counterparts. Will only deliver results when https://github.com/cs3org/reva/pull/4684 and https://github.com/owncloud/ocis/pull/8504 are merged.

Intentionally didn't add a changelog item because there is no user facing value to this.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)