### PR TITLE
feat: add secure viewer to space roles

### DIFF
--- a/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersPanel.vue
@@ -33,6 +33,14 @@
         <h3 class="oc-text-bold oc-text-medium" v-text="$gettext('Viewers')" />
         <members-role-section :members="filteredSpaceViewers" />
       </div>
+      <div
+        v-if="filteredSpaceSecureViewers.length"
+        class="oc-mb-m"
+        data-testid="space-members-role-secure-viewers"
+      >
+        <h3 class="oc-text-bold oc-text-medium" v-text="$gettext('Secure viewers')" />
+        <members-role-section :members="filteredSpaceSecureViewers" />
+      </div>
     </div>
   </div>
 </template>
@@ -74,6 +82,10 @@ export default defineComponent({
         ...unref(resource).spaceRoles.viewer.map((r) => ({
           ...r,
           roleType: 'viewer'
+        })),
+        ...unref(resource).spaceRoles['secure-viewer'].map((r) => ({
+          ...r,
+          roleType: 'secure-viewer'
         }))
       ].sort((a, b) => a.displayName.localeCompare(b.displayName))
     })
@@ -89,6 +101,9 @@ export default defineComponent({
     })
     const filteredSpaceViewers = computed(() => {
       return unref(filteredSpaceMembers).filter((m) => m.roleType === 'viewer')
+    })
+    const filteredSpaceSecureViewers = computed(() => {
+      return unref(filteredSpaceMembers).filter((m) => m.roleType === 'secure-viewer')
     })
 
     watch(filterTerm, () => {
@@ -108,6 +123,7 @@ export default defineComponent({
       filteredSpaceManagers,
       filteredSpaceEditors,
       filteredSpaceViewers,
+      filteredSpaceSecureViewers,
       membersListRef
     }
   }

--- a/packages/web-app-admin-settings/tests/unit/components/Spaces/SideBar/MembersPanel.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Spaces/SideBar/MembersPanel.spec.ts
@@ -11,7 +11,8 @@ const spaceMock = mock<SpaceResource>({
       { kind: 'user', displayName: 'einstein' },
       { kind: 'group', displayName: 'physic-haters' }
     ],
-    viewer: [{ kind: 'user', displayName: 'marie' }]
+    viewer: [{ kind: 'user', displayName: 'marie' }],
+    'secure-viewer': [{ kind: 'user', displayName: 'kathrine' }]
   }
 })
 

--- a/packages/web-app-admin-settings/tests/unit/components/Spaces/SideBar/__snapshots__/MembersPanel.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/components/Spaces/SideBar/__snapshots__/MembersPanel.spec.ts.snap
@@ -10,6 +10,7 @@ exports[`MembersPanel > should display an empty result if no matching members fo
     <!--v-if-->
     <!--v-if-->
     <!--v-if-->
+    <!--v-if-->
   </div>
 </div>"
 `;
@@ -29,6 +30,10 @@ exports[`MembersPanel > should render all members accordingly to their role assi
     </div>
     <div class="oc-mb-m" data-testid="space-members-role-viewers">
       <h3 class="oc-text-bold oc-text-medium">Viewers</h3>
+      <members-role-section-stub members="[object Object]"></members-role-section-stub>
+    </div>
+    <div class="oc-mb-m" data-testid="space-members-role-secure-viewers">
+      <h3 class="oc-text-bold oc-text-medium">Secure viewers</h3>
       <members-role-section-stub members="[object Object]"></members-role-section-stub>
     </div>
   </div>

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -372,11 +372,7 @@ export default defineComponent({
       return formatFileSize(space.spaceQuota.remaining, currentLanguage)
     }
     const getMemberCount = (space: SpaceResource) => {
-      return (
-        space.spaceRoles.manager.length +
-        space.spaceRoles.editor.length +
-        space.spaceRoles.viewer.length
-      )
+      return Object.values(space.spaceRoles).flat().length
     }
 
     onMounted(async () => {

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -124,7 +124,7 @@ export function buildSpace(
 ): SpaceResource {
   let spaceImageData: DriveItem, spaceReadmeData: DriveItem
   let disabled = false
-  const spaceRoles: SpaceRoles = { viewer: [], editor: [], manager: [] }
+  const spaceRoles: SpaceRoles = { viewer: [], editor: [], manager: [], 'secure-viewer': [] }
 
   if (data.special) {
     spaceImageData = data.special.find((el) => el.specialFolder.name === 'image')
@@ -284,6 +284,9 @@ export function buildSpace(
     },
     isManager(user: User): boolean {
       return this.spaceRoles.manager.map((r) => r.isMember(user)).some(Boolean)
+    },
+    isSecureViewer(user: User): boolean {
+      return this.spaceRoles['secure-viewer'].map((r) => r.isMember(user)).some(Boolean)
     },
     isMember(user: User): boolean {
       return this.isViewer(user) || this.isEditor(user) || this.isManager(user)

--- a/packages/web-client/src/helpers/space/types.ts
+++ b/packages/web-client/src/helpers/space/types.ts
@@ -21,6 +21,7 @@ export interface SpaceRoles {
   viewer: SpaceRole[]
   editor: SpaceRole[]
   manager: SpaceRole[]
+  'secure-viewer': SpaceRole[]
 }
 
 export interface SpaceResource extends Resource {


### PR DESCRIPTION
## Description
Adds the new secure view role to our space roles.

With the new permission and role concept it doesn't feel too great to have these roles "hard-coded" in a space... Especially since the addition of the new role broke Web (see https://github.com/owncloud/ocis/issues/9128#issuecomment-2114750861). But that's something for https://github.com/owncloud/web/issues/10770 I guess.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/ocis/issues/9128

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
