### PR TITLE
fix: deleting newly created folders/pasted resources inside shares

### DIFF
--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCreateNewFolder.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCreateNewFolder.ts
@@ -1,4 +1,4 @@
-import { SpaceResource } from '@ownclouders/web-client'
+import { SpaceResource, isShareSpaceResource } from '@ownclouders/web-client'
 import { computed, nextTick, unref } from 'vue'
 import { useClientService } from '../../clientService'
 import { useRouter } from '../../router'
@@ -74,6 +74,10 @@ export const useFileActionsCreateNewFolder = ({ space }: { space?: SpaceResource
           ancestorMetaData: unref(ancestorMetaData),
           user: userRoleStore.user
         })
+      }
+
+      if (isShareSpaceResource(space)) {
+        resource.remoteItemId = space.id
       }
 
       resourcesStore.upsertResource(resource)

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsPaste.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsPaste.ts
@@ -10,7 +10,7 @@ import { useClientService } from '../../clientService'
 import { useLoadingService } from '../../loadingService'
 import { useRouter } from '../../router'
 import { FileAction, FileActionOptions } from '../types'
-import { Resource, SpaceResource } from '@ownclouders/web-client'
+import { Resource, SpaceResource, isShareSpaceResource } from '@ownclouders/web-client'
 import { useClipboardStore, useResourcesStore } from '../../piniaStores'
 import { ClipboardActions, ResourceTransfer, TransferType } from '../../../helpers'
 import { storeToRefs } from 'pinia'
@@ -77,6 +77,12 @@ export const useFileActionsPaste = () => {
       }
 
       return Promise.all(loadingResources).then(() => {
+        if (isShareSpaceResource(targetSpace)) {
+          fetchedResources.forEach((r) => {
+            r.remoteItemId = targetSpace.id
+          })
+        }
+
         resourcesStore.upsertResources(fetchedResources)
         resourcesStore.loadIndicators(targetSpace, unref(currentFolder).path)
       })

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsCreateNewFolder.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsCreateNewFolder.spec.ts
@@ -6,7 +6,7 @@ import {
   useModals,
   useResourcesStore
 } from '../../../../../src/composables/piniaStores'
-import { SpaceResource } from '@ownclouders/web-client'
+import { ShareSpaceResource, SpaceResource } from '@ownclouders/web-client'
 import { FolderResource, Resource } from '@ownclouders/web-client'
 import { RouteLocation, defaultComponentMocks, getComposableWrapper } from 'web-test-helpers/src'
 import { useScrollToMock } from '../../../../mocks/useScrollToMock'
@@ -69,6 +69,20 @@ describe('useFileActionsCreateNewFolder', () => {
             })
           )
           consoleErrorMock.mockRestore()
+        }
+      })
+    })
+    it('adds the remoteItemId if the current space is a share space', () => {
+      const space = mock<ShareSpaceResource>({ id: '1', driveType: 'share' })
+      getWrapper({
+        space,
+        setup: async ({ addNewFolder }) => {
+          await addNewFolder('myfolder')
+
+          const { upsertResource } = useResourcesStore()
+          expect(upsertResource).toHaveBeenCalledWith(
+            expect.objectContaining({ remoteItemId: '1' })
+          )
         }
       })
     })


### PR DESCRIPTION
## Description
Fixes deleting newly created folders and pasted resources inside shares.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10933

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
