### PR TITLE
fix: prevent resource deselection when right-clicking empty space

### DIFF
--- a/changelog/unreleased/bugfix-resource-deselection-on-right-click
+++ b/changelog/unreleased/bugfix-resource-deselection-on-right-click
@@ -1,0 +1,6 @@
+Bugfix: Resource deselection on right-click
+
+We've fixed an issue where right-clicking any empty space inside the files table would reset the current selection.
+
+https://github.com/owncloud/web/issues/10918
+https://github.com/owncloud/web/pull/10936

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -154,7 +154,16 @@
 <script lang="ts">
 import { debounce, omit, last } from 'lodash-es'
 import { basename } from 'path'
-import { computed, defineComponent, PropType, onBeforeUnmount, onMounted, unref, ref } from 'vue'
+import {
+  computed,
+  ComponentPublicInstance,
+  defineComponent,
+  PropType,
+  onBeforeUnmount,
+  onMounted,
+  unref,
+  ref
+} from 'vue'
 import { RouteLocationNamedRaw } from 'vue-router'
 import { mapGetters, mapState, mapActions, mapMutations, useStore } from 'vuex'
 import { useGettext } from 'vue3-gettext'
@@ -504,9 +513,8 @@ export default defineComponent({
       eventBus.unsubscribe('app.files.list.load', loadResourcesEventToken)
     })
 
-    const whitespaceContextMenu = ref(null)
-    const showContextMenu = (event) => {
-      store.commit('Files/RESET_SELECTION')
+    const whitespaceContextMenu = ref<ComponentPublicInstance<typeof WhitespaceContextMenu>>(null)
+    const showContextMenu = (event: MouseEvent) => {
       displayPositionedDropdown(
         unref(whitespaceContextMenu).$el._tippy,
         event,
@@ -528,8 +536,8 @@ export default defineComponent({
       performLoaderTask,
       ViewModeConstants,
       viewModes,
-      uploadHint: $gettext(
-        'Drag files and folders here or use the "New" or "Upload" buttons to add files'
+      uploadHint: computed(() =>
+        $gettext('Drag files and folders here or use the "New" or "Upload" buttons to add files')
       ),
       whitespaceContextMenu,
       clientService,


### PR DESCRIPTION


## Description
Prevents the currently selected resource from being deselected when right-clicking any empty space inside the files table.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10918

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
