### PR TITLE
fix: space reactivity on space navigation

### DIFF
--- a/changelog/unreleased/bugfix-space-not-updating
+++ b/changelog/unreleased/bugfix-space-not-updating
@@ -1,0 +1,6 @@
+Bugfix: Space not updating on navigation
+
+We've fixed an issue where the current space did not update when navigating from one space into another directly, e.g. via search results. That could lead to uploads and file actions not working properly.
+
+https://github.com/owncloud/web/issues/10941
+https://github.com/owncloud/web/pull/10943

--- a/packages/web-app-files/src/HandleUpload.ts
+++ b/packages/web-app-files/src/HandleUpload.ts
@@ -23,7 +23,7 @@ export interface HandleUploadOptions {
   store: Store<any>
   uppyService: UppyService
   id?: string
-  space?: SpaceResource
+  space?: Ref<SpaceResource>
   quotaCheckEnabled?: boolean
   directoryTreeCreateEnabled?: boolean
   conflictHandlingEnabled?: boolean
@@ -47,7 +47,7 @@ export class HandleUpload extends BasePlugin {
   hasSpaces: Ref<boolean>
   language: Language
   route: Ref<RouteLocationNormalizedLoaded>
-  space: SpaceResource
+  space: Ref<SpaceResource>
   store: Store<any>
   uppyService: UppyService
   quotaCheckEnabled: boolean
@@ -107,7 +107,7 @@ export class HandleUpload extends BasePlugin {
       // public file drop
       const publicLinkToken = queryItemAsString(unref(this.route).params.token)
       let endpoint = urlJoin(
-        this.clientService.webdav.getPublicFileUrl(this.space, publicLinkToken),
+        this.clientService.webdav.getPublicFileUrl(unref(this.space), publicLinkToken),
         { trailingSlash: true }
       )
 
@@ -148,7 +148,7 @@ export class HandleUpload extends BasePlugin {
         topLevelFolderId = topLevelFolderIds[topLevelDirectory]
       }
 
-      const webDavUrl = this.space.getWebDavUrl({
+      const webDavUrl = unref(this.space).getWebDavUrl({
         path: currentFolderPath.split('/').map(encodeURIComponent).join('/')
       })
 
@@ -164,10 +164,10 @@ export class HandleUpload extends BasePlugin {
         name: file.name,
         mtime: (file.data as any).lastModified / 1000,
         // current path & space
-        spaceId: this.space.id,
-        spaceName: this.space.name,
-        driveAlias: this.space.driveAlias,
-        driveType: this.space.driveType,
+        spaceId: unref(this.space).id,
+        spaceName: unref(this.space).name,
+        driveAlias: unref(this.space).driveAlias,
+        driveType: unref(this.space).driveType,
         currentFolder: currentFolderPath,
         currentFolderId,
         // upload data
@@ -266,7 +266,7 @@ export class HandleUpload extends BasePlugin {
    */
   async createDirectoryTree(filesToUpload: UppyResource[]): Promise<UppyResource[]> {
     const { webdav } = this.clientService
-    const space = this.space
+    const space = unref(this.space)
     const { id: currentFolderId, path: currentFolderPath } = this.currentFolder
 
     const routeName = filesToUpload[0].meta.routeName

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -169,7 +169,7 @@
       <oc-button
         :disabled="uploadOrFileCreationBlocked"
         class="paste-files-btn"
-        @click="pasteFileAction({ space })"
+        @click="pasteFileAction"
       >
         <oc-icon fill-type="line" name="clipboard" />
         <span v-text="$gettext('Paste here')" />
@@ -262,6 +262,8 @@ export default defineComponent({
     const hasSpaces = useCapabilitySpacesEnabled(store)
     const areFileExtensionsShown = computed(() => unref(store.state.Files.areFileExtensionsShown))
 
+    const space = computed(() => props.space)
+
     useUpload({ uppyService })
 
     if (!uppyService.getPlugin('HandleUpload')) {
@@ -270,7 +272,7 @@ export default defineComponent({
         hasSpaces,
         language,
         route,
-        space: props.space,
+        space,
         store,
         uppyService
       })
@@ -279,15 +281,18 @@ export default defineComponent({
     let uploadCompletedSub
 
     const { actions: pasteFileActions } = useFileActionsPaste({ store })
-    const pasteFileAction = unref(pasteFileActions)[0].handler
+
+    const pasteFileAction = () => {
+      return unref(pasteFileActions)[0].handler({ space: unref(space) })
+    }
 
     const { actions: createNewFolder } = useFileActionsCreateNewFolder({
       store,
-      space: props.space
+      space
     })
     const createNewFolderAction = computed(() => unref(createNewFolder)[0].handler)
 
-    const { actions: createNewShortcut } = useFileActionsCreateNewShortcut({ space: props.space })
+    const { actions: createNewShortcut } = useFileActionsCreateNewShortcut({ space })
 
     const createNewShortcutAction = computed(() => unref(createNewShortcut)[0].handler)
 
@@ -295,7 +300,7 @@ export default defineComponent({
 
     const { actions: createNewFileActions } = useFileActionsCreateNewFile({
       store,
-      space: props.space,
+      space,
       newFileHandlers: newFileHandlers
     })
 
@@ -309,7 +314,7 @@ export default defineComponent({
 
     const { actions: createNewFileMimeTypeActions } = useFileActionsCreateNewFile({
       store,
-      space: props.space,
+      space,
       mimetypesAllowedForCreation: mimetypesAllowedForCreation
     })
 
@@ -383,10 +388,10 @@ export default defineComponent({
         }
 
         const sameFolder =
-          props.itemId && !isShareSpaceResource(props.space)
+          props.itemId && !isShareSpaceResource(unref(space))
             ? props.itemId.toString().startsWith(currentFolderId.toString())
             : currentFolder === props.item
-        const fileIsInCurrentPath = spaceId === props.space.id && sameFolder
+        const fileIsInCurrentPath = spaceId === unref(space).id && sameFolder
         if (fileIsInCurrentPath) {
           eventBus.publish('app.files.list.load')
         }

--- a/packages/web-app-files/src/components/Spaces/WhitespaceContextMenu.vue
+++ b/packages/web-app-files/src/components/Spaces/WhitespaceContextMenu.vue
@@ -45,15 +45,17 @@ export default defineComponent({
   setup(props) {
     const { $gettext } = useGettext()
     const store = useStore()
+
+    const space = computed(() => props.space)
     const contextMenuLabel = computed(() => $gettext('Show context menu'))
     const currentFolder = computed(() => store.getters['Files/currentFolder'])
     const actionOptions = computed(() => ({
-      space: props.space,
+      space: unref(space),
       resources: [currentFolder.value]
     }))
     const { actions: createNewFolderAction } = useFileActionsCreateNewFolder({
       store,
-      space: props.space
+      space
     })
     const { actions: showDetailsAction } = useFileActionsShowDetails({ store })
     const { actions: pasteAction } = useFileActionsPaste({ store })

--- a/packages/web-app-files/src/composables/keyboardActions/useKeyboardTableSpaceActions.ts
+++ b/packages/web-app-files/src/composables/keyboardActions/useKeyboardTableSpaceActions.ts
@@ -4,8 +4,12 @@ import { useStore } from '@ownclouders/web-pkg'
 import { useGettext } from 'vue3-gettext'
 import { unref } from 'vue'
 import { useFileActionsPaste } from '@ownclouders/web-pkg'
+import { Ref } from 'vue'
 
-export const useKeyboardTableSpaceActions = (keyActions: KeyboardActions, space: SpaceResource) => {
+export const useKeyboardTableSpaceActions = (
+  keyActions: KeyboardActions,
+  space: Ref<SpaceResource>
+) => {
   const store = useStore()
   const language = useGettext()
 
@@ -15,19 +19,19 @@ export const useKeyboardTableSpaceActions = (keyActions: KeyboardActions, space:
   keyActions.bindKeyAction({ modifier: ModifierKey.Ctrl, primary: Key.C }, () => {
     store.dispatch('Files/copySelectedFiles', {
       ...language,
-      space: space,
+      space: unref(space),
       resources: store.getters['Files/selectedFiles']
     })
   })
 
   keyActions.bindKeyAction({ modifier: ModifierKey.Ctrl, primary: Key.V }, () => {
-    pasteFileAction({ space: space })
+    pasteFileAction({ space: unref(space) })
   })
 
   keyActions.bindKeyAction({ modifier: ModifierKey.Ctrl, primary: Key.X }, () => {
     store.dispatch('Files/cutSelectedFiles', {
       ...language,
-      space: space,
+      space: unref(space),
       resources: store.getters['Files/selectedFiles']
     })
   })

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -269,9 +269,12 @@ export default defineComponent({
     const hasShareJail = useCapabilityShareJailEnabled()
     const { breadcrumbsFromPath, concatBreadcrumbs } = useBreadcrumbsFromPath()
     const { openWithDefaultApp } = useOpenWithDefaultApp()
+
+    const space = computed(() => props.space)
+
     const { actions: createNewFolder } = useFileActionsCreateNewFolder({
       store,
-      space: props.space
+      space
     })
     const { isEnabled: isEmbedModeEnabled } = useEmbedMode()
 
@@ -291,8 +294,8 @@ export default defineComponent({
       path,
       fileId
     }: CreateTargetRouteOptions): RouteLocationNamedRaw => {
-      const { params, query } = createFileRouteOptions(props.space, { path, fileId })
-      if (isPublicSpaceResource(props.space)) {
+      const { params, query } = createFileRouteOptions(unref(space), { path, fileId })
+      if (isPublicSpaceResource(unref(space))) {
         return createLocationPublic('files-public-link', { params, query })
       }
       return createLocationSpaces('files-spaces-generic', { params, query })
@@ -300,7 +303,7 @@ export default defineComponent({
 
     const hasSpaceHeader = computed(() => {
       // for now the space header is only available in the root of a project space.
-      return props.space.driveType === 'project' && props.item === '/'
+      return unref(space).driveType === 'project' && props.item === '/'
     })
 
     const folderNotFound = computed(() => store.getters['Files/currentFolder'] === null)
@@ -310,7 +313,7 @@ export default defineComponent({
     )
 
     const titleSegments = computed(() => {
-      const segments = [props.space.name]
+      const segments = [unref(space).name]
       if (props.item !== '/') {
         segments.unshift(basename(props.item))
       }
@@ -321,16 +324,15 @@ export default defineComponent({
 
     const route = useRoute()
     const breadcrumbs = computed(() => {
-      const space = props.space
       const rootBreadcrumbItems: BreadcrumbItem[] = []
-      if (isProjectSpaceResource(space)) {
+      if (isProjectSpaceResource(unref(space))) {
         rootBreadcrumbItems.push({
           id: uuidv4(),
           text: $gettext('Spaces'),
           to: createLocationSpaces('files-spaces-projects'),
           isStaticNav: true
         })
-      } else if (isShareSpaceResource(space)) {
+      } else if (isShareSpaceResource(unref(space))) {
         rootBreadcrumbItems.push(
           {
             id: uuidv4(),
@@ -348,30 +350,30 @@ export default defineComponent({
       }
 
       let spaceBreadcrumbItem: BreadcrumbItem
-      let { params, query } = createFileRouteOptions(space, { fileId: space.fileId })
+      let { params, query } = createFileRouteOptions(unref(space), { fileId: unref(space).fileId })
       query = omit({ ...unref(route).query, ...query }, 'page')
-      if (isPersonalSpaceResource(space)) {
+      if (isPersonalSpaceResource(unref(space))) {
         spaceBreadcrumbItem = {
           id: uuidv4(),
-          text: space.name,
-          ...(space.isOwner(store.getters.user) && {
+          text: unref(space).name,
+          ...(unref(space).isOwner(store.getters.user) && {
             to: createLocationSpaces('files-spaces-generic', {
               params,
               query
             })
           })
         }
-      } else if (isShareSpaceResource(space)) {
+      } else if (isShareSpaceResource(unref(space))) {
         spaceBreadcrumbItem = {
           id: uuidv4(),
           allowContextActions: true,
-          text: space.name,
+          text: unref(space).name,
           to: createLocationSpaces('files-spaces-generic', {
             params,
             query: omit(query, 'fileId')
           })
         }
-      } else if (isPublicSpaceResource(space)) {
+      } else if (isPublicSpaceResource(unref(space))) {
         spaceBreadcrumbItem = {
           id: uuidv4(),
           text: $gettext('Public link'),
@@ -385,7 +387,7 @@ export default defineComponent({
         spaceBreadcrumbItem = {
           id: uuidv4(),
           allowContextActions: !unref(hasSpaceHeader),
-          text: space.name,
+          text: unref(space).name,
           to: createLocationSpaces('files-spaces-generic', {
             params,
             query
@@ -445,7 +447,7 @@ export default defineComponent({
       resourcesViewDefaults.viewMode
     )
     useKeyboardTableMouseActions(keyActions, resourcesViewDefaults.viewMode)
-    useKeyboardTableSpaceActions(keyActions, props.space)
+    useKeyboardTableSpaceActions(keyActions, space)
 
     const performLoaderTask = async (
       sameRoute: boolean,
@@ -456,9 +458,9 @@ export default defineComponent({
         return
       }
 
-      const options: FolderLoaderOptions = { loadShares: !isPublicSpaceResource(props.space) }
+      const options: FolderLoaderOptions = { loadShares: !isPublicSpaceResource(unref(space)) }
       await resourcesViewDefaults.loadResourcesTask.perform(
-        props.space,
+        unref(space),
         path || props.item,
         fileId || props.itemId,
         options
@@ -473,7 +475,7 @@ export default defineComponent({
 
       if (unref(openWithDefaultAppQuery) === 'true') {
         openWithDefaultApp({
-          space: props.space,
+          space: unref(space),
           resource: unref(resourcesViewDefaults.selectedResources)[0]
         })
       }

--- a/packages/web-app-files/tests/unit/HandleUpload.spec.ts
+++ b/packages/web-app-files/tests/unit/HandleUpload.spec.ts
@@ -43,10 +43,10 @@ describe('HandleUpload', () => {
 
     expect(processedFiles[0].tus.endpoint).toEqual('/')
     expect(processedFiles[0].meta.name).toEqual(fileToUpload.name)
-    expect(processedFiles[0].meta.spaceId).toEqual(mocks.opts.space.id)
-    expect(processedFiles[0].meta.spaceName).toEqual(mocks.opts.space.name)
-    expect(processedFiles[0].meta.driveAlias).toEqual(mocks.opts.space.driveAlias)
-    expect(processedFiles[0].meta.driveType).toEqual(mocks.opts.space.driveType)
+    expect(processedFiles[0].meta.spaceId).toEqual(unref(mocks.opts.space).id)
+    expect(processedFiles[0].meta.spaceName).toEqual(unref(mocks.opts.space).name)
+    expect(processedFiles[0].meta.driveAlias).toEqual(unref(mocks.opts.space).driveAlias)
+    expect(processedFiles[0].meta.driveType).toEqual(unref(mocks.opts.space).driveType)
     expect(processedFiles[0].meta.currentFolder).toEqual(currentFolder.path)
     expect(processedFiles[0].meta.currentFolderId).toEqual(currentFolder.id)
     expect(processedFiles[0].meta.tusEndpoint).toEqual(currentFolder.path)
@@ -74,10 +74,10 @@ describe('HandleUpload', () => {
           isFolder: true,
           type: 'folder',
           meta: expect.objectContaining({
-            spaceId: mocks.opts.space.id,
-            spaceName: mocks.opts.space.name,
-            driveAlias: mocks.opts.space.driveAlias,
-            driveType: mocks.opts.space.driveType,
+            spaceId: unref(mocks.opts.space).id,
+            spaceName: unref(mocks.opts.space).name,
+            driveAlias: unref(mocks.opts.space).driveAlias,
+            driveType: unref(mocks.opts.space).driveType,
             currentFolder: currentFolder.path,
             currentFolderId: currentFolder.id,
             relativeFolder: '',
@@ -89,10 +89,13 @@ describe('HandleUpload', () => {
         })
       )
       expect(mocks.opts.clientService.webdav.createFolder).toHaveBeenCalledTimes(1)
-      expect(mocks.opts.clientService.webdav.createFolder).toHaveBeenCalledWith(mocks.opts.space, {
-        path: relativeFolder,
-        fetchFolder: true
-      })
+      expect(mocks.opts.clientService.webdav.createFolder).toHaveBeenCalledWith(
+        unref(mocks.opts.space),
+        {
+          path: relativeFolder,
+          fetchFolder: true
+        }
+      )
       expect(result.length).toBe(1)
     })
     it('filters out files whose folders could not be created', async () => {
@@ -280,7 +283,7 @@ const getWrapper = ({
     language: mock<Language>(),
     route: ref(route),
     store,
-    space: mock<SpaceResource>(),
+    space: ref(mock<SpaceResource>()),
     uppyService: mock<UppyService>(),
     conflictHandlingEnabled,
     directoryTreeCreateEnabled,

--- a/packages/web-pkg/src/components/AppBar/AppBar.vue
+++ b/packages/web-pkg/src/components/AppBar/AppBar.vue
@@ -151,6 +151,8 @@ export default defineComponent({
     const { $gettext } = useGettext()
     const { can } = useAbility()
 
+    const space = computed(() => props.space)
+
     const { actions: acceptShareActions } = useFileActionsAcceptShare({ store })
     const { actions: hideShareActions } = useFileActionsToggleHideShare({ store })
     const { actions: copyActions } = useFileActionsCopy({ store })
@@ -204,7 +206,7 @@ export default defineComponent({
       }
 
       return actions.filter((item) =>
-        item.isEnabled({ space: props.space, resources: store.getters['Files/selectedFiles'] })
+        item.isEnabled({ space: unref(space), resources: store.getters['Files/selectedFiles'] })
       )
     })
 
@@ -233,12 +235,10 @@ export default defineComponent({
     })
 
     const breadcrumbTruncationOffset = computed(() => {
-      if (!props.space) {
+      if (!unref(space)) {
         return 2
       }
-      return isProjectSpaceResource(unref(props.space)) || isShareSpaceResource(unref(props.space))
-        ? 3
-        : 2
+      return isProjectSpaceResource(unref(space)) || isShareSpaceResource(unref(space)) ? 3 : 2
     })
     const fileDroppedBreadcrumb = async (data) => {
       emit(EVENT_ITEM_DROPPED, data)
@@ -249,7 +249,7 @@ export default defineComponent({
       if (unref(routeMetaTitle)) {
         return $gettext(unref(routeMetaTitle))
       }
-      return props.space?.name || ''
+      return unref(space)?.name || ''
     })
 
     return {

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCreateNewFile.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCreateNewFile.ts
@@ -29,7 +29,7 @@ export const useFileActionsCreateNewFile = ({
   mimetypesAllowedForCreation
 }: {
   store?: Store<any>
-  space?: SpaceResource
+  space?: Ref<SpaceResource>
   newFileHandlers?: Ref<any> // FIXME: type?
   mimetypesAllowedForCreation?: Ref<any> // FIXME: type?
 } = {}) => {
@@ -99,13 +99,13 @@ export const useFileActionsCreateNewFile = ({
         throw new Error(`An error has occurred: ${response.status}`)
       }
       const path = join(unref(currentFolder).path, fileName) || ''
-      const resource = await (clientService.webdav as WebDAV).getFileInfo(space, {
+      const resource = await (clientService.webdav as WebDAV).getFileInfo(unref(space), {
         path
       })
       if (unref(loadIndicatorsForNewFile)) {
         resource.indicators = getIndicators({ resource, ancestorMetaData: unref(ancestorMetaData) })
       }
-      triggerDefaultAction({ space: space, resources: [resource] })
+      triggerDefaultAction({ space: unref(space), resources: [resource] })
       store.commit('Files/UPSERT_RESOURCE', resource)
       store.dispatch('hideModal')
       store.dispatch('showMessage', {
@@ -121,7 +121,9 @@ export const useFileActionsCreateNewFile = ({
   }
 
   const loadIndicatorsForNewFile = computed(() => {
-    return isLocationSpacesActive(router, 'files-spaces-generic') && space.driveType !== 'share'
+    return (
+      isLocationSpacesActive(router, 'files-spaces-generic') && unref(space).driveType !== 'share'
+    )
   })
 
   const addNewFile = async (fileName, openAction) => {
@@ -131,7 +133,7 @@ export const useFileActionsCreateNewFile = ({
 
     try {
       const path = join(unref(currentFolder).path, fileName)
-      const resource = await (clientService.webdav as WebDAV).putFileContents(space, {
+      const resource = await (clientService.webdav as WebDAV).putFileContents(unref(space), {
         path
       })
 
@@ -144,11 +146,11 @@ export const useFileActionsCreateNewFile = ({
       if (openAction) {
         openEditor(
           openAction,
-          space.getDriveAliasAndItem(resource),
+          unref(space).getDriveAliasAndItem(resource),
           resource.webDavPath,
           resource.fileId,
           EDITOR_MODE_CREATE,
-          space.shareId
+          unref(space).shareId
         )
         store.dispatch('hideModal')
 

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCreateNewFolder.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCreateNewFolder.ts
@@ -1,6 +1,6 @@
 import { Resource, SpaceResource } from '@ownclouders/web-client/src/helpers'
 import { Store } from 'vuex'
-import { computed, nextTick, unref } from 'vue'
+import { computed, nextTick, Ref, unref } from 'vue'
 import { useClientService } from '../../clientService'
 import { useRouter } from '../../router'
 import { useStore } from '../../store'
@@ -17,7 +17,7 @@ import { AncestorMetaData } from '../../../types'
 export const useFileActionsCreateNewFolder = ({
   store,
   space
-}: { store?: Store<any>; space?: SpaceResource } = {}) => {
+}: { store?: Store<any>; space?: Ref<SpaceResource> } = {}) => {
   store = store || useStore()
   const router = useRouter()
   const { $gettext } = useGettext()
@@ -57,7 +57,9 @@ export const useFileActionsCreateNewFolder = ({
   }
 
   const loadIndicatorsForNewFile = computed(() => {
-    return isLocationSpacesActive(router, 'files-spaces-generic') && space.driveType !== 'share'
+    return (
+      isLocationSpacesActive(router, 'files-spaces-generic') && unref(space).driveType !== 'share'
+    )
   })
 
   const addNewFolder = async (folderName) => {
@@ -65,7 +67,7 @@ export const useFileActionsCreateNewFolder = ({
 
     try {
       const path = join(unref(currentFolder).path, folderName)
-      const resource = await (clientService.webdav as WebDAV).createFolder(space, {
+      const resource = await (clientService.webdav as WebDAV).createFolder(unref(space), {
         path
       })
 

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCreateNewShortcut.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCreateNewShortcut.ts
@@ -1,11 +1,11 @@
 import { Resource, SpaceResource } from '@ownclouders/web-client/src/helpers'
-import { computed, unref } from 'vue'
+import { Ref, computed, unref } from 'vue'
 import { useStore } from '../../store'
 import { FileAction } from '../../../composables'
 import { CreateShortcutModal } from '../../../components'
 import { useGettext } from 'vue3-gettext'
 
-export const useFileActionsCreateNewShortcut = ({ space }: { space: SpaceResource }) => {
+export const useFileActionsCreateNewShortcut = ({ space }: { space: Ref<SpaceResource> }) => {
   const store = useStore()
   const { $gettext } = useGettext()
   const currentFolder = computed((): Resource => store.getters['Files/currentFolder'])
@@ -15,7 +15,7 @@ export const useFileActionsCreateNewShortcut = ({ space }: { space: SpaceResourc
       title: $gettext('Create a Shortcut'),
       hideActions: true,
       customComponent: CreateShortcutModal,
-      customComponentAttrs: () => ({ space })
+      customComponentAttrs: () => ({ space: unref(space) })
     })
   }
 

--- a/packages/web-pkg/src/composables/breadcrumbs/useBreadcrumbsFromPath.ts
+++ b/packages/web-pkg/src/composables/breadcrumbs/useBreadcrumbsFromPath.ts
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { SpaceResource } from '@ownclouders/web-client/src'
 import { urlJoin } from '@ownclouders/web-client/src/utils'
 import { useGetMatchingSpace } from '../spaces'
+import { Ref, unref } from 'vue'
 
 export const useBreadcrumbsFromPath = () => {
   const { isResourceAccessible } = useGetMatchingSpace()
@@ -16,7 +17,7 @@ export const useBreadcrumbsFromPath = () => {
     resourcePath
   }: {
     route: RouteLocation
-    space: SpaceResource
+    space: Ref<SpaceResource>
     resourcePath: string
   }): BreadcrumbItem[] => {
     const pathSplit = (p = '') => p.split('/').filter(Boolean)
@@ -25,7 +26,7 @@ export const useBreadcrumbsFromPath = () => {
 
     return resource.map((text, i) => {
       const isAccessible = isResourceAccessible({
-        space,
+        space: unref(space),
         path: urlJoin(...resource.slice(0, i + 1), { leadingSlash: true })
       })
 

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsCreateNewFile.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsCreateNewFile.spec.ts
@@ -136,7 +136,7 @@ function getWrapper({
       () => {
         const instance = useFileActionsCreateNewFile({
           store,
-          space,
+          space: ref(space),
           newFileHandlers: ref([{ action: null, ext: '.txt', menuTitle: jest.fn() }])
         })
         setup(instance, { storeOptions })

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsCreateNewFolder.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsCreateNewFolder.spec.ts
@@ -1,5 +1,5 @@
 import { mock } from 'jest-mock-extended'
-import { nextTick, unref } from 'vue'
+import { nextTick, ref, unref } from 'vue'
 import { useFileActionsCreateNewFolder } from '../../../../../src/composables/actions'
 import { SpaceResource } from '@ownclouders/web-client/src'
 import { FolderResource } from '@ownclouders/web-client/src/helpers'
@@ -134,7 +134,7 @@ function getWrapper({
   return {
     wrapper: getComposableWrapper(
       () => {
-        const instance = useFileActionsCreateNewFolder({ store, space })
+        const instance = useFileActionsCreateNewFolder({ store, space: ref(space) })
         setup(instance, { storeOptions })
       },
       {

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsCreateNewShortcut.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsCreateNewShortcut.spec.ts
@@ -1,5 +1,5 @@
 import { mock } from 'jest-mock-extended'
-import { unref } from 'vue'
+import { ref, unref } from 'vue'
 import {
   createStore,
   defaultComponentMocks,
@@ -72,7 +72,7 @@ function getWrapper({
   return {
     wrapper: getComposableWrapper(
       () => {
-        const instance = useFileActionsCreateNewShortcut({ space: mock<SpaceResource>() })
+        const instance = useFileActionsCreateNewShortcut({ space: ref(mock<SpaceResource>()) })
         setup(instance, { storeOptions })
       },
       {

--- a/packages/web-pkg/tests/unit/composables/breadcrumbs/useBreadcrumbsFromPath.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/breadcrumbs/useBreadcrumbsFromPath.spec.ts
@@ -3,6 +3,7 @@ import { SpaceResource } from '@ownclouders/web-client/src'
 import { RouteLocation, getComposableWrapper } from 'web-test-helpers/src'
 import { useBreadcrumbsFromPath } from '../../../../src/composables/breadcrumbs'
 import { ConfigurationManager } from '../../../../src/configuration'
+import { ref } from 'vue'
 
 jest.mock('../../../../src/composables/configuration/useConfigurationManager', () => ({
   useConfigurationManager: () =>
@@ -22,7 +23,7 @@ describe('useBreadcrumbsFromPath', () => {
       const { breadcrumbsFromPath } = wrapper.vm as ReturnType<typeof useBreadcrumbsFromPath>
       const breadCrumbs = breadcrumbsFromPath({
         route: { path: '/files/spaces/personal/home/test' } as RouteLocation,
-        space: mock<SpaceResource>(),
+        space: ref(mock<SpaceResource>()),
         resourcePath: '/test'
       })
       expect(breadCrumbs).toEqual([
@@ -44,7 +45,7 @@ describe('useBreadcrumbsFromPath', () => {
       const initialBreadCrumbs = [{ text: 'Foo' }, { text: 'Bar' }]
       const breadCrumbsFromPath = breadcrumbsFromPath({
         route: { path: '/app/foo/bar?all=500' } as RouteLocation,
-        space: mock<SpaceResource>(),
+        space: ref(mock<SpaceResource>()),
         resourcePath: '/bar'
       })
       const result = concatBreadcrumbs(...initialBreadCrumbs, ...breadCrumbsFromPath)


### PR DESCRIPTION
## Description
Fixes an issue where the current space did not update when navigating from one space into another directly, e.g. via search results. That could lead to uploads and file actions not working properly.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10941

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
