### PR TITLE
Exif and audio panels

### DIFF
--- a/changelog/unreleased/enhancement-audio-metadata-panel
+++ b/changelog/unreleased/enhancement-audio-metadata-panel
@@ -1,0 +1,7 @@
+Enhancement: Audio metadata panel
+
+We've added a right sidebar panel with the name `Audio Info`, which display `audio` metadata if present on the given resource.
+It is registered by the files app and becomes visible in the global right sidebar in all file contexts, e.g. file listing 
+with single select on an audio file with indexed id3 information or when listening to an audio file in the preview app.
+
+https://github.com/owncloud/web/pull/10956

--- a/changelog/unreleased/enhancement-exif-panel
+++ b/changelog/unreleased/enhancement-exif-panel
@@ -1,6 +1,6 @@
 Enhancement: EXIF metadata panel
 
-We've added a right sidebar panel with the name `Image Info`, which display `image`, `photo` and `location`
+We've added a right sidebar panel with the name `Image Info`, which displays `image`, `photo` and `location`
 metadata if present on the given resource. It is registered by the files app and becomes visible in the global right sidebar
 in all file contexts, e.g. file listing with single select on an image or the preview app displaying an image.
 

--- a/changelog/unreleased/enhancement-exif-panel
+++ b/changelog/unreleased/enhancement-exif-panel
@@ -1,0 +1,7 @@
+Enhancement: EXIF metadata panel
+
+We've added a right sidebar panel with the name `Image Info`, which display `image`, `photo` and `location`
+metadata if present on the given resource. It is registered by the files app and becomes visible in the global right sidebar
+in all file contexts, e.g. file listing with single select on an image or the preview app displaying an image.
+
+https://github.com/owncloud/web/pull/10956

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -59,7 +59,9 @@ Depending on the backend you are using, there are sample config files provided i
     - `options.feedbackLink.ariaLabel` Since the link only has an icon, you can set an e.g. screen reader accessible label. Defaults to `ownCloud feedback survey`.
     - `options.feedbackLink.description` Provide any description you want to see as tooltip and as accessible description. Defaults to `Provide your feedback: We'd like to improve the web design and would be happy to hear your feedback. Thank you! Your ownCloud team.`
 - `options.sharingRecipientsPerPage` Sets the amount of users shown as recipients in the dropdown when sharing resources. Default amount is 200.
-- `options.sidebar.shares.showAllOnLoad` Sets the list of (link) shares list in the sidebar to be initially expanded (default is a collapsed state, only showing the first three shares).
+- `options.sidebar` This accepts an object with the following fields to customize the right sidebar behaviour:
+    - `options.sidebar.shares.showAllOnLoad` Sets the list of (link) shares list in the sidebar to be initially expanded (default is a collapsed state, only showing the first three shares).
+    - `options.sidebar.exif.showLocation` Sets the `location` data in the exif panel to visible or hidden. One might want to hide the location info when a map view of the location is available from another app (the GPX Viewer app provides such a sidebar panel).  
 - `options.runningOnEos` Set this option to `true` if running on an [EOS storage backend](https://eos-web.web.cern.ch/eos-web/) to enable its specific features. Defaults to `false`, and we recommend reaching out to [the ownCloud web team](https://talk.owncloud.com/channel/web) if you're not CERN and thinking about enabling this feature flag.
 - `options.cernFeatures` Enabling this will activate CERN-specific features. Defaults to `false`.
 - `options.hoverableQuickActions` Set this option to `true` to hide the quick actions (buttons appearing on file rows), and only show them when the user

--- a/packages/web-app-files/src/components/SideBar/Audio/AudioMetaPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Audio/AudioMetaPanel.vue
@@ -1,0 +1,133 @@
+<template>
+  <div id="files-sidebar-panel-audio">
+    <dl class="audio-data-list">
+      <template v-if="title">
+        <dt v-text="$gettext('Title')" />
+        <dd v-text="title" />
+      </template>
+      <template v-if="duration">
+        <dt v-text="$gettext('Duration')" />
+        <dd v-text="duration" />
+      </template>
+      <template v-if="artist">
+        <dt v-text="$gettext('Authors')" />
+        <dd v-text="artist" />
+      </template>
+      <template v-if="album">
+        <dt v-text="$gettext('Album')" />
+        <dd v-text="album" />
+      </template>
+      <template v-if="genre">
+        <dt v-text="$gettext('Genre')" />
+        <dd v-text="genre" />
+      </template>
+      <template v-if="year">
+        <dt v-text="$gettext('Year recorded')" />
+        <dd v-text="year" />
+      </template>
+      <template v-if="track">
+        <dt v-text="$gettext('Track')" />
+        <dd v-text="track" />
+      </template>
+      <template v-if="disc">
+        <dt v-text="$gettext('Disc')" />
+        <dd v-text="disc" />
+      </template>
+    </dl>
+  </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, inject, Ref, unref } from 'vue'
+import { Resource } from '@ownclouders/web-client'
+import { Duration } from 'luxon'
+
+export default defineComponent({
+  name: 'AudioMetaPanel',
+  setup() {
+    const resource = inject<Ref<Resource>>('resource')
+
+    const album = computed(() => {
+      return unref(resource).audio.album
+    })
+
+    const artist = computed(() => {
+      return unref(resource).audio.artist
+    })
+
+    const albumArtist = computed(() => {
+      return unref(resource).audio.albumArtist
+    })
+
+    const genre = computed(() => {
+      return unref(resource).audio.genre
+    })
+
+    const title = computed(() => {
+      return unref(resource).audio.title
+    })
+
+    const duration = computed(() => {
+      const milliseconds = unref(resource).audio.duration
+      if (milliseconds) {
+        const d = Duration.fromMillis(milliseconds)
+        if (d.hours > 0) {
+          return d.toFormat('hh:mm:ss')
+        }
+        return d.toFormat('mm:ss')
+      }
+      return ''
+    })
+
+    const track = computed(() => {
+      const audio = unref(resource).audio
+      if (audio.track && audio.trackCount) {
+        return `${audio.track} / ${audio.trackCount}`
+      }
+      return audio.track
+    })
+
+    const disc = computed(() => {
+      const audio = unref(resource).audio
+      if (audio.disc && audio.discCount) {
+        return `${audio.disc} / ${audio.discCount}`
+      }
+      return audio.disc
+    })
+
+    const year = computed(() => {
+      return unref(resource).audio?.year
+    })
+
+    return {
+      album,
+      artist,
+      albumArtist,
+      genre,
+      title,
+      duration,
+      track,
+      disc,
+      year
+    }
+  }
+})
+</script>
+
+<style lang="scss">
+.audio-data-list {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  dt,
+  dd {
+    margin-bottom: var(--oc-space-small);
+  }
+  dt {
+    font-weight: bold;
+    white-space: nowrap;
+  }
+  dd {
+    margin-inline-start: var(--oc-space-medium);
+  }
+}
+</style>

--- a/packages/web-app-files/src/components/SideBar/Audio/AudioMetaPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Audio/AudioMetaPanel.vue
@@ -69,14 +69,14 @@ export default defineComponent({
 
     const duration = computed(() => {
       const milliseconds = unref(resource).audio.duration
-      if (milliseconds) {
-        const d = Duration.fromMillis(milliseconds)
-        if (d.hours > 0) {
-          return d.toFormat('hh:mm:ss')
-        }
-        return d.toFormat('mm:ss')
+      if (!milliseconds) {
+        return ''
       }
-      return ''
+      const d = Duration.fromMillis(milliseconds)
+      if (d.hours > 0) {
+        return d.toFormat('hh:mm:ss')
+      }
+      return d.toFormat('mm:ss')
     })
 
     const track = computed(() => {

--- a/packages/web-app-files/src/components/SideBar/Audio/AudioMetaPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Audio/AudioMetaPanel.vue
@@ -1,38 +1,22 @@
 <template>
   <div id="files-sidebar-panel-audio">
     <dl class="audio-data-list">
-      <template v-if="title">
-        <dt v-text="$gettext('Title')" />
-        <dd v-text="title" />
-      </template>
-      <template v-if="duration">
-        <dt v-text="$gettext('Duration')" />
-        <dd v-text="duration" />
-      </template>
-      <template v-if="artist">
-        <dt v-text="$gettext('Authors')" />
-        <dd v-text="artist" />
-      </template>
-      <template v-if="album">
-        <dt v-text="$gettext('Album')" />
-        <dd v-text="album" />
-      </template>
-      <template v-if="genre">
-        <dt v-text="$gettext('Genre')" />
-        <dd v-text="genre" />
-      </template>
-      <template v-if="year">
-        <dt v-text="$gettext('Year recorded')" />
-        <dd v-text="year" />
-      </template>
-      <template v-if="track">
-        <dt v-text="$gettext('Track')" />
-        <dd v-text="track" />
-      </template>
-      <template v-if="disc">
-        <dt v-text="$gettext('Disc')" />
-        <dd v-text="disc" />
-      </template>
+      <dt v-text="$gettext('Title')" />
+      <dd v-text="title" />
+      <dt v-text="$gettext('Duration')" />
+      <dd v-text="duration" />
+      <dt v-text="$gettext('Authors')" />
+      <dd v-text="artist" />
+      <dt v-text="$gettext('Album')" />
+      <dd v-text="album" />
+      <dt v-text="$gettext('Genre')" />
+      <dd v-text="genre" />
+      <dt v-text="$gettext('Year recorded')" />
+      <dd v-text="year" />
+      <dt v-text="$gettext('Track')" />
+      <dd v-text="track" />
+      <dt v-text="$gettext('Disc')" />
+      <dd v-text="disc" />
     </dl>
   </div>
 </template>
@@ -48,29 +32,29 @@ export default defineComponent({
     const resource = inject<Ref<Resource>>('resource')
 
     const album = computed(() => {
-      return unref(resource).audio.album
+      return unref(resource).audio.album || '-'
     })
 
     const artist = computed(() => {
-      return unref(resource).audio.artist
+      return unref(resource).audio.artist || '-'
     })
 
     const albumArtist = computed(() => {
-      return unref(resource).audio.albumArtist
+      return unref(resource).audio.albumArtist || '-'
     })
 
     const genre = computed(() => {
-      return unref(resource).audio.genre
+      return unref(resource).audio.genre || '-'
     })
 
     const title = computed(() => {
-      return unref(resource).audio.title
+      return unref(resource).audio.title || '-'
     })
 
     const duration = computed(() => {
       const milliseconds = unref(resource).audio.duration
       if (!milliseconds) {
-        return ''
+        return '-'
       }
       const d = Duration.fromMillis(milliseconds)
       if (d.hours > 0) {
@@ -84,7 +68,7 @@ export default defineComponent({
       if (audio.track && audio.trackCount) {
         return `${audio.track} / ${audio.trackCount}`
       }
-      return audio.track
+      return audio.track || '-'
     })
 
     const disc = computed(() => {
@@ -92,11 +76,11 @@ export default defineComponent({
       if (audio.disc && audio.discCount) {
         return `${audio.disc} / ${audio.discCount}`
       }
-      return audio.disc
+      return audio.disc || '-'
     })
 
     const year = computed(() => {
-      return unref(resource).audio?.year
+      return unref(resource).audio?.year || '-'
     })
 
     return {

--- a/packages/web-app-files/src/components/SideBar/Audio/AudioMetaPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Audio/AudioMetaPanel.vue
@@ -80,7 +80,7 @@ export default defineComponent({
     })
 
     const year = computed(() => {
-      return unref(resource).audio?.year || '-'
+      return unref(resource).audio.year || '-'
     })
 
     return {

--- a/packages/web-app-files/src/components/SideBar/Audio/AudioMetaPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Audio/AudioMetaPanel.vue
@@ -2,21 +2,21 @@
   <div id="files-sidebar-panel-audio">
     <dl class="audio-data-list">
       <dt v-text="$gettext('Title')" />
-      <dd v-text="title" />
+      <dd data-testid="audio-panel-title" v-text="title" />
       <dt v-text="$gettext('Duration')" />
-      <dd v-text="duration" />
+      <dd data-testid="audio-panel-duration" v-text="duration" />
       <dt v-text="$gettext('Authors')" />
-      <dd v-text="artist" />
+      <dd data-testid="audio-panel-artist" v-text="artist" />
       <dt v-text="$gettext('Album')" />
-      <dd v-text="album" />
+      <dd data-testid="audio-panel-album" v-text="album" />
       <dt v-text="$gettext('Genre')" />
-      <dd v-text="genre" />
+      <dd data-testid="audio-panel-genre" v-text="genre" />
       <dt v-text="$gettext('Year recorded')" />
-      <dd v-text="year" />
+      <dd data-testid="audio-panel-year" v-text="year" />
       <dt v-text="$gettext('Track')" />
-      <dd v-text="track" />
+      <dd data-testid="audio-panel-track" v-text="track" />
       <dt v-text="$gettext('Disc')" />
-      <dd v-text="disc" />
+      <dd data-testid="audio-panel-disc" v-text="disc" />
     </dl>
   </div>
 </template>

--- a/packages/web-app-files/src/components/SideBar/Exif/ExifPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Exif/ExifPanel.vue
@@ -1,59 +1,40 @@
 <template>
   <div id="files-sidebar-panel-exif">
     <dl class="exif-data-list">
-      <template v-if="dimensions">
-        <dt v-text="$gettext('Dimensions')" />
-        <dd v-text="dimensions" />
-      </template>
-      <template v-if="cameraMake">
-        <dt v-text="$gettext('Device make')" />
-        <dd v-text="cameraMake" />
-      </template>
-      <template v-if="cameraModel">
-        <dt v-text="$gettext('Device model')" />
-        <dd v-text="cameraModel" />
-      </template>
-      <template v-if="focalLength">
-        <dt v-text="$gettext('Focal length')" />
-        <dd v-text="focalLength" />
-      </template>
-      <template v-if="fNumber">
-        <dt v-text="$gettext('F number')" />
-        <dd v-text="fNumber" />
-      </template>
-      <template v-if="exposureTime">
-        <dt v-text="$gettext('Exposure time')" />
-        <dd v-text="exposureTime" />
-      </template>
-      <template v-if="iso">
-        <dt v-text="$gettext('ISO')" />
-        <dd v-text="iso" />
-      </template>
-      <template v-if="orientation">
-        <dt v-text="$gettext('Orientation')" />
-        <dd v-text="orientation" />
-      </template>
-      <template v-if="takenDateTime">
-        <dt v-text="$gettext('Taken time')" />
-        <dd v-text="takenDateTime" />
-      </template>
-      <template v-if="location">
-        <dt v-text="$gettext('Location')" />
-        <dd v-if="isCopyToClipboardSupported">
-          <span>{{ location }}</span>
-          <oc-button
-            v-oc-tooltip="copyLocationToClipboardLabel"
-            size="small"
-            appearance="raw"
-            class="oc-ml-s"
-            :aria-label="copyLocationToClipboardLabel"
-            @click="copyLocationToClipboard"
-          >
-            <oc-icon size="small" :name="isCopiedToClipboard ? 'checkbox-circle' : 'file-copy'" />
-          </oc-button>
-        </dd>
-        <dd v-else v-text="location" />
-      </template>
+      <dt v-text="$gettext('Dimensions')" />
+      <dd v-text="dimensions" />
+      <dt v-text="$gettext('Device make')" />
+      <dd v-text="cameraMake" />
+      <dt v-text="$gettext('Device model')" />
+      <dd v-text="cameraModel" />
+      <dt v-text="$gettext('Focal length')" />
+      <dd v-text="focalLength" />
+      <dt v-text="$gettext('F number')" />
+      <dd v-text="fNumber" />
+      <dt v-text="$gettext('Exposure time')" />
+      <dd v-text="exposureTime" />
+      <dt v-text="$gettext('ISO')" />
+      <dd v-text="iso" />
+      <dt v-text="$gettext('Orientation')" />
+      <dd v-text="orientation" />
+      <dt v-text="$gettext('Taken time')" />
+      <dd v-text="takenDateTime" />
+      <dt v-text="$gettext('Location')" />
+      <dd v-if="isCopyToClipboardSupported">
+        <span>{{ location }}</span>
+        <oc-button
+          v-if="location"
+          v-oc-tooltip="copyLocationToClipboardLabel"
+          size="small"
+          appearance="raw"
+          class="oc-ml-s"
+          :aria-label="copyLocationToClipboardLabel"
+          @click="copyLocationToClipboard"
+        >
+          <oc-icon size="small" :name="isCopiedToClipboard ? 'checkbox-circle' : 'file-copy'" />
+        </oc-button>
+      </dd>
+      <dd v-else v-text="location" />
     </dl>
   </div>
 </template>
@@ -83,7 +64,7 @@ export default defineComponent({
       const width = image?.width
       const height = image?.height
       if (!width || !height) {
-        return ''
+        return '-'
       }
       if ([5, 6, 7, 8].includes(unref(resource).photo?.orientation)) {
         return `${height}x${width}`
@@ -92,50 +73,50 @@ export default defineComponent({
     })
 
     const cameraMake = computed(() => {
-      return unref(resource).photo?.cameraMake
+      return unref(resource).photo?.cameraMake || '-'
     })
 
     const cameraModel = computed(() => {
-      return unref(resource).photo?.cameraModel
+      return unref(resource).photo?.cameraModel || '-'
     })
 
     const focalLength = computed(() => {
       const photo = unref(resource).photo
-      return photo?.focalLength ? `${photo.focalLength} mm` : ''
+      return photo?.focalLength ? `${photo.focalLength} mm` : '-'
     })
 
     const fNumber = computed(() => {
       const photo = unref(resource).photo
-      return photo?.fNumber ? `f/${photo.fNumber}` : ''
+      return photo?.fNumber ? `f/${photo.fNumber}` : '-'
     })
 
     const exposureTime = computed(() => {
       const photo = unref(resource).photo
       return photo?.exposureDenominator
         ? `${photo.exposureNumerator}/${photo.exposureDenominator}`
-        : ''
+        : '-'
     })
 
     const iso = computed(() => {
-      return unref(resource).photo?.iso
+      return unref(resource).photo?.iso || '-'
     })
 
     const orientation = computed(() => {
-      return unref(resource).photo?.orientation
+      return unref(resource).photo?.orientation || '-'
     })
 
     const takenDateTime = computed(() => {
       const photo = unref(resource).photo
-      return photo?.takenDateTime ? formatDateFromISO(photo.takenDateTime, currentLanguage) : ''
+      return photo?.takenDateTime ? formatDateFromISO(photo.takenDateTime, currentLanguage) : '-'
     })
 
+    const isLocationVisible = computed(() => {
+      return config.options.sidebar?.exif?.showLocation !== false
+    })
     const location = computed(() => {
       const l = unref(resource).location
       if (!l?.latitude || !l?.longitude) {
-        return ''
-      }
-      if (config.options.sidebar?.exif?.showLocation === false) {
-        return ''
+        return '-'
       }
       return `${l.latitude}, ${l.longitude}`
     })
@@ -161,6 +142,7 @@ export default defineComponent({
       orientation,
       takenDateTime,
       location,
+      isLocationVisible,
       isCopyToClipboardSupported,
       isCopiedToClipboard,
       copyLocationToClipboardLabel,

--- a/packages/web-app-files/src/components/SideBar/Exif/ExifPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Exif/ExifPanel.vue
@@ -2,39 +2,41 @@
   <div id="files-sidebar-panel-exif">
     <dl class="exif-data-list">
       <dt v-text="$gettext('Dimensions')" />
-      <dd v-text="dimensions" />
+      <dd data-testid="exif-panel-dimensions" v-text="dimensions" />
       <dt v-text="$gettext('Device make')" />
-      <dd v-text="cameraMake" />
+      <dd data-testid="exif-panel-cameraMake" v-text="cameraMake" />
       <dt v-text="$gettext('Device model')" />
-      <dd v-text="cameraModel" />
+      <dd data-testid="exif-panel-cameraModel" v-text="cameraModel" />
       <dt v-text="$gettext('Focal length')" />
-      <dd v-text="focalLength" />
+      <dd data-testid="exif-panel-focalLength" v-text="focalLength" />
       <dt v-text="$gettext('F number')" />
-      <dd v-text="fNumber" />
+      <dd data-testid="exif-panel-fNumber" v-text="fNumber" />
       <dt v-text="$gettext('Exposure time')" />
-      <dd v-text="exposureTime" />
+      <dd data-testid="exif-panel-exposureTime" v-text="exposureTime" />
       <dt v-text="$gettext('ISO')" />
-      <dd v-text="iso" />
+      <dd data-testid="exif-panel-iso" v-text="iso" />
       <dt v-text="$gettext('Orientation')" />
-      <dd v-text="orientation" />
+      <dd data-testid="exif-panel-orientation" v-text="orientation" />
       <dt v-text="$gettext('Taken time')" />
-      <dd v-text="takenDateTime" />
-      <dt v-text="$gettext('Location')" />
-      <dd v-if="isCopyToClipboardSupported">
-        <span>{{ location }}</span>
-        <oc-button
-          v-if="location"
-          v-oc-tooltip="copyLocationToClipboardLabel"
-          size="small"
-          appearance="raw"
-          class="oc-ml-s"
-          :aria-label="copyLocationToClipboardLabel"
-          @click="copyLocationToClipboard"
-        >
-          <oc-icon size="small" :name="isCopiedToClipboard ? 'checkbox-circle' : 'file-copy'" />
-        </oc-button>
-      </dd>
-      <dd v-else v-text="location" />
+      <dd data-testid="exif-panel-takenDateTime" v-text="takenDateTime" />
+      <template v-if="isLocationVisible">
+        <dt v-text="$gettext('Location')" />
+        <dd v-if="isCopyToClipboardAvailable" data-testid="exif-panel-location">
+          <span>{{ location }}</span>
+          <oc-button
+            v-if="location"
+            v-oc-tooltip="copyLocationToClipboardLabel"
+            size="small"
+            appearance="raw"
+            class="oc-ml-s"
+            :aria-label="copyLocationToClipboardLabel"
+            @click="copyLocationToClipboard"
+          >
+            <oc-icon size="small" :name="isCopiedToClipboard ? 'checkbox-circle' : 'file-copy'" />
+          </oc-button>
+        </dd>
+        <dd v-else data-testid="exif-panel-location" v-text="location" />
+      </template>
     </dl>
   </div>
 </template>
@@ -67,6 +69,7 @@ export default defineComponent({
         return '-'
       }
       if ([5, 6, 7, 8].includes(unref(resource).photo?.orientation)) {
+        // these orientations indicate portrait mode. tika normalizes width and height according to orientation.
         return `${height}x${width}`
       }
       return `${width}x${height}`
@@ -121,6 +124,13 @@ export default defineComponent({
       return `${l.latitude}, ${l.longitude}`
     })
 
+    const isCopyToClipboardAvailable = computed(() => {
+      if (!unref(isCopyToClipboardSupported)) {
+        return false
+      }
+      const l = unref(resource).location
+      return l?.latitude && l?.longitude
+    })
     const copyLocationToClipboard = () => {
       copyToClipboard(unref(location))
       showMessage({
@@ -143,7 +153,7 @@ export default defineComponent({
       takenDateTime,
       location,
       isLocationVisible,
-      isCopyToClipboardSupported,
+      isCopyToClipboardAvailable,
       isCopiedToClipboard,
       copyLocationToClipboardLabel,
       copyLocationToClipboard

--- a/packages/web-app-files/src/components/SideBar/Exif/ExifPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Exif/ExifPanel.vue
@@ -61,7 +61,7 @@
 <script lang="ts">
 import { computed, defineComponent, inject, Ref, unref } from 'vue'
 import { Resource } from '@ownclouders/web-client'
-import { formatDateFromISO, useMessages } from '@ownclouders/web-pkg'
+import { formatDateFromISO, useConfigStore, useMessages } from '@ownclouders/web-pkg'
 import { useGettext } from 'vue3-gettext'
 import { useClipboard } from '@vueuse/core'
 
@@ -69,6 +69,7 @@ export default defineComponent({
   name: 'ExifPanel',
   setup() {
     const resource = inject<Ref<Resource>>('resource')
+    const config = useConfigStore()
     const { current: currentLanguage, $gettext } = useGettext()
     const { showMessage } = useMessages()
     const {
@@ -131,6 +132,9 @@ export default defineComponent({
     const location = computed(() => {
       const l = unref(resource).location
       if (!l?.latitude || !l?.longitude) {
+        return ''
+      }
+      if (config.options.sidebar?.exif?.showLocation === false) {
         return ''
       }
       return `${l.latitude}, ${l.longitude}`

--- a/packages/web-app-files/src/components/SideBar/Exif/ExifPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Exif/ExifPanel.vue
@@ -1,0 +1,185 @@
+<template>
+  <div id="files-sidebar-panel-exif">
+    <dl class="exif-data-list">
+      <template v-if="dimensions">
+        <dt v-text="$gettext('Dimensions')" />
+        <dd v-text="dimensions" />
+      </template>
+      <template v-if="cameraMake">
+        <dt v-text="$gettext('Device make')" />
+        <dd v-text="cameraMake" />
+      </template>
+      <template v-if="cameraModel">
+        <dt v-text="$gettext('Device model')" />
+        <dd v-text="cameraModel" />
+      </template>
+      <template v-if="focalLength">
+        <dt v-text="$gettext('Focal length')" />
+        <dd v-text="focalLength" />
+      </template>
+      <template v-if="fNumber">
+        <dt v-text="$gettext('F number')" />
+        <dd v-text="fNumber" />
+      </template>
+      <template v-if="exposureTime">
+        <dt v-text="$gettext('Exposure time')" />
+        <dd v-text="exposureTime" />
+      </template>
+      <template v-if="iso">
+        <dt v-text="$gettext('ISO')" />
+        <dd v-text="iso" />
+      </template>
+      <template v-if="orientation">
+        <dt v-text="$gettext('Orientation')" />
+        <dd v-text="orientation" />
+      </template>
+      <template v-if="takenDateTime">
+        <dt v-text="$gettext('Taken time')" />
+        <dd v-text="takenDateTime" />
+      </template>
+      <template v-if="location">
+        <dt v-text="$gettext('Location')" />
+        <dd v-if="isCopyToClipboardSupported">
+          <span>{{ location }}</span>
+          <oc-button
+            v-oc-tooltip="copyLocationToClipboardLabel"
+            size="small"
+            appearance="raw"
+            class="oc-ml-s"
+            :aria-label="copyLocationToClipboardLabel"
+            @click="copyLocationToClipboard"
+          >
+            <oc-icon size="small" :name="isCopiedToClipboard ? 'checkbox-circle' : 'file-copy'" />
+          </oc-button>
+        </dd>
+        <dd v-else v-text="location" />
+      </template>
+    </dl>
+  </div>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, inject, Ref, unref } from 'vue'
+import { Resource } from '@ownclouders/web-client'
+import { formatDateFromISO, useMessages } from '@ownclouders/web-pkg'
+import { useGettext } from 'vue3-gettext'
+import { useClipboard } from '@vueuse/core'
+
+export default defineComponent({
+  name: 'ExifPanel',
+  setup() {
+    const resource = inject<Ref<Resource>>('resource')
+    const { current: currentLanguage, $gettext } = useGettext()
+    const { showMessage } = useMessages()
+    const {
+      copy: copyToClipboard,
+      copied: isCopiedToClipboard,
+      isSupported: isCopyToClipboardSupported
+    } = useClipboard({ legacy: true, copiedDuring: 550 })
+
+    const dimensions = computed(() => {
+      const image = unref(resource).image
+      const width = image?.width
+      const height = image?.height
+      if (!width || !height) {
+        return ''
+      }
+      if ([5, 6, 7, 8].includes(unref(resource).photo?.orientation)) {
+        return `${height}x${width}`
+      }
+      return `${width}x${height}`
+    })
+
+    const cameraMake = computed(() => {
+      return unref(resource).photo?.cameraMake
+    })
+
+    const cameraModel = computed(() => {
+      return unref(resource).photo?.cameraModel
+    })
+
+    const focalLength = computed(() => {
+      const photo = unref(resource).photo
+      return photo?.focalLength ? `${photo.focalLength} mm` : ''
+    })
+
+    const fNumber = computed(() => {
+      const photo = unref(resource).photo
+      return photo?.fNumber ? `f/${photo.fNumber}` : ''
+    })
+
+    const exposureTime = computed(() => {
+      const photo = unref(resource).photo
+      return photo?.exposureDenominator
+        ? `${photo.exposureNumerator}/${photo.exposureDenominator}`
+        : ''
+    })
+
+    const iso = computed(() => {
+      return unref(resource).photo?.iso
+    })
+
+    const orientation = computed(() => {
+      return unref(resource).photo?.orientation
+    })
+
+    const takenDateTime = computed(() => {
+      const photo = unref(resource).photo
+      return photo?.takenDateTime ? formatDateFromISO(photo.takenDateTime, currentLanguage) : ''
+    })
+
+    const location = computed(() => {
+      const l = unref(resource).location
+      if (!l?.latitude || !l?.longitude) {
+        return ''
+      }
+      return `${l.latitude}, ${l.longitude}`
+    })
+
+    const copyLocationToClipboard = () => {
+      copyToClipboard(unref(location))
+      showMessage({
+        title: $gettext('The location has been copied to your clipboard.')
+      })
+    }
+    const copyLocationToClipboardLabel = computed(() => {
+      return $gettext('Copy location to clipboard')
+    })
+
+    return {
+      dimensions,
+      cameraMake,
+      cameraModel,
+      focalLength,
+      fNumber,
+      exposureTime,
+      iso,
+      orientation,
+      takenDateTime,
+      location,
+      isCopyToClipboardSupported,
+      isCopiedToClipboard,
+      copyLocationToClipboardLabel,
+      copyLocationToClipboard
+    }
+  }
+})
+</script>
+
+<style lang="scss">
+.exif-data-list {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  dt,
+  dd {
+    margin-bottom: var(--oc-space-small);
+  }
+  dt {
+    font-weight: bold;
+    white-space: nowrap;
+  }
+  dd {
+    margin-inline-start: var(--oc-space-medium);
+  }
+}
+</style>

--- a/packages/web-app-files/src/composables/extensions/useFileSideBars.ts
+++ b/packages/web-app-files/src/composables/extensions/useFileSideBars.ts
@@ -1,5 +1,6 @@
 import FileDetails from '../../components/SideBar/Details/FileDetails.vue'
 import FileDetailsMultiple from '../../components/SideBar/Details/FileDetailsMultiple.vue'
+import ExifPanel from '../../components/SideBar/Exif/ExifPanel.vue'
 import FileActions from '../../components/SideBar/Actions/FileActions.vue'
 import FileVersions from '../../components/SideBar/Versions/FileVersions.vue'
 import SharesPanel from '../../components/SideBar/Shares/SharesPanel.vue'
@@ -33,6 +34,7 @@ import { Resource } from '@ownclouders/web-client'
 import { useGettext } from 'vue3-gettext'
 import { unref } from 'vue'
 import { fileSideBarExtensionPoint } from '../../extensionPoints'
+import { isEmpty } from 'lodash-es'
 
 export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resource, Resource>[] => {
   const router = useRouter()
@@ -135,6 +137,27 @@ export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resourc
             return false
           }
           return items?.length > 1
+        }
+      }
+    },
+    {
+      id: 'com.github.owncloud.web.files.sidebar-panel.exif',
+      type: 'sidebarPanel',
+      extensionPointIds: ['global.files.sidebar'],
+      panel: {
+        name: 'exif',
+        icon: 'image',
+        title: () => $gettext('Image Info'),
+        component: ExifPanel,
+        isVisible: ({ items }) => {
+          if (items?.length !== 1) {
+            return false
+          }
+          const item = items[0]
+          if (item.type !== 'file') {
+            return false
+          }
+          return !isEmpty(item.image) || !isEmpty(item.photo)
         }
       }
     },

--- a/packages/web-app-files/src/composables/extensions/useFileSideBars.ts
+++ b/packages/web-app-files/src/composables/extensions/useFileSideBars.ts
@@ -34,6 +34,7 @@ import { Resource } from '@ownclouders/web-client'
 import { useGettext } from 'vue3-gettext'
 import { unref } from 'vue'
 import { fileSideBarExtensionPoint } from '../../extensionPoints'
+import AudioMetaPanel from '../../components/SideBar/Audio/AudioMetaPanel.vue'
 import { isEmpty } from 'lodash-es'
 
 export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resource, Resource>[] => {
@@ -158,6 +159,27 @@ export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resourc
             return false
           }
           return !isEmpty(item.image) || !isEmpty(item.photo)
+        }
+      }
+    },
+    {
+      id: 'com.github.owncloud.web.files.sidebar-panel.audio-meta',
+      type: 'sidebarPanel',
+      extensionPointIds: ['global.files.sidebar'],
+      panel: {
+        name: 'audio-meta',
+        icon: 'music',
+        title: () => $gettext('Audio Info'),
+        component: AudioMetaPanel,
+        isVisible: ({ items }) => {
+          if (items?.length !== 1) {
+            return false
+          }
+          const item = items[0]
+          if (item.type !== 'file') {
+            return false
+          }
+          return !isEmpty(item.audio)
         }
       }
     },

--- a/packages/web-app-files/tests/unit/components/SideBar/Audio/AudioMetaPanel.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Audio/AudioMetaPanel.spec.ts
@@ -1,0 +1,81 @@
+import { Resource } from '@ownclouders/web-client'
+import { defaultPlugins, shallowMount } from 'web-test-helpers'
+import AudioMetaPanel from '../../../../../src/components/SideBar/Audio/AudioMetaPanel.vue'
+import { mock } from 'vitest-mock-extended'
+import { Audio } from '@ownclouders/web-client/graph/generated'
+
+describe('AudioMeta SideBar Panel', () => {
+  const keys = ['title', 'duration', 'artist', 'album', 'genre', 'year', 'track', 'disc']
+  it.each(keys)('shows value in panel for key "%s"', (key) => {
+    const resource = mock<Resource>({
+      audio: mock<Audio>({
+        title: 'Jingle Bells',
+        duration: 510000,
+        artist: 'Horst Horstsen',
+        album: 'Christmas Gedöns',
+        genre: 'Christmas',
+        year: 1956,
+        track: 23,
+        trackCount: 42,
+        disc: 4,
+        discCount: 12
+      })
+    })
+    const expectedValues = {
+      title: resource.audio.title,
+      duration: '08:30',
+      artist: resource.audio.artist,
+      album: resource.audio.album,
+      genre: resource.audio.genre,
+      year: resource.audio.year.toString(),
+      track: `${resource.audio.track} / ${resource.audio.trackCount}`,
+      disc: `${resource.audio.disc} / ${resource.audio.discCount}`
+    }
+    const { wrapper } = createWrapper({ resource })
+    expect(wrapper.find(`[data-testid="audio-panel-${key}"]`).text()).toBe(expectedValues[key])
+  })
+  it.each(keys)('shows "-" in panel if key "%s" has no value in provided data', (key) => {
+    const emptyPhotoResourceMock = mock<Resource>({})
+    const { wrapper } = createWrapper({ resource: emptyPhotoResourceMock })
+    expect(wrapper.find(`[data-testid="audio-panel-${key}"]`).text()).toEqual('-')
+  })
+  it('shows "track" without "trackCount" if absent', () => {
+    const resource = mock<Resource>({
+      audio: mock<Audio>({
+        duration: undefined,
+        track: 23,
+        trackCount: undefined
+      })
+    })
+    const { wrapper } = createWrapper({ resource })
+    expect(wrapper.find('[data-testid="audio-panel-track"]').text()).toBe(
+      resource.audio.track.toString()
+    )
+  })
+  it('shows "disc" without "discCount" if absent', () => {
+    const resource = mock<Resource>({
+      audio: mock<Audio>({
+        duration: undefined,
+        disc: 500,
+        discCount: undefined
+      })
+    })
+    const { wrapper } = createWrapper({ resource })
+    expect(wrapper.find('[data-testid="audio-panel-disc"]').text()).toBe(
+      resource.audio.disc.toString()
+    )
+  })
+})
+
+function createWrapper({ resource }: { resource: Resource }) {
+  return {
+    wrapper: shallowMount(AudioMetaPanel, {
+      global: {
+        plugins: [...defaultPlugins({})],
+        provide: {
+          resource
+        }
+      }
+    })
+  }
+}

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.ts
@@ -1,10 +1,9 @@
 import FileDetails from '../../../../../src/components/SideBar/Details/FileDetails.vue'
 import { Resource, ShareResource, ShareTypes } from '@ownclouders/web-client'
-import { defaultComponentMocks, defaultPlugins, RouteLocation } from 'web-test-helpers'
+import { mount, defaultComponentMocks, defaultPlugins, RouteLocation } from 'web-test-helpers'
 import { mock, mockDeep } from 'vitest-mock-extended'
 import { SpaceResource } from '@ownclouders/web-client'
 import { AncestorMetaData } from '@ownclouders/web-pkg/'
-import { mount } from '@vue/test-utils'
 import { User } from '@ownclouders/web-client/graph/generated'
 
 const getResourceMock = ({

--- a/packages/web-app-files/tests/unit/components/SideBar/Exif/ExifPanel.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Exif/ExifPanel.spec.ts
@@ -1,0 +1,151 @@
+import ExifPanel from '../../../../../src/components/SideBar/Exif/ExifPanel.vue'
+import { defaultPlugins, shallowMount } from 'web-test-helpers'
+import { mock } from 'vitest-mock-extended'
+import { Photo, Image, GeoCoordinates } from '@ownclouders/web-client/graph/generated'
+import { Resource } from '@ownclouders/web-client'
+import { formatDateFromISO } from '@ownclouders/web-pkg'
+
+describe('Exif SideBar Panel', () => {
+  describe('photo metadata', () => {
+    const keys = [
+      'cameraMake',
+      'cameraModel',
+      'focalLength',
+      'fNumber',
+      'exposureTime',
+      'iso',
+      'orientation',
+      'takenDateTime'
+    ]
+    it.each(keys)('shows value in panel for key "%s"', (key) => {
+      const resource = mock<Resource>({
+        photo: mock<Photo>({
+          cameraMake: 'Canon',
+          cameraModel: 'Canon EOS 1300D',
+          focalLength: 222,
+          fNumber: 5.6,
+          exposureNumerator: 1,
+          exposureDenominator: 20,
+          iso: 320,
+          orientation: 1,
+          takenDateTime: '2017-02-11T14:54:50Z'
+        })
+      })
+      const expectedValues = {
+        cameraMake: resource.photo.cameraMake,
+        cameraModel: resource.photo.cameraModel,
+        focalLength: `${resource.photo.focalLength} mm`,
+        fNumber: `f/${resource.photo.fNumber}`,
+        exposureTime: `${resource.photo.exposureNumerator}/${resource.photo.exposureDenominator}`,
+        iso: resource.photo.iso.toString(),
+        orientation: resource.photo.orientation.toString(),
+        takenDateTime: formatDateFromISO(resource.photo.takenDateTime, 'en')
+      }
+      const { wrapper } = createWrapper({ resource })
+      expect(wrapper.find(`[data-testid="exif-panel-${key}"]`).text()).toBe(expectedValues[key])
+    })
+    it.each(keys)('shows "-" in panel if key "%s" has no value in provided data', (key) => {
+      const emptyPhotoResourceMock = mock<Resource>({})
+      const { wrapper } = createWrapper({ resource: emptyPhotoResourceMock })
+      expect(wrapper.find(`[data-testid="exif-panel-${key}"]`).text()).toEqual('-')
+    })
+  })
+  describe('image metadata', () => {
+    const dimensionsSelector = '[data-testid="exif-panel-dimensions"]'
+    it('shows "width x height" if both props provided in data', () => {
+      const resource = mock<Resource>({
+        image: mock<Image>({
+          width: 5000,
+          height: 3000
+        })
+      })
+      const { wrapper } = createWrapper({ resource })
+      expect(wrapper.find(dimensionsSelector).text()).toEqual('5000x3000')
+    })
+    it.each([
+      { width: 5000, height: undefined },
+      { width: undefined, height: 3000 },
+      { width: undefined, height: undefined }
+    ])('shows "-" if width or height is missing in data', (options) => {
+      const resource = mock<Resource>({
+        image: mock<Image>(options)
+      })
+      const { wrapper } = createWrapper({ resource })
+      expect(wrapper.find(dimensionsSelector).text()).toEqual('-')
+    })
+    it.each([5, 6, 7, 8])(
+      'flips width and height because photo orientation "%s" indicates portrait mode',
+      (orientation) => {
+        const resource = mock<Resource>({
+          image: mock<Image>({ width: 5000, height: 3000 }),
+          photo: mock<Photo>({ orientation })
+        })
+        const { wrapper } = createWrapper({ resource })
+        expect(wrapper.find(dimensionsSelector).text()).toBe('3000x5000')
+      }
+    )
+  })
+  describe('location metadata', () => {
+    const locationSelector = '[data-testid="exif-panel-location"]'
+    it('shows "latitude, longitude" if both props provided in data', () => {
+      const resource = mock<Resource>({
+        location: mock<GeoCoordinates>({
+          latitude: 51.30044714422953,
+          longitude: 7.373170282627126
+        })
+      })
+      const { wrapper } = createWrapper({ resource })
+      expect(wrapper.find(locationSelector).text()).toBe(
+        `${resource.location.latitude}, ${resource.location.longitude}`
+      )
+    })
+    it.each([
+      { latitude: 51.30044714422953, longitude: undefined },
+      { latitude: undefined, longitude: 7.373170282627126 },
+      { latitude: undefined, longitude: undefined }
+    ])('shows "-" if latitude or longitude is missing in data', ({ latitude, longitude }) => {
+      const resource = mock<Resource>({
+        location: mock<GeoCoordinates>({ latitude, longitude })
+      })
+      const { wrapper } = createWrapper({ resource })
+      expect(wrapper.find(locationSelector).text()).toEqual('-')
+    })
+    it("doesn't show the location at all if forbidden in config", () => {
+      const resource = mock<Resource>({
+        location: mock<GeoCoordinates>({
+          latitude: 51.30044714422953,
+          longitude: 7.373170282627126
+        })
+      })
+      const { wrapper } = createWrapper({ resource, locationForbidden: true })
+      expect(wrapper.find(locationSelector).exists()).toBeFalsy()
+    })
+  })
+})
+
+function createWrapper({
+  resource,
+  locationForbidden
+}: {
+  resource: Resource
+  locationForbidden?: boolean
+}) {
+  return {
+    wrapper: shallowMount(ExifPanel, {
+      global: {
+        plugins: [
+          ...defaultPlugins({
+            piniaOptions: {
+              configState: {
+                options: { sidebar: { exif: { showLocation: locationForbidden !== true } } }
+              }
+            }
+          })
+        ],
+        provide: {
+          resource
+        }
+      }
+    })
+  }
+}

--- a/packages/web-client/src/helpers/resource/functions.ts
+++ b/packages/web-client/src/helpers/resource/functions.ts
@@ -2,6 +2,7 @@ import path, { basename, dirname } from 'path'
 import { urlJoin } from '../../utils'
 import { DavPermission, DavProperty } from '../../webdav/constants'
 import { Resource, ResourceIndicator, WebDavResponseResource } from './types'
+import { camelCase } from 'lodash-es'
 
 const fileExtensions = {
   complex: ['tar.bz2', 'tar.gz', 'tar.xz']
@@ -64,6 +65,17 @@ export const extractParentFolderName = (resource: Resource): string | null => {
 
 export const isShareRoot = (resource: Resource) => {
   return typeof resource.isShareRoot === 'function' && resource.isShareRoot()
+}
+
+const convertObjectToCamelCaseKeys = (data: Record<string, any>) => {
+  if (!data) {
+    return data
+  }
+  const converted = {}
+  Object.keys(data).forEach((key) => {
+    converted[camelCase(key)] = data[key]
+  })
+  return converted
 }
 
 export function buildResource(resource: WebDavResponseResource): Resource {
@@ -136,8 +148,10 @@ export function buildResource(resource: WebDavResponseResource): Resource {
       displayName: resource.props[DavProperty.OwnerDisplayName]
     },
     tags: (resource.props[DavProperty.Tags] || '').split(',').filter(Boolean),
-    audio: resource.props[DavProperty.Audio],
-    location: resource.props[DavProperty.Location],
+    audio: convertObjectToCamelCaseKeys(resource.props[DavProperty.Audio]),
+    location: convertObjectToCamelCaseKeys(resource.props[DavProperty.Location]),
+    image: convertObjectToCamelCaseKeys(resource.props[DavProperty.Image]),
+    photo: convertObjectToCamelCaseKeys(resource.props[DavProperty.Photo]),
     canUpload: function () {
       return this.permissions.indexOf(DavPermission.FolderCreateable) >= 0
     },

--- a/packages/web-client/src/helpers/resource/functions.ts
+++ b/packages/web-client/src/helpers/resource/functions.ts
@@ -71,7 +71,7 @@ const convertObjectToCamelCaseKeys = (data: Record<string, any>) => {
   if (!data) {
     return data
   }
-  const converted = {}
+  const converted: Record<string, any> = {}
   Object.keys(data).forEach((key) => {
     converted[camelCase(key)] = data[key]
   })
@@ -126,7 +126,7 @@ export function buildResource(resource: WebDavResponseResource): Resource {
     webDavPath: resource.filename,
     type: isFolder ? 'folder' : resource.type,
     isFolder,
-    locked: activeLock ? true : false,
+    locked: !!activeLock,
     lockOwnerName,
     lockTime,
     processing: resource.processing || false,

--- a/packages/web-client/src/helpers/resource/types.ts
+++ b/packages/web-client/src/helpers/resource/types.ts
@@ -1,8 +1,7 @@
 import { DavFileInfoResponse } from '@ownclouders/web-client/webdav'
-import { Identity, User } from '../../graph/generated'
+import { Audio, GeoCoordinates, Identity, Image, Photo, User } from '../../graph/generated'
 import { MongoAbility, SubjectRawRule } from '@casl/ability'
 import { DAVResultResponseProps, FileStat } from 'webdav'
-import { Audio, GeoCoordinates } from '../../graph/generated'
 
 export type AbilityActions =
   | 'create'
@@ -56,6 +55,8 @@ export interface Resource {
   tags?: string[]
   audio?: Audio
   location?: GeoCoordinates
+  image?: Image
+  photo?: Photo
   path: string
   webDavPath?: string
   downloadURL?: string

--- a/packages/web-pkg/src/composables/piniaStores/config/config.ts
+++ b/packages/web-pkg/src/composables/piniaStores/config/config.ts
@@ -43,6 +43,9 @@ const defaultOptions = {
   sidebar: {
     shares: {
       showAllOnLoad: false
+    },
+    exif: {
+      showLocation: true
     }
   },
   tokenStorageLocal: true,

--- a/packages/web-pkg/src/composables/piniaStores/config/types.ts
+++ b/packages/web-pkg/src/composables/piniaStores/config/types.ts
@@ -123,6 +123,11 @@ const OptionsConfigSchema = z.object({
         .object({
           showAllOnLoad: z.boolean().optional()
         })
+        .optional(),
+      exif: z
+        .object({
+          showLocation: z.boolean().optional()
+        })
         .optional()
     })
     .optional(),


### PR DESCRIPTION
## Description
This PR introduces an `EXIF` panel, which displays image, photo and location metadata if that's available on the given resource as well as an `Audio Info` panel, which displays audio metadata if that's available on the given resource.

## Related Issue
- Relates to https://github.com/owncloud/web/issues/7930

## Motivation and Context
Provide useful additional information.

## Screenshots
<img width="449" alt="Screenshot 2024-05-23 at 16 16 12" src="https://github.com/owncloud/web/assets/3532843/7cc49239-fd74-4812-b645-838cfe8d16e4">

<img width="442" alt="Screenshot 2024-05-24 at 14 57 39" src="https://github.com/owncloud/web/assets/3532843/cb449391-819a-4df9-9b3c-0b18bcf3fff4">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
- [x] Changelog item
- [x] Unit tests
- [x] Blocked by https://github.com/cs3org/reva/pull/4695
