### PR TITLE
[tests-only][full-ci]Run more e2e tests on keycloak

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1907,7 +1907,6 @@ def e2eTestsOnKeycloak(ctx):
                          "KEYCLOAK_HOST": "keycloak:8443",
                      },
                      "commands": [
-                         "pnpm test:e2e:cucumber tests/e2e/cucumber/features/journeys",
                          "pnpm test:e2e:cucumber tests/e2e/cucumber/features/admin-settings/users.feature:20",
                          "pnpm test:e2e:cucumber tests/e2e/cucumber/features/admin-settings/spaces.feature",
                      ],

--- a/.drone.star
+++ b/.drone.star
@@ -175,7 +175,7 @@ def stagePipelines(ctx):
 
     e2e_pipelines = e2eTests(ctx)
     keycloak_pipelines = e2eTestsOnKeycloak(ctx)
-    return unit_test_pipelines + buildAndTestDesignSystem(ctx) + pipelinesDependsOn(e2e_pipelines + keycloak_pipelines, unit_test_pipelines)
+    return keycloak_pipelines
 
 def afterPipelines(ctx):
     return build(ctx) + pipelinesDependsOn(notify(), build(ctx))

--- a/.drone.star
+++ b/.drone.star
@@ -1908,6 +1908,8 @@ def e2eTestsOnKeycloak(ctx):
                      },
                      "commands": [
                          "pnpm test:e2e:cucumber tests/e2e/cucumber/features/journeys",
+                         "pnpm test:e2e:cucumber tests/e2e/cucumber/features/admin-settings/users.feature:20",
+                         "pnpm test:e2e:cucumber tests/e2e/cucumber/features/admin-settings/spaces.feature",
                      ],
                  },
              ] + \

--- a/.drone.star
+++ b/.drone.star
@@ -175,7 +175,7 @@ def stagePipelines(ctx):
 
     e2e_pipelines = e2eTests(ctx)
     keycloak_pipelines = e2eTestsOnKeycloak(ctx)
-    return keycloak_pipelines
+    return unit_test_pipelines + buildAndTestDesignSystem(ctx) + pipelinesDependsOn(e2e_pipelines + keycloak_pipelines, unit_test_pipelines)
 
 def afterPipelines(ctx):
     return build(ctx) + pipelinesDependsOn(notify(), build(ctx))
@@ -1856,6 +1856,11 @@ def keycloakService():
     ]
 
 def e2eTestsOnKeycloak(ctx):
+    e2e_Keycloak_tests = [
+        "journeys",
+        "admin-settings/users.feature:20",
+    ]
+
     e2e_volumes = [
         {
             "name": "uploads",
@@ -1907,8 +1912,8 @@ def e2eTestsOnKeycloak(ctx):
                          "KEYCLOAK_HOST": "keycloak:8443",
                      },
                      "commands": [
-                         "pnpm test:e2e:cucumber tests/e2e/cucumber/features/admin-settings/users.feature:20",
-                         "pnpm test:e2e:cucumber tests/e2e/cucumber/features/admin-settings/spaces.feature",
+                         "cd tests/e2e",
+                         "bash run-e2e.sh %s" % " ".join(["cucumber/features/" + tests for tests in e2e_Keycloak_tests]),
                      ],
                  },
              ] + \

--- a/tests/e2e/cucumber/features/admin-settings/spaces.feature
+++ b/tests/e2e/cucumber/features/admin-settings/spaces.feature
@@ -5,6 +5,10 @@ Feature: spaces management
       | id    |
       | Alice |
       | Brian |
+    And "Alice" logs in
+    And "Brian" logs in
+    And "Alice" logs out
+    When "Brian" logs out
     And "Admin" assigns following roles to the users using API
       | id    | role        |
       | Alice | Space Admin |
@@ -39,6 +43,8 @@ Feature: spaces management
     Given "Admin" creates following user using API
       | id    |
       | Alice |
+    And "Alice" logs in
+    And "Alice" logs out
     And "Admin" assigns following roles to the users using API
       | id    | role        |
       | Alice | Space Admin |
@@ -98,6 +104,8 @@ Feature: spaces management
       | Carol |
       | David |
       | Edith |
+    And "Alice" logs in
+    And "Alice" logs out
     And "Admin" assigns following roles to the users using API
       | id    | role        |
       | Alice | Space Admin |
@@ -130,6 +138,12 @@ Feature: spaces management
       | Alice |
       | Brian |
       | Carol |
+    And "Alice" logs in
+    And "Brian" logs in
+    And "Carol" logs in
+    And "Alice" logs out
+    When "Brian" logs out
+    When "Carol" logs out
     And "Admin" assigns following roles to the users using API
       | id    | role        |
       | Alice | Admin       |

--- a/tests/e2e/cucumber/features/admin-settings/spaces.feature
+++ b/tests/e2e/cucumber/features/admin-settings/spaces.feature
@@ -5,10 +5,6 @@ Feature: spaces management
       | id    |
       | Alice |
       | Brian |
-    And "Alice" logs in
-    And "Brian" logs in
-    And "Alice" logs out
-    When "Brian" logs out
     And "Admin" assigns following roles to the users using API
       | id    | role        |
       | Alice | Space Admin |
@@ -43,8 +39,6 @@ Feature: spaces management
     Given "Admin" creates following user using API
       | id    |
       | Alice |
-    And "Alice" logs in
-    And "Alice" logs out
     And "Admin" assigns following roles to the users using API
       | id    | role        |
       | Alice | Space Admin |
@@ -104,8 +98,6 @@ Feature: spaces management
       | Carol |
       | David |
       | Edith |
-    And "Alice" logs in
-    And "Alice" logs out
     And "Admin" assigns following roles to the users using API
       | id    | role        |
       | Alice | Space Admin |
@@ -138,12 +130,6 @@ Feature: spaces management
       | Alice |
       | Brian |
       | Carol |
-    And "Alice" logs in
-    And "Brian" logs in
-    And "Carol" logs in
-    And "Alice" logs out
-    When "Brian" logs out
-    When "Carol" logs out
     And "Admin" assigns following roles to the users using API
       | id    | role        |
       | Alice | Admin       |

--- a/tests/e2e/cucumber/steps/api.ts
+++ b/tests/e2e/cucumber/steps/api.ts
@@ -22,6 +22,15 @@ Given(
     const admin = this.usersEnvironment.getUser({ key: stepUser })
     for await (const info of stepTable.hashes()) {
       const user = this.usersEnvironment.getUser({ key: info.id })
+      /**
+         The oCIS API request for assigning roles allows only one role per user,
+         whereas the Keycloak API request can assign multiple roles to a user.
+         If multiple roles are assigned to a user in Keycloak,
+         oCIS map the highest priority role among Keycloak assigned roles.
+         Therefore, we need to unassign the previous role before
+         assigning a new one when using the Keycloak API.
+      */
+      await api.provision.unAssignRole({ admin, user })
       await api.provision.assignRole({ admin, user, role: info.role })
     }
   }

--- a/tests/e2e/support/api/provision/user.ts
+++ b/tests/e2e/support/api/provision/user.ts
@@ -8,7 +8,8 @@ import {
 import {
   createUser as keycloakCreateUser,
   deleteUser as keycloakDeleteUser,
-  assignRole as keycloakAssignRole
+  assignRole as keycloakAssignRole,
+  unAssignRole as keycloakUnAssignRole
 } from '../keycloak'
 import { config } from '../../../config'
 import { UsersEnvironment } from '../../environment'
@@ -43,5 +44,13 @@ export const assignRole = async ({
   } else {
     const id = await getUserId({ user, admin })
     await graphAssignRole(admin, id, role)
+  }
+}
+
+export const unAssignRole = async ({ admin, user }: { admin: User; user: User }): Promise<void> => {
+  if (config.keycloak) {
+    const usersEnvironment = new UsersEnvironment()
+    const createdUser = usersEnvironment.getCreatedUser({ key: user.id })
+    await keycloakUnAssignRole({ admin, uuid: createdUser.uuid, role: createdUser.role })
   }
 }

--- a/tests/e2e/support/types.ts
+++ b/tests/e2e/support/types.ts
@@ -27,6 +27,7 @@ export interface User {
   displayName: string
   password: string
   email: string
+  role?: string
 }
 
 export interface File {


### PR DESCRIPTION
## Description
- Keycloak supports assigning multiple realm roles to a user but oCIS supports only one role for a user. 
If multiple roles are assigned to a user in Keycloak, oCIS map the highest priority role among Keycloak assigned roles.
So, before assigning role we have to unassign previous role using keycloak api. This part has been implemented in this PR.
 - added more tests to run on CI admin-settings/users.feature:20 related to quota change


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/web/issues/10458

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- LOCALLY


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
