### PR TITLE
[docs-only] Add documentation for running e2e tests on keycloak

### DIFF
--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -131,3 +131,22 @@ To see all available options run
 ```bash
 node tests/e2e/cucumber/report --help
 ```
+
+### E2E Tests on oCIS With Keycloak
+We can run some of the e2e tests on oCIS setup with Keycloak as an external idp. To run tests against locally, please follow the steps below:
+
+#### Run oCIS With Keycloak
+There's a documentation to serve [oCIS with Keycloak](https://owncloud.dev/ocis/deployment/ocis_keycloak/). Please follow each step to run **oCIS with Keycloak**.
+
+#### Run E2E Tests
+```bash
+KEYCLOAK=true \
+BASE_URL_OCIS=ocis.owncloud.test \
+pnpm run test:e2e:cucumber tests/e2e/cucumber/features/journeys
+```
+
+Following environment variables come in use while running e2e tests on oCIS with Keycloak:
+- `BASE_URL_OCIS` sets oCIS url (e.g.: ocis.owncloud.test)
+- `KEYCLOAK_HOST` sets Keycloak url (e.g.: keycloak.owncloud.test)
+- `KEYCLOAK=true` runs the tests with Keycloak
+- `KEYCLOAK_REALM` sets oCIS realm name used on Keycloak


### PR DESCRIPTION
## Description
This PR adds documentation to run e2e tests on ocis with keycloak locally.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/web/issues/10458

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [x] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
