### PR TITLE
fix: encode app name for app provider

### DIFF
--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -106,7 +106,7 @@ export default defineComponent({
         const query = stringify({
           file_id: fileId,
           lang: language.current,
-          ...(unref(applicationName) && { app_name: unref(applicationName) }),
+          ...(unref(applicationName) && { app_name: encodeURIComponent(unref(applicationName)) }),
           ...(viewMode && { view_mode: viewMode })
         })
 


### PR DESCRIPTION
## Description
Fixing the case that the app name for the app provider has e.g. a space in it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
