### PR TITLE
perf: early return space member checks

### DIFF
--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -265,16 +265,16 @@ export function buildSpace(
       return urlJoin(webDavTrashUrl, path)
     },
     isViewer(user: User): boolean {
-      return this.spaceRoles.viewer.map((r) => r.isMember(user)).some(Boolean)
+      return this.spaceRoles.viewer.some((r) => r.isMember(user))
     },
     isEditor(user: User): boolean {
-      return this.spaceRoles.editor.map((r) => r.isMember(user)).some(Boolean)
+      return this.spaceRoles.editor.some((r) => r.isMember(user))
     },
     isManager(user: User): boolean {
-      return this.spaceRoles.manager.map((r) => r.isMember(user)).some(Boolean)
+      return this.spaceRoles.manager.some((r) => r.isMember(user))
     },
     isSecureViewer(user: User): boolean {
-      return this.spaceRoles['secure-viewer'].map((r) => r.isMember(user)).some(Boolean)
+      return this.spaceRoles['secure-viewer'].some((r) => r.isMember(user))
     },
     isMember(user: User): boolean {
       return this.isViewer(user) || this.isEditor(user) || this.isManager(user)


### PR DESCRIPTION
## Description
I noticed that for the space member checks we first map all users of a role to the result of `isMember`, checking whether the given user is member of that specific space role, and only after that early return with the first boolean `true` we find. So we always run through the whole array once and then again until the first `true` value is hit. The computation complexity can be reduced to doing the early return with the `isMember` check, so we only run once through the list of users in a space role  and early return if `isMember` evaluates to `true`. For spaces with large amounts of members this is a tiny improvement. 😁 

## Related Issue
- Relates to https://github.com/owncloud/web/issues/6660

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
- [x] Performance