### PR TITLE
fix: opening pdf files

### DIFF
--- a/dev/docker/ocis/csp.yaml
+++ b/dev/docker/ocis/csp.yaml
@@ -11,6 +11,7 @@ directives:
     - '''self'''
   frame-src:
     - '''self'''
+    - 'blob:'
     - 'https://embed.diagrams.net/'
     # In contrast to bash and docker the default is given after the | character
     - 'https://${ONLYOFFICE_DOMAIN|host.docker.internal:9981}/'

--- a/tests/drone/csp.yaml
+++ b/tests/drone/csp.yaml
@@ -13,6 +13,7 @@ directives:
     - '''self'''
   frame-src:
     - '''self'''
+    - 'blob:'
     - 'https://embed.diagrams.net/'
     # In contrast to bash and docker the default is given after the | character
     - 'https://${ONLYOFFICE_DOMAIN|onlyoffice:443}/'


### PR DESCRIPTION
## Description
Adds `blob:` as possible entry for `frame-src` to allow opening pdf files, since those are being embedded as a blob.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
