### PR TITLE
[full-ci]show console errors in e2e tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -497,6 +497,7 @@ def e2eTests(ctx):
         "db": "mysql:5.5",
         "suites": [],
         "tikaNeeded": False,
+        "failOnUncaughtConsoleError": "false",
     }
 
     e2e_trigger = {
@@ -524,12 +525,15 @@ def e2eTests(ctx):
 
         if ("with-tracing" in ctx.build.title.lower()):
             params["reportTracing"] = "true"
+        if ("check-console-errors" in ctx.build.title.lower()):
+            params["failOnUncaughtConsoleError"] = "true"
 
         environment = {
             "HEADLESS": "true",
             "RETRY": "1",
             "REPORT_TRACING": params["reportTracing"],
             "BASE_URL_OCIS": "ocis:9200",
+            "FAIL_ON_UNCAUGHT_CONSOLE_ERR": params["failOnUncaughtConsoleError"],
         }
 
         steps = skipIfUnchanged(ctx, "e2e-tests") + \

--- a/tests/e2e/config.js
+++ b/tests/e2e/config.js
@@ -38,5 +38,6 @@ exports.config = {
   reportDir: process.env.REPORT_DIR || 'reports/e2e',
   reportVideo: process.env.REPORT_VIDEO === 'true',
   reportHar: process.env.REPORT_HAR === 'true',
-  reportTracing: process.env.REPORT_TRACING === 'true'
+  reportTracing: process.env.REPORT_TRACING === 'true',
+  failOnUncaughtConsoleError: process.env.FAIL_ON_UNCAUGHT_CONSOLE_ERR === 'true'
 }

--- a/tests/e2e/cucumber/environment/world.ts
+++ b/tests/e2e/cucumber/environment/world.ts
@@ -28,7 +28,8 @@ export class World extends CucumberWorld {
         reportDir: config.reportDir,
         reportHar: config.reportHar,
         reportTracing: config.reportTracing,
-        reportVideo: config.reportVideo
+        reportVideo: config.reportVideo,
+        failOnUncaughtConsoleError: config.failOnUncaughtConsoleError
       },
       browser: state.browser
     })

--- a/tests/e2e/support/environment/actor/actor.ts
+++ b/tests/e2e/support/environment/actor/actor.ts
@@ -1,6 +1,6 @@
 import { Actor } from '../../types'
 import { ActorOptions, buildBrowserContextOptions } from './shared'
-import { BrowserContext, Page } from '@playwright/test'
+import { BrowserContext, Page, expect } from '@playwright/test'
 import path from 'path'
 import EventEmitter from 'events'
 
@@ -22,6 +22,14 @@ export class ActorEnvironment extends EventEmitter implements Actor {
     }
 
     this.page = await this.context.newPage()
+
+    this.page.on('pageerror', (exception) => {
+      console.log(`[UNCAUGHT EXCEPTION] "${exception}"`)
+      // make the test fail if FAIL_ON_UNCAUGHT_CONSOLE_ERR=true
+      if (this.options.context.failOnUncaughtConsoleError) {
+        expect(exception).not.toBeDefined()
+      }
+    })
   }
 
   public async newPage(newPage: Page): Promise<Page> {

--- a/tests/e2e/support/environment/actor/shared.ts
+++ b/tests/e2e/support/environment/actor/shared.ts
@@ -9,6 +9,7 @@ export interface ActorsOptions {
     reportVideo: boolean
     reportHar: boolean
     reportTracing: boolean
+    failOnUncaughtConsoleError: boolean
   }
 }
 


### PR DESCRIPTION
related https://github.com/owncloud/web/issues/6397
In this PR I check console error and put error to output 

example: 
<img width="780" alt="image" src="https://github.com/owncloud/web/assets/84779829/bd16d4fd-f274-417f-8423-f2f4f6199de8">

Until we fix all `uncaught errors` we don't interrupt tests if console error occurs

In order to abort tests when an uncaught error occurs, we need to:
- use `FAIL_ON_UNCAUGHT_CONSOLE_ERR=true pnpm test:e2e:cucumber tests/e2e/cucumber/features/` if you are running the test locally
- use `[check-console-errors]` in the PR header to abort the test in CI if a console error occurs

this is what CI looks if PR header contains `[check-console-errors]`
https://drone.owncloud.com/owncloud/web/44914
<img width="1250" alt="Screenshot 2024-06-05 at 17 43 48" src="https://github.com/owncloud/web/assets/84779829/a296e058-bd14-4988-bc0a-5d97e0773070">

I only display the error text. you can find all the error details in the trace (open trace all users. the error often appears for a different user than the one who did the last action). 

<img width="1453" alt="Screenshot 2024-06-05 at 17 51 37" src="https://github.com/owncloud/web/assets/84779829/05cf5b84-fdd1-4feb-807d-58c0604c6502">



After we fix all `uncaught errors` I'll make the test abort by default when `uncaught errors` occurs

cc @kulmann 