### PR TITLE
fix: wrap file name in quotes in modal title

### DIFF
--- a/packages/web-pkg/src/composables/actions/helpers/useFileActionsDeleteResources.ts
+++ b/packages/web-pkg/src/composables/actions/helpers/useFileActionsDeleteResources.ts
@@ -18,7 +18,6 @@ import {
   useModals,
   useSpacesStore,
   useConfigStore,
-  useSharesStore,
   useResourcesStore
 } from '../../piniaStores'
 import { storeToRefs } from 'pinia'
@@ -35,7 +34,6 @@ export const useFileActionsDeleteResources = () => {
   const clientService = useClientService()
   const { dispatchModal } = useModals()
   const spacesStore = useSpacesStore()
-  const sharesStore = useSharesStore()
   const { startWorker } = useDeleteWorker()
 
   const resourcesStore = useResourcesStore()
@@ -69,7 +67,7 @@ export const useFileActionsDeleteResources = () => {
     if (currentResources.length === 1) {
       if (isFolder) {
         title = $gettext(
-          'Permanently delete folder %{name}',
+          'Permanently delete folder "%{name}"',
           {
             name: currentResources[0].name
           },
@@ -77,7 +75,7 @@ export const useFileActionsDeleteResources = () => {
         )
       } else {
         title = $gettext(
-          'Permanently delete file %{name}',
+          'Permanently delete file "%{name}"',
           {
             name: currentResources[0].name
           },


### PR DESCRIPTION
## Description
Wrapping file name in quotes in modal title (in this case: permanent deletion from trash for a file or folder).

## Related Issue
- Fixes https://github.com/owncloud/web/issues/8122

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
