### PR TITLE
refactor: useful graph abstraction for users

### DIFF
--- a/packages/web-app-admin-settings/src/components/Users/AddToGroupsModal.vue
+++ b/packages/web-app-admin-settings/src/components/Users/AddToGroupsModal.vue
@@ -120,8 +120,8 @@ export default defineComponent({
           usersToFetch.map((userId) => client.users.getUser(userId))
         )
 
-        usersResponse.forEach(({ data }) => {
-          userSettingsStore.upsertUser(data)
+        usersResponse.forEach((user) => {
+          userSettingsStore.upsertUser(user)
         })
       } catch (e) {
         console.error(e)

--- a/packages/web-app-admin-settings/src/components/Users/CreateUserModal.vue
+++ b/packages/web-app-admin-settings/src/components/Users/CreateUserModal.vue
@@ -111,9 +111,8 @@ export default defineComponent({
 
       try {
         const client = clientService.graphAuthenticated
-        const { data } = await client.users.createUser(unref(user))
-        const { id: createdUserId } = data
-        const { data: createdUser } = await client.users.getUser(createdUserId)
+        const { id: createdUserId } = await client.users.createUser(unref(user))
+        const createdUser = await client.users.getUser(createdUserId)
         showMessage({ title: $gettext('User was created successfully') })
         userSettingsStore.upsertUser(createdUser)
       } catch (error) {

--- a/packages/web-app-admin-settings/src/components/Users/LoginModal.vue
+++ b/packages/web-app-admin-settings/src/components/Users/LoginModal.vue
@@ -132,12 +132,12 @@ export default defineComponent({
       try {
         const usersResponse = await Promise.all(
           succeeded.map(({ value }) => {
-            return client.users.getUser(value.data.id)
+            return client.users.getUser(value.id)
           })
         )
 
-        usersResponse.forEach(({ data }) => {
-          userSettingsStore.upsertUser(data)
+        usersResponse.forEach((user) => {
+          userSettingsStore.upsertUser(user)
         })
       } catch (e) {
         console.error(e)

--- a/packages/web-app-admin-settings/src/components/Users/RemoveFromGroupsModal.vue
+++ b/packages/web-app-admin-settings/src/components/Users/RemoveFromGroupsModal.vue
@@ -119,8 +119,8 @@ export default defineComponent({
           usersToFetch.map((userId) => client.users.getUser(userId))
         )
 
-        usersResponse.forEach(({ data }) => {
-          userSettingsStore.upsertUser(data)
+        usersResponse.forEach((user) => {
+          userSettingsStore.upsertUser(user)
         })
       } catch (e) {
         console.error(e)

--- a/packages/web-app-admin-settings/src/components/Users/SideBar/EditPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Users/SideBar/EditPanel.vue
@@ -278,7 +278,7 @@ export default defineComponent({
           await onUpdateUserAppRoleAssignments(user, editUser)
         }
 
-        const { data: updatedUser } = await client.users.getUser(user.id)
+        const updatedUser = await client.users.getUser(user.id)
         userSettingsStore.upsertUser(updatedUser)
 
         eventBus.publish('sidebar.entity.saved')

--- a/packages/web-app-admin-settings/src/views/Users.vue
+++ b/packages/web-app-admin-settings/src/views/Users.vue
@@ -270,12 +270,12 @@ export default defineComponent({
         .filter(Boolean)
         .join(' and ')
 
-      const usersResponse = yield clientService.graphAuthenticated.users.listUsers(
-        'displayName',
+      const usersResponse = yield clientService.graphAuthenticated.users.listUsers({
+        orderBy: ['displayName'],
         filter,
-        ['appRoleAssignments']
-      )
-      userSettingsStore.setUsers(usersResponse.data.value || [])
+        expand: ['appRoleAssignments']
+      })
+      userSettingsStore.setUsers(usersResponse || [])
     })
 
     const isLoading = computed(() => {
@@ -306,7 +306,7 @@ export default defineComponent({
         return
       }
 
-      const { data } = yield clientService.graphAuthenticated.users.getUser(user.id)
+      const data = yield clientService.graphAuthenticated.users.getUser(user.id)
       unref(additionalUserDataLoadedForUserIds).push(user.id)
 
       Object.assign(user, data)

--- a/packages/web-app-admin-settings/tests/unit/components/Users/AddToGroupsModal.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/AddToGroupsModal.spec.ts
@@ -1,10 +1,5 @@
 import AddToGroupsModal from '../../../../src/components/Users/AddToGroupsModal.vue'
-import {
-  defaultComponentMocks,
-  defaultPlugins,
-  mockAxiosResolve,
-  shallowMount
-} from 'web-test-helpers'
+import { defaultComponentMocks, defaultPlugins, shallowMount } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
 import { Group, User } from '@ownclouders/web-client/graph/generated'
 import { Modal, useMessages } from '@ownclouders/web-pkg'
@@ -23,7 +18,7 @@ describe('AddToGroupsModal', () => {
       const { wrapper, mocks } = getWrapper({ users, groups })
       mocks.$clientService.graphAuthenticated.groups.addMember.mockResolvedValue(undefined)
       mocks.$clientService.graphAuthenticated.users.getUser.mockResolvedValue(
-        mockAxiosResolve({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
+        mock<User>({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
       )
 
       wrapper.vm.selectedOptions = groups

--- a/packages/web-app-admin-settings/tests/unit/components/Users/CreateUserModal.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/CreateUserModal.spec.ts
@@ -3,13 +3,12 @@ import {
   defaultComponentMocks,
   defaultPlugins,
   mockAxiosReject,
-  mockAxiosResolve,
   shallowMount
 } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
-import { AxiosResponse } from 'axios'
 import { Modal, eventBus, useMessages } from '@ownclouders/web-pkg'
 import { useUserSettingsStore } from '../../../../src/composables/stores/userSettings'
+import { User } from '@ownclouders/web-client/graph/generated'
 
 describe('CreateUserModal', () => {
   describe('computed method "isFormInvalid"', () => {
@@ -52,7 +51,7 @@ describe('CreateUserModal', () => {
       const { wrapper, mocks } = getWrapper()
       const graphMock = mocks.$clientService.graphAuthenticated
       const getUserStub = graphMock.users.getUser.mockResolvedValue(
-        mock<AxiosResponse>({ data: { onPremisesSamAccountName: 'jan' } })
+        mock<User>({ onPremisesSamAccountName: 'jan' })
       )
       wrapper.vm.user.onPremisesSamAccountName = 'jan'
       expect(await wrapper.vm.validateUserName()).toBeFalsy()
@@ -141,10 +140,10 @@ describe('CreateUserModal', () => {
       wrapper.vm.validatePassword()
 
       mocks.$clientService.graphAuthenticated.users.createUser.mockResolvedValue(
-        mockAxiosResolve({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
+        mock<User>({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
       )
       mocks.$clientService.graphAuthenticated.users.getUser.mockResolvedValueOnce(
-        mockAxiosResolve({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
+        mock<User>({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
       )
 
       await wrapper.vm.onConfirm()
@@ -171,7 +170,7 @@ describe('CreateUserModal', () => {
       wrapper.vm.validatePassword()
 
       mocks.$clientService.graphAuthenticated.users.createUser.mockResolvedValue(
-        mockAxiosResolve({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
+        mock<User>({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
       )
       const eventSpy = vi.spyOn(eventBus, 'publish')
       await wrapper.vm.onConfirm()

--- a/packages/web-app-admin-settings/tests/unit/components/Users/LoginModal.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/LoginModal.spec.ts
@@ -1,10 +1,5 @@
 import LoginModal from '../../../../src/components/Users/LoginModal.vue'
-import {
-  defaultComponentMocks,
-  defaultPlugins,
-  mockAxiosResolve,
-  shallowMount
-} from 'web-test-helpers'
+import { defaultComponentMocks, defaultPlugins, shallowMount } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
 import { User } from '@ownclouders/web-client/graph/generated'
 import { Modal, useMessages } from '@ownclouders/web-pkg'
@@ -27,10 +22,10 @@ describe('LoginModal', () => {
       const users = [mock<User>(), mock<User>()]
       const { wrapper, mocks } = getWrapper(users)
       mocks.$clientService.graphAuthenticated.users.editUser.mockResolvedValue(
-        mockAxiosResolve({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
+        mock<User>({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
       )
       mocks.$clientService.graphAuthenticated.users.getUser.mockResolvedValue(
-        mockAxiosResolve({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
+        mock<User>({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
       )
 
       await wrapper.vm.onConfirm()
@@ -46,10 +41,10 @@ describe('LoginModal', () => {
       const users = [mock<User>({ id: '1' }), mock<User>()]
       const { wrapper, mocks } = getWrapper(users)
       mocks.$clientService.graphAuthenticated.users.editUser.mockResolvedValue(
-        mockAxiosResolve({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
+        mock<User>({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
       )
       mocks.$clientService.graphAuthenticated.users.getUser.mockResolvedValue(
-        mockAxiosResolve({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
+        mock<User>({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
       )
 
       await wrapper.vm.onConfirm()

--- a/packages/web-app-admin-settings/tests/unit/components/Users/RemoveFromGroupsModal.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/RemoveFromGroupsModal.spec.ts
@@ -1,10 +1,5 @@
 import RemoveFromGroupsModal from '../../../../src/components/Users/RemoveFromGroupsModal.vue'
-import {
-  defaultComponentMocks,
-  defaultPlugins,
-  mockAxiosResolve,
-  shallowMount
-} from 'web-test-helpers'
+import { defaultComponentMocks, defaultPlugins, shallowMount } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
 import { Group, User } from '@ownclouders/web-client/graph/generated'
 import { Modal, useMessages } from '@ownclouders/web-pkg'
@@ -26,7 +21,7 @@ describe('RemoveFromGroupsModal', () => {
       const { wrapper, mocks } = getWrapper({ users, groups })
       mocks.$clientService.graphAuthenticated.groups.deleteMember.mockResolvedValue(undefined)
       mocks.$clientService.graphAuthenticated.users.getUser.mockResolvedValue(
-        mockAxiosResolve({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
+        mock<User>({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
       )
 
       wrapper.vm.selectedOptions = groups

--- a/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/EditPanel.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/EditPanel.spec.ts
@@ -6,8 +6,7 @@ import {
   shallowMount
 } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
-import { Group } from '@ownclouders/web-client/graph/generated'
-import { AxiosResponse } from 'axios'
+import { Group, User } from '@ownclouders/web-client/graph/generated'
 import { CapabilityStore } from '@ownclouders/web-pkg'
 import GroupSelect from '../../../../../src/components/Users/GroupSelect.vue'
 
@@ -93,7 +92,7 @@ describe('EditPanel', () => {
       const { wrapper, mocks } = getWrapper()
       const graphMock = mocks.$clientService.graphAuthenticated
       const getUserStub = graphMock.users.getUser.mockResolvedValue(
-        mock<AxiosResponse>({ data: { onPremisesSamAccountName: 'jan' } })
+        mock<User>({ onPremisesSamAccountName: 'jan' })
       )
       wrapper.vm.editUser.onPremisesSamAccountName = 'jan'
       expect(await wrapper.vm.validateUserName()).toBeFalsy()

--- a/packages/web-app-admin-settings/tests/unit/views/Users.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/views/Users.spec.ts
@@ -72,15 +72,9 @@ const getDefaultApplications = () => {
 
 const getClientService = () => {
   const clientService = mockDeep<ClientService>()
-  clientService.graphAuthenticated.users.listUsers.mockResolvedValue(
-    mock<AxiosResponse>({ data: { value: [getDefaultUser()] } })
-  )
-  clientService.graphAuthenticated.users.getUser.mockResolvedValue(
-    mock<AxiosResponse>({ data: getDefaultUser() })
-  )
-  clientService.graphAuthenticated.users.editUser.mockResolvedValue(
-    mock<AxiosResponse>({ data: getDefaultUser() })
-  )
+  clientService.graphAuthenticated.users.listUsers.mockResolvedValue([mock<User>(getDefaultUser())])
+  clientService.graphAuthenticated.users.getUser.mockResolvedValue(mock<User>(getDefaultUser()))
+  clientService.graphAuthenticated.users.editUser.mockResolvedValue(mock<User>(getDefaultUser()))
   clientService.graphAuthenticated.groups.listGroups.mockResolvedValue(
     mock<AxiosResponse>({ data: { value: [] } })
   )
@@ -193,12 +187,11 @@ describe('Users view', () => {
           .vm.$emit('selectionChange', [{ id: '1' }])
         await wrapper.vm.$nextTick()
         expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenCalledTimes(2)
-        expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenNthCalledWith(
-          2,
-          'displayName',
-          "(memberOf/any(m:m/id eq '1'))",
-          ['appRoleAssignments']
-        )
+        expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenNthCalledWith(2, {
+          orderBy: ['displayName'],
+          filter: "(memberOf/any(m:m/id eq '1'))",
+          expand: ['appRoleAssignments']
+        })
       })
       it('does filter initially if group ids are given via query param', async () => {
         const groupIdsQueryParam = '1+2'
@@ -209,11 +202,11 @@ describe('Users view', () => {
           groupFilterQuery: groupIdsQueryParam
         })
         await wrapper.vm.loadResourcesTask.last
-        expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenCalledWith(
-          'displayName',
-          "(memberOf/any(m:m/id eq '1') or memberOf/any(m:m/id eq '2'))",
-          ['appRoleAssignments']
-        )
+        expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenCalledWith({
+          orderBy: ['displayName'],
+          filter: "(memberOf/any(m:m/id eq '1') or memberOf/any(m:m/id eq '2'))",
+          expand: ['appRoleAssignments']
+        })
       })
     })
     describe('roles', () => {
@@ -227,12 +220,11 @@ describe('Users view', () => {
           .vm.$emit('selectionChange', [{ id: '1' }])
         await wrapper.vm.$nextTick()
         expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenCalledTimes(2)
-        expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenNthCalledWith(
-          2,
-          'displayName',
-          "(appRoleAssignments/any(m:m/appRoleId eq '1'))",
-          ['appRoleAssignments']
-        )
+        expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenNthCalledWith(2, {
+          orderBy: ['displayName'],
+          filter: "(appRoleAssignments/any(m:m/appRoleId eq '1'))",
+          expand: ['appRoleAssignments']
+        })
       })
       it('does filter initially if role ids are given via query param', async () => {
         const roleIdsQueryParam = '1+2'
@@ -243,11 +235,12 @@ describe('Users view', () => {
           roleFilterQuery: roleIdsQueryParam
         })
         await wrapper.vm.loadResourcesTask.last
-        expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenCalledWith(
-          'displayName',
-          "(appRoleAssignments/any(m:m/appRoleId eq '1') or appRoleAssignments/any(m:m/appRoleId eq '2'))",
-          ['appRoleAssignments']
-        )
+        expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenCalledWith({
+          orderBy: ['displayName'],
+          filter:
+            "(appRoleAssignments/any(m:m/appRoleId eq '1') or appRoleAssignments/any(m:m/appRoleId eq '2'))",
+          expand: ['appRoleAssignments']
+        })
       })
     })
     describe('displayName', () => {
@@ -260,11 +253,11 @@ describe('Users view', () => {
           displayNameFilterQuery: displayNameFilterQueryParam
         })
         await wrapper.vm.loadResourcesTask.last
-        expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenCalledWith(
-          'displayName',
-          "contains(displayName,'Albert')",
-          ['appRoleAssignments']
-        )
+        expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenCalledWith({
+          orderBy: ['displayName'],
+          filter: "contains(displayName,'Albert')",
+          expand: ['appRoleAssignments']
+        })
       })
     })
   })

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -289,14 +289,15 @@ export default defineComponent({
 
     const fetchRecipientsTask = useTask(function* (signal, query: string) {
       const client = clientService.graphAuthenticated
-      const { data: userData } = yield* call(
-        client.users.listUsers('displayName', null, null, `"${query}"`)
+      const userData = yield* call(
+        client.users.listUsers({ orderBy: ['displayName'], search: `"${query}"` })
       )
+
       const { data: groupData } = yield* call(
         client.groups.listGroups('displayName', null, `"${query}"`)
       )
 
-      const users = (userData.value || []).map((u) => ({
+      const users = (userData || []).map((u) => ({
         ...u,
         shareType: ShareTypes.user.value
       })) as CollaboratorAutoCompleteItem[]

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.ts
@@ -169,9 +169,7 @@ function getWrapper({
     currentRoute: mock<RouteLocation>({ params: { storageId } })
   })
 
-  mocks.$clientService.graphAuthenticated.users.listUsers.mockResolvedValue(
-    mock<AxiosResponse>({ data: { value: users } })
-  )
+  mocks.$clientService.graphAuthenticated.users.listUsers.mockResolvedValue(users)
   mocks.$clientService.graphAuthenticated.groups.listGroups.mockResolvedValue(
     mock<AxiosResponse>({ data: { value: groups } })
   )

--- a/packages/web-client/src/graph/types.ts
+++ b/packages/web-client/src/graph/types.ts
@@ -1,0 +1,12 @@
+import type { AxiosInstance } from 'axios'
+import type { Configuration } from './generated'
+
+export interface GraphFactoryOptions {
+  axiosClient: AxiosInstance
+  config: Configuration
+}
+
+export interface GraphRequestOptions {
+  headers?: Record<string, string>
+  params?: Record<string, string>
+}

--- a/packages/web-client/src/graph/users/index.ts
+++ b/packages/web-client/src/graph/users/index.ts
@@ -1,0 +1,2 @@
+export * from './types'
+export * from './users'

--- a/packages/web-client/src/graph/users/types.ts
+++ b/packages/web-client/src/graph/users/types.ts
@@ -1,0 +1,67 @@
+import type {
+  AppRoleAssignment,
+  ExportPersonalDataRequest,
+  PasswordChange,
+  User
+} from '../generated'
+import type { GraphRequestOptions } from '../types'
+
+export interface GraphUsers {
+  getUser: (
+    id: string,
+    options?: {
+      expand?: Array<'memberOf' | 'drive' | 'drives' | 'appRoleAssignments'>
+      select?: Array<
+        | 'id'
+        | 'displayName'
+        | 'drive'
+        | 'drives'
+        | 'mail'
+        | 'memberOf'
+        | 'onPremisesSamAccountName'
+        | 'surname'
+      >
+    },
+    requestOptions?: GraphRequestOptions
+  ) => Promise<User>
+  createUser: (data: User, requestOptions?: GraphRequestOptions) => Promise<User>
+  editUser: (id: string, data: User, requestOptions?: GraphRequestOptions) => Promise<User>
+  deleteUser: (id: string, ifMatch?: string, requestOptions?: GraphRequestOptions) => Promise<void>
+  listUsers: (
+    options?: {
+      expand?: Array<'memberOf' | 'drive' | 'drives' | 'appRoleAssignments'>
+      filter?: string
+      orderBy?: Array<
+        | 'displayName'
+        | 'displayName desc'
+        | 'mail'
+        | 'mail desc'
+        | 'onPremisesSamAccountName'
+        | 'onPremisesSamAccountName desc'
+      >
+      search?: string
+      select?: Array<
+        'id' | 'displayName' | 'mail' | 'memberOf' | 'onPremisesSamAccountName' | 'surname'
+      >
+    },
+    requestOptions?: GraphRequestOptions
+  ) => Promise<User[]>
+  getMe: (
+    options?: {
+      expand?: Array<'memberOf'>
+    },
+    requestOptions?: GraphRequestOptions
+  ) => Promise<User>
+  editMe: (user: User, requestOptions?: GraphRequestOptions) => Promise<User>
+  changeOwnPassword: (change: PasswordChange, requestOptions?: GraphRequestOptions) => Promise<void>
+  exportPersonalData: (
+    id: string,
+    destination?: ExportPersonalDataRequest,
+    requestOptions?: GraphRequestOptions
+  ) => Promise<void>
+  createUserAppRoleAssignment: (
+    id: string,
+    roleAssignment: AppRoleAssignment,
+    requestOptions?: GraphRequestOptions
+  ) => Promise<AppRoleAssignment>
+}

--- a/packages/web-client/src/graph/users/users.ts
+++ b/packages/web-client/src/graph/users/users.ts
@@ -1,0 +1,97 @@
+import {
+  MeChangepasswordApiFactory,
+  MeUserApiFactory,
+  UserApiFactory,
+  UserAppRoleAssignmentApiFactory,
+  UsersApiFactory
+} from './../generated'
+import type { GraphFactoryOptions } from './../types'
+import type { GraphUsers } from './types'
+
+export const UsersFactory = ({ axiosClient, config }: GraphFactoryOptions): GraphUsers => {
+  const userApiFactory = UserApiFactory(config, config.basePath, axiosClient)
+  const usersApiFactory = UsersApiFactory(config, config.basePath, axiosClient)
+  const meUserApiFactory = MeUserApiFactory(config, config.basePath, axiosClient)
+  const meChangepasswordApiFactory = MeChangepasswordApiFactory(
+    config,
+    config.basePath,
+    axiosClient
+  )
+  const userAppRoleAssignmentApiFactory = UserAppRoleAssignmentApiFactory(
+    config,
+    config.basePath,
+    axiosClient
+  )
+
+  return {
+    async getUser(id, options, requestOptions) {
+      const { data } = await userApiFactory.getUser(
+        id,
+        options?.select ? new Set([...options.select]) : null,
+        options?.expand
+          ? new Set([...options.expand])
+          : new Set(['drive', 'memberOf', 'appRoleAssignments']),
+        requestOptions
+      )
+      return data
+    },
+
+    async createUser(data, requestOptions) {
+      const { data: user } = await usersApiFactory.createUser(data, requestOptions)
+      return user
+    },
+
+    async editUser(id, data, requestOptions) {
+      const { data: user } = await userApiFactory.updateUser(id, data, requestOptions)
+      return user
+    },
+
+    async deleteUser(id, ifMatch, requestOptions) {
+      await userApiFactory.deleteUser(id, ifMatch, requestOptions)
+    },
+
+    async listUsers(options, requestOptions) {
+      const {
+        data: { value }
+      } = await usersApiFactory.listUsers(
+        options?.search,
+        options?.filter,
+        options?.orderBy ? new Set([...options.orderBy]) : null,
+        options?.select ? new Set([...options.select]) : null,
+        options?.expand ? new Set([...options.expand]) : null,
+        requestOptions
+      )
+      return value
+    },
+
+    async getMe(options, requestOptions) {
+      const { data } = await meUserApiFactory.getOwnUser(
+        options?.expand ? new Set([...options.expand]) : new Set(['memberOf']),
+        requestOptions
+      )
+      return data
+    },
+
+    async editMe(user, requestOptions) {
+      const { data } = await meUserApiFactory.updateOwnUser(user, requestOptions)
+      return data
+    },
+
+    async changeOwnPassword(change, requestOptions) {
+      await meChangepasswordApiFactory.changeOwnPassword(change, requestOptions)
+    },
+
+    async exportPersonalData(id, destination, requestOptions) {
+      await userApiFactory.exportPersonalData(id, destination, requestOptions)
+    },
+
+    async createUserAppRoleAssignment(id, roleAssignment, requestOptions) {
+      const { data } = await userAppRoleAssignmentApiFactory.userCreateAppRoleAssignments(
+        id,
+        roleAssignment,
+        requestOptions
+      )
+      return data
+    }
+  }
+}

--- a/packages/web-runtime/src/components/EditPasswordModal.vue
+++ b/packages/web-runtime/src/components/EditPasswordModal.vue
@@ -62,7 +62,10 @@ export default defineComponent({
 
     const onConfirm = () => {
       return clientService.graphAuthenticated.users
-        .changeOwnPassword(unref(currentPassword).trim(), unref(newPassword).trim())
+        .changeOwnPassword({
+          currentPassword: unref(currentPassword).trim(),
+          newPassword: unref(newPassword).trim()
+        })
         .then(() => {
           showMessage({ title: $gettext('Password was changed successfully') })
         })

--- a/packages/web-runtime/src/pages/account.vue
+++ b/packages/web-runtime/src/pages/account.vue
@@ -314,8 +314,7 @@ export default defineComponent({
       }
 
       try {
-        const { data } = yield* call(clientService.graphAuthenticated.users.getMe())
-        graphUser.value = data
+        graphUser.value = yield* call(clientService.graphAuthenticated.users.getMe())
       } catch (e) {
         console.error(e)
         showErrorMessage({

--- a/packages/web-runtime/src/services/auth/userManager.ts
+++ b/packages/web-runtime/src/services/auth/userManager.ts
@@ -189,22 +189,22 @@ export class UserManager extends OidcUserManager {
 
     const graphClient = this.clientService.graphAuthenticated
     const [graphUser, roles] = await Promise.all([graphClient.users.getMe(), this.fetchRoles()])
-    const role = await this.fetchRole({ graphUser: graphUser.data, roles })
+    const role = await this.fetchRole({ graphUser, roles })
 
     this.userStore.setUser({
-      id: graphUser.data.id,
-      onPremisesSamAccountName: graphUser.data.onPremisesSamAccountName,
-      displayName: graphUser.data.displayName,
-      mail: graphUser.data.mail,
-      memberOf: graphUser.data.memberOf,
+      id: graphUser.id,
+      onPremisesSamAccountName: graphUser.onPremisesSamAccountName,
+      displayName: graphUser.displayName,
+      mail: graphUser.mail,
+      memberOf: graphUser.memberOf,
       appRoleAssignments: role ? [role as any] : [], // FIXME
-      preferredLanguage: graphUser.data.preferredLanguage || ''
+      preferredLanguage: graphUser.preferredLanguage || ''
     })
 
-    if (graphUser?.data?.preferredLanguage) {
+    if (graphUser.preferredLanguage) {
       setCurrentLanguage({
         language: this.language,
-        languageSetting: graphUser.data.preferredLanguage
+        languageSetting: graphUser.preferredLanguage
       })
     }
   }

--- a/packages/web-runtime/tests/unit/pages/account.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/account.spec.ts
@@ -7,7 +7,6 @@ import {
   mockAxiosReject
 } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
-import { AxiosResponse } from 'axios'
 import {
   Extension,
   ExtensionPoint,
@@ -184,9 +183,7 @@ describe('account page', () => {
       const { wrapper, mocks } = getWrapper({})
       await blockLoadingState(wrapper)
 
-      mocks.$clientService.graphAuthenticated.users.editMe.mockResolvedValueOnce(
-        mockAxiosResolve({})
-      )
+      mocks.$clientService.graphAuthenticated.users.editMe.mockResolvedValueOnce(undefined)
       await wrapper.vm.updateSelectedLanguage({ value: 'en' } as LanguageOption)
       const { showMessage } = useMessages()
       expect(showMessage).toHaveBeenCalled()
@@ -197,9 +194,7 @@ describe('account page', () => {
       const { wrapper, mocks } = getWrapper({})
       await blockLoadingState(wrapper)
 
-      mocks.$clientService.graphAuthenticated.users.editMe.mockImplementation(() =>
-        mockAxiosReject('err')
-      )
+      mocks.$clientService.graphAuthenticated.users.editMe.mockRejectedValue(new Error())
       await wrapper.vm.updateSelectedLanguage({ value: 'en' } as LanguageOption)
       const { showErrorMessage } = useMessages()
       expect(showErrorMessage).toHaveBeenCalled()
@@ -340,9 +335,7 @@ function getWrapper({
 
     return Promise.resolve(mockAxiosResolve(response))
   })
-  mocks.$clientService.graphAuthenticated.users.getMe.mockResolvedValue(
-    mock<AxiosResponse>({ data: { id: '1' } })
-  )
+  mocks.$clientService.graphAuthenticated.users.getMe.mockResolvedValue(mock<User>({ id: '1' }))
 
   return {
     mocks,


### PR DESCRIPTION
## Description
Refactors the graph abstraction layer for users to make it more practical and convenient to use.

The new implementation has improved method parameters, types and destructures API responses so users of the abstraction don't need to care about such things.

This is the first PR of a whole series, groups will be next. I currently work on it when I have some spare time, although it would be nice to have this completed for the `9.0.0` release (especially now that we decided to couple web-client releases to Web releases).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/10808

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
