### PR TITLE
fix: viewer light role permission loading

### DIFF
--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -216,15 +216,13 @@ export const bootstrapApp = async (configurationPath: string): Promise<void> => 
       await spacesStore.loadSpaces({ graphClient: clientService.graphAuthenticated })
       const personalSpace = spacesStore.spaces.find(isPersonalSpaceResource)
 
-      if (!personalSpace) {
-        return
+      if (personalSpace) {
+        spacesStore.updateSpaceField({
+          id: personalSpace.id,
+          field: 'name',
+          value: app.config.globalProperties.$gettext('Personal')
+        })
       }
-
-      spacesStore.updateSpaceField({
-        id: personalSpace.id,
-        field: 'name',
-        value: app.config.globalProperties.$gettext('Personal')
-      })
 
       // load sharing roles from graph API
       const { data } =


### PR DESCRIPTION
## Description
loading role permissions is shadowed by a early return which get triggered if the user does not have a personal space.
In some cases, for example if the logged in user is of type (role), user-light, this is a valid use-case.

This is fixed by the pr, but we have to discuss (and test) possible side effects of the change.

## How Has This Been Tested?
- ci
- manuell testing

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)