### PR TITLE
feat: remove allow-same-origin from drawio iframe sandbox

### DIFF
--- a/changelog/unreleased/drawio-sandbox
+++ b/changelog/unreleased/drawio-sandbox
@@ -1,0 +1,7 @@
+Enhancement: Execute drawio with a miniman iframe sandbox
+
+Starting with v24.5.2 drawio can be properly sanboxed
+
+https://github.com/owncloud/web/issues/10716
+https://github.com/jgraph/drawio/issues/4340
+https://github.com/owncloud/web/pull/11010

--- a/packages/web-app-draw-io/src/App.vue
+++ b/packages/web-app-draw-io/src/App.vue
@@ -4,7 +4,7 @@
     ref="drawIoEditor"
     :src="iframeSource"
     :title="$gettext('Draw.io editor')"
-    sandbox="allow-scripts allow-same-origin"
+    sandbox="allow-scripts"
   />
 </template>
 


### PR DESCRIPTION
## Description
Drawio v24.5.2 no longer requires `allow-same-origin`

https://github.com/jgraph/drawio/issues/4340

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
