### PR TITLE
[full-ci][tests-only]Trigger tracing step pipeline when e2e tests run on CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1508,10 +1508,6 @@ def uploadTracingResult(ctx):
         },
         "when": {
             "status": status,
-            "event": [
-                "pull_request",
-                "cron",
-            ],
         },
     }]
 
@@ -1531,10 +1527,6 @@ def logTracingResult(ctx, suite):
         ],
         "when": {
             "status": status,
-            "event": [
-                "pull_request",
-                "cron",
-            ],
         },
     }]
 


### PR DESCRIPTION
## Description
This PR remove event from `log-tracing-result` and `upload-tracing-result` so that those step pipleine triggers whenever `e2e-tests-oCIS-x` pipeline triggers

## Related Issue
- 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
