### PR TITLE
refactor: useful graph abstraction for groups

### DIFF
--- a/packages/web-app-admin-settings/src/components/Groups/CreateGroupModal.vue
+++ b/packages/web-app-admin-settings/src/components/Groups/CreateGroupModal.vue
@@ -61,9 +61,9 @@ export default defineComponent({
 
       try {
         const client = clientService.graphAuthenticated
-        const response = await client.groups.createGroup(unref(group))
+        const createdGroup = await client.groups.createGroup(unref(group))
         showMessage({ title: $gettext('Group was created successfully') })
-        groupSettingsStore.upsertGroup(response?.data)
+        groupSettingsStore.upsertGroup(createdGroup)
       } catch (error) {
         console.error(error)
         showErrorMessage({

--- a/packages/web-app-admin-settings/src/components/Groups/SideBar/EditPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Groups/SideBar/EditPanel.vue
@@ -63,7 +63,7 @@ export default defineComponent({
       try {
         const client = clientService.graphAuthenticated
         await client.groups.editGroup(editGroup.id, editGroup)
-        const { data: updatedGroup } = await client.groups.getGroup(editGroup.id)
+        const updatedGroup = await client.groups.getGroup(editGroup.id)
         groupSettingsStore.upsertGroup(updatedGroup)
 
         eventBus.publish('sidebar.entity.saved')

--- a/packages/web-app-admin-settings/src/components/Users/AddToGroupsModal.vue
+++ b/packages/web-app-admin-settings/src/components/Users/AddToGroupsModal.vue
@@ -11,7 +11,7 @@ import { defineComponent, PropType, ref, unref, watch } from 'vue'
 import { useGettext } from 'vue3-gettext'
 import { Group, User } from '@ownclouders/web-client/graph/generated'
 import GroupSelect from './GroupSelect.vue'
-import { useClientService, Modal, useMessages, useConfigStore } from '@ownclouders/web-pkg'
+import { useClientService, Modal, useMessages } from '@ownclouders/web-pkg'
 import { useUserSettingsStore } from '../../composables/stores/userSettings'
 
 export default defineComponent({
@@ -32,7 +32,6 @@ export default defineComponent({
   setup(props, { emit, expose }) {
     const { showMessage, showErrorMessage } = useMessages()
     const clientService = useClientService()
-    const configStore = useConfigStore()
     const { $gettext, $ngettext } = useGettext()
     const userSettingsStore = useUserSettingsStore()
 
@@ -55,7 +54,7 @@ export default defineComponent({
       const promises = unref(selectedOptions).reduce((acc, group) => {
         for (const user of props.users) {
           if (!user.memberOf.find((userGroup) => userGroup.id === group.id)) {
-            acc.push(client.groups.addMember(group.id, user.id, configStore.serverUrl))
+            acc.push(client.groups.addMember(group.id, user.id))
             if (!usersToFetch.includes(user.id)) {
               usersToFetch.push(user.id)
             }

--- a/packages/web-app-admin-settings/src/components/Users/SideBar/EditPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Users/SideBar/EditPanel.vue
@@ -119,7 +119,6 @@ import {
   useCapabilityStore,
   useEventBus,
   useMessages,
-  useConfigStore,
   useSpacesStore
 } from '@ownclouders/web-pkg'
 import GroupSelect from '../GroupSelect.vue'
@@ -171,7 +170,6 @@ export default defineComponent({
     const clientService = useClientService()
     const userStore = useUserStore()
     const userSettingsStore = useUserSettingsStore()
-    const configStore = useConfigStore()
     const spacesStore = useSpacesStore()
     const eventBus = useEventBus()
     const { showErrorMessage } = useMessages()
@@ -222,7 +220,7 @@ export default defineComponent({
       const requests = []
 
       for (const groupToAdd of groupsToAdd) {
-        requests.push(client.groups.addMember(groupToAdd.id, user.id, configStore.serverUrl))
+        requests.push(client.groups.addMember(groupToAdd.id, user.id))
       }
       for (const groupToDelete of groupsToDelete) {
         requests.push(client.groups.deleteMember(groupToDelete.id, user.id))

--- a/packages/web-app-admin-settings/src/views/Groups.vue
+++ b/packages/web-app-admin-settings/src/views/Groups.vue
@@ -74,8 +74,8 @@ import { Group } from '@ownclouders/web-client/graph/generated'
 import { computed, defineComponent, ref, unref, onBeforeUnmount, onMounted } from 'vue'
 import { useTask } from 'vue-concurrency'
 import { useGettext } from 'vue3-gettext'
-
 import { storeToRefs } from 'pinia'
+import { call } from '@ownclouders/web-client'
 
 export default defineComponent({
   components: {
@@ -101,10 +101,13 @@ export default defineComponent({
     const createGroupAction = computed(() => unref(createGroupActions)[0])
 
     const loadResourcesTask = useTask(function* (signal) {
-      const response = yield clientService.graphAuthenticated.groups.listGroups('displayName', [
-        'members'
-      ])
-      groupSettingsStore.setGroups(response.data.value || [])
+      const loadedGroups = yield* call(
+        clientService.graphAuthenticated.groups.listGroups({
+          orderBy: ['displayName'],
+          expand: ['members']
+        })
+      )
+      groupSettingsStore.setGroups(loadedGroups || [])
     })
 
     const { actions: deleteActions } = useGroupActionsDelete()

--- a/packages/web-app-admin-settings/src/views/Users.vue
+++ b/packages/web-app-admin-settings/src/views/Users.vue
@@ -174,6 +174,7 @@ import { omit } from 'lodash-es'
 import { storeToRefs } from 'pinia'
 
 import { useUserSettingsStore } from '../composables/stores/userSettings'
+import { call } from '@ownclouders/web-client'
 
 export default defineComponent({
   name: 'UsersView',
@@ -231,16 +232,18 @@ export default defineComponent({
     let editQuotaActionEventToken: string
 
     const loadGroupsTask = useTask(function* (signal) {
-      const groupsResponse = yield clientService.graphAuthenticated.groups.listGroups(
-        'displayName',
-        ['members']
+      groups.value = yield* call(
+        clientService.graphAuthenticated.groups.listGroups({
+          orderBy: ['displayName'],
+          expand: ['members']
+        })
       )
-      groups.value = groupsResponse.data.value
     })
 
     const loadAppRolesTask = useTask(function* (signal) {
-      const applicationsResponse =
-        yield clientService.graphAuthenticated.applications.listApplications()
+      const applicationsResponse = yield* call(
+        clientService.graphAuthenticated.applications.listApplications()
+      )
       roles.value = applicationsResponse.data.value[0].appRoles
       applicationId.value = applicationsResponse.data.value[0].id
     })

--- a/packages/web-app-admin-settings/tests/unit/components/Groups/CreateGroupModal.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Groups/CreateGroupModal.spec.ts
@@ -7,9 +7,9 @@ import {
   shallowMount
 } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
-import { AxiosResponse } from 'axios'
 import { Modal, eventBus, useMessages } from '@ownclouders/web-pkg'
 import { useGroupSettingsStore } from '../../../../src/composables'
+import { Group } from '@ownclouders/web-client/graph/generated'
 
 describe('CreateGroupModal', () => {
   describe('computed method "isFormInvalid"', () => {
@@ -42,7 +42,7 @@ describe('CreateGroupModal', () => {
       const graphMock = mocks.$clientService.graphAuthenticated
       wrapper.vm.group.displayName = 'admins'
       const getGroupSub = graphMock.groups.getGroup.mockResolvedValue(
-        mock<AxiosResponse>({ data: { displayName: 'admins' } })
+        mock<Group>({ displayName: 'admins' })
       )
       expect(await wrapper.vm.validateDisplayName()).toBeFalsy()
       expect(getGroupSub).toHaveBeenCalled()
@@ -78,7 +78,7 @@ describe('CreateGroupModal', () => {
       await wrapper.vm.validateDisplayName()
 
       mocks.$clientService.graphAuthenticated.groups.createGroup.mockResolvedValueOnce(
-        mockAxiosResolve({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
+        mock<Group>({ id: 'e3515ffb-d264-4dfc-8506-6c239f6673b5' })
       )
 
       await wrapper.vm.onConfirm()

--- a/packages/web-app-admin-settings/tests/unit/components/Groups/SideBar/EditPanel.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Groups/SideBar/EditPanel.spec.ts
@@ -1,14 +1,8 @@
 import EditPanel from '../../../../../src/components/Groups/SideBar/EditPanel.vue'
-import {
-  defaultComponentMocks,
-  defaultPlugins,
-  mockAxiosReject,
-  mockAxiosResolve,
-  mount
-} from 'web-test-helpers'
+import { defaultComponentMocks, defaultPlugins, mockAxiosReject, mount } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
-import { AxiosResponse } from 'axios'
 import { eventBus, useMessages } from '@ownclouders/web-pkg'
+import { Group } from '@ownclouders/web-client/graph/generated'
 
 describe('EditPanel', () => {
   it('renders all available inputs', () => {
@@ -56,7 +50,7 @@ describe('EditPanel', () => {
       wrapper.vm.editGroup.displayName = 'users'
       const graphMock = mocks.$clientService.graphAuthenticated
       const getGroupStub = graphMock.groups.getGroup.mockResolvedValue(
-        mock<AxiosResponse>({ data: { displayName: 'group' } })
+        mock<Group>({ displayName: 'group' })
       )
       expect(await wrapper.vm.validateDisplayName()).toBeFalsy()
       expect(getGroupStub).toHaveBeenCalled()
@@ -68,9 +62,9 @@ describe('EditPanel', () => {
       const { wrapper, mocks } = getWrapper()
 
       const clientService = mocks.$clientService
-      clientService.graphAuthenticated.groups.editGroup.mockResolvedValue(mockAxiosResolve())
+      clientService.graphAuthenticated.groups.editGroup.mockResolvedValue()
       clientService.graphAuthenticated.groups.getGroup.mockResolvedValue(
-        mockAxiosResolve({ id: '1', displayName: 'administrators' })
+        mock<Group>({ id: '1', displayName: 'administrators' })
       )
 
       const editGroup = {
@@ -90,7 +84,7 @@ describe('EditPanel', () => {
       vi.spyOn(console, 'error').mockImplementation(() => undefined)
       const { wrapper, mocks } = getWrapper()
       const clientService = mocks.$clientService
-      clientService.graphAuthenticated.groups.editGroup.mockImplementation(() => mockAxiosReject())
+      clientService.graphAuthenticated.groups.editGroup.mockRejectedValue(undefined)
       await wrapper.vm.onEditGroup({})
 
       const { showErrorMessage } = useMessages()

--- a/packages/web-app-admin-settings/tests/unit/views/Groups.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/views/Groups.spec.ts
@@ -1,6 +1,5 @@
 import Groups from '../../../src/views/Groups.vue'
-import { mockAxiosResolve } from 'web-test-helpers/src/mocks'
-import { mockDeep } from 'vitest-mock-extended'
+import { mock, mockDeep } from 'vitest-mock-extended'
 import { ClientService } from '@ownclouders/web-pkg'
 import { defaultComponentMocks, defaultPlugins, mount } from 'web-test-helpers'
 import { Group } from '@ownclouders/web-client/graph/generated'
@@ -8,9 +7,9 @@ import { Group } from '@ownclouders/web-client/graph/generated'
 const selectors = { batchActionsStub: 'batch-actions-stub' }
 const getClientServiceMock = () => {
   const clientService = mockDeep<ClientService>()
-  clientService.graphAuthenticated.groups.listGroups.mockResolvedValue(
-    mockAxiosResolve({ value: [{ id: '1', name: 'users', groupTypes: [] }] })
-  )
+  clientService.graphAuthenticated.groups.listGroups.mockResolvedValue([
+    mock<Group>({ id: '1', displayName: 'users', groupTypes: [] })
+  ])
   return clientService
 }
 vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({

--- a/packages/web-app-admin-settings/tests/unit/views/Users.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/views/Users.spec.ts
@@ -75,9 +75,7 @@ const getClientService = () => {
   clientService.graphAuthenticated.users.listUsers.mockResolvedValue([mock<User>(getDefaultUser())])
   clientService.graphAuthenticated.users.getUser.mockResolvedValue(mock<User>(getDefaultUser()))
   clientService.graphAuthenticated.users.editUser.mockResolvedValue(mock<User>(getDefaultUser()))
-  clientService.graphAuthenticated.groups.listGroups.mockResolvedValue(
-    mock<AxiosResponse>({ data: { value: [] } })
-  )
+  clientService.graphAuthenticated.groups.listGroups.mockResolvedValue([])
   clientService.graphAuthenticated.applications.listApplications.mockResolvedValue(
     mock<AxiosResponse>({ data: { value: getDefaultApplications() } })
   )

--- a/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Users.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Users.spec.ts.snap
@@ -23,7 +23,7 @@ exports[`Users view > list view > renders initially warning if filters are manda
         <div class="user-filters oc-flex oc-flex-between oc-flex-wrap oc-flex-bottom oc-mx-m oc-mb-m">
           <div data-v-32efd9c6="" class="oc-flex oc-flex-middle">
             <div data-v-32efd9c6="" class="oc-mr-m oc-flex oc-flex-middle"><span data-v-32efd9c6="" class="oc-icon oc-icon-m oc-icon-passive oc-mr-xs"><!----></span> <span data-v-32efd9c6="">Filter:</span></div>
-            <item-filter-stub data-v-32efd9c6="" filterlabel="Groups" filtername="groups" optionfilterlabel="Filter groups" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false" class="oc-mr-s" items="undefined"></item-filter-stub>
+            <item-filter-stub data-v-32efd9c6="" filterlabel="Groups" filtername="groups" optionfilterlabel="Filter groups" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false" class="oc-mr-s" items=""></item-filter-stub>
             <item-filter-stub data-v-32efd9c6="" filterlabel="Roles" filtername="roles" optionfilterlabel="Filter roles" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false" items="undefined"></item-filter-stub>
           </div>
           <div data-v-32efd9c6="" class="oc-flex oc-flex-middle">
@@ -71,7 +71,7 @@ exports[`Users view > list view > renders list initially 1`] = `
         <div class="user-filters oc-flex oc-flex-between oc-flex-wrap oc-flex-bottom oc-mx-m oc-mb-m">
           <div data-v-32efd9c6="" class="oc-flex oc-flex-middle">
             <div data-v-32efd9c6="" class="oc-mr-m oc-flex oc-flex-middle"><span data-v-32efd9c6="" class="oc-icon oc-icon-m oc-icon-passive oc-mr-xs"><!----></span> <span data-v-32efd9c6="">Filter:</span></div>
-            <item-filter-stub data-v-32efd9c6="" filterlabel="Groups" filtername="groups" optionfilterlabel="Filter groups" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false" class="oc-mr-s" items="undefined"></item-filter-stub>
+            <item-filter-stub data-v-32efd9c6="" filterlabel="Groups" filtername="groups" optionfilterlabel="Filter groups" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false" class="oc-mr-s" items=""></item-filter-stub>
             <item-filter-stub data-v-32efd9c6="" filterlabel="Roles" filtername="roles" optionfilterlabel="Filter roles" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false" items="undefined"></item-filter-stub>
           </div>
           <div data-v-32efd9c6="" class="oc-flex oc-flex-middle">

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -293,8 +293,8 @@ export default defineComponent({
         client.users.listUsers({ orderBy: ['displayName'], search: `"${query}"` })
       )
 
-      const { data: groupData } = yield* call(
-        client.groups.listGroups('displayName', null, `"${query}"`)
+      const groupData = yield* call(
+        client.groups.listGroups({ orderBy: ['displayName'], search: `"${query}"` })
       )
 
       const users = (userData || []).map((u) => ({
@@ -302,7 +302,7 @@ export default defineComponent({
         shareType: ShareTypes.user.value
       })) as CollaboratorAutoCompleteItem[]
 
-      const groups = (groupData.value || []).map((u) => ({
+      const groups = (groupData || []).map((u) => ({
         ...u,
         shareType: ShareTypes.group.value
       })) as CollaboratorAutoCompleteItem[]

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.ts
@@ -15,7 +15,6 @@ import {
   ShareRole
 } from '@ownclouders/web-client'
 import { Group, User } from '@ownclouders/web-client/graph/generated'
-import { AxiosResponse } from 'axios'
 import OcButton from 'design-system/src/components/OcButton/OcButton.vue'
 
 vi.mock('lodash-es', () => ({ debounce: (fn: any) => fn() }))
@@ -170,9 +169,7 @@ function getWrapper({
   })
 
   mocks.$clientService.graphAuthenticated.users.listUsers.mockResolvedValue(users)
-  mocks.$clientService.graphAuthenticated.groups.listGroups.mockResolvedValue(
-    mock<AxiosResponse>({ data: { value: groups } })
-  )
+  mocks.$clientService.graphAuthenticated.groups.listGroups.mockResolvedValue(groups)
 
   const capabilities = { files_sharing: { federation: { incoming: true, outgoing: true } } }
 

--- a/packages/web-client/src/graph/groups/groups.ts
+++ b/packages/web-client/src/graph/groups/groups.ts
@@ -1,0 +1,60 @@
+import { urlJoin } from '../../utils'
+import { GroupApiFactory, GroupsApiFactory } from './../generated'
+import type { GraphFactoryOptions } from './../types'
+import type { GraphGroups } from './types'
+
+export const GroupsFactory = ({ axiosClient, config }: GraphFactoryOptions): GraphGroups => {
+  const groupApiFactory = GroupApiFactory(config, config.basePath, axiosClient)
+  const groupsApiFactory = GroupsApiFactory(config, config.basePath, axiosClient)
+
+  return {
+    async getGroup(id, options, requestOptions) {
+      const { data } = await groupApiFactory.getGroup(
+        id,
+        options?.select ? new Set([...options.select]) : null,
+        options?.expand ? new Set([...options.expand]) : new Set(['members']),
+        requestOptions
+      )
+      return data
+    },
+
+    async createGroup(data, requestOptions) {
+      const { data: group } = await groupsApiFactory.createGroup(data, requestOptions)
+      return group
+    },
+
+    async editGroup(id, data, requestOptions) {
+      const { data: group } = await groupApiFactory.updateGroup(id, data, requestOptions)
+      return group
+    },
+
+    async deleteGroup(id, ifMatch, requestOptions) {
+      await groupApiFactory.deleteGroup(id, ifMatch, requestOptions)
+    },
+
+    async listGroups(options, requestOptions) {
+      const {
+        data: { value }
+      } = await groupsApiFactory.listGroups(
+        options?.search,
+        options?.orderBy ? new Set([...options.orderBy]) : null,
+        options?.select ? new Set([...options.select]) : null,
+        options?.expand ? new Set([...options.expand]) : null,
+        requestOptions
+      )
+      return value
+    },
+
+    async addMember(groupId, userId, requestOptions) {
+      await groupApiFactory.addMember(
+        groupId,
+        { '@odata.id': urlJoin(config.basePath, 'v1.0', 'users', userId) },
+        requestOptions
+      )
+    },
+
+    async deleteMember(groupId, userId, ifMatch, requestOptions) {
+      await groupApiFactory.deleteMember(groupId, userId, ifMatch, requestOptions)
+    }
+  }
+}

--- a/packages/web-client/src/graph/groups/index.ts
+++ b/packages/web-client/src/graph/groups/index.ts
@@ -1,0 +1,2 @@
+export * from './groups'
+export * from './types'

--- a/packages/web-client/src/graph/groups/types.ts
+++ b/packages/web-client/src/graph/groups/types.ts
@@ -1,0 +1,36 @@
+import type { Group } from '../generated'
+import type { GraphRequestOptions } from '../types'
+
+export interface GraphGroups {
+  getGroup: (
+    id: string,
+    options?: {
+      expand?: Array<'members'>
+      select?: Array<'id' | 'description' | 'displayName' | 'members'>
+    },
+    requestOptions?: GraphRequestOptions
+  ) => Promise<Group>
+  createGroup: (data: Group, requestOptions?: GraphRequestOptions) => Promise<Group>
+  editGroup: (id: string, data: Group, requestOptions?: GraphRequestOptions) => Promise<void>
+  deleteGroup: (id: string, ifMatch?: string, requestOptions?: GraphRequestOptions) => Promise<void>
+  listGroups: (
+    options?: {
+      expand?: Array<'members'>
+      orderBy?: Array<'displayName' | 'displayName desc'>
+      search?: string
+      select?: Array<'id' | 'description' | 'displayName' | 'mail' | 'members'>
+    },
+    requestOptions?: GraphRequestOptions
+  ) => Promise<Group[]>
+  addMember: (
+    groupId: string,
+    userId: string,
+    requestOptions?: GraphRequestOptions
+  ) => Promise<void>
+  deleteMember: (
+    groupId: string,
+    userId: string,
+    ifMatch?: string,
+    requestOptions?: GraphRequestOptions
+  ) => Promise<void>
+}

--- a/packages/web-client/src/graph/index.ts
+++ b/packages/web-client/src/graph/index.ts
@@ -1,13 +1,9 @@
 import { AxiosInstance, AxiosPromise, AxiosResponse } from 'axios'
 import {
   CollectionOfDrives,
-  CollectionOfGroup,
   Configuration,
   Drive,
   DrivesApiFactory,
-  Group,
-  GroupApiFactory,
-  GroupsApiFactory,
   MeDrivesApi,
   TagsApiFactory,
   CollectionOfTags,
@@ -32,6 +28,7 @@ import {
   CollectionOfPermissionsWithAllowedValues
 } from './generated'
 import { type GraphUsers, UsersFactory } from './users'
+import { type GraphGroups, GroupsFactory } from './groups'
 
 export interface Graph {
   applications: {
@@ -61,19 +58,7 @@ export interface Graph {
     createDriveItem: (driveId: string, driveItem: DriveItem) => AxiosPromise<DriveItem>
   }
   users: GraphUsers
-  groups: {
-    listGroups: (
-      orderBy?: string,
-      expand?: Array<'members'>,
-      search?: string
-    ) => AxiosPromise<CollectionOfGroup>
-    createGroup: (group: Group) => AxiosPromise<Group>
-    getGroup: (groupId: string) => AxiosPromise<Group>
-    editGroup: (groupId: string, group: Group) => AxiosPromise<void>
-    deleteGroup: (groupId: string) => AxiosPromise<void>
-    addMember: (groupId: string, userId: string, server: string) => AxiosPromise<void>
-    deleteMember: (groupId: string, userId: string) => AxiosPromise<void>
-  }
+  groups: GraphGroups
   roleManagement: {
     listPermissionRoleDefinitions: () => AxiosPromise<UnifiedRoleDefinition>
   }
@@ -142,8 +127,6 @@ export const graph = (baseURI: string, axiosClient: AxiosInstance): Graph => {
   const allDrivesApi = new DrivesGetDrivesApi(config, config.basePath, axiosClient)
   const meDriveApiFactory = MeDriveApiFactory(config, config.basePath, axiosClient)
   const applicationsApiFactory = ApplicationsApiFactory(config, config.basePath, axiosClient)
-  const groupApiFactory = GroupApiFactory(config, config.basePath, axiosClient)
-  const groupsApiFactory = GroupsApiFactory(config, config.basePath, axiosClient)
   const drivesApiFactory = DrivesApiFactory(config, config.basePath, axiosClient)
   const tagsApiFactory = TagsApiFactory(config, config.basePath, axiosClient)
   const roleManagementApiFactory = RoleManagementApiFactory(config, config.basePath, axiosClient)
@@ -192,24 +175,7 @@ export const graph = (baseURI: string, axiosClient: AxiosInstance): Graph => {
         drivesRootApiFactory.createDriveItem(driveId, driveItem)
     },
     users: UsersFactory({ axiosClient, config }),
-    groups: {
-      createGroup: (group: Group) => groupsApiFactory.createGroup(group),
-      editGroup: (groupId: string, group: Group) => groupApiFactory.updateGroup(groupId, group),
-      getGroup: (groupId: string) =>
-        groupApiFactory.getGroup(groupId, new Set<any>([]), new Set<any>(['members'])),
-      deleteGroup: (groupId: string) => groupApiFactory.deleteGroup(groupId),
-      listGroups: (orderBy?: any, expand?: Array<'members'>, search: string = '') =>
-        groupsApiFactory.listGroups(
-          search,
-          orderBy ? new Set<any>([orderBy]) : null,
-          null,
-          expand ? new Set<any>(expand) : null
-        ),
-      addMember: (groupId: string, userId: string, server: string) =>
-        groupApiFactory.addMember(groupId, { '@odata.id': `${server}graph/v1.0/users/${userId}` }),
-      deleteMember: (groupId: string, userId: string) =>
-        groupApiFactory.deleteMember(groupId, userId)
-    },
+    groups: GroupsFactory({ axiosClient, config }),
     roleManagement: {
       listPermissionRoleDefinitions: () => roleManagementApiFactory.listPermissionRoleDefinitions()
     },


### PR DESCRIPTION
## Description
Refactors the graph abstraction layer for groups to make it more practical and convenient to use.

The new implementation has improved method parameters, types and destructures API responses so users of the abstraction don't need to care about such things.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/10808

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
