### PR TITLE
perf: prevent setting all languages for all apps on initial load

### DIFF
--- a/changelog/unreleased/enhancement-page-loading-times
+++ b/changelog/unreleased/enhancement-page-loading-times
@@ -2,7 +2,7 @@ Enhancement: Faster page loading times
 
 We've massively decreased the initial page loading times. This is especially noticeable with slower network connections.
 
-According to the lighthouse performance metrics, we improved from a score of 60 to 94.
+According to the lighthouse performance metrics, we improved from a score of 60 to 94 out of 100.
 
 This has been achieved by taking several different actions:
 

--- a/changelog/unreleased/enhancement-page-loading-times
+++ b/changelog/unreleased/enhancement-page-loading-times
@@ -1,0 +1,19 @@
+Enhancement: Faster page loading times
+
+We've massively decreased the initial page loading times. This is especially noticeable with slower network connections.
+
+According to the lighthouse performance metrics, we improved from a score of 60 to 94.
+
+This has been achieved by taking several different actions:
+
+- Lazy load large dependencies
+- Improve chunking
+- Enable server side compression
+- Reduce the size of the main font we're using
+- Only register translations for the currently selected language
+
+https://github.com/owncloud/web/pull/10976
+https://github.com/owncloud/web/pull/10979
+https://github.com/owncloud/web/pull/11040
+https://github.com/owncloud/web/issues/7964
+https://github.com/owncloud/web/issues/11035

--- a/packages/web-pkg/src/apps/types.ts
+++ b/packages/web-pkg/src/apps/types.ts
@@ -3,6 +3,7 @@ import { RouteLocationRaw, Router, RouteRecordRaw } from 'vue-router'
 import { Extension, ExtensionPoint } from '../composables/piniaStores'
 import { IconFillType } from '../helpers'
 import { Resource, SpaceResource } from '@ownclouders/web-client'
+import { Translations } from 'vue3-gettext'
 
 export interface AppReadyHookArgs {
   globalProperties: ComponentCustomProperties & Record<string, any>
@@ -77,6 +78,7 @@ export interface ApplicationInformation {
   defaultExtension?: string
   type?: string
   applicationMenu?: ApplicationMenuItem
+  translations?: Translations
 }
 
 /**

--- a/packages/web-pkg/src/composables/piniaStores/apps.ts
+++ b/packages/web-pkg/src/composables/piniaStores/apps.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { computed, ref, unref } from 'vue'
 import { AppConfigObject, ApplicationInformation, ApplicationFileExtension } from '../../apps'
+import { Translations } from 'vue3-gettext'
 
 export const useAppsStore = defineStore('apps', () => {
   const apps = ref<Record<string, ApplicationInformation>>({})
@@ -9,7 +10,7 @@ export const useAppsStore = defineStore('apps', () => {
 
   const appIds = computed(() => Object.keys(unref(apps)))
 
-  const registerApp = (appInfo: ApplicationInformation) => {
+  const registerApp = (appInfo: ApplicationInformation, translations?: Translations) => {
     if (!appInfo.id) {
       return
     }
@@ -25,6 +26,7 @@ export const useAppsStore = defineStore('apps', () => {
       defaultExtension: appInfo.defaultExtension || '',
       icon: 'check_box_outline_blank',
       name: appInfo.name || appInfo.id,
+      translations,
       ...appInfo
     }
   }

--- a/packages/web-runtime/src/container/api.ts
+++ b/packages/web-runtime/src/container/api.ts
@@ -8,10 +8,9 @@ import {
   ExtensionRegistry,
   SidebarNavExtension
 } from '@ownclouders/web-pkg'
-import { isEqual, isObject, isArray, merge } from 'lodash-es'
+import { isEqual, isObject, isArray } from 'lodash-es'
 import { App, Component, computed, h } from 'vue'
-import { ApplicationTranslations, AppNavigationItem } from '@ownclouders/web-pkg'
-import type { Language } from 'vue3-gettext'
+import { AppNavigationItem } from '@ownclouders/web-pkg'
 
 /**
  * inject application specific routes into runtime
@@ -97,29 +96,6 @@ const announceNavigationItems = (
 }
 
 /**
- * inject application specific translations into runtime
- *
- * @param translations
- * @param appTranslations
- * @param supportedLanguages
- */
-const announceTranslations = (
-  supportedLanguages: { [key: string]: string },
-  gettext: Language,
-  appTranslations: ApplicationTranslations
-): void => {
-  if (!isObject(gettext.translations)) {
-    throw new ApiError("translations can't be blank")
-  }
-
-  Object.keys(supportedLanguages).forEach((lang) => {
-    if (gettext.translations[lang] && appTranslations[lang]) {
-      gettext.translations = merge(gettext.translations, { [lang]: appTranslations[lang] })
-    }
-  })
-}
-
-/**
  * open a wormhole portal, this wraps vue-portal
  *
  * @param instance
@@ -165,27 +141,16 @@ const requestRouter = (router: Router): Router => {
  * specific data to the implementations.
  *
  * each application get its own provisioned api!
- *
- * @param applicationName
- * @param applicationId
- * @param store
- * @param router
- * @param translations
- * @param supportedLanguages
  */
 export const buildRuntimeApi = ({
   applicationName,
   applicationId,
   router,
-  gettext,
-  supportedLanguages,
   extensionRegistry
 }: {
   applicationName: string
   applicationId: string
-  gettext: Language
   router: Router
-  supportedLanguages: { [key: string]: string }
   extensionRegistry: ExtensionRegistry
 }): RuntimeApi => {
   if (!applicationName) {
@@ -201,8 +166,6 @@ export const buildRuntimeApi = ({
       announceRoutes(applicationId, router, routes),
     announceNavigationItems: (navigationItems: AppNavigationItem[]): void =>
       announceNavigationItems(applicationId, extensionRegistry, navigationItems),
-    announceTranslations: (appTranslations: ApplicationTranslations): void =>
-      announceTranslations(supportedLanguages, gettext, appTranslations),
     requestRouter: (): Router => requestRouter(router),
     openPortal: (
       instance: App,

--- a/packages/web-runtime/src/container/application/classic.ts
+++ b/packages/web-runtime/src/container/application/classic.ts
@@ -7,7 +7,6 @@ import { Router } from 'vue-router'
 import { RuntimeError, useAppsStore } from '@ownclouders/web-pkg'
 import { AppConfigObject, AppReadyHookArgs, ClassicApplicationScript } from '@ownclouders/web-pkg'
 import { useExtensionRegistry } from '@ownclouders/web-pkg'
-import type { Language } from 'vue3-gettext'
 
 /**
  * this wraps a classic application structure into a next application format.
@@ -24,14 +23,13 @@ class ClassicApplication extends NextApplication {
   }
 
   initialize(): Promise<void> {
-    const { routes, navItems, translations } = this.applicationScript
+    const { routes, navItems } = this.applicationScript
     const { globalProperties } = this.app.config
     const _routes = typeof routes === 'function' ? routes(globalProperties) : routes
     const _navItems = typeof navItems === 'function' ? navItems(globalProperties) : navItems
 
     routes && this.runtimeApi.announceRoutes(_routes)
     navItems && this.runtimeApi.announceNavigationItems(_navItems)
-    translations && this.runtimeApi.announceTranslations(translations)
 
     return Promise.resolve(undefined)
   }
@@ -64,28 +62,16 @@ class ClassicApplication extends NextApplication {
   }
 }
 
-/**
- *
- * @param app
- * @param applicationPath
- * @param router
- * @param translations
- * @param supportedLanguages
- */
 export const convertClassicApplication = ({
   app,
   applicationScript,
   applicationConfig,
-  router,
-  gettext,
-  supportedLanguages
+  router
 }: {
   app: App
   applicationScript: ClassicApplicationScript
   applicationConfig: AppConfigObject
   router: Router
-  gettext: Language
-  supportedLanguages: { [key: string]: string }
 }): NextApplication => {
   if (applicationScript.setup) {
     applicationScript = app.runWithContext(() => {
@@ -117,13 +103,11 @@ export const convertClassicApplication = ({
     applicationName,
     applicationId,
     router,
-    gettext,
-    supportedLanguages,
     extensionRegistry
   })
 
   const appsStore = useAppsStore()
-  appsStore.registerApp(applicationScript.appInfo)
+  appsStore.registerApp(applicationScript.appInfo, applicationScript.translations)
 
   if (applicationScript.extensions) {
     extensionRegistry.registerExtensions(applicationScript.extensions)

--- a/packages/web-runtime/src/container/application/index.ts
+++ b/packages/web-runtime/src/container/application/index.ts
@@ -4,7 +4,6 @@ import { convertClassicApplication } from './classic'
 import { RuntimeError, ConfigStore } from '@ownclouders/web-pkg'
 import { applicationStore } from '../store'
 import { isObject } from 'lodash-es'
-import type { Language } from 'vue3-gettext'
 
 // import modules to provide them to applications
 import * as vue from 'vue' // eslint-disable-line
@@ -65,26 +64,20 @@ const loadScriptRequireJS = <T>(moduleUri: string) => {
 }
 /**
  * sniffs arguments and decides if given manifest is of next or current application style.
- *
- * @param args
  */
 export const buildApplication = async ({
   app,
   applicationPath,
   applicationConfig,
   router,
-  gettext,
-  supportedLanguages,
   configStore
 }: {
   app: App
   applicationPath: string
   applicationConfig: AppConfigObject
   router: Router
-  gettext: Language
-  supportedLanguages: { [key: string]: string }
   configStore: ConfigStore
-}): Promise<NextApplication> => {
+}) => {
   if (applicationStore.has(applicationPath)) {
     throw new RuntimeError('application already announced', applicationPath)
   }
@@ -128,14 +121,7 @@ export const buildApplication = async ({
     if (!isObject(applicationScript.appInfo) && !applicationScript.setup) {
       throw new RuntimeError('next applications not implemented yet, stay tuned')
     } else {
-      application = convertClassicApplication({
-        app,
-        applicationScript,
-        applicationConfig,
-        router,
-        gettext,
-        supportedLanguages
-      })
+      application = convertClassicApplication({ app, applicationScript, applicationConfig, router })
     }
   } catch (err) {
     throw new RuntimeError('cannot create application', err.message, applicationPath)

--- a/packages/web-runtime/src/container/types.ts
+++ b/packages/web-runtime/src/container/types.ts
@@ -1,12 +1,11 @@
 import { Router, RouteRecordRaw } from 'vue-router'
 import { App, Component } from 'vue'
-import { AppNavigationItem, ApplicationTranslations } from '@ownclouders/web-pkg'
+import { AppNavigationItem } from '@ownclouders/web-pkg'
 
 /** RuntimeApi defines the publicly available runtime api */
 export interface RuntimeApi {
   announceRoutes: (routes: RouteRecordRaw[]) => void
   announceNavigationItems: (navigationItems: AppNavigationItem[]) => void
-  announceTranslations: (appTranslations: ApplicationTranslations) => void
   requestRouter: () => Router
   openPortal: (
     instance: App,

--- a/packages/web-runtime/src/helpers/customTranslations.ts
+++ b/packages/web-runtime/src/helpers/customTranslations.ts
@@ -1,12 +1,13 @@
 import { ConfigStore } from '@ownclouders/web-pkg'
 import { v4 as uuidV4 } from 'uuid'
 import merge from 'lodash-es/merge'
+import { Translations } from 'vue3-gettext'
 
 export const loadCustomTranslations = async ({
   configStore
 }: {
   configStore: ConfigStore
-}): Promise<unknown> => {
+}): Promise<Translations> => {
   const customTranslations = {}
   for (const customTranslation of configStore.customTranslations) {
     const customTranslationResponse = await fetch(customTranslation.url, {

--- a/packages/web-runtime/src/helpers/language.ts
+++ b/packages/web-runtime/src/helpers/language.ts
@@ -1,4 +1,6 @@
-import { Language } from 'vue3-gettext'
+import { ApplicationInformation } from '@ownclouders/web-pkg'
+import { merge } from 'lodash-es'
+import { Language, Translations } from 'vue3-gettext'
 
 export const setCurrentLanguage = ({
   language,
@@ -15,4 +17,30 @@ export const setCurrentLanguage = ({
     language.current = currentLanguage
     document.documentElement.lang = currentLanguage
   }
+}
+
+/**
+ * Loads all app translations for one given language.
+ * This should be called each time the language is being changed.
+ */
+export const loadAppTranslations = ({
+  apps,
+  gettext,
+  lang
+}: {
+  apps: Record<string, ApplicationInformation>
+  gettext: Language
+  lang: string
+}) => {
+  const appTranslations: Translations = {}
+  Object.values(apps).forEach((app) => {
+    const { translations } = app
+    if (gettext.translations[lang] && translations[lang]) {
+      Object.assign(appTranslations, translations[lang])
+    }
+  })
+
+  gettext.translations = merge(gettext.translations, {
+    [lang]: appTranslations
+  })
 }

--- a/packages/web-runtime/src/pages/account.vue
+++ b/packages/web-runtime/src/pages/account.vue
@@ -195,6 +195,7 @@ import EditPasswordModal from '../components/EditPasswordModal.vue'
 import { SettingsBundle, LanguageOption, SettingsValue } from '../helpers/settings'
 import { computed, defineComponent, onMounted, unref, ref } from 'vue'
 import {
+  useAppsStore,
   useAuthStore,
   useCapabilityStore,
   useClientService,
@@ -208,7 +209,7 @@ import {
 } from '@ownclouders/web-pkg'
 import { useTask } from 'vue-concurrency'
 import { useGettext } from 'vue3-gettext'
-import { setCurrentLanguage } from 'web-runtime/src/helpers/language'
+import { setCurrentLanguage, loadAppTranslations } from 'web-runtime/src/helpers/language'
 import GdprExport from '../components/Account/GdprExport.vue'
 import ThemeSwitcher from '../components/Account/ThemeSwitcher.vue'
 import ExtensionPreference from '../components/Account/ExtensionPreference.vue'
@@ -235,6 +236,7 @@ export default defineComponent({
     const { $gettext } = language
     const clientService = useClientService()
     const resourcesStore = useResourcesStore()
+    const appsStore = useAppsStore()
 
     const valuesList = ref<SettingsValue[]>()
     const graphUser = ref<User>()
@@ -401,6 +403,12 @@ export default defineComponent({
 
     const updateSelectedLanguage = async (option: LanguageOption) => {
       try {
+        loadAppTranslations({
+          apps: appsStore.apps,
+          gettext: language,
+          lang: option.value
+        })
+
         selectedLanguageValue.value = option
         setCurrentLanguage({
           language,

--- a/packages/web-runtime/src/services/auth/userManager.ts
+++ b/packages/web-runtime/src/services/auth/userManager.ts
@@ -6,13 +6,13 @@ import {
   User,
   ErrorResponse
 } from 'oidc-client-ts'
-import { buildUrl } from '@ownclouders/web-pkg'
+import { buildUrl, useAppsStore } from '@ownclouders/web-pkg'
 import { getAbilities } from './abilities'
 import { AuthStore, UserStore, CapabilityStore, ConfigStore } from '@ownclouders/web-pkg'
 import { ClientService } from '@ownclouders/web-pkg'
 import { Ability } from '@ownclouders/web-client'
 import { Language } from 'vue3-gettext'
-import { setCurrentLanguage } from 'web-runtime/src/helpers/language'
+import { loadAppTranslations, setCurrentLanguage } from 'web-runtime/src/helpers/language'
 import { router } from 'web-runtime/src/router'
 import { SSEAdapter } from '@ownclouders/web-client/sse'
 import { User as OcUser } from '@ownclouders/web-client/graph/generated'
@@ -202,6 +202,14 @@ export class UserManager extends OidcUserManager {
     })
 
     if (graphUser.preferredLanguage) {
+      const appsStore = useAppsStore()
+
+      loadAppTranslations({
+        apps: appsStore.apps,
+        gettext: this.language,
+        lang: graphUser.preferredLanguage
+      })
+
       setCurrentLanguage({
         language: this.language,
         languageSetting: graphUser.preferredLanguage

--- a/packages/web-runtime/tests/unit/container/bootstrap.spec.ts
+++ b/packages/web-runtime/tests/unit/container/bootstrap.spec.ts
@@ -43,9 +43,7 @@ describe('initialize applications', () => {
     const applications = await initializeApplications({
       app: createApp(defineComponent({})),
       configStore,
-      router: undefined,
-      gettext: undefined,
-      supportedLanguages: {}
+      router: undefined
     })
 
     expect(buildApplicationMock).toHaveBeenCalledTimes(4)


### PR DESCRIPTION
## Description
Changes the way how app languages get set in `gettext` so only the current language is being considered initially. Other languages will be set dynamically when changing the current language.

Also refactors the language setup process a bit to make it simpler.

`announceGettext` sets up gettext in our Vue app, without any translations yet though. `announceTranslations` gets called later during the bootstrap process and provides all translations to `gettext`: the ones for core, additional ones and the ones for the apps for the current language. That way we have all that stuff in one place.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/11035

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
