### PR TITLE
fix: keep translations of apps optional

### DIFF
--- a/packages/web-runtime/src/helpers/language.ts
+++ b/packages/web-runtime/src/helpers/language.ts
@@ -35,7 +35,7 @@ export const loadAppTranslations = ({
   const appTranslations: Translations = {}
   Object.values(apps).forEach((app) => {
     const { translations } = app
-    if (gettext.translations[lang] && translations[lang]) {
+    if (gettext.translations[lang] && translations?.[lang]) {
       Object.assign(appTranslations, translations[lang])
     }
   })


### PR DESCRIPTION
## Description
It's probably not happening in reality for production, but might occur during development, that an app has no translations. In that case the bootstrapping process would fail hard because translations were not optional.

## Motivation and Context
Keep DX as easy as possible.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)