### PR TITLE
fix: editor save after token renewal

### DIFF
--- a/changelog/unreleased/bugfix-editor-save-after-token-renewal
+++ b/changelog/unreleased/bugfix-editor-save-after-token-renewal
@@ -1,0 +1,6 @@
+Bugfix: Editor save after token renewal
+
+We've fixed a bug where saving changes in an editor would not work after the access token has been renewed.
+
+https://github.com/owncloud/web/pull/11068
+https://github.com/owncloud/web/issues/11062

--- a/packages/web-pkg/src/composables/appDefaults/useAppFileHandling.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppFileHandling.ts
@@ -36,9 +36,9 @@ export interface AppFileHandlingResult {
 }
 
 export function useAppFileHandling({
-  clientService: { webdav }
+  clientService
 }: AppFileHandlingOptions): AppFileHandlingResult {
-  const clientService = useClientService()
+  clientService = clientService || useClientService()
   const capabilityStore = useCapabilityStore()
   const userStore = useUserStore()
 
@@ -63,7 +63,7 @@ export function useAppFileHandling({
     fileContext: MaybeRef<FileContext>,
     options: { responseType?: 'arraybuffer' | 'blob' | 'text' } & Record<string, any>
   ) => {
-    return webdav.getFileContents(
+    return clientService.webdav.getFileContents(
       unref(unref(fileContext).space),
       {
         path: unref(unref(fileContext).item)
@@ -78,7 +78,7 @@ export function useAppFileHandling({
     fileContext: MaybeRef<FileContext>,
     options: ListFilesOptions = {}
   ): Promise<Resource> => {
-    return webdav.getFileInfo(
+    return clientService.webdav.getFileInfo(
       unref(unref(fileContext).space),
       {
         path: unref(unref(fileContext).item),
@@ -92,7 +92,7 @@ export function useAppFileHandling({
     fileContext: MaybeRef<FileContext>,
     options: { content?: string } & Record<string, any>
   ) => {
-    return webdav.putFileContents(unref(unref(fileContext).space), {
+    return clientService.webdav.putFileContents(unref(unref(fileContext).space), {
       path: unref(unref(fileContext).item),
       ...options
     })


### PR DESCRIPTION
## Description
The issue existed because the `ClientService` had been destructured, which lead to the request headers not being reactive.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/11062

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
