### PR TITLE
[tests-only][full-ci] properly close the sse connections

### DIFF
--- a/tests/e2e/cucumber/environment/index.ts
+++ b/tests/e2e/cucumber/environment/index.ts
@@ -135,7 +135,13 @@ After(async function (this: World, { result, willBeRetried }: ITestCaseHookParam
   closeSSEConnections()
 })
 
-AfterAll(() => state.browser && state.browser.close())
+AfterAll(async () => {
+  closeSSEConnections()
+
+  if (state.browser) {
+    await state.browser.close()
+  }
+})
 
 setWorldConstructor(World)
 

--- a/tests/e2e/support/environment/sse.ts
+++ b/tests/e2e/support/environment/sse.ts
@@ -3,10 +3,13 @@ import { getAuthHeader } from '../api/http'
 import { User } from '../types'
 
 const sseEventStore: Record<string, string[]> = {}
-const ctrl = new AbortController()
+const sseConnections = []
 
 export const listenSSE = (baseUrl: string, user: User): Promise<void> => {
   const sseUrl = new URL('ocs/v2.php/apps/notifications/api/v1/notifications/sse', baseUrl).href
+
+  const ctrl = new AbortController()
+  sseConnections.push(ctrl)
 
   return fetchEventSource(sseUrl, {
     headers: {
@@ -46,5 +49,7 @@ export const getSSEEvents = (user: string): Array<string> => {
 }
 
 export const closeSSEConnections = () => {
-  ctrl.abort()
+  Object.keys(sseEventStore).forEach((key) => delete sseEventStore[key])
+  sseConnections.forEach((connection) => connection.abort())
+  sseConnections.length = 0
 }


### PR DESCRIPTION
## Description
Created one `AbortController` for each sse connection and added the controller to the list. This helps to close each sse connections properly. 

## Related Issue
- Fixes https://github.com/owncloud/web/issues/11016

## How Has This Been Tested?
- :hand: :computer: 

![Screenshot from 2024-06-19 17-26-05](https://github.com/owncloud/web/assets/52366632/9878bced-8d31-47e4-b8cf-213a46e055ed)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
