### PR TITLE
chore: use ocis-rolling docker image for development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 x-ocis-server: &ocis-service
-  image: ${OCIS_IMAGE:-owncloud/ocis:latest}
+  image: ${OCIS_IMAGE:-owncloud/ocis-rolling:latest}
   entrypoint: /bin/sh
   command: ['-c', 'ocis init || true && ocis server']
   environment: &ocis-environment
@@ -164,7 +164,7 @@ services:
       traefik.http.services.companion.loadbalancer.server.port: 3020
 
   ocis-appprovider-collabora:
-    image: ${OCIS_IMAGE:-owncloud/ocis:latest}
+    image: ${OCIS_IMAGE:-owncloud/ocis-rolling:latest}
     command: app-provider server
     environment:
       APP_PROVIDER_LOG_LEVEL: error
@@ -193,7 +193,7 @@ services:
     restart: always
 
   ocis-appprovider-onlyoffice:
-    image: ${OCIS_IMAGE:-owncloud/ocis:latest}
+    image: ${OCIS_IMAGE:-owncloud/ocis-rolling:latest}
     user: '0' # needed for apk add in entrypoint script
     entrypoint:
       - /bin/sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 x-ocis-server: &ocis-service
-  image: ${OCIS_IMAGE:-owncloud/ocis-rolling:latest}
+  image: ${OCIS_IMAGE:-owncloud/ocis-rolling:master}
   entrypoint: /bin/sh
   command: ['-c', 'ocis init || true && ocis server']
   environment: &ocis-environment
@@ -164,7 +164,7 @@ services:
       traefik.http.services.companion.loadbalancer.server.port: 3020
 
   ocis-appprovider-collabora:
-    image: ${OCIS_IMAGE:-owncloud/ocis-rolling:latest}
+    image: ${OCIS_IMAGE:-owncloud/ocis-rolling:master}
     command: app-provider server
     environment:
       APP_PROVIDER_LOG_LEVEL: error
@@ -193,7 +193,7 @@ services:
     restart: always
 
   ocis-appprovider-onlyoffice:
-    image: ${OCIS_IMAGE:-owncloud/ocis-rolling:latest}
+    image: ${OCIS_IMAGE:-owncloud/ocis-rolling:master}
     user: '0' # needed for apk add in entrypoint script
     entrypoint:
       - /bin/sh


### PR DESCRIPTION
## Description
Since ocis daily builds are now available on [owncloud/ocis-rolling:master](https://hub.docker.com/r/owncloud/ocis-rolling/tags), this PR changes the docker image to the rolling one where ocis daily builds are available.
During web development, we were using daily builds so this change ensures that daily builds are up-to-date with `docker compose pull`

## Related Issue

## Motivation and Context

## How Has This Been Tested?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
