### PR TITLE
refactor: use AppWrapper for preview app

### DIFF
--- a/packages/web-app-preview/src/components/Sources/MediaImage.vue
+++ b/packages/web-app-preview/src/components/Sources/MediaImage.vue
@@ -49,6 +49,7 @@ export default defineComponent({
 
     const initPanzoom = async () => {
       if (unref(panzoom)) {
+        await nextTick()
         ;(unref(img) as unknown as HTMLElement).removeEventListener(
           'panzoomchange',
           onPanZoomChange

--- a/packages/web-app-preview/src/index.ts
+++ b/packages/web-app-preview/src/index.ts
@@ -1,4 +1,4 @@
-import { defineWebApplication } from '@ownclouders/web-pkg'
+import { AppWrapperRoute, defineWebApplication } from '@ownclouders/web-pkg'
 import translations from '../l10n/translations.json'
 import * as app from './App.vue'
 import { useGettext } from 'vue3-gettext'
@@ -13,7 +13,12 @@ export default defineWebApplication({
     const routes = [
       {
         path: '/:driveAliasAndItem(.*)?',
-        component: App,
+        component: AppWrapperRoute(App, {
+          applicationId: appId,
+          urlForResourceOptions: {
+            disposition: 'inline'
+          }
+        }),
         name: 'media',
         meta: {
           authContext: 'hybrid',

--- a/packages/web-app-preview/tests/unit/app.spec.ts
+++ b/packages/web-app-preview/tests/unit/app.spec.ts
@@ -1,15 +1,8 @@
 import App from '../../src/App.vue'
-import { nextTick, ref } from 'vue'
+import { nextTick } from 'vue'
 import { defaultComponentMocks, defaultPlugins, shallowMount } from 'web-test-helpers'
-import { useAppDefaultsMock } from 'web-test-helpers/src/mocks/useAppDefaultsMock'
-import { FileContext, useAppDefaults } from '@ownclouders/web-pkg'
+import { FileContext } from '@ownclouders/web-pkg'
 import { mock } from 'vitest-mock-extended'
-
-vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
-  ...(await importOriginal<any>()),
-  useAppDefaults: vi.fn(),
-  useAppFileHandling: vi.fn()
-}))
 
 const activeFiles = [
   {
@@ -86,26 +79,25 @@ describe('Preview app', () => {
 })
 
 function createShallowMountWrapper() {
-  vi.mocked(useAppDefaults).mockImplementation(() =>
-    useAppDefaultsMock({
-      currentFileContext: ref(
-        mock<FileContext>({
+  const mocks = defaultComponentMocks()
+  mocks.$previewService.loadPreview.mockResolvedValue('')
+  return {
+    wrapper: shallowMount(App, {
+      props: {
+        currentFileContext: mock<FileContext>({
           path: 'personal/admin/bear.png',
           space: {
             getDriveAliasAndItem: vi.fn().mockImplementation((file) => {
               return activeFiles.find((filteredFile) => filteredFile.id == file.id)?.path
             })
           }
-        })
-      ),
-      activeFiles: ref(activeFiles)
-    })
-  )
-
-  const mocks = defaultComponentMocks()
-  mocks.$previewService.loadPreview.mockResolvedValue('')
-  return {
-    wrapper: shallowMount(App, {
+        }),
+        activeFiles,
+        isFolderLoading: true,
+        revokeUrl: vi.fn(),
+        getUrlForResource: vi.fn(),
+        loadFolderForFileContext: vi.fn()
+      },
       global: {
         plugins: [...defaultPlugins()],
         mocks,

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -18,7 +18,8 @@ const downloadFileButtonSideBar =
 const downloadFolderButtonSideBar =
   '#oc-files-actions-sidebar .oc-files-actions-download-archive-trigger'
 const downloadButtonBatchAction = '.oc-files-actions-download-archive-trigger'
-const downloadPreviewButton = '#preview-download'
+const appBarContextMenu = '#oc-openfile-contextmenu-trigger'
+const appBarDownloadFileButton = '#oc-openfile-contextmenu .oc-files-actions-download-file-trigger'
 const deleteButtonBatchAction = '.oc-files-actions-delete-trigger'
 const createSpaceFromResourceAction = '.oc-files-actions-create-space-from-resource-trigger'
 const checkBox = `//*[@data-test-resource-name="%s"]//ancestor::tr//input`
@@ -757,9 +758,14 @@ export const downloadResources = async (args: downloadResourcesArgs): Promise<Do
     }
 
     case 'PREVIEW_TOPBAR':
+      await Promise.all([
+        page.locator(appBarDownloadFileButton).waitFor(),
+        page.locator(appBarContextMenu).click()
+      ])
+
       const [download] = await Promise.all([
         page.waitForEvent('download'),
-        page.locator(downloadPreviewButton).click()
+        page.locator(appBarDownloadFileButton).click()
       ])
       downloads.push(download)
       break


### PR DESCRIPTION
## Description
Makes use of the `AppWrapper` component in the preview app. This reduces boilerplate code in the app and enables the context menu in the app bar.

The resource loading still happens in the preview app because it's heavily tied to it. The loading in the `AppWrapper` is being bypassed during this.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/11065

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
