### PR TITLE
fix: enforce protocol in shortcut urls

### DIFF
--- a/changelog/unreleased/bugfix-enforce-shortcut-url-protocol
+++ b/changelog/unreleased/bugfix-enforce-shortcut-url-protocol
@@ -1,0 +1,6 @@
+Bugfix: Enforce shortcut URL protocol
+
+We've fixed a bug where the protocol in shortcut URLs was not enforced. Now, the shortcut URL always starts `https://` if no protocol is provided by the user.
+
+https://github.com/owncloud/web/issues/11063
+https://github.com/owncloud/web/pull/11076

--- a/packages/web-pkg/src/components/CreateShortcutModal.vue
+++ b/packages/web-pkg/src/components/CreateShortcutModal.vue
@@ -154,14 +154,16 @@ export default defineComponent({
     const isDropOpen = ref(false)
     let markInstance = null
 
-    const dropItemUrl = computed(() => {
-      let url = unref(inputUrl).trim()
-
+    const getInputUrlWithProtocol = (input: string) => {
+      let url = input.trim()
       if (isMaybeUrl(url)) {
         return url
       }
-
       return `https://${url}`
+    }
+
+    const dropItemUrl = computed(() => {
+      return getInputUrlWithProtocol(unref(inputUrl))
     })
 
     const confirmButtonDisabled = computed(
@@ -327,7 +329,9 @@ export default defineComponent({
     const onConfirm = async () => {
       try {
         // Omit possible xss code
-        const sanitizedUrl = DOMPurify.sanitize(unref(inputUrl), { USE_PROFILES: { html: true } })
+        const sanitizedUrl = DOMPurify.sanitize(getInputUrlWithProtocol(unref(inputUrl)), {
+          USE_PROFILES: { html: true }
+        })
 
         const content = `[InternetShortcut]\nURL=${sanitizedUrl}`
         const path = urlJoin(unref(currentFolder).path, `${unref(inputFilename)}.url`)


### PR DESCRIPTION
## Description
If the user types a URL without protocol and doesn't click on the proposed URL in the dropdown (which would include `https://` as protocol), the resulting .url file wouldn't have a protocol in the URL. This PR fixes that by enforcing `https://` as prefix for the user input if none was given. Technically this would've been possible by using `unref(dropItemUrl)` instead of `unref(inputUrl)`, but I've decided to extract the body of `dropItemUrl` into a function and use that, because it would be confusing to use `dropItemUrl` as the final input on confirm.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/11063

## Motivation and Context
Enforce url protocol so that mobile clients won't have trouble opening the URLs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
