### PR TITLE
perf: reduce network load on token renewal

### DIFF
--- a/changelog/unreleased/enhancement-reduce-network-load-on-token-renewal
+++ b/changelog/unreleased/enhancement-reduce-network-load-on-token-renewal
@@ -1,0 +1,6 @@
+Enhancement: Reduce network load on token renewal
+
+We've reduced the network load on token renewal, resulting in better overall performance of the Web client and less token renewal failures on slow network connections.
+
+https://github.com/owncloud/web/pull/11077
+https://github.com/owncloud/web/issues/11069

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -1,5 +1,4 @@
 import { getSizeClass } from './utils/sizeClasses'
-import './utils/webFontLoader'
 import { App } from 'vue'
 
 import * as components from './components'
@@ -20,6 +19,8 @@ export const applyCustomProp = (key: string, value: string | undefined) => {
 
 export default {
   install(app: App, options: any = {}) {
+    import('./utils/webFontLoader')
+
     const themeOptions = options.tokens
     initializeCustomProps(themeOptions?.breakpoints, 'breakpoint-')
     initializeCustomProps(themeOptions?.colorPalette, 'color-')

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -1,7 +1,7 @@
 import { registerClient } from '../services/clientRegistration'
 import { buildApplication, NextApplication } from './application'
 import { RouteLocationRaw, Router, RouteRecordNormalized } from 'vue-router'
-import { App, watch } from 'vue'
+import { App, computed, watch } from 'vue'
 import { loadTheme } from '../helpers/theme'
 import { createGettext, GetTextOptions, Language, Translations } from 'vue3-gettext'
 import { getBackendVersion, getWebVersion } from './versions'
@@ -28,7 +28,8 @@ import {
   ResourcesStore,
   SpacesStore,
   MessageStore,
-  SharesStore
+  SharesStore,
+  ArchiverService
 } from '@ownclouders/web-pkg'
 import { authService } from '../services/auth'
 import {
@@ -75,6 +76,7 @@ import {
 } from './sse'
 import { useWebWorkersStore, WebWorkersStore } from '@ownclouders/web-pkg'
 import { loadAppTranslations } from '../helpers/language'
+import { urlJoin } from '@ownclouders/web-client'
 
 const getEmbedConfigFromQuery = (
   doesEmbedEnabledOptionExists: boolean
@@ -408,6 +410,37 @@ export const announceClientService = ({
   })
   app.config.globalProperties.$clientService = clientService
   app.provide('$clientService', clientService)
+}
+
+export const announceArchiverService = ({
+  app,
+  configStore,
+  userStore,
+  capabilityStore
+}: {
+  app: App
+  configStore: ConfigStore
+  userStore: UserStore
+  capabilityStore: CapabilityStore
+}): void => {
+  app.config.globalProperties.$archiverService = new ArchiverService(
+    app.config.globalProperties.$clientService,
+    userStore,
+    configStore.serverUrl,
+    computed(
+      () =>
+        capabilityStore.filesArchivers || [
+          {
+            enabled: true,
+            version: '1.0.0',
+            formats: ['tar', 'zip'],
+            archiver_url: urlJoin(configStore.serverUrl, 'index.php/apps/files/ajax/download.php')
+          }
+        ]
+    )
+  )
+
+  app.provide('$archiverService', app.config.globalProperties.$archiverService)
 }
 
 /**

--- a/packages/web-runtime/src/defaults/index.ts
+++ b/packages/web-runtime/src/defaults/index.ts
@@ -1,14 +1,15 @@
 import merge from 'lodash-es/merge'
 import App from '../App.vue'
+import TokenRenewal from '../pages/tokenRenewal.vue'
 import missingOrInvalidConfigPage from '../pages/missingOrInvalidConfig.vue'
 
-// fontawesome-free attributions console message
-import '@fortawesome/fontawesome-free/attribution'
-
-export { default as DesignSystem } from 'design-system'
 export * from './languages'
 
-export const pages = { success: App, failure: missingOrInvalidConfigPage }
+export const pages = {
+  success: App,
+  failure: missingOrInvalidConfigPage,
+  tokenRenewal: TokenRenewal
+}
 
 export const loadTranslations = async () => {
   const { coreTranslations, clientTranslations, pkgTranslations, odsTranslations } = await import(
@@ -16,4 +17,11 @@ export const loadTranslations = async () => {
   )
 
   return merge({}, coreTranslations, clientTranslations, pkgTranslations, odsTranslations)
+}
+
+export const loadDesignSystem = async () => {
+  // fontawesome-free attributions console message
+  import('@fortawesome/fontawesome-free/attribution')
+
+  return (await import('design-system')).default
 }

--- a/packages/web-runtime/src/helpers/silentRedirect.ts
+++ b/packages/web-runtime/src/helpers/silentRedirect.ts
@@ -1,0 +1,1 @@
+export const isSilentRedirectRoute = () => window.location.pathname === '/web-oidc-silent-redirect'

--- a/packages/web-runtime/src/pages/oidcCallback.vue
+++ b/packages/web-runtime/src/pages/oidcCallback.vue
@@ -32,8 +32,8 @@ export default defineComponent({
 
     const error = ref(false)
 
-    const footerSlogan = computed(() => currentTheme.value.common.slogan)
-    const logoImg = computed(() => currentTheme.value.logo.login)
+    const footerSlogan = computed(() => unref(currentTheme)?.common.slogan)
+    const logoImg = computed(() => unref(currentTheme)?.logo.login)
 
     const route = useRoute()
 

--- a/packages/web-runtime/src/pages/tokenRenewal.vue
+++ b/packages/web-runtime/src/pages/tokenRenewal.vue
@@ -1,0 +1,13 @@
+<template>
+  <router-view />
+</template>
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+/**
+ * This page gets rendered in the iFrame for the silent token renewal to take place.
+ */
+export default defineComponent({
+  name: 'TokenRenewal'
+})
+</script>

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -22,6 +22,7 @@ import { Ability } from '@ownclouders/web-client'
 import { Language } from 'vue3-gettext'
 import { PublicLinkType } from '@ownclouders/web-client'
 import { WebWorkersStore } from '@ownclouders/web-pkg'
+import { isSilentRedirectRoute } from '../../helpers/silentRedirect'
 
 export class AuthService implements AuthServiceInterface {
   private clientService: ClientService
@@ -109,7 +110,9 @@ export class AuthService implements AuthServiceInterface {
         accessTokenExpiryThreshold: this.accessTokenExpiryThreshold
       })
 
-      if (!this.tokenTimerWorker) {
+      // don't load worker in the silent redirect iframe
+      const isSilentRedirect = isSilentRedirectRoute()
+      if (!this.tokenTimerWorker && !isSilentRedirect) {
         const { options } = this.configStore
 
         if (!options.embed?.enabled || !options.embed?.delegateAuthentication) {


### PR DESCRIPTION
## Description
Reduces the network load on token renewal by not bootstrapping the whole application. Parts that are skipped loading during token renewal are:

* loading applications
* loading the inter font
* loading translations
* loading the theme

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/11069

## Benchmarks

Network load during token renewal - **before**:

<img width="334" alt="Pasted Graphic 4" src="https://github.com/owncloud/web/assets/50302941/38735294-da63-453d-8f02-4f1ce62825fc">


Network load during token renewal - **after**:

<img width="336" alt="Pasted Graphic 3" src="https://github.com/owncloud/web/assets/50302941/a94a4031-69bf-4d06-bf18-e43c5f2b8586">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
