### PR TITLE
fix: visiting public links with expired access token

### DIFF
--- a/changelog/unreleased/bugfix-opening-public-links-with-expired-token
+++ b/changelog/unreleased/bugfix-opening-public-links-with-expired-token
@@ -1,0 +1,5 @@
+Bugfix: Opening public links with an expired token
+
+We've fixed a bug where opening public links with an expired token would falsely show the access denied page. Instead, Web now tries to login the user. If that doesn't work, the expired user session gets removed.
+
+https://github.com/owncloud/web/pull/11086

--- a/packages/web-runtime/src/pages/resolvePublicLink.vue
+++ b/packages/web-runtime/src/pages/resolvePublicLink.vue
@@ -3,17 +3,7 @@
     class="oc-link-resolve oc-height-viewport oc-flex oc-flex-column oc-flex-center oc-flex-middle"
   >
     <div class="oc-card oc-text-center oc-width-large">
-      <template v-if="isLoading">
-        <div class="oc-card-header">
-          <h2 key="public-link-loading">
-            <span v-text="$gettext('Loading public link…')" />
-          </h2>
-        </div>
-        <div class="oc-card-body">
-          <oc-spinner :aria-hidden="true" />
-        </div>
-      </template>
-      <template v-else-if="errorMessage">
+      <template v-if="errorMessage">
         <div class="oc-card-header oc-link-resolve-error-title">
           <h2 key="public-link-error">
             <span v-text="$gettext('An error occurred while loading the public link')" />
@@ -50,6 +40,16 @@
             </oc-button>
           </div>
         </form>
+      </template>
+      <template v-else>
+        <div class="oc-card-header">
+          <h2 key="public-link-loading">
+            <span v-text="$gettext('Loading public link…')" />
+          </h2>
+        </div>
+        <div class="oc-card-body">
+          <oc-spinner :aria-hidden="true" />
+        </div>
       </template>
       <div class="oc-card-footer oc-pt-rm">
         <p>{{ footerSlogan }}</p>
@@ -278,23 +278,6 @@ export default defineComponent({
       router.push(targetLocation)
     })
 
-    const isLoading = computed<boolean>(() => {
-      if (unref(errorMessage)) {
-        return false
-      }
-      if (
-        loadTokenInfoTask.isRunning ||
-        !loadTokenInfoTask.last ||
-        isPasswordRequiredTask.isRunning ||
-        !isPasswordRequiredTask.last
-      ) {
-        return true
-      }
-      if (!unref(isPasswordRequired)) {
-        return resolvePublicLinkTask.isRunning || !resolvePublicLinkTask.last
-      }
-      return false
-    })
     const errorMessage = computed<string>(() => {
       if (resolvePublicLinkTask.isError && resolvePublicLinkTask.last.error.statusCode !== 401) {
         return resolvePublicLinkTask.last.error.message
@@ -339,7 +322,6 @@ export default defineComponent({
       wrongPassword,
       passwordFieldLabel,
       wrongPasswordMessage,
-      isLoading,
       errorMessage,
       footerSlogan,
       loadTokenInfoTask,

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -84,6 +84,18 @@ export class AuthService {
       })
     }
 
+    if (isPublicLinkContextRequired(this.router, to)) {
+      const user = await this.userManager.getUser()
+
+      if (user?.expired) {
+        try {
+          await this.userManager.signinSilent()
+        } catch (e) {
+          await this.userManager.removeUser()
+        }
+      }
+    }
+
     if (!isAnonymousContext(this.router, to)) {
       const fetchUserData = !isIdpContextRequired(this.router, to)
 


### PR DESCRIPTION
## Description
Fixes bug where opening public links with an expired token would falsely show the access denied page. Instead, Web now tries to login the user. If that doesn't work, the user gets logged out.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/6734

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
