### PR TITLE
fix: issues with closing editor in dirty state

### DIFF
--- a/changelog/unreleased/bugfix-browser-confirmation-after-closing-editor
+++ b/changelog/unreleased/bugfix-browser-confirmation-after-closing-editor
@@ -1,6 +1,6 @@
 Bugfix: Browser confirmation dialog after closing editor
 
-We've fixed a bug where the browser falsey asked the user for confirmation when closing or reloading the page after an editor with unsaved chages had been closed.
+We've fixed a bug where the browser falsely asked the user for confirmation when closing or reloading the page after an editor with unsaved changes had been closed.
 
 https://github.com/owncloud/web/issues/11092
 https://github.com/owncloud/web/pull/11094

--- a/changelog/unreleased/bugfix-browser-confirmation-after-closing-editor
+++ b/changelog/unreleased/bugfix-browser-confirmation-after-closing-editor
@@ -1,0 +1,6 @@
+Bugfix: Browser confirmation dialog after closing editor
+
+We've fixed a bug where the browser falsey asked the user for confirmation when closing or reloading the page after an editor with unsaved chages had been closed.
+
+https://github.com/owncloud/web/issues/11092
+https://github.com/owncloud/web/pull/11094

--- a/changelog/unreleased/bugfix-button-focus-closing-editor
+++ b/changelog/unreleased/bugfix-button-focus-closing-editor
@@ -1,0 +1,6 @@
+Bugfix: Button focus when closing editor
+
+When closing an editor with unsaved changes, the modal now correctly focuses the primary "Save"-button.
+
+https://github.com/owncloud/web/issues/11091
+https://github.com/owncloud/web/pull/11094

--- a/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
+++ b/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
@@ -419,6 +419,7 @@ export default defineComponent({
           message: $gettext('Your changes were not saved. Do you want to save them?'),
           cancelText: $gettext("Don't Save"),
           confirmText: $gettext('Save'),
+          focusTrapInitial: '.oc-modal-body-actions-confirm',
           onCancel() {
             store.dispatch('hideModal')
             next()

--- a/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
+++ b/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
@@ -51,7 +51,8 @@ import {
   useRouteQuery,
   useStore,
   useSelectedResources,
-  useSideBar
+  useSideBar,
+  useLoadingService
 } from '../../composables'
 import {
   Action,
@@ -106,6 +107,7 @@ export default defineComponent({
     const router = useRouter()
     const currentRoute = useRoute()
     const clientService = useClientService()
+    const loadingService = useLoadingService()
     const { getResourceContext } = useGetResourceContext()
     const { selectedResources } = useSelectedResources({ store })
 
@@ -280,12 +282,6 @@ export default defineComponent({
       { immediate: true }
     )
 
-    onBeforeUnmount(() => {
-      if (unref(hasProp('url'))) {
-        revokeUrl(url.value)
-      }
-    })
-
     const errorPopup = (error: HttpError) => {
       console.error(error)
       store.dispatch('showErrorMessage', {
@@ -378,6 +374,14 @@ export default defineComponent({
       }
     })
     onBeforeUnmount(() => {
+      if (!loadingService.isLoading) {
+        window.removeEventListener('beforeunload', preventUnload)
+      }
+
+      if (unref(hasProp('url'))) {
+        revokeUrl(url.value)
+      }
+
       if (!unref(isEditor)) {
         return
       }

--- a/packages/web-runtime/src/App.vue
+++ b/packages/web-runtime/src/App.vue
@@ -29,6 +29,7 @@
       :contextual-helper-label="modal.contextualHelperLabel"
       :contextual-helper-data="modal.contextualHelperData"
       :hide-actions="modal.hideActions"
+      :focus-trap-initial="modal.focusTrapInitial"
       @cancel="onModalCancel"
       @confirm="onModalConfirm"
       @input="modal.onInput"

--- a/packages/web-runtime/src/store/modal.ts
+++ b/packages/web-runtime/src/store/modal.ts
@@ -80,6 +80,7 @@ const mutations = {
     state.customComponentAttrs = modal.customComponentAttrs
     state.customContent = modal.customContent || ''
     state.hideActions = modal.hideActions || false
+    state.focusTrapInitial = modal.focusTrapInitial
   },
 
   HIDE_MODAL(state) {


### PR DESCRIPTION
## Description
* fix: button focus when closing editor with unsaved changes
* fix: browser confirmation dialog after closing editor

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- fixes https://github.com/owncloud/web/issues/11091
- fixes https://github.com/owncloud/web/issues/11092

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
