### PR TITLE
Add missing aria-labels for OcDrops, hide WhiteSpaceContextMenu from screenreader

### DIFF
--- a/changelog/unreleased/enhancement-accessibility-improvements
+++ b/changelog/unreleased/enhancement-accessibility-improvements
@@ -6,3 +6,4 @@ https://github.com/owncloud/web/issues/5387
 https://github.com/owncloud/web/issues/5398
 https://github.com/owncloud/web/pull/11087
 https://github.com/owncloud/web/pull/11096
+https://github.com/owncloud/web/pull/11098

--- a/packages/design-system/src/components/OcContextualHelper/OcContextualHelper.vue
+++ b/packages/design-system/src/components/OcContextualHelper/OcContextualHelper.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="oc-contextual-helper">
-    <oc-button :id="buttonId" appearance="raw">
+    <oc-button :id="buttonId" :aria-label="$gettext('Show more information')" appearance="raw">
       <oc-icon name="question" fill-type="line" size="small" />
     </oc-button>
     <oc-info-drop :drop-id="dropId" :toggle="toggleId" v-bind="$props as any" />

--- a/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Links/DetailsAndEdit.vue
@@ -60,6 +60,7 @@
       <div v-if="isModifiable">
         <oc-button
           :id="`edit-public-link-dropdown-toggl-${linkShare.id}`"
+          :aria-label="$gettext('More options')"
           appearance="raw"
           class="edit-drop-trigger"
           :data-testid="`files-link-id-${linkShare.id}-btn-edit`"

--- a/packages/web-app-files/src/components/Spaces/WhitespaceContextMenu.vue
+++ b/packages/web-app-files/src/components/Spaces/WhitespaceContextMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <oc-button id="context-menu-trigger-whitespace" appearance="raw">
+  <oc-button id="context-menu-trigger-whitespace" aria-hidden appearance="raw">
     <oc-drop
       drop-id="context-menu-drop-whitespace"
       toggle="#context-menu-trigger-whitespace"

--- a/packages/web-pkg/src/components/CreateLinkModal.vue
+++ b/packages/web-pkg/src/components/CreateLinkModal.vue
@@ -71,6 +71,7 @@
     <oc-button
       v-if="!onlyInternalLinksAllowed"
       id="link-modal-context-menu-toggle"
+      :aria-label="$gettext('More options')"
       appearance="raw"
     >
       <oc-icon name="more-2" />


### PR DESCRIPTION
## Description
As discussed with @kulmann 