### PR TITLE
fix: keyboard navigation breaking

### DIFF
--- a/changelog/unreleased/bugfix-keyboard-navigation-breaking
+++ b/changelog/unreleased/bugfix-keyboard-navigation-breaking
@@ -1,0 +1,6 @@
+Bugfix: Keyboard navigation breaking
+
+We've fixed a bug where the keyboard navigation would break in certain scenarios, e.g. when opening a folder from the search results.
+
+https://github.com/owncloud/web/issues/10942
+https://github.com/owncloud/web/pull/11099

--- a/packages/web-pkg/src/composables/keyboardActions/useKeyboardActions.ts
+++ b/packages/web-pkg/src/composables/keyboardActions/useKeyboardActions.ts
@@ -49,11 +49,11 @@ const areCustomKeyBindingsDisabled = () => {
   ) {
     return true
   }
-  const closestSelectionEl = window.getSelection().focusNode as HTMLElement
+  const closestSelectionEl = document.activeElement
   if (!closestSelectionEl) {
     return false
   }
-  let customKeyBindings
+  let customKeyBindings: Element
   try {
     customKeyBindings = closestSelectionEl?.closest("[data-custom-key-bindings-disabled='true']")
   } catch {


### PR DESCRIPTION
## Description
Fixes the keyboard navigation breaking in certain scenarios.

The issue was that `window.getSelection()` would not always return the currently focused element when checking if we need to disable our custom keybindings. So e.g. when clicking the search input and then clicking a file in the file list, the focused element would still be the search input, leading to our keybindings not working.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10942

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
