### PR TITLE
Dynamic app provider apps

### DIFF
--- a/packages/web-app-external/package.json
+++ b/packages/web-app-external/package.json
@@ -11,6 +11,7 @@
   "peerDependencies": {
     "@ownclouders/web-client": "workspace:*",
     "@ownclouders/web-pkg": "workspace:*",
+    "pinia": "2.1.7",
     "uuid": "9.0.1",
     "vue-concurrency": "5.0.1",
     "vue3-gettext": "2.4.0",

--- a/packages/web-app-external/package.json
+++ b/packages/web-app-external/package.json
@@ -11,6 +11,7 @@
   "peerDependencies": {
     "@ownclouders/web-client": "workspace:*",
     "@ownclouders/web-pkg": "workspace:*",
+    "lodash-es": "4.17.21",
     "pinia": "2.1.7",
     "uuid": "9.0.1",
     "vue-concurrency": "5.0.1",

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -26,7 +26,17 @@
 
 <script lang="ts">
 import { stringify } from 'qs'
-import { PropType, computed, defineComponent, unref, nextTick, ref, watch, VNodeRef } from 'vue'
+import {
+  PropType,
+  computed,
+  defineComponent,
+  unref,
+  nextTick,
+  ref,
+  watch,
+  VNodeRef,
+  onMounted
+} from 'vue'
 import { useTask } from 'vue-concurrency'
 import { useGettext } from 'vue3-gettext'
 
@@ -34,18 +44,18 @@ import { Resource, SpaceResource } from '@ownclouders/web-client'
 import { urlJoin } from '@ownclouders/web-client'
 import {
   isSameResource,
-  queryItemAsString,
   useCapabilityStore,
   useConfigStore,
   useMessages,
-  useRequest,
-  useRouteQuery
+  useRequest
 } from '@ownclouders/web-pkg'
 import {
   isProjectSpaceResource,
   isPublicSpaceResource,
   isShareSpaceResource
 } from '@ownclouders/web-client'
+import { useRoute } from 'vue-router'
+import { useAppProviderService } from '@ownclouders/web-pkg/src/composables/appProviderService'
 
 export default defineComponent({
   name: 'ExternalApp',
@@ -54,31 +64,34 @@ export default defineComponent({
     resource: { type: Object as PropType<Resource>, required: true },
     isReadOnly: { type: Boolean, required: true }
   },
-  emits: ['update:applicationName'],
   setup(props, { emit }) {
     const language = useGettext()
     const { $gettext } = language
     const { showErrorMessage } = useMessages()
     const capabilityStore = useCapabilityStore()
     const configStore = useConfigStore()
-
+    const route = useRoute()
+    const appProviderService = useAppProviderService()
     const { makeRequest } = useRequest()
 
-    const appNameQuery = useRouteQuery('app')
+    const appName = computed(() => {
+      const lowerCaseAppName = route.path
+        .split('/')
+        .find((item) => item.startsWith('external-'))
+        .replace('external-', '')
+      return appProviderService.appNames.find(
+        (appName) => appName.toLowerCase() === lowerCaseAppName
+      )
+    })
+
     const appUrl = ref()
     const formParameters = ref({})
     const method = ref()
     const subm: VNodeRef = ref()
 
-    const applicationName = computed(() => {
-      const appName = queryItemAsString(unref(appNameQuery))
-      emit('update:applicationName', appName)
-      return appName
-    })
-
     const iFrameTitle = computed(() => {
       return $gettext('"%{appName}" app content area', {
-        appName: unref(applicationName)
+        appName: unref(appName)
       })
     })
 
@@ -106,7 +119,7 @@ export default defineComponent({
         const query = stringify({
           file_id: fileId,
           lang: language.current,
-          ...(unref(applicationName) && { app_name: encodeURIComponent(unref(applicationName)) }),
+          ...(unref(appName) && { app_name: encodeURIComponent(unref(appName)) }),
           ...(viewMode && { view_mode: viewMode })
         })
 
@@ -168,19 +181,13 @@ export default defineComponent({
         }
       } catch (e) {}
     }
-    watch(
-      applicationName,
-      (newAppName, oldAppName) => {
-        if (determineOpenAsPreview(newAppName) && newAppName !== oldAppName) {
-          window.addEventListener('message', catchClickMicrosoftEdit)
-        } else {
-          window.removeEventListener('message', catchClickMicrosoftEdit)
-        }
-      },
-      {
-        immediate: true
+    onMounted(() => {
+      if (determineOpenAsPreview(unref(appName))) {
+        window.addEventListener('message', catchClickMicrosoftEdit)
+      } else {
+        window.removeEventListener('message', catchClickMicrosoftEdit)
       }
-    )
+    })
 
     watch(
       [props.resource],
@@ -191,7 +198,7 @@ export default defineComponent({
 
         let viewMode = props.isReadOnly ? 'view' : 'write'
         if (
-          determineOpenAsPreview(unref(applicationName)) &&
+          determineOpenAsPreview(unref(appName)) &&
           (isShareSpaceResource(props.space) ||
             isPublicSpaceResource(props.space) ||
             isProjectSpaceResource(props.space))

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -75,10 +75,10 @@ export default defineComponent({
     const { makeRequest } = useRequest()
 
     const appName = computed(() => {
-      const lowerCaseAppName = route.path
-        .split('/')
-        .find((item) => item.startsWith('external-'))
+      const lowerCaseAppName = unref(route)
+        .name.toString()
         .replace('external-', '')
+        .replace('-apps', '')
       return appProviderService.appNames.find(
         (appName) => appName.toLowerCase() === lowerCaseAppName
       )

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -64,7 +64,7 @@ export default defineComponent({
     resource: { type: Object as PropType<Resource>, required: true },
     isReadOnly: { type: Boolean, required: true }
   },
-  setup(props, { emit }) {
+  setup(props) {
     const language = useGettext()
     const { $gettext } = language
     const { showErrorMessage } = useMessages()

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -47,15 +47,15 @@ import {
   useCapabilityStore,
   useConfigStore,
   useMessages,
-  useRequest
+  useRequest,
+  useAppProviderService,
+  useRoute
 } from '@ownclouders/web-pkg'
 import {
   isProjectSpaceResource,
   isPublicSpaceResource,
   isShareSpaceResource
 } from '@ownclouders/web-client'
-import { useRoute } from 'vue-router'
-import { useAppProviderService } from '@ownclouders/web-pkg/src/composables/appProviderService'
 
 export default defineComponent({
   name: 'ExternalApp',

--- a/packages/web-app-external/src/Redirect.vue
+++ b/packages/web-app-external/src/Redirect.vue
@@ -1,0 +1,78 @@
+<template>
+  <main
+    class="external-redirect oc-height-viewport oc-flex oc-flex-column oc-flex-center oc-flex-middle"
+  >
+    <h1 class="oc-invisible-sr" v-text="pageTitle" />
+    <div class="oc-card oc-card-body oc-text-center oc-width-large">
+      <h2 key="external-redirect-loading">
+        <span v-text="$gettext('One moment please…')" />
+      </h2>
+      <p v-text="$gettext('You are being redirected.')" />
+    </div>
+  </main>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, unref, watch } from 'vue'
+import { queryItemAsString, useRouteMeta, useRouteQuery } from '@ownclouders/web-pkg'
+import { useRouter } from 'vue-router'
+import { omit } from 'lodash-es'
+import { useGettext } from 'vue3-gettext'
+import { useApplicationReadyStore } from './piniaStores'
+import { storeToRefs } from 'pinia'
+
+export default defineComponent({
+  setup() {
+    const { $gettext } = useGettext()
+
+    const appNameQuery = useRouteQuery('app')
+    const appName = computed(() => {
+      return queryItemAsString(unref(appNameQuery))
+    })
+    const router = useRouter()
+    const { isReady } = storeToRefs(useApplicationReadyStore())
+
+    watch(
+      isReady,
+      (ready) => {
+        if (!ready) {
+          return
+        }
+
+        router.replace({
+          name: `external-${unref(appName).toLowerCase()}-apps`,
+          query: omit(unref(router.currentRoute).query, 'app')
+        })
+      },
+      { immediate: true }
+    )
+
+    const title = useRouteMeta('title')
+    const pageTitle = computed(() => {
+      return $gettext(unref(title))
+    })
+
+    return {
+      pageTitle
+    }
+  }
+})
+</script>
+
+<style lang="scss">
+.external-redirect {
+  .oc-card {
+    background: var(--oc-color-background-highlight);
+    border-radius: 15px;
+
+    &-body {
+      h2 {
+        margin-top: 0;
+      }
+      p {
+        font-size: var(--oc-font-size-large);
+      }
+    }
+  }
+}
+</style>

--- a/packages/web-app-external/src/Redirect.vue
+++ b/packages/web-app-external/src/Redirect.vue
@@ -14,7 +14,7 @@
 
 <script lang="ts">
 import { computed, defineComponent, unref, watch } from 'vue'
-import { queryItemAsString, useRouteMeta, useRouteQuery } from '@ownclouders/web-pkg'
+import { queryItemAsString, useRouteMeta, useRouteParam, useRouteQuery } from '@ownclouders/web-pkg'
 import { useRouter } from 'vue-router'
 import { omit } from 'lodash-es'
 import { useGettext } from 'vue3-gettext'
@@ -26,7 +26,11 @@ export default defineComponent({
     const { $gettext } = useGettext()
 
     const appNameQuery = useRouteQuery('app')
+    const appNameParam = useRouteParam('appCatchAll')
     const appName = computed(() => {
+      if (unref(appNameParam)) {
+        return unref(appNameParam)
+      }
       return queryItemAsString(unref(appNameQuery))
     })
     const router = useRouter()

--- a/packages/web-app-external/src/index.ts
+++ b/packages/web-app-external/src/index.ts
@@ -13,18 +13,43 @@ import { Resource, SpaceResource } from '@ownclouders/web-client'
 import { join } from 'path'
 import { useGettext } from 'vue3-gettext'
 import { useAppProviderService } from '@ownclouders/web-pkg/src/composables/appProviderService'
+import Redirect from './Redirect.vue'
+import { useApplicationReadyStore } from './piniaStores'
 
 export default defineWebApplication({
   setup(options: any) {
-    if (!Object.hasOwn(options, 'appName')) {
-      throw new Error('appName is required for the external app')
-    }
-
     const capabilityStore = useCapabilityStore()
     const { makeRequest } = useRequest()
     const clientService = useClientService()
     const { $gettext } = useGettext()
     const appProviderService = useAppProviderService()
+
+    if (!Object.hasOwn(options, 'appName')) {
+      const appInfo: ApplicationInformation = {
+        name: $gettext('External'),
+        id: 'external'
+      }
+      const routes = [
+        {
+          name: 'apps',
+          path: '/:driveAliasAndItem(.*)?',
+          component: Redirect,
+          meta: {
+            authContext: 'hybrid',
+            title: $gettext('Redirecting to external app'),
+            patchCleanPath: true
+          }
+        }
+      ]
+      return {
+        appInfo,
+        routes,
+        ready: () => {
+          const applicationReadyStore = useApplicationReadyStore()
+          applicationReadyStore.setReady()
+        }
+      }
+    }
 
     const { appName } = options
     const appId = `external-${appName.toLowerCase()}`

--- a/packages/web-app-external/src/index.ts
+++ b/packages/web-app-external/src/index.ts
@@ -2,108 +2,98 @@ import {
   AppWrapperRoute,
   defineWebApplication,
   useCapabilityStore,
-  useAppsStore,
   useClientService,
-  useRequest
+  useRequest,
+  ApplicationInformation
 } from '@ownclouders/web-pkg'
 import translations from '../l10n/translations.json'
 import App from './App.vue'
 import { stringify } from 'qs'
 import { Resource, SpaceResource } from '@ownclouders/web-client'
 import { join } from 'path'
-import { AppListSchema } from './schemas'
 import { useGettext } from 'vue3-gettext'
-
-const appInfo = {
-  name: 'External',
-  id: 'external'
-}
-
-const routes = [
-  {
-    name: 'apps',
-    path: '/:driveAliasAndItem(.*)?',
-    component: AppWrapperRoute(App, {
-      applicationId: appInfo.id
-    }),
-    meta: {
-      authContext: 'hybrid',
-      patchCleanPath: true
-    }
-  }
-]
+import { useAppProviderService } from '@ownclouders/web-pkg/src/composables/appProviderService'
 
 export default defineWebApplication({
-  setup() {
+  setup(options: any) {
+    if (!Object.hasOwn(options, 'appName')) {
+      throw new Error('appName is required for the external app')
+    }
+
     const capabilityStore = useCapabilityStore()
-    const appsStore = useAppsStore()
     const { makeRequest } = useRequest()
     const clientService = useClientService()
     const { $gettext } = useGettext()
+    const appProviderService = useAppProviderService()
+
+    const { appName } = options
+    const appId = `external-${appName.toLowerCase()}`
+    const mimeTypes = appProviderService.getMimeTypesByAppName(appName)
+    const appInfo: ApplicationInformation = {
+      name: appName,
+      id: appId,
+      isFileEditor: true,
+      extensions: mimeTypes.map((mimeType) => {
+        const provider = mimeType.app_providers.find((provider) => provider.name === appName)
+        return {
+          extension: mimeType.ext,
+          label: $gettext('Open in %{app}', { app: provider.name }),
+          icon: provider.icon,
+          name: provider.name,
+          mimeType: mimeType.mime_type,
+          secureView: provider.secure_view,
+          routeName: `${appId}-apps`,
+          hasPriority: mimeType.default_application === provider.name,
+          ...(mimeType.allow_creation && { newFileMenu: { menuTitle: () => mimeType.name } }),
+          createFileHandler: async ({
+            fileName,
+            space,
+            currentFolder
+          }: {
+            fileName: string
+            space: SpaceResource
+            currentFolder: Resource
+          }) => {
+            if (fileName === '') {
+              return
+            }
+
+            const query = stringify({
+              parent_container_id: currentFolder.fileId,
+              filename: fileName
+            })
+            const url = `${capabilityStore.filesAppProviders[0].new_url}?${query}`
+            const response = await makeRequest('POST', url)
+            if (response.status !== 200) {
+              throw new Error(`An error has occurred: ${response.status}`)
+            }
+
+            const path = join(currentFolder.path, fileName) || ''
+            return clientService.webdav.getFileInfo(space, { path })
+          }
+        }
+      })
+    }
+
+    const routes = [
+      {
+        name: 'apps',
+        path: '/:driveAliasAndItem(.*)?',
+        component: AppWrapperRoute(App, {
+          applicationId: appInfo.id
+        }),
+        meta: {
+          authContext: 'hybrid',
+          title: appName,
+          patchCleanPath: true
+        }
+      }
+    ]
 
     return {
       appInfo,
       routes,
-      translations,
-      ready: async () => {
-        if (!capabilityStore.filesAppProviders[0]?.enabled) {
-          return
-        }
-
-        const {
-          data: { 'mime-types': mimeTypes }
-        } = await clientService.httpUnAuthenticated.get(
-          capabilityStore.filesAppProviders[0].apps_url,
-          {
-            schema: AppListSchema
-          }
-        )
-
-        mimeTypes.forEach((mimeType) => {
-          mimeType.app_providers.forEach((provider) => {
-            appsStore.registerFileExtension({
-              appId: 'external',
-              data: {
-                extension: mimeType.ext,
-                label: $gettext('Open in %{app}', { app: provider.name }),
-                icon: provider.icon,
-                name: provider.name,
-                mimeType: mimeType.mime_type,
-                secureView: provider.secure_view,
-                routeName: 'external-apps',
-                hasPriority: mimeType.default_application === provider.name,
-                ...(mimeType.allow_creation && { newFileMenu: { menuTitle: () => mimeType.name } }),
-                createFileHandler: async ({
-                  fileName,
-                  space,
-                  currentFolder
-                }: {
-                  fileName: string
-                  space: SpaceResource
-                  currentFolder: Resource
-                }) => {
-                  if (fileName === '') {
-                    return
-                  }
-
-                  const query = stringify({
-                    parent_container_id: currentFolder.fileId,
-                    filename: fileName
-                  })
-                  const url = `${capabilityStore.filesAppProviders[0].new_url}?${query}`
-                  const response = await makeRequest('POST', url)
-                  if (response.status !== 200) {
-                    throw new Error(`An error has occurred: ${response.status}`)
-                  }
-
-                  const path = join(currentFolder.path, fileName) || ''
-                  return clientService.webdav.getFileInfo(space, { path })
-                }
-              }
-            })
-          })
-        })
-      }
+      translations
     }
   }
 })

--- a/packages/web-app-external/src/index.ts
+++ b/packages/web-app-external/src/index.ts
@@ -31,6 +31,8 @@ export default defineWebApplication({
       }
       const routes = [
         {
+          // catch-all route for page reloads, because dynamic external app routes are not available immediately on page reload.
+          // can be deleted as soon as app provider apps are not loaded after login anymore (app provider listing endpoint must be hardcoded and public)
           name: 'catch-all',
           path: '-:appCatchAll/:driveAliasAndItem(.*)?',
           component: Redirect,
@@ -41,6 +43,7 @@ export default defineWebApplication({
           }
         },
         {
+          // fallback route for old external-app URLs, in case someone made a bookmark. Can be removed with the next major release.
           name: 'apps',
           path: '/:driveAliasAndItem(.*)?',
           component: Redirect,

--- a/packages/web-app-external/src/index.ts
+++ b/packages/web-app-external/src/index.ts
@@ -33,6 +33,7 @@ export default defineWebApplication({
         {
           // catch-all route for page reloads, because dynamic external app routes are not available immediately on page reload.
           // can be deleted as soon as app provider apps are not loaded after login anymore (app provider listing endpoint must be hardcoded and public)
+          // prerequisite: https://github.com/owncloud/ocis/issues/9489
           name: 'catch-all',
           path: '-:appCatchAll/:driveAliasAndItem(.*)?',
           component: Redirect,

--- a/packages/web-app-external/src/index.ts
+++ b/packages/web-app-external/src/index.ts
@@ -31,6 +31,16 @@ export default defineWebApplication({
       }
       const routes = [
         {
+          name: 'catch-all',
+          path: '-:appCatchAll/:driveAliasAndItem(.*)?',
+          component: Redirect,
+          meta: {
+            authContext: 'hybrid',
+            title: $gettext('Redirecting to external app'),
+            patchCleanPath: true
+          }
+        },
+        {
           name: 'apps',
           path: '/:driveAliasAndItem(.*)?',
           component: Redirect,

--- a/packages/web-app-external/src/piniaStores/applicationReady.ts
+++ b/packages/web-app-external/src/piniaStores/applicationReady.ts
@@ -1,0 +1,15 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useApplicationReadyStore = defineStore('applicationReady', () => {
+  const isReady = ref<boolean>(false)
+
+  const setReady = () => {
+    isReady.value = true
+  }
+
+  return {
+    isReady,
+    setReady
+  }
+})

--- a/packages/web-app-external/src/piniaStores/index.ts
+++ b/packages/web-app-external/src/piniaStores/index.ts
@@ -1,0 +1,1 @@
+export * from './applicationReady'

--- a/packages/web-app-external/tests/unit/app.spec.ts
+++ b/packages/web-app-external/tests/unit/app.spec.ts
@@ -1,15 +1,16 @@
 import { mock } from 'vitest-mock-extended'
 import { defaultPlugins, shallowMount } from 'web-test-helpers'
-import { useRequest, useRouteQuery } from '@ownclouders/web-pkg'
+import { AppProviderService, useRequest, useRoute } from '@ownclouders/web-pkg'
 import { ref } from 'vue'
 
 import { Resource } from '@ownclouders/web-client'
 import App from '../../src/App.vue'
+import { RouteLocation } from 'vue-router'
 
 vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
   ...(await importOriginal<any>()),
   useRequest: vi.fn(),
-  useRouteQuery: vi.fn()
+  useRoute: vi.fn()
 }))
 
 const appUrl = 'https://example.test/d12ab86/loe009157-MzBw'
@@ -75,8 +76,12 @@ function createShallowMountWrapper(makeRequest = vi.fn().mockResolvedValue({ sta
   vi.mocked(useRequest).mockImplementation(() => ({
     makeRequest
   }))
-
-  vi.mocked(useRouteQuery).mockImplementation(() => ref('example-app'))
+  vi.mocked(useRoute).mockImplementation(() =>
+    ref(mock<RouteLocation>({ name: 'external-example-app-apps' }))
+  )
+  const mocks = {
+    $appProviderService: mock<AppProviderService>({ appNames: ['example-app'] })
+  }
 
   const capabilities = {
     files: {
@@ -99,7 +104,9 @@ function createShallowMountWrapper(makeRequest = vi.fn().mockResolvedValue({ sta
               configState: { options: { editor: { openAsPreview: true } } }
             }
           })
-        ]
+        ],
+        provide: mocks,
+        mocks
       }
     })
   }

--- a/packages/web-app-files/tests/unit/components/AppBar/__snapshots__/CreateAndUpload.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/AppBar/__snapshots__/CreateAndUpload.spec.ts.snap
@@ -9,25 +9,24 @@ exports[`CreateAndUpload component > action buttons > should show and be enabled
           <!-- @slot Content of the button -->
           <resource-icon-stub resource="[object Object]" size="medium"></resource-icon-stub> <span>Folder</span>
         </button></li>
-      <li class="create-list-file oc-menu-item-hover"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
+      <li class="create-list-file oc-menu-item-hover top-separator"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw new-file-btn-txt">
           <!--v-if-->
           <!-- @slot Content of the button -->
           <resource-icon-stub resource="[object Object]" size="medium"></resource-icon-stub> <span class="create-list-file-item-text">Plain text file</span>
           <!--v-if-->
         </button></li>
-      <li class="create-list-file oc-menu-item-hover"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
+      <li class="create-list-file oc-menu-item-hover"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw new-file-btn-md">
           <!--v-if-->
           <!-- @slot Content of the button -->
           <resource-icon-stub resource="[object Object]" size="medium"></resource-icon-stub> <span class="create-list-file-item-text">Mark-down file</span>
           <!--v-if-->
         </button></li>
-      <li class="create-list-file oc-menu-item-hover"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
+      <li class="create-list-file oc-menu-item-hover"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw new-file-btn-drawio">
           <!--v-if-->
           <!-- @slot Content of the button -->
           <resource-icon-stub resource="[object Object]" size="medium"></resource-icon-stub> <span class="create-list-file-item-text">Draw.io document</span>
           <!--v-if-->
         </button></li>
-      <!--v-if-->
       <li class="create-list-shortcut oc-menu-item-hover"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="new-shortcut-btn">
           <!--v-if-->
           <!-- @slot Content of the button -->
@@ -60,25 +59,24 @@ exports[`CreateAndUpload component > file handlers > should show entries for all
           <!-- @slot Content of the button -->
           <resource-icon-stub resource="[object Object]" size="medium"></resource-icon-stub> <span>Folder</span>
         </button></li>
-      <li class="create-list-file oc-menu-item-hover"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
+      <li class="create-list-file oc-menu-item-hover top-separator"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw new-file-btn-txt">
           <!--v-if-->
           <!-- @slot Content of the button -->
           <resource-icon-stub resource="[object Object]" size="medium"></resource-icon-stub> <span class="create-list-file-item-text">Plain text file</span>
           <!--v-if-->
         </button></li>
-      <li class="create-list-file oc-menu-item-hover"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
+      <li class="create-list-file oc-menu-item-hover"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw new-file-btn-md">
           <!--v-if-->
           <!-- @slot Content of the button -->
           <resource-icon-stub resource="[object Object]" size="medium"></resource-icon-stub> <span class="create-list-file-item-text">Mark-down file</span>
           <!--v-if-->
         </button></li>
-      <li class="create-list-file oc-menu-item-hover"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
+      <li class="create-list-file oc-menu-item-hover"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw new-file-btn-drawio">
           <!--v-if-->
           <!-- @slot Content of the button -->
           <resource-icon-stub resource="[object Object]" size="medium"></resource-icon-stub> <span class="create-list-file-item-text">Draw.io document</span>
           <!--v-if-->
         </button></li>
-      <!--v-if-->
       <li class="create-list-shortcut oc-menu-item-hover"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="new-shortcut-btn">
           <!--v-if-->
           <!-- @slot Content of the button -->

--- a/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
+++ b/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
@@ -144,7 +144,6 @@ export default defineComponent({
       return Boolean(props.wrappedComponent.emits?.includes('update:resource'))
     })
 
-    const applicationName = ref('')
     const resource: Ref<Resource> = ref()
     const space: Ref<SpaceResource> = ref()
     const currentETag = ref('')
@@ -203,7 +202,7 @@ export default defineComponent({
       const { name: appName } = unref(applicationMeta)
 
       return $gettext(`%{appName} for %{fileName}`, {
-        appName: unref(applicationName) || $gettext(appName),
+        appName: $gettext(appName),
         fileName: unref(unref(currentFileContext).fileName)
       })
     })
@@ -545,9 +544,6 @@ export default defineComponent({
       },
       'onUpdate:currentContent': (value: unknown) => {
         currentContent.value = value
-      },
-      'onUpdate:applicationName': (value: string) => {
-        applicationName.value = value
       },
 
       onSave: save,

--- a/packages/web-pkg/src/composables/actions/files/useFileActions.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActions.ts
@@ -170,7 +170,6 @@ export const useFileActions = () => {
       query: {
         ...(remoteItemId && { shareId: remoteItemId }),
         ...(resource.fileId && configStore.options.routing.idBased && { fileId: resource.fileId }),
-        ...(appFileExtension.app === 'external' && { app: appFileExtension.name }),
         ...routeToContextQuery(unref(router.currentRoute))
       }
     }

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCreateNewFile.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCreateNewFile.ts
@@ -184,7 +184,7 @@ export const useFileActionsCreateNewFile = ({ space }: { space?: Ref<SpaceResour
         componentType: 'button',
         class: 'oc-files-actions-create-new-file',
         ext: appFileExtension.extension,
-        isExternal: appFileExtension.app.startsWith('external-')
+        isExternal: appFileExtension.app?.startsWith('external-')
       })
     }
 

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCreateNewFile.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCreateNewFile.ts
@@ -184,7 +184,7 @@ export const useFileActionsCreateNewFile = ({ space }: { space?: Ref<SpaceResour
         componentType: 'button',
         class: 'oc-files-actions-create-new-file',
         ext: appFileExtension.extension,
-        isExternal: appFileExtension.app === 'external'
+        isExternal: appFileExtension.app.startsWith('external-')
       })
     }
 

--- a/packages/web-pkg/src/composables/appProviderService/index.ts
+++ b/packages/web-pkg/src/composables/appProviderService/index.ts
@@ -1,0 +1,1 @@
+export * from './useAppProviderService'

--- a/packages/web-pkg/src/composables/appProviderService/useAppProviderService.ts
+++ b/packages/web-pkg/src/composables/appProviderService/useAppProviderService.ts
@@ -1,0 +1,6 @@
+import { useService } from '../service'
+import { AppProviderService } from '../../services'
+
+export const useAppProviderService = (): AppProviderService => {
+  return useService('$appProviderService')
+}

--- a/packages/web-pkg/src/composables/index.ts
+++ b/packages/web-pkg/src/composables/index.ts
@@ -1,6 +1,7 @@
 export * from './ability'
 export * from './actions'
 export * from './appDefaults'
+export * from './appProviderService'
 export * from './archiverService'
 export * from './authContext'
 export * from './breadcrumbs'

--- a/packages/web-pkg/src/services/appProvider/index.ts
+++ b/packages/web-pkg/src/services/appProvider/index.ts
@@ -1,0 +1,2 @@
+export * from './schemas'
+export * from './service'

--- a/packages/web-pkg/src/services/appProvider/schemas.ts
+++ b/packages/web-pkg/src/services/appProvider/schemas.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+
+const AppSchema = z.object({
+  icon: z.string(),
+  name: z.string(),
+  secure_view: z.boolean().optional()
+})
+
+const MimeTypeSchema = z.object({
+  allow_creation: z.boolean().optional(),
+  app_providers: z.array(AppSchema),
+  default_application: z.string().optional(),
+  description: z.string().optional(),
+  ext: z.string().optional(),
+  mime_type: z.string(),
+  name: z.string().optional()
+})
+export type MimeType = z.infer<typeof MimeTypeSchema>
+
+export const MimeTypesToAppsSchema = z.object({
+  'mime-types': z.array(MimeTypeSchema)
+})

--- a/packages/web-pkg/src/services/appProvider/service.ts
+++ b/packages/web-pkg/src/services/appProvider/service.ts
@@ -1,0 +1,55 @@
+import { MimeType, MimeTypesToAppsSchema } from './schemas'
+import { ref, unref } from 'vue'
+import { CapabilityStore } from '../../composables'
+import { ClientService } from '../client'
+
+export class AppProviderService {
+  private _mimeTypes = ref<MimeType[]>([])
+  private capabilityStore: CapabilityStore
+  private clientService: ClientService
+
+  constructor(capabilityStore: CapabilityStore, clientService: ClientService) {
+    this.capabilityStore = capabilityStore
+    this.clientService = clientService
+  }
+
+  public async loadData(): Promise<void> {
+    const appProviderCapability = this.capabilityStore.filesAppProviders.find(
+      (appProvider) => appProvider.enabled
+    )
+    if (!appProviderCapability) {
+      return
+    }
+
+    const {
+      data: { 'mime-types': mimeTypes }
+    } = await this.clientService.httpUnAuthenticated.get(appProviderCapability.apps_url, {
+      schema: MimeTypesToAppsSchema
+    })
+    this._mimeTypes.value = mimeTypes
+  }
+
+  set mimeTypes(value: MimeType[]) {
+    this._mimeTypes.value = value
+  }
+
+  get mimeTypes() {
+    return unref(this._mimeTypes)
+  }
+
+  get appNames(): string[] {
+    return [
+      ...new Set(
+        unref(this._mimeTypes).flatMap((mimeType) =>
+          mimeType.app_providers.map((appProvider) => appProvider.name)
+        )
+      )
+    ]
+  }
+
+  public getMimeTypesByAppName(appName: string): MimeType[] {
+    return unref(this._mimeTypes).filter((mimeType) =>
+      mimeType.app_providers.some((appProvider) => appProvider.name === appName)
+    )
+  }
+}

--- a/packages/web-pkg/src/services/index.ts
+++ b/packages/web-pkg/src/services/index.ts
@@ -1,3 +1,4 @@
+export * from './appProvider'
 export * from './archiver'
 export * from './cache'
 export * from './client'

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsCreateNewFile.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsCreateNewFile.spec.ts
@@ -109,6 +109,7 @@ function getWrapper({
             appsState: {
               fileExtensions: [
                 mock<ApplicationFileExtension>({
+                  app: 'text-editor',
                   extension: '.txt',
                   newFileMenu: { menuTitle: vi.fn() }
                 })

--- a/packages/web-runtime/src/container/application/classic.ts
+++ b/packages/web-runtime/src/container/application/classic.ts
@@ -64,11 +64,13 @@ class ClassicApplication extends NextApplication {
 
 export const convertClassicApplication = ({
   app,
+  appName,
   applicationScript,
   applicationConfig,
   router
 }: {
   app: App
+  appName?: string
   applicationScript: ClassicApplicationScript
   applicationConfig: AppConfigObject
   router: Router
@@ -76,6 +78,7 @@ export const convertClassicApplication = ({
   if (applicationScript.setup) {
     applicationScript = app.runWithContext(() => {
       return applicationScript.setup({
+        ...(appName && { appName }),
         ...(applicationConfig && { applicationConfig })
       })
     })

--- a/packages/web-runtime/src/container/application/index.ts
+++ b/packages/web-runtime/src/container/application/index.ts
@@ -68,6 +68,7 @@ const loadScriptRequireJS = <T>(moduleUri: string) => {
 export const buildApplication = async ({
   app,
   appName,
+  applicationKey,
   applicationPath,
   applicationConfig,
   router,
@@ -75,13 +76,14 @@ export const buildApplication = async ({
 }: {
   app: App
   appName?: string
+  applicationKey: string
   applicationPath: string
   applicationConfig: AppConfigObject
   router: Router
   configStore: ConfigStore
 }) => {
-  if (applicationStore.has(applicationPath)) {
-    throw new RuntimeError('application already announced', applicationPath)
+  if (applicationStore.has(applicationKey)) {
+    throw new RuntimeError('application already announced', applicationKey, applicationPath)
   }
 
   let applicationScript: ClassicApplicationScript
@@ -135,7 +137,7 @@ export const buildApplication = async ({
     throw new RuntimeError('cannot create application', err.message, applicationPath)
   }
 
-  applicationStore.set(applicationPath, application)
+  applicationStore.set(applicationKey, application)
 
   return application
 }

--- a/packages/web-runtime/src/container/application/index.ts
+++ b/packages/web-runtime/src/container/application/index.ts
@@ -67,12 +67,14 @@ const loadScriptRequireJS = <T>(moduleUri: string) => {
  */
 export const buildApplication = async ({
   app,
+  appName,
   applicationPath,
   applicationConfig,
   router,
   configStore
 }: {
   app: App
+  appName?: string
   applicationPath: string
   applicationConfig: AppConfigObject
   router: Router
@@ -121,7 +123,13 @@ export const buildApplication = async ({
     if (!isObject(applicationScript.appInfo) && !applicationScript.setup) {
       throw new RuntimeError('next applications not implemented yet, stay tuned')
     } else {
-      application = convertClassicApplication({ app, applicationScript, applicationConfig, router })
+      application = convertClassicApplication({
+        app,
+        appName,
+        applicationScript,
+        applicationConfig,
+        router
+      })
     }
   } catch (err) {
     throw new RuntimeError('cannot create application', err.message, applicationPath)

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -204,6 +204,7 @@ export const initializeApplications = async ({
         buildApplication({
           app,
           appName,
+          applicationKey: `web-app-external-${appName}`,
           applicationPath: 'web-app-external',
           applicationConfig: {},
           router,
@@ -213,17 +214,16 @@ export const initializeApplications = async ({
     )
   } else {
     const rawApplications: RawApplication[] = [
-      ...configStore.apps
-        .filter((application) => (application === 'external') === dynamicApps)
-        .map((application) => ({
-          path: `web-app-${application}`
-        })),
+      ...configStore.apps.map((application) => ({
+        path: `web-app-${application}`
+      })),
       ...configStore.externalApps
     ]
     applicationResults = await Promise.allSettled(
       rawApplications.map((rawApplication) =>
         buildApplication({
           app,
+          applicationKey: rawApplication.path,
           applicationPath: rawApplication.path,
           applicationConfig: rawApplication.config,
           router,

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -29,30 +29,30 @@ import {
   SpacesStore,
   MessageStore,
   SharesStore,
-  ArchiverService
-} from '@ownclouders/web-pkg'
-import { authService } from '../services/auth'
-import {
+  ArchiverService,
+  RawConfigSchema,
+  SentryConfig,
+  AppProviderService,
+  WebWorkersStore,
+  useWebWorkersStore,
   ClientService,
   LoadingService,
   PasswordPolicyService,
   PreviewService,
-  UppyService
-} from '@ownclouders/web-pkg'
-import { init as sentryInit } from '@sentry/vue'
-import { v4 as uuidV4 } from 'uuid'
-import { merge } from 'lodash-es'
-import {
+  UppyService,
   AppConfigObject,
   resourceIconMappingInjectionKey,
   ResourceIconMapping
 } from '@ownclouders/web-pkg'
+import { authService } from '../services/auth'
+import { init as sentryInit } from '@sentry/vue'
+import { v4 as uuidV4 } from 'uuid'
+import { merge } from 'lodash-es'
 import { MESSAGE_TYPE } from '@ownclouders/web-client/sse'
 import { getQueryParam } from '../helpers/url'
 import PQueue from 'p-queue'
 import { storeToRefs } from 'pinia'
 import { getExtensionNavItems } from '../helpers/navItems'
-import { RawConfigSchema, SentryConfig } from '@ownclouders/web-pkg'
 import {
   onSSEFileLockingEvent,
   onSSEItemRenamedEvent,
@@ -74,7 +74,6 @@ import {
   SseEventWrapperOptions,
   onSSELinkUpdatedEvent
 } from './sse'
-import { useWebWorkersStore, WebWorkersStore } from '@ownclouders/web-pkg'
 import { loadAppTranslations } from '../helpers/language'
 import { urlJoin } from '@ownclouders/web-client'
 
@@ -183,35 +182,56 @@ export const announceClient = async (configStore: ConfigStore): Promise<void> =>
 export const initializeApplications = async ({
   app,
   configStore,
-  router
+  router,
+  appProviderService,
+  dynamicApps
 }: {
   app: App
   configStore: ConfigStore
   router: Router
+  appProviderService: AppProviderService
+  dynamicApps?: boolean
 }): Promise<NextApplication[]> => {
   type RawApplication = {
     path?: string
     config?: AppConfigObject
   }
 
-  const rawApplications: RawApplication[] = [
-    ...rewriteDeprecatedAppNames(configStore).map((application) => ({
-      path: `web-app-${application}`
-    })),
-    ...configStore.externalApps
-  ]
-
-  const applicationResults = await Promise.allSettled(
-    rawApplications.map((rawApplication) =>
-      buildApplication({
-        app,
-        applicationPath: rawApplication.path,
-        applicationConfig: rawApplication.config,
-        router,
-        configStore
-      })
+  let applicationResults: PromiseSettledResult<NextApplication>[] = []
+  if (dynamicApps) {
+    applicationResults = await Promise.allSettled(
+      appProviderService.appNames.map((appName) =>
+        buildApplication({
+          app,
+          appName,
+          applicationPath: 'web-app-external',
+          applicationConfig: {},
+          router,
+          configStore
+        })
+      )
     )
-  )
+  } else {
+    const rawApplications: RawApplication[] = [
+      ...configStore.apps
+        .filter((application) => (application === 'external') === dynamicApps)
+        .map((application) => ({
+          path: `web-app-${application}`
+        })),
+      ...configStore.externalApps
+    ]
+    applicationResults = await Promise.allSettled(
+      rawApplications.map((rawApplication) =>
+        buildApplication({
+          app,
+          applicationPath: rawApplication.path,
+          applicationConfig: rawApplication.config,
+          router,
+          configStore
+        })
+      )
+    )
+  }
 
   const applications = applicationResults.reduce<NextApplication[]>((acc, applicationResult) => {
     // we don't want to fail hard with the full system when one specific application can't get loaded. only log the error.
@@ -408,7 +428,7 @@ export const announceClientService = ({
   app: App
   configStore: ConfigStore
   authStore: AuthStore
-}): void => {
+}): ClientService => {
   const clientService = new ClientService({
     configStore,
     language: app.config.globalProperties.$language,
@@ -416,6 +436,7 @@ export const announceClientService = ({
   })
   app.config.globalProperties.$clientService = clientService
   app.provide('$clientService', clientService)
+  return clientService
 }
 
 export const announceArchiverService = ({
@@ -541,6 +562,28 @@ export const announceAuthService = ({
   )
   app.config.globalProperties.$authService = authService
   app.provide('$authService', authService)
+}
+
+/**
+ * Announce the app provider service (collaborative apps)
+ *
+ * @param app
+ * @param capabilityStore
+ * @param clientService
+ */
+export const announceAppProviderService = ({
+  app,
+  capabilityStore,
+  clientService
+}: {
+  app: App
+  capabilityStore: CapabilityStore
+  clientService: ClientService
+}): AppProviderService => {
+  const appProviderService = new AppProviderService(capabilityStore, clientService)
+  app.config.globalProperties.$appProviderService = appProviderService
+  app.provide('$appProviderService', appProviderService)
+  return appProviderService
 }
 
 /**

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -120,8 +120,7 @@ export const bootstrapApp = async (configurationPath: string, appsReadyCallback:
       app,
       configStore,
       router,
-      appProviderService,
-      dynamicApps: false
+      appProviderService
     })
     const translationsPromise = loadTranslations()
     const customTranslationsPromise = loadCustomTranslations({ configStore })

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -1,6 +1,6 @@
 import { loadDesignSystem, pages, loadTranslations, supportedLanguages } from './defaults'
 import { router } from './router'
-import { PortalTarget } from '@ownclouders/web-pkg'
+import { PortalTarget, AppProviderService } from '@ownclouders/web-pkg'
 import { createHead } from '@vueuse/head'
 import { abilitiesPlugin } from '@casl/vue'
 import { createMongoAbility } from '@casl/ability'
@@ -27,7 +27,8 @@ import {
   registerSSEEventListeners,
   setViewOptions,
   announceGettext,
-  announceArchiverService
+  announceArchiverService,
+  announceAppProviderService
 } from './container/bootstrap'
 import { applicationStore } from './container/store'
 import {
@@ -77,7 +78,7 @@ export const bootstrapApp = async (configurationPath: string, appsReadyCallback:
 
   const gettext = announceGettext({ app, availableLanguages: supportedLanguages })
 
-  announceClientService({ app, configStore, authStore })
+  const clientService = announceClientService({ app, configStore, authStore })
   announceAuthService({
     app,
     configStore,
@@ -88,11 +89,13 @@ export const bootstrapApp = async (configurationPath: string, appsReadyCallback:
     webWorkersStore
   })
 
+  let appProviderService: AppProviderService
   if (!isSilentRedirect) {
     const designSystem = await loadDesignSystem()
 
     announceUppyService({ app })
     startSentry(configStore, app)
+    appProviderService = announceAppProviderService({ app, capabilityStore, clientService })
     announceArchiverService({ app, configStore, userStore, capabilityStore })
     announceLoadingService({ app })
     announcePreviewService({
@@ -113,7 +116,13 @@ export const bootstrapApp = async (configurationPath: string, appsReadyCallback:
     })
     app.component('PortalTarget', PortalTarget)
 
-    const applicationsPromise = initializeApplications({ app, configStore, router })
+    const applicationsPromise = initializeApplications({
+      app,
+      configStore,
+      router,
+      appProviderService,
+      dynamicApps: false
+    })
     const translationsPromise = loadTranslations()
     const customTranslationsPromise = loadCustomTranslations({ configStore })
     const themePromise = announceTheme({ app, designSystem, configStore })
@@ -156,7 +165,22 @@ export const bootstrapApp = async (configurationPath: string, appsReadyCallback:
         return
       }
       announceVersions({ capabilityStore })
-      await announceApplicationsReady({ app, appsStore, applications })
+
+      await appProviderService.loadData()
+      const appProviderApps = await initializeApplications({
+        app,
+        configStore,
+        router,
+        appProviderService,
+        dynamicApps: true
+      })
+      appProviderApps.forEach((application) => application.mounted(app))
+
+      await announceApplicationsReady({
+        app,
+        appsStore,
+        applications: [...applications, ...appProviderApps]
+      })
       appsReadyCallback()
     },
     {

--- a/packages/web-runtime/tests/unit/container/bootstrap.spec.ts
+++ b/packages/web-runtime/tests/unit/container/bootstrap.spec.ts
@@ -43,7 +43,8 @@ describe('initialize applications', () => {
     const applications = await initializeApplications({
       app: createApp(defineComponent({})),
       configStore,
-      router: undefined
+      router: undefined,
+      appProviderService: undefined
     })
 
     expect(buildApplicationMock).toHaveBeenCalledTimes(4)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -680,6 +680,9 @@ importers:
       '@ownclouders/web-pkg':
         specifier: workspace:*
         version: link:../web-pkg
+      pinia:
+        specifier: 2.1.7
+        version: 2.1.7(typescript@5.4.5)(vue@3.4.21(typescript@5.4.5))
       uuid:
         specifier: 9.0.1
         version: 9.0.1
@@ -11072,10 +11075,10 @@ snapshots:
       '@cucumber/ci-environment': 9.1.0
       '@cucumber/cucumber-expressions': 16.1.1
       '@cucumber/gherkin': 26.0.3
-      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@24.0.1))(@cucumber/messages@21.0.1)
+      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@21.0.1))(@cucumber/messages@21.0.1)
       '@cucumber/gherkin-utils': 8.0.2
       '@cucumber/html-formatter': 20.2.1(@cucumber/messages@21.0.1)
-      '@cucumber/message-streams': 4.0.1(@cucumber/messages@21.0.1)
+      '@cucumber/message-streams': 4.0.1(@cucumber/messages@24.0.1)
       '@cucumber/messages': 21.0.1
       '@cucumber/tag-expressions': 5.0.1
       assertion-error-formatter: 3.0.0
@@ -11110,10 +11113,10 @@ snapshots:
       yaml: 2.3.4
       yup: 0.32.11
 
-  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@24.0.1))(@cucumber/messages@21.0.1)':
+  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@21.0.1))(@cucumber/messages@21.0.1)':
     dependencies:
       '@cucumber/gherkin': 26.0.3
-      '@cucumber/message-streams': 4.0.1(@cucumber/messages@21.0.1)
+      '@cucumber/message-streams': 4.0.1(@cucumber/messages@24.0.1)
       '@cucumber/messages': 21.0.1
       commander: 9.1.0
       source-map-support: 0.5.21
@@ -11154,13 +11157,13 @@ snapshots:
     dependencies:
       '@cucumber/messages': 22.0.0
 
-  '@cucumber/message-streams@4.0.1(@cucumber/messages@21.0.1)':
-    dependencies:
-      '@cucumber/messages': 21.0.1
-
   '@cucumber/message-streams@4.0.1(@cucumber/messages@22.0.0)':
     dependencies:
       '@cucumber/messages': 22.0.0
+
+  '@cucumber/message-streams@4.0.1(@cucumber/messages@24.0.1)':
+    dependencies:
+      '@cucumber/messages': 24.0.1
 
   '@cucumber/messages@19.1.4':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -680,6 +680,9 @@ importers:
       '@ownclouders/web-pkg':
         specifier: workspace:*
         version: link:../web-pkg
+      lodash-es:
+        specifier: 4.17.21
+        version: 4.17.21
       pinia:
         specifier: 2.1.7
         version: 2.1.7(typescript@5.4.5)(vue@3.4.21(typescript@5.4.5))


### PR DESCRIPTION
## Description
Dynamically register one instance of the `external` app per app provider app.

## Motivation and Context
No special handling for `open file in editor/viewer` actions anymore.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
- [x] fix broken page reload from within editor (routes are registered too late in the boot process... maybe we can have a catch all route and remove it once external apps are registered)
- [x] remove file action composable special handling
- [x] segmentation of viewers/editors into `app provider apps` and `native apps` was very useful in the `+ New`-menu. Can we skip it in the future or do we want to have some sort of categorization for it?
