### PR TITLE
[test-only]delete deprecated playwright method

### DIFF
--- a/tests/e2e/support/objects/app-files/share/collaborator.ts
+++ b/tests/e2e/support/objects/app-files/share/collaborator.ts
@@ -199,7 +199,7 @@ export default class Collaborator {
       page.locator(Collaborator.removeCollaboratorConfirmationButton).click()
     ])
     if (removeOwnSpaceAccess) {
-      await page.waitForNavigation()
+      await page.waitForURL(/.*\/files\/spaces.*/)
     }
   }
 

--- a/tests/e2e/support/objects/app-files/utils/editor.ts
+++ b/tests/e2e/support/objects/app-files/utils/editor.ts
@@ -8,7 +8,7 @@ const imageViewer = '.stage'
 
 export const close = (page: Page): Promise<unknown> => {
   return Promise.all([
-    page.waitForNavigation(),
+    page.waitForURL(/.*\/files\/(spaces|shares|link|search)\/.*/),
     page.locator(closeTextEditorOrViewerButton).click()
   ])
 }


### PR DESCRIPTION
https://playwright.dev/docs/api/class-page#page-wait-for-navigation is deprecated. I changed it for `page.waitForURL`