### PR TITLE
refactor: remove unused css regarding custom share permissions

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
@@ -274,20 +274,5 @@ export default defineComponent({
   &-role-select-btn {
     max-width: 100%;
   }
-
-  &-custom-permissions-drop-cancel-confirm-btns {
-    background: var(--oc-color-background-hover);
-    text-align: right;
-  }
-}
-
-.files-collaborators-permission-checkbox::v-deep {
-  .oc-checkbox {
-    border: 2px solid var(--oc-color-border);
-  }
-
-  label {
-    margin-left: var(--oc-space-small);
-  }
 }
 </style>


### PR DESCRIPTION
## Description
CSS regarding custom share permissions can be removed since they don't exist anymore.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/11127

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
