### PR TITLE
fix: duplicated elements on public link page

### DIFF
--- a/changelog/unreleased/bugfix-duplicated-ui-elements-public-link
+++ b/changelog/unreleased/bugfix-duplicated-ui-elements-public-link
@@ -1,0 +1,6 @@
+Bugfix: Duplicated elements on public link page
+
+We've fixed a bug where clicking the ownCloud logo on a public link page would lead to certain UI elements being duplicated.
+
+https://github.com/owncloud/web/pull/11137
+https://github.com/owncloud/web/issues/10371

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCopy.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCopy.ts
@@ -66,7 +66,7 @@ export const useFileActionsCopy = () => {
           }
 
           if (isLocationPublicActive(router, 'files-public-link')) {
-            return unref(currentFolder).canCreate()
+            return unref(currentFolder)?.canCreate()
           }
 
           if (

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsPaste.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsPaste.ts
@@ -162,7 +162,7 @@ export const useFileActionsPaste = () => {
         }
 
         if (isLocationPublicActive(router, 'files-public-link') && unref(currentFolder)) {
-          return unref(currentFolder).canCreate()
+          return unref(currentFolder)?.canCreate()
         }
 
         // copy can't be restricted in authenticated context, because

--- a/packages/web-pkg/src/composables/piniaStores/extensionRegistry/extensionRegistry.ts
+++ b/packages/web-pkg/src/composables/piniaStores/extensionRegistry/extensionRegistry.ts
@@ -11,6 +11,11 @@ export const useExtensionRegistry = defineStore('extensionRegistry', () => {
   const registerExtensions = (e: Ref<Extension[]>) => {
     extensions.value.push(e)
   }
+  const unregisterExtensions = (ids: string[]) => {
+    extensions.value = unref(extensions)
+      .map((e) => ref(unref(e).filter(({ id }) => !ids.includes(id))))
+      .filter((e) => unref(e).length)
+  }
   const requestExtensions = <T extends Extension>(extensionPoint: ExtensionPoint<T>) => {
     if (!extensionPoint.id || !extensionPoint.extensionType) {
       throw new Error('ExtensionPoint must have an id and an extensionType')
@@ -29,6 +34,11 @@ export const useExtensionRegistry = defineStore('extensionRegistry', () => {
   const extensionPoints = ref<Ref<ExtensionPoint<Extension>[]>[]>([])
   const registerExtensionPoints = <T extends Extension>(e: Ref<ExtensionPoint<T>[]>) => {
     extensionPoints.value.push(e)
+  }
+  const unregisterExtensionPoints = (ids: string[]) => {
+    extensionPoints.value = unref(extensionPoints)
+      .map((e) => ref(unref(e).filter(({ id }) => !ids.includes(id))))
+      .filter((e) => unref(e).length)
   }
   const getExtensionPoints = <T extends ExtensionPoint<Extension>>(
     options: {
@@ -52,9 +62,11 @@ export const useExtensionRegistry = defineStore('extensionRegistry', () => {
   return {
     extensions,
     registerExtensions,
+    unregisterExtensions,
     requestExtensions,
     extensionPoints,
     registerExtensionPoints,
+    unregisterExtensionPoints,
     getExtensionPoints
   }
 })

--- a/packages/web-pkg/tests/unit/composables/piniaStores/extensionRegistry/extensionRegistry.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/piniaStores/extensionRegistry/extensionRegistry.spec.ts
@@ -132,6 +132,36 @@ describe('useExtensionRegistry', () => {
         }
       })
     })
+
+    it('unregisters extensions', () => {
+      const extensionPoint: ExtensionPoint<CustomComponentExtension> = mock<
+        ExtensionPoint<CustomComponentExtension>
+      >({
+        id: 'extension-point-id',
+        extensionType: 'customComponent'
+      })
+
+      const extension = mock<Extension>({
+        id: 'foo-1',
+        type: 'customComponent',
+        extensionPointIds: [extensionPoint.id]
+      })
+      const extensions = computed(() => [extension])
+
+      getWrapper({
+        setup: (instance) => {
+          instance.registerExtensions(extensions)
+
+          const result1 = instance.requestExtensions(extensionPoint)
+          expect(result1.length).toBe(1)
+
+          instance.unregisterExtensions([extension.id])
+
+          const result2 = instance.requestExtensions(extensionPoint)
+          expect(result2.length).toBe(0)
+        }
+      })
+    })
   })
 
   describe('register and get extensionPoints', () => {
@@ -193,6 +223,29 @@ describe('useExtensionRegistry', () => {
 
           const result2 = instance.getExtensionPoints({ extensionType: 'sidebarPanel' })
           expect(result2.map((ep) => ep.id)).toEqual([unref(extensionPoints)[1].id])
+        }
+      })
+    })
+
+    it('unregisters extension points', () => {
+      const extensionPoint = mock<ExtensionPoint<CustomComponentExtension>>({
+        id: 'foo-1',
+        extensionType: 'customComponent'
+      })
+
+      const extensionPoints = computed<ExtensionPoint<Extension>[]>(() => [extensionPoint])
+
+      getWrapper({
+        setup: (instance) => {
+          instance.registerExtensionPoints(extensionPoints)
+
+          const result1 = instance.getExtensionPoints({ extensionType: 'customComponent' })
+          expect(result1.length).toBe(1)
+
+          instance.unregisterExtensionPoints([extensionPoint.id])
+
+          const result2 = instance.getExtensionPoints({ extensionType: 'customComponent' })
+          expect(result2.length).toBe(0)
         }
       })
     })

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -93,7 +93,8 @@ export class AuthService implements AuthServiceInterface {
       if (publicLinkToken) {
         await this.publicLinkManager.updateContext(publicLinkToken)
       }
-    } else {
+    } else if (to.name !== 'resolvePublicLink') {
+      // no need to clear public context if we're routing the to public link resolving page
       this.publicLinkManager.clearContext()
     }
 


### PR DESCRIPTION
## Description
Fixes a bug where clicking the ownCloud logo on a public link page would lead to certain UI elements being duplicated.

This happens because some extensions and extension points are being registered more than once because the application layout gets unmounted on mounted again when clicking the logo. The solution is to properly unregister those extensions on unmount.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10371

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
