### PR TITLE
fix: secure view default action

### DIFF
--- a/changelog/unreleased/bugfix-secure-view-default-action
+++ b/changelog/unreleased/bugfix-secure-view-default-action
@@ -1,0 +1,6 @@
+Bugfix: Secure view default action
+
+Clicking files that have been shared via secure view without having a compatible app to view such (or the file type is not supported) is no longer possible. This prevents errors and other file actions from falsely registering themselves as default.
+
+https://github.com/owncloud/web/pull/11139
+https://github.com/owncloud/web/issues/11138

--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -258,7 +258,8 @@ import {
   useConfigStore,
   useClipboardStore,
   useResourcesStore,
-  useRouter
+  useRouter,
+  useCanBeOpenedWithSecureView
 } from '../../composables'
 import ResourceListItem from './ResourceListItem.vue'
 import ResourceGhostElement from './ResourceGhostElement.vue'
@@ -505,6 +506,7 @@ export default defineComponent({
     const router = useRouter()
     const capabilityStore = useCapabilityStore()
     const { getMatchingSpace } = useGetMatchingSpace()
+    const { canBeOpenedWithSecureView } = useCanBeOpenedWithSecureView()
     const {
       isLocationPicker,
       isFilePicker,
@@ -559,6 +561,24 @@ export default defineComponent({
       )
     })
 
+    const isResourceClickable = (resource: Resource) => {
+      if (!props.areResourcesClickable) {
+        return false
+      }
+
+      if (!resource.isFolder) {
+        if (!resource.canDownload() && !canBeOpenedWithSecureView(resource)) {
+          return false
+        }
+
+        if (unref(isEmbedModeEnabled) && !unref(isFilePicker)) {
+          return false
+        }
+      }
+
+      return !unref(disabledResources).includes(resource.id)
+    }
+
     return {
       router,
       configOptions,
@@ -593,7 +613,8 @@ export default defineComponent({
       isEmbedModeEnabled,
       toggleSelection,
       areFileExtensionsShown,
-      latestSelectedId
+      latestSelectedId,
+      isResourceClickable
     }
   },
   data() {
@@ -1056,17 +1077,6 @@ export default defineComponent({
        * @property {object} resource resource for which the event is triggered
        */
       this.$emit('fileClick', { space, resources: [resource] })
-    },
-    isResourceClickable(resource: Resource) {
-      if (!this.areResourcesClickable) {
-        return false
-      }
-
-      if (this.isEmbedModeEnabled && !this.isFilePicker && !resource.isFolder) {
-        return false
-      }
-
-      return !this.disabledResources.includes(resource.id)
     },
     getResourceCheckboxLabel(resource: Resource) {
       if (resource.type === 'folder') {

--- a/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
@@ -156,7 +156,8 @@ import {
   useTileSize,
   useResourcesStore,
   useViewSizeMax,
-  useEmbedMode
+  useEmbedMode,
+  useCanBeOpenedWithSecureView
 } from '../../composables'
 
 type ResourceTileRef = ComponentPublicInstance<typeof ResourceTile>
@@ -221,6 +222,7 @@ export default defineComponent({
     const { showMessage } = useMessages()
     const { $gettext } = useGettext()
     const resourcesStore = useResourcesStore()
+    const { canBeOpenedWithSecureView } = useCanBeOpenedWithSecureView()
     const { emit } = context
     const {
       isEnabled: isEmbedModeEnabled,
@@ -311,7 +313,15 @@ export default defineComponent({
     }
 
     const isResourceClickable = (resource: Resource) => {
-      if (unref(isEmbedModeEnabled) && !unref(isFilePicker) && !resource.isFolder) {
+      if (resource.isFolder) {
+        return true
+      }
+
+      if (!resource.canDownload() && !canBeOpenedWithSecureView(resource)) {
+        return false
+      }
+
+      if (unref(isEmbedModeEnabled) && !unref(isFilePicker)) {
         return false
       }
 

--- a/packages/web-pkg/src/composables/resources/index.ts
+++ b/packages/web-pkg/src/composables/resources/index.ts
@@ -1,3 +1,4 @@
+export * from './useCanBeOpenedWithSecureView'
 export * from './useGetResourceContext'
 export * from './useLoadFileInfoById'
 export * from './useResourceContents'

--- a/packages/web-pkg/src/composables/resources/useCanBeOpenedWithSecureView.ts
+++ b/packages/web-pkg/src/composables/resources/useCanBeOpenedWithSecureView.ts
@@ -1,0 +1,13 @@
+import { Resource } from '@ownclouders/web-client'
+import { useAppsStore } from '../piniaStores'
+
+export const useCanBeOpenedWithSecureView = () => {
+  const appsStore = useAppsStore()
+
+  const canBeOpenedWithSecureView = (resource: Resource) => {
+    const secureViewExtensions = appsStore.fileExtensions.filter(({ secureView }) => secureView)
+    return secureViewExtensions.some(({ mimeType }) => mimeType === resource.mimeType)
+  }
+
+  return { canBeOpenedWithSecureView }
+}

--- a/packages/web-pkg/tests/unit/composables/resources/useCanBeOpenedWithSecureView.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/resources/useCanBeOpenedWithSecureView.spec.ts
@@ -1,0 +1,70 @@
+import { getComposableWrapper } from 'web-test-helpers'
+import { mock } from 'vitest-mock-extended'
+import { Resource } from '@ownclouders/web-client'
+import { useCanBeOpenedWithSecureView } from '../../../../src/composables/resources'
+import { ApplicationFileExtension } from '../../../../src/apps/types'
+
+describe('canBeOpenedWithSecureView', () => {
+  describe('resource', () => {
+    it('can be opened if a matching file extension with secure view exists', () => {
+      getWrapper({
+        setup: ({ canBeOpenedWithSecureView }) => {
+          const canBeOpened = canBeOpenedWithSecureView(mock<Resource>({ mimeType: 'text/plain' }))
+          expect(canBeOpened).toBeTruthy()
+        },
+        fileExtensions: [
+          mock<ApplicationFileExtension>({ secureView: true, mimeType: 'text/plain' })
+        ]
+      })
+    })
+    it('can not be opened if no file extension with secure view exists', () => {
+      getWrapper({
+        setup: ({ canBeOpenedWithSecureView }) => {
+          const canBeOpened = canBeOpenedWithSecureView(mock<Resource>({ mimeType: 'text/plain' }))
+          expect(canBeOpened).toBeFalsy()
+        },
+        fileExtensions: [
+          mock<ApplicationFileExtension>({ secureView: false, mimeType: 'text/plain' })
+        ]
+      })
+    })
+    it('can not be opened if no file extension exists', () => {
+      getWrapper({
+        setup: ({ canBeOpenedWithSecureView }) => {
+          const canBeOpened = canBeOpenedWithSecureView(mock<Resource>({ mimeType: 'text/plain' }))
+          expect(canBeOpened).toBeFalsy()
+        },
+        fileExtensions: []
+      })
+    })
+    it("can not be opened if the file extension's mime type doesn't match the one of the resource", () => {
+      getWrapper({
+        setup: ({ canBeOpenedWithSecureView }) => {
+          const canBeOpened = canBeOpenedWithSecureView(mock<Resource>({ mimeType: 'text/plain' }))
+          expect(canBeOpened).toBeFalsy()
+        },
+        fileExtensions: [
+          mock<ApplicationFileExtension>({ secureView: true, mimeType: 'image/jpg' })
+        ]
+      })
+    })
+  })
+})
+
+function getWrapper({
+  setup,
+  fileExtensions = [mock<ApplicationFileExtension>()]
+}: {
+  setup: (instance: ReturnType<typeof useCanBeOpenedWithSecureView>) => void
+  fileExtensions?: ApplicationFileExtension[]
+}) {
+  return {
+    wrapper: getComposableWrapper(
+      () => {
+        const instance = useCanBeOpenedWithSecureView()
+        setup(instance)
+      },
+      { pluginOptions: { piniaOptions: { appsState: { fileExtensions } } } }
+    )
+  }
+}


### PR DESCRIPTION
## Description
Prevents files that have been shared via secure view without having a compatible app to view such (or the file type is not supported) from being clicked.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/11138

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
