### PR TITLE
fix: multiple dav requests on public link page

### DIFF
--- a/packages/web-app-files/src/views/spaces/DriveResolver.vue
+++ b/packages/web-app-files/src/views/spaces/DriveResolver.vue
@@ -150,14 +150,22 @@ export default defineComponent({
           }
         }
 
-        let publicSpace = (await getSpaceResource()) as PublicSpaceResource
+        /**
+         * This is to make sure that an already resolved public link still resolves correctly
+         * upon reload if the link type has been changed to "Uploader" meanwhile.
+         * If the space ids differ, it means we're coming from the public link resolving page,
+         * which already handled a potential link of type "Uploader".
+         **/
+        if (space.fileId === space.id) {
+          let publicSpace = (await getSpaceResource()) as PublicSpaceResource
 
-        // FIXME: check for type once https://github.com/owncloud/ocis/issues/8740 is resolved
-        if (publicSpace.publicLinkPermission === SharePermissionBit.Create) {
-          router.push({
-            name: locationPublicUpload.name,
-            params: { token: space.id.toString() }
-          })
+          // FIXME: check for type once https://github.com/owncloud/ocis/issues/8740 is resolved
+          if (publicSpace.publicLinkPermission === SharePermissionBit.Create) {
+            router.push({
+              name: locationPublicUpload.name,
+              params: { token: space.id.toString() }
+            })
+          }
         }
       }
 

--- a/packages/web-app-files/src/views/spaces/DriveResolver.vue
+++ b/packages/web-app-files/src/views/spaces/DriveResolver.vue
@@ -153,8 +153,12 @@ export default defineComponent({
         /**
          * This is to make sure that an already resolved public link still resolves correctly
          * upon reload if the link type has been changed to "Uploader" meanwhile.
-         * If the space ids differ, it means we're coming from the public link resolving page,
-         * which already handled a potential link of type "Uploader".
+         * If the space ids differ, it means we're coming from the resolvePublicLink page
+         * that already feetched the space. Hence the fileId and the id differ.
+         * It also means the resolvePublicLink page already handled a link of type "Uploader".
+         *
+         * Ideally we would redirect the user via the resolvePublicLink page, but we didn't
+         * find an easy way to do that.
          **/
         if (space.fileId === space.id) {
           let publicSpace = (await getSpaceResource()) as PublicSpaceResource

--- a/packages/web-app-files/tests/unit/views/spaces/DriveResolver.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/DriveResolver.spec.ts
@@ -50,6 +50,7 @@ describe('DriveResolver view', () => {
   it('redirects to the public drop page in a public context with "upload-only"-permissions', async () => {
     const space = mock<SpaceResource>({
       id: '1',
+      fileId: '1',
       getDriveAliasAndItem: vi.fn(),
       driveType: 'public'
     })

--- a/packages/web-runtime/tests/unit/pages/resolvePublicLink.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/resolvePublicLink.spec.ts
@@ -33,20 +33,20 @@ describe('resolvePublicLink', () => {
   describe('password required form', () => {
     it('should display if password is required', async () => {
       const { wrapper } = getWrapper({ passwordRequired: true })
-      await wrapper.vm.loadLinkMetaDataTask.last
+      await wrapper.vm.loadPublicSpaceTask.last
 
       expect(wrapper.find('form').html()).toMatchSnapshot()
     })
     describe('submit button', () => {
       it('should be set as disabled if "password" is empty', async () => {
         const { wrapper } = getWrapper({ passwordRequired: true })
-        await wrapper.vm.loadLinkMetaDataTask.last
+        await wrapper.vm.loadPublicSpaceTask.last
 
         expect(wrapper.find(selectors.submitButton).attributes().disabled).toBe('true')
       })
       it('should be set as enabled if "password" is not empty', async () => {
         const { wrapper } = getWrapper({ passwordRequired: true })
-        await wrapper.vm.loadLinkMetaDataTask.last
+        await wrapper.vm.loadPublicSpaceTask.last
         wrapper.vm.password = 'password'
         await wrapper.vm.$nextTick()
 
@@ -55,7 +55,7 @@ describe('resolvePublicLink', () => {
       it('should resolve the public link on click', async () => {
         const resolvePublicLinkSpy = vi.spyOn(authService, 'resolvePublicLink')
         const { wrapper } = getWrapper({ passwordRequired: true })
-        await wrapper.vm.loadLinkMetaDataTask.last
+        await wrapper.vm.loadPublicSpaceTask.last
 
         wrapper.vm.password = 'password'
         await wrapper.vm.$nextTick()
@@ -69,7 +69,7 @@ describe('resolvePublicLink', () => {
   describe('internal link', () => {
     it('redirects the user to the login page', async () => {
       const { wrapper, mocks } = getWrapper({ isInternalLink: true })
-      await wrapper.vm.loadLinkMetaDataTask.last
+      await wrapper.vm.loadPublicSpaceTask.last
 
       expect(mocks.$router.push).toHaveBeenCalledWith({
         name: 'login',
@@ -86,7 +86,7 @@ function getWrapper({
   const $clientService = mockDeep<ClientService>()
   const spaceResource = mockDeep<SpaceResource>({ driveType: 'public' })
 
-  // loadLinkMetaDataTask response
+  // loadPublicSpaceTask response
   if (passwordRequired) {
     $clientService.webdav.getFileInfo.mockRejectedValueOnce(
       new HttpError("No 'Authorization: Basic' header found", undefined, 401)
@@ -95,8 +95,6 @@ function getWrapper({
     $clientService.webdav.getFileInfo.mockRejectedValueOnce(
       new HttpError("No 'Authorization: Bearer' header found", undefined, 401)
     )
-  } else {
-    $clientService.webdav.getFileInfo.mockResolvedValueOnce(spaceResource)
   }
 
   $clientService.webdav.getFileInfo.mockResolvedValueOnce(spaceResource)


### PR DESCRIPTION
## Description
Reduces the amount of dav requests when resolving public links from 5 to 2. This is the least we can go since the first request is being used to correctly resolve the link and the second one is being used to list the content.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10870

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

