### PR TITLE
feat: add abort signals when listing users/groups

### DIFF
--- a/packages/web-app-admin-settings/src/views/Groups.vue
+++ b/packages/web-app-admin-settings/src/views/Groups.vue
@@ -102,13 +102,16 @@ export default defineComponent({
 
     const loadResourcesTask = useTask(function* (signal) {
       const loadedGroups = yield* call(
-        clientService.graphAuthenticated.groups.listGroups({
-          orderBy: ['displayName'],
-          expand: ['members']
-        })
+        clientService.graphAuthenticated.groups.listGroups(
+          {
+            orderBy: ['displayName'],
+            expand: ['members']
+          },
+          { signal }
+        )
       )
       groupSettingsStore.setGroups(loadedGroups || [])
-    })
+    }).restartable()
 
     const { actions: deleteActions } = useGroupActionsDelete()
     const batchActions = computed(() => {

--- a/packages/web-app-admin-settings/src/views/Users.vue
+++ b/packages/web-app-admin-settings/src/views/Users.vue
@@ -233,12 +233,15 @@ export default defineComponent({
 
     const loadGroupsTask = useTask(function* (signal) {
       groups.value = yield* call(
-        clientService.graphAuthenticated.groups.listGroups({
-          orderBy: ['displayName'],
-          expand: ['members']
-        })
+        clientService.graphAuthenticated.groups.listGroups(
+          {
+            orderBy: ['displayName'],
+            expand: ['members']
+          },
+          { signal }
+        )
       )
-    })
+    }).restartable()
 
     const loadAppRolesTask = useTask(function* (signal) {
       const applicationsResponse = yield* call(
@@ -273,11 +276,14 @@ export default defineComponent({
         .filter(Boolean)
         .join(' and ')
 
-      const usersResponse = yield clientService.graphAuthenticated.users.listUsers({
-        orderBy: ['displayName'],
-        filter,
-        expand: ['appRoleAssignments']
-      })
+      const usersResponse = yield clientService.graphAuthenticated.users.listUsers(
+        {
+          orderBy: ['displayName'],
+          filter,
+          expand: ['appRoleAssignments']
+        },
+        { signal }
+      )
       userSettingsStore.setUsers(usersResponse || [])
     })
 

--- a/packages/web-app-admin-settings/tests/unit/views/Users.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/views/Users.spec.ts
@@ -185,11 +185,15 @@ describe('Users view', () => {
           .vm.$emit('selectionChange', [{ id: '1' }])
         await wrapper.vm.$nextTick()
         expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenCalledTimes(2)
-        expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenNthCalledWith(2, {
-          orderBy: ['displayName'],
-          filter: "(memberOf/any(m:m/id eq '1'))",
-          expand: ['appRoleAssignments']
-        })
+        expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenNthCalledWith(
+          2,
+          {
+            orderBy: ['displayName'],
+            filter: "(memberOf/any(m:m/id eq '1'))",
+            expand: ['appRoleAssignments']
+          },
+          expect.anything()
+        )
       })
       it('does filter initially if group ids are given via query param', async () => {
         const groupIdsQueryParam = '1+2'
@@ -200,11 +204,14 @@ describe('Users view', () => {
           groupFilterQuery: groupIdsQueryParam
         })
         await wrapper.vm.loadResourcesTask.last
-        expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenCalledWith({
-          orderBy: ['displayName'],
-          filter: "(memberOf/any(m:m/id eq '1') or memberOf/any(m:m/id eq '2'))",
-          expand: ['appRoleAssignments']
-        })
+        expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenCalledWith(
+          {
+            orderBy: ['displayName'],
+            filter: "(memberOf/any(m:m/id eq '1') or memberOf/any(m:m/id eq '2'))",
+            expand: ['appRoleAssignments']
+          },
+          expect.anything()
+        )
       })
     })
     describe('roles', () => {
@@ -218,11 +225,15 @@ describe('Users view', () => {
           .vm.$emit('selectionChange', [{ id: '1' }])
         await wrapper.vm.$nextTick()
         expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenCalledTimes(2)
-        expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenNthCalledWith(2, {
-          orderBy: ['displayName'],
-          filter: "(appRoleAssignments/any(m:m/appRoleId eq '1'))",
-          expand: ['appRoleAssignments']
-        })
+        expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenNthCalledWith(
+          2,
+          {
+            orderBy: ['displayName'],
+            filter: "(appRoleAssignments/any(m:m/appRoleId eq '1'))",
+            expand: ['appRoleAssignments']
+          },
+          expect.anything()
+        )
       })
       it('does filter initially if role ids are given via query param', async () => {
         const roleIdsQueryParam = '1+2'
@@ -233,12 +244,15 @@ describe('Users view', () => {
           roleFilterQuery: roleIdsQueryParam
         })
         await wrapper.vm.loadResourcesTask.last
-        expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenCalledWith({
-          orderBy: ['displayName'],
-          filter:
-            "(appRoleAssignments/any(m:m/appRoleId eq '1') or appRoleAssignments/any(m:m/appRoleId eq '2'))",
-          expand: ['appRoleAssignments']
-        })
+        expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenCalledWith(
+          {
+            orderBy: ['displayName'],
+            filter:
+              "(appRoleAssignments/any(m:m/appRoleId eq '1') or appRoleAssignments/any(m:m/appRoleId eq '2'))",
+            expand: ['appRoleAssignments']
+          },
+          expect.anything()
+        )
       })
     })
     describe('displayName', () => {
@@ -251,11 +265,14 @@ describe('Users view', () => {
           displayNameFilterQuery: displayNameFilterQueryParam
         })
         await wrapper.vm.loadResourcesTask.last
-        expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenCalledWith({
-          orderBy: ['displayName'],
-          filter: "contains(displayName,'Albert')",
-          expand: ['appRoleAssignments']
-        })
+        expect(clientService.graphAuthenticated.users.listUsers).toHaveBeenCalledWith(
+          {
+            orderBy: ['displayName'],
+            filter: "contains(displayName,'Albert')",
+            expand: ['appRoleAssignments']
+          },
+          expect.anything()
+        )
       })
     })
   })

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -290,11 +290,11 @@ export default defineComponent({
     const fetchRecipientsTask = useTask(function* (signal, query: string) {
       const client = clientService.graphAuthenticated
       const userData = yield* call(
-        client.users.listUsers({ orderBy: ['displayName'], search: `"${query}"` })
+        client.users.listUsers({ orderBy: ['displayName'], search: `"${query}"` }, { signal })
       )
 
       const groupData = yield* call(
-        client.groups.listGroups({ orderBy: ['displayName'], search: `"${query}"` })
+        client.groups.listGroups({ orderBy: ['displayName'], search: `"${query}"` }, { signal })
       )
 
       const users = (userData || []).map((u) => ({

--- a/packages/web-client/src/graph/types.ts
+++ b/packages/web-client/src/graph/types.ts
@@ -9,4 +9,5 @@ export interface GraphFactoryOptions {
 export interface GraphRequestOptions {
   headers?: Record<string, string>
   params?: Record<string, string>
+  signal?: AbortSignal
 }


### PR DESCRIPTION
## Description
As per title. This allows those requests to be cancelled when a task is being cancelled/restarted.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/6517

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
