### PR TITLE
[tests-only][full-ci] bump ocis commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=aa6041abb6e8094306216fbe354403df14b47c70
+OCIS_COMMITID=6666c3e7353fe3d82476c72808e40ed9cd0c6505
 OCIS_BRANCH=master


### PR DESCRIPTION
run e2e with different deployment: 
this is part of the release process https://github.com/owncloud/ocis/issues/9558