### PR TITLE
refactor: useful graph abstraction for drives and driveItems

### DIFF
--- a/packages/web-app-admin-settings/src/components/Users/SideBar/EditPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Users/SideBar/EditPanel.vue
@@ -123,13 +123,7 @@ import {
 } from '@ownclouders/web-pkg'
 import GroupSelect from '../GroupSelect.vue'
 import { cloneDeep, isEmpty, isEqual, omit } from 'lodash-es'
-import {
-  AppRole,
-  AppRoleAssignment,
-  Drive,
-  Group,
-  User
-} from '@ownclouders/web-client/graph/generated'
+import { AppRole, AppRoleAssignment, Group, User } from '@ownclouders/web-client/graph/generated'
 import { MaybeRef, useClientService } from '@ownclouders/web-pkg'
 import { storeToRefs } from 'pinia'
 import { diff } from 'deep-object-diff'
@@ -231,18 +225,17 @@ export default defineComponent({
 
     const onUpdateUserDrive = async (editUser: User) => {
       const client = clientService.graphAuthenticated
-      const updateDriveResponse = await client.drives.updateDrive(
-        editUser.drive.id,
-        { quota: { total: editUser.drive.quota.total } } as Drive,
-        {}
-      )
+      const updateSpace = await client.drives.updateDrive(editUser.drive.id, {
+        name: editUser.drive.name,
+        quota: { total: editUser.drive.quota.total }
+      })
 
       if (editUser.id === userStore.user.id) {
         // Load current user quota
         spacesStore.updateSpaceField({
           id: editUser.drive.id,
           field: 'spaceQuota',
-          value: updateDriveResponse.data.quota
+          value: updateSpace.spaceQuota
         })
       }
     }

--- a/packages/web-app-admin-settings/src/views/Spaces.vue
+++ b/packages/web-app-admin-settings/src/views/Spaces.vue
@@ -70,10 +70,9 @@ import {
   useSpaceActionsDisable,
   useSpaceActionsRestore,
   useSpaceActionsEditQuota,
-  useConfigStore,
   AppLoadingSpinner
 } from '@ownclouders/web-pkg'
-import { buildSpace, call, SpaceResource } from '@ownclouders/web-client'
+import { call, SpaceResource } from '@ownclouders/web-client'
 import { computed, defineComponent, onBeforeUnmount, onMounted, ref, unref } from 'vue'
 import { useTask } from 'vue-concurrency'
 import { useGettext } from 'vue3-gettext'
@@ -101,7 +100,6 @@ export default defineComponent({
     const clientService = useClientService()
     const { $gettext } = useGettext()
     const { isSideBarOpen, sideBarActivePanel } = useSideBar()
-    const configStore = useConfigStore()
 
     const loadResourcesEventToken = ref(null)
     let updateQuotaForSpaceEventToken: string
@@ -120,13 +118,11 @@ export default defineComponent({
     })
 
     const loadResourcesTask = useTask(function* (signal) {
-      const {
-        data: { value: drivesResponse }
-      } = yield* call(
-        clientService.graphAuthenticated.drives.listAllDrives('name asc', 'driveType eq project')
-      )
-      const drives = drivesResponse.map((space) =>
-        buildSpace({ ...space, serverUrl: configStore.serverUrl })
+      const drives = yield* call(
+        clientService.graphAuthenticated.drives.listAllDrives({
+          orderBy: 'name asc',
+          filter: 'driveType eq project'
+        })
       )
       spaceSettingsStore.setSpaces(drives)
     })

--- a/packages/web-app-admin-settings/tests/unit/views/Spaces.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/views/Spaces.spec.ts
@@ -1,12 +1,10 @@
-import { mockAxiosResolve } from 'web-test-helpers/src/mocks'
 import { SpaceResource } from '@ownclouders/web-client'
 import { Graph } from '@ownclouders/web-client/graph'
-import { mock, mockDeep } from 'vitest-mock-extended'
+import { mockDeep } from 'vitest-mock-extended'
 import { ClientService, useAppDefaults } from '@ownclouders/web-pkg'
 import { defaultComponentMocks, defaultPlugins, mount } from 'web-test-helpers'
 import Spaces from '../../../src/views/Spaces.vue'
 import { useAppDefaultsMock } from 'web-test-helpers/src/mocks/useAppDefaultsMock'
-import { Drive } from '@ownclouders/web-client/graph/generated'
 
 vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
   ...(await importOriginal<any>()),
@@ -39,7 +37,7 @@ describe('Spaces view', () => {
   })
   it('should render no content message if no spaces found', async () => {
     const graph = mockDeep<Graph>()
-    graph.drives.listAllDrives.mockResolvedValue(mockAxiosResolve({ value: [] }))
+    graph.drives.listAllDrives.mockResolvedValue([])
     const { wrapper } = getWrapper({ spaces: [] })
     await wrapper.vm.loadResourcesTask.last
     expect(wrapper.find(selectors.noContentMessageStub).exists()).toBeTruthy()
@@ -80,9 +78,7 @@ function getWrapper({
   selectedSpaces = []
 }: { spaces?: SpaceResource[]; selectedSpaces?: SpaceResource[] } = {}) {
   const $clientService = mockDeep<ClientService>()
-  $clientService.graphAuthenticated.drives.listAllDrives.mockResolvedValue(
-    mockAxiosResolve({ value: spaces.map(() => mock<Drive>()) })
-  )
+  $clientService.graphAuthenticated.drives.listAllDrives.mockResolvedValue(spaces)
   const mocks = {
     ...defaultComponentMocks(),
     $clientService

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -361,11 +361,11 @@ export default defineComponent({
 
           if (driveType === 'project' || isOwnSpace) {
             const client = clientService.graphAuthenticated
-            const driveResponse = await client.drives.getDrive(spaceId)
+            const updatedSpace = await client.drives.getDrive(spaceId)
             spacesStore.updateSpaceField({
-              id: driveResponse.data.id,
+              id: updatedSpace.id,
               field: 'spaceQuota',
-              value: driveResponse.data.quota
+              value: updatedSpace.spaceQuota
             })
           }
         }

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -159,7 +159,7 @@ import { DateTime } from 'luxon'
 import { OcDrop } from 'design-system/src/components'
 import { useTask } from 'vue-concurrency'
 import { useGettext } from 'vue3-gettext'
-import { buildSpace, isProjectSpaceResource } from '@ownclouders/web-client'
+import { isProjectSpaceResource } from '@ownclouders/web-client'
 
 // just a dummy function to trick gettext tools
 const $gettext = (str: string) => {
@@ -377,11 +377,11 @@ export default defineComponent({
       const results = await Promise.allSettled(savePromises)
 
       if (isProjectSpaceResource(unref(resource))) {
-        const graphResponse = await clientService.graphAuthenticated.drives.getDrive(
+        const updatedSpace = await clientService.graphAuthenticated.drives.getDrive(
           unref(resource).id
         )
 
-        upsertSpace(buildSpace(graphResponse.data))
+        upsertSpace(updatedSpace)
 
         addedShares.forEach((member) => {
           upsertSpaceMember({ member })

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
@@ -151,7 +151,7 @@ import { OcInfoDrop, OcDrop } from 'design-system/src/components'
 import { RouteLocationNamedRaw } from 'vue-router'
 import { useGettext } from 'vue3-gettext'
 import { SpaceResource } from '@ownclouders/web-client'
-import { buildSpace, isProjectSpaceResource } from '@ownclouders/web-client'
+import { isProjectSpaceResource } from '@ownclouders/web-client'
 import { ContextualHelperDataListItem } from 'design-system/src/helpers'
 
 export default defineComponent({
@@ -425,9 +425,9 @@ export default defineComponent({
 
         if (isProjectSpaceResource(this.resource)) {
           const client = this.clientService.graphAuthenticated
-          const graphResponse = await client.drives.getDrive(this.resource.id)
+          const space = await client.drives.getDrive(this.resource.id)
 
-          this.upsertSpace(buildSpace(graphResponse.data))
+          this.upsertSpace(space)
           this.upsertSpaceMember({ member: share })
         }
 

--- a/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
@@ -86,7 +86,7 @@ import {
 } from '@ownclouders/web-pkg'
 import { defineComponent, inject, ref, Ref } from 'vue'
 import { shareSpaceAddMemberHelp } from '../../../helpers/contextualHelpers'
-import { ProjectSpaceResource, CollaboratorShare, buildSpace } from '@ownclouders/web-client'
+import { ProjectSpaceResource, CollaboratorShare } from '@ownclouders/web-client'
 import { useClientService } from '@ownclouders/web-pkg'
 import Fuse from 'fuse.js'
 import Mark from 'mark.js'
@@ -223,8 +223,8 @@ export default defineComponent({
 
             if (!currentUserRemoved) {
               const client = this.clientService.graphAuthenticated
-              const graphResponse = await client.drives.getDrive(share.resourceId)
-              this.upsertSpace(buildSpace(graphResponse.data))
+              const space = await client.drives.getDrive(share.resourceId)
+              this.upsertSpace(space)
             }
 
             this.removeSpaceMember({ member: share })

--- a/packages/web-app-files/src/services/folder/loaderSharedViaLink.ts
+++ b/packages/web-app-files/src/services/folder/loaderSharedViaLink.ts
@@ -25,9 +25,7 @@ export class FolderLoaderSharedViaLink implements FolderLoader {
         yield spacesStore.loadMountPoints({ graphClient: clientService.graphAuthenticated })
       }
 
-      const {
-        data: { value }
-      } = yield* call(clientService.graphAuthenticated.drives.listSharedByMe())
+      const value = yield* call(clientService.graphAuthenticated.driveItems.listSharedByMe())
 
       const resources = value
         .filter((s) => s.permissions.some(({ link }) => !!link))

--- a/packages/web-app-files/src/services/folder/loaderSharedWithMe.ts
+++ b/packages/web-app-files/src/services/folder/loaderSharedWithMe.ts
@@ -25,9 +25,7 @@ export class FolderLoaderSharedWithMe implements FolderLoader {
         yield spacesStore.loadMountPoints({ graphClient: clientService.graphAuthenticated })
       }
 
-      const {
-        data: { value }
-      } = yield* call(clientService.graphAuthenticated.drives.listSharedWithMe())
+      const value = yield* call(clientService.graphAuthenticated.driveItems.listSharedWithMe())
 
       const resources = value.map((driveItem) =>
         buildIncomingShareResource({ driveItem, graphRoles: sharesStore.graphRoles })

--- a/packages/web-app-files/src/services/folder/loaderSharedWithOthers.ts
+++ b/packages/web-app-files/src/services/folder/loaderSharedWithOthers.ts
@@ -25,9 +25,7 @@ export class FolderLoaderSharedWithOthers implements FolderLoader {
         yield spacesStore.loadMountPoints({ graphClient: clientService.graphAuthenticated })
       }
 
-      const {
-        data: { value }
-      } = yield* call(clientService.graphAuthenticated.drives.listSharedByMe())
+      const value = yield* call(clientService.graphAuthenticated.driveItems.listSharedByMe())
 
       const resources = value
         .filter((s) => s.permissions.some(({ link }) => !link))

--- a/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.ts
+++ b/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.ts
@@ -1,7 +1,6 @@
 import CreateAndUpload from 'web-app-files/src/components/AppBar/CreateAndUpload.vue'
 import { mock } from 'vitest-mock-extended'
 import { Resource, SpaceResource } from '@ownclouders/web-client'
-import { Drive } from '@ownclouders/web-client/graph/generated'
 import {
   FileAction,
   useFileActionsCreateNewFile,
@@ -13,12 +12,7 @@ import {
   useExtensionRegistry
 } from '@ownclouders/web-pkg'
 import { eventBus, UppyResource } from '@ownclouders/web-pkg'
-import {
-  defaultPlugins,
-  shallowMount,
-  defaultComponentMocks,
-  mockAxiosResolve
-} from 'web-test-helpers'
+import { defaultPlugins, shallowMount, defaultComponentMocks } from 'web-test-helpers'
 import { RouteLocation } from 'vue-router'
 import { ref } from 'vue'
 import { OcButton } from 'design-system/src/components'
@@ -124,7 +118,7 @@ describe('CreateAndUpload component', () => {
       ]
       const { wrapper, mocks } = getWrapper({ spaces })
       const graphMock = mocks.$clientService.graphAuthenticated
-      graphMock.drives.getDrive.mockResolvedValue(mockAxiosResolve<Drive>())
+      graphMock.drives.getDrive.mockResolvedValue(mock<SpaceResource>())
       await wrapper.vm.onUploadComplete({ successful: [file], failed: [] })
       const spacesStore = useSpacesStore()
       expect(spacesStore.updateSpaceField).toHaveBeenCalledTimes(updated)
@@ -138,7 +132,7 @@ describe('CreateAndUpload component', () => {
         meta: { driveType: 'project', spaceId: space.id, currentFolderId: itemId }
       })
       const graphMock = mocks.$clientService.graphAuthenticated
-      graphMock.drives.getDrive.mockResolvedValue(mockAxiosResolve<Drive>())
+      graphMock.drives.getDrive.mockResolvedValue(mock<SpaceResource>())
       await wrapper.vm.onUploadComplete({ successful: [file], failed: [] })
       expect(eventSpy).toHaveBeenCalled()
     })

--- a/packages/web-app-files/tests/unit/components/AppBar/CreateSpace.spec.ts
+++ b/packages/web-app-files/tests/unit/components/AppBar/CreateSpace.spec.ts
@@ -1,8 +1,7 @@
 import CreateSpace from '../../../../src/components/AppBar/CreateSpace.vue'
 import { mockDeep } from 'vitest-mock-extended'
-import { Resource } from '@ownclouders/web-client'
-import { Drive } from '@ownclouders/web-client/graph/generated'
-import { defaultPlugins, mount, defaultComponentMocks, mockAxiosResolve } from 'web-test-helpers'
+import { Resource, SpaceResource } from '@ownclouders/web-client'
+import { defaultPlugins, mount, defaultComponentMocks } from 'web-test-helpers'
 import { useMessages, useModals, useSpacesStore } from '@ownclouders/web-pkg'
 import { unref } from 'vue'
 
@@ -29,9 +28,9 @@ describe('CreateSpace component', () => {
       await wrapper.find(selectors.newSpaceBtn).trigger('click')
 
       const graphMock = mocks.$clientService.graphAuthenticated
-      const drive = mockDeep<Drive>()
-      graphMock.drives.createDrive.mockResolvedValue(mockAxiosResolve(drive))
-      graphMock.drives.updateDrive.mockResolvedValue(mockAxiosResolve(drive))
+      const space = mockDeep<SpaceResource>()
+      graphMock.drives.createDrive.mockResolvedValue(space)
+      graphMock.drives.updateDrive.mockResolvedValue(space)
       mocks.$clientService.webdav.putFileContents.mockResolvedValue(mockDeep<Resource>())
       await unref(modals)[0].onConfirm('New Space')
 

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/ListItem.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/ListItem.spec.ts
@@ -10,8 +10,7 @@ import {
   mount,
   defaultStubs,
   defaultComponentMocks,
-  nextTicks,
-  mockAxiosResolve
+  nextTicks
 } from 'web-test-helpers'
 import { useMessages, useSharesStore, useSpacesStore } from '@ownclouders/web-pkg'
 import EditDropdown from '../../../../../../src/components/SideBar/Shares/Collaborators/EditDropdown.vue'
@@ -232,9 +231,7 @@ function createWrapper({
   resource?: Resource
 } = {}) {
   const mocks = defaultComponentMocks()
-  mocks.$clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(
-    mockAxiosResolve(undefined)
-  )
+  mocks.$clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(undefined)
 
   return {
     wrapper: mount(ListItem, {

--- a/packages/web-app-files/tests/unit/composables/actions/spaces/useSpaceActionsUploadImage.spec.ts
+++ b/packages/web-app-files/tests/unit/composables/actions/spaces/useSpaceActionsUploadImage.spec.ts
@@ -1,15 +1,9 @@
 import { useSpaceActionsUploadImage } from 'web-app-files/src/composables/actions/spaces/useSpaceActionsUploadImage'
 import { mock } from 'vitest-mock-extended'
-import {
-  defaultComponentMocks,
-  RouteLocation,
-  getComposableWrapper,
-  mockAxiosResolve
-} from 'web-test-helpers'
+import { defaultComponentMocks, RouteLocation, getComposableWrapper } from 'web-test-helpers'
 import { unref, VNodeRef } from 'vue'
 import { eventBus, useMessages } from '@ownclouders/web-pkg'
 import { Resource, SpaceResource } from '@ownclouders/web-client'
-import { Drive } from '@ownclouders/web-client/graph/generated'
 
 describe('uploadImage', () => {
   describe('method "uploadImageSpace"', () => {
@@ -17,10 +11,8 @@ describe('uploadImage', () => {
       getWrapper({
         setup: async ({ uploadImageSpace }, { clientService }) => {
           const busStub = vi.spyOn(eventBus, 'publish')
-          const driveMock = mock<Drive>({ special: [{ specialFolder: { name: 'image' } }] })
-          clientService.graphAuthenticated.drives.updateDrive.mockResolvedValue(
-            mockAxiosResolve(driveMock)
-          )
+          const spaceMock = mock<SpaceResource>({ spaceImageData: {} })
+          clientService.graphAuthenticated.drives.updateDrive.mockResolvedValue(spaceMock)
           clientService.webdav.putFileContents.mockResolvedValue(
             mock<Resource>({
               fileId:

--- a/packages/web-client/README.md
+++ b/packages/web-client/README.md
@@ -40,14 +40,10 @@ const { graph, ocs, webdav } = client({ axiosClient, baseURI })
 
 ### Graph
 
-The following example demonstrates how to retrieve all drives accessible to the user and subsequently convert them into a `SpaceResource`. Such a resource can then be used to e.g. fetch files and folders (see example down below).
+The following example demonstrates how to retrieve all spaces accessible to the user. A `SpaceResource` can then be used to e.g. fetch files and folders (see example down below).
 
 ```
-import { buildSpace } from '@ownclouders/web-client'
-
-const myDrives = await graph.drives.listMyDrives()
-
-const spaceResources = myDrives.data.value.map(buildSpace)
+const mySpaces = await graph.drives.listMyDrives()
 ```
 
 ### OCS

--- a/packages/web-client/src/graph/driveItems/driveItems.ts
+++ b/packages/web-client/src/graph/driveItems/driveItems.ts
@@ -1,0 +1,52 @@
+import { DriveItemApiFactory, DrivesRootApiFactory, MeDriveApiFactory } from './../generated'
+import type { GraphFactoryOptions } from './../types'
+import type { GraphDriveItems } from './types'
+
+export const DriveItemsFactory = ({
+  axiosClient,
+  config
+}: GraphFactoryOptions): GraphDriveItems => {
+  const driveItemApiFactory = DriveItemApiFactory(config, config.basePath, axiosClient)
+  const drivesRootApiFactory = DrivesRootApiFactory(config, config.basePath, axiosClient)
+  const meDriveApiFactory = MeDriveApiFactory(config, config.basePath, axiosClient)
+
+  return {
+    async getDriveItem(driveId, itemId, requestOptions) {
+      const { data } = await driveItemApiFactory.getDriveItem(driveId, itemId, requestOptions)
+      return data
+    },
+
+    async createDriveItem(driveId, data, requestOptions) {
+      const { data: driveItem } = await drivesRootApiFactory.createDriveItem(
+        driveId,
+        data,
+        requestOptions
+      )
+      return driveItem
+    },
+
+    async updateDriveItem(driveId, itemId, data, requestOptions) {
+      const { data: driveItem } = await driveItemApiFactory.updateDriveItem(
+        driveId,
+        itemId,
+        data,
+        requestOptions
+      )
+      return driveItem
+    },
+
+    async deleteDriveItem(driveId, itemId, requestOptions) {
+      await driveItemApiFactory.deleteDriveItem(driveId, itemId, requestOptions)
+    },
+
+    async listSharedByMe(requestOptions) {
+      const { data } = await meDriveApiFactory.listSharedByMe(requestOptions)
+      return data?.value || []
+    },
+
+    async listSharedWithMe(requestOptions) {
+      const { data } = await meDriveApiFactory.listSharedWithMe(requestOptions)
+      return data?.value || []
+    }
+  }
+}

--- a/packages/web-client/src/graph/driveItems/index.ts
+++ b/packages/web-client/src/graph/driveItems/index.ts
@@ -1,0 +1,2 @@
+export * from './driveItems'
+export * from './types'

--- a/packages/web-client/src/graph/driveItems/types.ts
+++ b/packages/web-client/src/graph/driveItems/types.ts
@@ -1,0 +1,28 @@
+import { DriveItem } from '../generated'
+import type { GraphRequestOptions } from '../types'
+
+export interface GraphDriveItems {
+  getDriveItem: (
+    driveId: string,
+    itemId: string,
+    requestOptions?: GraphRequestOptions
+  ) => Promise<DriveItem>
+  createDriveItem: (
+    driveId: string,
+    data: DriveItem,
+    requestOptions?: GraphRequestOptions
+  ) => Promise<DriveItem>
+  updateDriveItem: (
+    driveId: string,
+    itemId: string,
+    data: DriveItem,
+    requestOptions?: GraphRequestOptions
+  ) => Promise<DriveItem>
+  deleteDriveItem: (
+    driveId: string,
+    itemId: string,
+    requestOptions?: GraphRequestOptions
+  ) => Promise<void>
+  listSharedByMe: (requestOptions?: GraphRequestOptions) => Promise<DriveItem[]>
+  listSharedWithMe: (requestOptions?: GraphRequestOptions) => Promise<DriveItem[]>
+}

--- a/packages/web-client/src/graph/drives/drives.ts
+++ b/packages/web-client/src/graph/drives/drives.ts
@@ -1,0 +1,57 @@
+import { buildSpace } from '../../helpers'
+import { Drive, DrivesApiFactory, DrivesGetDrivesApi, MeDrivesApi } from './../generated'
+import type { GraphFactoryOptions } from './../types'
+import type { GraphDrives } from './types'
+
+const getServerUrlFromDrive = (drive: Drive) => new URL(drive.webUrl).origin
+
+export const DrivesFactory = ({ axiosClient, config }: GraphFactoryOptions): GraphDrives => {
+  const drivesApiFactory = DrivesApiFactory(config, config.basePath, axiosClient)
+  const meDrivesApi = new MeDrivesApi(config, config.basePath, axiosClient)
+  const allDrivesApi = new DrivesGetDrivesApi(config, config.basePath, axiosClient)
+
+  return {
+    async getDrive(id, requestOptions) {
+      const { data: drive } = await drivesApiFactory.getDrive(id, requestOptions)
+      return buildSpace({ ...drive, serverUrl: getServerUrlFromDrive(drive) })
+    },
+
+    async createDrive(data, requestOptions) {
+      const { data: drive } = await drivesApiFactory.createDrive(data, requestOptions)
+      return buildSpace({ ...drive, serverUrl: getServerUrlFromDrive(drive) })
+    },
+
+    async updateDrive(id, data, requestOptions) {
+      const { data: drive } = await drivesApiFactory.updateDrive(id, data, requestOptions)
+      return buildSpace({ ...drive, serverUrl: getServerUrlFromDrive(drive) })
+    },
+
+    async disableDrive(id, ifMatch, requestOptions) {
+      await drivesApiFactory.deleteDrive(id, ifMatch, requestOptions)
+    },
+
+    async deleteDrive(id, ifMatch, requestOptions) {
+      await drivesApiFactory.deleteDrive(id, ifMatch, {
+        headers: {
+          ...((requestOptions?.headers && requestOptions.headers) || {}),
+          Purge: 'T'
+        },
+        ...((requestOptions && { requestOptions }) || {})
+      })
+    },
+
+    async listMyDrives(options, requestOptions) {
+      const {
+        data: { value }
+      } = await meDrivesApi.listMyDrives(options?.orderBy, options?.filter, requestOptions)
+      return value.map((d) => buildSpace({ ...d, serverUrl: getServerUrlFromDrive(d) }))
+    },
+
+    async listAllDrives(options, requestOptions) {
+      const {
+        data: { value }
+      } = await allDrivesApi.listAllDrives(options?.orderBy, options?.filter, requestOptions)
+      return value.map((d) => buildSpace({ ...d, serverUrl: getServerUrlFromDrive(d) }))
+    }
+  }
+}

--- a/packages/web-client/src/graph/drives/index.ts
+++ b/packages/web-client/src/graph/drives/index.ts
@@ -1,0 +1,2 @@
+export * from './drives'
+export * from './types'

--- a/packages/web-client/src/graph/drives/types.ts
+++ b/packages/web-client/src/graph/drives/types.ts
@@ -1,0 +1,33 @@
+import type { SpaceResource } from '../../helpers'
+import type { Drive } from '../generated'
+import type { GraphRequestOptions } from '../types'
+
+export interface GraphDrives {
+  getDrive: (id: string, requestOptions?: GraphRequestOptions) => Promise<SpaceResource>
+  createDrive: (data: Drive, requestOptions?: GraphRequestOptions) => Promise<SpaceResource>
+  updateDrive: (
+    id: string,
+    data: Drive,
+    requestOptions?: GraphRequestOptions
+  ) => Promise<SpaceResource>
+  disableDrive: (
+    id: string,
+    ifMatch?: string,
+    requestOptions?: GraphRequestOptions
+  ) => Promise<void>
+  deleteDrive: (id: string, ifMatch?: string, requestOptions?: GraphRequestOptions) => Promise<void>
+  listMyDrives: (
+    options?: {
+      orderBy?: string
+      filter?: string
+    },
+    requestOptions?: GraphRequestOptions
+  ) => Promise<SpaceResource[]>
+  listAllDrives: (
+    options?: {
+      orderBy?: string
+      filter?: string
+    },
+    requestOptions?: GraphRequestOptions
+  ) => Promise<SpaceResource[]>
+}

--- a/packages/web-client/src/graph/index.ts
+++ b/packages/web-client/src/graph/index.ts
@@ -1,13 +1,9 @@
-import { AxiosInstance, AxiosPromise, AxiosResponse } from 'axios'
+import { AxiosInstance, AxiosPromise } from 'axios'
 import {
   Configuration,
-  MeDriveApiFactory,
   RoleManagementApiFactory,
   UnifiedRoleDefinition,
-  CollectionOfDriveItems1,
-  DriveItemApiFactory,
   DrivesRootApiFactory,
-  DriveItem,
   DrivesPermissionsApiFactory,
   Permission,
   DriveItemCreateLink,
@@ -20,6 +16,7 @@ import { type GraphUsers, UsersFactory } from './users'
 import { type GraphGroups, GroupsFactory } from './groups'
 import { ApplicationsFactory, GraphApplications } from './applications'
 import { DrivesFactory, GraphDrives } from './drives'
+import { DriveItemsFactory, GraphDriveItems } from './driveItems'
 import { TagsFactory, GraphTags } from './tags'
 import { ActivitiesFactory, GraphActivities } from './activities'
 
@@ -27,17 +24,8 @@ export interface Graph {
   activities: GraphActivities
   applications: GraphApplications
   tags: GraphTags
-  drives: GraphDrives & {
-    listSharedWithMe: () => AxiosPromise<CollectionOfDriveItems1>
-    listSharedByMe: () => AxiosPromise<CollectionOfDriveItems1>
-    deleteDriveItem: (driveId: string, itemId: string) => AxiosPromise<void>
-    updateDriveItem: (
-      driveId: string,
-      itemId: string,
-      driveItem: DriveItem
-    ) => AxiosPromise<DriveItem>
-    createDriveItem: (driveId: string, driveItem: DriveItem) => AxiosPromise<DriveItem>
-  }
+  drives: GraphDrives
+  driveItems: GraphDriveItems
   users: GraphUsers
   groups: GraphGroups
   roleManagement: {
@@ -104,9 +92,7 @@ export const graph = (baseURI: string, axiosClient: AxiosInstance): Graph => {
     basePath: url.href
   })
 
-  const meDriveApiFactory = MeDriveApiFactory(config, config.basePath, axiosClient)
   const roleManagementApiFactory = RoleManagementApiFactory(config, config.basePath, axiosClient)
-  const driveItemApiFactory = DriveItemApiFactory(config, config.basePath, axiosClient)
   const drivesRootApiFactory = DrivesRootApiFactory(config, config.basePath, axiosClient)
   const drivesPermissionsApiFactory = DrivesPermissionsApiFactory(
     config,
@@ -118,19 +104,8 @@ export const graph = (baseURI: string, axiosClient: AxiosInstance): Graph => {
     activities: ActivitiesFactory({ axiosClient, config }),
     applications: ApplicationsFactory({ axiosClient, config }),
     tags: TagsFactory({ axiosClient, config }),
-    drives: {
-      ...DrivesFactory({ axiosClient, config }),
-
-      // TODO: split into DriveItemsFactory
-      listSharedWithMe: () => meDriveApiFactory.listSharedWithMe(),
-      listSharedByMe: () => meDriveApiFactory.listSharedByMe(),
-      deleteDriveItem: (driveId: string, itemId: string) =>
-        driveItemApiFactory.deleteDriveItem(driveId, itemId),
-      updateDriveItem: (driveId: string, itemId: string, driveItem: DriveItem) =>
-        driveItemApiFactory.updateDriveItem(driveId, itemId, driveItem),
-      createDriveItem: (driveId: string, driveItem: DriveItem) =>
-        drivesRootApiFactory.createDriveItem(driveId, driveItem)
-    },
+    drives: DrivesFactory({ axiosClient, config }),
+    driveItems: DriveItemsFactory({ axiosClient, config }),
     users: UsersFactory({ axiosClient, config }),
     groups: GroupsFactory({ axiosClient, config }),
     roleManagement: {

--- a/packages/web-client/src/graph/index.ts
+++ b/packages/web-client/src/graph/index.ts
@@ -1,11 +1,6 @@
 import { AxiosInstance, AxiosPromise, AxiosResponse } from 'axios'
 import {
-  CollectionOfDrives,
   Configuration,
-  Drive,
-  DrivesApiFactory,
-  MeDrivesApi,
-  DrivesGetDrivesApi,
   MeDriveApiFactory,
   RoleManagementApiFactory,
   UnifiedRoleDefinition,
@@ -24,6 +19,7 @@ import {
 import { type GraphUsers, UsersFactory } from './users'
 import { type GraphGroups, GroupsFactory } from './groups'
 import { ApplicationsFactory, GraphApplications } from './applications'
+import { DrivesFactory, GraphDrives } from './drives'
 import { TagsFactory, GraphTags } from './tags'
 import { ActivitiesFactory, GraphActivities } from './activities'
 
@@ -31,16 +27,9 @@ export interface Graph {
   activities: GraphActivities
   applications: GraphApplications
   tags: GraphTags
-  drives: {
-    listMyDrives: (orderBy?: string, filter?: string) => Promise<AxiosResponse<CollectionOfDrives>>
-    listAllDrives: (orderBy?: string, filter?: string) => Promise<AxiosResponse<CollectionOfDrives>>
+  drives: GraphDrives & {
     listSharedWithMe: () => AxiosPromise<CollectionOfDriveItems1>
     listSharedByMe: () => AxiosPromise<CollectionOfDriveItems1>
-    getDrive: (id: string) => AxiosPromise<Drive>
-    createDrive: (drive: Drive, options: any) => AxiosPromise<Drive>
-    updateDrive: (id: string, drive: Drive, options: any) => AxiosPromise<Drive>
-    disableDrive: (id: string) => AxiosPromise<void>
-    deleteDrive: (id: string) => AxiosPromise<void>
     deleteDriveItem: (driveId: string, itemId: string) => AxiosPromise<void>
     updateDriveItem: (
       driveId: string,
@@ -115,10 +104,7 @@ export const graph = (baseURI: string, axiosClient: AxiosInstance): Graph => {
     basePath: url.href
   })
 
-  const meDrivesApi = new MeDrivesApi(config, config.basePath, axiosClient)
-  const allDrivesApi = new DrivesGetDrivesApi(config, config.basePath, axiosClient)
   const meDriveApiFactory = MeDriveApiFactory(config, config.basePath, axiosClient)
-  const drivesApiFactory = DrivesApiFactory(config, config.basePath, axiosClient)
   const roleManagementApiFactory = RoleManagementApiFactory(config, config.basePath, axiosClient)
   const driveItemApiFactory = DriveItemApiFactory(config, config.basePath, axiosClient)
   const drivesRootApiFactory = DrivesRootApiFactory(config, config.basePath, axiosClient)
@@ -133,24 +119,11 @@ export const graph = (baseURI: string, axiosClient: AxiosInstance): Graph => {
     applications: ApplicationsFactory({ axiosClient, config }),
     tags: TagsFactory({ axiosClient, config }),
     drives: {
-      listMyDrives: (orderBy?: string, filter?: string) =>
-        meDrivesApi.listMyDrives(orderBy, filter),
-      listAllDrives: (orderBy?: string, filter?: string) =>
-        allDrivesApi.listAllDrives(orderBy, filter),
+      ...DrivesFactory({ axiosClient, config }),
+
+      // TODO: split into DriveItemsFactory
       listSharedWithMe: () => meDriveApiFactory.listSharedWithMe(),
       listSharedByMe: () => meDriveApiFactory.listSharedByMe(),
-      getDrive: (id: string) => drivesApiFactory.getDrive(id),
-      createDrive: (drive: Drive, options: any): AxiosPromise<Drive> =>
-        drivesApiFactory.createDrive(drive, options),
-      updateDrive: (id: string, drive: Drive, options: any): AxiosPromise<Drive> =>
-        drivesApiFactory.updateDrive(id, drive, options),
-      disableDrive: (id: string): AxiosPromise<void> => drivesApiFactory.deleteDrive(id, '', {}),
-      deleteDrive: (id: string): AxiosPromise<void> =>
-        drivesApiFactory.deleteDrive(id, '', {
-          headers: {
-            Purge: 'T'
-          }
-        }),
       deleteDriveItem: (driveId: string, itemId: string) =>
         driveItemApiFactory.deleteDriveItem(driveId, itemId),
       updateDriveItem: (driveId: string, itemId: string, driveItem: DriveItem) =>

--- a/packages/web-pkg/src/components/Spaces/QuotaModal.vue
+++ b/packages/web-pkg/src/components/Spaces/QuotaModal.vue
@@ -31,7 +31,6 @@ import {
 } from '../../composables'
 import { useRouter } from '../../composables/router'
 import { eventBus } from '../../services'
-import { Drive } from '@ownclouders/web-client/graph/generated'
 import { storeToRefs } from 'pinia'
 import { ContextualHelperData } from 'design-system/src/helpers'
 
@@ -134,28 +133,32 @@ export default defineComponent({
     const onConfirm = async () => {
       const client = clientService.graphAuthenticated
       const requests = props.spaces.map(async (space): Promise<void> => {
-        const { data: driveData } = await client.drives.updateDrive(
-          space.id.toString(),
-          { quota: { total: unref(selectedOption) } } as Drive,
+        const updatedSpace = await client.drives.updateDrive(
+          space.id,
+          { name: space.name, quota: { total: unref(selectedOption) } },
           {}
         )
         if (unref(router.currentRoute).name === 'admin-settings-spaces') {
           eventBus.publish('app.admin-settings.spaces.space.quota.updated', {
             spaceId: space.id,
-            quota: driveData.quota
+            quota: updatedSpace.spaceQuota
           })
         }
         if (unref(router.currentRoute).name === 'admin-settings-users') {
           eventBus.publish('app.admin-settings.users.user.quota.updated', {
             spaceId: space.id,
-            quota: driveData.quota
+            quota: updatedSpace.spaceQuota
           })
         }
-        spacesStore.updateSpaceField({ id: space.id, field: 'spaceQuota', value: driveData.quota })
+        spacesStore.updateSpaceField({
+          id: space.id,
+          field: 'spaceQuota',
+          value: updatedSpace.spaceQuota
+        })
         updateResourceField<SpaceResource>({
           id: space.id,
           field: 'spaceQuota',
-          value: driveData.quota
+          value: updatedSpace.spaceQuota
         })
       })
       const results = await Promise.allSettled<Array<unknown>>(requests)

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsDisableSync.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsDisableSync.ts
@@ -34,7 +34,7 @@ export const useFileActionsDisableSync = () => {
         triggerQueue.add(async () => {
           try {
             const { graphAuthenticated } = clientService
-            await graphAuthenticated.drives.deleteDriveItem(resource.driveId, resource.id)
+            await graphAuthenticated.driveItems.deleteDriveItem(resource.driveId, resource.id)
 
             updateResourceField<IncomingShareResource>({
               id: resource.id,

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsEnableSync.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsEnableSync.ts
@@ -32,7 +32,7 @@ export const useFileActionsEnableSync = () => {
         triggerQueue.add(async () => {
           try {
             const { graphAuthenticated } = clientService
-            await graphAuthenticated.drives.createDriveItem(resource.driveId, {
+            await graphAuthenticated.driveItems.createDriveItem(resource.driveId, {
               name: resource.name,
               remoteItem: { id: resource.fileId }
             })

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsRestore.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsRestore.ts
@@ -143,11 +143,11 @@ export const useFileActionsRestore = () => {
 
         // Reload quota
         const graphClient = clientService.graphAuthenticated
-        const driveResponse = await graphClient.drives.getDrive(space.id)
+        const updatedSpace = await graphClient.drives.getDrive(space.id)
         spacesStore.updateSpaceField({
-          id: driveResponse.data.id,
+          id: updatedSpace.id,
           field: 'spaceQuota',
-          value: driveResponse.data.quota
+          value: updatedSpace.spaceQuota
         })
       }
 

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsSetImage.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsSetImage.ts
@@ -6,8 +6,6 @@ import { useRouter } from '../../router'
 import { useGettext } from 'vue3-gettext'
 import { computed } from 'vue'
 import { FileAction, FileActionOptions } from '../types'
-import { Drive } from '@ownclouders/web-client/graph/generated'
-import { buildSpace } from '@ownclouders/web-client'
 import { useMessages, useSpacesStore, useUserStore } from '../../piniaStores'
 
 export const useFileActionsSetImage = () => {
@@ -46,25 +44,15 @@ export const useFileActionsSetImage = () => {
 
       const file = await getFileInfo(space, { path: destinationPath })
 
-      const { data: updatedDriveData } = await graphClient.drives.updateDrive(
-        storageId,
-        {
-          special: [
-            {
-              specialFolder: {
-                name: 'image'
-              },
-              id: file.id as string
-            }
-          ]
-        } as Drive,
-        {}
-      )
+      const updatedSpace = await graphClient.drives.updateDrive(storageId, {
+        name: space.name,
+        special: [{ specialFolder: { name: 'image' }, id: file.id }]
+      })
 
       spacesStore.updateSpaceField({
         id: storageId,
         field: 'spaceImageData',
-        value: buildSpace(updatedDriveData).spaceImageData
+        value: updatedSpace.spaceImageData
       })
 
       showMessage({ title: $gettext('Space image was set successfully') })

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsSetReadme.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsSetReadme.ts
@@ -3,8 +3,6 @@ import { useGettext } from 'vue3-gettext'
 import { useClientService } from '../../clientService'
 import { useRouter } from '../../router'
 import { FileAction, FileActionOptions } from '../types'
-import { Drive } from '@ownclouders/web-client/graph/generated'
-import { buildSpace } from '@ownclouders/web-client'
 import { useMessages, useSpacesStore, useUserStore } from '../../piniaStores'
 import { useCreateSpace } from '../../spaces'
 
@@ -33,24 +31,15 @@ export const useFileActionsSetReadme = () => {
         content: fileContent
       })
       const file = await webdav.getFileInfo(space, { path: '.space/readme.md' })
-      const { data: updatedDriveData } = await graphAuthenticated.drives.updateDrive(
-        space.id as string,
-        {
-          special: [
-            {
-              specialFolder: {
-                name: 'readme'
-              },
-              id: file.id
-            }
-          ]
-        } as Drive,
-        {}
-      )
+      const updatedSpace = await graphAuthenticated.drives.updateDrive(space.id, {
+        name: space.name,
+        special: [{ specialFolder: { name: 'readme' }, id: file.id }]
+      })
+
       spacesStore.updateSpaceField({
         id: space.id,
         field: 'spaceReadmeData',
-        value: buildSpace(updatedDriveData).spaceReadmeData
+        value: updatedSpace.spaceReadmeData
       })
       showMessage({ title: $gettext('Space description was set successfully') })
     } catch (error) {

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsToggleHideShare.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsToggleHideShare.ts
@@ -31,7 +31,7 @@ export const useFileActionsToggleHideShare = () => {
       triggerPromises.push(
         triggerQueue.add(async () => {
           try {
-            await clientService.graphAuthenticated.drives.updateDriveItem(
+            await clientService.graphAuthenticated.driveItems.updateDriveItem(
               resource.driveId,
               resource.id,
               { '@UI.Hidden': hidden }

--- a/packages/web-pkg/src/composables/actions/helpers/useFileActionsDeleteResources.ts
+++ b/packages/web-pkg/src/composables/actions/helpers/useFileActionsDeleteResources.ts
@@ -224,11 +224,11 @@ export const useFileActionsDeleteResources = () => {
               !['public', 'share'].includes(spaceForDeletion?.driveType)
             ) {
               const graphClient = clientService.graphAuthenticated
-              const driveResponse = await graphClient.drives.getDrive(unref(resources)[0].storageId)
+              const updatedSpace = await graphClient.drives.getDrive(unref(resources)[0].storageId)
               spacesStore.updateSpaceField({
-                id: driveResponse.data.id,
+                id: updatedSpace.id,
                 field: 'spaceQuota',
-                value: driveResponse.data.quota
+                value: updatedSpace.spaceQuota
               })
             }
 

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsDelete.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsDelete.ts
@@ -35,7 +35,7 @@ export const useSpaceActionsDelete = () => {
   const deleteSpaces = async (spaces: SpaceResource[]) => {
     const client = clientService.graphAuthenticated
     const promises = spaces.map((space) =>
-      client.drives.deleteDrive(space.id.toString()).then(() => {
+      client.drives.deleteDrive(space.id).then(() => {
         removeResources([space])
         spacesStore.removeSpace(space)
         return true

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsDisable.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsDisable.ts
@@ -30,7 +30,7 @@ export const useSpaceActionsDisable = () => {
 
     const client = clientService.graphAuthenticated
     const promises = spaces.map((space) =>
-      client.drives.disableDrive(space.id.toString()).then(() => {
+      client.drives.disableDrive(space.id).then(() => {
         if (currentRoute.name === 'files-spaces-generic') {
           router.push({ name: 'files-spaces-projects' })
         }

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditDescription.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditDescription.ts
@@ -1,4 +1,3 @@
-import { Drive } from '@ownclouders/web-client/graph/generated'
 import { computed, unref } from 'vue'
 import { SpaceAction, SpaceActionOptions } from '../types'
 import { useRoute } from '../../router'
@@ -21,7 +20,7 @@ export const useSpaceActionsEditDescription = () => {
   const editDescriptionSpace = (space: SpaceResource, description: string) => {
     const graphClient = clientService.graphAuthenticated
     return graphClient.drives
-      .updateDrive(space.id as string, { description } as Drive, {})
+      .updateDrive(space.id, { name: space.name, description })
       .then(() => {
         spacesStore.updateSpaceField({ id: space.id, field: 'description', value: description })
         if (unref(route).name === 'admin-settings-spaces') {

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditReadmeContent.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditReadmeContent.ts
@@ -3,11 +3,10 @@ import { computed } from 'vue'
 import { useGettext } from 'vue3-gettext'
 
 import { useOpenWithDefaultApp } from '../useOpenWithDefaultApp'
-import { buildSpace, getRelativeSpecialFolderSpacePath } from '@ownclouders/web-client'
+import { getRelativeSpecialFolderSpacePath } from '@ownclouders/web-client'
 import { useClientService } from '../../clientService'
-import { useConfigStore, useSpacesStore, useUserStore } from '../../piniaStores'
+import { useSpacesStore, useUserStore } from '../../piniaStores'
 import { useCreateSpace } from '../../spaces'
-import { Drive } from '@ownclouders/web-client/graph/generated'
 
 export const useSpaceActionsEditReadmeContent = () => {
   const clientService = useClientService()
@@ -15,7 +14,6 @@ export const useSpaceActionsEditReadmeContent = () => {
   const { createDefaultMetaFolder } = useCreateSpace()
   const userStore = useUserStore()
   const spacesStore = useSpacesStore()
-  const configStore = useConfigStore()
   const { $gettext } = useGettext()
 
   const handler = async ({ resources }: SpaceActionOptions) => {
@@ -28,25 +26,18 @@ export const useSpaceActionsEditReadmeContent = () => {
         path: '.space/readme.md'
       })
 
-      const { data: updatedDriveData } = await clientService.graphAuthenticated.drives.updateDrive(
+      const updatedSpace = await clientService.graphAuthenticated.drives.updateDrive(
         resources[0].id,
         {
-          special: [
-            {
-              specialFolder: {
-                name: 'readme'
-              },
-              id: markdownResource.id
-            }
-          ]
-        } as Drive,
-        {}
+          name: resources[0].name,
+          special: [{ specialFolder: { name: 'readme' }, id: markdownResource.id }]
+        }
       )
 
       spacesStore.updateSpaceField({
         id: resources[0].id,
         field: 'spaceReadmeData',
-        value: buildSpace({ ...updatedDriveData, serverUrl: configStore.serverUrl }).spaceReadmeData
+        value: updatedSpace.spaceReadmeData
       })
     }
 

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsRestore.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsRestore.ts
@@ -30,15 +30,11 @@ export const useSpaceActionsRestore = () => {
     const client = clientService.graphAuthenticated
     const promises = spaces.map((space) =>
       client.drives
-        .updateDrive(space.id.toString(), {} as any, {
-          headers: {
-            Restore: true
-          }
-        })
+        .updateDrive(space.id, { name: space.name }, { headers: { Restore: 'true' } })
         .then((updatedSpace) => {
           if (unref(route).name === 'admin-settings-spaces') {
             space.disabled = false
-            space.spaceQuota = updatedSpace.data.quota
+            space.spaceQuota = updatedSpace.spaceQuota
           }
           spacesStore.updateSpaceField({ id: space.id, field: 'disabled', value: false })
           return true

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsSetIcon.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsSetIcon.ts
@@ -6,9 +6,7 @@ import { useLoadingService } from '../../loadingService'
 import { useGettext } from 'vue3-gettext'
 import { useMessages, useModals, useSpacesStore, useUserStore } from '../../piniaStores'
 import { useCreateSpace } from '../../spaces'
-import { buildSpace } from '@ownclouders/web-client'
 import { eventBus } from '../../../services'
-import { Drive } from '@ownclouders/web-client/graph/generated'
 import { blobToArrayBuffer, canvasToBlob } from '../../../helpers'
 import EmojiPickerModal from '../../../components/Modals/EmojiPickerModal.vue'
 
@@ -84,28 +82,18 @@ export const useSpaceActionsSetIcon = () => {
           overwrite: true
         })
 
-        const { data } = await graphClient.drives.updateDrive(
-          space.id.toString(),
-          {
-            special: [
-              {
-                specialFolder: {
-                  name: 'image'
-                },
-                id: fileId
-              }
-            ]
-          } as Drive,
-          {}
-        )
+        const updatedSpace = await graphClient.drives.updateDrive(space.id, {
+          name: space.name,
+          special: [{ specialFolder: { name: 'image' }, id: fileId }]
+        })
 
         spacesStore.updateSpaceField({
           id: space.id.toString(),
           field: 'spaceImageData',
-          value: data.special.find((special) => special.specialFolder.name === 'image')
+          value: updatedSpace.spaceImageData
         })
         showMessage({ title: $gettext('Space icon was set successfully') })
-        eventBus.publish('app.files.spaces.uploaded-image', buildSpace(data))
+        eventBus.publish('app.files.spaces.uploaded-image', updatedSpace)
       } catch (error) {
         console.error(error)
         showErrorMessage({

--- a/packages/web-pkg/src/composables/piniaStores/spaces.ts
+++ b/packages/web-pkg/src/composables/piniaStores/spaces.ts
@@ -36,23 +36,20 @@ export const getSpacesByType = async ({
   driveType: string
   configStore: ConfigStore
 }) => {
-  const graphResponse = await graphClient.drives.listMyDrives(
-    'name asc',
-    `driveType eq ${driveType}`
-  )
-  if (!graphResponse.data) {
+  const mountpoints = await graphClient.drives.listMyDrives({
+    orderBy: 'name asc',
+    filter: `driveType eq ${driveType}`
+  })
+  if (!mountpoints.length) {
     return []
   }
 
-  const mountpoints = graphResponse.data.value.map((space) =>
-    buildSpace({ ...space, serverUrl: configStore.serverUrl })
-  )
   if (driveType !== 'mountpoint' || !configStore.options.routing?.fullShareOwnerPaths) {
     return mountpoints
   }
 
   const rootSpaceDriveAliasMapping: Record<string, string> = {}
-  graphResponse.data.value.forEach((space) => {
+  mountpoints.forEach((space) => {
     const { rootId, driveAlias } = space.root.remoteItem
     rootSpaceDriveAliasMapping[rootId] = driveAlias
   })

--- a/packages/web-pkg/src/composables/spaces/useCreateSpace.ts
+++ b/packages/web-pkg/src/composables/spaces/useCreateSpace.ts
@@ -1,22 +1,14 @@
-import { buildSpace, extractStorageId, SpaceResource } from '@ownclouders/web-client'
+import { extractStorageId, SpaceResource } from '@ownclouders/web-client'
 import { useClientService } from '../clientService'
-import { useConfigStore, useResourcesStore } from '../piniaStores'
+import { useResourcesStore } from '../piniaStores'
 
 export const useCreateSpace = () => {
   const clientService = useClientService()
-  const configStore = useConfigStore()
   const resourcesStore = useResourcesStore()
 
-  const createSpace = async (name: string) => {
+  const createSpace = (name: string) => {
     const { graphAuthenticated } = clientService
-    const { data: createdSpace } = await graphAuthenticated.drives.createDrive(
-      { name },
-      { params: { template: 'default' } }
-    )
-    return buildSpace({
-      ...createdSpace,
-      serverUrl: configStore.serverUrl
-    })
+    return graphAuthenticated.drives.createDrive({ name }, { params: { template: 'default' } })
   }
 
   const createDefaultMetaFolder = async (space: SpaceResource) => {

--- a/packages/web-pkg/tests/unit/components/Spaces/QuotaModal.spec.ts
+++ b/packages/web-pkg/tests/unit/components/Spaces/QuotaModal.spec.ts
@@ -1,23 +1,18 @@
 import QuotaModal from '../../../../src/components/Spaces/QuotaModal.vue'
-import {
-  defaultComponentMocks,
-  defaultPlugins,
-  defaultStubs,
-  mount,
-  mockAxiosResolve
-} from 'web-test-helpers'
+import { defaultComponentMocks, defaultPlugins, defaultStubs, mount } from 'web-test-helpers'
 import { useMessages, useSpacesStore } from '../../../../src/composables/piniaStores'
 import { SpaceResource } from '@ownclouders/web-client'
+import { mock } from 'vitest-mock-extended'
 
 describe('QuotaModal', () => {
   describe('method "editQuota"', () => {
     it('should show message on success', async () => {
       const { wrapper, mocks } = getWrapper()
       mocks.$clientService.graphAuthenticated.drives.updateDrive.mockResolvedValue(
-        mockAxiosResolve({
+        mock<SpaceResource>({
           id: '1fe58d8b-aa69-4c22-baf7-97dd57479f22',
           name: 'any',
-          quota: {
+          spaceQuota: {
             remaining: 9999999836,
             state: 'normal',
             total: 10000000000,

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsRestore.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsRestore.spec.ts
@@ -5,8 +5,6 @@ import { useMessages, useResourcesStore } from '../../../../../src/composables/p
 import { unref } from 'vue'
 import { HttpError, Resource, TrashResource } from '@ownclouders/web-client'
 import { ProjectSpaceResource, SpaceResource } from '@ownclouders/web-client'
-import { Drive } from '@ownclouders/web-client/graph/generated'
-import { AxiosResponse } from 'axios'
 import { useRestoreWorker } from '../../../../../src/composables/webWorkers/restoreWorker'
 
 vi.mock('../../../../../src/composables/webWorkers/restoreWorker')
@@ -191,9 +189,7 @@ function getWrapper({
   mocks.$clientService.webdav.listFiles.mockImplementation(() => {
     return Promise.resolve({ resource: mock<Resource>(), children: [] })
   })
-  mocks.$clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(
-    mock<AxiosResponse>({ data: { value: mock<Drive>() } })
-  )
+  mocks.$clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(mock<SpaceResource>())
 
   return {
     mocks,

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsSetImage.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsSetImage.spec.ts
@@ -2,12 +2,7 @@ import { useFileActionsSetImage } from '../../../../../src'
 import { useMessages } from '../../../../../src/composables/piniaStores'
 import { buildSpace, Resource, SpaceResource } from '@ownclouders/web-client'
 import { mock } from 'vitest-mock-extended'
-import {
-  defaultComponentMocks,
-  RouteLocation,
-  getComposableWrapper,
-  mockAxiosResolve
-} from 'web-test-helpers'
+import { defaultComponentMocks, RouteLocation, getComposableWrapper } from 'web-test-helpers'
 import { unref } from 'vue'
 import { Drive } from '@ownclouders/web-client/graph/generated'
 
@@ -101,14 +96,11 @@ describe('setImage', () => {
 
   describe('handler', () => {
     it('should show message on success', () => {
-      const driveMock = mock<Drive>({ special: [{ specialFolder: { name: 'image' } }] })
-
       const space = mock<SpaceResource>({ id: '1' })
+
       getWrapper({
         setup: async ({ actions }, { clientService }) => {
-          clientService.graphAuthenticated.drives.updateDrive.mockResolvedValue(
-            mockAxiosResolve(driveMock)
-          )
+          clientService.graphAuthenticated.drives.updateDrive.mockResolvedValue(space)
           await unref(actions)[0].handler({
             space,
             resources: [

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsSetReadme.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsSetReadme.spec.ts
@@ -2,13 +2,7 @@ import { useFileActionsSetReadme } from '../../../../../src'
 import { useMessages } from '../../../../../src/composables/piniaStores'
 import { buildSpace, FileResource, SpaceResource } from '@ownclouders/web-client'
 import { mock } from 'vitest-mock-extended'
-
-import {
-  defaultComponentMocks,
-  RouteLocation,
-  getComposableWrapper,
-  mockAxiosResolve
-} from 'web-test-helpers'
+import { defaultComponentMocks, RouteLocation, getComposableWrapper } from 'web-test-helpers'
 import { unref } from 'vue'
 import { GetFileContentsResponse } from '@ownclouders/web-client/webdav'
 import { Drive } from '@ownclouders/web-client/graph/generated'
@@ -173,22 +167,20 @@ function getWrapper({
   )
 
   mocks.$clientService.graphAuthenticated.drives.updateDrive.mockResolvedValue(
-    mockAxiosResolve({
+    mock<SpaceResource>({
       id: '1',
       name: 'space',
-      special: [
-        {
-          eTag: '6721ccbd5754e8b46ddccebad12fa23f',
-          file: {
-            mimeType: 'text/markdown'
-          },
-          id: '1',
-          name: 'readme.md',
-          specialFolder: {
-            name: 'readme'
-          }
+      spaceReadmeData: {
+        eTag: '6721ccbd5754e8b46ddccebad12fa23f',
+        file: {
+          mimeType: 'text/markdown'
+        },
+        id: '1',
+        name: 'readme.md',
+        specialFolder: {
+          name: 'readme'
         }
-      ]
+      }
     })
   )
 

--- a/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsDelete.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsDelete.spec.ts
@@ -1,12 +1,7 @@
 import { useSpaceActionsDelete } from '../../../../../src/composables/actions'
 import { useMessages, useModals } from '../../../../../src/composables/piniaStores'
 import { buildSpace, SpaceResource } from '@ownclouders/web-client'
-import {
-  defaultComponentMocks,
-  mockAxiosResolve,
-  RouteLocation,
-  getComposableWrapper
-} from 'web-test-helpers'
+import { defaultComponentMocks, RouteLocation, getComposableWrapper } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
 import { unref } from 'vue'
 import { Drive } from '@ownclouders/web-client/graph/generated'
@@ -104,7 +99,7 @@ describe('delete', () => {
     it('should show message on success', () => {
       getWrapper({
         setup: async ({ deleteSpaces }, { clientService }) => {
-          clientService.graphAuthenticated.drives.deleteDrive.mockResolvedValue(mockAxiosResolve())
+          clientService.graphAuthenticated.drives.deleteDrive.mockResolvedValue()
 
           await deleteSpaces([
             mock<SpaceResource>({ id: '1', canBeDeleted: () => true, driveType: 'project' })

--- a/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsDisable.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsDisable.spec.ts
@@ -1,12 +1,7 @@
 import { useSpaceActionsDisable } from '../../../../../src/composables/actions/spaces'
 import { useMessages, useModals } from '../../../../../src/composables/piniaStores'
 import { buildSpace, SpaceResource } from '@ownclouders/web-client'
-import {
-  defaultComponentMocks,
-  mockAxiosResolve,
-  RouteLocation,
-  getComposableWrapper
-} from 'web-test-helpers'
+import { defaultComponentMocks, RouteLocation, getComposableWrapper } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
 import { unref } from 'vue'
 import { Drive } from '@ownclouders/web-client/graph/generated'
@@ -102,7 +97,7 @@ describe('disable', () => {
     it('should show message on success', () => {
       getWrapper({
         setup: async ({ disableSpaces }, { clientService }) => {
-          clientService.graphAuthenticated.drives.disableDrive.mockResolvedValue(mockAxiosResolve())
+          clientService.graphAuthenticated.drives.disableDrive.mockResolvedValue()
           await disableSpaces([
             mock<SpaceResource>({ id: '1', canDisable: () => true, driveType: 'project' })
           ])

--- a/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsDuplicate.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsDuplicate.spec.ts
@@ -1,12 +1,7 @@
 import { useSpaceActionsDuplicate } from '../../../../../src/composables/actions/spaces'
 import { AbilityRule, SpaceResource } from '@ownclouders/web-client'
 import { mock } from 'vitest-mock-extended'
-import {
-  defaultComponentMocks,
-  mockAxiosResolve,
-  RouteLocation,
-  getComposableWrapper
-} from 'web-test-helpers'
+import { defaultComponentMocks, RouteLocation, getComposableWrapper } from 'web-test-helpers'
 import { unref } from 'vue'
 import { ListFilesResult } from '@ownclouders/web-client/webdav'
 import {
@@ -109,10 +104,9 @@ describe('restore', () => {
       getWrapper({
         setup: async ({ duplicateSpace }, { clientService }) => {
           clientService.graphAuthenticated.drives.createDrive.mockResolvedValue(
-            mockAxiosResolve({
+            mock<SpaceResource>({
               id: '1',
-              name: 'Moon (1)',
-              special: []
+              name: 'Moon (1)'
             })
           )
           clientService.webdav.listFiles.mockResolvedValue({ children: [] } as ListFilesResult)
@@ -139,10 +133,9 @@ describe('restore', () => {
         currentRouteName: 'files-spaces-projects',
         setup: async ({ duplicateSpace }, { clientService }) => {
           clientService.graphAuthenticated.drives.createDrive.mockResolvedValue(
-            mockAxiosResolve({
+            mock<SpaceResource>({
               id: '1',
-              name: 'Moon (1)',
-              special: []
+              name: 'Moon (1)'
             })
           )
           clientService.webdav.listFiles.mockResolvedValue({ children: [] } as ListFilesResult)

--- a/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsEditDescription.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsEditDescription.spec.ts
@@ -1,11 +1,6 @@
 import { useSpaceActionsEditDescription } from '../../../../../src/composables/actions'
 import { useMessages, useModals } from '../../../../../src/composables/piniaStores'
-import {
-  defaultComponentMocks,
-  mockAxiosResolve,
-  RouteLocation,
-  getComposableWrapper
-} from 'web-test-helpers'
+import { defaultComponentMocks, RouteLocation, getComposableWrapper } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
 import { unref } from 'vue'
 import { SpaceResource } from '@ownclouders/web-client'
@@ -38,7 +33,9 @@ describe('editDescription', () => {
     it('should show message on success', () => {
       getWrapper({
         setup: async ({ editDescriptionSpace }, { clientService }) => {
-          clientService.graphAuthenticated.drives.updateDrive.mockResolvedValue(mockAxiosResolve())
+          clientService.graphAuthenticated.drives.updateDrive.mockResolvedValue(
+            mock<SpaceResource>()
+          )
           await editDescriptionSpace(mock<SpaceResource>(), 'doesntmatter')
 
           const { showMessage } = useMessages()

--- a/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsRename.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsRename.spec.ts
@@ -1,12 +1,7 @@
 import { useSpaceActionsRename } from '../../../../../src/composables/actions/spaces'
 import { useMessages, useModals } from '../../../../../src/composables/piniaStores'
 import { mock } from 'vitest-mock-extended'
-import {
-  defaultComponentMocks,
-  mockAxiosResolve,
-  RouteLocation,
-  getComposableWrapper
-} from 'web-test-helpers'
+import { defaultComponentMocks, RouteLocation, getComposableWrapper } from 'web-test-helpers'
 import { unref } from 'vue'
 import { SpaceResource } from '@ownclouders/web-client'
 
@@ -39,7 +34,9 @@ describe('rename', () => {
     it('should show message on success', () => {
       getWrapper({
         setup: async ({ renameSpace }, { clientService }) => {
-          clientService.graphAuthenticated.drives.updateDrive.mockResolvedValue(mockAxiosResolve())
+          clientService.graphAuthenticated.drives.updateDrive.mockResolvedValue(
+            mock<SpaceResource>()
+          )
           await renameSpace(mock<SpaceResource>({ id: '1' }), 'renamed space')
 
           const { showMessage } = useMessages()

--- a/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsRestore.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsRestore.spec.ts
@@ -1,12 +1,7 @@
 import { useSpaceActionsRestore } from '../../../../../src/composables/actions/spaces'
 import { buildSpace, SpaceResource } from '@ownclouders/web-client'
 import { mock } from 'vitest-mock-extended'
-import {
-  defaultComponentMocks,
-  mockAxiosResolve,
-  RouteLocation,
-  getComposableWrapper
-} from 'web-test-helpers'
+import { defaultComponentMocks, RouteLocation, getComposableWrapper } from 'web-test-helpers'
 import { unref } from 'vue'
 import { Drive } from '@ownclouders/web-client/graph/generated'
 import { useMessages, useModals } from '../../../../../src/composables/piniaStores'
@@ -102,7 +97,9 @@ describe('restore', () => {
     it('should show message on success', () => {
       getWrapper({
         setup: async ({ restoreSpaces }, { clientService }) => {
-          clientService.graphAuthenticated.drives.updateDrive.mockResolvedValue(mockAxiosResolve())
+          clientService.graphAuthenticated.drives.updateDrive.mockResolvedValue(
+            mock<SpaceResource>()
+          )
           await restoreSpaces([mock<SpaceResource>({ id: '1', canRestore: () => true })])
 
           const { showMessage } = useMessages()

--- a/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsSetIcon.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsSetIcon.spec.ts
@@ -1,11 +1,6 @@
 import { useSpaceActionsSetIcon } from '../../../../../src/composables/actions/spaces/useSpaceActionsSetIcon'
 import { useMessages, useModals } from '../../../../../src/composables/piniaStores'
-import {
-  defaultComponentMocks,
-  mockAxiosResolve,
-  RouteLocation,
-  getComposableWrapper
-} from 'web-test-helpers'
+import { defaultComponentMocks, RouteLocation, getComposableWrapper } from 'web-test-helpers'
 import { unref } from 'vue'
 import { SpaceResource } from '@ownclouders/web-client'
 import { mock } from 'vitest-mock-extended'
@@ -91,7 +86,9 @@ describe('setIcon', () => {
     it('should show message on success', () => {
       getWrapper({
         setup: async ({ setIconSpace }, { clientService }) => {
-          clientService.graphAuthenticated.drives.updateDrive.mockResolvedValue(mockAxiosResolve())
+          clientService.graphAuthenticated.drives.updateDrive.mockResolvedValue(
+            mock<SpaceResource>()
+          )
           await setIconSpace(mock<SpaceResource>(), '🐻')
 
           const { showMessage } = useMessages()

--- a/packages/web-pkg/tests/unit/composables/piniaStores/spaces.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/piniaStores/spaces.spec.ts
@@ -16,7 +16,6 @@ import {
 import { Graph } from '@ownclouders/web-client/graph'
 import {
   CollectionOfPermissionsWithAllowedValues,
-  Drive,
   Permission,
   User
 } from '@ownclouders/web-client/graph/generated'
@@ -187,22 +186,20 @@ describe('spaces', () => {
     it('correctly loads personal and project spaces', () => {
       getWrapper({
         setup: async (instance) => {
-          const drives = [mock<Drive>({ id: '1' })]
+          const spaces = [mock<SpaceResource>({ id: '1' })]
           const graphClient = mockDeep<Graph>()
-          graphClient.drives.listMyDrives.mockResolvedValue(mockAxiosResolve({ value: drives }))
+          graphClient.drives.listMyDrives.mockResolvedValue(spaces)
           await instance.loadSpaces({ graphClient })
 
           expect(graphClient.drives.listMyDrives).toHaveBeenCalledTimes(2)
-          expect(graphClient.drives.listMyDrives).toHaveBeenNthCalledWith(
-            1,
-            'name asc',
-            'driveType eq personal'
-          )
-          expect(graphClient.drives.listMyDrives).toHaveBeenNthCalledWith(
-            2,
-            'name asc',
-            'driveType eq project'
-          )
+          expect(graphClient.drives.listMyDrives).toHaveBeenNthCalledWith(1, {
+            orderBy: 'name asc',
+            filter: 'driveType eq personal'
+          })
+          expect(graphClient.drives.listMyDrives).toHaveBeenNthCalledWith(2, {
+            orderBy: 'name asc',
+            filter: 'driveType eq project'
+          })
           expect(instance.spaces.length).toBe(2)
           expect(instance.spacesLoading).toBeFalsy()
           expect(instance.spacesInitialized).toBeTruthy()
@@ -214,16 +211,16 @@ describe('spaces', () => {
     it('correctly loads mount points', () => {
       getWrapper({
         setup: async (instance) => {
-          const drives = [mock<Drive>({ id: '1' })]
+          const spaces = [mock<SpaceResource>({ id: '1' })]
           const graphClient = mockDeep<Graph>()
-          graphClient.drives.listMyDrives.mockResolvedValue(mockAxiosResolve({ value: drives }))
+          graphClient.drives.listMyDrives.mockResolvedValue(spaces)
           await instance.loadMountPoints({ graphClient })
 
           expect(graphClient.drives.listMyDrives).toHaveBeenCalledTimes(1)
-          expect(graphClient.drives.listMyDrives).toHaveBeenCalledWith(
-            'name asc',
-            'driveType eq mountpoint'
-          )
+          expect(graphClient.drives.listMyDrives).toHaveBeenCalledWith({
+            orderBy: 'name asc',
+            filter: 'driveType eq mountpoint'
+          })
           expect(instance.spaces.length).toBe(1)
           expect(instance.mountPointsInitialized).toBeTruthy()
         }
@@ -234,16 +231,16 @@ describe('spaces', () => {
     it('correctly reloads project spaces', () => {
       getWrapper({
         setup: async (instance) => {
-          const drives = [mock<Drive>({ id: '1' })]
+          const spaces = [mock<SpaceResource>({ id: '1' })]
           const graphClient = mockDeep<Graph>()
-          graphClient.drives.listMyDrives.mockResolvedValue(mockAxiosResolve({ value: drives }))
+          graphClient.drives.listMyDrives.mockResolvedValue(spaces)
           await instance.reloadProjectSpaces({ graphClient })
 
           expect(graphClient.drives.listMyDrives).toHaveBeenCalledTimes(1)
-          expect(graphClient.drives.listMyDrives).toHaveBeenCalledWith(
-            'name asc',
-            'driveType eq project'
-          )
+          expect(graphClient.drives.listMyDrives).toHaveBeenCalledWith({
+            orderBy: 'name asc',
+            filter: 'driveType eq project'
+          })
           expect(instance.spaces.length).toBe(1)
         }
       })

--- a/packages/web-runtime/src/container/sse/shares.ts
+++ b/packages/web-runtime/src/container/sse/shares.ts
@@ -150,8 +150,8 @@ export const onSSEShareCreatedEvent = async ({
 
   if (isLocationSharesActive(router, 'files-shares-with-me')) {
     // FIXME: get drive item by id as soon as server supports it
-    const { data } = await clientService.graphAuthenticated.drives.listSharedWithMe()
-    const driveItem = data.value.find(({ remoteItem }) => remoteItem.id === sseData.itemid)
+    const driveItems = await clientService.graphAuthenticated.driveItems.listSharedWithMe()
+    const driveItem = driveItems.find(({ remoteItem }) => remoteItem.id === sseData.itemid)
     if (!driveItem) {
       return
     }
@@ -161,8 +161,8 @@ export const onSSEShareCreatedEvent = async ({
 
   if (isLocationSharesActive(router, 'files-shares-with-others')) {
     // FIXME: get drive item by id as soon as server supports it
-    const { data } = await clientService.graphAuthenticated.drives.listSharedByMe()
-    const driveItem = data.value.find(({ id }) => id === sseData.itemid)
+    const driveItems = await clientService.graphAuthenticated.driveItems.listSharedByMe()
+    const driveItem = driveItems.find(({ id }) => id === sseData.itemid)
     if (!driveItem) {
       return
     }
@@ -193,8 +193,8 @@ export const onSSEShareUpdatedEvent = async ({
 
   if (isLocationSharesActive(router, 'files-shares-with-me')) {
     // FIXME: get drive item by id as soon as server supports it
-    const { data } = await clientService.graphAuthenticated.drives.listSharedWithMe()
-    const driveItem = data.value.find(({ remoteItem }) => remoteItem.id === sseData.itemid)
+    const driveItems = await clientService.graphAuthenticated.driveItems.listSharedWithMe()
+    const driveItem = driveItems.find(({ remoteItem }) => remoteItem.id === sseData.itemid)
     if (!driveItem) {
       return
     }
@@ -332,8 +332,8 @@ export const onSSELinkCreatedEvent = async ({
 
   if (isLocationSharesActive(router, 'files-shares-via-link')) {
     // FIXME: get drive item by id as soon as server supports it
-    const { data } = await clientService.graphAuthenticated.drives.listSharedByMe()
-    const driveItem = data.value.find(({ id }) => id === sseData.itemid)
+    const driveItems = await clientService.graphAuthenticated.driveItems.listSharedByMe()
+    const driveItem = driveItems.find(({ id }) => id === sseData.itemid)
     if (!driveItem) {
       return
     }

--- a/packages/web-runtime/src/container/sse/shares.ts
+++ b/packages/web-runtime/src/container/sse/shares.ts
@@ -1,7 +1,6 @@
 import {
   buildIncomingShareResource,
   buildOutgoingShareResource,
-  buildSpace,
   ShareTypes
 } from '@ownclouders/web-client'
 import {
@@ -25,8 +24,7 @@ export const onSSESpaceMemberAddedEvent = async ({
     return
   }
 
-  const { data } = await clientService.graphAuthenticated.drives.getDrive(sseData.itemid)
-  const space = buildSpace(data)
+  const space = await clientService.graphAuthenticated.drives.getDrive(sseData.itemid)
   spacesStore.upsertSpace(space)
 
   if (!isLocationSpacesActive(router, 'files-spaces-projects')) {
@@ -52,8 +50,7 @@ export const onSSESpaceMemberRemovedEvent = async ({
   }
 
   if (!sseData.affecteduserids?.includes(userStore.user.id)) {
-    const { data } = await clientService.graphAuthenticated.drives.getDrive(sseData.itemid)
-    const space = buildSpace(data)
+    const space = await clientService.graphAuthenticated.drives.getDrive(sseData.itemid)
     return spacesStore.upsertSpace(space)
   }
 
@@ -96,8 +93,7 @@ export const onSSESpaceShareUpdatedEvent = async ({
     return
   }
 
-  const { data } = await clientService.graphAuthenticated.drives.getDrive(sseData.itemid)
-  const space = buildSpace(data)
+  const space = await clientService.graphAuthenticated.drives.getDrive(sseData.itemid)
   spacesStore.upsertSpace(space)
 
   if (

--- a/packages/web-runtime/src/pages/resolvePrivateLink.vue
+++ b/packages/web-runtime/src/pages/resolvePrivateLink.vue
@@ -54,14 +54,12 @@ import {
   useClientService
 } from '@ownclouders/web-pkg'
 import { unref, defineComponent, computed, onMounted, ref, Ref } from 'vue'
-// import { createLocationSpaces } from 'web-app-files/src/router'
 import { dirname } from 'path'
 import { createFileRouteOptions, useGetResourceContext } from '@ownclouders/web-pkg'
 import { useTask } from 'vue-concurrency'
 import { isShareSpaceResource, Resource, SHARE_JAIL_ID } from '@ownclouders/web-client'
 import { RouteLocationNamedRaw } from 'vue-router'
 import { useGettext } from 'vue3-gettext'
-import { DriveItem } from '@ownclouders/web-client/graph/generated'
 
 export default defineComponent({
   name: 'ResolvePrivateLink',
@@ -124,10 +122,8 @@ export default defineComponent({
         resourceIsNestedInShare = path !== '/'
         if (!resourceIsNestedInShare) {
           // FIXME: get drive item by id as soon as server supports it
-          const { data } = yield clientService.graphAuthenticated.drives.listSharedWithMe()
-          const share = (data.value as DriveItem[]).find(
-            ({ remoteItem }) => remoteItem.id === resource.id
-          )
+          const driveItems = yield clientService.graphAuthenticated.driveItems.listSharedWithMe()
+          const share = driveItems.find(({ remoteItem }) => remoteItem.id === resource.id)
 
           isHiddenShare = share?.['@UI.Hidden']
         }

--- a/packages/web-runtime/tests/unit/container/sse/shares.spec.ts
+++ b/packages/web-runtime/tests/unit/container/sse/shares.spec.ts
@@ -20,8 +20,8 @@ import {
   onSSESpaceShareUpdatedEvent
 } from '../../../../src/container/sse'
 import { mock, mockDeep } from 'vitest-mock-extended'
-import { Drive, DriveItem, User } from '@ownclouders/web-client/graph/generated'
-import { ShareTypes, buildSpace, Resource, SpaceResource } from '@ownclouders/web-client'
+import { DriveItem, User } from '@ownclouders/web-client/graph/generated'
+import { ShareTypes, Resource, SpaceResource } from '@ownclouders/web-client'
 import { createTestingPinia, mockAxiosResolve, defaultComponentMocks } from 'web-test-helpers'
 import { Language } from 'vue3-gettext'
 import PQueue from 'p-queue'
@@ -31,52 +31,40 @@ import { RouteLocation } from 'vue-router'
 describe('shares events', () => {
   describe('onSSESpaceMemberAddedEvent', () => {
     it('calls "upsertSpace" when space member has been added', async () => {
-      const drive = mockDeep<Drive>({ id: 'space1', root: { permissions: [] } })
+      const space = mock<SpaceResource>({ id: 'space1' })
       const mocks = getMocks({ currentRouteFilesSpacesGeneric: true })
       const sseData = mock<EventSchemaType>({
-        itemid: drive.id,
-        spaceid: drive.id
+        itemid: space.id,
+        spaceid: space.id
       })
-      mocks.clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(
-        mockDeep<AxiosResponse>({
-          data: drive
-        })
-      )
+      mocks.clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(space)
       await onSSESpaceMemberAddedEvent({ sseData, ...mocks })
       expect(mocks.clientService.graphAuthenticated.drives.getDrive).toHaveBeenCalled()
       expect(mocks.spacesStore.upsertSpace).toHaveBeenCalled()
       expect(mocks.resourcesStore.upsertResource).not.toHaveBeenCalled()
     })
     it('calls "upsertResource" when space member has been added and current route equals "files-spaces-projects"', async () => {
-      const drive = mockDeep<Drive>({ id: 'space1', root: { permissions: [] } })
+      const space = mock<SpaceResource>({ id: 'space1' })
       const mocks = getMocks({ currentRouteFilesSpacesProjects: true })
       const sseData = mock<EventSchemaType>({
-        itemid: drive.id,
-        spaceid: drive.id
+        itemid: space.id,
+        spaceid: space.id
       })
-      mocks.clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(
-        mockDeep<AxiosResponse>({
-          data: drive
-        })
-      )
+      mocks.clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(space)
       await onSSESpaceMemberAddedEvent({ sseData, ...mocks })
       expect(mocks.clientService.graphAuthenticated.drives.getDrive).toHaveBeenCalled()
       expect(mocks.spacesStore.upsertSpace).toHaveBeenCalled()
       expect(mocks.resourcesStore.upsertResource).toHaveBeenCalled()
     })
     it('does not trigger any action when initiator ids are identical', async () => {
-      const drive = mockDeep<Drive>({ id: 'space1', root: { permissions: [] } })
+      const space = mock<SpaceResource>({ id: 'space1' })
       const mocks = getMocks({ currentRouteFilesSpacesProjects: true })
       const sseData = mock<EventSchemaType>({
-        itemid: drive.id,
-        spaceid: drive.id,
+        itemid: space.id,
+        spaceid: space.id,
         initiatorid: 'local1'
       })
-      mocks.clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(
-        mock<AxiosResponse>({
-          data: drive
-        })
-      )
+      mocks.clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(space)
       await onSSESpaceMemberAddedEvent({ sseData, ...mocks })
       expect(mocks.clientService.graphAuthenticated.drives.getDrive).not.toHaveBeenCalled()
       expect(mocks.spacesStore.upsertSpace).not.toHaveBeenCalled()
@@ -85,18 +73,14 @@ describe('shares events', () => {
   })
   describe('onSSESpaceMemberRemovedEvent', () => {
     it('calls "upsertSpace" when space member has been removed and current user is not affected', async () => {
-      const drive = mockDeep<Drive>({ id: 'space1', root: { permissions: [] } })
+      const space = mock<SpaceResource>({ id: 'space1' })
       const mocks = getMocks()
       const sseData = mock<EventSchemaType>({
-        itemid: drive.id,
-        spaceid: drive.id,
+        itemid: space.id,
+        spaceid: space.id,
         affecteduserids: ['2']
       })
-      mocks.clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(
-        mockDeep<AxiosResponse>({
-          data: drive
-        })
-      )
+      mocks.clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(space)
       await onSSESpaceMemberRemovedEvent({ sseData, ...mocks })
       expect(mocks.clientService.graphAuthenticated.drives.getDrive).toHaveBeenCalled()
       expect(mocks.spacesStore.upsertSpace).toHaveBeenCalled()
@@ -104,18 +88,14 @@ describe('shares events', () => {
       expect(mocks.messageStore.showMessage).not.toHaveBeenCalled()
     })
     it('calls "removeSpace" when space member has been removed and current user is affected', async () => {
-      const drive = mockDeep<Drive>({ id: 'space1', root: { permissions: [] } })
-      const mocks = getMocks({ currentRouteFilesSpacesProjects: true, spaces: [buildSpace(drive)] })
+      const space = mock<SpaceResource>({ id: 'space1' })
+      const mocks = getMocks({ currentRouteFilesSpacesProjects: true, spaces: [space] })
       const sseData = mock<EventSchemaType>({
-        itemid: drive.id,
-        spaceid: drive.id,
+        itemid: space.id,
+        spaceid: space.id,
         affecteduserids: ['1']
       })
-      mocks.clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(
-        mock<AxiosResponse>({
-          data: drive
-        })
-      )
+      mocks.clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(space)
       await onSSESpaceMemberRemovedEvent({ sseData, ...mocks })
       expect(mocks.clientService.graphAuthenticated.drives.getDrive).not.toHaveBeenCalled()
       expect(mocks.spacesStore.upsertSpace).not.toHaveBeenCalled()
@@ -123,18 +103,14 @@ describe('shares events', () => {
       expect(mocks.messageStore.showMessage).not.toHaveBeenCalled()
     })
     it('calls "showMessage" when space member has been removed and current user is affected and navigated to space', async () => {
-      const drive = mockDeep<Drive>({ id: 'space1', root: { permissions: [] } })
-      const mocks = getMocks({ currentRouteFilesSpacesGeneric: true, spaces: [buildSpace(drive)] })
+      const space = mock<SpaceResource>({ id: 'space1' })
+      const mocks = getMocks({ currentRouteFilesSpacesGeneric: true, spaces: [space] })
       const sseData = mock<EventSchemaType>({
-        itemid: drive.id,
-        spaceid: drive.id,
+        itemid: space.id,
+        spaceid: space.id,
         affecteduserids: ['1']
       })
-      mocks.clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(
-        mock<AxiosResponse>({
-          data: drive
-        })
-      )
+      mocks.clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(space)
       await onSSESpaceMemberRemovedEvent({ sseData, ...mocks })
       expect(mocks.clientService.graphAuthenticated.drives.getDrive).not.toHaveBeenCalled()
       expect(mocks.spacesStore.upsertSpace).not.toHaveBeenCalled()
@@ -142,19 +118,15 @@ describe('shares events', () => {
       expect(mocks.messageStore.showMessage).toHaveBeenCalled()
     })
     it('does not trigger any action when initiator ids are identical', async () => {
-      const drive = mockDeep<Drive>({ id: 'space1', root: { permissions: [] } })
-      const mocks = getMocks({ currentRouteFilesSpacesProjects: true, spaces: [buildSpace(drive)] })
+      const space = mock<SpaceResource>({ id: 'space1' })
+      const mocks = getMocks({ currentRouteFilesSpacesProjects: true, spaces: [space] })
       const sseData = mock<EventSchemaType>({
-        itemid: drive.id,
-        spaceid: drive.id,
+        itemid: space.id,
+        spaceid: space.id,
         affecteduserids: ['1'],
         initiatorid: 'local1'
       })
-      mocks.clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(
-        mock<AxiosResponse>({
-          data: drive
-        })
-      )
+      mocks.clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(space)
       await onSSESpaceMemberRemovedEvent({ sseData, ...mocks })
       expect(mocks.clientService.graphAuthenticated.drives.getDrive).not.toHaveBeenCalled()
       expect(mocks.spacesStore.upsertSpace).not.toHaveBeenCalled()
@@ -164,18 +136,14 @@ describe('shares events', () => {
   })
   describe('onSSESpaceShareUpdatedEvent', () => {
     it('calls "upsertSpace" when space share has been updated', async () => {
-      const drive = mockDeep<Drive>({ id: 'space1', root: { permissions: [] } })
+      const space = mock<SpaceResource>({ id: 'space1' })
       const mocks = getMocks()
       const sseData = mock<EventSchemaType>({
-        itemid: drive.id,
-        spaceid: drive.id,
+        itemid: space.id,
+        spaceid: space.id,
         affecteduserids: ['2']
       })
-      mocks.clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(
-        mockDeep<AxiosResponse>({
-          data: drive
-        })
-      )
+      mocks.clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(space)
       const busStub = vi.spyOn(eventBus, 'publish')
       await onSSESpaceShareUpdatedEvent({ sseData, ...mocks })
       expect(mocks.clientService.graphAuthenticated.drives.getDrive).toHaveBeenCalled()
@@ -183,18 +151,14 @@ describe('shares events', () => {
       expect(busStub).not.toHaveBeenCalled()
     })
     it('calls "eventBus.publish" when space share has been updated and current user is affected and navigated to space', async () => {
-      const drive = mockDeep<Drive>({ id: 'space1', root: { permissions: [] } })
-      const mocks = getMocks({ currentRouteFilesSpacesGeneric: true, spaces: [buildSpace(drive)] })
+      const space = mock<SpaceResource>({ id: 'space1' })
+      const mocks = getMocks({ currentRouteFilesSpacesGeneric: true, spaces: [space] })
       const sseData = mock<EventSchemaType>({
-        itemid: drive.id,
-        spaceid: drive.id,
+        itemid: space.id,
+        spaceid: space.id,
         affecteduserids: ['1']
       })
-      mocks.clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(
-        mock<AxiosResponse>({
-          data: drive
-        })
-      )
+      mocks.clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(space)
       const busStub = vi.spyOn(eventBus, 'publish')
       await onSSESpaceShareUpdatedEvent({ sseData, ...mocks })
       expect(mocks.clientService.graphAuthenticated.drives.getDrive).toHaveBeenCalled()
@@ -202,19 +166,15 @@ describe('shares events', () => {
       expect(busStub).toHaveBeenCalled()
     })
     it('does not trigger any action when initiator ids are identical', async () => {
-      const drive = mockDeep<Drive>({ id: 'space1', root: { permissions: [] } })
-      const mocks = getMocks({ currentRouteFilesSpacesGeneric: true, spaces: [buildSpace(drive)] })
+      const space = mock<SpaceResource>({ id: 'space1' })
+      const mocks = getMocks({ currentRouteFilesSpacesGeneric: true, spaces: [space] })
       const sseData = mock<EventSchemaType>({
-        itemid: drive.id,
-        spaceid: drive.id,
+        itemid: space.id,
+        spaceid: space.id,
         affecteduserids: ['1'],
         initiatorid: 'local1'
       })
-      mocks.clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(
-        mock<AxiosResponse>({
-          data: drive
-        })
-      )
+      mocks.clientService.graphAuthenticated.drives.getDrive.mockResolvedValue(space)
       const busStub = vi.spyOn(eventBus, 'publish')
       await onSSESpaceShareUpdatedEvent({ sseData, ...mocks })
       expect(mocks.clientService.graphAuthenticated.drives.getDrive).not.toHaveBeenCalled()

--- a/packages/web-runtime/tests/unit/container/sse/shares.spec.ts
+++ b/packages/web-runtime/tests/unit/container/sse/shares.spec.ts
@@ -22,10 +22,9 @@ import {
 import { mock, mockDeep } from 'vitest-mock-extended'
 import { DriveItem, User } from '@ownclouders/web-client/graph/generated'
 import { ShareTypes, Resource, SpaceResource } from '@ownclouders/web-client'
-import { createTestingPinia, mockAxiosResolve, defaultComponentMocks } from 'web-test-helpers'
+import { createTestingPinia, defaultComponentMocks } from 'web-test-helpers'
 import { Language } from 'vue3-gettext'
 import PQueue from 'p-queue'
-import { AxiosResponse } from 'axios'
 import { RouteLocation } from 'vue-router'
 
 describe('shares events', () => {
@@ -203,8 +202,12 @@ describe('shares events', () => {
       expect(mocks.clientService.webdav.getFileInfo).toHaveBeenCalled()
       expect(mocks.resourcesStore.upsertResource).toHaveBeenCalled()
       expect(mocks.resourcesStore.updateResourceField).toHaveBeenCalled()
-      expect(mocks.clientService.graphAuthenticated.drives.listSharedWithMe).not.toHaveBeenCalled()
-      expect(mocks.clientService.graphAuthenticated.drives.listSharedByMe).not.toHaveBeenCalled()
+      expect(
+        mocks.clientService.graphAuthenticated.driveItems.listSharedWithMe
+      ).not.toHaveBeenCalled()
+      expect(
+        mocks.clientService.graphAuthenticated.driveItems.listSharedByMe
+      ).not.toHaveBeenCalled()
     })
 
     it('calls "upsertResource" when resource has been shared and current route equals "files-shares-with-me"', async () => {
@@ -222,17 +225,17 @@ describe('shares events', () => {
       const sseData = mock<EventSchemaType>({
         itemid: sharedDrive.remoteItem.id
       })
-      mocks.clientService.graphAuthenticated.drives.listSharedWithMe.mockResolvedValue(
-        mockAxiosResolve({
-          value: [sharedDrive]
-        })
-      )
+      mocks.clientService.graphAuthenticated.driveItems.listSharedWithMe.mockResolvedValue([
+        sharedDrive
+      ])
       await onSSEShareCreatedEvent({ sseData, ...mocks })
-      expect(mocks.clientService.graphAuthenticated.drives.listSharedWithMe).toHaveBeenCalled()
+      expect(mocks.clientService.graphAuthenticated.driveItems.listSharedWithMe).toHaveBeenCalled()
       expect(mocks.resourcesStore.upsertResource).toHaveBeenCalled()
       expect(mocks.resourcesStore.updateResourceField).not.toHaveBeenCalled()
       expect(mocks.clientService.webdav.getFileInfo).not.toHaveBeenCalled()
-      expect(mocks.clientService.graphAuthenticated.drives.listSharedByMe).not.toHaveBeenCalled()
+      expect(
+        mocks.clientService.graphAuthenticated.driveItems.listSharedByMe
+      ).not.toHaveBeenCalled()
     })
     it('calls "upsertResource" when resource has been shared and current route equals "files-shares-with-others"', async () => {
       const sharedDrive = mockDeep<DriveItem>({
@@ -246,17 +249,17 @@ describe('shares events', () => {
       const sseData = mock<EventSchemaType>({
         itemid: sharedDrive.id
       })
-      mocks.clientService.graphAuthenticated.drives.listSharedByMe.mockResolvedValue(
-        mockDeep<AxiosResponse>({
-          data: { value: [sharedDrive] }
-        })
-      )
+      mocks.clientService.graphAuthenticated.driveItems.listSharedByMe.mockResolvedValue([
+        sharedDrive
+      ])
       await onSSEShareCreatedEvent({ sseData, ...mocks })
-      expect(mocks.clientService.graphAuthenticated.drives.listSharedByMe).toHaveBeenCalled()
+      expect(mocks.clientService.graphAuthenticated.driveItems.listSharedByMe).toHaveBeenCalled()
       expect(mocks.resourcesStore.upsertResource).toHaveBeenCalled()
       expect(mocks.resourcesStore.updateResourceField).not.toHaveBeenCalled()
       expect(mocks.clientService.webdav.getFileInfo).not.toHaveBeenCalled()
-      expect(mocks.clientService.graphAuthenticated.drives.listSharedWithMe).not.toHaveBeenCalled()
+      expect(
+        mocks.clientService.graphAuthenticated.driveItems.listSharedWithMe
+      ).not.toHaveBeenCalled()
     })
     it('does not trigger any action when initiator ids are identical', async () => {
       const sharedResource = mock<Resource>({
@@ -276,8 +279,12 @@ describe('shares events', () => {
       expect(mocks.clientService.webdav.getFileInfo).not.toHaveBeenCalled()
       expect(mocks.resourcesStore.upsertResource).not.toHaveBeenCalled()
       expect(mocks.resourcesStore.updateResourceField).not.toHaveBeenCalled()
-      expect(mocks.clientService.graphAuthenticated.drives.listSharedWithMe).not.toHaveBeenCalled()
-      expect(mocks.clientService.graphAuthenticated.drives.listSharedByMe).not.toHaveBeenCalled()
+      expect(
+        mocks.clientService.graphAuthenticated.driveItems.listSharedWithMe
+      ).not.toHaveBeenCalled()
+      expect(
+        mocks.clientService.graphAuthenticated.driveItems.listSharedByMe
+      ).not.toHaveBeenCalled()
     })
   })
   describe('onSSEShareUpdatedEvent', () => {
@@ -296,7 +303,9 @@ describe('shares events', () => {
       const busStub = vi.spyOn(eventBus, 'publish')
       await onSSEShareUpdatedEvent({ sseData, ...mocks })
       expect(busStub).toHaveBeenCalled()
-      expect(mocks.clientService.graphAuthenticated.drives.listSharedWithMe).not.toHaveBeenCalled()
+      expect(
+        mocks.clientService.graphAuthenticated.driveItems.listSharedWithMe
+      ).not.toHaveBeenCalled()
       expect(mocks.resourcesStore.upsertResource).not.toHaveBeenCalled()
     })
     it('calls "upsertResource" when share has been updated and current route equals "files-shares-with-me"', async () => {
@@ -314,14 +323,12 @@ describe('shares events', () => {
       const sseData = mock<EventSchemaType>({
         itemid: sharedDrive.remoteItem.id
       })
-      mocks.clientService.graphAuthenticated.drives.listSharedWithMe.mockResolvedValue(
-        mockAxiosResolve({
-          value: [sharedDrive]
-        })
-      )
+      mocks.clientService.graphAuthenticated.driveItems.listSharedWithMe.mockResolvedValue([
+        sharedDrive
+      ])
       const busStub = vi.spyOn(eventBus, 'publish')
       await onSSEShareUpdatedEvent({ sseData, ...mocks })
-      expect(mocks.clientService.graphAuthenticated.drives.listSharedWithMe).toHaveBeenCalled()
+      expect(mocks.clientService.graphAuthenticated.driveItems.listSharedWithMe).toHaveBeenCalled()
       expect(mocks.resourcesStore.upsertResource).toHaveBeenCalled()
       expect(busStub).not.toHaveBeenCalled()
     })
@@ -341,7 +348,9 @@ describe('shares events', () => {
       const busStub = vi.spyOn(eventBus, 'publish')
       await onSSEShareUpdatedEvent({ sseData, ...mocks })
       expect(busStub).not.toHaveBeenCalled()
-      expect(mocks.clientService.graphAuthenticated.drives.listSharedWithMe).not.toHaveBeenCalled()
+      expect(
+        mocks.clientService.graphAuthenticated.driveItems.listSharedWithMe
+      ).not.toHaveBeenCalled()
       expect(mocks.resourcesStore.upsertResource).not.toHaveBeenCalled()
     })
   })
@@ -503,7 +512,9 @@ describe('shares events', () => {
       expect(mocks.clientService.webdav.getFileInfo).toHaveBeenCalled()
       expect(mocks.resourcesStore.upsertResource).toHaveBeenCalled()
       expect(mocks.resourcesStore.updateResourceField).toHaveBeenCalled()
-      expect(mocks.clientService.graphAuthenticated.drives.listSharedByMe).not.toHaveBeenCalled()
+      expect(
+        mocks.clientService.graphAuthenticated.driveItems.listSharedByMe
+      ).not.toHaveBeenCalled()
     })
     it('calls "upsertResource" when resource has been shared via link and current route equals "files-shares-via-link"', async () => {
       const sharedDrive = mockDeep<DriveItem>({
@@ -517,13 +528,11 @@ describe('shares events', () => {
       const sseData = mock<EventSchemaType>({
         itemid: sharedDrive.id
       })
-      mocks.clientService.graphAuthenticated.drives.listSharedByMe.mockResolvedValue(
-        mockDeep<AxiosResponse>({
-          data: { value: [sharedDrive] }
-        })
-      )
+      mocks.clientService.graphAuthenticated.driveItems.listSharedByMe.mockResolvedValue([
+        sharedDrive
+      ])
       await onSSELinkCreatedEvent({ sseData, ...mocks })
-      expect(mocks.clientService.graphAuthenticated.drives.listSharedByMe).toHaveBeenCalled()
+      expect(mocks.clientService.graphAuthenticated.driveItems.listSharedByMe).toHaveBeenCalled()
       expect(mocks.resourcesStore.upsertResource).toHaveBeenCalled()
       expect(mocks.resourcesStore.updateResourceField).not.toHaveBeenCalled()
       expect(mocks.clientService.webdav.getFileInfo).not.toHaveBeenCalled()
@@ -549,7 +558,9 @@ describe('shares events', () => {
       expect(mocks.clientService.webdav.getFileInfo).not.toHaveBeenCalled()
       expect(mocks.resourcesStore.upsertResource).not.toHaveBeenCalled()
       expect(mocks.resourcesStore.updateResourceField).not.toHaveBeenCalled()
-      expect(mocks.clientService.graphAuthenticated.drives.listSharedByMe).not.toHaveBeenCalled()
+      expect(
+        mocks.clientService.graphAuthenticated.driveItems.listSharedByMe
+      ).not.toHaveBeenCalled()
     })
   })
   describe('onSSELinkRemovedEvent', () => {

--- a/packages/web-runtime/tests/unit/pages/resolvePrivateLink.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/resolvePrivateLink.spec.ts
@@ -1,14 +1,8 @@
 import resolvePrivateLink from '../../../src/pages/resolvePrivateLink.vue'
-import {
-  defaultPlugins,
-  defaultComponentMocks,
-  shallowMount,
-  mockAxiosResolve
-} from 'web-test-helpers'
+import { defaultPlugins, defaultComponentMocks, shallowMount } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
 import { queryItemAsString, useGetResourceContext } from '@ownclouders/web-pkg'
 import { Resource, SHARE_JAIL_ID, SpaceResource } from '@ownclouders/web-client'
-import { DriveItem } from '@ownclouders/web-client/graph/generated'
 
 vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
   ...(await importOriginal<any>()),
@@ -183,11 +177,9 @@ function getWrapper({
   })
 
   const mocks = { ...defaultComponentMocks() }
-  mocks.$clientService.graphAuthenticated.drives.listSharedWithMe.mockResolvedValue(
-    mockAxiosResolve({
-      value: [{ remoteItem: { id: '1' }, '@UI.Hidden': hiddenShare } as DriveItem]
-    })
-  )
+  mocks.$clientService.graphAuthenticated.driveItems.listSharedWithMe.mockResolvedValue([
+    { remoteItem: { id: '1' }, '@UI.Hidden': hiddenShare }
+  ])
 
   return {
     mocks,


### PR DESCRIPTION
## Description
Refactors the graph abstraction layer for drives and driveItems to make them more practical and convenient to use.

The new implementation has improved method parameters, types and destructures API responses so users of the abstraction don't need to care about such things.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/10808

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)