### PR TITLE
refactor: make graph abstraction layer useful for permissions

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -348,7 +348,7 @@ export default defineComponent({
         savePromises.push(
           saveQueue.add(async () => {
             try {
-              const shares = await addShare({
+              const share = await addShare({
                 clientService,
                 space: unref(space),
                 resource: unref(resource),
@@ -364,7 +364,7 @@ export default defineComponent({
                 }
               })
 
-              addedShares.push(...shares)
+              addedShares.push(share)
             } catch (error) {
               console.error(error)
               errors.push({ displayName, error })

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.ts
@@ -138,7 +138,7 @@ describe('InviteCollaboratorForm', () => {
       wrapper.vm.selectedCollaborators = [mock<CollaboratorAutoCompleteItem>()]
 
       const { addShare } = useSharesStore()
-      vi.mocked(addShare).mockResolvedValue([])
+      vi.mocked(addShare).mockResolvedValue(undefined)
 
       await wrapper.vm.$nextTick()
       await wrapper.vm.share()

--- a/packages/web-client/src/graph/index.ts
+++ b/packages/web-client/src/graph/index.ts
@@ -1,17 +1,5 @@
-import { AxiosInstance, AxiosPromise } from 'axios'
-import {
-  Configuration,
-  RoleManagementApiFactory,
-  UnifiedRoleDefinition,
-  DrivesRootApiFactory,
-  DrivesPermissionsApiFactory,
-  Permission,
-  DriveItemCreateLink,
-  DriveItemInvite,
-  SharingLinkPassword,
-  CollectionOfPermissions,
-  CollectionOfPermissionsWithAllowedValues
-} from './generated'
+import { AxiosInstance } from 'axios'
+import { Configuration } from './generated'
 import { type GraphUsers, UsersFactory } from './users'
 import { type GraphGroups, GroupsFactory } from './groups'
 import { ApplicationsFactory, GraphApplications } from './applications'
@@ -19,6 +7,7 @@ import { DrivesFactory, GraphDrives } from './drives'
 import { DriveItemsFactory, GraphDriveItems } from './driveItems'
 import { TagsFactory, GraphTags } from './tags'
 import { ActivitiesFactory, GraphActivities } from './activities'
+import { PermissionsFactory, GraphPermissions } from './permissions'
 
 export interface Graph {
   activities: GraphActivities
@@ -28,61 +17,7 @@ export interface Graph {
   driveItems: GraphDriveItems
   users: GraphUsers
   groups: GraphGroups
-  roleManagement: {
-    listPermissionRoleDefinitions: () => AxiosPromise<UnifiedRoleDefinition>
-  }
-  permissions: {
-    getPermission: (driveId: string, itemId: string, permId: string) => AxiosPromise<Permission>
-    listPermissions: (
-      driveId: string,
-      itemId: string
-    ) => AxiosPromise<CollectionOfPermissionsWithAllowedValues>
-    listPermissionsSpaceRoot: (
-      driveId: string
-    ) => AxiosPromise<CollectionOfPermissionsWithAllowedValues>
-    createLink: (
-      driveId: string,
-      itemId: string,
-      driveItemCreateLink?: DriveItemCreateLink
-    ) => AxiosPromise<Permission>
-    createLinkSpaceRoot: (
-      driveId: string,
-      driveItemCreateLink?: DriveItemCreateLink
-    ) => AxiosPromise<Permission>
-    invite: (
-      driveId: string,
-      itemId: string,
-      driveItemInvite?: DriveItemInvite
-    ) => AxiosPromise<CollectionOfPermissions>
-    inviteSpaceRoot: (
-      driveId: string,
-      driveItemInvite?: DriveItemInvite
-    ) => AxiosPromise<CollectionOfPermissions>
-    deletePermission: (driveId: string, itemId: string, permId: string) => AxiosPromise<void>
-    deletePermissionSpaceRoot: (driveId: string, permId: string) => AxiosPromise<void>
-    updatePermission: (
-      driveId: string,
-      itemId: string,
-      permId: string,
-      permission: Permission
-    ) => AxiosPromise<Permission>
-    updatePermissionSpaceRoot: (
-      driveId: string,
-      permId: string,
-      permission: Permission
-    ) => AxiosPromise<Permission>
-    setPermissionPassword: (
-      driveId: string,
-      itemId: string,
-      permId: string,
-      sharingLinkPassword: SharingLinkPassword
-    ) => AxiosPromise<Permission>
-    setPermissionPasswordSpaceRoot: (
-      driveId: string,
-      permId: string,
-      sharingLinkPassword: SharingLinkPassword
-    ) => AxiosPromise<Permission>
-  }
+  permissions: GraphPermissions
 }
 
 export const graph = (baseURI: string, axiosClient: AxiosInstance): Graph => {
@@ -92,14 +27,6 @@ export const graph = (baseURI: string, axiosClient: AxiosInstance): Graph => {
     basePath: url.href
   })
 
-  const roleManagementApiFactory = RoleManagementApiFactory(config, config.basePath, axiosClient)
-  const drivesRootApiFactory = DrivesRootApiFactory(config, config.basePath, axiosClient)
-  const drivesPermissionsApiFactory = DrivesPermissionsApiFactory(
-    config,
-    config.basePath,
-    axiosClient
-  )
-
   return <Graph>{
     activities: ActivitiesFactory({ axiosClient, config }),
     applications: ApplicationsFactory({ axiosClient, config }),
@@ -108,49 +35,6 @@ export const graph = (baseURI: string, axiosClient: AxiosInstance): Graph => {
     driveItems: DriveItemsFactory({ axiosClient, config }),
     users: UsersFactory({ axiosClient, config }),
     groups: GroupsFactory({ axiosClient, config }),
-    roleManagement: {
-      listPermissionRoleDefinitions: () => roleManagementApiFactory.listPermissionRoleDefinitions()
-    },
-    permissions: {
-      getPermission: (driveId: string, itemId: string, permId: string) =>
-        drivesPermissionsApiFactory.getPermission(driveId, itemId, permId),
-      listPermissions: (driveId: string, itemId: string) =>
-        drivesPermissionsApiFactory.listPermissions(driveId, itemId),
-      listPermissionsSpaceRoot: (driveId: string) =>
-        drivesRootApiFactory.listPermissionsSpaceRoot(driveId),
-      createLink: (driveId: string, itemId: string, driveItemCreateLink?: DriveItemCreateLink) =>
-        drivesPermissionsApiFactory.createLink(driveId, itemId, driveItemCreateLink),
-      createLinkSpaceRoot: (driveId: string, driveItemCreateLink?: DriveItemCreateLink) =>
-        drivesRootApiFactory.createLinkSpaceRoot(driveId, driveItemCreateLink),
-      invite: (driveId: string, itemId: string, driveItemInvite?: DriveItemInvite) =>
-        drivesPermissionsApiFactory.invite(driveId, itemId, driveItemInvite),
-      inviteSpaceRoot: (driveId: string, driveItemInvite?: DriveItemInvite) =>
-        drivesRootApiFactory.inviteSpaceRoot(driveId, driveItemInvite),
-      deletePermission: (driveId: string, itemId: string, permId: string) =>
-        drivesPermissionsApiFactory.deletePermission(driveId, itemId, permId),
-      deletePermissionSpaceRoot: (driveId: string, permId: string) =>
-        drivesRootApiFactory.deletePermissionSpaceRoot(driveId, permId),
-      updatePermission: (driveId: string, itemId: string, permId: string, permission: Permission) =>
-        drivesPermissionsApiFactory.updatePermission(driveId, itemId, permId, permission),
-      updatePermissionSpaceRoot: (driveId: string, permId: string, permission: Permission) =>
-        drivesRootApiFactory.updatePermissionSpaceRoot(driveId, permId, permission),
-      setPermissionPassword: (
-        driveId: string,
-        itemId: string,
-        permId: string,
-        sharingLinkPassword: SharingLinkPassword
-      ) =>
-        drivesPermissionsApiFactory.setPermissionPassword(
-          driveId,
-          itemId,
-          permId,
-          sharingLinkPassword
-        ),
-      setPermissionPasswordSpaceRoot: (
-        driveId: string,
-        permId: string,
-        sharingLinkPassword: SharingLinkPassword
-      ) => drivesRootApiFactory.setPermissionPasswordSpaceRoot(driveId, permId, sharingLinkPassword)
-    }
+    permissions: PermissionsFactory({ axiosClient, config })
   }
 }

--- a/packages/web-client/src/graph/permissions/index.ts
+++ b/packages/web-client/src/graph/permissions/index.ts
@@ -1,0 +1,2 @@
+export * from './permissions'
+export * from './types'

--- a/packages/web-client/src/graph/permissions/permissions.ts
+++ b/packages/web-client/src/graph/permissions/permissions.ts
@@ -1,0 +1,232 @@
+import { buildCollaboratorShare, buildLinkShare, CollaboratorShare, LinkShare } from '../../helpers'
+import {
+  CollectionOfPermissionsWithAllowedValues,
+  DrivesPermissionsApiFactory,
+  DrivesRootApiFactory,
+  Permission,
+  RoleManagementApiFactory,
+  UnifiedRoleDefinition
+} from './../generated'
+import type { GraphFactoryOptions, GraphRequestOptions } from './../types'
+import type { GraphPermissions } from './types'
+
+export const PermissionsFactory = ({
+  axiosClient,
+  config
+}: GraphFactoryOptions): GraphPermissions => {
+  const drivesRootApiFactory = DrivesRootApiFactory(config, config.basePath, axiosClient)
+  const roleManagementApiFactory = RoleManagementApiFactory(config, config.basePath, axiosClient)
+  const drivesPermissionsApiFactory = DrivesPermissionsApiFactory(
+    config,
+    config.basePath,
+    axiosClient
+  )
+
+  return {
+    async getPermission<T extends CollaboratorShare | LinkShare>(
+      driveId: string,
+      itemId: string,
+      permId: string,
+      graphRoles: UnifiedRoleDefinition[],
+      requestOptions: GraphRequestOptions
+    ): Promise<T> {
+      const { data: permission } = await drivesPermissionsApiFactory.getPermission(
+        driveId,
+        itemId,
+        permId,
+        requestOptions
+      )
+
+      if (permission.link) {
+        return buildLinkShare({ graphPermission: permission, resourceId: itemId }) as T
+      }
+
+      return buildCollaboratorShare({
+        graphPermission: permission,
+        resourceId: itemId,
+        graphRoles: graphRoles || []
+      }) as T
+    },
+
+    async listPermissions(driveId, itemId, isSpaceRoot, graphRoles, requestOptions) {
+      let responseData: CollectionOfPermissionsWithAllowedValues
+
+      if (isSpaceRoot) {
+        const { data } = await drivesRootApiFactory.listPermissionsSpaceRoot(
+          driveId,
+          requestOptions
+        )
+        responseData = data
+      } else {
+        const { data } = await drivesPermissionsApiFactory.listPermissions(
+          driveId,
+          itemId,
+          requestOptions
+        )
+        responseData = data
+      }
+
+      const permissions = responseData.value || []
+      const allowedActions = responseData['@libre.graph.permissions.actions.allowedValues']
+      const allowedRoles = responseData['@libre.graph.permissions.roles.allowedValues']
+
+      const shares = permissions.map((permission) => {
+        if (permission.link) {
+          return buildLinkShare({ graphPermission: permission, resourceId: itemId })
+        }
+
+        return buildCollaboratorShare({
+          graphPermission: permission,
+          resourceId: itemId,
+          graphRoles: graphRoles || []
+        })
+      })
+
+      return { shares, allowedActions, allowedRoles }
+    },
+
+    async updatePermission<T extends CollaboratorShare | LinkShare>(
+      driveId: string,
+      itemId: string,
+      permId: string,
+      data: Permission,
+      isSpaceRoot: boolean,
+      graphRoles: UnifiedRoleDefinition[],
+      requestOptions: GraphRequestOptions
+    ): Promise<T> {
+      let permission: Permission
+
+      if (isSpaceRoot) {
+        const { data: perm } = await drivesRootApiFactory.updatePermissionSpaceRoot(
+          driveId,
+          permId,
+          data,
+          requestOptions
+        )
+
+        permission = perm
+      } else {
+        const { data: perm } = await drivesPermissionsApiFactory.updatePermission(
+          driveId,
+          itemId,
+          permId,
+          data,
+          requestOptions
+        )
+
+        permission = perm
+      }
+
+      if (permission.link) {
+        return buildLinkShare({ graphPermission: permission, resourceId: itemId }) as T
+      }
+
+      return buildCollaboratorShare({
+        graphPermission: permission,
+        resourceId: itemId,
+        graphRoles: graphRoles || []
+      }) as T
+    },
+
+    async deletePermission(driveId, itemId, permId, isSpaceRoot, requestOptions) {
+      if (isSpaceRoot) {
+        await drivesRootApiFactory.deletePermissionSpaceRoot(driveId, permId, requestOptions)
+        return
+      }
+
+      await drivesPermissionsApiFactory.deletePermission(driveId, itemId, permId, requestOptions)
+    },
+
+    async createInvite(driveId, itemId, data, isSpaceRoot, graphRoles, requestOptions) {
+      let permission: Permission | undefined
+
+      if (isSpaceRoot) {
+        const { data: perm } = await drivesRootApiFactory.inviteSpaceRoot(
+          driveId,
+          data,
+          requestOptions
+        )
+
+        permission = perm.value?.[0]
+      } else {
+        const { data: perm } = await drivesPermissionsApiFactory.invite(
+          driveId,
+          itemId,
+          data,
+          requestOptions
+        )
+
+        permission = perm.value?.[0]
+      }
+
+      if (!permission) {
+        throw new Error('no permission returned')
+      }
+
+      return buildCollaboratorShare({
+        graphPermission: permission,
+        resourceId: itemId,
+        graphRoles: graphRoles || []
+      })
+    },
+
+    async createLink(driveId, itemId, data, isSpaceRoot, requestOptions) {
+      let permission: Permission
+
+      if (isSpaceRoot) {
+        const { data: perm } = await drivesRootApiFactory.createLinkSpaceRoot(
+          driveId,
+          data,
+          requestOptions
+        )
+
+        permission = perm
+      } else {
+        const { data: perm } = await drivesPermissionsApiFactory.createLink(
+          driveId,
+          itemId,
+          data,
+          requestOptions
+        )
+
+        permission = perm
+      }
+
+      return buildLinkShare({ graphPermission: permission, resourceId: itemId })
+    },
+
+    async setPermissionPassword(driveId, itemId, permId, data, isSpaceRoot, requestOptions) {
+      let permission: Permission
+
+      if (isSpaceRoot) {
+        const { data: perm } = await drivesRootApiFactory.setPermissionPasswordSpaceRoot(
+          driveId,
+          permId,
+          data,
+          requestOptions
+        )
+
+        permission = perm
+      } else {
+        const { data: perm } = await drivesPermissionsApiFactory.setPermissionPassword(
+          driveId,
+          itemId,
+          permId,
+          data,
+          requestOptions
+        )
+
+        permission = perm
+      }
+
+      return buildLinkShare({ graphPermission: permission, resourceId: itemId })
+    },
+
+    async listRoleDefinitions(requestOptions) {
+      const { data } = await roleManagementApiFactory.listPermissionRoleDefinitions(requestOptions)
+
+      // FIXME: graph type is wrong
+      return data as Promise<UnifiedRoleDefinition[]>
+    }
+  }
+}

--- a/packages/web-client/src/graph/permissions/permissions.ts
+++ b/packages/web-client/src/graph/permissions/permissions.ts
@@ -48,10 +48,10 @@ export const PermissionsFactory = ({
       }) as T
     },
 
-    async listPermissions(driveId, itemId, isSpaceRoot, graphRoles, requestOptions) {
+    async listPermissions(driveId, itemId, graphRoles, requestOptions) {
       let responseData: CollectionOfPermissionsWithAllowedValues
 
-      if (isSpaceRoot) {
+      if (driveId === itemId) {
         const { data } = await drivesRootApiFactory.listPermissionsSpaceRoot(
           driveId,
           requestOptions
@@ -90,13 +90,12 @@ export const PermissionsFactory = ({
       itemId: string,
       permId: string,
       data: Permission,
-      isSpaceRoot: boolean,
       graphRoles: UnifiedRoleDefinition[],
       requestOptions: GraphRequestOptions
     ): Promise<T> {
       let permission: Permission
 
-      if (isSpaceRoot) {
+      if (driveId === itemId) {
         const { data: perm } = await drivesRootApiFactory.updatePermissionSpaceRoot(
           driveId,
           permId,
@@ -128,8 +127,8 @@ export const PermissionsFactory = ({
       }) as T
     },
 
-    async deletePermission(driveId, itemId, permId, isSpaceRoot, requestOptions) {
-      if (isSpaceRoot) {
+    async deletePermission(driveId, itemId, permId, requestOptions) {
+      if (driveId === itemId) {
         await drivesRootApiFactory.deletePermissionSpaceRoot(driveId, permId, requestOptions)
         return
       }
@@ -137,10 +136,10 @@ export const PermissionsFactory = ({
       await drivesPermissionsApiFactory.deletePermission(driveId, itemId, permId, requestOptions)
     },
 
-    async createInvite(driveId, itemId, data, isSpaceRoot, graphRoles, requestOptions) {
+    async createInvite(driveId, itemId, data, graphRoles, requestOptions) {
       let permission: Permission | undefined
 
-      if (isSpaceRoot) {
+      if (driveId === itemId) {
         const { data: perm } = await drivesRootApiFactory.inviteSpaceRoot(
           driveId,
           data,
@@ -170,10 +169,10 @@ export const PermissionsFactory = ({
       })
     },
 
-    async createLink(driveId, itemId, data, isSpaceRoot, requestOptions) {
+    async createLink(driveId, itemId, data, requestOptions) {
       let permission: Permission
 
-      if (isSpaceRoot) {
+      if (driveId === itemId) {
         const { data: perm } = await drivesRootApiFactory.createLinkSpaceRoot(
           driveId,
           data,
@@ -195,10 +194,10 @@ export const PermissionsFactory = ({
       return buildLinkShare({ graphPermission: permission, resourceId: itemId })
     },
 
-    async setPermissionPassword(driveId, itemId, permId, data, isSpaceRoot, requestOptions) {
+    async setPermissionPassword(driveId, itemId, permId, data, requestOptions) {
       let permission: Permission
 
-      if (isSpaceRoot) {
+      if (driveId === itemId) {
         const { data: perm } = await drivesRootApiFactory.setPermissionPasswordSpaceRoot(
           driveId,
           permId,

--- a/packages/web-client/src/graph/permissions/types.ts
+++ b/packages/web-client/src/graph/permissions/types.ts
@@ -1,0 +1,74 @@
+import { CollaboratorShare, LinkShare } from '../../helpers'
+import type {
+  DriveItemCreateLink,
+  DriveItemInvite,
+  Permission,
+  SharingLinkPassword,
+  UnifiedRoleDefinition
+} from '../generated'
+import type { GraphRequestOptions } from '../types'
+
+type Share = CollaboratorShare | LinkShare
+
+type ListPermissionsResponse = {
+  shares: Share[]
+  allowedActions: string[]
+  allowedRoles: UnifiedRoleDefinition[]
+}
+
+export interface GraphPermissions {
+  getPermission<T extends Share>(
+    driveId: string,
+    itemId: string,
+    permId: string,
+    graphRoles?: UnifiedRoleDefinition[],
+    requestOptions?: GraphRequestOptions
+  ): Promise<T>
+  listPermissions(
+    driveId: string,
+    itemId: string,
+    isSpaceRoot?: boolean,
+    graphRoles?: UnifiedRoleDefinition[],
+    requestOptions?: GraphRequestOptions
+  ): Promise<ListPermissionsResponse>
+  updatePermission<T extends Share>(
+    driveId: string,
+    itemId: string,
+    permId: string,
+    data: Permission,
+    isSpaceRoot?: boolean,
+    graphRoles?: UnifiedRoleDefinition[],
+    requestOptions?: GraphRequestOptions
+  ): Promise<T>
+  deletePermission(
+    driveId: string,
+    itemId: string,
+    permId: string,
+    isSpaceRoot?: boolean,
+    requestOptions?: GraphRequestOptions
+  ): Promise<void>
+  createInvite(
+    driveId: string,
+    itemId: string,
+    data: DriveItemInvite,
+    isSpaceRoot?: boolean,
+    graphRoles?: UnifiedRoleDefinition[],
+    requestOptions?: GraphRequestOptions
+  ): Promise<CollaboratorShare>
+  createLink(
+    driveId: string,
+    itemId: string,
+    data: DriveItemCreateLink,
+    isSpaceRoot?: boolean,
+    requestOptions?: GraphRequestOptions
+  ): Promise<LinkShare>
+  setPermissionPassword(
+    driveId: string,
+    itemId: string,
+    permId: string,
+    data: SharingLinkPassword,
+    isSpaceRoot?: boolean,
+    requestOptions?: GraphRequestOptions
+  ): Promise<LinkShare>
+  listRoleDefinitions(requestOptions?: GraphRequestOptions): Promise<UnifiedRoleDefinition[]>
+}

--- a/packages/web-client/src/graph/permissions/types.ts
+++ b/packages/web-client/src/graph/permissions/types.ts
@@ -27,7 +27,6 @@ export interface GraphPermissions {
   listPermissions(
     driveId: string,
     itemId: string,
-    isSpaceRoot?: boolean,
     graphRoles?: UnifiedRoleDefinition[],
     requestOptions?: GraphRequestOptions
   ): Promise<ListPermissionsResponse>
@@ -36,7 +35,6 @@ export interface GraphPermissions {
     itemId: string,
     permId: string,
     data: Permission,
-    isSpaceRoot?: boolean,
     graphRoles?: UnifiedRoleDefinition[],
     requestOptions?: GraphRequestOptions
   ): Promise<T>
@@ -44,14 +42,12 @@ export interface GraphPermissions {
     driveId: string,
     itemId: string,
     permId: string,
-    isSpaceRoot?: boolean,
     requestOptions?: GraphRequestOptions
   ): Promise<void>
   createInvite(
     driveId: string,
     itemId: string,
     data: DriveItemInvite,
-    isSpaceRoot?: boolean,
     graphRoles?: UnifiedRoleDefinition[],
     requestOptions?: GraphRequestOptions
   ): Promise<CollaboratorShare>
@@ -59,7 +55,6 @@ export interface GraphPermissions {
     driveId: string,
     itemId: string,
     data: DriveItemCreateLink,
-    isSpaceRoot?: boolean,
     requestOptions?: GraphRequestOptions
   ): Promise<LinkShare>
   setPermissionPassword(
@@ -67,7 +62,6 @@ export interface GraphPermissions {
     itemId: string,
     permId: string,
     data: SharingLinkPassword,
-    isSpaceRoot?: boolean,
     requestOptions?: GraphRequestOptions
   ): Promise<LinkShare>
   listRoleDefinitions(requestOptions?: GraphRequestOptions): Promise<UnifiedRoleDefinition[]>

--- a/packages/web-client/src/helpers/share/functions.ts
+++ b/packages/web-client/src/helpers/share/functions.ts
@@ -27,6 +27,16 @@ export const isIncomingShareResource = (resource: Resource): resource is Incomin
   return isShareResource(resource) && !resource.outgoing
 }
 
+export const isCollaboratorShare = (
+  share: CollaboratorShare | LinkShare
+): share is CollaboratorShare => {
+  return Object.hasOwn(share, 'role')
+}
+
+export const isLinkShare = (share: CollaboratorShare | LinkShare): share is LinkShare => {
+  return !Object.hasOwn(share, 'role')
+}
+
 export const getShareResourceRoles = ({
   driveItem,
   graphRoles
@@ -231,13 +241,11 @@ export function buildCollaboratorShare({
   graphPermission,
   graphRoles,
   resourceId,
-  user,
   indirect = false
 }: {
   graphPermission: Permission
   graphRoles: UnifiedRoleDefinition[]
   resourceId: string
-  user: User
   indirect?: boolean
 }): CollaboratorShare {
   const role = graphRoles.find(({ id }) => id === graphPermission.roles?.[0])
@@ -248,7 +256,7 @@ export function buildCollaboratorShare({
     indirect,
     shareType: graphPermission.grantedToV2.group ? ShareTypes.group.value : ShareTypes.user.value,
     role,
-    sharedBy: { id: user.id, displayName: user.displayName },
+    sharedBy: { id: '', displayName: '' }, // FIXME: see https://github.com/owncloud/ocis/issues/9571
     sharedWith: graphPermission.grantedToV2.user || graphPermission.grantedToV2.group,
     permissions: (graphPermission['@libre.graph.permissions.actions']
       ? graphPermission['@libre.graph.permissions.actions']
@@ -260,12 +268,10 @@ export function buildCollaboratorShare({
 
 export function buildLinkShare({
   graphPermission,
-  user,
   resourceId,
   indirect = false
 }: {
   graphPermission: Permission
-  user: User
   resourceId: string
   indirect?: boolean
 }): LinkShare {
@@ -274,7 +280,7 @@ export function buildLinkShare({
     resourceId,
     indirect,
     shareType: ShareTypes.link.value,
-    sharedBy: { id: user.id, displayName: user.displayName },
+    sharedBy: { id: '', displayName: '' }, // FIXME: see https://github.com/owncloud/ocis/issues/9571
     hasPassword: graphPermission.hasPassword,
     createdDateTime: graphPermission.createdDateTime,
     expirationDateTime: graphPermission.expirationDateTime,

--- a/packages/web-client/tests/unit/helpers/share/functions.spec.ts
+++ b/packages/web-client/tests/unit/helpers/share/functions.spec.ts
@@ -204,7 +204,6 @@ describe('share helper functions', () => {
       { id: '2', rolePermissions: [{ allowedResourceActions: ['edit'] }] }
     ] as UnifiedRoleDefinition[]
 
-    const user = { id: '1', displayName: 'user1' } as User
     const resourceId = '1'
 
     it('sets ids based on the permission and the given resource id', () => {
@@ -213,8 +212,7 @@ describe('share helper functions', () => {
       const result = buildCollaboratorShare({
         graphPermission,
         graphRoles,
-        resourceId,
-        user
+        resourceId
       })
 
       expect(result.id).toEqual(graphPermission.id)
@@ -230,8 +228,7 @@ describe('share helper functions', () => {
         const result = buildCollaboratorShare({
           graphPermission,
           graphRoles,
-          resourceId,
-          user
+          resourceId
         })
 
         expect(result.shareType).toEqual(ShareTypes.user.value)
@@ -245,8 +242,7 @@ describe('share helper functions', () => {
         const result = buildCollaboratorShare({
           graphPermission,
           graphRoles,
-          resourceId,
-          user
+          resourceId
         })
 
         expect(result.shareType).toEqual(ShareTypes.group.value)
@@ -262,8 +258,7 @@ describe('share helper functions', () => {
         const result = buildCollaboratorShare({
           graphPermission,
           graphRoles,
-          resourceId,
-          user
+          resourceId
         })
 
         expect(result.permissions).toEqual(permissions)
@@ -277,8 +272,7 @@ describe('share helper functions', () => {
         const result = buildCollaboratorShare({
           graphPermission,
           graphRoles,
-          resourceId,
-          user
+          resourceId
         })
 
         expect(result.permissions).toEqual(
@@ -291,19 +285,18 @@ describe('share helper functions', () => {
   })
 
   describe('buildLinkShare', () => {
-    const user = { id: '1', displayName: 'user1' } as User
     const resourceId = '1'
 
     it('sets ids based on the permission and the given resource id', () => {
       const graphPermission = mock<Permission>({ '@libre.graph.permissions.actions': [] })
-      const result = buildLinkShare({ graphPermission, resourceId, user })
+      const result = buildLinkShare({ graphPermission, resourceId })
 
       expect(result.id).toEqual(graphPermission.id)
       expect(result.resourceId).toEqual(resourceId)
     })
     it('sets the sharing link type', () => {
       const graphPermission = mock<Permission>({ '@libre.graph.permissions.actions': [] })
-      const result = buildLinkShare({ graphPermission, resourceId, user })
+      const result = buildLinkShare({ graphPermission, resourceId })
 
       expect(result.shareType).toEqual(ShareTypes.link.value)
     })

--- a/packages/web-pkg/src/components/SideBar/FileSideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/FileSideBar.vue
@@ -199,12 +199,7 @@ export default defineComponent({
 
       // load direct shares
       const { shares, allowedRoles } = yield* call(
-        client.listPermissions(
-          props.space?.id,
-          resource.id,
-          isSpaceResource(resource),
-          sharesStore.graphRoles
-        )
+        client.listPermissions(props.space?.id, resource.id, sharesStore.graphRoles)
       )
 
       const loadedCollaboratorShares = shares.filter(isCollaboratorShare)
@@ -253,7 +248,7 @@ export default defineComponent({
       const promises = ancestorIds.map((id) => {
         return queue.add(() =>
           clientService.graphAuthenticated.permissions
-            .listPermissions(props.space?.id, id, false, sharesStore.graphRoles)
+            .listPermissions(props.space?.id, id, sharesStore.graphRoles)
             .then((result) => {
               const indirectShares = result.shares.map((s) => ({ ...s, indirect: true }))
               loadedCollaboratorShares.push(...indirectShares.filter(isCollaboratorShare))

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCopyQuicklink.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCopyQuicklink.ts
@@ -8,7 +8,6 @@ import { useClipboard } from '../../clipboard'
 import { Resource, SpaceResource } from '@ownclouders/web-client'
 import { useFileActionsCreateLink } from './useFileActionsCreateLink'
 import { useMessages } from '../../piniaStores'
-import { isSpaceResource } from '@ownclouders/web-client'
 
 export const useFileActionsCopyQuickLink = () => {
   const { showMessage, showErrorMessage } = useMessages()
@@ -56,13 +55,7 @@ export const useFileActionsCopyQuickLink = () => {
     resource: Resource
   }) => {
     const client = clientService.graphAuthenticated.permissions
-
-    const { shares } = await client.listPermissions(
-      space.id,
-      resource.id,
-      isSpaceResource(resource)
-    )
-
+    const { shares } = await client.listPermissions(space.id, resource.id)
     return shares.filter(isLinkShare).find(({ isQuickLink }) => isQuickLink)
   }
 

--- a/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
+++ b/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
@@ -4,8 +4,7 @@ import {
   Share,
   ShareRole,
   ShareTypes,
-  isProjectSpaceResource,
-  isSpaceResource
+  isProjectSpaceResource
 } from '@ownclouders/web-client'
 import { defineStore } from 'pinia'
 import { Ref, ref, unref } from 'vue'
@@ -146,14 +145,7 @@ export const useSharesStore = defineStore('shares', () => {
 
   const addShare = async ({ clientService, space, resource, options }: AddShareOptions) => {
     const client = clientService.graphAuthenticated.permissions
-
-    const share = await client.createInvite(
-      space.id,
-      resource.id,
-      options,
-      isSpaceResource(resource),
-      unref(graphRoles)
-    )
+    const share = await client.createInvite(space.id, resource.id, options, unref(graphRoles))
 
     addCollaboratorShares([share])
     updateFileShareTypes(resource.path)
@@ -180,7 +172,6 @@ export const useSharesStore = defineStore('shares', () => {
       resource.id,
       collaboratorShare.id,
       payload,
-      isSpaceResource(resource),
       unref(graphRoles)
     )
 
@@ -197,12 +188,7 @@ export const useSharesStore = defineStore('shares', () => {
   }: DeleteShareOptions) => {
     const client = clientService.graphAuthenticated.permissions
 
-    await client.deletePermission(
-      space.id,
-      resource.id,
-      collaboratorShare.id,
-      isSpaceResource(resource)
-    )
+    await client.deletePermission(space.id, resource.id, collaboratorShare.id)
 
     removeCollaboratorShare(collaboratorShare)
     updateFileShareTypes(resource.id)
@@ -213,7 +199,7 @@ export const useSharesStore = defineStore('shares', () => {
 
   const addLink = async ({ clientService, space, resource, options }: AddLinkOptions) => {
     const client = clientService.graphAuthenticated.permissions
-    const link = await client.createLink(space.id, resource.id, options, isSpaceResource(resource))
+    const link = await client.createLink(space.id, resource.id, options)
 
     const selectedFiles = resourcesStore.selectedResources
     const fileIsSelected =
@@ -253,13 +239,9 @@ export const useSharesStore = defineStore('shares', () => {
     let link: LinkShare
 
     if (Object.hasOwn(options, 'password')) {
-      link = await client.setPermissionPassword(
-        space.id,
-        resource.id,
-        linkShare.id,
-        { password: options.password },
-        isSpaceResource(resource)
-      )
+      link = await client.setPermissionPassword(space.id, resource.id, linkShare.id, {
+        password: options.password
+      })
 
       linkShare.hasPassword = !!options.password
     } else {
@@ -273,13 +255,7 @@ export const useSharesStore = defineStore('shares', () => {
         expirationDateTime: options.expirationDateTime
       } satisfies Permission
 
-      link = await client.updatePermission<LinkShare>(
-        space.id,
-        resource.id,
-        linkShare.id,
-        payload,
-        isSpaceResource(resource)
-      )
+      link = await client.updatePermission<LinkShare>(space.id, resource.id, linkShare.id, payload)
     }
 
     upsertLinkShare(link)
@@ -294,7 +270,7 @@ export const useSharesStore = defineStore('shares', () => {
     loadIndicators = false
   }: DeleteLinkOptions) => {
     const client = clientService.graphAuthenticated.permissions
-    await client.deletePermission(space.id, resource.id, linkShare.id, isSpaceResource(resource))
+    await client.deletePermission(space.id, resource.id, linkShare.id)
 
     removeLinkShare(linkShare)
     updateFileShareTypes(resource.id)

--- a/packages/web-pkg/src/composables/piniaStores/spaces.ts
+++ b/packages/web-pkg/src/composables/piniaStores/spaces.ts
@@ -194,7 +194,6 @@ export const useSpacesStore = defineStore('spaces', () => {
     const { shares } = await graphClient.permissions.listPermissions(
       space.id,
       space.id,
-      true,
       sharesStore.graphRoles
     )
 

--- a/packages/web-pkg/src/composables/piniaStores/spaces.ts
+++ b/packages/web-pkg/src/composables/piniaStores/spaces.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { computed, ref, unref } from 'vue'
-import { SpaceResource } from '@ownclouders/web-client'
+import { isCollaboratorShare, SpaceResource } from '@ownclouders/web-client'
 import { Graph } from '@ownclouders/web-client/graph'
 import {
   GraphShareRoleIdMap,
@@ -12,7 +12,6 @@ import {
 import type { CollaboratorShare } from '@ownclouders/web-client'
 import { useUserStore } from './user'
 import { ConfigStore, useConfigStore } from './config'
-import { buildCollaboratorShare } from '@ownclouders/web-client'
 import { useSharesStore } from './shares'
 
 export const sortSpaceMembers = (shares: CollaboratorShare[]) => {
@@ -191,24 +190,15 @@ export const useSpacesStore = defineStore('spaces', () => {
     space: SpaceResource
   }) => {
     spaceMembers.value = []
-    const spaceShares: CollaboratorShare[] = []
 
-    const { data } = await graphClient.permissions.listPermissionsSpaceRoot(space.id)
+    const { shares } = await graphClient.permissions.listPermissions(
+      space.id,
+      space.id,
+      true,
+      sharesStore.graphRoles
+    )
 
-    const permissions = data.value || []
-    permissions.forEach((graphPermission) => {
-      if (!graphPermission.link) {
-        spaceShares.push(
-          buildCollaboratorShare({
-            graphPermission,
-            graphRoles: sharesStore.graphRoles,
-            resourceId: space.id,
-            user: userStore.user
-          })
-        )
-      }
-    })
-
+    const spaceShares = shares.filter(isCollaboratorShare)
     spaceMembers.value = sortSpaceMembers(spaceShares)
   }
 

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -43,7 +43,6 @@ import PortalVue, { createWormhole } from 'portal-vue'
 import { createPinia } from 'pinia'
 import Avatar from './components/Avatar.vue'
 import focusMixin from './mixins/focusMixin'
-import { UnifiedRoleDefinition } from '@ownclouders/web-client/graph/generated'
 import { extensionPoints } from './extensionPoints'
 import { isSilentRedirectRoute } from './helpers/silentRedirect'
 
@@ -234,11 +233,9 @@ export const bootstrapApp = async (configurationPath: string, appsReadyCallback:
       }
 
       // load sharing roles from graph API
-      const { data } =
-        await clientService.graphAuthenticated.roleManagement.listPermissionRoleDefinitions()
-
-      // FIXME: graph type is wrong
-      sharesStore.setGraphRoles(data as UnifiedRoleDefinition[])
+      const graphRoleDefinitions =
+        await clientService.graphAuthenticated.permissions.listRoleDefinitions()
+      sharesStore.setGraphRoles(graphRoleDefinitions)
     },
     {
       immediate: true


### PR DESCRIPTION
## Description
Refactors the graph abstraction layer for permissions (= shares) to make them more practical and convenient to use.

The new implementation has improved method parameters, types and destructures API responses so users of the abstraction don't need to care about such things.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- fixes https://github.com/owncloud/web/issues/10808
- refs https://github.com/owncloud/web/issues/11167

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)