### PR TITLE
[tests-only][full-ci]bump latest ocis stable commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=214491134f5674ac735635ea259969663d9ad4c7
+OCIS_COMMITID=b4f5957e7197f21655a796c65194e359d38edbcf
 OCIS_BRANCH=stable-5.0


### PR DESCRIPTION
### Description
Bump latest ocis stable commit id.

Part of: https://github.com/owncloud/QA/issues/856