### PR TITLE
[full-ci] enable secure view test

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -899,6 +899,7 @@ def ocisService(type, tika_enabled = False, enforce_password_public_link = False
         environment["NATS_NATS_PORT"] = 9233
         environment["COLLABORA_DOMAIN"] = "collabora:9980"
         environment["ONLYOFFICE_DOMAIN"] = "onlyoffice:443"
+        environment["FRONTEND_APP_HANDLER_SECURE_VIEW_APP_ADDR"] = "com.owncloud.api.collaboration.Collabora"
     else:
         environment["WEB_UI_CONFIG_FILE"] = "%s" % dir["ocisConfig"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       PROXY_CSP_CONFIG_FILE_LOCATION: /etc/ocis/csp.yaml
       ONLYOFFICE_DOMAIN: host.docker.internal:9981
       COLLABORA_DOMAIN: host.docker.internal:9980
-      FRONTEND_APP_HANDLER_SECURE_VIEW_APP_ADDR: com.owncloud.api.app-provider-collabora
+      FRONTEND_APP_HANDLER_SECURE_VIEW_APP_ADDR: com.owncloud.api.collaboration.Collabora
     labels:
       traefik.enable: true
       traefik.http.routers.ocis.tls: true

--- a/tests/e2e/cucumber/features/app-provider/officeSuites.feature
+++ b/tests/e2e/cucumber/features/app-provider/officeSuites.feature
@@ -138,29 +138,52 @@ Feature: Integrate with online office suites like Collabora and OnlyOffice
     And "Alice" logs out
     And "Brian" logs out
 
-  # Please enable this code again after moving the new collaboration server to the web repository
-  # Scenario: open a secure view file with Collabora
-  #   Given "Admin" creates following users using API
-  #     | id    |
-  #     | Brian |
-  #   When "Alice" creates the following resources
-  #     | resource           | type         | content                 |
-  #     | secureDocument.odt | OpenDocument | very important document |
-  #   And "Alice" shares the following resources using the sidebar panel
-  #     | resource           | recipient | type | role              |
-  #     | secureDocument.odt | Brian     | user | Can view (secure) |
-  #   And "Alice" logs out
 
-  #   And "Brian" logs in
-  #   And "Brian" navigates to the shared with me page
-  #   When "Brian" opens the following file in Collabora
-  #     | resource           |
-  #     | secureDocument.odt |
+  Scenario: open a secure view file with Collabora
+    Given "Alice" creates the following folder in personal space using API
+      | name          |
+      | shared folder |
+    And "Alice" uploads the following resource
+      | resource        | to            |
+      | simple.pdf      | shared folder |
+      | testavatar.jpeg | shared folder |
+      | lorem.txt       | shared folder |
+    And "Alice" creates the following resources
+      | resource           | type         | content                 |
+      | secureDocument.odt | OpenDocument | very important document |
 
-  #   # we copy the contents of the file and compare the clipboard with the expected contents.
-  #   # In case the user does not have download permissions and tries to copy file content, the clipboard should be set to “Copying from document disabled”.
-  #   Then "Brian" should see the content "Copying from the document disabled" in editor "Collabora"
-  #   And "Brian" logs out
+    And "Alice" shares the following resources using the sidebar panel
+      | resource           | recipient | type | role              |
+      | secureDocument.odt | Brian     | user | Can view (secure) |
+      | shared folder      | Brian     | user | Can view (secure) |
+    And "Alice" logs out
+
+    And "Brian" logs in
+    And "Brian" navigates to the shared with me page
+    When "Brian" opens the following file in Collabora
+      | resource           |
+      | secureDocument.odt |
+
+    # we copy the contents of the file and compare the clipboard with the expected contents.
+    # In case the user does not have download permissions and tries to copy file content, the clipboard should be set to “Copying from document disabled”.
+    Then "Brian" should see the content "Copying from the document disabled" in editor "Collabora"
+    And "Brian" closes the file viewer
+    When "Brian" opens folder "shared folder"
+    And "Brian" opens the following file in Collabora
+      | resource   |
+      | simple.pdf |
+    Then "Brian" should see the content "Copying from the document disabled" in editor "Collabora"
+    And "Brian" closes the file viewer
+    And "Brian" opens the following file in Collabora
+      | resource        |
+      | testavatar.jpeg |
+    Then "Brian" should see the content "Copying from the document disabled" in editor "Collabora"
+    And "Brian" closes the file viewer
+    And "Brian" opens the following file in Collabora
+      | resource  |
+      | lorem.txt |
+    Then "Brian" should see the content "Copying from the document disabled" in editor "Collabora"
+    And "Brian" logs out
 
 
   Scenario: public creates a Microsoft Word file with OnlyOffice


### PR DESCRIPTION
- [x] enabled secure view tests
- [x] user opens different type of files in the collabora secure mod 
- [x] enabled collabora the secure view in the docker-compose and in the drone.star
- [ ] update collabora to version collabora/code:24.04.5.1.1 - doesn't work. We cannot open file in the collabora because `SSL verification warning (handshake): self-signed certificate| net/SslSocket.hpp:448`