### PR TITLE
test: use file name with blanks in download e2e test

### DIFF
--- a/tests/e2e/cucumber/features/file-action/download.feature
+++ b/tests/e2e/cucumber/features/file-action/download.feature
@@ -17,8 +17,8 @@ Feature: Download
       | folderPublic |
       | emptyFolder  |
     And "Alice" creates the following files into personal space using API
-      | pathToFile             | content     |
-      | folderPublic/lorem.txt | lorem ipsum |
+      | pathToFile                | content     |
+      | folderPublic/new file.txt | lorem ipsum |
     And "Alice" uploads the following local file into personal space using API
       | localFile                     | to             |
       | filesForUpload/testavatar.jpg | testavatar.jpg |
@@ -52,7 +52,7 @@ Feature: Download
       | testavatar.jpg | file   |
     And "Brian" downloads the following resources using the sidebar panel
       | resource       | from         | type   |
-      | lorem.txt      | folderPublic | file   |
+      | new file.txt   | folderPublic | file   |
       | testavatar.jpg |              | file   |
       | folderPublic   |              | folder |
       | emptyFolder    |              | folder |


### PR DESCRIPTION
## Description
As per title. This makes sure that regressions like https://github.com/owncloud/web/issues/11169 are found immediately.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/11169

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
