### PR TITLE
refactor: id-based share indicators

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -145,8 +145,7 @@ export default defineComponent({
     const { canShare } = useCanShare()
 
     const resourcesStore = useResourcesStore()
-    const { removeResources } = resourcesStore
-    const { ancestorMetaData } = storeToRefs(resourcesStore)
+    const { removeResources, getAncestorById } = resourcesStore
 
     const spacesStore = useSpacesStore()
     const { spaceMembers } = storeToRefs(spacesStore)
@@ -174,10 +173,6 @@ export default defineComponent({
     const currentUserIsMemberOfSpace = computed(() => {
       return unref(spaceMembers).some((member) => member.sharedWith?.id === unref(user)?.id)
     })
-
-    const getSharedAncestor = (fileId: string) => {
-      return Object.values(unref(ancestorMetaData)).find((a) => a.id === fileId)
-    }
 
     const matchingSpace = computed(() => {
       return getMatchingSpace(unref(resource))
@@ -221,14 +216,13 @@ export default defineComponent({
       currentUserIsMemberOfSpace,
       hasShareCanDenyAccess: capabilityRefs.sharingDenyAccess,
       filesPrivateLinks: capabilityRefs.filesPrivateLinks,
-      getSharedAncestor,
+      getAncestorById,
       configStore,
       configOptions,
       dispatchModal,
       spaceMembers,
       removeResources,
       collaborators,
-      ancestorMetaData,
       canShare,
       ...useMessages()
     }
@@ -423,7 +417,7 @@ export default defineComponent({
       if (!collaborator.indirect) {
         return null
       }
-      const sharedAncestor = this.getSharedAncestor(collaborator.resourceId)
+      const sharedAncestor = this.getAncestorById(collaborator.resourceId)
       if (!sharedAncestor) {
         return null
       }

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
@@ -191,6 +191,7 @@ function getWrapper({
         plugins: [
           ...defaultPlugins({
             piniaOptions: {
+              stubActions: false,
               userState: { user },
               spacesState: { spaceMembers },
               capabilityState: { capabilities },

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsPaste.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsPaste.ts
@@ -107,7 +107,7 @@ export const useFileActionsPaste = () => {
       }
 
       resourcesStore.upsertResources(fetchedResources)
-      resourcesStore.loadIndicators(targetSpace, unref(currentFolder).path)
+      resourcesStore.loadIndicators(targetSpace, unref(currentFolder).id)
     })
   }
 

--- a/packages/web-pkg/src/composables/piniaStores/resources.ts
+++ b/packages/web-pkg/src/composables/piniaStores/resources.ts
@@ -291,6 +291,10 @@ export const useResourcesStore = defineStore('resources', () => {
     })
   }
 
+  const getAncestorById = (id: string) => {
+    return Object.values(unref(ancestorMetaData)).find((a) => id === a.id)
+  }
+
   return {
     resources,
     currentFolder,
@@ -333,7 +337,8 @@ export const useResourcesStore = defineStore('resources', () => {
     ancestorMetaData,
     setAncestorMetaData,
     updateAncestorField,
-    loadAncestorMetaData
+    loadAncestorMetaData,
+    getAncestorById
   }
 })
 

--- a/packages/web-pkg/src/composables/piniaStores/resources.ts
+++ b/packages/web-pkg/src/composables/piniaStores/resources.ts
@@ -182,8 +182,8 @@ export const useResourcesStore = defineStore('resources', () => {
     window.localStorage.setItem('oc_webDavDetailsShown', value.toString())
   }
 
-  const loadIndicators = (space: SpaceResource, path: string) => {
-    const files = unref(resources).filter((f) => f.path.startsWith(path))
+  const loadIndicators = (space: SpaceResource, id: string) => {
+    const files = unref(resources).filter((f) => [f.id, f.parentFolderId].includes(id))
     for (const resource of files) {
       const indicators = getIndicators({
         space,

--- a/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
+++ b/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
@@ -115,7 +115,7 @@ export const useSharesStore = defineStore('shares', () => {
     loading.value = value
   }
 
-  const updateFileShareTypes = (path: string) => {
+  const updateFileShareTypes = (id: string) => {
     const computeShareTypes = (shares: Share[]) => {
       const shareTypes = new Set<number>()
       shares.forEach((share) => {
@@ -125,7 +125,7 @@ export const useSharesStore = defineStore('shares', () => {
     }
 
     const file = [...resourcesStore.resources, resourcesStore.currentFolder].find(
-      (f) => f?.path === path
+      (f) => f?.id === id
     )
     if (!file || isProjectSpaceResource(file)) {
       return
@@ -138,7 +138,7 @@ export const useSharesStore = defineStore('shares', () => {
       value: computeShareTypes(allShares.filter((s) => !s.indirect))
     })
 
-    const ancestorEntry = resourcesStore.ancestorMetaData[file.path] ?? null
+    const ancestorEntry = Object.values(resourcesStore.ancestorMetaData).find((a) => a.id === id)
     if (ancestorEntry) {
       resourcesStore.updateAncestorField({
         path: ancestorEntry.path,
@@ -183,8 +183,8 @@ export const useSharesStore = defineStore('shares', () => {
     })
 
     addCollaboratorShares(builtShares)
-    updateFileShareTypes(resource.path)
-    resourcesStore.loadIndicators(space, resource.path)
+    updateFileShareTypes(resource.id)
+    resourcesStore.loadIndicators(space, resource.id)
     return builtShares
   }
 
@@ -246,9 +246,9 @@ export const useSharesStore = defineStore('shares', () => {
     }
 
     removeCollaboratorShare(collaboratorShare)
-    updateFileShareTypes(resource.path)
+    updateFileShareTypes(resource.id)
     if (loadIndicators) {
-      resourcesStore.loadIndicators(space, resource.path)
+      resourcesStore.loadIndicators(space, resource.id)
     }
   }
 
@@ -276,7 +276,7 @@ export const useSharesStore = defineStore('shares', () => {
       (selectedFiles.length === 0 && resourcesStore.currentFolder.fileId === resource.fileId)
 
     upsertLinkShare(link)
-    updateFileShareTypes(resource.path)
+    updateFileShareTypes(resource.id)
 
     if (!fileIsSelected) {
       // we might need to update the share types for the ancestor resource as well
@@ -293,7 +293,7 @@ export const useSharesStore = defineStore('shares', () => {
       }
     }
 
-    resourcesStore.loadIndicators(space, resource.path)
+    resourcesStore.loadIndicators(space, resource.id)
     return link
   }
 
@@ -362,9 +362,9 @@ export const useSharesStore = defineStore('shares', () => {
     }
 
     removeLinkShare(linkShare)
-    updateFileShareTypes(resource.path)
+    updateFileShareTypes(resource.id)
     if (loadIndicators) {
-      resourcesStore.loadIndicators(space, resource.path)
+      resourcesStore.loadIndicators(space, resource.id)
     }
   }
 

--- a/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
+++ b/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
@@ -138,7 +138,7 @@ export const useSharesStore = defineStore('shares', () => {
       value: computeShareTypes(allShares.filter((s) => !s.indirect))
     })
 
-    const ancestorEntry = Object.values(resourcesStore.ancestorMetaData).find((a) => a.id === id)
+    const ancestorEntry = resourcesStore.getAncestorById(id)
     if (ancestorEntry) {
       resourcesStore.updateAncestorField({
         path: ancestorEntry.path,

--- a/packages/web-pkg/tests/unit/composables/piniaStores/resources.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/piniaStores/resources.spec.ts
@@ -1,0 +1,70 @@
+import { createTestingPinia, getComposableWrapper } from 'web-test-helpers'
+import { useResourcesStore } from '../../../../src/composables/piniaStores'
+import { mock } from 'vitest-mock-extended'
+import { Resource, ShareTypes, SpaceResource } from '@ownclouders/web-client'
+
+describe('useResourcesStore', () => {
+  beforeEach(() => {
+    createTestingPinia({
+      stubActions: false
+    })
+  })
+
+  describe('loadIndicators', () => {
+    it('loads sharing indicator for a direct resource', () => {
+      getWrapper({
+        setup: (instance) => {
+          const space = mock<SpaceResource>({ driveType: 'project', isMember: () => true })
+          const resource = mock<Resource>({
+            id: '1',
+            shareTypes: [ShareTypes.user.value],
+            indicators: []
+          })
+          const resources = [resource]
+          instance.resources = resources
+
+          expect(resource.indicators.some(({ category }) => category === 'sharing')).toBeFalsy()
+          instance.loadIndicators(space, resource.id)
+
+          expect(resource.indicators.some(({ category }) => category === 'sharing')).toBeTruthy()
+        }
+      })
+    })
+    it('loads sharing indicator for an indirect resource (parent)', () => {
+      getWrapper({
+        setup: (instance) => {
+          const space = mock<SpaceResource>({ driveType: 'project', isMember: () => true })
+          const resource = mock<Resource>({
+            id: '1',
+            parentFolderId: '2',
+            shareTypes: [ShareTypes.user.value],
+            indicators: []
+          })
+          const resources = [resource]
+          instance.resources = resources
+
+          expect(resource.indicators.some(({ category }) => category === 'sharing')).toBeFalsy()
+          instance.loadIndicators(space, resource.parentFolderId)
+
+          expect(resource.indicators.some(({ category }) => category === 'sharing')).toBeTruthy()
+        }
+      })
+    })
+  })
+})
+
+function getWrapper({
+  setup
+}: {
+  setup: (instance: ReturnType<typeof useResourcesStore>) => void
+}) {
+  return {
+    wrapper: getComposableWrapper(
+      () => {
+        const instance = useResourcesStore()
+        setup(instance)
+      },
+      { pluginOptions: { pinia: false } }
+    )
+  }
+}


### PR DESCRIPTION
## Description
Changes the computing of share types and loading share indicators to work id-based instead of path-based.

This is a prerequisite for having id-based webdav requests in the future.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Works towards https://github.com/owncloud/web/issues/9786

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
