### PR TITLE
feat: add apps folder for dev setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,8 @@ tests/report/cucumber_report.html
 # third party licenses
 /third-party-licenses
 
-# dev setup certificates
+# dev setup
 /dev/docker/ocis-ca
 /dev/docker/traefik/certificates
 docker-compose.override.yml
+/dev/docker/apps

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ x-ocis-server: &ocis-service
 
     # WEB
     WEB_ASSET_CORE_PATH: ${WEB_ASSET_CORE_PATH:-/web/dist}
+    WEB_ASSET_APPS_PATH: ${WEB_ASSET_APPS_PATH:-/web/apps}
     WEB_UI_THEME_PATH: ${WEB_UI_THEME_PATH:-/themes/owncloud/theme.json}
     WEB_UI_CONFIG_FILE: ${WEB_UI_CONFIG_FILE:-/web/config.json}
 
@@ -110,6 +111,7 @@ services:
       - ./dev/docker/ocis.idp.config.yaml:/etc/ocis/idp.yaml
       - ./dev/docker/ocis-ca:/var/lib/ocis/proxy
       - ./dev/docker/ocis.storage.ocmproviders.json:/etc/ocis/ocmproviders.json
+      - ./dev/docker/apps:/web/apps
       - ./dist:/web/dist
       - ./dev/docker/ocis/app-registry.yaml:/etc/ocis/app-registry.yaml
       - ocis-config:/etc/ocis


### PR DESCRIPTION
Adds an `apps` folder for the dev stack and automatically mounts it in the docker compose stack, using it as ocis web apps folder. This is supposed to make it easier to test third party apps in our dev stack.