### PR TITLE
[full-ci] refactor: initialize app provider apps earlier

### DIFF
--- a/packages/web-app-external/src/Redirect.vue
+++ b/packages/web-app-external/src/Redirect.vue
@@ -18,7 +18,6 @@ import {
   queryItemAsString,
   useAppProviderService,
   useRouteMeta,
-  useRouteParam,
   useRouteQuery
 } from '@ownclouders/web-pkg'
 import { useRouter } from 'vue-router'
@@ -36,11 +35,7 @@ export default defineComponent({
 
     const appQuery = useRouteQuery('app')
     const appNameQuery = useRouteQuery('appName')
-    const appNameParam = useRouteParam('appCatchAll')
     const appName = computed(() => {
-      if (unref(appNameParam)) {
-        return unref(appNameParam)
-      }
       if (unref(appQuery)) {
         return queryItemAsString(unref(appQuery))
       }

--- a/packages/web-app-external/src/index.ts
+++ b/packages/web-app-external/src/index.ts
@@ -31,19 +31,6 @@ export default defineWebApplication({
       }
       const routes = [
         {
-          // catch-all route for page reloads, because dynamic external app routes are not available immediately on page reload.
-          // can be deleted as soon as app provider apps are not loaded after login anymore (app provider listing endpoint must be hardcoded and public)
-          // prerequisite: https://github.com/owncloud/ocis/issues/9489
-          name: 'catch-all',
-          path: '-:appCatchAll/:driveAliasAndItem(.*)?',
-          component: Redirect,
-          meta: {
-            authContext: 'hybrid',
-            title: $gettext('Redirecting to external app'),
-            patchCleanPath: true
-          }
-        },
-        {
           // fallback route for old external-app URLs, in case someone made a bookmark. Can be removed with the next major release.
           name: 'apps',
           path: '/:driveAliasAndItem(.*)?',

--- a/packages/web-pkg/src/services/appProvider/service.ts
+++ b/packages/web-pkg/src/services/appProvider/service.ts
@@ -1,29 +1,23 @@
 import { MimeType, MimeTypesToAppsSchema } from './schemas'
 import { ref, unref } from 'vue'
-import { CapabilityStore } from '../../composables'
 import { ClientService } from '../client'
+import { urlJoin } from '@ownclouders/web-client'
 
 export class AppProviderService {
   private _mimeTypes = ref<MimeType[]>([])
-  private capabilityStore: CapabilityStore
-  private clientService: ClientService
+  private readonly serverUrl: string
+  private readonly clientService: ClientService
 
-  constructor(capabilityStore: CapabilityStore, clientService: ClientService) {
-    this.capabilityStore = capabilityStore
+  constructor(serverUrl: string, clientService: ClientService) {
+    this.serverUrl = serverUrl
     this.clientService = clientService
   }
 
   public async loadData(): Promise<void> {
-    const appProviderCapability = this.capabilityStore.filesAppProviders.find(
-      (appProvider) => appProvider.enabled
-    )
-    if (!appProviderCapability) {
-      return
-    }
-
+    const appListUrl = urlJoin(this.serverUrl, 'app', 'list')
     const {
       data: { 'mime-types': mimeTypes }
-    } = await this.clientService.httpUnAuthenticated.get(appProviderCapability.apps_url, {
+    } = await this.clientService.httpUnAuthenticated.get(appListUrl, {
       schema: MimeTypesToAppsSchema
     })
     this._mimeTypes.value = mimeTypes

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -163,7 +163,7 @@ export const announceConfiguration = async ({
  *
  * @param configStore
  */
-export const announceClient = async (configStore: ConfigStore): Promise<void> => {
+export const announceAuthClient = async (configStore: ConfigStore): Promise<void> => {
   const openIdConnect = configStore.openIdConnect || {}
 
   if (!openIdConnect.dynamic) {
@@ -185,13 +185,13 @@ export const initializeApplications = async ({
   configStore,
   router,
   appProviderService,
-  dynamicApps
+  appProviderApps
 }: {
   app: App
   configStore: ConfigStore
   router: Router
   appProviderService: AppProviderService
-  dynamicApps?: boolean
+  appProviderApps?: boolean
 }): Promise<NextApplication[]> => {
   type RawApplication = {
     path?: string
@@ -199,7 +199,7 @@ export const initializeApplications = async ({
   }
 
   let applicationResults: PromiseSettledResult<NextApplication>[] = []
-  if (dynamicApps) {
+  if (appProviderApps) {
     applicationResults = await Promise.allSettled(
       appProviderService.appNames.map((appName) =>
         buildApplication({
@@ -574,14 +574,14 @@ export const announceAuthService = ({
  */
 export const announceAppProviderService = ({
   app,
-  capabilityStore,
+  serverUrl,
   clientService
 }: {
   app: App
-  capabilityStore: CapabilityStore
+  serverUrl: string
   clientService: ClientService
 }): AppProviderService => {
-  const appProviderService = new AppProviderService(capabilityStore, clientService)
+  const appProviderService = new AppProviderService(serverUrl, clientService)
   app.config.globalProperties.$appProviderService = appProviderService
   app.provide('$appProviderService', appProviderService)
   return appProviderService


### PR DESCRIPTION
## Description
Since the ocis backend guarantees that the /app/list endpoint exists we can hardcode the url and initialize the app provider apps before the vue-router is being initialized. This saves us a redirect on page reload in an app provider app, because we don't have to wait for the capabilities being loaded before fetching the app provider app listing.

## Related Issue
See https://github.com/owncloud/ocis/issues/9489 for server requirements (were already fulfilled without us realising it :-) ).

## Motivation and Context
Reduce bootstrap complexity.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)