### PR TITLE
use zip instead of tar in the e2e

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=4e0ecd1451ac8d0b03795e1835373bd8b0837be8
+OCIS_COMMITID=de194c7076570f610ee1f206dad821a26d7baa46
 OCIS_BRANCH=master

--- a/tests/e2e/cucumber/steps/ui/spaces.ts
+++ b/tests/e2e/cucumber/steps/ui/spaces.ts
@@ -212,6 +212,6 @@ When(
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const spacesObject = new objects.applicationFiles.Spaces({ page })
     const downloadedResource = await spacesObject.downloadSpace()
-    expect(downloadedResource).toContain('download.tar')
+    expect(downloadedResource).toContain('download.zip')
   }
 )


### PR DESCRIPTION
related https://github.com/owncloud/ocis/pull/9621

now we download zip by default