### PR TITLE
[full-ci]check e2e test without redundant config

### DIFF
--- a/dev/docker/ocis.web.config.json
+++ b/dev/docker/ocis.web.config.json
@@ -9,9 +9,7 @@
     "scope": "openid profile email"
   },
   "options": {
-    "topCenterNotifications": true,
     "disablePreviews": true,
-    "displayResourcesLazy": false,
     "sidebar": {
       "shares": {
         "showAllOnLoad": true

--- a/tests/drone/config-ocis.json
+++ b/tests/drone/config-ocis.json
@@ -9,9 +9,7 @@
     "scope": "openid profile email"
   },
   "options": {
-    "topCenterNotifications": true,
     "disablePreviews": true,
-    "displayResourcesLazy": false,
     "sidebar": {
       "shares": {
         "showAllOnLoad": true


### PR DESCRIPTION
related https://github.com/owncloud/web/issues/11215

run e2e test in the CI without: 
```
"topCenterNotifications": true,
"displayResourcesLazy": false,
```