### PR TITLE
refactor: setting space image and readme data id-based

### DIFF
--- a/packages/web-app-files/tests/unit/composables/actions/spaces/useSpaceActionsUploadImage.spec.ts
+++ b/packages/web-app-files/tests/unit/composables/actions/spaces/useSpaceActionsUploadImage.spec.ts
@@ -2,8 +2,13 @@ import { useSpaceActionsUploadImage } from 'web-app-files/src/composables/action
 import { mock } from 'vitest-mock-extended'
 import { defaultComponentMocks, RouteLocation, getComposableWrapper } from 'web-test-helpers'
 import { unref, VNodeRef } from 'vue'
-import { eventBus, useMessages } from '@ownclouders/web-pkg'
+import { eventBus, useMessages, useSpaceHelpers } from '@ownclouders/web-pkg'
 import { Resource, SpaceResource } from '@ownclouders/web-client'
+
+vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
+  ...(await importOriginal<any>()),
+  useSpaceHelpers: vi.fn()
+}))
 
 describe('uploadImage', () => {
   describe('method "uploadImageSpace"', () => {
@@ -80,6 +85,11 @@ function getWrapper({
     }
   ) => void
 }) {
+  vi.mocked(useSpaceHelpers).mockReturnValue({
+    checkSpaceNameModalInput: vi.fn(),
+    getDefaultMetaFolder: () => new Promise(() => mock<Resource>())
+  })
+
   const mocks = {
     ...defaultComponentMocks({
       currentRoute: mock<RouteLocation>({ name: 'files-spaces-generic' })

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -28,6 +28,9 @@ export function buildWebDavSpacesTrashPath(storageId: string, path = '') {
 export function getRelativeSpecialFolderSpacePath(space: SpaceResource, type: 'image' | 'readme') {
   const typeMap = { image: 'spaceImageData', readme: 'spaceReadmeData' } as const
   const specialProp = space[typeMap[type]]
+  if (!specialProp) {
+    return ''
+  }
   const webDavPathComponents = decodeURI(specialProp.webDavUrl).split('/')
   const idComponent = webDavPathComponents.find((c) => c.startsWith(space.id))
   if (!idComponent) {

--- a/packages/web-client/src/webdav/utils.ts
+++ b/packages/web-client/src/webdav/utils.ts
@@ -24,5 +24,5 @@ export const getWebDavPath = (
     return urlJoin('spaces', fileId, name || '')
   }
 
-  throw new Error('either a fileId or a path must be provided')
+  return space.webDavPath
 }

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditReadmeContent.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditReadmeContent.ts
@@ -18,6 +18,7 @@ export const useSpaceActionsEditReadmeContent = () => {
   const { getDefaultMetaFolder } = useSpaceHelpers()
 
   const createReadme = async (space: SpaceResource, metaFolder: Resource) => {
+    // FIXME: remove path as soon as we make the full switch to id-based dav requests
     const markdownResource = await clientService.webdav.putFileContents(space, {
       path: '.space/readme.md',
       parentFolderId: metaFolder.id,

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditReadmeContent.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditReadmeContent.ts
@@ -3,7 +3,7 @@ import { computed } from 'vue'
 import { useGettext } from 'vue3-gettext'
 
 import { useOpenWithDefaultApp } from '../useOpenWithDefaultApp'
-import { getRelativeSpecialFolderSpacePath, Resource } from '@ownclouders/web-client'
+import { getRelativeSpecialFolderSpacePath, Resource, SpaceResource } from '@ownclouders/web-client'
 import { useClientService } from '../../clientService'
 import { useSpacesStore, useUserStore } from '../../piniaStores'
 import { useCreateSpace, useSpaceHelpers } from '../../spaces'
@@ -17,38 +17,43 @@ export const useSpaceActionsEditReadmeContent = () => {
   const { $gettext } = useGettext()
   const { getDefaultMetaFolder } = useSpaceHelpers()
 
+  const createReadme = async (space: SpaceResource, metaFolder: Resource) => {
+    const markdownResource = await clientService.webdav.putFileContents(space, {
+      path: '.space/readme.md',
+      parentFolderId: metaFolder.id,
+      fileName: 'readme.md'
+    })
+
+    const updatesSpace = await clientService.graphAuthenticated.drives.updateDrive(space.id, {
+      name: space.name,
+      special: [{ specialFolder: { name: 'readme' }, id: markdownResource.id }]
+    })
+
+    spacesStore.updateSpaceField({
+      id: space.id,
+      field: 'spaceReadmeData',
+      value: updatesSpace.spaceReadmeData
+    })
+
+    return markdownResource
+  }
+
   const handler = async ({ resources }: SpaceActionOptions) => {
     let markdownResource: Resource = null
 
     let metaFolder = await getDefaultMetaFolder(resources[0])
     if (!metaFolder) {
       metaFolder = await createDefaultMetaFolder(resources[0])
-      markdownResource = await clientService.webdav.putFileContents(resources[0], {
-        path: '.space/readme.md',
-        parentFolderId: metaFolder.id,
-        fileName: 'readme.md'
-      })
-
-      const updatedSpace = await clientService.graphAuthenticated.drives.updateDrive(
-        resources[0].id,
-        {
-          name: resources[0].name,
-          special: [{ specialFolder: { name: 'readme' }, id: markdownResource.id }]
-        }
-      )
-
-      spacesStore.updateSpaceField({
-        id: resources[0].id,
-        field: 'spaceReadmeData',
-        value: updatedSpace.spaceReadmeData
-      })
+      markdownResource = await createReadme(resources[0], metaFolder)
     }
 
     if (!markdownResource) {
-      console.log(345)
-      markdownResource = await clientService.webdav.getFileInfo(resources[0], {
-        path: getRelativeSpecialFolderSpacePath(resources[0], 'readme')
-      })
+      const path = getRelativeSpecialFolderSpacePath(resources[0], 'readme')
+      if (path) {
+        markdownResource = await clientService.webdav.getFileInfo(resources[0], { path })
+      } else {
+        markdownResource = await createReadme(resources[0], metaFolder)
+      }
     }
 
     openWithDefaultApp({ space: resources[0], resource: markdownResource })

--- a/packages/web-pkg/src/composables/spaces/useCreateSpace.ts
+++ b/packages/web-pkg/src/composables/spaces/useCreateSpace.ts
@@ -16,6 +16,8 @@ export const useCreateSpace = () => {
     if (extractStorageId(spaceFolder.parentFolderId) === resourcesStore.currentFolder?.id) {
       resourcesStore.upsertResource(spaceFolder)
     }
+
+    return spaceFolder
   }
 
   return { createSpace, createDefaultMetaFolder }

--- a/packages/web-pkg/src/composables/spaces/useSpaceHelpers.ts
+++ b/packages/web-pkg/src/composables/spaces/useSpaceHelpers.ts
@@ -1,7 +1,10 @@
+import { SpaceResource } from '@ownclouders/web-client'
 import { useGettext } from 'vue3-gettext'
+import { useClientService } from '../clientService'
 
 export const useSpaceHelpers = () => {
   const { $gettext } = useGettext()
+  const clientService = useClientService()
 
   const checkSpaceNameModalInput = (name: string, setError: (value: string) => void) => {
     if (name.trim() === '') {
@@ -18,5 +21,10 @@ export const useSpaceHelpers = () => {
     return setError(null)
   }
 
-  return { checkSpaceNameModalInput }
+  const getDefaultMetaFolder = async (space: SpaceResource) => {
+    const { children } = await clientService.webdav.listFiles(space)
+    return children.find(({ name }) => name === '.space')
+  }
+
+  return { checkSpaceNameModalInput, getDefaultMetaFolder }
 }

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsSetImage.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsSetImage.spec.ts
@@ -5,6 +5,11 @@ import { mock } from 'vitest-mock-extended'
 import { defaultComponentMocks, RouteLocation, getComposableWrapper } from 'web-test-helpers'
 import { unref } from 'vue'
 import { Drive } from '@ownclouders/web-client/graph/generated'
+import { useSpaceHelpers } from '../../../../../src/composables/spaces/useSpaceHelpers'
+
+vi.mock('../../../../../src/composables/spaces/useSpaceHelpers', () => ({
+  useSpaceHelpers: vi.fn()
+}))
 
 describe('setImage', () => {
   describe('isVisible property', () => {
@@ -150,6 +155,11 @@ function getWrapper({
   ) => void
   isMimetypeSupported?: boolean
 }) {
+  vi.mocked(useSpaceHelpers).mockReturnValue({
+    checkSpaceNameModalInput: vi.fn(),
+    getDefaultMetaFolder: () => new Promise(() => mock<Resource>())
+  })
+
   const mocks = {
     ...defaultComponentMocks({
       currentRoute: mock<RouteLocation>({ name: 'files-spaces-generic' })

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsSetReadme.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsSetReadme.spec.ts
@@ -1,11 +1,16 @@
 import { useFileActionsSetReadme } from '../../../../../src'
 import { useMessages } from '../../../../../src/composables/piniaStores'
-import { buildSpace, FileResource, SpaceResource } from '@ownclouders/web-client'
+import { buildSpace, FileResource, Resource, SpaceResource } from '@ownclouders/web-client'
 import { mock } from 'vitest-mock-extended'
 import { defaultComponentMocks, RouteLocation, getComposableWrapper } from 'web-test-helpers'
 import { unref } from 'vue'
 import { GetFileContentsResponse } from '@ownclouders/web-client/webdav'
 import { Drive } from '@ownclouders/web-client/graph/generated'
+import { useSpaceHelpers } from '../../../../../src/composables/spaces/useSpaceHelpers'
+
+vi.mock('../../../../../src/composables/spaces/useSpaceHelpers', () => ({
+  useSpaceHelpers: vi.fn()
+}))
 
 describe('setReadme', () => {
   describe('isVisible property', () => {
@@ -146,6 +151,11 @@ function getWrapper({
   space?: SpaceResource
   setup: (instance: ReturnType<typeof useFileActionsSetReadme>) => void
 }) {
+  vi.mocked(useSpaceHelpers).mockReturnValue({
+    checkSpaceNameModalInput: vi.fn(),
+    getDefaultMetaFolder: () => new Promise(() => mock<Resource>())
+  })
+
   const mocks = {
     ...defaultComponentMocks({
       currentRoute: mock<RouteLocation>({ name: 'files-spaces-generic' })

--- a/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsEditReadmeContent.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsEditReadmeContent.spec.ts
@@ -2,15 +2,20 @@ import {
   useOpenWithDefaultApp,
   useSpaceActionsEditReadmeContent
 } from '../../../../../src/composables/actions'
-import { SpaceResource, buildSpace } from '@ownclouders/web-client'
+import { Resource, SpaceResource, buildSpace } from '@ownclouders/web-client'
 import { getComposableWrapper } from 'web-test-helpers'
 import { unref } from 'vue'
 import { mock, mockDeep } from 'vitest-mock-extended'
 import { Drive } from '@ownclouders/web-client/graph/generated'
-import { ClientService } from '../../../../../src'
+import { ClientService } from '../../../../../src/services'
+import { useSpaceHelpers } from '../../../../../src/composables/spaces/useSpaceHelpers'
 
 vi.mock('../../../../../src/composables/actions/useOpenWithDefaultApp', () => ({
   useOpenWithDefaultApp: vi.fn()
+}))
+
+vi.mock('../../../../../src/composables/spaces/useSpaceHelpers', () => ({
+  useSpaceHelpers: vi.fn()
 }))
 
 describe('editReadmeContent', () => {
@@ -88,6 +93,11 @@ function getWrapper({
       openWithDefaultApp
     })
   )
+
+  vi.mocked(useSpaceHelpers).mockReturnValue({
+    checkSpaceNameModalInput: vi.fn(),
+    getDefaultMetaFolder: () => new Promise(() => mock<Resource>())
+  })
 
   const mocks = { openWithDefaultApp }
 


### PR DESCRIPTION
## Description
Refactors setting/updating space image and readme data to work id-based. The big difference is that we need to retrieve the id of the `.space` meta folder so it can be used for the requests.

Also fixes an issue in scenarios where we want to list files for a space root where no `fileId` and no `path` are being provided. We need to fall back to the space id in such case.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- works towards https://github.com/owncloud/web/issues/9786

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
