### PR TITLE
[tests-only][full-ci] bump ocis stable commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=b4f5957e7197f21655a796c65194e359d38edbcf
+OCIS_COMMITID=caecf781e3e5c50c5767d82f8eaad55ff093e097
 OCIS_BRANCH=stable-5.0


### PR DESCRIPTION
### Description
Bump latest ocis stable commit id.

Part of: https://github.com/owncloud/QA/issues/856