### PR TITLE
[full-ci] user should not see thumbnail and preview for secure view file

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=9fc37e7b8173884231d3f7bda671ff81984dc960
+OCIS_COMMITID=c7a3ec2ed0fce86166a44ab6c769661b73546342
 OCIS_BRANCH=master

--- a/tests/e2e/cucumber/features/app-provider/secureView.feature
+++ b/tests/e2e/cucumber/features/app-provider/secureView.feature
@@ -18,11 +18,11 @@ Feature: Secure view
     Given "Alice" creates the following folder in personal space using API
       | name          |
       | shared folder |
-    And "Alice" uploads the following resource
-      | resource        | to            |
-      | simple.pdf      | shared folder |
-      | testavatar.jpeg | shared folder |
-      | lorem.txt       | shared folder |
+    And "Alice" uploads the following local file into personal space using API
+      | localFile                      | to                            |
+      | filesForUpload/simple.pdf      | shared folder/simple.pdf      |
+      | filesForUpload/testavatar.jpeg | shared folder/testavatar.jpeg |
+      | filesForUpload/lorem.txt       | shared folder/lorem.txt       |
     And "Alice" creates the following resources
       | resource           | type         | content                 |
       | secureDocument.odt | OpenDocument | very important document |
@@ -65,11 +65,11 @@ Feature: Secure view
     Given "Alice" creates the following folder in personal space using API
       | name          |
       | shared folder |
-    And "Alice" uploads the following resource
-      | resource        | to            |
-      | simple.pdf      | shared folder |
-      | testavatar.jpeg | shared folder |
-      | lorem.txt       | shared folder |
+    And "Alice" uploads the following local file into personal space using API
+      | localFile                      | to                             |
+      | filesForUpload/simple.pdf      | shared folder/secure.pdf       |
+      | filesForUpload/testavatar.jpeg | shared folder/securePhoto.jpeg |
+      | filesForUpload/lorem.txt       | shared folder/secureFile.txt   |
     And "Alice" creates the following resources
       | resource           | type         | content                 |
       | secureDocument.odt | OpenDocument | very important document |
@@ -81,6 +81,8 @@ Feature: Secure view
 
     And "Brian" logs in
     And "Brian" navigates to the shared with me page
+
+    # .odt file
     Then "Brian" should see following actions for file "secureDocument.odt"
       | action            |
       | Open in Collabora |
@@ -89,51 +91,100 @@ Feature: Secure view
       | Download           |
       | Copy               |
       | Open in OnlyOffice |
-    And "Brian" should not see following actions for folder "shared folder"
+    And "Brian" should not see preview for file "secureDocument.odt"
+
+    # folder
+    Then "Brian" should not see following actions for folder "shared folder"
       | action   |
       | Download |
       | Copy     |
     When "Brian" opens folder "shared folder"
-    Then "Brian" should see following actions for file "simple.pdf"
+
+    # .pdf file
+    Then "Brian" should see following actions for file "secure.pdf"
       | action            |
       | Open in Collabora |
-    But "Brian" should not see following actions for file "simple.pdf"
+    But "Brian" should not see following actions for file "secure.pdf"
       | action             |
       | Download           |
       | Copy               |
       | Open in PDF Viewer |
-    And "Brian" should see following actions for file "testavatar.jpeg"
+    And "Brian" should not see thumbnail and preview for file "secure.pdf"
+
+    # .jpeg file
+    Then "Brian" should see following actions for file "securePhoto.jpeg"
       | action            |
       | Open in Collabora |
-    But "Brian" should not see following actions for file "testavatar.jpeg"
+    But "Brian" should not see following actions for file "securePhoto.jpeg"
       | action   |
       | Download |
       | Copy     |
       | Preview  |
-    And "Brian" should see following actions for file "lorem.txt"
+    And "Brian" should not see thumbnail and preview for file "securePhoto.jpeg"
+
+    # .txt file
+    Then "Brian" should see following actions for file "secureFile.txt"
       | action            |
       | Open in Collabora |
-    But "Brian" should not see following actions for file "lorem.txt"
+    But "Brian" should not see following actions for file "secureFile.txt"
       | action              |
       | Download            |
       | Copy                |
       | Open in Text Editor |
       | Open in OnlyOffice  |
+    And "Brian" should not see thumbnail and preview for file "secureFile.txt"
 
-    # check available actions in the seach result puge
-    When "Brian" searches "lorem" using the global search and the "all files" filter and presses enter
+    # check available actions and files preview in the seach result page
+    When "Brian" searches "secure" using the global search and the "all files" filter and presses enter
     Then following resources should be displayed in the files list for user "Brian"
-      | resource  |
-      | lorem.txt |
-    And "Brian" should see following actions for file "lorem.txt"
+      | resource           |
+      | secureFile.txt     |
+      | securePhoto.jpeg   |
+      | secure.pdf         |
+      | secureDocument.odt |
+
+    # .txt file
+    Then "Brian" should see following actions for file "secureFile.txt"
       | action            |
       | Open in Collabora |
-    # please enable again after fixing https://github.com/owncloud/ocis/issues/9608
-    # But "Brian" should not see following actions for file "lorem.txt"
-    #   | action              |
-    #   | Download            |
-    #   | Copy                |
-    #   | Open in Text Editor |
-    #   | Open in OnlyOffice  |
+    But "Brian" should not see following actions for file "secureFile.txt"
+      | action              |
+      | Download            |
+      | Copy                |
+      | Open in Text Editor |
+      | Open in OnlyOffice  |
+    And "Brian" should not see thumbnail and preview for file "secureFile.txt"
 
+    # .jpeg file
+    Then "Brian" should see following actions for file "securePhoto.jpeg"
+      | action            |
+      | Open in Collabora |
+    But "Brian" should not see following actions for file "securePhoto.jpeg"
+      | action   |
+      | Download |
+      | Copy     |
+      | Preview  |
+    And "Brian" should not see thumbnail and preview for file "securePhoto.jpeg"
+
+    # .pdf file
+    Then "Brian" should see following actions for file "secure.pdf"
+      | action            |
+      | Open in Collabora |
+    But "Brian" should not see following actions for file "secure.pdf"
+      | action             |
+      | Download           |
+      | Copy               |
+      | Open in PDF Viewer |
+    And "Brian" should not see preview for file "secure.pdf"
+
+    # .odt file
+    Then "Brian" should see following actions for file "secureDocument.odt"
+      | action            |
+      | Open in Collabora |
+    But "Brian" should not see following actions for file "secureDocument.odt"
+      | action             |
+      | Download           |
+      | Copy               |
+      | Open in OnlyOffice |
+    And "Brian" should not see preview for file "secureDocument.odt"
     And "Brian" logs out

--- a/tests/e2e/cucumber/features/shares/share.feature
+++ b/tests/e2e/cucumber/features/shares/share.feature
@@ -100,6 +100,10 @@ Feature: share
       | test_video.mp4  |
       | testavatar.jpeg |
       | testavatar.png  |
+    Then "Alice" should see thumbnail and preview for file "sampleGif.gif"
+    And "Alice" should see thumbnail and preview for file "testavatar.jpeg"
+    And "Alice" should see thumbnail and preview for file "testavatar.png"
+    And "Alice" should see preview for file "shareToBrian.txt"
     When "Alice" opens a file "testavatar.png" in the media-viewer using the sidebar panel
     Then "Alice" is in a media-viewer
     When "Alice" closes the file viewer

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -933,3 +933,26 @@ Then(
     }
   }
 )
+
+Then(
+  /^"([^"]*)" (should|should not) see (thumbnail and preview|preview) for file "([^"]*)"$/,
+  async function (
+    this: World,
+    stepUser: string,
+    actionType: string,
+    action: string,
+    resource: string
+  ): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const resourceObject = new objects.applicationFiles.Resource({ page })
+    if (actionType === 'should') {
+      action === 'thumbnail and preview' &&
+        (await expect(resourceObject.getFileThumbnailLocator(resource)).toBeVisible())
+      await resourceObject.shouldSeeFilePreview({ resource })
+    } else {
+      action === 'thumbnail and preview' &&
+        (await expect(resourceObject.getFileThumbnailLocator(resource)).not.toBeVisible())
+      await resourceObject.shouldNotSeeFilePreview({ resource })
+    }
+  }
+)

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -136,6 +136,9 @@ const onlyOfficeCanvasEditorSelector = '#id_viewer_overlay'
 const onlyOfficeCanvasCursorSelector = '#id_target_cursor'
 const onlyOfficeInfoDialog = '.alert .info-box'
 const onlyOfficeInfoDialogConfirm = `.alert button[result="ok"]`
+const fileThumbnail = `//span[@data-test-resource-name="%s"]/ancestor::tr[contains(@class, "oc-tbody-tr")]//img[contains(@class,"oc-resource-thumbnail")]`
+const fileIconWrapper = '#oc-file-details-sidebar .details-icon-wrapper'
+const fileIconPreview = '#oc-file-details-sidebar .details-preview'
 
 export const clickResource = async ({
   page,
@@ -2026,4 +2029,33 @@ export const getAllAvailableActions = async ({
   await sidebar.open({ page: page, resource })
   await sidebar.openPanel({ page: page, name: 'actions' })
   return await page.getByTestId('action-label').allTextContents()
+}
+
+export const getFileThumbnailLocator = (args: { page: Page; resource: string }): Locator => {
+  const { page, resource } = args
+  return page.locator(util.format(fileThumbnail, resource))
+}
+
+export const shouldSeeFilePreview = async ({
+  page,
+  resource
+}: {
+  page: Page
+  resource: string
+}): Promise<void> => {
+  await sidebar.open({ page: page, resource })
+  await expect(page.locator(fileIconPreview)).toHaveCSS('background-image', /blob/)
+  await sidebar.close({ page: page })
+}
+
+export const shouldNotSeeFilePreview = async ({
+  page,
+  resource
+}: {
+  page: Page
+  resource: string
+}): Promise<void> => {
+  await sidebar.open({ page: page, resource })
+  await expect(page.locator(fileIconWrapper)).toBeVisible()
+  await sidebar.close({ page: page })
 }

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -342,4 +342,16 @@ export class Resource {
   async getAllAvailableActions({ resource }: { resource: string }): Promise<string[]> {
     return await po.getAllAvailableActions({ page: this.#page, resource })
   }
+
+  getFileThumbnailLocator(resource: string): Locator {
+    return po.getFileThumbnailLocator({ page: this.#page, resource })
+  }
+
+  async shouldSeeFilePreview({ resource }: { resource: string }): Promise<void> {
+    await po.shouldSeeFilePreview({ page: this.#page, resource })
+  }
+
+  async shouldNotSeeFilePreview({ resource }: { resource: string }): Promise<void> {
+    await po.shouldNotSeeFilePreview({ page: this.#page, resource })
+  }
 }


### PR DESCRIPTION
- [x] check that user can not see thumbnail and preview for secure view file
- [x] check that user can see thumbnail and preview(was not implemented)
- [x] enabled skipped steps after fixing https://github.com/owncloud/ocis/issues/9608 and https://github.com/owncloud/ocis/issues/9607
- [x] updated ocis commit to bring the fix to the web 
- [ ] ~~check that mobile and desktop cannot open secure view in the OnlyOffice (should be only available for Collabora)~~ will be in the another PR