### PR TITLE
feat: parse dav error codes in web-client 

### DIFF
--- a/packages/web-client/src/errors.ts
+++ b/packages/web-client/src/errors.ts
@@ -1,3 +1,5 @@
+import { DavErrorCode } from './webdav'
+
 export class HttpError extends Error {
   public response: Response
   public statusCode: number
@@ -6,5 +8,19 @@ export class HttpError extends Error {
     super(message)
     this.response = response
     this.statusCode = statusCode
+  }
+}
+
+export class DavHttpError extends HttpError {
+  public errorCode: DavErrorCode
+
+  constructor(
+    message: string,
+    errorCode: DavErrorCode,
+    response: Response,
+    statusCode: number = null
+  ) {
+    super(message, response, statusCode)
+    this.errorCode = errorCode
   }
 }

--- a/packages/web-client/src/webdav/client/dav.ts
+++ b/packages/web-client/src/webdav/client/dav.ts
@@ -12,7 +12,7 @@ import { DavMethod, DavPropertyValue } from '../constants'
 import { buildPropFindBody, buildPropPatchBody } from './builders'
 import { parseError, parseMultiStatus, parseTusHeaders } from './parsers'
 import { WebDavResponseResource } from '../../helpers'
-import { HttpError } from '../../errors'
+import { DavHttpError } from '../../errors'
 import { AxiosInstance } from 'axios'
 
 export interface DAVOptions {
@@ -217,7 +217,12 @@ export class DAV {
       const { response } = error
       const body = await response.text()
       const errorMessage = parseError(body)
-      throw new HttpError(errorMessage, response, response.status)
+      throw new DavHttpError(
+        errorMessage.message,
+        errorMessage.errorCode,
+        response,
+        response.status
+      )
     }
   }
 }

--- a/packages/web-client/src/webdav/constants/dav.ts
+++ b/packages/web-client/src/webdav/constants/dav.ts
@@ -14,6 +14,13 @@ export abstract class DavPermission {
   static readonly SecureView: string = 'X'
 }
 
+export type DavErrorCode =
+  | 'ERR_LISTING_MEMBERS_NOT_ALLOWED'
+  | 'ERR_INVALID_CREDENTIALS'
+  | 'ERR_MISSING_BASIC_AUTH'
+  | 'ERR_MISSING_BEARER_AUTH'
+  | 'ERR_FILE_NOT_FOUND_IN_ROOT'
+
 export enum DavMethod {
   copy = 'COPY',
   delete = 'DELETE',

--- a/packages/web-runtime/tests/unit/pages/resolvePublicLink.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/resolvePublicLink.spec.ts
@@ -2,7 +2,7 @@ import ResolvePublicLink from '../../../src/pages/resolvePublicLink.vue'
 import { defaultPlugins, defaultComponentMocks, shallowMount } from 'web-test-helpers'
 import { mockDeep } from 'vitest-mock-extended'
 import { CapabilityStore, ClientService, useRouteParam } from '@ownclouders/web-pkg'
-import { HttpError, SpaceResource } from '@ownclouders/web-client'
+import { DavHttpError, SpaceResource } from '@ownclouders/web-client'
 import { authService } from 'web-runtime/src/services/auth'
 import { ref } from 'vue'
 
@@ -89,11 +89,11 @@ function getWrapper({
   // loadPublicSpaceTask response
   if (passwordRequired) {
     $clientService.webdav.getFileInfo.mockRejectedValueOnce(
-      new HttpError("No 'Authorization: Basic' header found", undefined, 401)
+      new DavHttpError('', 'ERR_MISSING_BASIC_AUTH', undefined, 401)
     )
   } else if (isInternalLink) {
     $clientService.webdav.getFileInfo.mockRejectedValueOnce(
-      new HttpError("No 'Authorization: Bearer' header found", undefined, 401)
+      new DavHttpError('', 'ERR_MISSING_BEARER_AUTH', undefined, 401)
     )
   }
 


### PR DESCRIPTION
## Description
Failed dav requests now throw a new `DavHttpError`, which extends our regular `HttpError` and additionally contains a potential error code from the server response.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
