### PR TITLE
[tests-only][full-ci] create resources via API steps

### DIFF
--- a/tests/e2e/cucumber/features/smoke/tags.feature
+++ b/tests/e2e/cucumber/features/smoke/tags.feature
@@ -8,10 +8,10 @@ Feature: Users can use web to organize tags
 
   Scenario: Tag management
     When "Alice" logs in
+    And "Alice" creates the following files into personal space using API
+      | pathToFile | content     |
+      | lorem.txt  | lorem ipsum |
     And "Alice" opens the "files" app
-    And "Alice" uploads the following resource
-      | resource  |
-      | lorem.txt |
     And "Alice" adds the following tags for the following resources using the sidebar panel
       | resource  | tags         |
       | lorem.txt | tag 1, tag 2 |
@@ -35,11 +35,11 @@ Feature: Users can use web to organize tags
 
   Scenario: Tag search
     When "Alice" logs in
+    And "Alice" creates the following files into personal space using API
+      | pathToFile   | content     |
+      | lorem.txt    | lorem ipsum |
+      | textfile.txt | test file   |
     And "Alice" opens the "files" app
-    And "Alice" uploads the following resource
-      | resource     |
-      | lorem.txt    |
-      | textfile.txt |
     And "Alice" adds the following tags for the following resources using the sidebar panel
       | resource  | tags       |
       | lorem.txt | tag1, tag2 |
@@ -55,13 +55,13 @@ Feature: Users can use web to organize tags
 
   Scenario: Tag sharing
     When "Alice" logs in
+    And "Alice" creates the following folders in personal space using API
+      | name             |
+      | folder_to_shared |
+    And "Alice" creates the following files into personal space using API
+      | pathToFile                 | content     |
+      | folder_to_shared/lorem.txt | lorem ipsum |
     And "Alice" opens the "files" app
-    And "Alice" creates the following resources
-      | resource         | type   |
-      | folder_to_shared | folder |
-    And "Alice" uploads the following resource
-      | resource  | to               |
-      | lorem.txt | folder_to_shared |
     And "Alice" adds the following tags for the following resources using the sidebar panel
       | resource                   | tags         |
       | folder_to_shared/lorem.txt | tag 1, tag 2 |

--- a/tests/e2e/support/objects/app-files/utils/sidebar.ts
+++ b/tests/e2e/support/objects/app-files/utils/sidebar.ts
@@ -1,5 +1,9 @@
 import { Page } from '@playwright/test'
+import util from 'util'
 import { locatorUtils } from '../../../utils'
+
+const contextMenuSelector =
+  '//span[@data-test-resource-name="%s"]/ancestor::tr[contains(@class, "oc-tbody-tr")]//button[contains(@class, "resource-table-btn-action-dropdown")]'
 
 const openForResource = async ({
   page,
@@ -8,11 +12,7 @@ const openForResource = async ({
   page: Page
   resource: string
 }): Promise<void> => {
-  await page
-    .locator(
-      `//span[@data-test-resource-name="${resource}"]/ancestor::tr[contains(@class, "oc-tbody-tr")]//button[contains(@class, "resource-table-btn-action-dropdown")]`
-    )
-    .click()
+  await page.locator(util.format(contextMenuSelector, resource)).click()
   await page.locator('.oc-files-actions-show-details-trigger').click()
 }
 
@@ -25,11 +25,7 @@ export const openPanelForResource = async ({
   resource: string
   panel: string
 }): Promise<void> => {
-  await page
-    .locator(
-      `//span[@data-test-resource-name="${resource}"]/ancestor::tr[contains(@class, "oc-tbody-tr")]//button[contains(@class, "resource-table-btn-action-dropdown")]`
-    )
-    .click()
+  await page.locator(util.format(contextMenuSelector, resource)).click()
   await page.locator(`.oc-files-actions-show-${panel}-trigger`).click()
 }
 


### PR DESCRIPTION
## Description
Create required resources via API steps.

The flakiness reported in https://github.com/owncloud/web/issues/11246 was due to sidebar being refreshed - maybe due to post-processing activity updates which led the inserted tags to disappear.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/11246

## Motivation and Context

## How Has This Been Tested?
- :raised_back_of_hand: 

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
