### PR TITLE
Prune shares when we enter a project space view, to avoid showing quick link from another space

### DIFF
--- a/changelog/unreleased/bugfix-space-show-links-from-other-spaces
+++ b/changelog/unreleased/bugfix-space-show-links-from-other-spaces
@@ -1,0 +1,6 @@
+Bugfix: Space show links from other spaces
+
+We've fixed a bug where in a special constellation, links from other spaces were shown in the space. This is now fixed.
+
+https://github.com/owncloud/web/pull/11263
+https://github.com/owncloud/web/issues/11261

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -491,6 +491,11 @@ export default defineComponent({
     }
 
     onMounted(() => {
+      // Workaround fix for https://github.com/owncloud/web/issues/11262. Don't transfer to mater, because it's properly fixed
+      if (isProjectSpaceResource(unref(space))) {
+        store.commit('Files/PRUNE_SHARES')
+      }
+
       performLoaderTask(false)
       loadResourcesEventToken = eventBus.subscribe(
         'app.files.list.load',

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -491,7 +491,7 @@ export default defineComponent({
     }
 
     onMounted(() => {
-      // Workaround fix for https://github.com/owncloud/web/issues/11262. Don't transfer to mater, because it's properly fixed
+      // Workaround fix for https://github.com/owncloud/web/issues/11262. Don't transfer to master, because it's properly fixed
       if (isProjectSpaceResource(unref(space))) {
         store.commit('Files/PRUNE_SHARES')
       }

--- a/packages/web-test-helpers/src/mocks/store/filesModuleMockOptions.ts
+++ b/packages/web-test-helpers/src/mocks/store/filesModuleMockOptions.ts
@@ -37,7 +37,8 @@ export const filesModuleMockOptions = {
       RESET_SELECTION: jest.fn(),
       SET_LATEST_SELECTED_FILE_ID: jest.fn(),
       CLEAR_FILES_SEARCHED: jest.fn(),
-      CLEAR_CLIPBOARD: jest.fn()
+      CLEAR_CLIPBOARD: jest.fn(),
+      PRUNE_SHARES: jest.fn()
     },
     actions: {
       deleteFiles: jest.fn(),


### PR DESCRIPTION

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #11262 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
