### PR TITLE
refactor: make use of menu items extension point

### DIFF
--- a/docs/extension-system/viewer-editor-apps.md
+++ b/docs/extension-system/viewer-editor-apps.md
@@ -77,7 +77,6 @@ export default defineWebApplication({
         name: 'Advanced PDF Viewer',
         id: appId,
         defaultExtension: 'pdf',
-        isFileEditor: true,
         extensions: [
           // This makes sure all files with the "pdf" extension will be routed to your app when being opened.
           // See the `ApplicationFileExtension` interface down below for a list of all possible properties.

--- a/packages/web-app-admin-settings/src/index.ts
+++ b/packages/web-app-admin-settings/src/index.ts
@@ -159,8 +159,7 @@ export default defineWebApplication({
       name: $gettext('Admin Settings'),
       id: appId,
       icon: 'settings-4',
-      color: '#2b2b2b',
-      isFileEditor: false
+      color: '#2b2b2b'
     }
 
     const menuItems = computed<AppMenuItemExtension[]>(() => {

--- a/packages/web-app-external/src/index.ts
+++ b/packages/web-app-external/src/index.ts
@@ -58,7 +58,6 @@ export default defineWebApplication({
     const appInfo: ApplicationInformation = {
       name: appName,
       id: appId,
-      isFileEditor: true,
       extensions: mimeTypes.map((mimeType) => {
         const provider = mimeType.app_providers.find((provider) => provider.name === appName)
         return {

--- a/packages/web-app-files/src/extensions.ts
+++ b/packages/web-app-files/src/extensions.ts
@@ -1,21 +1,25 @@
 import {
+  ApplicationInformation,
   Extension,
   useCapabilityStore,
   useConfigStore,
   useFileActionsCopyQuickLink,
   useFileActionsShowShares,
   useRouter,
-  useSearch
+  useSearch,
+  useUserStore
 } from '@ownclouders/web-pkg'
 import { computed, unref } from 'vue'
 import { SDKSearch } from './search'
 import { useSideBarPanels } from './composables/extensions/useFileSideBars'
 import { useFolderViews } from './composables/extensions/useFolderViews'
 import { quickActionsExtensionPoint } from './extensionPoints'
+import { urlJoin } from '@ownclouders/web-client'
 
-export const extensions = () => {
+export const extensions = (appInfo: ApplicationInformation) => {
   const capabilityStore = useCapabilityStore()
   const configStore = useConfigStore()
+  const userStore = useUserStore()
   const router = useRouter()
   const { search: searchFunction } = useSearch()
 
@@ -45,6 +49,18 @@ export const extensions = () => {
       extensionPointIds: [quickActionsExtensionPoint.id],
       type: 'action',
       action: unref(quickLinkActions)[0]
-    }
+    },
+    ...((userStore.user && [
+      {
+        id: `app.${appInfo.id}.menuItem`,
+        type: 'appMenuItem',
+        label: () => appInfo.name,
+        color: appInfo.color,
+        icon: appInfo.icon,
+        priority: 10,
+        path: urlJoin(appInfo.id)
+      }
+    ]) ||
+      [])
   ])
 }

--- a/packages/web-app-files/src/index.ts
+++ b/packages/web-app-files/src/index.ts
@@ -35,7 +35,6 @@ const appInfo: ApplicationInformation = {
   id: 'files',
   icon: 'resource-type-folder',
   color: 'var(--oc-color-swatch-primary-muted)',
-  isFileEditor: false,
   extensions: []
 }
 

--- a/packages/web-app-files/src/index.ts
+++ b/packages/web-app-files/src/index.ts
@@ -127,18 +127,8 @@ export const navItems = (context: ComponentCustomProperties): AppNavigationItem[
 
 export default defineWebApplication({
   setup() {
-    const userStore = useUserStore()
-
     return {
-      appInfo: {
-        ...appInfo,
-        applicationMenu: {
-          enabled: () => {
-            return !!userStore.user
-          },
-          priority: 10
-        }
-      },
+      appInfo,
       routes: buildRoutes({
         App,
         Favorites,
@@ -159,7 +149,7 @@ export default defineWebApplication({
       }),
       navItems,
       translations,
-      extensions: extensions(),
+      extensions: extensions(appInfo),
       extensionPoints: extensionPoints()
     }
   }

--- a/packages/web-app-ocm/src/extensions.ts
+++ b/packages/web-app-ocm/src/extensions.ts
@@ -1,19 +1,22 @@
 import {
+  ApplicationInformation,
   FileActionOptions,
   useClientService,
   useConfigStore,
   useMessages,
+  useUserStore,
   useWindowOpen
 } from '@ownclouders/web-pkg'
 import { useGettext } from 'vue3-gettext'
 import { computed } from 'vue'
 import { Extension } from '@ownclouders/web-pkg'
-import { OCM_PROVIDER_ID } from '@ownclouders/web-client'
+import { OCM_PROVIDER_ID, urlJoin } from '@ownclouders/web-client'
 
-export const extensions = () => {
+export const extensions = (appInfo: ApplicationInformation) => {
   const { showErrorMessage } = useMessages()
   const clientService = useClientService()
   const configStore = useConfigStore()
+  const userStore = useUserStore()
   const { $gettext } = useGettext()
   const { openUrl } = useWindowOpen()
 
@@ -69,6 +72,17 @@ export const extensions = () => {
         componentType: 'button',
         class: 'oc-files-actions-open-file-remote'
       }
-    }
+    },
+    ...((userStore.user && [
+      {
+        id: `app.${appInfo.id}.menuItem`,
+        type: 'appMenuItem',
+        label: () => appInfo.name,
+        color: appInfo.color,
+        icon: appInfo.icon,
+        path: urlJoin(appInfo.id)
+      }
+    ]) ||
+      [])
   ])
 }

--- a/packages/web-app-ocm/src/index.ts
+++ b/packages/web-app-ocm/src/index.ts
@@ -32,8 +32,7 @@ export default defineWebApplication({
       name: $gettext('ScienceMesh'),
       id: 'ocm',
       color: '#AE291D',
-      icon: 'contacts-book',
-      isFileEditor: false
+      icon: 'contacts-book'
     }
 
     router.addRoute({

--- a/packages/web-app-ocm/src/index.ts
+++ b/packages/web-app-ocm/src/index.ts
@@ -1,5 +1,5 @@
 import App from './views/App.vue'
-import { defineWebApplication, useRouter, useUserStore } from '@ownclouders/web-pkg'
+import { ApplicationInformation, defineWebApplication, useRouter } from '@ownclouders/web-pkg'
 import translations from '../l10n/translations.json'
 import { extensions } from './extensions'
 import { RouteRecordRaw } from 'vue-router'
@@ -27,19 +27,13 @@ export default defineWebApplication({
   setup() {
     const { $gettext } = useGettext()
     const router = useRouter()
-    const userStore = useUserStore()
 
-    const appInfo = {
+    const appInfo: ApplicationInformation = {
       name: $gettext('ScienceMesh'),
       id: 'ocm',
       color: '#AE291D',
       icon: 'contacts-book',
-      isFileEditor: false,
-      applicationMenu: {
-        enabled: () => {
-          return !!userStore.user
-        }
-      }
+      isFileEditor: false
     }
 
     router.addRoute({
@@ -64,7 +58,7 @@ export default defineWebApplication({
       appInfo,
       routes,
       navItems,
-      extensions: extensions(),
+      extensions: extensions(appInfo),
       translations
     }
   }

--- a/packages/web-app-search/src/index.ts
+++ b/packages/web-app-search/src/index.ts
@@ -15,8 +15,7 @@ const $gettext = (msg: string) => {
 const appInfo: ApplicationInformation = {
   name: $gettext('Search'),
   id: 'search',
-  icon: 'folder',
-  isFileEditor: false
+  icon: 'folder'
 }
 
 export default defineWebApplication({

--- a/packages/web-app-text-editor/src/index.ts
+++ b/packages/web-app-text-editor/src/index.ts
@@ -104,7 +104,6 @@ export default defineWebApplication({
       id: appId,
       icon: 'file-text',
       color: '#0D856F',
-      isFileEditor: true,
       defaultExtension: 'txt',
       extensions: fileExtensions().map((extensionItem) => {
         return {

--- a/packages/web-app-webfinger/src/index.ts
+++ b/packages/web-app-webfinger/src/index.ts
@@ -9,8 +9,7 @@ function $gettext(msg: string) {
 const appInfo = {
   name: $gettext('Webfinger'),
   id: 'webfinger',
-  icon: 'fingerprint',
-  isFileEditor: false
+  icon: 'fingerprint'
 }
 
 const routes = () => [

--- a/packages/web-pkg/src/apps/types.ts
+++ b/packages/web-pkg/src/apps/types.ts
@@ -74,6 +74,7 @@ export interface ApplicationInformation {
   iconFillType?: IconFillType
   iconColor?: string
   img?: string
+  /** @deprecated */
   isFileEditor?: boolean
   extensions?: ApplicationFileExtension[]
   defaultExtension?: string

--- a/packages/web-pkg/src/apps/types.ts
+++ b/packages/web-pkg/src/apps/types.ts
@@ -77,6 +77,7 @@ export interface ApplicationInformation {
   isFileEditor?: boolean
   extensions?: ApplicationFileExtension[]
   defaultExtension?: string
+  /** @deprecated */
   type?: string
   translations?: Translations
   /** @deprecated */

--- a/packages/web-pkg/src/composables/actions/index.ts
+++ b/packages/web-pkg/src/composables/actions/index.ts
@@ -4,5 +4,6 @@ export * from './spaces'
 export * from './types'
 
 export * from './useActionsShowDetails'
+export * from './useOpenEmptyEditor'
 export * from './useOpenWithDefaultApp'
 export * from './useWindowOpen'

--- a/packages/web-pkg/src/composables/actions/useOpenEmptyEditor.ts
+++ b/packages/web-pkg/src/composables/actions/useOpenEmptyEditor.ts
@@ -1,0 +1,54 @@
+import { useGettext } from 'vue3-gettext'
+import { useGetMatchingSpace } from '../spaces'
+import { useAppsStore, useResourcesStore, useSpacesStore } from '../piniaStores'
+import { useClientService } from '../clientService'
+import { EDITOR_MODE_EDIT, useFileActions } from './files'
+import { storeToRefs } from 'pinia'
+import { unref } from 'vue'
+import { resolveFileNameDuplicate } from '../../helpers'
+import { urlJoin } from '@ownclouders/web-client'
+
+// open an editor with an empty file within the current folder
+export const useOpenEmptyEditor = () => {
+  const { getMatchingSpace } = useGetMatchingSpace()
+  const spacesStore = useSpacesStore()
+  const appsStore = useAppsStore()
+  const resourcesStore = useResourcesStore()
+  const clientService = useClientService()
+  const { $gettext } = useGettext()
+  const { openEditor } = useFileActions()
+  const { resources, currentFolder } = storeToRefs(resourcesStore)
+
+  const openEmptyEditor = async (appId: string, extension: string) => {
+    let destinationSpace = unref(currentFolder) ? getMatchingSpace(unref(currentFolder)) : null
+    let destinationFiles = unref(resources)
+    let filePath = unref(currentFolder)?.path
+
+    if (!destinationSpace || !unref(currentFolder).canCreate()) {
+      destinationSpace = spacesStore.personalSpace
+      destinationFiles = (await clientService.webdav.listFiles(destinationSpace)).children
+      filePath = ''
+    }
+
+    let fileName = $gettext('New file') + `.${extension}`
+
+    if (destinationFiles.some((f) => f.name === fileName)) {
+      fileName = resolveFileNameDuplicate(fileName, extension, destinationFiles)
+    }
+
+    const emptyResource = await clientService.webdav.putFileContents(destinationSpace, {
+      path: urlJoin(filePath, fileName)
+    })
+
+    const space = getMatchingSpace(emptyResource)
+    const appFileExtension = appsStore.fileExtensions.find(
+      ({ app, extension: ext }) => app === appId && ext === extension
+    )
+
+    openEditor(appFileExtension, space, emptyResource, EDITOR_MODE_EDIT)
+  }
+
+  return {
+    openEmptyEditor
+  }
+}

--- a/packages/web-pkg/src/composables/piniaStores/extensionRegistry/types.ts
+++ b/packages/web-pkg/src/composables/piniaStores/extensionRegistry/types.ts
@@ -60,7 +60,7 @@ export interface AppMenuItemExtension extends Extension {
   type: 'appMenuItem'
   label: () => string
   color?: string
-  handler?: () => void
+  handler?: () => Promise<void> | void
   icon?: string
   path?: string
   priority?: number

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActions.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActions.spec.ts
@@ -82,7 +82,6 @@ function getWrapper({ setup }: { setup: (instance: ReturnType<typeof useFileActi
                   name: 'Text Editor',
                   id: 'text-editor',
                   color: '#0D856F',
-                  isFileEditor: true,
                   extensions: [
                     {
                       extension: 'txt'

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActions.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActions.spec.ts
@@ -77,11 +77,6 @@ function getWrapper({ setup }: { setup: (instance: ReturnType<typeof useFileActi
             appsState: {
               apps: {
                 'text-editor': {
-                  applicationMenu: {
-                    priority: 20,
-                    openAsEditor: true,
-                    enabled: () => true
-                  },
                   defaultExtension: 'txt',
                   icon: 'file-text',
                   name: 'Text Editor',
@@ -95,9 +90,6 @@ function getWrapper({ setup }: { setup: (instance: ReturnType<typeof useFileActi
                   ]
                 },
                 external: {
-                  applicationMenu: {
-                    enabled: () => true
-                  },
                   defaultExtension: '',
                   icon: 'check_box_outline_blank',
                   name: 'External',

--- a/tests/e2e/support/objects/runtime/application.ts
+++ b/tests/e2e/support/objects/runtime/application.ts
@@ -23,7 +23,7 @@ export class Application {
   async open({ name }: { name: string }): Promise<void> {
     await this.#page.waitForTimeout(1000)
     await this.#page.locator(appSwitcherButton).click()
-    await this.#page.locator(util.format(appSelector, name)).click()
+    await this.#page.locator(util.format(appSelector, `app.${name}.menuItem`)).click()
   }
 
   async getNotificationMessages(): Promise<string[]> {


### PR DESCRIPTION
## Description
Refactors apps to use the new `appMenuItem` extension point instead of the deprecated `applicationMenu` property.

Also deprecates 2 unused app info properties: `type` and `isFileEditor`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/11259

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
