### PR TITLE
refactor: maintain loading and error state per file

### DIFF
--- a/packages/web-app-preview/src/components/MediaControls.vue
+++ b/packages/web-app-preview/src/components/MediaControls.vue
@@ -47,7 +47,7 @@
           />
         </oc-button>
       </div>
-      <div v-if="isImage" class="oc-flex oc-flex-middle">
+      <div v-if="showImageControls" class="oc-flex oc-flex-middle">
         <div class="oc-flex">
           <oc-button
             v-oc-tooltip="imageShrinkDescription"
@@ -142,7 +142,7 @@ export default defineComponent({
       type: Boolean,
       default: false
     },
-    isImage: {
+    showImageControls: {
       type: Boolean,
       default: false
     },

--- a/packages/web-app-preview/src/composables/index.ts
+++ b/packages/web-app-preview/src/composables/index.ts
@@ -1,0 +1,4 @@
+export * from './useFileTypes'
+export * from './useFullScreenMode'
+export * from './useImageControls'
+export * from './usePreviewDimensions'

--- a/packages/web-app-preview/src/composables/useFileTypes.ts
+++ b/packages/web-app-preview/src/composables/useFileTypes.ts
@@ -1,0 +1,19 @@
+import { Resource } from '@ownclouders/web-client'
+
+export const useFileTypes = () => {
+  const isFileTypeImage = (file: Resource) => {
+    return !isFileTypeAudio(file) && !isFileTypeVideo(file)
+  }
+  const isFileTypeAudio = (file: Resource) => {
+    return file.mimeType.toLowerCase().startsWith('audio')
+  }
+  const isFileTypeVideo = (file: Resource) => {
+    return file.mimeType.toLowerCase().startsWith('video')
+  }
+
+  return {
+    isFileTypeImage,
+    isFileTypeAudio,
+    isFileTypeVideo
+  }
+}

--- a/packages/web-app-preview/src/composables/useFullScreenMode.ts
+++ b/packages/web-app-preview/src/composables/useFullScreenMode.ts
@@ -1,0 +1,36 @@
+import { onBeforeUnmount, onMounted, ref, unref } from 'vue'
+
+export const useFullScreenMode = () => {
+  const isFullScreenModeActivated = ref(false)
+
+  const toggleFullScreenMode = () => {
+    const activateFullscreen = !unref(isFullScreenModeActivated)
+    isFullScreenModeActivated.value = activateFullscreen
+    if (activateFullscreen) {
+      if (document.documentElement.requestFullscreen) {
+        document.documentElement.requestFullscreen()
+      }
+    } else {
+      if (document.exitFullscreen) {
+        document.exitFullscreen()
+      }
+    }
+  }
+
+  const handleFullScreenChangeEvent = () => {
+    if (document.fullscreenElement === null) {
+      isFullScreenModeActivated.value = false
+    }
+  }
+  onMounted(() => {
+    document.addEventListener('fullscreenchange', handleFullScreenChangeEvent)
+  })
+  onBeforeUnmount(() => {
+    document.removeEventListener('fullscreenchange', handleFullScreenChangeEvent)
+  })
+
+  return {
+    isFullScreenModeActivated,
+    toggleFullScreenMode
+  }
+}

--- a/packages/web-app-preview/src/composables/useImageControls.ts
+++ b/packages/web-app-preview/src/composables/useImageControls.ts
@@ -1,0 +1,30 @@
+import { PanzoomEventDetail } from '@panzoom/panzoom'
+import { ref } from 'vue'
+
+export const useImageControls = () => {
+  const currentImageZoom = ref(1)
+  const currentImageRotation = ref(0)
+  const currentImagePositionX = ref(0)
+  const currentImagePositionY = ref(0)
+
+  const onPanZoomChanged = ({ detail }: { detail: PanzoomEventDetail }) => {
+    currentImagePositionX.value = detail.x
+    currentImagePositionY.value = detail.y
+  }
+
+  const resetImage = () => {
+    currentImageZoom.value = 1
+    currentImageRotation.value = 0
+    currentImagePositionX.value = 0
+    currentImagePositionY.value = 0
+  }
+
+  return {
+    currentImageZoom,
+    currentImageRotation,
+    currentImagePositionX,
+    currentImagePositionY,
+    onPanZoomChanged,
+    resetImage
+  }
+}

--- a/packages/web-app-preview/src/composables/usePreviewDimensions.ts
+++ b/packages/web-app-preview/src/composables/usePreviewDimensions.ts
@@ -1,0 +1,14 @@
+import { computed } from 'vue'
+
+export const usePreviewDimensions = () => {
+  const widths = [1024, 1280, 1920, 2160]
+  const fallback = 3840
+  const dimensions = computed<[number, number]>(() => {
+    const width = widths.find((width) => window.innerWidth <= width) || fallback
+    return [width, width]
+  })
+
+  return {
+    dimensions
+  }
+}

--- a/packages/web-app-preview/src/helpers/types.ts
+++ b/packages/web-app-preview/src/helpers/types.ts
@@ -1,3 +1,5 @@
+import { Ref } from 'vue'
+
 export type CachedFile = {
   id: string
   name: string
@@ -7,4 +9,6 @@ export type CachedFile = {
   isVideo: boolean
   isImage: boolean
   isAudio: boolean
+  isLoading: Ref<boolean>
+  isError: Ref<boolean>
 }

--- a/packages/web-app-preview/tests/unit/app.spec.ts
+++ b/packages/web-app-preview/tests/unit/app.spec.ts
@@ -67,13 +67,17 @@ describe('Preview app', () => {
       const { wrapper } = createShallowMountWrapper()
       await nextTick()
 
-      wrapper.vm.toPreloadImageIds = []
-      wrapper.vm.preloadImageCount = 3
+      wrapper.vm.cachedFiles = {}
       wrapper.vm.setActiveFile('personal/admin/sleeping_dog.gif')
 
       await nextTick()
 
-      expect(wrapper.vm.toPreloadImageIds).toEqual(['8', '9', '1', '6', '4'])
+      expect(
+        Object.values(wrapper.vm.cachedFiles)
+          .filter((cachedFile) => cachedFile.isImage)
+          .map((cachedFile) => cachedFile.id)
+          .sort((a, b) => a.localeCompare(b))
+      ).toEqual(['1', '2', '4', '6', '7', '8', '9'])
     })
   })
 })

--- a/packages/web-app-preview/tests/unit/components/MediaControls.spec.ts
+++ b/packages/web-app-preview/tests/unit/components/MediaControls.spec.ts
@@ -52,33 +52,33 @@ describe('MediaControls component', () => {
   describe('size', () => {
     describe('shrink button', () => {
       it('exists if file is an image', () => {
-        const { wrapper } = getWrapper({ isImage: true })
+        const { wrapper } = getWrapper({ showImageControls: true })
         expect(wrapper.find(selectors.controlsImageShrink).exists()).toBeTruthy()
       })
       it('emits "setZoom"-event on click', async () => {
-        const { wrapper } = getWrapper({ isImage: true })
+        const { wrapper } = getWrapper({ showImageControls: true })
         await wrapper.find(selectors.controlsImageShrink).trigger('click')
         expect(wrapper.emitted('setZoom').length).toBeDefined()
       })
     })
     describe('zoom button', () => {
       it('exists if file is an image', () => {
-        const { wrapper } = getWrapper({ isImage: true })
+        const { wrapper } = getWrapper({ showImageControls: true })
         expect(wrapper.find(selectors.controlsImageZoom).exists()).toBeTruthy()
       })
       it('emits "setZoom"-event on click', async () => {
-        const { wrapper } = getWrapper({ isImage: true })
+        const { wrapper } = getWrapper({ showImageControls: true })
         await wrapper.find(selectors.controlsImageZoom).trigger('click')
         expect(wrapper.emitted('setZoom').length).toBeDefined()
       })
     })
     describe('original size button', () => {
       it('exists if file is an image', () => {
-        const { wrapper } = getWrapper({ isImage: true })
+        const { wrapper } = getWrapper({ showImageControls: true })
         expect(wrapper.find(selectors.controlsImageOriginalSize).exists()).toBeTruthy()
       })
       it('emits "setZoom"-event on click', async () => {
-        const { wrapper } = getWrapper({ isImage: true })
+        const { wrapper } = getWrapper({ showImageControls: true })
         await wrapper.find(selectors.controlsImageOriginalSize).trigger('click')
         expect(wrapper.emitted('setZoom').length).toBeDefined()
       })
@@ -87,22 +87,22 @@ describe('MediaControls component', () => {
   describe('rotation', () => {
     describe('left button', () => {
       it('exists if file is an image', () => {
-        const { wrapper } = getWrapper({ isImage: true })
+        const { wrapper } = getWrapper({ showImageControls: true })
         expect(wrapper.find(selectors.controlsRotateLeft).exists()).toBeTruthy()
       })
       it('emits "setRotation"-event on click', async () => {
-        const { wrapper } = getWrapper({ isImage: true })
+        const { wrapper } = getWrapper({ showImageControls: true })
         await wrapper.find(selectors.controlsRotateLeft).trigger('click')
         expect(wrapper.emitted('setRotation').length).toBeDefined()
       })
     })
     describe('right button', () => {
       it('exists if file is an image', () => {
-        const { wrapper } = getWrapper({ isImage: true })
+        const { wrapper } = getWrapper({ showImageControls: true })
         expect(wrapper.find(selectors.controlsRotateRight).exists()).toBeTruthy()
       })
       it('emits "setRotation"-event on click', async () => {
-        const { wrapper } = getWrapper({ isImage: true })
+        const { wrapper } = getWrapper({ showImageControls: true })
         await wrapper.find(selectors.controlsRotateRight).trigger('click')
         expect(wrapper.emitted('setRotation').length).toBeDefined()
       })
@@ -111,11 +111,11 @@ describe('MediaControls component', () => {
   describe('reset', () => {
     describe('reset button', () => {
       it('exists if file is an image', () => {
-        const { wrapper } = getWrapper({ isImage: true })
+        const { wrapper } = getWrapper({ showImageControls: true })
         expect(wrapper.find(selectors.controlsImageReset).exists()).toBeTruthy()
       })
       it('emits "resetImage"-event on click', async () => {
-        const { wrapper } = getWrapper({ isImage: true })
+        const { wrapper } = getWrapper({ showImageControls: true })
         await wrapper.find(selectors.controlsImageReset).trigger('click')
         expect(wrapper.emitted('resetImage').length).toBeDefined()
       })


### PR DESCRIPTION
## Description
I noticed that if preloaded images failed loading then we wouldn't show an error state for the image, but we'd have a broken `<img>` instead. So I refactored the loading- and error-states to be individual for each file. And then I refactored more. And more... there's more to refactor (options-api to composition api, putting data loading into a composable, etc), but I don't want to spend more time on it now. Hope the current state is an improvement over current master.

This can be tested easily by starting ocis with `THUMBNAILS_MAX_INPUT_IMAGE_FILE_SIZE=500KB` and then upload some images with 100kb, some with 2mb and then cycle through the folder within the preview app. :-)

This also now makes sure that the file navigation controls are visible on files with loading- or error-state. Previously the controls were only visible for rendered files.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
