### PR TITLE
fix: upload overlay breaking with nested folders

### DIFF
--- a/changelog/unreleased/bugfix-upload-nested-folders
+++ b/changelog/unreleased/bugfix-upload-nested-folders
@@ -1,0 +1,6 @@
+Bugfix: Uploading nested folders
+
+We've fixed a bug where the upload overlay breaks when uploading a folder that contains exactly one folder (which then contains some files).
+
+https://github.com/owncloud/web/issues/11299
+https://github.com/owncloud/web/pull/11302

--- a/packages/web-app-files/src/HandleUpload.ts
+++ b/packages/web-app-files/src/HandleUpload.ts
@@ -280,9 +280,8 @@ export class HandleUpload extends BasePlugin {
     for (const file of filesToUpload.filter(({ meta }) => !!meta.relativeFolder)) {
       const folders = file.meta.relativeFolder.split('/').filter(Boolean)
       let current = directoryTree
-      if (folders.length <= 1) {
-        topLevelIds[file.meta.relativeFolder] = file.meta.topLevelFolderId
-      }
+      // first folder is always top level
+      topLevelIds[urlJoin(folders[0])] = file.meta.topLevelFolderId
       for (const folder of folders) {
         current[folder] = current[folder] || {}
         current = current[folder]


### PR DESCRIPTION
## Description
Fixes an issue where the upload overlay breaks when uploading a folder that contains exactly one folder (which then contains some files).

The top level folder did not have an upload id in such case, hence the overlay could not retrieve the correct information.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/11299
- Possibly fixes https://github.com/owncloud/web/issues/10492

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
