### PR TITLE
chore: add new csp rules to allow unzipping files

### DIFF
--- a/deployments/examples/ocis_web/config/ocis/csp.yaml
+++ b/deployments/examples/ocis_web/config/ocis/csp.yaml
@@ -1,6 +1,7 @@
 directives:
   child-src:
     - '''self'''
+    - 'blob:'
   connect-src:
     - '''self'''
     - 'https://${COMPANION_DOMAIN|companion.owncloud.test}/'
@@ -32,6 +33,7 @@ directives:
   script-src:
     - '''self'''
     - '''unsafe-inline'''
+    - '''wasm-unsafe-eval'''
   style-src:
     - '''self'''
     - '''unsafe-inline'''

--- a/dev/docker/ocis/csp.yaml
+++ b/dev/docker/ocis/csp.yaml
@@ -1,6 +1,7 @@
 directives:
   child-src:
     - '''self'''
+    - 'blob:'
   connect-src:
     - '''self'''
   default-src:
@@ -33,6 +34,7 @@ directives:
   script-src:
     - '''self'''
     - '''unsafe-inline'''
+    - '''wasm-unsafe-eval'''
   style-src:
     - '''self'''
     - '''unsafe-inline'''


### PR DESCRIPTION
## Description
Adds these 2 CSP rules to our dev setup to make unzipping via wasm work:

- `child-src: blob`
- `script-src: wasm-unsafe-eval`

Tbh I'm not sure how "unsafe" the second rule is... but AFAIK it's needed for wasm to work. If that isn't an option, we need to look for a different library for unzipping.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Works towards https://github.com/owncloud/web/issues/11264

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
