### PR TITLE
fix: toggling checkboxes via enter key

### DIFF
--- a/changelog/unreleased/bugfix-keyboard-checkbox-toggle
+++ b/changelog/unreleased/bugfix-keyboard-checkbox-toggle
@@ -1,6 +1,7 @@
 Bugfix: Toggling checkboxes via keyboard
 
-Toggling checkboxes via the keyboard enter key in the resources table has been fixed and does now work.
+Toggling checkboxes via the keyboard enter key has been fixed and does now work.
 
 https://github.com/owncloud/web/pull/11312
+https://github.com/owncloud/web/pull/11315
 https://github.com/owncloud/web/issues/10730

--- a/packages/design-system/src/components/OcCheckbox/OcCheckbox.vue
+++ b/packages/design-system/src/components/OcCheckbox/OcCheckbox.vue
@@ -8,7 +8,7 @@
       :class="classes"
       :value="option"
       :disabled="disabled"
-      @keydown.enter="$emit('click', $event)"
+      @keydown.enter="keydownEnter"
     />
     <label :for="id" :class="labelClasses" v-text="label" />
   </span>
@@ -132,6 +132,12 @@ export default defineComponent({
         return this.model
       }
       return this.model.some((m) => isEqual(m, this.option))
+    }
+  },
+  methods: {
+    keydownEnter(event: KeyboardEvent) {
+      this.model = !this.model
+      this.$emit('click', event)
     }
   }
 })


### PR DESCRIPTION
## Description
Follow-up of #11312: fixes all checkboxes in Web by adjusting the `OcCheckbox` component. The enter press event did not set any value, which was the issue.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10730

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
