### PR TITLE
Analyze change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,3 +64,13 @@ l10n-read: node_modules
 .PHONY: l10n-write
 l10n-write: node_modules
 	make -C packages/web-runtime/l10n translations
+
+.PHONY: generate-qa-activity-report
+generate-qa-activity-report: node_modules
+	@if [ -z "${MONTH}" ] || [ -z "${YEAR}" ]; then \
+		echo "Please set the MONTH and YEAR environment variables. Usage: make generate-qa-activity-report MONTH=<month> YEAR=<year>"; \
+		exit 1; \
+	fi
+	# git checkout master
+	# git pull
+	pnpm exec node generate-qa-activity-report.js --month ${MONTH} --year ${YEAR}

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,4 @@ generate-qa-activity-report: node_modules
 		echo "Please set the MONTH and YEAR environment variables. Usage: make generate-qa-activity-report MONTH=<month> YEAR=<year>"; \
 		exit 1; \
 	fi
-	# git checkout master
-	# git pull
 	pnpm exec node generate-qa-activity-report.js --month ${MONTH} --year ${YEAR}

--- a/generate-qa-activity-report.js
+++ b/generate-qa-activity-report.js
@@ -1,0 +1,168 @@
+import simpleGit from 'simple-git';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+import { Command } from 'commander';
+import fs from 'fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const git = simpleGit();
+const program = new Command();
+
+program
+  .option('-d, --days <number>', 'number of days to look back')
+  .option('-m, --month <number>', 'month to look back')
+  .option('-y, --year <number>', 'year to look back')
+  .parse(process.argv);
+
+const options = program.opts();
+
+function getGitDateFormat(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function getStartAndEndDate(month, year) {
+  const startDate = new Date(year, month - 1, 1);
+  const endDate = new Date(year, month, 0);
+  return { startDate, endDate };
+}
+
+async function getRecentChanges() {
+  try {
+    const repoPath = path.resolve(__dirname);
+    await git.cwd(repoPath);
+
+    let formattedSinceDate, formattedUntilDate, period;
+
+    if (options.month && options.year) {
+      const { startDate, endDate } = getStartAndEndDate(options.month, options.year);
+      formattedSinceDate = getGitDateFormat(startDate);
+      formattedUntilDate = getGitDateFormat(endDate);
+      period = `Month: ${options.month}, Year: ${options.year}`;
+    } else if (options.days) {
+      const today = new Date();
+      today.setDate(today.getDate() - options.days);
+      formattedSinceDate = getGitDateFormat(today);
+      formattedUntilDate = getGitDateFormat(new Date());
+      period = `Last ${options.days} days`;
+    } else {
+      console.error('Please provide either days or month and year.');
+      return;
+    }
+
+    const reportDate = getGitDateFormat(new Date());
+
+    const logOptions = {
+      file: 'tests/e2e/cucumber/features',
+      '--since': formattedSinceDate,
+    };
+    if (formattedUntilDate) {
+      logOptions['--until'] = formattedUntilDate;
+    }
+
+    const logs = await git.log(logOptions);
+
+    let addedLines = 0;
+    let deletedLines = 0;
+    const commits = [];
+
+    for (const log of logs.all) {
+      const diff = await git.diff([`${log.hash}~1`, log.hash, '--', 'tests/e2e/cucumber/features']);
+      const diffLines = diff.split('\n');
+
+      let commitAddedLines = 0;
+      let commitDeletedLines = 0;
+      const features = new Map(); // Track changes per feature file
+      let currentFile = null;
+
+      for (const line of diffLines) {
+        if (line.startsWith('diff --git')) {
+          const match = line.match(/ b\/(tests\/e2e\/cucumber\/features\/[^\s]+)/);
+          if (match) {
+            currentFile = match[1];
+            if (!features.has(currentFile)) {
+              features.set(currentFile, { addedLines: 0, deletedLines: 0 });
+            }
+          }
+        } else if (line.startsWith('+++ b/')) {
+          const match = line.match(/b\/(tests\/e2e\/cucumber\/features\/[^\s]+)/);
+          if (match) {
+            currentFile = match[1];
+            if (!features.has(currentFile)) {
+              features.set(currentFile, { addedLines: 0, deletedLines: 0 });
+            }
+          }
+        } else if (line.startsWith('+') && !line.startsWith('+++')) {
+          if (currentFile) {
+            features.get(currentFile).addedLines += 1;
+            commitAddedLines += 1;
+          }
+        } else if (line.startsWith('-') && !line.startsWith('---')) {
+          if (currentFile) {
+            features.get(currentFile).deletedLines += 1;
+            commitDeletedLines += 1;
+          }
+        }
+      }
+
+      addedLines += commitAddedLines;
+      deletedLines += commitDeletedLines;
+
+      commits.push({
+        hash: log.hash,
+        date: log.date,
+        message: log.message,
+        author: log.author_name,
+        features: Array.from(features.entries()).map(([file, stats]) => ({
+          file,
+          ...stats
+        })),
+        addedLines: commitAddedLines,
+        deletedLines: commitDeletedLines
+      });
+    }
+
+    const reportContent = `
+# QA Activity Report for ${period}
+Date: ${reportDate}
+
+## Summary
+- **Added steps to the .feature files:** ${addedLines}
+- **Deleted steps in the .feature files:** ${deletedLines}
+- **Modified steps in the .feature files:** ${addedLines + deletedLines}
+
+## Commits:
+${commits.map(commit => `
+### Commit: ${commit.hash}
+- **Date:** ${commit.date}
+- **Author:** ${commit.author}
+- **Message:** ${commit.message}
+${commit.features.map(feature => `
+- **Feature:** ${feature.file}
+  - **Added steps:** ${feature.addedLines}
+  - **Deleted steps:** ${feature.deletedLines}
+`).join('')}
+- **Total Added steps:** ${commit.addedLines}
+- **Total Deleted steps:** ${commit.deletedLines}
+`).join('')}
+    `;
+
+    fs.writeFile('QA_Activity_Report.md', reportContent, (err) => {
+      if (err) {
+        console.error('Error writing report:', err);
+      } else {
+        console.log('Report generated successfully.');
+      }
+    });
+
+  } catch (error) {
+    console.error('Error:', error);
+  }
+}
+
+getRecentChanges();

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "eslint": "8.56.0",
     "flush-promises": "1.0.2",
     "git-repo-info": "2.1.1",
+    "simple-git": "3.25.0",
     "glob": "10.3.12",
     "happy-dom": "13.3.1",
     "join-path": "1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       sass:
         specifier: 1.69.7
         version: 1.69.7
+      simple-git:
+        specifier: 3.25.0
+        version: 3.25.0
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@types/node@18.11.9)(typescript@5.5.3)
@@ -2329,6 +2332,12 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@kwsites/file-exists@1.1.1':
+    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
+
+  '@kwsites/promise-deferred@1.1.1':
+    resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
   '@leichtgewicht/ip-codec@2.0.4':
     resolution: {integrity: sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==}
@@ -8363,6 +8372,9 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-git@3.25.0:
+    resolution: {integrity: sha512-KIY5sBnzc4yEcJXW7Tdv4viEz8KyG+nU0hay+DWZasvdFOYKeUZ6Xc25LUHHjw0tinPT7O1eY6pzX7pRT1K8rw==}
+
   sirv@2.0.4:
     resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
     engines: {node: '>= 10'}
@@ -10832,10 +10844,10 @@ snapshots:
       '@cucumber/ci-environment': 9.1.0
       '@cucumber/cucumber-expressions': 16.1.1
       '@cucumber/gherkin': 26.0.3
-      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@21.0.1))(@cucumber/messages@21.0.1)
+      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@24.0.1))(@cucumber/messages@21.0.1)
       '@cucumber/gherkin-utils': 8.0.2
       '@cucumber/html-formatter': 20.2.1(@cucumber/messages@21.0.1)
-      '@cucumber/message-streams': 4.0.1(@cucumber/messages@24.0.1)
+      '@cucumber/message-streams': 4.0.1(@cucumber/messages@21.0.1)
       '@cucumber/messages': 21.0.1
       '@cucumber/tag-expressions': 5.0.1
       assertion-error-formatter: 3.0.0
@@ -10870,10 +10882,10 @@ snapshots:
       yaml: 2.3.4
       yup: 0.32.11
 
-  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@21.0.1))(@cucumber/messages@21.0.1)':
+  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@24.0.1))(@cucumber/messages@21.0.1)':
     dependencies:
       '@cucumber/gherkin': 26.0.3
-      '@cucumber/message-streams': 4.0.1(@cucumber/messages@24.0.1)
+      '@cucumber/message-streams': 4.0.1(@cucumber/messages@21.0.1)
       '@cucumber/messages': 21.0.1
       commander: 9.1.0
       source-map-support: 0.5.21
@@ -10914,13 +10926,13 @@ snapshots:
     dependencies:
       '@cucumber/messages': 22.0.0
 
+  '@cucumber/message-streams@4.0.1(@cucumber/messages@21.0.1)':
+    dependencies:
+      '@cucumber/messages': 21.0.1
+
   '@cucumber/message-streams@4.0.1(@cucumber/messages@22.0.0)':
     dependencies:
       '@cucumber/messages': 22.0.0
-
-  '@cucumber/message-streams@4.0.1(@cucumber/messages@24.0.1)':
-    dependencies:
-      '@cucumber/messages': 24.0.1
 
   '@cucumber/messages@19.1.4':
     dependencies:
@@ -11125,6 +11137,14 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
+
+  '@kwsites/file-exists@1.1.1':
+    dependencies:
+      debug: 4.3.5(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@kwsites/promise-deferred@1.1.1': {}
 
   '@leichtgewicht/ip-codec@2.0.4': {}
 
@@ -17944,6 +17964,14 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  simple-git@3.25.0:
+    dependencies:
+      '@kwsites/file-exists': 1.1.1
+      '@kwsites/promise-deferred': 1.1.1
+      debug: 4.3.5(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
 
   sirv@2.0.4:
     dependencies:


### PR DESCRIPTION
how to run: 

- `make generate-qa-activity-report MONTH=06 YEAR=2024`
or
- `pnpm exec node analyzeChanges.js --month 7 --year 2024`
- `pnpm exec node analyzeChanges.js --days 10`

report should be generated to `QA_Activity_Report.md`

example: 

[QA_Activity_report-07.24.md](https://github.com/user-attachments/files/16503128/QA_Activity_report-07.24.md)

<img width="742" alt="image" src="https://github.com/user-attachments/assets/03ac847b-33dc-403d-8ff2-03686fab361f">
