### PR TITLE
[docs-only] add changelog template for csv changelog output

### DIFF
--- a/changelog/changelog-csv.tmpl
+++ b/changelog/changelog-csv.tmpl
@@ -1,0 +1,8 @@
+## Release, Date, Type, Title, Primary ID, Primary URL
+{{ range . -}}
+{{ $v := .Version -}}
+{{ $d := .Date -}}
+{{ range $entry := .Entries -}}
+{{ $v }},{{ $d }},{{ .Type }},'{{ .Title }}',{{ .PrimaryID }},{{ .PrimaryURL }}
+{{ end -}}
+{{ end -}}


### PR DESCRIPTION
To be able to create "the spreadsheet", we need the changelog in CSV format.

Somebody with drone knowledge should add the following command line to the file `.drone.star` (it seems):
```
calens -o dist/changelog.csv -t changelog/changelog-csv.tmpl 
```
to be executed when releasing.