### PR TITLE
fix: share indicator not appearing when adding a new share

### DIFF
--- a/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
+++ b/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
@@ -148,7 +148,7 @@ export const useSharesStore = defineStore('shares', () => {
     const share = await client.createInvite(space.id, resource.id, options, unref(graphRoles))
 
     addCollaboratorShares([share])
-    updateFileShareTypes(resource.path)
+    updateFileShareTypes(resource.id)
     resourcesStore.loadIndicators(space, resource.id)
     return share
   }


### PR DESCRIPTION
## Description
As per title. Was forgotten in https://github.com/owncloud/web/pull/11188.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
