### PR TITLE
feat: external collaborator search filter

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
@@ -109,6 +109,11 @@ export default defineComponent({
     isLocked: {
       type: Boolean,
       default: false
+    },
+    // only show external share roles
+    isExternal: {
+      type: Boolean,
+      default: false
     }
   },
   emits: ['optionChange'],
@@ -128,7 +133,14 @@ export default defineComponent({
       return ''
     })
 
-    const availableRoles = inject<Ref<ShareRole[]>>('availableShareRoles')
+    const availableInternalRoles = inject<Ref<ShareRole[]>>('availableInternalShareRoles')
+    const availableExternalRoles = inject<Ref<ShareRole[]>>('availableExternalShareRoles')
+    const availableRoles = computed(() => {
+      if (props.isExternal) {
+        return unref(availableExternalRoles)
+      }
+      return unref(availableInternalRoles)
+    })
 
     const initialSelectedRole = props.existingRole ? props.existingRole : unref(availableRoles)[0]
     const selectedRole = ref<ShareRole>(initialSelectedRole)

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.ts
@@ -16,6 +16,8 @@ import {
 } from '@ownclouders/web-client'
 import { Group, User } from '@ownclouders/web-client/graph/generated'
 import OcButton from 'design-system/src/components/OcButton/OcButton.vue'
+import RoleDropdown from '../../../../../../../src/components/SideBar/Shares/Collaborators/RoleDropdown.vue'
+import { ShareRoleType } from '../../../../../../../src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue'
 
 vi.mock('lodash-es', () => ({ debounce: (fn: any) => fn() }))
 
@@ -147,6 +149,27 @@ describe('InviteCollaboratorForm', () => {
     })
     it.todo('resets focus upon selecting an invitee')
   })
+  describe('share role type filter', () => {
+    it.each([
+      { externalRoles: [], available: false },
+      { externalRoles: [mock<ShareRole>()], available: true }
+    ])(
+      'is present depending on the available external share roles',
+      ({ externalRoles, available }) => {
+        const { wrapper } = getWrapper({ externalShareRoles: externalRoles })
+        expect(wrapper.find('.invite-form-share-role-type').exists()).toBe(available)
+      }
+    )
+    it('correctly passes the external prop to the role dropdown component', async () => {
+      const externalRoles = [mock<ShareRole>()]
+      const { wrapper } = getWrapper({ externalShareRoles: externalRoles })
+      wrapper.vm.currentShareRoleType = mock<ShareRoleType>({ id: '2' })
+      await wrapper.vm.$nextTick()
+
+      const roleDropdown = wrapper.findComponent<typeof RoleDropdown>('role-dropdown-stub')
+      expect(roleDropdown.props('isExternal')).toBeTruthy()
+    })
+  })
 })
 
 function getWrapper({
@@ -155,6 +178,7 @@ function getWrapper({
   users = [],
   groups = [],
   existingCollaborators = [],
+  externalShareRoles = [],
   user = mock<User>({ id: '1' })
 }: {
   storageId?: string
@@ -162,6 +186,7 @@ function getWrapper({
   users?: User[]
   groups?: Group[]
   existingCollaborators?: CollaboratorShare[]
+  externalShareRoles?: ShareRole[]
   user?: User
 } = {}) {
   const mocks = defaultComponentMocks({
@@ -193,8 +218,9 @@ function getWrapper({
             }
           })
         ],
-        provide: { ...mocks, resource },
-        mocks
+        provide: { ...mocks, resource, availableExternalShareRoles: externalShareRoles },
+        mocks,
+        stubs: { OcSelect: false, VueSelect: false }
       }
     })
   }

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/RoleDropdown.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/RoleDropdown.spec.ts
@@ -27,7 +27,7 @@ describe('RoleDropdown', () => {
   it('does not render a button if only one role is available', () => {
     const { wrapper } = getWrapper({
       mountType: shallowMount,
-      availableShareRoles: [mock<ShareRole>({ displayName: 'Can view', description: '' })]
+      availableInternalShareRoles: [mock<ShareRole>({ displayName: 'Can view', description: '' })]
     })
     expect(wrapper.find(selectors.recipientRoleBtn).exists()).toBeFalsy()
   })
@@ -41,24 +41,42 @@ describe('RoleDropdown', () => {
     const { wrapper } = getWrapper({ mountType: shallowMount })
     expect(wrapper.findAll(selectors.roleButton).length).toBe(2)
   })
+  it('uses available external share roles if "isExternal" is given', () => {
+    const externalShareRole2 = mock<ShareRole>({ id: 'external1', displayName: '' })
+    const externalShareRole1 = mock<ShareRole>({ id: 'external2', displayName: '' })
+    const { wrapper } = getWrapper({
+      mountType: shallowMount,
+      isExternal: true,
+      availableExternalShareRoles: [externalShareRole1, externalShareRole2]
+    })
+
+    expect(
+      wrapper.find(`oc-button-stub#files-recipient-role-drop-btn-${externalShareRole1.id}`).exists()
+    ).toBeTruthy()
+  })
 })
 
 function getWrapper({
   mountType = mount,
   existingRole = null,
-  availableShareRoles = [
+  isExternal = false,
+  availableInternalShareRoles = [
     mock<ShareRole>({ displayName: 'Can view', description: '' }),
     mock<ShareRole>({ displayName: 'Can edit', description: '' })
-  ]
+  ],
+  availableExternalShareRoles = []
 }: {
   mountType?: typeof mount
   existingRole?: ShareRole
-  availableShareRoles?: ShareRole[]
+  isExternal?: boolean
+  availableInternalShareRoles?: ShareRole[]
+  availableExternalShareRoles?: ShareRole[]
 } = {}) {
   return {
     wrapper: mountType(RoleDropdown, {
       props: {
-        existingRole
+        existingRole,
+        isExternal
       },
       global: {
         plugins: [
@@ -69,7 +87,8 @@ function getWrapper({
         renderStubDefaultSlot: true,
         provide: {
           resource: mock<Resource>(),
-          availableShareRoles
+          availableInternalShareRoles,
+          availableExternalShareRoles
         }
       }
     })

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/ListItem.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/ListItem.spec.ts.snap
@@ -11,7 +11,7 @@ exports[`Collaborator ListItem component > share inheritance indicators > show w
         <div data-v-ccf14be2="" class="oc-text-truncate"><span data-v-ccf14be2="" aria-hidden="true" class="files-collaborators-collaborator-name">einstein</span> <span data-v-ccf14be2="" class="oc-invisible-sr">Share receiver name: einstein</span></div>
         <div data-v-ccf14be2="">
           <div data-v-ccf14be2="" class="oc-flex oc-flex-nowrap oc-flex-middle">
-            <role-dropdown-stub data-v-ccf14be2="" existingrole="undefined" domselector="1" mode="edit" showicon="false" islocked="false" class="files-collaborators-collaborator-role"></role-dropdown-stub>
+            <role-dropdown-stub data-v-ccf14be2="" existingrole="undefined" domselector="1" mode="edit" showicon="false" islocked="false" isexternal="false" class="files-collaborators-collaborator-role"></role-dropdown-stub>
           </div>
         </div>
       </div>

--- a/packages/web-app-ocm/src/views/IncomingInvitations.vue
+++ b/packages/web-app-ocm/src/views/IncomingInvitations.vue
@@ -124,7 +124,7 @@ export default defineComponent({
 
         const { token: currentToken, providerDomain, ...query } = unref(route).query
         router.replace({
-          name: 'ocm-app-invitations',
+          name: 'open-cloud-mesh-invitations',
           query
         })
 

--- a/packages/web-pkg/src/composables/piniaStores/apps.ts
+++ b/packages/web-pkg/src/composables/piniaStores/apps.ts
@@ -60,6 +60,10 @@ export const useAppsStore = defineStore('apps', () => {
     externalAppConfig.value = { ...unref(externalAppConfig), [appId]: config }
   }
 
+  const isAppEnabled = (appId: string) => {
+    return unref(appIds).includes(appId)
+  }
+
   return {
     apps,
     externalAppConfig,
@@ -68,7 +72,8 @@ export const useAppsStore = defineStore('apps', () => {
 
     registerApp,
     registerFileExtension,
-    loadExternalAppConfig
+    loadExternalAppConfig,
+    isAppEnabled
   }
 })
 

--- a/packages/web-pkg/src/composables/scrollTo/useScrollTo.ts
+++ b/packages/web-pkg/src/composables/scrollTo/useScrollTo.ts
@@ -50,7 +50,7 @@ export const useScrollTo = (): ScrollToResult => {
     // files-app-bar, admin-settings-app-bar
     const topbarElement = document.getElementById(options.topbarElement)
     // topbar height + th height + height of one row = offset needed when scrolling top
-    const topOffset = topbarElement.offsetHeight + resourceElement.offsetHeight * 2
+    const topOffset = topbarElement?.offsetHeight || 0 + resourceElement.offsetHeight * 2
 
     if (
       resourceElement.getBoundingClientRect().bottom > window.innerHeight ||

--- a/packages/web-pkg/tests/unit/components/sidebar/FileSideBar.spec.ts
+++ b/packages/web-pkg/tests/unit/components/sidebar/FileSideBar.spec.ts
@@ -10,6 +10,7 @@ import {
 import { defineComponent, ref } from 'vue'
 import { useSelectedResources } from '../../../../src/composables/selection'
 import {
+  useAppsStore,
   useExtensionRegistry,
   useResourcesStore,
   useSharesStore,
@@ -170,6 +171,24 @@ describe('FileSideBar', () => {
       await wrapper.vm.loadSharesTask.perform(resource)
 
       expect(loadSpaceMembers).toHaveBeenCalled()
+    })
+    it('loads available external share roles if the ocm app is enabled', async () => {
+      const resource = mock<Resource>()
+      const { wrapper, mocks } = createWrapper()
+
+      mocks.$clientService.graphAuthenticated.permissions.listPermissions.mockResolvedValue({
+        shares: [],
+        allowedActions: [],
+        allowedRoles: []
+      })
+
+      const { isAppEnabled } = useAppsStore()
+      vi.mocked(isAppEnabled).mockReturnValue(true)
+      await wrapper.vm.loadSharesTask.perform(resource)
+
+      expect(
+        mocks.$clientService.graphAuthenticated.permissions.listPermissions
+      ).toHaveBeenCalledTimes(2)
     })
     describe('cache', () => {
       it('is being used in non-flat file lists', async () => {


### PR DESCRIPTION
## Description
Adds a filter inside the collaborator share search input to enable searching for external users.

The available share roles are different for external users, hence there is a clear separation needed between internal and external sharing.

This filter is only available when the OCM app is enabled.

<img width="424" alt="image" src="https://github.com/user-attachments/assets/6d0add7a-89eb-4383-8f44-20f6a584ac96">

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/ocis/issues/9735
- refs https://github.com/owncloud/ocis/issues/9747

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
