### PR TITLE
refactor: remove share role checks

### DIFF
--- a/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersPanel.vue
@@ -68,7 +68,15 @@ export default defineComponent({
     const availableRoles = computed<ShareRole[]>(() => {
       const permissionsWithRole = unref(spaceMembers).filter((p) => !!p.roleId)
       const roleIds = [...new Set(permissionsWithRole.map((p) => p.roleId))]
-      return roleIds.map((r) => sharesStore.graphRoles[r]).filter(Boolean)
+      return roleIds
+        .map((r) => sharesStore.graphRoles[r])
+        .filter(Boolean)
+        .sort((a, b) => {
+          // sort roles by amount of permissions (most likely translates to manager > editor > viewer)
+          const permissionsA = a.rolePermissions.flatMap((r) => r.allowedResourceActions)
+          const permissionsB = b.rolePermissions.flatMap((r) => r.allowedResourceActions)
+          return permissionsB.length - permissionsA.length
+        })
     })
 
     const membersWithoutRole = computed<SpaceMember[]>(() => {

--- a/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersRoleSection.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/SideBar/MembersRoleSection.vue
@@ -1,14 +1,14 @@
 <template>
   <ul class="oc-list">
     <li
-      v-for="(member, index) in members"
+      v-for="(m, index) in members"
       :key="index"
       class="oc-flex oc-flex-middle oc-mb-s"
       data-testid="space-members-list"
     >
       <oc-avatar
-        v-if="member.kind === 'user'"
-        :user-name="member.displayName"
+        v-if="m.grantedTo.user"
+        :user-name="m.grantedTo.user.displayName"
         :width="36"
         class="oc-mr-s"
       /><oc-avatar-item
@@ -19,20 +19,19 @@
         name="group"
         class="oc-mr-s"
       />
-      {{ member.displayName }}
+      {{ (m.grantedTo.user || m.grantedTo.group).displayName }}
     </li>
   </ul>
 </template>
 <script lang="ts">
 import { computed, defineComponent, PropType } from 'vue'
-import { ShareTypes } from '@ownclouders/web-client'
-import { SpaceRole } from '@ownclouders/web-client'
+import { ShareTypes, SpaceMember } from '@ownclouders/web-client'
 
 export default defineComponent({
   name: 'MembersRoleSection',
   props: {
     members: {
-      type: Array as PropType<SpaceRole[]>,
+      type: Array as PropType<SpaceMember[]>,
       required: true
     }
   },

--- a/packages/web-app-admin-settings/src/components/Spaces/SpacesList.vue
+++ b/packages/web-app-admin-settings/src/components/Spaces/SpacesList.vue
@@ -137,7 +137,7 @@ import {
   unref,
   watch
 } from 'vue'
-import { SpaceResource } from '@ownclouders/web-client'
+import { getSpaceManagers, SpaceResource } from '@ownclouders/web-client'
 import Mark from 'mark.js'
 import Fuse from 'fuse.js'
 import { useGettext } from 'vue3-gettext'
@@ -352,9 +352,11 @@ export default defineComponent({
     ])
 
     const getManagerNames = (space: SpaceResource) => {
-      const allManagers = space.spaceRoles.manager
+      const allManagers = getSpaceManagers(space)
       const managers = allManagers.length > 2 ? allManagers.slice(0, 2) : allManagers
-      let managerStr = managers.map((m) => m.displayName).join(', ')
+      let managerStr = managers
+        .map(({ grantedTo }) => (grantedTo.user || grantedTo.group).displayName)
+        .join(', ')
       if (allManagers.length > 2) {
         managerStr += `... +${allManagers.length - 2}`
       }
@@ -386,11 +388,7 @@ export default defineComponent({
       return formatFileSize(space.spaceQuota.remaining, language.current)
     }
     const getMemberCount = (space: SpaceResource) => {
-      return (
-        space.spaceRoles.manager.length +
-        space.spaceRoles.editor.length +
-        space.spaceRoles.viewer.length
-      )
+      return Object.keys(space.members).length
     }
 
     const getSelectSpaceLabel = (space: SpaceResource) => {

--- a/packages/web-app-admin-settings/src/components/Users/SideBar/EditPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Users/SideBar/EditPanel.vue
@@ -119,7 +119,8 @@ import {
   useCapabilityStore,
   useEventBus,
   useMessages,
-  useSpacesStore
+  useSpacesStore,
+  useSharesStore
 } from '@ownclouders/web-pkg'
 import GroupSelect from '../GroupSelect.vue'
 import { cloneDeep, isEmpty, isEqual, omit } from 'lodash-es'
@@ -165,6 +166,7 @@ export default defineComponent({
     const userStore = useUserStore()
     const userSettingsStore = useUserSettingsStore()
     const spacesStore = useSpacesStore()
+    const sharesStore = useSharesStore()
     const eventBus = useEventBus()
     const { showErrorMessage } = useMessages()
     const { $gettext } = useGettext()
@@ -225,10 +227,14 @@ export default defineComponent({
 
     const onUpdateUserDrive = async (editUser: User) => {
       const client = clientService.graphAuthenticated
-      const updateSpace = await client.drives.updateDrive(editUser.drive.id, {
-        name: editUser.drive.name,
-        quota: { total: editUser.drive.quota.total }
-      })
+      const updateSpace = await client.drives.updateDrive(
+        editUser.drive.id,
+        {
+          name: editUser.drive.name,
+          quota: { total: editUser.drive.quota.total }
+        },
+        sharesStore.graphRoles
+      )
 
       if (editUser.id === userStore.user.id) {
         // Load current user quota

--- a/packages/web-app-admin-settings/src/views/Spaces.vue
+++ b/packages/web-app-admin-settings/src/views/Spaces.vue
@@ -70,7 +70,8 @@ import {
   useSpaceActionsDisable,
   useSpaceActionsRestore,
   useSpaceActionsEditQuota,
-  AppLoadingSpinner
+  AppLoadingSpinner,
+  useSharesStore
 } from '@ownclouders/web-pkg'
 import { call, SpaceResource } from '@ownclouders/web-client'
 import { computed, defineComponent, onBeforeUnmount, onMounted, ref, unref } from 'vue'
@@ -100,6 +101,7 @@ export default defineComponent({
     const clientService = useClientService()
     const { $gettext } = useGettext()
     const { isSideBarOpen, sideBarActivePanel } = useSideBar()
+    const sharesStore = useSharesStore()
 
     const loadResourcesEventToken = ref(null)
     let updateQuotaForSpaceEventToken: string
@@ -119,7 +121,7 @@ export default defineComponent({
 
     const loadResourcesTask = useTask(function* (signal) {
       const drives = yield* call(
-        clientService.graphAuthenticated.drives.listAllDrives({
+        clientService.graphAuthenticated.drives.listAllDrives(sharesStore.graphRoles, {
           orderBy: 'name asc',
           filter: 'driveType eq project'
         })

--- a/packages/web-app-admin-settings/tests/unit/components/Spaces/SideBar/MembersPanel.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Spaces/SideBar/MembersPanel.spec.ts
@@ -5,9 +5,9 @@ import { ShareRole, SpaceResource } from '@ownclouders/web-client'
 import MembersRoleSection from '../../../../../src/components/Spaces/SideBar/MembersRoleSection.vue'
 
 const graphRoles = {
-  '1': mock<ShareRole>({ id: '1', displayName: 'Managers' }),
-  '2': mock<ShareRole>({ id: '2', displayName: 'Editors' }),
-  '3': mock<ShareRole>({ id: '3', displayName: 'Viewers' })
+  '1': mock<ShareRole>({ id: '1', displayName: 'Managers', rolePermissions: [] }),
+  '2': mock<ShareRole>({ id: '2', displayName: 'Editors', rolePermissions: [] }),
+  '3': mock<ShareRole>({ id: '3', displayName: 'Viewers', rolePermissions: [] })
 }
 
 const spaceMock = {

--- a/packages/web-app-admin-settings/tests/unit/components/Spaces/SideBar/MembersPanel.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Spaces/SideBar/MembersPanel.spec.ts
@@ -1,23 +1,26 @@
 import MembersPanel from '../../../../../src/components/Spaces/SideBar/MembersPanel.vue'
 import { defaultPlugins, shallowMount } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
-import { SpaceResource } from '@ownclouders/web-client'
+import { ShareRole, SpaceResource } from '@ownclouders/web-client'
 import MembersRoleSection from '../../../../../src/components/Spaces/SideBar/MembersRoleSection.vue'
 
-const spaceMock = mock<SpaceResource>({
-  spaceRoles: {
-    manager: [{ kind: 'user', displayName: 'admin' }],
-    editor: [
-      { kind: 'user', displayName: 'einstein' },
-      { kind: 'group', displayName: 'physic-haters' }
-    ],
-    viewer: [{ kind: 'user', displayName: 'marie' }],
-    'secure-viewer': [{ kind: 'user', displayName: 'kathrine' }]
+const graphRoles = {
+  '1': mock<ShareRole>({ id: '1', displayName: 'Managers' }),
+  '2': mock<ShareRole>({ id: '2', displayName: 'Editors' }),
+  '3': mock<ShareRole>({ id: '3', displayName: 'Viewers' })
+}
+
+const spaceMock = {
+  members: {
+    '1': { roleId: '1', grantedTo: { user: { displayName: 'admin' } } },
+    '2': { roleId: '2', grantedTo: { user: { displayName: 'marie' } } },
+    '3': { roleId: '3', grantedTo: { user: { displayName: 'einstein' } } }
   }
-})
+} as undefined as SpaceResource
 
 const selectors = {
-  membersRolePanelStub: 'members-role-section-stub'
+  membersRolePanelStub: 'members-role-section-stub',
+  spaceMembersCustom: '.space-members-custom'
 }
 
 describe('MembersPanel', () => {
@@ -26,22 +29,31 @@ describe('MembersPanel', () => {
     expect(wrapper.html()).toMatchSnapshot()
   })
   it('should filter members accordingly to the entered search term', async () => {
-    const userToFilterFor = spaceMock.spaceRoles.editor[0]
+    const userToFilterFor = spaceMock.members['3']
     const { wrapper } = getWrapper()
     wrapper.vm.filterTerm = 'ein'
-    await wrapper.vm.$nextTick
+    await wrapper.vm.$nextTick()
     expect(wrapper.findAll(selectors.membersRolePanelStub).length).toBe(1)
     expect(
       wrapper.findComponent<typeof MembersRoleSection>(selectors.membersRolePanelStub).props()
-        .members[0].displayName
-    ).toEqual(userToFilterFor.displayName)
+        .members[0].grantedTo.user.displayName
+    ).toEqual(userToFilterFor.grantedTo.user.displayName)
   })
   it('should display an empty result if no matching members found', async () => {
     const { wrapper } = getWrapper()
     wrapper.vm.filterTerm = 'no-match'
-    await wrapper.vm.$nextTick
+    await wrapper.vm.$nextTick()
     expect(wrapper.findAll(selectors.membersRolePanelStub).length).toBe(0)
     expect(wrapper.html()).toMatchSnapshot()
+  })
+  it('should display members without role under the custom section', () => {
+    const spaceResource = {
+      members: {
+        '1': { grantedTo: { user: { displayName: 'admin' } } }
+      }
+    } as undefined as SpaceResource
+    const { wrapper } = getWrapper({ spaceResource })
+    expect(wrapper.find(selectors.spaceMembersCustom).exists()).toBeTruthy()
   })
 })
 
@@ -49,7 +61,7 @@ function getWrapper({ spaceResource = spaceMock } = {}) {
   return {
     wrapper: shallowMount(MembersPanel, {
       global: {
-        plugins: [...defaultPlugins()],
+        plugins: [...defaultPlugins({ piniaOptions: { sharesState: { graphRoles } } })],
         provide: { resource: spaceResource }
       }
     })

--- a/packages/web-app-admin-settings/tests/unit/components/Spaces/SideBar/MembersRoleSection.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Spaces/SideBar/MembersRoleSection.spec.ts
@@ -1,20 +1,20 @@
 import MembersRoleSection from '../../../../../src/components/Spaces/SideBar/MembersRoleSection.vue'
 import { defaultPlugins, shallowMount } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
-import { SpaceRole } from '@ownclouders/web-client'
+import { SpaceMember } from '@ownclouders/web-client'
 
 describe('MembersRoleSection', () => {
   it('should render all members accordingly', () => {
     const members = [
-      mock<SpaceRole>({ kind: 'user', displayName: 'einstein' }),
-      mock<SpaceRole>({ kind: 'group', displayName: 'physic-lovers' })
+      mock<SpaceMember>({ grantedTo: { user: { displayName: 'einstein' }, group: undefined } }),
+      mock<SpaceMember>({ grantedTo: { group: { displayName: 'physic-lovers' }, user: undefined } })
     ]
     const { wrapper } = getWrapper({ members })
     expect(wrapper.html()).toMatchSnapshot()
   })
 })
 
-function getWrapper({ members = [] }: { members?: SpaceRole[] } = {}) {
+function getWrapper({ members = [] }: { members?: SpaceMember[] } = {}) {
   return {
     wrapper: shallowMount(MembersRoleSection, {
       props: {

--- a/packages/web-app-admin-settings/tests/unit/components/Spaces/SideBar/__snapshots__/MembersPanel.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/components/Spaces/SideBar/__snapshots__/MembersPanel.spec.ts.snap
@@ -7,9 +7,15 @@ exports[`MembersPanel > should display an empty result if no matching members fo
     <div>
       <h3 class="oc-text-bold oc-text-medium">No members found</h3>
     </div>
-    <!--v-if-->
-    <!--v-if-->
-    <!--v-if-->
+    <div>
+      <!--v-if-->
+    </div>
+    <div>
+      <!--v-if-->
+    </div>
+    <div>
+      <!--v-if-->
+    </div>
     <!--v-if-->
   </div>
 </div>"
@@ -20,22 +26,25 @@ exports[`MembersPanel > should render all members accordingly to their role assi
   <oc-text-input-stub id="oc-textinput-1" type="text" modelvalue="" clearbuttonenabled="false" clearbuttonaccessiblelabel="" disabled="false" label="Filter members" fixmessageline="false" readonly="false" passwordpolicy="[object Object]" class="oc-text-truncate oc-mr-s oc-mt-m"></oc-text-input-stub>
   <div data-testid="space-members">
     <!--v-if-->
-    <div class="oc-mb-m" data-testid="space-members-role-managers">
-      <h3 class="oc-text-bold oc-text-medium">Managers</h3>
-      <members-role-section-stub members="[object Object]"></members-role-section-stub>
+    <div>
+      <div class="oc-mb-m" data-testid="space-members-role-Managers">
+        <h3 class="oc-text-bold oc-text-medium">Managers</h3>
+        <members-role-section-stub members="[object Object]"></members-role-section-stub>
+      </div>
     </div>
-    <div class="oc-mb-m" data-testid="space-members-role-editors">
-      <h3 class="oc-text-bold oc-text-medium">Editors</h3>
-      <members-role-section-stub members="[object Object],[object Object]"></members-role-section-stub>
+    <div>
+      <div class="oc-mb-m" data-testid="space-members-role-Editors">
+        <h3 class="oc-text-bold oc-text-medium">Editors</h3>
+        <members-role-section-stub members="[object Object]"></members-role-section-stub>
+      </div>
     </div>
-    <div class="oc-mb-m" data-testid="space-members-role-viewers">
-      <h3 class="oc-text-bold oc-text-medium">Viewers</h3>
-      <members-role-section-stub members="[object Object]"></members-role-section-stub>
+    <div>
+      <div class="oc-mb-m" data-testid="space-members-role-Viewers">
+        <h3 class="oc-text-bold oc-text-medium">Viewers</h3>
+        <members-role-section-stub members="[object Object]"></members-role-section-stub>
+      </div>
     </div>
-    <div class="oc-mb-m" data-testid="space-members-role-secure-viewers">
-      <h3 class="oc-text-bold oc-text-medium">Secure viewers</h3>
-      <members-role-section-stub members="[object Object]"></members-role-section-stub>
-    </div>
+    <!--v-if-->
   </div>
 </div>"
 `;

--- a/packages/web-app-admin-settings/tests/unit/components/Spaces/SpacesList.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Spaces/SpacesList.spec.ts
@@ -7,48 +7,66 @@ import { nextTick } from 'vue'
 import { useSpaceSettingsStore } from '../../../../src/composables'
 import { mock } from 'vitest-mock-extended'
 import { OcTable } from 'design-system/src/components'
-import { SpaceResource } from '@ownclouders/web-client'
+import { GraphSharePermission, SpaceMember, SpaceResource } from '@ownclouders/web-client'
 
 const spaceMocks = [
-  {
+  mock<SpaceResource>({
     id: '1',
     name: '1 Some space',
     disabled: false,
-    spaceRoles: {
-      manager: [
-        { id: 'user1', displayName: 'user1' },
-        { id: 'user2', displayName: 'user2' },
-        { id: 'user3', displayName: 'user3' }
-      ],
-      editor: [],
-      viewer: []
+    members: {
+      '1': mock<SpaceMember>({
+        permissions: [GraphSharePermission.deletePermissions],
+        grantedTo: { user: { displayName: 'user1' } }
+      }),
+      '2': mock<SpaceMember>({
+        permissions: [GraphSharePermission.deletePermissions],
+        grantedTo: { user: { displayName: 'user2' } }
+      }),
+      '3': mock<SpaceMember>({
+        permissions: [GraphSharePermission.deletePermissions],
+        grantedTo: { user: { displayName: 'user3' } }
+      })
     },
     spaceQuota: {
       total: 1000000000,
       used: 0,
       remaining: 1000000000
     }
-  },
-  {
+  }),
+  mock<SpaceResource>({
     id: '2',
     name: '2 Another space',
     disabled: true,
-    spaceRoles: {
-      manager: [
-        { id: 'user1', displayName: 'user1' },
-        { id: 'user2', displayName: 'user2' },
-        { id: 'user3', displayName: 'user3' }
-      ],
-      editor: [{ id: 'user4', displayName: 'user4' }],
-      viewer: [{ id: 'user5', displayName: 'user5' }]
+    members: {
+      '1': mock<SpaceMember>({
+        permissions: [GraphSharePermission.deletePermissions],
+        grantedTo: { user: { displayName: 'user1' } }
+      }),
+      '2': mock<SpaceMember>({
+        permissions: [GraphSharePermission.deletePermissions],
+        grantedTo: { user: { displayName: 'user2' } }
+      }),
+      '3': mock<SpaceMember>({
+        permissions: [GraphSharePermission.deletePermissions],
+        grantedTo: { user: { displayName: 'user3' } }
+      }),
+      '4': mock<SpaceMember>({
+        permissions: [],
+        grantedTo: { user: { displayName: 'user4' } }
+      }),
+      '5': mock<SpaceMember>({
+        permissions: [],
+        grantedTo: { user: { displayName: 'user5' } }
+      })
     },
     spaceQuota: {
       total: 2000000000,
       used: 500000000,
       remaining: 1500000000
     }
-  }
-] as SpaceResource[]
+  })
+]
 
 const selectors = {
   ocTableStub: 'oc-table-stub'

--- a/packages/web-app-admin-settings/tests/unit/components/Spaces/__snapshots__/SpacesList.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/components/Spaces/__snapshots__/SpacesList.spec.ts.snap
@@ -60,7 +60,7 @@ exports[`SpacesList > should render all spaces in a table 1`] = `
     <tbody class="has-item-context-menu">
       <tr tabindex="-1" class="oc-tbody-tr oc-tbody-tr-1" data-item-id="1" draggable="false">
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-select oc-pl-s">
-          <oc-checkbox-stub id="oc-checkbox-2" disabled="false" modelvalue="false" option="[object Object]" label="Select 1 Some space" hidelabel="true" size="large" outline="false" class="oc-ml-s"></oc-checkbox-stub>
+          <oc-checkbox-stub id="oc-checkbox-2" disabled="false" modelvalue="false" option="undefined" label="Select 1 Some space" hidelabel="true" size="large" outline="false" class="oc-ml-s"></oc-checkbox-stub>
         </td>
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-icon"><span class="oc-icon oc-icon-m oc-icon-passive"><!----></span></td>
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-name mark-element"><span class="spaces-table-space-name" data-test-space-name="1 Some space">1 Some space</span></td>
@@ -86,7 +86,7 @@ exports[`SpacesList > should render all spaces in a table 1`] = `
       </tr>
       <tr tabindex="-1" class="oc-tbody-tr oc-tbody-tr-2" data-item-id="2" draggable="false">
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-select oc-pl-s">
-          <oc-checkbox-stub id="oc-checkbox-3" disabled="false" modelvalue="false" option="[object Object]" label="Select 2 Another space" hidelabel="true" size="large" outline="false" class="oc-ml-s"></oc-checkbox-stub>
+          <oc-checkbox-stub id="oc-checkbox-3" disabled="false" modelvalue="false" option="undefined" label="Select 2 Another space" hidelabel="true" size="large" outline="false" class="oc-ml-s"></oc-checkbox-stub>
         </td>
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-icon"><span class="oc-icon oc-icon-m oc-icon-passive"><!----></span></td>
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-name mark-element"><span class="spaces-table-space-name" data-test-space-name="2 Another space">2 Another space</span></td>

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -175,6 +175,7 @@ import {
   useFileActionsCreateNewShortcut,
   useMessages,
   useResourcesStore,
+  useSharesStore,
   useSpacesStore,
   useUserStore
 } from '@ownclouders/web-pkg'
@@ -248,6 +249,7 @@ export default defineComponent({
     const userStore = useUserStore()
     const spacesStore = useSpacesStore()
     const messageStore = useMessages()
+    const sharesStore = useSharesStore()
     const route = useRoute()
     const language = useGettext()
 
@@ -361,7 +363,7 @@ export default defineComponent({
 
           if (driveType === 'project' || isOwnSpace) {
             const client = clientService.graphAuthenticated
-            const updatedSpace = await client.drives.getDrive(spaceId)
+            const updatedSpace = await client.drives.getDrive(spaceId, sharesStore.graphRoles)
             spacesStore.updateSpaceField({
               id: updatedSpace.id,
               field: 'spaceQuota',

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -425,7 +425,8 @@ export default defineComponent({
 
       if (isProjectSpaceResource(unref(resource))) {
         const updatedSpace = await clientService.graphAuthenticated.drives.getDrive(
-          unref(resource).id
+          unref(resource).id,
+          sharesStore.graphRoles
         )
 
         upsertSpace(updatedSpace)

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -169,7 +169,6 @@ import ExpirationDatepicker from './ExpirationDatepicker.vue'
 import {
   CollaboratorAutoCompleteItem,
   CollaboratorShare,
-  GraphShareRoleIdMap,
   ShareRole,
   ShareTypes,
   call
@@ -242,7 +241,7 @@ export default defineComponent({
 
     const sharesStore = useSharesStore()
     const { addShare } = sharesStore
-    const { collaboratorShares, graphRoles } = storeToRefs(sharesStore)
+    const { collaboratorShares } = storeToRefs(sharesStore)
 
     const searchQuery = ref('')
     const searchInProgress = ref(false)
@@ -258,9 +257,8 @@ export default defineComponent({
 
     const resource = inject<Resource>('resource')
     const space = inject<SpaceResource>('space')
+    const availableInternalRoles = inject<Ref<ShareRole[]>>('availableInternalShareRoles')
     const availableExternalRoles = inject<Ref<ShareRole[]>>('availableExternalShareRoles')
-
-    const resourceIsSpace = computed(() => unref(resource).type === 'space')
 
     const markInstance = ref(null)
 
@@ -302,9 +300,9 @@ export default defineComponent({
     })
 
     onMounted(async () => {
-      selectedRole.value = unref(resourceIsSpace)
-        ? unref(graphRoles)[GraphShareRoleIdMap.SpaceViewer]
-        : unref(graphRoles)[GraphShareRoleIdMap.Viewer]
+      selectedRole.value = unref(isExternalShareRoleType)
+        ? unref(availableExternalRoles)[0]
+        : unref(availableInternalRoles)[0]
 
       await nextTick()
       markInstance.value = new Mark('.mark-element')

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
@@ -203,7 +203,9 @@ export default defineComponent({
     const { $gettext } = language
     const { dispatchModal } = useModals()
 
-    const { updateShare } = useSharesStore()
+    const sharesStore = useSharesStore()
+    const { graphRoles } = storeToRefs(sharesStore)
+    const { updateShare } = sharesStore
     const { upsertSpace, upsertSpaceMember } = useSpacesStore()
 
     const { user } = storeToRefs(userStore)
@@ -245,6 +247,7 @@ export default defineComponent({
       clientService,
       sharedParentDir,
       shareDate,
+      graphRoles,
       setDenyShare,
       showNotifyShareModal,
       showMessage,
@@ -425,7 +428,7 @@ export default defineComponent({
 
         if (isProjectSpaceResource(this.resource)) {
           const client = this.clientService.graphAuthenticated
-          const space = await client.drives.getDrive(this.resource.id)
+          const space = await client.drives.getDrive(this.resource.id, this.graphRoles)
 
           this.upsertSpace(space)
           this.upsertSpaceMember({ member: share })

--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -437,8 +437,8 @@ export default defineComponent({
         return false
       }
 
-      if (isProjectSpaceResource(this.space) && !this.space.isManager(this.user)) {
-        return false
+      if (isProjectSpaceResource(this.space)) {
+        return this.space.canShare({ user: this.user })
       }
 
       return true

--- a/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
@@ -105,7 +105,9 @@ export default defineComponent({
     const clientService = useClientService()
     const { canShare } = useCanShare()
     const { dispatchModal } = useModals()
-    const { deleteShare } = useSharesStore()
+    const sharesStore = useSharesStore()
+    const { deleteShare } = sharesStore
+    const { graphRoles } = storeToRefs(sharesStore)
     const spacesStore = useSpacesStore()
     const { upsertSpace, removeSpaceMember } = spacesStore
     const { spaceMembers } = storeToRefs(spacesStore)
@@ -133,6 +135,7 @@ export default defineComponent({
       canShare,
       markInstance,
       filesPrivateLinks,
+      graphRoles,
       ...useMessages()
     }
   },
@@ -226,7 +229,7 @@ export default defineComponent({
 
             if (!currentUserRemoved) {
               const client = this.clientService.graphAuthenticated
-              const space = await client.drives.getDrive(share.resourceId)
+              const space = await client.drives.getDrive(share.resourceId, this.graphRoles)
               this.upsertSpace(space)
             }
 

--- a/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
@@ -71,7 +71,7 @@
 import { storeToRefs } from 'pinia'
 import CollaboratorListItem from './Collaborators/ListItem.vue'
 import InviteCollaboratorForm from './Collaborators/InviteCollaborator/InviteCollaboratorForm.vue'
-import { GraphShareRoleIdMap } from '@ownclouders/web-client'
+import { GraphSharePermission } from '@ownclouders/web-client'
 import {
   createLocationSpaces,
   isLocationSpacesActive,
@@ -193,13 +193,16 @@ export default defineComponent({
         return false
       }
 
-      if (share.role.id !== GraphShareRoleIdMap.SpaceManager) {
+      const memberCanUpdateMembers = share.permissions.includes(
+        GraphSharePermission.updatePermissions
+      )
+      if (!memberCanUpdateMembers) {
         return true
       }
 
-      // forbid to remove last manager of a space
-      const managers = this.spaceMembers.filter(
-        ({ role }) => role.id === GraphShareRoleIdMap.SpaceManager
+      // make sure at least one member can edit other members
+      const managers = this.spaceMembers.filter(({ permissions }) =>
+        permissions.includes(GraphSharePermission.updatePermissions)
       )
       return managers.length > 1
     },

--- a/packages/web-app-files/src/components/Spaces/SpaceHeader.vue
+++ b/packages/web-app-files/src/components/Spaces/SpaceHeader.vue
@@ -261,7 +261,7 @@ export default defineComponent({
     )
 
     const memberCount = computed(() => {
-      return Object.values(props.space.spaceRoles).flat().length
+      return Object.keys(props.space.members).length
     })
     const memberCountString = computed(() => {
       return $ngettext('%{count} member', '%{count} members', unref(memberCount), {

--- a/packages/web-app-files/src/composables/actions/spaces/useSpaceActionsUploadImage.ts
+++ b/packages/web-app-files/src/composables/actions/spaces/useSpaceActionsUploadImage.ts
@@ -7,7 +7,8 @@ import {
   useUserStore,
   useMessages,
   useSpacesStore,
-  useSpaceHelpers
+  useSpaceHelpers,
+  useSharesStore
 } from '@ownclouders/web-pkg'
 import { eventBus } from '@ownclouders/web-pkg'
 import { useGettext } from 'vue3-gettext'
@@ -22,6 +23,7 @@ export const useSpaceActionsUploadImage = ({ spaceImageInput }: { spaceImageInpu
   const loadingService = useLoadingService()
   const previewService = usePreviewService()
   const spacesStore = useSpacesStore()
+  const sharesStore = useSharesStore()
   const { createDefaultMetaFolder } = useCreateSpace()
   const { getDefaultMetaFolder } = useSpaceHelpers()
 
@@ -75,10 +77,14 @@ export const useSpaceActionsUploadImage = ({ spaceImageInput }: { spaceImageInpu
           overwrite: true
         })
 
-        const updatedSpace = await graphClient.drives.updateDrive(selectedSpace.id, {
-          name: selectedSpace.name,
-          special: [{ specialFolder: { name: 'image' }, id: fileId }]
-        })
+        const updatedSpace = await graphClient.drives.updateDrive(
+          selectedSpace.id,
+          {
+            name: selectedSpace.name,
+            special: [{ specialFolder: { name: 'image' }, id: fileId }]
+          },
+          sharesStore.graphRoles
+        )
 
         spacesStore.updateSpaceField({
           id: selectedSpace.id,

--- a/packages/web-app-files/src/composables/extensions/useFileSideBars.ts
+++ b/packages/web-app-files/src/composables/extensions/useFileSideBars.ts
@@ -363,9 +363,7 @@ export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resourc
           ) {
             return false
           }
-          return [...items[0].spaceRoles.manager, ...items[0].spaceRoles.editor].some(
-            (role) => role.id === userStore.user.id
-          )
+          return true
         }
       }
     },

--- a/packages/web-app-files/src/views/spaces/GenericTrash.vue
+++ b/packages/web-app-files/src/views/spaces/GenericTrash.vue
@@ -174,8 +174,8 @@ export default defineComponent({
     showActions() {
       return (
         !isProjectSpaceResource(this.space) ||
-        this.space.isEditor(this.user) ||
-        this.space.isManager(this.user)
+        this.space.canDeleteFromTrashBin({ user: this.user }) ||
+        this.space.canRestoreFromTrashbin({ user: this.user })
       )
     }
   }

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -198,6 +198,7 @@ import {
 } from '@ownclouders/web-pkg'
 import SpaceContextActions from '../../components/Spaces/SpaceContextActions.vue'
 import {
+  getSpaceManagers,
   isProjectSpaceResource,
   ProjectSpaceResource,
   SpaceResource
@@ -367,9 +368,11 @@ export default defineComponent({
     useKeyboardTableActions(keyActions)
 
     const getManagerNames = (space: SpaceResource) => {
-      const allManagers = space.spaceRoles.manager
+      const allManagers = getSpaceManagers(space)
       const managers = allManagers.length > 2 ? allManagers.slice(0, 2) : allManagers
-      let managerStr = managers.map((m) => m.displayName).join(', ')
+      let managerStr = managers
+        .map(({ grantedTo }) => (grantedTo.user || grantedTo.group).displayName)
+        .join(', ')
       if (allManagers.length > 2) {
         managerStr += `... +${allManagers.length - 2}`
       }
@@ -396,7 +399,7 @@ export default defineComponent({
       return formatFileSize(space.spaceQuota.remaining, language.current)
     }
     const getMemberCount = (space: SpaceResource) => {
-      return Object.values(space.spaceRoles).flat().length
+      return Object.keys(space.members).length
     }
 
     onMounted(async () => {

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.ts
@@ -8,12 +8,7 @@ import {
 } from 'web-test-helpers'
 import { Resource, SpaceResource } from '@ownclouders/web-client'
 import { useSharesStore } from '@ownclouders/web-pkg'
-import {
-  CollaboratorAutoCompleteItem,
-  CollaboratorShare,
-  GraphShareRoleIdMap,
-  ShareRole
-} from '@ownclouders/web-client'
+import { CollaboratorAutoCompleteItem, CollaboratorShare, ShareRole } from '@ownclouders/web-client'
 import { Group, User } from '@ownclouders/web-client/graph/generated'
 import OcButton from 'design-system/src/components/OcButton/OcButton.vue'
 import RoleDropdown from '../../../../../../../src/components/SideBar/Shares/Collaborators/RoleDropdown.vue'
@@ -209,16 +204,17 @@ function getWrapper({
               capabilityState: { capabilities },
               configState: { options: { concurrentRequests: { shares: { create: 1 } } } },
               sharesState: {
-                graphRoles: {
-                  [GraphShareRoleIdMap.Viewer]: mock<ShareRole>(),
-                  [GraphShareRoleIdMap.SpaceViewer]: mock<ShareRole>()
-                },
                 collaboratorShares: existingCollaborators
               }
             }
           })
         ],
-        provide: { ...mocks, resource, availableExternalShareRoles: externalShareRoles },
+        provide: {
+          ...mocks,
+          resource,
+          availableExternalShareRoles: externalShareRoles,
+          availableInternalShareRoles: [mock<ShareRole>()]
+        },
         mocks,
         stubs: { OcSelect: false, VueSelect: false }
       }

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/FileShares.spec.ts
@@ -97,22 +97,22 @@ describe('FileShares', () => {
       const { wrapper } = getWrapper({ space, mountType: shallowMount, collaborators })
       expect(wrapper.vm.isShareModifiable(collaborators[0])).toBe(true)
     })
-    it('share should not be modifiable if its not personal space share', () => {
-      const space = mock<SpaceResource>({ driveType: 'project' })
-      const { wrapper } = getWrapper({ space, mountType: shallowMount, collaborators })
-      expect(wrapper.vm.isShareModifiable(collaborators[0])).toBe(false)
-    })
     it('share should not be modifiable if collaborator is indirect', () => {
       const space = mock<SpaceResource>({ driveType: 'personal' })
       const { wrapper } = getWrapper({ space, mountType: shallowMount, collaborators })
       collaborators[0]['indirect'] = true
       expect(wrapper.vm.isShareModifiable(collaborators[0])).toBe(false)
     })
-    it('share should not be modifiable if user is not manager', () => {
-      const space = mock<SpaceResource>({ driveType: 'project', isManager: () => false })
+    it('share should not be modifiable if its a project space user cannot share', () => {
+      const space = mock<SpaceResource>({ driveType: 'project', canShare: () => false })
       collaborators[0]['indirect'] = true
       const { wrapper } = getWrapper({ space, mountType: shallowMount, collaborators })
       expect(wrapper.vm.isShareModifiable(collaborators[0])).toBe(false)
+    })
+    it('share should be modifiable if its a project space and user can share', () => {
+      const space = mock<SpaceResource>({ driveType: 'project', canShare: () => true })
+      const { wrapper } = getWrapper({ space, mountType: shallowMount, collaborators })
+      expect(wrapper.vm.isShareModifiable(collaborators[0])).toBe(true)
     })
   })
 

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/SpaceMembers.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/SpaceMembers.spec.ts
@@ -3,7 +3,7 @@ import {
   ShareTypes,
   ShareRole,
   CollaboratorShare,
-  GraphShareRoleIdMap
+  GraphSharePermission
 } from '@ownclouders/web-client'
 import { mock } from 'vitest-mock-extended'
 import { ProjectSpaceResource, SpaceResource } from '@ownclouders/web-client'
@@ -31,8 +31,8 @@ const memberMocks = [
       id: 'alice',
       displayName: 'alice'
     },
-    role: mock<ShareRole>({ id: GraphShareRoleIdMap.SpaceManager }),
-    permissions: [],
+    role: mock<ShareRole>(),
+    permissions: [GraphSharePermission.updatePermissions],
     resourceId: '1',
     indirect: false,
     sharedBy: { id: 'admin', displayName: 'admin' }
@@ -44,7 +44,7 @@ const memberMocks = [
       onPremisesSamAccountName: 'Einstein',
       displayName: 'einstein'
     },
-    role: mock<ShareRole>({ id: GraphShareRoleIdMap.SpaceEditor }),
+    role: mock<ShareRole>(),
     permissions: [],
     resourceId: '1',
     indirect: false,
@@ -57,7 +57,7 @@ const memberMocks = [
       onPremisesSamAccountName: 'Marie',
       displayName: 'marie'
     },
-    role: mock<ShareRole>({ id: GraphShareRoleIdMap.SpaceViewer }),
+    role: mock<ShareRole>(),
     permissions: [],
     resourceId: '1',
     indirect: false,

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/SpaceMembers.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/SpaceMembers.spec.ts
@@ -112,7 +112,7 @@ describe('SpaceMembers', () => {
 
   describe('filter', () => {
     it('toggles the filter on click', async () => {
-      const space = mock<ProjectSpaceResource>({ isManager: () => true })
+      const space = mock<ProjectSpaceResource>()
       const wrapper = getWrapper({ mountType: mount, space })
       expect(wrapper.vm.isFilterOpen).toBeFalsy()
       await wrapper.find('.open-filter-btn').trigger('click')

--- a/packages/web-app-files/tests/unit/components/Spaces/SpaceContextActions.spec.ts
+++ b/packages/web-app-files/tests/unit/components/Spaces/SpaceContextActions.spec.ts
@@ -6,7 +6,9 @@ import { Drive } from '@ownclouders/web-client/graph/generated'
 
 const spaceMock = mock<Drive>({
   id: '1',
-  root: { permissions: [{ roles: ['manager'], grantedToIdentities: [{ user: { id: '1' } }] }] },
+  root: {
+    permissions: [{ '@libre.graph.permissions.actions': [], grantedToV2: { user: { id: '1' } } }]
+  },
   driveType: 'project',
   special: null
 })
@@ -14,7 +16,7 @@ const spaceMock = mock<Drive>({
 describe('SpaceContextActions', () => {
   describe('action handlers', () => {
     it('renders actions that are always available: "Members", "Edit Quota", "Details"', () => {
-      const { wrapper } = getWrapper(buildSpace(spaceMock))
+      const { wrapper } = getWrapper(buildSpace(spaceMock, {}))
 
       expect(
         wrapper.findAll('[data-testid="action-label"]').some((el) => el.text() === 'Members')

--- a/packages/web-app-files/tests/unit/components/Spaces/SpaceHeader.spec.ts
+++ b/packages/web-app-files/tests/unit/components/Spaces/SpaceHeader.spec.ts
@@ -1,7 +1,7 @@
 import { nextTick, ref } from 'vue'
 import SpaceHeader from 'web-app-files/src/components/Spaces/SpaceHeader.vue'
-import { Drive } from '@ownclouders/web-client/graph/generated'
-import { SpaceResource, buildSpace, Resource } from '@ownclouders/web-client'
+import { DriveItem } from '@ownclouders/web-client/graph/generated'
+import { SpaceResource, Resource } from '@ownclouders/web-client'
 import { defaultPlugins, mount, defaultComponentMocks } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
 
@@ -12,35 +12,37 @@ vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
   })
 }))
 
+const getSpaceMock = (spaceImageData: DriveItem = undefined) =>
+  mock<SpaceResource>({
+    id: '1',
+    name: '',
+    description: '',
+    spaceReadmeData: undefined,
+    spaceImageData
+  })
+
 describe('SpaceHeader', () => {
   it('should add the "squashed"-class when the sidebar is opened', () => {
-    const wrapper = getWrapper({
-      space: buildSpace({ id: '1' } as unknown as Drive),
-      isSideBarOpen: true
-    })
+    const wrapper = getWrapper({ space: getSpaceMock(), isSideBarOpen: true })
     expect(wrapper.find('.space-header-squashed').exists()).toBeTruthy()
     expect(wrapper.html()).toMatchSnapshot()
   })
   describe('space image', () => {
     it('should show the default image if no other image is set', () => {
-      const wrapper = getWrapper({ space: buildSpace({ id: '1' } as unknown as Drive) })
+      const wrapper = getWrapper({ space: getSpaceMock() })
       expect(wrapper.find('.space-header-image-default').exists()).toBeTruthy()
       expect(wrapper.html()).toMatchSnapshot()
     })
     it('should show the set image', async () => {
-      const spaceMock = { spaceImageData: { webDavUrl: '/' } }
-      const wrapper = getWrapper({
-        space: { ...buildSpace({ id: '1' } as unknown as Drive), ...spaceMock }
-      })
+      const wrapper = getWrapper({ space: getSpaceMock({ webDavUrl: '/' }) })
       await wrapper.vm.loadPreviewTask.last
       expect(wrapper.find('.space-header-image-default').exists()).toBeFalsy()
       expect(wrapper.find('.space-header-image img').exists()).toBeTruthy()
       expect(wrapper.html()).toMatchSnapshot()
     })
     it('should take full width in mobile view', () => {
-      const spaceMock = { spaceImageData: { webDavUrl: '/' } }
       const wrapper = getWrapper({
-        space: { ...buildSpace({ id: '1' } as unknown as Drive), ...spaceMock },
+        space: getSpaceMock({ webDavUrl: '/' }),
         isMobileWidth: true
       })
       expect(wrapper.find('.space-header').classes()).not.toContain('oc-flex')
@@ -49,7 +51,7 @@ describe('SpaceHeader', () => {
   })
   describe('space description', () => {
     it('should show the description', async () => {
-      const wrapper = getWrapper({ space: buildSpace({ id: '1' } as unknown as Drive) })
+      const wrapper = getWrapper({ space: getSpaceMock() })
       wrapper.vm.markdownResource = mock<Resource>()
       wrapper.vm.markdownContent = 'content'
       await nextTick()

--- a/packages/web-app-files/tests/unit/components/Spaces/__snapshots__/SpaceHeader.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/Spaces/__snapshots__/SpaceHeader.spec.ts.snap
@@ -17,8 +17,10 @@ exports[`SpaceHeader > should add the "squashed"-class when the sidebar is opene
             <space-context-actions-stub actionoptions="[object Object]"></space-context-actions-stub>
           </div>
         </div>
-      </div>
-      <!--v-if-->
+      </div> <button type="button" aria-label="Open context menu and show members" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
+        <!--v-if-->
+        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">17 members</span>
+      </button>
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -44,8 +46,10 @@ exports[`SpaceHeader > space description > should show the description 1`] = `
             <space-context-actions-stub actionoptions="[object Object]"></space-context-actions-stub>
           </div>
         </div>
-      </div>
-      <!--v-if-->
+      </div> <button type="button" aria-label="Open context menu and show members" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
+        <!--v-if-->
+        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">17 members</span>
+      </button>
     </div>
     <!--v-if-->
     <div class="markdown-container oc-flex oc-flex-middle">
@@ -74,8 +78,10 @@ exports[`SpaceHeader > space image > should show the default image if no other i
             <space-context-actions-stub actionoptions="[object Object]"></space-context-actions-stub>
           </div>
         </div>
-      </div>
-      <!--v-if-->
+      </div> <button type="button" aria-label="Open context menu and show members" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
+        <!--v-if-->
+        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">17 members</span>
+      </button>
     </div>
     <!--v-if-->
     <!--v-if-->
@@ -99,8 +105,10 @@ exports[`SpaceHeader > space image > should show the set image 1`] = `
             <space-context-actions-stub actionoptions="[object Object]"></space-context-actions-stub>
           </div>
         </div>
-      </div>
-      <!--v-if-->
+      </div> <button type="button" aria-label="Open context menu and show members" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
+        <!--v-if-->
+        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">17 members</span>
+      </button>
     </div>
     <!--v-if-->
     <!--v-if-->

--- a/packages/web-app-files/tests/unit/views/trash/Overview.spec.ts
+++ b/packages/web-app-files/tests/unit/views/trash/Overview.spec.ts
@@ -92,7 +92,7 @@ describe('TrashOverview', () => {
     })
     it('should set the sort parameters accordingly when calling "handleSort"', () => {
       const { wrapper } = getWrapper({ spaces: [spaceMocks[0]] })
-      const sortBy = 'spaceRoles'
+      const sortBy = 'members'
       const sortDir = SortDir.Desc
       wrapper.vm.handleSort({ sortBy, sortDir })
       expect(wrapper.vm.sortBy).toEqual(sortBy)

--- a/packages/web-client/src/graph/drives/drives.ts
+++ b/packages/web-client/src/graph/drives/drives.ts
@@ -5,25 +5,47 @@ import type { GraphDrives } from './types'
 
 const getServerUrlFromDrive = (drive: Drive) => new URL(drive.webUrl).origin
 
+const roleIdv1Tov2Map = {
+  manager: '312c0871-5ef7-4b3a-85b6-0e4074c64049',
+  editor: '58c63c02-1d89-4572-916a-870abc5a1b7d',
+  viewer: 'a8d5fe5e-96e3-418d-825b-534dbdf22b99'
+}
+
+// FIXME: convert old v1 drive to v2 drive. remove with https://github.com/owncloud/ocis/issues/9884
+const v1Tov2Drive = (drive: Drive) => {
+  drive.root?.permissions?.forEach((p) => {
+    p.grantedToV2 = p.grantedToV2 || p.grantedToIdentities?.[0]
+    delete p.grantedToIdentities
+    const oldRole = p.roles[0]
+    if (oldRole) {
+      p.roles[0] = roleIdv1Tov2Map[oldRole]
+    }
+  })
+  return drive
+}
+
 export const DrivesFactory = ({ axiosClient, config }: GraphFactoryOptions): GraphDrives => {
   const drivesApiFactory = DrivesApiFactory(config, config.basePath, axiosClient)
   const meDrivesApi = new MeDrivesApi(config, config.basePath, axiosClient)
   const allDrivesApi = new DrivesGetDrivesApi(config, config.basePath, axiosClient)
 
   return {
-    async getDrive(id, requestOptions) {
-      const { data: drive } = await drivesApiFactory.getDrive(id, requestOptions)
-      return buildSpace({ ...drive, serverUrl: getServerUrlFromDrive(drive) })
+    async getDrive(id, graphRoles, requestOptions) {
+      let { data: drive } = await drivesApiFactory.getDrive(id, requestOptions)
+      drive = v1Tov2Drive(drive)
+      return buildSpace({ ...drive, serverUrl: getServerUrlFromDrive(drive) }, graphRoles)
     },
 
-    async createDrive(data, requestOptions) {
-      const { data: drive } = await drivesApiFactory.createDrive(data, requestOptions)
-      return buildSpace({ ...drive, serverUrl: getServerUrlFromDrive(drive) })
+    async createDrive(data, graphRoles, requestOptions) {
+      let { data: drive } = await drivesApiFactory.createDrive(data, requestOptions)
+      drive = v1Tov2Drive(drive)
+      return buildSpace({ ...drive, serverUrl: getServerUrlFromDrive(drive) }, graphRoles)
     },
 
-    async updateDrive(id, data, requestOptions) {
-      const { data: drive } = await drivesApiFactory.updateDrive(id, data, requestOptions)
-      return buildSpace({ ...drive, serverUrl: getServerUrlFromDrive(drive) })
+    async updateDrive(id, data, graphRoles, requestOptions) {
+      let { data: drive } = await drivesApiFactory.updateDrive(id, data, requestOptions)
+      drive = v1Tov2Drive(drive)
+      return buildSpace({ ...drive, serverUrl: getServerUrlFromDrive(drive) }, graphRoles)
     },
 
     async disableDrive(id, ifMatch, requestOptions) {
@@ -40,18 +62,18 @@ export const DrivesFactory = ({ axiosClient, config }: GraphFactoryOptions): Gra
       })
     },
 
-    async listMyDrives(options, requestOptions) {
+    async listMyDrives(graphRoles, options, requestOptions) {
       const {
         data: { value }
-      } = await meDrivesApi.listMyDrives(options?.orderBy, options?.filter, requestOptions)
-      return value.map((d) => buildSpace({ ...d, serverUrl: getServerUrlFromDrive(d) }))
+      } = await meDrivesApi.listMyDrivesBeta(options?.orderBy, options?.filter, requestOptions)
+      return value.map((d) => buildSpace({ ...d, serverUrl: getServerUrlFromDrive(d) }, graphRoles))
     },
 
-    async listAllDrives(options, requestOptions) {
+    async listAllDrives(graphRoles, options, requestOptions) {
       const {
         data: { value }
-      } = await allDrivesApi.listAllDrives(options?.orderBy, options?.filter, requestOptions)
-      return value.map((d) => buildSpace({ ...d, serverUrl: getServerUrlFromDrive(d) }))
+      } = await allDrivesApi.listAllDrivesBeta(options?.orderBy, options?.filter, requestOptions)
+      return value.map((d) => buildSpace({ ...d, serverUrl: getServerUrlFromDrive(d) }, graphRoles))
     }
   }
 }

--- a/packages/web-client/src/graph/drives/types.ts
+++ b/packages/web-client/src/graph/drives/types.ts
@@ -1,13 +1,22 @@
-import type { SpaceResource } from '../../helpers'
+import type { ShareRole, SpaceResource } from '../../helpers'
 import type { Drive } from '../generated'
 import type { GraphRequestOptions } from '../types'
 
 export interface GraphDrives {
-  getDrive: (id: string, requestOptions?: GraphRequestOptions) => Promise<SpaceResource>
-  createDrive: (data: Drive, requestOptions?: GraphRequestOptions) => Promise<SpaceResource>
+  getDrive: (
+    id: string,
+    graphRoles: Record<string, ShareRole>,
+    requestOptions?: GraphRequestOptions
+  ) => Promise<SpaceResource>
+  createDrive: (
+    data: Drive,
+    graphRoles: Record<string, ShareRole>,
+    requestOptions?: GraphRequestOptions
+  ) => Promise<SpaceResource>
   updateDrive: (
     id: string,
     data: Drive,
+    graphRoles: Record<string, ShareRole>,
     requestOptions?: GraphRequestOptions
   ) => Promise<SpaceResource>
   disableDrive: (
@@ -17,6 +26,7 @@ export interface GraphDrives {
   ) => Promise<void>
   deleteDrive: (id: string, ifMatch?: string, requestOptions?: GraphRequestOptions) => Promise<void>
   listMyDrives: (
+    graphRoles: Record<string, ShareRole>,
     options?: {
       orderBy?: string
       filter?: string
@@ -24,6 +34,7 @@ export interface GraphDrives {
     requestOptions?: GraphRequestOptions
   ) => Promise<SpaceResource[]>
   listAllDrives: (
+    graphRoles: Record<string, ShareRole>,
     options?: {
       orderBy?: string
       filter?: string

--- a/packages/web-client/src/helpers/resource/types.ts
+++ b/packages/web-client/src/helpers/resource/types.ts
@@ -90,7 +90,6 @@ export interface Resource {
   canRename?(args?: { user?: User; ability?: Ability }): boolean
   canBeDeleted?(args?: { user?: User; ability?: Ability }): boolean
   canDeny?(): boolean
-  canRemoveFromTrashbin?({ user }: { user?: User }): boolean
   canEditTags?(): boolean
 
   getDomSelector?(): string

--- a/packages/web-client/src/helpers/share/constants.ts
+++ b/packages/web-client/src/helpers/share/constants.ts
@@ -7,14 +7,3 @@ export abstract class SharePermissionBit {
   static readonly Delete: number = 8
   static readonly Share: number = 16
 }
-
-// map human readable role names to graph share role ids
-export const GraphShareRoleIdMap = {
-  Viewer: 'b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5',
-  SpaceViewer: 'a8d5fe5e-96e3-418d-825b-534dbdf22b99',
-  FileEditor: '2d00ce52-1fc2-4dbc-8b95-a73b73395f5a',
-  FolderEditor: 'fb6c3e19-e378-47e5-b277-9732f9de6e21',
-  SpaceEditor: '58c63c02-1d89-4572-916a-870abc5a1b7d',
-  SpaceManager: '312c0871-5ef7-4b3a-85b6-0e4074c64049',
-  SecureViewer: 'aa97fe03-7980-45ac-9e50-b325749fd7e6'
-} as const

--- a/packages/web-client/src/helpers/share/functions.ts
+++ b/packages/web-client/src/helpers/share/functions.ts
@@ -14,7 +14,6 @@ import { buildWebDavSpacesPath } from '../space'
 import { DriveItem, Identity, Permission, UnifiedRoleDefinition, User } from '../../graph/generated'
 import { urlJoin } from '../../utils'
 import { uniq } from 'lodash-es'
-import { GraphShareRoleIdMap } from './constants'
 
 export const isShareResource = (resource: Resource): resource is ShareResource => {
   return Object.hasOwn(resource, 'sharedWith')
@@ -151,9 +150,7 @@ export function buildIncomingShareResource({
     sharePermissions,
     outgoing: false,
     canRename: () => driveItem['@client.synchronize'],
-    canDownload: () =>
-      sharePermissions.includes(GraphSharePermission.readBasic) &&
-      !shareRoles.some((shareRole) => shareRole.id === GraphShareRoleIdMap.SecureViewer),
+    canDownload: () => sharePermissions.includes(GraphSharePermission.readContent),
     canUpload: () => sharePermissions.includes(GraphSharePermission.createUpload),
     canCreate: () => sharePermissions.includes(GraphSharePermission.createChildren),
     canBeDeleted: () => sharePermissions.includes(GraphSharePermission.deleteStandard),

--- a/packages/web-client/src/helpers/share/types.ts
+++ b/packages/web-client/src/helpers/share/types.ts
@@ -14,7 +14,9 @@ export enum GraphSharePermission {
   updatePath = 'libre.graph/driveItem/path/update',
   updateDeleted = 'libre.graph/driveItem/deleted/update',
   updatePermissions = 'libre.graph/driveItem/permissions/update',
-  deleteStandard = 'libre.graph/driveItem/standard/delete'
+  deleteStandard = 'libre.graph/driveItem/standard/delete',
+  deleteDeleted = 'libre.graph/driveItem/deleted/delete',
+  deletePermissions = 'libre.graph/driveItem/permissions/delete'
 }
 
 export interface ShareResource extends Resource {

--- a/packages/web-client/src/helpers/share/types.ts
+++ b/packages/web-client/src/helpers/share/types.ts
@@ -13,6 +13,7 @@ export enum GraphSharePermission {
   readDeleted = 'libre.graph/driveItem/deleted/read',
   updatePath = 'libre.graph/driveItem/path/update',
   updateDeleted = 'libre.graph/driveItem/deleted/update',
+  updatePermissions = 'libre.graph/driveItem/permissions/update',
   deleteStandard = 'libre.graph/driveItem/standard/delete'
 }
 

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -131,6 +131,7 @@ export function buildSpace(
     }
   }
 
+  console.log('data', data)
   if (data.root?.permissions) {
     for (const permission of data.root.permissions) {
       spaceRoles[permission.roles[0] as keyof SpaceRoles].push(

--- a/packages/web-client/src/helpers/space/types.ts
+++ b/packages/web-client/src/helpers/space/types.ts
@@ -6,22 +6,21 @@
 // ```
 // because in the else block resource gets the type never. If this is changed in a later TypeScript version
 // or all types get different members, the underscored props can be removed.
-import { DriveItem, Identity, Quota, User } from '@ownclouders/web-client/graph/generated'
+import {
+  DriveItem,
+  Quota,
+  SharePointIdentitySet,
+  User
+} from '@ownclouders/web-client/graph/generated'
 import { Ability, Resource } from '../resource'
 
 export const SHARE_JAIL_ID = 'a0ca6a90-a365-4782-871e-d44447bbc668'
 export const OCM_PROVIDER_ID = '89f37a33-858b-45fa-8890-a1f2b27d90e1'
 
-export interface SpaceRole extends Identity {
-  kind: 'user' | 'group'
-  isMember(u: User): boolean
-}
-
-export interface SpaceRoles {
-  viewer: SpaceRole[]
-  editor: SpaceRole[]
-  manager: SpaceRole[]
-  'secure-viewer': SpaceRole[]
+export type SpaceMember = {
+  grantedTo: SharePointIdentitySet
+  permissions: string[]
+  roleId: string
 }
 
 export interface SpaceResource extends Resource {
@@ -30,7 +29,7 @@ export interface SpaceResource extends Resource {
   driveAlias: string
   driveType: 'mountpoint' | 'personal' | 'project' | 'share' | 'public' | (string & unknown)
   root: DriveItem
-  spaceRoles: SpaceRoles
+  members: Record<string, SpaceMember>
   spaceQuota: Quota
   spaceImageData: DriveItem
   spaceReadmeData: DriveItem
@@ -41,15 +40,13 @@ export interface SpaceResource extends Resource {
   canEditImage(args?: { user?: User }): boolean
   canEditReadme(args?: { user?: User }): boolean
   canRestore(args?: { user?: User; ability?: Ability }): boolean
+  canDeleteFromTrashBin(args?: { user?: User }): boolean
+  canRestoreFromTrashbin(args?: { user?: User }): boolean
 
   getWebDavUrl({ path }: { path: string }): string
   getWebDavTrashUrl({ path }: { path: string }): string
   getDriveAliasAndItem(resource: Resource): string
 
-  isViewer(user: User): boolean
-  isSecureViewer(user: User): boolean
-  isEditor(user: User): boolean
-  isManager(user: User): boolean
   isMember(user: User): boolean
   isOwner(user: User): boolean
 }

--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -716,14 +716,14 @@ export default defineComponent({
 
             {
               name: 'manager',
-              prop: 'spaceRoles',
+              prop: 'members',
               title: this.$gettext('Manager'),
               type: 'slot'
             },
             {
               name: 'members',
               title: this.$gettext('Members'),
-              prop: 'spaceRoles',
+              prop: 'members',
               type: 'slot'
             },
             {

--- a/packages/web-pkg/src/components/SideBar/Spaces/Details/SpaceDetails.vue
+++ b/packages/web-pkg/src/components/SideBar/Spaces/Details/SpaceDetails.vue
@@ -83,7 +83,11 @@
 import { storeToRefs } from 'pinia'
 import { defineComponent, inject, ref, Ref, computed, unref } from 'vue'
 import { useTask } from 'vue-concurrency'
-import { getRelativeSpecialFolderSpacePath, SpaceResource } from '@ownclouders/web-client'
+import {
+  getRelativeSpecialFolderSpacePath,
+  getSpaceManagers,
+  SpaceResource
+} from '@ownclouders/web-client'
 import {
   usePreviewService,
   useClientService,
@@ -230,12 +234,14 @@ export default defineComponent({
       return formatDateFromISO(this.resource.mdate, this.$language.current)
     },
     ownerUsernames() {
-      return this.resource.spaceRoles.manager
+      const managers = getSpaceManagers(this.resource)
+      return managers
         .map((share) => {
-          if (share.id === this.user?.id) {
-            return this.$gettext('%{displayName} (me)', { displayName: share.displayName })
+          const member = share.grantedTo.user || share.grantedTo.group
+          if (member.id === this.user?.id) {
+            return this.$gettext('%{displayName} (me)', { displayName: member.displayName })
           }
-          return share.displayName
+          return member.displayName
         })
         .join(', ')
     },
@@ -246,7 +252,7 @@ export default defineComponent({
       return this.linkShareCount > 0
     },
     memberShareCount() {
-      return this.spaceMembers.length
+      return Object.keys(this.resource.members).length
     },
     memberShareLabel() {
       return this.$ngettext(

--- a/packages/web-pkg/src/components/Spaces/QuotaModal.vue
+++ b/packages/web-pkg/src/components/Spaces/QuotaModal.vue
@@ -28,7 +28,8 @@ import {
   useMessages,
   useSpacesStore,
   useCapabilityStore,
-  useResourcesStore
+  useResourcesStore,
+  useSharesStore
 } from '../../composables'
 import { useRouter } from '../../composables/router'
 import { eventBus } from '../../services'
@@ -72,6 +73,7 @@ export default defineComponent({
     const clientService = useClientService()
     const router = useRouter()
     const spacesStore = useSpacesStore()
+    const sharesStore = useSharesStore()
     const { updateResourceField } = useResourcesStore()
 
     const selectedOption = ref(0)
@@ -137,7 +139,7 @@ export default defineComponent({
         const updatedSpace = await client.drives.updateDrive(
           space.id,
           { name: space.name, quota: { total: unref(selectedOption) } },
-          {}
+          sharesStore.graphRoles
         )
         if (unref(router.currentRoute).name === 'admin-settings-spaces') {
           eventBus.publish('app.admin-settings.spaces.space.quota.updated', {

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsDelete.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsDelete.ts
@@ -99,7 +99,7 @@ export const useFileActionsDelete = () => {
 
         if (
           isProjectSpaceResource(space) &&
-          !space.canRemoveFromTrashbin({ user: userStore.user })
+          !space.canDeleteFromTrashBin({ user: userStore.user })
         ) {
           return false
         }

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsEmptyTrashBin.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsEmptyTrashBin.ts
@@ -70,7 +70,7 @@ export const useFileActionsEmptyTrashBin = () => {
 
         if (
           isProjectSpaceResource(space) &&
-          !space.canRemoveFromTrashbin({ user: userStore.user })
+          !space.canDeleteFromTrashBin({ user: userStore.user })
         ) {
           return false
         }

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsRename.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsRename.ts
@@ -20,8 +20,10 @@ import {
   useModals,
   useCapabilityStore,
   useConfigStore,
-  useResourcesStore
+  useResourcesStore,
+  useUserStore
 } from '../../piniaStores'
+import { useAbility } from '../../ability'
 
 export const useFileActionsRename = () => {
   const { showErrorMessage } = useMessages()
@@ -31,6 +33,8 @@ export const useFileActionsRename = () => {
   const clientService = useClientService()
   const configStore = useConfigStore()
   const { dispatchModal } = useModals()
+  const userStore = useUserStore()
+  const ability = useAbility()
 
   const resourcesStore = useResourcesStore()
   const { setCurrentFolder, upsertResource } = resourcesStore
@@ -238,7 +242,7 @@ export const useFileActionsRename = () => {
         }
 
         const renameDisabled = resources.some((resource) => {
-          return !resource.canRename() || resource.processing
+          return !resource.canRename({ user: userStore.user, ability }) || resource.processing
         })
         return !renameDisabled
       },

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsRestore.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsRestore.ts
@@ -20,7 +20,13 @@ import { useRouter } from '../../router'
 import { computed, unref } from 'vue'
 import { useGettext } from 'vue3-gettext'
 import type { FileAction, FileActionOptions } from '../types'
-import { useMessages, useSpacesStore, useUserStore, useResourcesStore } from '../../piniaStores'
+import {
+  useMessages,
+  useSpacesStore,
+  useUserStore,
+  useResourcesStore,
+  useSharesStore
+} from '../../piniaStores'
 import { useRestoreWorker } from '../../webWorkers/restoreWorker'
 
 export const useFileActionsRestore = () => {
@@ -30,6 +36,7 @@ export const useFileActionsRestore = () => {
   const { $gettext, $ngettext } = useGettext()
   const clientService = useClientService()
   const spacesStore = useSpacesStore()
+  const sharesStore = useSharesStore()
   const resourcesStore = useResourcesStore()
   const { startWorker } = useRestoreWorker()
 
@@ -143,7 +150,7 @@ export const useFileActionsRestore = () => {
 
         // Reload quota
         const graphClient = clientService.graphAuthenticated
-        const updatedSpace = await graphClient.drives.getDrive(space.id)
+        const updatedSpace = await graphClient.drives.getDrive(space.id, sharesStore.graphRoles)
         spacesStore.updateSpaceField({
           id: updatedSpace.id,
           field: 'spaceQuota',
@@ -220,8 +227,7 @@ export const useFileActionsRestore = () => {
 
         if (
           isProjectSpaceResource(space) &&
-          !space.isEditor(userStore.user) &&
-          !space.isManager(userStore.user)
+          !space.canRestoreFromTrashbin({ user: userStore.user })
         ) {
           return false
         }

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsSetImage.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsSetImage.ts
@@ -6,7 +6,7 @@ import { useRouter } from '../../router'
 import { useGettext } from 'vue3-gettext'
 import { computed } from 'vue'
 import { FileAction, FileActionOptions } from '../types'
-import { useMessages, useSpacesStore, useUserStore } from '../../piniaStores'
+import { useMessages, useSharesStore, useSpacesStore, useUserStore } from '../../piniaStores'
 import { useCreateSpace, useSpaceHelpers } from '../../spaces'
 
 export const useFileActionsSetImage = () => {
@@ -18,6 +18,7 @@ export const useFileActionsSetImage = () => {
   const loadingService = useLoadingService()
   const previewService = usePreviewService()
   const spacesStore = useSpacesStore()
+  const sharesStore = useSharesStore()
   const { createDefaultMetaFolder } = useCreateSpace()
   const { getDefaultMetaFolder } = useSpaceHelpers()
 
@@ -43,10 +44,14 @@ export const useFileActionsSetImage = () => {
       }
 
       const { fileId } = await getFileInfo(space, { fileId: resources[0].id })
-      const updatedSpace = await graphClient.drives.updateDrive(storageId, {
-        name: space.name,
-        special: [{ specialFolder: { name: 'image' }, id: fileId }]
-      })
+      const updatedSpace = await graphClient.drives.updateDrive(
+        storageId,
+        {
+          name: space.name,
+          special: [{ specialFolder: { name: 'image' }, id: fileId }]
+        },
+        sharesStore.graphRoles
+      )
 
       spacesStore.updateSpaceField({
         id: storageId,

--- a/packages/web-pkg/src/composables/actions/helpers/useFileActionsDeleteResources.ts
+++ b/packages/web-pkg/src/composables/actions/helpers/useFileActionsDeleteResources.ts
@@ -17,7 +17,8 @@ import {
   useModals,
   useSpacesStore,
   useConfigStore,
-  useResourcesStore
+  useResourcesStore,
+  useSharesStore
 } from '../../piniaStores'
 import { storeToRefs } from 'pinia'
 import { useDeleteWorker } from '../../webWorkers'
@@ -32,6 +33,7 @@ export const useFileActionsDeleteResources = () => {
   const clientService = useClientService()
   const { dispatchModal } = useModals()
   const spacesStore = useSpacesStore()
+  const sharesStore = useSharesStore()
   const { startWorker } = useDeleteWorker({
     concurrentRequests: configStore.options.concurrentRequests.resourceBatchActions
   })
@@ -224,7 +226,10 @@ export const useFileActionsDeleteResources = () => {
               !['public', 'share'].includes(spaceForDeletion?.driveType)
             ) {
               const graphClient = clientService.graphAuthenticated
-              const updatedSpace = await graphClient.drives.getDrive(unref(resources)[0].storageId)
+              const updatedSpace = await graphClient.drives.getDrive(
+                unref(resources)[0].storageId,
+                sharesStore.graphRoles
+              )
               spacesStore.updateSpaceField({
                 id: updatedSpace.id,
                 field: 'spaceQuota',

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsDuplicate.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsDuplicate.ts
@@ -11,11 +11,18 @@ import { resolveFileNameDuplicate } from '../../../helpers/resource/conflictHand
 import PQueue from 'p-queue'
 import { useRouter } from '../../router'
 import { isLocationSpacesActive } from '../../../router'
-import { useConfigStore, useMessages, useResourcesStore, useSpacesStore } from '../../piniaStores'
+import {
+  useConfigStore,
+  useMessages,
+  useResourcesStore,
+  useSharesStore,
+  useSpacesStore
+} from '../../piniaStores'
 
 export const useSpaceActionsDuplicate = () => {
   const configStore = useConfigStore()
   const spacesStore = useSpacesStore()
+  const sharesStore = useSharesStore()
   const { showMessage, showErrorMessage } = useMessages()
   const router = useRouter()
   const { $gettext } = useGettext()
@@ -37,7 +44,7 @@ export const useSpaceActionsDuplicate = () => {
           description: existingSpace.description,
           quota: { total: existingSpace.spaceQuota.total }
         },
-        {}
+        sharesStore.graphRoles
       )
 
       const existingSpaceFiles = await clientService.webdav.listFiles(existingSpace)
@@ -91,7 +98,8 @@ export const useSpaceActionsDuplicate = () => {
 
         duplicatedSpace = await clientService.graphAuthenticated.drives.updateDrive(
           duplicatedSpace.id,
-          specialRequestData
+          specialRequestData,
+          sharesStore.graphRoles
         )
       }
 

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditDescription.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditDescription.ts
@@ -5,7 +5,13 @@ import { useAbility } from '../../ability'
 import { useClientService } from '../../clientService'
 import { useGettext } from 'vue3-gettext'
 import { SpaceResource } from '@ownclouders/web-client'
-import { useMessages, useModals, useSpacesStore, useUserStore } from '../../piniaStores'
+import {
+  useMessages,
+  useModals,
+  useSharesStore,
+  useSpacesStore,
+  useUserStore
+} from '../../piniaStores'
 
 export const useSpaceActionsEditDescription = () => {
   const { showMessage, showErrorMessage } = useMessages()
@@ -16,11 +22,12 @@ export const useSpaceActionsEditDescription = () => {
   const route = useRoute()
   const { dispatchModal } = useModals()
   const spacesStore = useSpacesStore()
+  const sharesStore = useSharesStore()
 
   const editDescriptionSpace = (space: SpaceResource, description: string) => {
     const graphClient = clientService.graphAuthenticated
     return graphClient.drives
-      .updateDrive(space.id, { name: space.name, description })
+      .updateDrive(space.id, { name: space.name, description }, sharesStore.graphRoles)
       .then(() => {
         spacesStore.updateSpaceField({ id: space.id, field: 'description', value: description })
         if (unref(route).name === 'admin-settings-spaces') {

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditReadmeContent.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditReadmeContent.ts
@@ -5,7 +5,7 @@ import { useGettext } from 'vue3-gettext'
 import { useOpenWithDefaultApp } from '../useOpenWithDefaultApp'
 import { getRelativeSpecialFolderSpacePath, Resource, SpaceResource } from '@ownclouders/web-client'
 import { useClientService } from '../../clientService'
-import { useSpacesStore, useUserStore } from '../../piniaStores'
+import { useSharesStore, useSpacesStore, useUserStore } from '../../piniaStores'
 import { useCreateSpace, useSpaceHelpers } from '../../spaces'
 
 export const useSpaceActionsEditReadmeContent = () => {
@@ -14,6 +14,7 @@ export const useSpaceActionsEditReadmeContent = () => {
   const { createDefaultMetaFolder } = useCreateSpace()
   const userStore = useUserStore()
   const spacesStore = useSpacesStore()
+  const sharesStore = useSharesStore()
   const { $gettext } = useGettext()
   const { getDefaultMetaFolder } = useSpaceHelpers()
 
@@ -25,10 +26,14 @@ export const useSpaceActionsEditReadmeContent = () => {
       fileName: 'readme.md'
     })
 
-    const updatesSpace = await clientService.graphAuthenticated.drives.updateDrive(space.id, {
-      name: space.name,
-      special: [{ specialFolder: { name: 'readme' }, id: markdownResource.id }]
-    })
+    const updatesSpace = await clientService.graphAuthenticated.drives.updateDrive(
+      space.id,
+      {
+        name: space.name,
+        special: [{ specialFolder: { name: 'readme' }, id: markdownResource.id }]
+      },
+      sharesStore.graphRoles
+    )
 
     spacesStore.updateSpaceField({
       id: space.id,
@@ -70,10 +75,6 @@ export const useSpaceActionsEditReadmeContent = () => {
       handler,
       isVisible: ({ resources }) => {
         if (resources.length !== 1) {
-          return false
-        }
-
-        if (resources[0].disabled) {
           return false
         }
 

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsRename.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsRename.ts
@@ -6,7 +6,13 @@ import { useAbility } from '../../ability'
 import { useRoute } from '../../router'
 import { SpaceAction, SpaceActionOptions } from '../types'
 import { SpaceResource } from '@ownclouders/web-client'
-import { useMessages, useModals, useSpacesStore, useUserStore } from '../../piniaStores'
+import {
+  useMessages,
+  useModals,
+  useSharesStore,
+  useSpacesStore,
+  useUserStore
+} from '../../piniaStores'
 
 export const useSpaceActionsRename = () => {
   const { showMessage, showErrorMessage } = useMessages()
@@ -18,11 +24,12 @@ export const useSpaceActionsRename = () => {
   const { checkSpaceNameModalInput } = useSpaceHelpers()
   const { dispatchModal } = useModals()
   const spacesStore = useSpacesStore()
+  const sharesStore = useSharesStore()
 
   const renameSpace = (space: SpaceResource, name: string) => {
     const graphClient = clientService.graphAuthenticated
     return graphClient.drives
-      .updateDrive(space.id, { name }, {})
+      .updateDrive(space.id, { name }, sharesStore.graphRoles)
       .then(() => {
         if (unref(route).name === 'admin-settings-spaces') {
           space.name = name

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsRestore.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsRestore.ts
@@ -7,7 +7,13 @@ import { useClientService } from '../../clientService'
 import { useLoadingService } from '../../loadingService'
 import { useGettext } from 'vue3-gettext'
 import { isProjectSpaceResource } from '@ownclouders/web-client'
-import { useMessages, useModals, useSpacesStore, useUserStore } from '../../piniaStores'
+import {
+  useMessages,
+  useModals,
+  useSharesStore,
+  useSpacesStore,
+  useUserStore
+} from '../../piniaStores'
 
 export const useSpaceActionsRestore = () => {
   const { showMessage, showErrorMessage } = useMessages()
@@ -19,6 +25,7 @@ export const useSpaceActionsRestore = () => {
   const route = useRoute()
   const { dispatchModal } = useModals()
   const spacesStore = useSpacesStore()
+  const sharesStore = useSharesStore()
 
   const filterResourcesToRestore = (resources: SpaceResource[]): SpaceResource[] => {
     return resources.filter(
@@ -30,7 +37,9 @@ export const useSpaceActionsRestore = () => {
     const client = clientService.graphAuthenticated
     const promises = spaces.map((space) =>
       client.drives
-        .updateDrive(space.id, { name: space.name }, { headers: { Restore: 'true' } })
+        .updateDrive(space.id, { name: space.name }, sharesStore.graphRoles, {
+          headers: { Restore: 'true' }
+        })
         .then((updatedSpace) => {
           if (unref(route).name === 'admin-settings-spaces') {
             space.disabled = false

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsSetIcon.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsSetIcon.ts
@@ -4,7 +4,13 @@ import { SpaceAction, SpaceActionOptions } from '../types'
 import { useClientService } from '../../clientService'
 import { useLoadingService } from '../../loadingService'
 import { useGettext } from 'vue3-gettext'
-import { useMessages, useModals, useSpacesStore, useUserStore } from '../../piniaStores'
+import {
+  useMessages,
+  useModals,
+  useSharesStore,
+  useSpacesStore,
+  useUserStore
+} from '../../piniaStores'
 import { useCreateSpace, useSpaceHelpers } from '../../spaces'
 import { eventBus } from '../../../services'
 import { blobToArrayBuffer, canvasToBlob } from '../../../helpers'
@@ -20,6 +26,7 @@ export const useSpaceActionsSetIcon = () => {
   const { createDefaultMetaFolder } = useCreateSpace()
   const { dispatchModal } = useModals()
   const { getDefaultMetaFolder } = useSpaceHelpers()
+  const sharesStore = useSharesStore()
 
   const handler = ({ resources }: SpaceActionOptions) => {
     if (resources.length !== 1) {
@@ -84,10 +91,14 @@ export const useSpaceActionsSetIcon = () => {
           overwrite: true
         })
 
-        const updatedSpace = await graphClient.drives.updateDrive(space.id, {
-          name: space.name,
-          special: [{ specialFolder: { name: 'image' }, id: fileId }]
-        })
+        const updatedSpace = await graphClient.drives.updateDrive(
+          space.id,
+          {
+            name: space.name,
+            special: [{ specialFolder: { name: 'image' }, id: fileId }]
+          },
+          sharesStore.graphRoles
+        )
 
         spacesStore.updateSpaceField({
           id: space.id,

--- a/packages/web-pkg/src/composables/piniaStores/spaces.ts
+++ b/packages/web-pkg/src/composables/piniaStores/spaces.ts
@@ -3,7 +3,6 @@ import { computed, ref, unref } from 'vue'
 import { isCollaboratorShare, SpaceResource } from '@ownclouders/web-client'
 import { Graph } from '@ownclouders/web-client/graph'
 import {
-  GraphShareRoleIdMap,
   buildSpace,
   extractStorageId,
   isPersonalSpaceResource,
@@ -14,16 +13,9 @@ import { useUserStore } from './user'
 import { ConfigStore, useConfigStore } from './config'
 import { useSharesStore } from './shares'
 
+// sort space members with higher permissions (managers) at the top
 export const sortSpaceMembers = (shares: CollaboratorShare[]) => {
-  const sortedManagers = shares
-    .filter((share) => share.role.id === GraphShareRoleIdMap.SpaceManager)
-    .sort((a, b) => a.sharedWith.displayName.localeCompare(b.sharedWith.displayName))
-
-  const sortedRest = shares
-    .filter((share) => share.role.id !== GraphShareRoleIdMap.SpaceManager)
-    .sort((a, b) => a.sharedWith.displayName.localeCompare(b.sharedWith.displayName))
-
-  return [...sortedManagers, ...sortedRest]
+  return shares.sort((a, b) => b.permissions.length - a.permissions.length)
 }
 
 export const getSpacesByType = async ({

--- a/packages/web-pkg/src/composables/resources/useGetResourceContext.ts
+++ b/packages/web-pkg/src/composables/resources/useGetResourceContext.ts
@@ -8,13 +8,14 @@ import {
 import { computed, unref } from 'vue'
 import { useClientService } from '../clientService'
 import { urlJoin } from '@ownclouders/web-client'
-import { useSpacesStore, useConfigStore } from '../piniaStores'
+import { useSpacesStore, useConfigStore, useSharesStore } from '../piniaStores'
 import { DavProperty } from '@ownclouders/web-client/webdav'
 
 export const useGetResourceContext = () => {
   const clientService = useClientService()
   const configStore = useConfigStore()
   const spacesStore = useSpacesStore()
+  const shareStore = useSharesStore()
 
   const spaces = computed(() => spacesStore.spaces)
 
@@ -35,7 +36,7 @@ export const useGetResourceContext = () => {
       DavProperty.ResourceType
     ]
 
-    const tmpSpace = buildSpace({ id: fileId, name: '' })
+    const tmpSpace = buildSpace({ id: fileId, name: '' }, shareStore.graphRoles)
     return clientService.webdav.getFileInfo(tmpSpace, { fileId }, { davProperties })
   }
 

--- a/packages/web-pkg/src/composables/shares/useCanShare.ts
+++ b/packages/web-pkg/src/composables/shares/useCanShare.ts
@@ -17,7 +17,7 @@ export const useCanShare = () => {
       return false
     }
 
-    if (isProjectSpaceResource(space) && !space.isManager(userStore.user)) {
+    if (isProjectSpaceResource(space) && !space.canShare({ user: userStore.user })) {
       return false
     }
 

--- a/packages/web-pkg/src/composables/spaces/useCreateSpace.ts
+++ b/packages/web-pkg/src/composables/spaces/useCreateSpace.ts
@@ -1,14 +1,17 @@
 import { extractStorageId, SpaceResource } from '@ownclouders/web-client'
 import { useClientService } from '../clientService'
-import { useResourcesStore } from '../piniaStores'
+import { useResourcesStore, useSharesStore } from '../piniaStores'
 
 export const useCreateSpace = () => {
   const clientService = useClientService()
   const resourcesStore = useResourcesStore()
+  const sharesStore = useSharesStore()
 
   const createSpace = (name: string) => {
     const { graphAuthenticated } = clientService
-    return graphAuthenticated.drives.createDrive({ name }, { params: { template: 'default' } })
+    return graphAuthenticated.drives.createDrive({ name }, sharesStore.graphRoles, {
+      params: { template: 'default' }
+    })
   }
 
   const createDefaultMetaFolder = async (space: SpaceResource) => {

--- a/packages/web-pkg/tests/unit/components/sidebar/Spaces/Details/SpaceDetails.spec.ts
+++ b/packages/web-pkg/tests/unit/components/sidebar/Spaces/Details/SpaceDetails.spec.ts
@@ -1,11 +1,5 @@
 import SpaceDetails from '../../../../../../src/components/SideBar/Spaces/Details/SpaceDetails.vue'
-import {
-  CollaboratorShare,
-  ShareRole,
-  GraphShareRoleIdMap,
-  SpaceResource,
-  Resource
-} from '@ownclouders/web-client'
+import { CollaboratorShare, ShareRole, SpaceResource, Resource } from '@ownclouders/web-client'
 import { mock } from 'vitest-mock-extended'
 import { defaultComponentMocks, defaultPlugins, shallowMount } from 'web-test-helpers'
 import { RouteLocation } from 'vue-router'
@@ -33,7 +27,7 @@ const spaceShare = {
     id: 'Alice',
     displayName: 'alice'
   },
-  role: mock<ShareRole>({ id: GraphShareRoleIdMap.SpaceManager })
+  role: mock<ShareRole>()
 } as CollaboratorShare
 
 const selectors = {

--- a/packages/web-pkg/tests/unit/components/sidebar/Spaces/Details/SpaceDetails.spec.ts
+++ b/packages/web-pkg/tests/unit/components/sidebar/Spaces/Details/SpaceDetails.spec.ts
@@ -1,5 +1,12 @@
 import SpaceDetails from '../../../../../../src/components/SideBar/Spaces/Details/SpaceDetails.vue'
-import { CollaboratorShare, ShareRole, SpaceResource, Resource } from '@ownclouders/web-client'
+import {
+  CollaboratorShare,
+  ShareRole,
+  SpaceResource,
+  Resource,
+  SpaceMember,
+  GraphSharePermission
+} from '@ownclouders/web-client'
 import { mock } from 'vitest-mock-extended'
 import { defaultComponentMocks, defaultPlugins, shallowMount } from 'web-test-helpers'
 import { RouteLocation } from 'vue-router'
@@ -10,11 +17,12 @@ const spaceMock = {
   name: ' space',
   id: '1',
   mdate: 'Wed, 21 Oct 2015 07:28:00 GMT',
-  spaceRoles: {
-    manager: [{ id: '1', displayName: 'alice' }],
-    editor: [],
-    viewer: []
-  },
+  members: [
+    mock<SpaceMember>({
+      permissions: [GraphSharePermission.deletePermissions],
+      grantedTo: { user: { id: '1', displayName: 'alice' }, group: undefined }
+    })
+  ],
   spaceQuota: {
     used: 100,
     total: 1000

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsCopy.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsCopy.spec.ts
@@ -83,8 +83,7 @@ function getWrapper({
   const mocks = {
     ...defaultComponentMocks({ currentRoute: mock<RouteLocation>({ name: routeName }) }),
     space: {
-      driveType: 'personal',
-      spaceRoles: { viewer: [], editor: [], manager: [] }
+      driveType: 'personal'
     } as unknown as SpaceResource
   }
   return {

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsDelete.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsDelete.spec.ts
@@ -149,8 +149,7 @@ function getWrapper({
   const mocks = {
     ...defaultComponentMocks({ currentRoute: mock<RouteLocation>({ name: routeName }) }),
     space: {
-      driveType: 'personal',
-      spaceRoles: { viewer: [], editor: [], manager: [] }
+      driveType: 'personal'
     } as unknown as SpaceResource
   }
   const capabilities = {

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsDownloadArchive.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsDownloadArchive.spec.ts
@@ -67,8 +67,7 @@ function getWrapper({
   const mocks = {
     ...defaultComponentMocks({ currentRoute: mock<RouteLocation>({ name: routeName }) }),
     space: {
-      driveType: 'personal',
-      spaceRoles: { viewer: [], editor: [], manager: [] }
+      driveType: 'personal'
     } as unknown as SpaceResource
   }
 

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsEmptyTrashBin.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsEmptyTrashBin.spec.ts
@@ -96,7 +96,7 @@ function getWrapper({
         name: invalidLocation ? 'files-spaces-generic' : 'files-trash-generic'
       })
     }),
-    space: mock<ProjectSpaceResource>({ driveType, isEditor: () => false, isManager: () => false })
+    space: mock<ProjectSpaceResource>({ driveType })
   }
 
   if (resolveClearTrashBin) {

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsRestore.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsRestore.spec.ts
@@ -180,11 +180,7 @@ function getWrapper({
         name: invalidLocation ? 'files-spaces-generic' : 'files-trash-generic'
       })
     }),
-    space: mock<ProjectSpaceResource>({
-      driveType,
-      isEditor: () => false,
-      isManager: () => false
-    })
+    space: mock<ProjectSpaceResource>({ driveType })
   }
   mocks.$clientService.webdav.listFiles.mockImplementation(() => {
     return Promise.resolve({ resource: mock<Resource>(), children: [] })

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsSetImage.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsSetImage.spec.ts
@@ -1,10 +1,10 @@
 import { useFileActionsSetImage } from '../../../../../src'
 import { useMessages } from '../../../../../src/composables/piniaStores'
-import { buildSpace, Resource, SpaceResource } from '@ownclouders/web-client'
+import { Resource, SpaceResource } from '@ownclouders/web-client'
 import { mock } from 'vitest-mock-extended'
 import { defaultComponentMocks, RouteLocation, getComposableWrapper } from 'web-test-helpers'
 import { unref } from 'vue'
-import { Drive, User } from '@ownclouders/web-client/graph/generated'
+import { User } from '@ownclouders/web-client/graph/generated'
 import { useSpaceHelpers } from '../../../../../src/composables/spaces/useSpaceHelpers'
 
 vi.mock('../../../../../src/composables/spaces/useSpaceHelpers', () => ({
@@ -14,16 +14,8 @@ vi.mock('../../../../../src/composables/spaces/useSpaceHelpers', () => ({
 describe('setImage', () => {
   describe('isVisible property', () => {
     it('should be false when no resource given', () => {
-      const space = buildSpace(
-        mock<Drive>({
-          id: '1',
-          quota: {},
-          root: {
-            permissions: [{ roles: ['manager'], grantedToIdentities: [{ user: { id: '1' } }] }]
-          },
-          special: [{ specialFolder: { name: 'image' }, file: { mimeType: 'image/png' } }]
-        })
-      )
+      const space = mock<SpaceResource>({ canEditImage: () => true })
+
       getWrapper({
         setup: ({ actions }) => {
           expect(unref(actions)[0].isVisible({ space, resources: [] as Resource[] })).toBe(false)
@@ -31,16 +23,7 @@ describe('setImage', () => {
       })
     })
     it('should be false when mimeType is not image', () => {
-      const space = buildSpace(
-        mock<Drive>({
-          id: '1',
-          quota: {},
-          root: {
-            permissions: [{ roles: ['manager'], grantedToIdentities: [{ user: { id: '1' } }] }]
-          },
-          special: [{ specialFolder: { name: 'image' }, file: { mimeType: 'image/png' } }]
-        })
-      )
+      const space = mock<SpaceResource>({ canEditImage: () => true })
       getWrapper({
         setup: ({ actions }) => {
           expect(
@@ -54,16 +37,7 @@ describe('setImage', () => {
       })
     })
     it('should be true when the mimeType is image', () => {
-      const space = buildSpace(
-        mock<Drive>({
-          id: '1',
-          quota: {},
-          root: {
-            permissions: [{ roles: ['manager'], grantedToIdentities: [{ user: { id: '1' } }] }]
-          },
-          special: [{ specialFolder: { name: 'image' }, file: { mimeType: 'image/png' } }]
-        })
-      )
+      const space = mock<SpaceResource>({ canEditImage: () => true })
       getWrapper({
         setup: ({ actions }) => {
           expect(
@@ -75,17 +49,8 @@ describe('setImage', () => {
         }
       })
     })
-    it('should be false when the current user is a viewer', () => {
-      const space = buildSpace(
-        mock<Drive>({
-          id: '1',
-          quota: {},
-          root: {
-            permissions: [{ roles: ['viewer'], grantedToIdentities: [{ user: { id: '1' } }] }]
-          },
-          special: [{ specialFolder: { name: 'image' }, file: { mimeType: 'image/png' } }]
-        })
-      )
+    it('should be false when canEditImage is false', () => {
+      const space = mock<SpaceResource>({ canEditImage: () => false })
       getWrapper({
         setup: ({ actions }) => {
           expect(

--- a/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsDelete.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsDelete.spec.ts
@@ -1,10 +1,10 @@
 import { useSpaceActionsDelete } from '../../../../../src/composables/actions'
 import { useMessages, useModals } from '../../../../../src/composables/piniaStores'
-import { buildSpace, SpaceResource } from '@ownclouders/web-client'
+import { SpaceResource } from '@ownclouders/web-client'
 import { defaultComponentMocks, RouteLocation, getComposableWrapper } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
 import { unref } from 'vue'
-import { Drive, User } from '@ownclouders/web-client/graph/generated'
+import { User } from '@ownclouders/web-client/graph/generated'
 
 describe('delete', () => {
   describe('isVisible property', () => {
@@ -15,50 +15,19 @@ describe('delete', () => {
         }
       })
     })
-    it('should be false when the space is not disabled', () => {
-      const spaceMock = mock<Drive>({
-        id: '1',
-        root: {
-          permissions: [{ roles: ['manager'], grantedToIdentities: [{ user: { id: '1' } }] }]
-        },
-        driveType: 'project',
-        special: null
-      })
+    it('should be false when the space can not be deleted', () => {
+      const spaceMock = mock<SpaceResource>({ driveType: 'project', canBeDeleted: () => false })
       getWrapper({
         setup: ({ actions }) => {
-          expect(unref(actions)[0].isVisible({ resources: [buildSpace(spaceMock)] })).toBe(false)
+          expect(unref(actions)[0].isVisible({ resources: [spaceMock] })).toBe(false)
         }
       })
     })
-    it('should be true when the space is disabled', () => {
-      const spaceMock = mock<Drive>({
-        id: '1',
-        root: {
-          permissions: [{ roles: ['manager'], grantedToIdentities: [{ user: { id: '1' } }] }],
-          deleted: { state: 'trashed' }
-        },
-        driveType: 'project',
-        special: null
-      })
+    it('should be true when the space can be deleted', () => {
+      const spaceMock = mock<SpaceResource>({ driveType: 'project', canBeDeleted: () => true })
       getWrapper({
         setup: ({ actions }) => {
-          expect(unref(actions)[0].isVisible({ resources: [buildSpace(spaceMock)] })).toBe(true)
-        }
-      })
-    })
-    it('should be false when the current user is a viewer', () => {
-      const spaceMock = mock<Drive>({
-        id: '1',
-        root: {
-          permissions: [{ roles: ['viewer'], grantedToIdentities: [{ user: { id: '1' } }] }],
-          deleted: { state: 'trashed' }
-        },
-        driveType: 'project',
-        special: null
-      })
-      getWrapper({
-        setup: ({ actions }) => {
-          expect(unref(actions)[0].isVisible({ resources: [buildSpace(spaceMock)] })).toBe(false)
+          expect(unref(actions)[0].isVisible({ resources: [spaceMock] })).toBe(true)
         }
       })
     })

--- a/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsDisable.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsDisable.spec.ts
@@ -1,10 +1,10 @@
 import { useSpaceActionsDisable } from '../../../../../src/composables/actions/spaces'
 import { useMessages, useModals } from '../../../../../src/composables/piniaStores'
-import { buildSpace, SpaceResource } from '@ownclouders/web-client'
+import { SpaceResource } from '@ownclouders/web-client'
 import { defaultComponentMocks, RouteLocation, getComposableWrapper } from 'web-test-helpers'
 import { mock } from 'vitest-mock-extended'
 import { unref } from 'vue'
-import { Drive, User } from '@ownclouders/web-client/graph/generated'
+import { User } from '@ownclouders/web-client/graph/generated'
 
 describe('disable', () => {
   describe('isVisible property', () => {
@@ -15,48 +15,19 @@ describe('disable', () => {
         }
       })
     })
-    it('should be true when the space is not disabled', () => {
-      const spaceMock = mock<Drive>({
-        id: '1',
-        root: {
-          permissions: [{ roles: ['manager'], grantedToIdentities: [{ user: { id: '1' } }] }]
-        },
-        driveType: 'project',
-        special: null
-      })
+    it('should be true when the space can be disabled', () => {
+      const spaceMock = mock<SpaceResource>({ driveType: 'project', canDisable: () => true })
       getWrapper({
         setup: ({ actions }) => {
-          expect(unref(actions)[0].isVisible({ resources: [buildSpace(spaceMock)] })).toBe(true)
+          expect(unref(actions)[0].isVisible({ resources: [spaceMock] })).toBe(true)
         }
       })
     })
-    it('should be false when the space is disabled', () => {
-      const spaceMock = mock<Drive>({
-        id: '1',
-        root: {
-          permissions: [{ roles: ['manager'], grantedToIdentities: [{ user: { id: '1' } }] }],
-          deleted: { state: 'trashed' }
-        },
-        special: null
-      })
+    it('should be false when the space can not be disabled', () => {
+      const spaceMock = mock<SpaceResource>({ driveType: 'project', canDisable: () => false })
       getWrapper({
         setup: ({ actions }) => {
-          expect(unref(actions)[0].isVisible({ resources: [buildSpace(spaceMock)] })).toBe(false)
-        }
-      })
-    })
-    it('should be false when current user is a viewer', () => {
-      const spaceMock = mock<Drive>({
-        id: '1',
-        root: {
-          permissions: [{ roles: ['viewer'], grantedToIdentities: [{ user: { id: '1' } }] }]
-        },
-        driveType: 'project',
-        special: null
-      })
-      getWrapper({
-        setup: ({ actions }) => {
-          expect(unref(actions)[0].isVisible({ resources: [buildSpace(spaceMock)] })).toBe(false)
+          expect(unref(actions)[0].isVisible({ resources: [spaceMock] })).toBe(false)
         }
       })
     })

--- a/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsEditQuota.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsEditQuota.spec.ts
@@ -1,10 +1,9 @@
 import { useSpaceActionsEditQuota } from '../../../../../src/composables/actions'
 import { useModals } from '../../../../../src/composables/piniaStores'
-import { buildSpace } from '@ownclouders/web-client'
+import { SpaceResource } from '@ownclouders/web-client'
 import { defaultComponentMocks, getComposableWrapper } from 'web-test-helpers'
 import { unref } from 'vue'
 import { mock } from 'vitest-mock-extended'
-import { Drive } from '@ownclouders/web-client/graph/generated'
 
 describe('editQuota', () => {
   describe('isVisible property', () => {
@@ -16,36 +15,20 @@ describe('editQuota', () => {
       })
     })
     it('should be true when the current user has the "set-space-quota"-permission', () => {
-      const spaceMock = mock<Drive>({
-        id: '1',
-        quota: {},
-        root: {
-          permissions: [{ roles: ['manager'], grantedToIdentities: [{ user: { id: '1' } }] }]
-        },
-        driveType: 'project',
-        special: null
-      })
+      const spaceMock = mock<SpaceResource>({ driveType: 'project' })
       getWrapper({
         canEditSpaceQuota: true,
         setup: ({ actions }) => {
-          expect(unref(actions)[0].isVisible({ resources: [buildSpace(spaceMock)] })).toBe(true)
+          expect(unref(actions)[0].isVisible({ resources: [spaceMock] })).toBe(true)
         }
       })
     })
     it('should be false when the current user does not have the "set-space-quota"-permission', () => {
-      const spaceMock = mock<Drive>({
-        id: '1',
-        quota: {},
-        root: {
-          permissions: [{ roles: ['manager'], grantedToIdentities: [{ user: { id: '1' } }] }]
-        },
-        driveType: 'project',
-        special: null
-      })
+      const spaceMock = mock<SpaceResource>({ driveType: 'project' })
       getWrapper({
         canEditSpaceQuota: false,
         setup: ({ actions }) => {
-          expect(unref(actions)[0].isVisible({ resources: [buildSpace(spaceMock)] })).toBe(false)
+          expect(unref(actions)[0].isVisible({ resources: [spaceMock] })).toBe(false)
         }
       })
     })

--- a/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsEditReadmeContent.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsEditReadmeContent.spec.ts
@@ -2,11 +2,11 @@ import {
   useOpenWithDefaultApp,
   useSpaceActionsEditReadmeContent
 } from '../../../../../src/composables/actions'
-import { Resource, SpaceResource, buildSpace } from '@ownclouders/web-client'
+import { Resource, SpaceResource } from '@ownclouders/web-client'
 import { getComposableWrapper } from 'web-test-helpers'
 import { unref } from 'vue'
 import { mock, mockDeep } from 'vitest-mock-extended'
-import { Drive, User } from '@ownclouders/web-client/graph/generated'
+import { User } from '@ownclouders/web-client/graph/generated'
 import { ClientService } from '../../../../../src/services'
 import { useSpaceHelpers } from '../../../../../src/composables/spaces/useSpaceHelpers'
 
@@ -20,20 +20,14 @@ vi.mock('../../../../../src/composables/spaces/useSpaceHelpers', () => ({
 
 describe('editReadmeContent', () => {
   describe('isVisible property', () => {
-    it('should be true for space managers', () => {
-      const spaceMock = mock<Drive>({
-        id: '1',
-        root: {
-          permissions: [{ roles: ['manager'], grantedToIdentities: [{ user: { id: '1' } }] }]
-        },
-        special: [{ specialFolder: { name: 'readme' } }]
-      })
+    it('should be true if canEditReadme is true', () => {
+      const spaceMock = mock<SpaceResource>({ canEditReadme: () => true })
 
       getWrapper({
         setup: ({ actions }) => {
           expect(
             unref(actions)[0].isVisible({
-              resources: [buildSpace(spaceMock)]
+              resources: [spaceMock]
             })
           ).toBe(true)
         }
@@ -46,30 +40,15 @@ describe('editReadmeContent', () => {
         }
       })
     })
-    it('should be false when the current user is a viewer', () => {
-      const spaceMock = mock<Drive>({
-        id: '1',
-        root: {
-          permissions: [{ roles: ['viewer'], grantedToIdentities: [{ user: { id: '1' } }] }]
-        },
-        special: null
-      })
+    it('should be false if canEditReadme is false', () => {
+      const spaceMock = mock<SpaceResource>({ canEditReadme: () => false })
 
       getWrapper({
         setup: ({ actions }) => {
           expect(
             unref(actions)[0].isVisible({
-              resources: [buildSpace(spaceMock)]
+              resources: [spaceMock]
             })
-          ).toBe(false)
-        }
-      })
-    })
-    it('should be false when resource is disabled', () => {
-      getWrapper({
-        setup: ({ actions }) => {
-          expect(
-            unref(actions)[0].isVisible({ resources: [mock<SpaceResource>({ disabled: true })] })
           ).toBe(false)
         }
       })

--- a/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsRestore.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/spaces/useSpaceActionsRestore.spec.ts
@@ -1,9 +1,9 @@
 import { useSpaceActionsRestore } from '../../../../../src/composables/actions/spaces'
-import { buildSpace, SpaceResource } from '@ownclouders/web-client'
+import { SpaceResource } from '@ownclouders/web-client'
 import { mock } from 'vitest-mock-extended'
 import { defaultComponentMocks, RouteLocation, getComposableWrapper } from 'web-test-helpers'
 import { unref } from 'vue'
-import { Drive, User } from '@ownclouders/web-client/graph/generated'
+import { User } from '@ownclouders/web-client/graph/generated'
 import { useMessages, useModals } from '../../../../../src/composables/piniaStores'
 
 describe('restore', () => {
@@ -15,50 +15,26 @@ describe('restore', () => {
         }
       })
     })
-    it('should be false when the space is not disabled', () => {
-      const spaceMock = mock<Drive>({
-        id: '1',
-        root: {
-          permissions: [{ roles: ['manager'], grantedToIdentities: [{ user: { id: '1' } }] }]
-        },
+    it('should be false when the space can not be restored', () => {
+      const spaceMock = mock<SpaceResource>({
         driveType: 'project',
-        special: null
+        canRestore: () => false
       })
       getWrapper({
         setup: ({ actions }) => {
-          expect(unref(actions)[0].isVisible({ resources: [buildSpace(spaceMock)] })).toBe(false)
+          expect(unref(actions)[0].isVisible({ resources: [spaceMock] })).toBe(false)
         }
       })
     })
-    it('should be true when the space is disabled', () => {
-      const spaceMock = mock<Drive>({
-        id: '1',
-        root: {
-          permissions: [{ roles: ['manager'], grantedToIdentities: [{ user: { id: '1' } }] }],
-          deleted: { state: 'trashed' }
-        },
+    it('should be true when the space can be restored', () => {
+      const spaceMock = mock<SpaceResource>({
         driveType: 'project',
-        special: null
+        canRestore: () => true
       })
+
       getWrapper({
         setup: ({ actions }) => {
-          expect(unref(actions)[0].isVisible({ resources: [buildSpace(spaceMock)] })).toBe(true)
-        }
-      })
-    })
-    it('should be false when the current user is a viewer', () => {
-      const spaceMock = mock<Drive>({
-        id: '1',
-        root: {
-          permissions: [{ roles: ['viewer'], grantedToIdentities: [{ user: { id: '1' } }] }],
-          deleted: { state: 'trashed' }
-        },
-        driveType: 'project',
-        special: null
-      })
-      getWrapper({
-        setup: ({ actions }) => {
-          expect(unref(actions)[0].isVisible({ resources: [buildSpace(spaceMock)] })).toBe(false)
+          expect(unref(actions)[0].isVisible({ resources: [spaceMock] })).toBe(true)
         }
       })
     })

--- a/packages/web-pkg/tests/unit/composables/piniaStores/spaces.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/piniaStores/spaces.spec.ts
@@ -190,14 +190,22 @@ describe('spaces', () => {
           await instance.loadSpaces({ graphClient })
 
           expect(graphClient.drives.listMyDrives).toHaveBeenCalledTimes(2)
-          expect(graphClient.drives.listMyDrives).toHaveBeenNthCalledWith(1, {
-            orderBy: 'name asc',
-            filter: 'driveType eq personal'
-          })
-          expect(graphClient.drives.listMyDrives).toHaveBeenNthCalledWith(2, {
-            orderBy: 'name asc',
-            filter: 'driveType eq project'
-          })
+          expect(graphClient.drives.listMyDrives).toHaveBeenNthCalledWith(
+            1,
+            {},
+            {
+              orderBy: 'name asc',
+              filter: 'driveType eq personal'
+            }
+          )
+          expect(graphClient.drives.listMyDrives).toHaveBeenNthCalledWith(
+            2,
+            {},
+            {
+              orderBy: 'name asc',
+              filter: 'driveType eq project'
+            }
+          )
           expect(instance.spaces.length).toBe(2)
           expect(instance.spacesLoading).toBeFalsy()
           expect(instance.spacesInitialized).toBeTruthy()
@@ -215,10 +223,13 @@ describe('spaces', () => {
           await instance.loadMountPoints({ graphClient })
 
           expect(graphClient.drives.listMyDrives).toHaveBeenCalledTimes(1)
-          expect(graphClient.drives.listMyDrives).toHaveBeenCalledWith({
-            orderBy: 'name asc',
-            filter: 'driveType eq mountpoint'
-          })
+          expect(graphClient.drives.listMyDrives).toHaveBeenCalledWith(
+            {},
+            {
+              orderBy: 'name asc',
+              filter: 'driveType eq mountpoint'
+            }
+          )
           expect(instance.spaces.length).toBe(1)
           expect(instance.mountPointsInitialized).toBeTruthy()
         }
@@ -235,10 +246,13 @@ describe('spaces', () => {
           await instance.reloadProjectSpaces({ graphClient })
 
           expect(graphClient.drives.listMyDrives).toHaveBeenCalledTimes(1)
-          expect(graphClient.drives.listMyDrives).toHaveBeenCalledWith({
-            orderBy: 'name asc',
-            filter: 'driveType eq project'
-          })
+          expect(graphClient.drives.listMyDrives).toHaveBeenCalledWith(
+            {},
+            {
+              orderBy: 'name asc',
+              filter: 'driveType eq project'
+            }
+          )
           expect(instance.spaces.length).toBe(1)
         }
       })

--- a/packages/web-pkg/tests/unit/composables/piniaStores/spaces.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/piniaStores/spaces.spec.ts
@@ -9,7 +9,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import { mock, mockDeep } from 'vitest-mock-extended'
 import {
   CollaboratorShare,
-  GraphShareRoleIdMap,
+  GraphSharePermission,
   ShareRole,
   SpaceResource
 } from '@ownclouders/web-client'
@@ -23,20 +23,22 @@ describe('spaces', () => {
   })
 
   describe('method "sortSpaceMembers"', () => {
-    it('always puts space managers first', () => {
+    it('sorts space members by amount of permissions', () => {
       const members = [
         mock<CollaboratorShare>({
-          role: { id: GraphShareRoleIdMap.SpaceEditor },
+          permissions: [],
           sharedWith: { displayName: 'user1' }
         }),
         mock<CollaboratorShare>({
-          role: { id: GraphShareRoleIdMap.SpaceManager },
+          permissions: [GraphSharePermission.updatePermissions],
           sharedWith: { displayName: 'user2' }
         })
       ]
 
       const sortedMembers = sortSpaceMembers(members)
-      expect(sortedMembers[0].role.id).toEqual(GraphShareRoleIdMap.SpaceManager)
+      expect(
+        sortedMembers[0].permissions.includes(GraphSharePermission.updatePermissions)
+      ).toBeTruthy()
     })
   })
 
@@ -278,6 +280,7 @@ describe('spaces', () => {
         setup: async (instance) => {
           const share = mock<CollaboratorShare>({
             id: '1',
+            permissions: [],
             role: mock<ShareRole>({ id: 'roleId' })
           })
           const clientService = mockDeep<ClientService>()

--- a/packages/web-pkg/tests/unit/helpers/resource/conflictHandling/resourcesTransfer.spec.ts
+++ b/packages/web-pkg/tests/unit/helpers/resource/conflictHandling/resourcesTransfer.spec.ts
@@ -38,8 +38,8 @@ describe('resourcesTransfer', () => {
     const spaceOptions = {
       id: 'c42c9504-2c19-44fd-87cc-b4fc20ecbb54'
     } as unknown as Drive
-    sourceSpace = buildSpace(spaceOptions)
-    targetSpace = buildSpace(spaceOptions)
+    sourceSpace = buildSpace(spaceOptions, {})
+    targetSpace = buildSpace(spaceOptions, {})
     targetFolder = {
       id: 'target',
       path: 'target',

--- a/packages/web-runtime/src/container/sse/shares.ts
+++ b/packages/web-runtime/src/container/sse/shares.ts
@@ -16,6 +16,7 @@ export const onSSESpaceMemberAddedEvent = async ({
   sseData,
   resourcesStore,
   spacesStore,
+  sharesStore,
   clientService,
   router
 }: SSEEventOptions) => {
@@ -24,7 +25,10 @@ export const onSSESpaceMemberAddedEvent = async ({
     return
   }
 
-  const space = await clientService.graphAuthenticated.drives.getDrive(sseData.itemid)
+  const space = await clientService.graphAuthenticated.drives.getDrive(
+    sseData.itemid,
+    sharesStore.graphRoles
+  )
   spacesStore.upsertSpace(space)
 
   if (!isLocationSpacesActive(router, 'files-spaces-projects')) {
@@ -38,6 +42,7 @@ export const onSSESpaceMemberRemovedEvent = async ({
   sseData,
   resourcesStore,
   spacesStore,
+  sharesStore,
   messageStore,
   clientService,
   language,
@@ -50,7 +55,10 @@ export const onSSESpaceMemberRemovedEvent = async ({
   }
 
   if (!sseData.affecteduserids?.includes(userStore.user.id)) {
-    const space = await clientService.graphAuthenticated.drives.getDrive(sseData.itemid)
+    const space = await clientService.graphAuthenticated.drives.getDrive(
+      sseData.itemid,
+      sharesStore.graphRoles
+    )
     return spacesStore.upsertSpace(space)
   }
 
@@ -84,6 +92,7 @@ export const onSSESpaceShareUpdatedEvent = async ({
   sseData,
   resourcesStore,
   spacesStore,
+  sharesStore,
   clientService,
   userStore,
   router
@@ -93,7 +102,10 @@ export const onSSESpaceShareUpdatedEvent = async ({
     return
   }
 
-  const space = await clientService.graphAuthenticated.drives.getDrive(sseData.itemid)
+  const space = await clientService.graphAuthenticated.drives.getDrive(
+    sseData.itemid,
+    sharesStore.graphRoles
+  )
   spacesStore.upsertSpace(space)
 
   if (

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -220,6 +220,11 @@ export const bootstrapApp = async (configurationPath: string, appsReadyCallback:
         })
       }
 
+      // load sharing roles from graph API
+      const graphRoleDefinitions =
+        await clientService.graphAuthenticated.permissions.listRoleDefinitions()
+      sharesStore.setGraphRoles(graphRoleDefinitions)
+
       // Load spaces to make them available across the application
       await spacesStore.loadSpaces({ graphClient: clientService.graphAuthenticated })
       const personalSpace = spacesStore.spaces.find(isPersonalSpaceResource)
@@ -231,11 +236,6 @@ export const bootstrapApp = async (configurationPath: string, appsReadyCallback:
           value: app.config.globalProperties.$gettext('Personal')
         })
       }
-
-      // load sharing roles from graph API
-      const graphRoleDefinitions =
-        await clientService.graphAuthenticated.permissions.listRoleDefinitions()
-      sharesStore.setGraphRoles(graphRoleDefinitions)
     },
     {
       immediate: true

--- a/tests/e2e/cucumber/steps/ui/adminSettings.ts
+++ b/tests/e2e/cucumber/steps/ui/adminSettings.ts
@@ -510,9 +510,9 @@ Then(
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const spacesObject = new objects.applicationAdminSettings.Spaces({ page })
     const actualMemberList = {
-      manager: await spacesObject.listMembers({ filter: 'managers' }),
-      viewer: await spacesObject.listMembers({ filter: 'viewers' }),
-      editor: await spacesObject.listMembers({ filter: 'editors' })
+      manager: await spacesObject.listMembers({ filter: 'Can manage' }),
+      viewer: await spacesObject.listMembers({ filter: 'Can view' }),
+      editor: await spacesObject.listMembers({ filter: 'Can edit' })
     }
     for (const info of stepTable.hashes()) {
       const shareRole = shareRoles[info.role as keyof typeof shareRoles]

--- a/tests/e2e/support/objects/app-admin-settings/spaces/actions.ts
+++ b/tests/e2e/support/objects/app-admin-settings/spaces/actions.ts
@@ -255,13 +255,13 @@ export const listSpaceMembers = async (args: {
   let users: string[] = []
   const names = []
   switch (filter) {
-    case 'managers':
+    case 'Can manage':
       users = await page.locator(util.format(spaceMemberList, filter)).allTextContents()
       break
-    case 'viewers':
+    case 'Can view':
       users = await page.locator(util.format(spaceMemberList, filter)).allTextContents()
       break
-    case 'editors':
+    case 'Can edit':
       users = await page.locator(util.format(spaceMemberList, filter)).allTextContents()
       break
   }


### PR DESCRIPTION
## Description
Use share permissions instead of roles since roles are a very loose concept and just act as a container for a specific set of share permissions.

This affects 2 main scenarios:

* A `SpaceResource` doesn't have properties like `manager`, `editor` anymore. The same goes for methods like `isManager`. Instead, there is the `members` property that holds information about all members. When checking if the current user is allowed to do certain actions, we need check for specific permissions now. E.g. when sharing, don't check for `isManager` but for `canShare`.
* Shares (in Graph terms: "permissions") will also have permissions (in Graph terms: "permission actions") that need to be checked instead of roles. Hence the `GraphShareRoleIdMap` is being removed.

You may notice a discrepancy in our naming and the Graph naming. IMO we should align... but that's a another story, I guess. Because ideally, I would also rename `Space` to `Drive`. It's just so confusing all the time.

There is one exception where Web still needs to assume and work with roles. That is when listing the managers of a space. Here we imply that if the user can remove space members, they are a space manager.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/10770

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
