### PR TITLE
refactor: transform graph roles to object

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -303,8 +303,8 @@ export default defineComponent({
 
     onMounted(async () => {
       selectedRole.value = unref(resourceIsSpace)
-        ? unref(graphRoles).find(({ id }) => id === GraphShareRoleIdMap.SpaceViewer)
-        : unref(graphRoles).find(({ id }) => id === GraphShareRoleIdMap.Viewer)
+        ? unref(graphRoles)[GraphShareRoleIdMap.SpaceViewer]
+        : unref(graphRoles)[GraphShareRoleIdMap.Viewer]
 
       await nextTick()
       markInstance.value = new Mark('.mark-element')

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
@@ -80,7 +80,6 @@ import {
 import { useAbility, useUserStore } from '@ownclouders/web-pkg'
 import { Resource } from '@ownclouders/web-client'
 import { useGettext } from 'vue3-gettext'
-import { useSharesStore } from '@ownclouders/web-pkg'
 import { ShareRole } from '@ownclouders/web-client'
 
 export default defineComponent({
@@ -121,8 +120,6 @@ export default defineComponent({
     const ability = useAbility()
     const userStore = useUserStore()
     const { user } = storeToRefs(userStore)
-    const sharesStore = useSharesStore()
-    const { graphRoles } = storeToRefs(sharesStore)
     const { $gettext } = useGettext()
 
     const dropButtonTooltip = computed(() => {
@@ -159,7 +156,6 @@ export default defineComponent({
       user,
       dropButtonTooltip,
       resource: inject<Resource>('resource'),
-      graphRoles,
       selectedRole,
       availableRoles,
       isSelectedRole,

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.ts
@@ -209,10 +209,10 @@ function getWrapper({
               capabilityState: { capabilities },
               configState: { options: { concurrentRequests: { shares: { create: 1 } } } },
               sharesState: {
-                graphRoles: [
-                  mock<ShareRole>({ id: GraphShareRoleIdMap.Viewer }),
-                  mock<ShareRole>({ id: GraphShareRoleIdMap.SpaceViewer })
-                ],
+                graphRoles: {
+                  [GraphShareRoleIdMap.Viewer]: mock<ShareRole>(),
+                  [GraphShareRoleIdMap.SpaceViewer]: mock<ShareRole>()
+                },
                 collaboratorShares: existingCollaborators
               }
             }

--- a/packages/web-client/src/graph/permissions/permissions.ts
+++ b/packages/web-client/src/graph/permissions/permissions.ts
@@ -1,4 +1,10 @@
-import { buildCollaboratorShare, buildLinkShare, CollaboratorShare, LinkShare } from '../../helpers'
+import {
+  buildCollaboratorShare,
+  buildLinkShare,
+  CollaboratorShare,
+  LinkShare,
+  ShareRole
+} from '../../helpers'
 import {
   CollectionOfPermissionsWithAllowedValues,
   DrivesPermissionsApiFactory,
@@ -27,7 +33,7 @@ export const PermissionsFactory = ({
       driveId: string,
       itemId: string,
       permId: string,
-      graphRoles: UnifiedRoleDefinition[],
+      graphRoles: Record<string, ShareRole>,
       requestOptions: GraphRequestOptions
     ): Promise<T> {
       const { data: permission } = await drivesPermissionsApiFactory.getPermission(
@@ -44,7 +50,7 @@ export const PermissionsFactory = ({
       return buildCollaboratorShare({
         graphPermission: permission,
         resourceId: itemId,
-        graphRoles: graphRoles || []
+        graphRoles: graphRoles || {}
       }) as T
     },
 
@@ -82,7 +88,7 @@ export const PermissionsFactory = ({
         return buildCollaboratorShare({
           graphPermission: permission,
           resourceId: itemId,
-          graphRoles: graphRoles || []
+          graphRoles: graphRoles || {}
         })
       })
 
@@ -94,7 +100,7 @@ export const PermissionsFactory = ({
       itemId: string,
       permId: string,
       data: Permission,
-      graphRoles: UnifiedRoleDefinition[],
+      graphRoles: Record<string, ShareRole>,
       requestOptions: GraphRequestOptions
     ): Promise<T> {
       let permission: Permission
@@ -127,7 +133,7 @@ export const PermissionsFactory = ({
       return buildCollaboratorShare({
         graphPermission: permission,
         resourceId: itemId,
-        graphRoles: graphRoles || []
+        graphRoles: graphRoles || {}
       }) as T
     },
 
@@ -169,7 +175,7 @@ export const PermissionsFactory = ({
       return buildCollaboratorShare({
         graphPermission: permission,
         resourceId: itemId,
-        graphRoles: graphRoles || []
+        graphRoles: graphRoles || {}
       })
     },
 

--- a/packages/web-client/src/graph/permissions/types.ts
+++ b/packages/web-client/src/graph/permissions/types.ts
@@ -1,4 +1,4 @@
-import { CollaboratorShare, LinkShare } from '../../helpers'
+import { CollaboratorShare, LinkShare, ShareRole } from '../../helpers'
 import type {
   DriveItemCreateLink,
   DriveItemInvite,
@@ -22,13 +22,13 @@ export interface GraphPermissions {
     driveId: string,
     itemId: string,
     permId: string,
-    graphRoles?: UnifiedRoleDefinition[],
+    graphRoles?: Record<string, ShareRole>,
     requestOptions?: GraphRequestOptions
   ): Promise<T>
   listPermissions(
     driveId: string,
     itemId: string,
-    graphRoles?: UnifiedRoleDefinition[],
+    graphRoles?: Record<string, ShareRole>,
     options?: {
       filter?: string
       select?: Array<ListPermissionsSpaceRootSelectEnum>
@@ -40,7 +40,7 @@ export interface GraphPermissions {
     itemId: string,
     permId: string,
     data: Permission,
-    graphRoles?: UnifiedRoleDefinition[],
+    graphRoles?: Record<string, ShareRole>,
     requestOptions?: GraphRequestOptions
   ): Promise<T>
   deletePermission(
@@ -53,7 +53,7 @@ export interface GraphPermissions {
     driveId: string,
     itemId: string,
     data: DriveItemInvite,
-    graphRoles?: UnifiedRoleDefinition[],
+    graphRoles?: Record<string, ShareRole>,
     requestOptions?: GraphRequestOptions
   ): Promise<CollaboratorShare>
   createLink(

--- a/packages/web-client/src/helpers/share/functions.ts
+++ b/packages/web-client/src/helpers/share/functions.ts
@@ -5,7 +5,8 @@ import {
   IncomingShareResource,
   CollaboratorShare,
   GraphSharePermission,
-  LinkShare
+  LinkShare,
+  ShareRole
 } from './types'
 import { extractDomSelector, extractExtensionFromFile, extractStorageId } from '../resource'
 import { ShareTypes } from './type'
@@ -42,11 +43,11 @@ export const getShareResourceRoles = ({
   graphRoles
 }: {
   driveItem: DriveItem
-  graphRoles: UnifiedRoleDefinition[]
+  graphRoles: Record<string, ShareRole>
 }) => {
   return driveItem.remoteItem?.permissions.reduce<UnifiedRoleDefinition[]>((acc, permission) => {
     permission.roles?.forEach((roleId) => {
-      const role = graphRoles.find(({ id }) => id === roleId)
+      const role = graphRoles[roleId]
       if (role && !acc.some(({ id }) => id === role.id)) {
         acc.push(role)
       }
@@ -94,7 +95,7 @@ export function buildIncomingShareResource({
   graphRoles
 }: {
   driveItem: DriveItem
-  graphRoles: UnifiedRoleDefinition[]
+  graphRoles: Record<string, ShareRole>
 }): IncomingShareResource {
   const resourceName = driveItem.name || driveItem.remoteItem.name
   const storageId = extractStorageId(driveItem.remoteItem.id)
@@ -244,11 +245,11 @@ export function buildCollaboratorShare({
   indirect = false
 }: {
   graphPermission: Permission
-  graphRoles: UnifiedRoleDefinition[]
+  graphRoles: Record<string, ShareRole>
   resourceId: string
   indirect?: boolean
 }): CollaboratorShare {
-  const role = graphRoles.find(({ id }) => id === graphPermission.roles?.[0])
+  const role = graphRoles[graphPermission.roles?.[0]]
   const invitedBy = graphPermission.invitation?.invitedBy?.user
 
   return {

--- a/packages/web-client/tests/unit/helpers/share/functions.spec.ts
+++ b/packages/web-client/tests/unit/helpers/share/functions.spec.ts
@@ -4,6 +4,7 @@ import {
   OutgoingShareResource,
   Resource,
   ShareResource,
+  ShareRole,
   ShareTypes
 } from '../../../../src/helpers'
 import {
@@ -75,7 +76,7 @@ describe('share helper functions', () => {
     it("returns all roles from a drive item's permissions that are also included in the graphRoles", () => {
       const driveItem = mockDeep<DriveItem>()
       driveItem.remoteItem.permissions = [{ roles: ['1', '2'] }, { roles: ['1', '3'] }]
-      const graphRoles = [{ id: '1' }, { id: '4' }] as UnifiedRoleDefinition[]
+      const graphRoles = { '1': mock<ShareRole>({ id: '1' }), '4': mock<ShareRole>({ id: '4' }) }
 
       const result = getShareResourceRoles({ driveItem, graphRoles })
 
@@ -122,10 +123,10 @@ describe('share helper functions', () => {
       }
     ]
 
-    const graphRoles = [
-      { id: '1', rolePermissions: [{ allowedResourceActions: ['view'] }] },
-      { id: '2', rolePermissions: [{ allowedResourceActions: ['edit'] }] }
-    ] as UnifiedRoleDefinition[]
+    const graphRoles = {
+      '1': mock<ShareRole>({ id: '1', rolePermissions: [{ allowedResourceActions: ['view'] }] }),
+      '2': mock<ShareRole>({ id: '1', rolePermissions: [{ allowedResourceActions: ['view'] }] })
+    }
 
     it('sets ids based on the drive item, its first permission and parent reference', () => {
       const result = buildIncomingShareResource({ driveItem, graphRoles })
@@ -199,10 +200,10 @@ describe('share helper functions', () => {
   })
 
   describe('buildCollaboratorShare', () => {
-    const graphRoles = [
-      { id: '1', rolePermissions: [{ allowedResourceActions: ['view'] }] },
-      { id: '2', rolePermissions: [{ allowedResourceActions: ['edit'] }] }
-    ] as UnifiedRoleDefinition[]
+    const graphRoles = {
+      '1': mock<ShareRole>({ id: '1', rolePermissions: [{ allowedResourceActions: ['view'] }] }),
+      '2': mock<ShareRole>({ id: '1', rolePermissions: [{ allowedResourceActions: ['view'] }] })
+    }
 
     const resourceId = '1'
 
@@ -266,7 +267,7 @@ describe('share helper functions', () => {
       it('sets permissions from the graph roles as fallback', () => {
         const graphPermission = mock<Permission>({
           '@libre.graph.permissions.actions': undefined,
-          roles: [graphRoles[0].id]
+          roles: [graphRoles['1'].id]
         })
 
         const result = buildCollaboratorShare({
@@ -276,7 +277,7 @@ describe('share helper functions', () => {
         })
 
         expect(result.permissions).toEqual(
-          graphRoles[0].rolePermissions.flatMap(
+          graphRoles['1'].rolePermissions.flatMap(
             ({ allowedResourceActions }) => allowedResourceActions
           )
         )

--- a/packages/web-pkg/src/components/SideBar/FileSideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/FileSideBar.vue
@@ -208,8 +208,9 @@ export default defineComponent({
       const loadedCollaboratorShares = shares.filter(isCollaboratorShare)
       const loadedLinkShares = shares.filter(isLinkShare)
 
+      const rolesArray = Object.values(sharesStore.graphRoles)
       availableInternalShareRoles.value =
-        sharesStore.graphRoles.filter((r) => allowedRoles?.map(({ id }) => id).includes(r.id)) || []
+        rolesArray.filter((r) => allowedRoles?.map(({ id }) => id).includes(r.id)) || []
 
       // load external share roles
       if (appsStore.isAppEnabled('open-cloud-mesh')) {
@@ -222,8 +223,7 @@ export default defineComponent({
         )
 
         availableExternalShareRoles.value =
-          sharesStore.graphRoles.filter((r) => allowedRoles?.map(({ id }) => id).includes(r.id)) ||
-          []
+          rolesArray.filter((r) => allowedRoles?.map(({ id }) => id).includes(r.id)) || []
       }
 
       // use cache for indirect shares

--- a/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
+++ b/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
@@ -26,13 +26,16 @@ export const useSharesStore = defineStore('shares', () => {
   const loading = ref(false)
   const collaboratorShares = ref<CollaboratorShare[]>([]) as Ref<CollaboratorShare[]>
   const linkShares = ref<LinkShare[]>([]) as Ref<LinkShare[]>
-  const graphRoles = ref<ShareRole[]>([]) as Ref<ShareRole[]>
+  const graphRoles = ref<Record<string, ShareRole>>({}) as Ref<Record<string, ShareRole>>
 
   const setGraphRoles = (values: UnifiedRoleDefinition[]) => {
-    graphRoles.value = values.map((v) => ({
-      ...v,
-      icon: getThemeRoleIcon(v)
-    }))
+    graphRoles.value = values.reduce<Record<string, ShareRole>>((acc, role) => {
+      acc[role.id] = {
+        ...role,
+        icon: getThemeRoleIcon(role)
+      }
+      return acc
+    }, {})
   }
 
   const upsertCollaboratorShare = (share: CollaboratorShare) => {

--- a/packages/web-pkg/tests/unit/composables/piniaStores/spaces.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/piniaStores/spaces.spec.ts
@@ -291,7 +291,7 @@ describe('spaces', () => {
           userStore.user = mock<User>()
 
           const sharesStore = useSharesStore()
-          sharesStore.graphRoles = [mock<ShareRole>({ id: 'roleId' })]
+          sharesStore.graphRoles = { roleId: mock<ShareRole>({ id: 'roleId' }) }
 
           await instance.loadSpaceMembers({
             graphClient: clientService.graphAuthenticated,

--- a/packages/web-test-helpers/src/mocks/pinia.ts
+++ b/packages/web-test-helpers/src/mocks/pinia.ts
@@ -61,7 +61,7 @@ export type PiniaMockOptions = {
   sharesState?: {
     collaboratorShares?: CollaboratorShare[]
     linkShares?: LinkShare[]
-    graphRoles?: ShareRole[]
+    graphRoles?: Record<string, ShareRole>
     loading?: boolean
   }
   spacesState?: { spaces?: SpaceResource[]; spaceMembers?: CollaboratorShare[] }


### PR DESCRIPTION
## Description
Refactors the unified graph role definitions from an array to an object because it simplifies the way how to work with those. When retrieving a role via its id (which is 99% of the use cases), it can now be done with the object index instead of looping through the array.

Works towards https://github.com/owncloud/web/issues/10770.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
