### PR TITLE
Disabled unified roles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 end_of_line = lf
 
-[*.{js,json,vue,feature}]
+[*.{js,json,vue,feature,ts}]
 indent_style = space
 indent_size = 2
 

--- a/changelog/unreleased/enhancement-display-disabled-role-permissions
+++ b/changelog/unreleased/enhancement-display-disabled-role-permissions
@@ -1,0 +1,5 @@
+Enhancement: Display disabled role permissions
+
+We've added a new feature to the sharing sidebar panel which allows you to see the permissions of a role that has been disabled.
+
+https://github.com/owncloud/web/pull/11387

--- a/packages/design-system/src/components/OcInfoDrop/OcInfoDrop.vue
+++ b/packages/design-system/src/components/OcInfoDrop/OcInfoDrop.vue
@@ -18,7 +18,7 @@
           <oc-icon name="close" fill-type="line" size="medium" variation="inherit" />
         </oc-button>
       </div>
-      <p class="info-text" v-text="$gettext(text)" />
+      <p v-if="text" class="info-text" v-text="$gettext(text)" />
       <dl v-if="list.length" class="info-list">
         <component :is="item.headline ? 'dt' : 'dd'" v-for="(item, index) in list" :key="index">
           {{ $gettext(item.text) }}
@@ -158,6 +158,14 @@ export default defineComponent({
   .info-title {
     font-size: 1.125rem;
     font-weight: normal;
+  }
+  .info-list:first-child,
+  .info-text:first-child {
+    margin-top: 0;
+  }
+  .info-list:last-child,
+  .info-text:last-child {
+    margin-bottom: 0;
   }
   .info-list {
     dt {

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
@@ -55,7 +55,8 @@
               <div v-if="modifiable" class="oc-flex oc-flex-nowrap oc-flex-middle">
                 <role-dropdown
                   :dom-selector="shareDomSelector"
-                  :existing-role="share.role"
+                  :existing-share-role="share.role"
+                  :existing-share-permissions="share.permissions"
                   :is-locked="isLocked"
                   class="files-collaborators-collaborator-role"
                   mode="edit"

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
@@ -21,7 +21,7 @@
       </oc-button>
       <oc-contextual-helper
         v-if="isDisabledRole"
-        class="oc-ml-xs"
+        class="oc-ml-xs files-permission-actions-list"
         :list="existingSharePermissions.map((permission) => ({ text: $gettext(permission) }))"
       />
     </div>

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/RoleDropdown.vue
@@ -22,7 +22,7 @@
       <oc-contextual-helper
         v-if="isDisabledRole"
         class="oc-ml-xs files-permission-actions-list"
-        :list="existingSharePermissions.map((permission) => ({ text: $gettext(permission) }))"
+        :list="existingSharePermissions.map((permission) => ({ text: permission }))"
       />
     </div>
     <oc-drop
@@ -86,7 +86,6 @@ import { useAbility, useUserStore } from '@ownclouders/web-pkg'
 import { Resource } from '@ownclouders/web-client'
 import { useGettext } from 'vue3-gettext'
 import { ShareRole } from '@ownclouders/web-client'
-import { $gettext } from '@ownclouders/web-pkg/src/router/utils'
 
 export default defineComponent({
   name: 'RoleDropdown',
@@ -216,7 +215,6 @@ export default defineComponent({
   },
 
   methods: {
-    $gettext,
     cycleRoles(event: KeyboardEvent) {
       // events only need to be captured if the roleSelect element is visible
       if (!get(this.$refs.rolesDrop, 'tippy.state.isShown', false)) {

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/RoleDropdown.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/RoleDropdown.spec.ts
@@ -7,7 +7,8 @@ import { User } from '@ownclouders/web-client/graph/generated'
 
 const selectors = {
   recipientRoleBtn: '.files-recipient-role-select-btn',
-  roleButton: '.files-recipient-role-drop-btn'
+  roleButton: '.files-recipient-role-drop-btn',
+  filesPermissionActionsList: '.files-permission-actions-list'
 }
 
 describe('RoleDropdown', () => {
@@ -19,10 +20,19 @@ describe('RoleDropdown', () => {
   it('renders a button with existing role if given', () => {
     const { wrapper } = getWrapper({
       mountType: shallowMount,
-      existingRole: mock<ShareRole>({ displayName: 'Can edit' })
+      existingShareRole: mock<ShareRole>({ displayName: 'Can edit' })
     })
     expect(wrapper.find(selectors.recipientRoleBtn).exists()).toBeTruthy()
     expect(wrapper.find(`${selectors.recipientRoleBtn} span`).text()).toEqual('Can edit')
+    expect(wrapper.find(selectors.filesPermissionActionsList).exists()).toBeFalsy()
+  })
+  it('lists permission actions if a role is unknown', () => {
+    const { wrapper } = getWrapper({
+      mountType: shallowMount,
+      existingSharePermissions: ['read', 'update']
+    })
+    expect(wrapper.find(selectors.recipientRoleBtn).exists()).toBeTruthy()
+    expect(wrapper.find(selectors.filesPermissionActionsList).exists()).toBeTruthy()
   })
   it('does not render a button if only one role is available', () => {
     const { wrapper } = getWrapper({
@@ -58,7 +68,8 @@ describe('RoleDropdown', () => {
 
 function getWrapper({
   mountType = mount,
-  existingRole = null,
+  existingShareRole = null,
+  existingSharePermissions = null,
   isExternal = false,
   availableInternalShareRoles = [
     mock<ShareRole>({ displayName: 'Can view', description: '' }),
@@ -67,7 +78,8 @@ function getWrapper({
   availableExternalShareRoles = []
 }: {
   mountType?: typeof mount
-  existingRole?: ShareRole
+  existingShareRole?: ShareRole
+  existingSharePermissions?: string[]
   isExternal?: boolean
   availableInternalShareRoles?: ShareRole[]
   availableExternalShareRoles?: ShareRole[]
@@ -75,7 +87,8 @@ function getWrapper({
   return {
     wrapper: mountType(RoleDropdown, {
       props: {
-        existingRole,
+        existingShareRole,
+        existingSharePermissions: existingSharePermissions ?? [],
         isExternal
       },
       global: {

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/ListItem.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/ListItem.spec.ts.snap
@@ -11,7 +11,7 @@ exports[`Collaborator ListItem component > share inheritance indicators > show w
         <div data-v-ccf14be2="" class="oc-text-truncate"><span data-v-ccf14be2="" aria-hidden="true" class="files-collaborators-collaborator-name">einstein</span> <span data-v-ccf14be2="" class="oc-invisible-sr">Share receiver name: einstein</span></div>
         <div data-v-ccf14be2="">
           <div data-v-ccf14be2="" class="oc-flex oc-flex-nowrap oc-flex-middle">
-            <role-dropdown-stub data-v-ccf14be2="" existingrole="undefined" domselector="1" mode="edit" showicon="false" islocked="false" isexternal="false" class="files-collaborators-collaborator-role"></role-dropdown-stub>
+            <role-dropdown-stub data-v-ccf14be2="" existingsharerole="undefined" existingsharepermissions="" domselector="1" mode="edit" showicon="false" islocked="false" isexternal="false" class="files-collaborators-collaborator-role"></role-dropdown-stub>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description
adds a new feature to the sharing sidebar panel which allows you to see the permissions of a role that has been disabled.

## Related Issue
- Fixes https://github.com/owncloud/ocis/pull/9727
- Part of https://github.com/owncloud/web/issues/10770

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)