### PR TITLE
[tests-only][full-ci] bump ocis latest commit id-stable5.0

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=db41f46697578a54c8bca3dd820fae7fad3ffaf1
+OCIS_COMMITID=ef277d326799c33524840c4a926927a4fddaf2ed
 OCIS_BRANCH=stable-5.0


### PR DESCRIPTION
Bump ocis commit id of stable5.0
Part of: https://github.com/owncloud/QA/issues/860