### PR TITLE
fix: displaying external shares on 'Shared With Me'-page

### DIFF
--- a/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
+++ b/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
@@ -36,9 +36,18 @@
           class="oc-text-nowrap oc-flex oc-flex-middle oc-flex-right"
         >
           <oc-icon
+            v-if="resource.shareRoles?.length"
             v-oc-tooltip="$gettext(resource.shareRoles[0].displayName)"
             :accessible-label="$gettext(resource.shareRoles[0].description)"
             :name="resource.shareRoles[0].icon"
+            fill-type="line"
+            size="small"
+          />
+          <oc-icon
+            v-else-if="isExternalShare(resource)"
+            v-oc-tooltip="ShareTypes.remote.label"
+            :accessible-label="ShareTypes.remote.label"
+            :name="ShareTypes.remote.icon"
             fill-type="line"
             size="small"
           />
@@ -104,7 +113,7 @@ import { VisibilityObserver } from '@ownclouders/web-pkg'
 import { SortDir, useGetMatchingSpace } from '@ownclouders/web-pkg'
 import { createLocationSpaces } from '@ownclouders/web-pkg'
 import ListInfo from '../../components/FilesList/ListInfo.vue'
-import { IncomingShareResource } from '@ownclouders/web-client'
+import { IncomingShareResource, ShareTypes } from '@ownclouders/web-client'
 import { ContextActions } from '@ownclouders/web-pkg'
 import { NoContentMessage } from '@ownclouders/web-pkg'
 import { useSelectedResources } from '@ownclouders/web-pkg'
@@ -195,6 +204,10 @@ export default defineComponent({
 
     const { updateResourceField } = useResourcesStore()
 
+    const isExternalShare = (resource: IncomingShareResource) => {
+      return resource.shareTypes.includes(ShareTypes.remote.value)
+    }
+
     const resourceTargetRouteCallback = ({
       path,
       fileId,
@@ -214,7 +227,9 @@ export default defineComponent({
       resourceTargetRouteCallback,
       ...useSelectedResources(),
       getMatchingSpace,
-      updateResourceField
+      updateResourceField,
+      isExternalShare,
+      ShareTypes
     }
   },
 

--- a/packages/web-client/src/helpers/share/functions.ts
+++ b/packages/web-client/src/helpers/share/functions.ts
@@ -99,7 +99,6 @@ export function buildIncomingShareResource({
   const resourceName = driveItem.name || driveItem.remoteItem.name
   const storageId = extractStorageId(driveItem.remoteItem.id)
 
-  const shareTypes = uniq(driveItem.remoteItem.permissions.map(getShareTypeFromPermission))
   const sharedWith = driveItem.remoteItem.permissions.map((permission) => {
     const { grantedToV2 } = permission
     const identity = grantedToV2.group || grantedToV2.user
@@ -116,6 +115,12 @@ export function buildIncomingShareResource({
     }
     return acc
   }, [])
+
+  let shareTypes = uniq(driveItem.remoteItem.permissions.map(getShareTypeFromPermission))
+  const isExternal = sharedBy.some((s) => s['@libre.graph.userType'] === 'Federated')
+  if (isExternal) {
+    shareTypes = [ShareTypes.remote.value]
+  }
 
   const shareRoles = getShareResourceRoles({ driveItem, graphRoles })
   const sharePermissions = getShareResourcePermissions({ driveItem, shareRoles })


### PR DESCRIPTION
## Description
Prevents the 'Shared With Me'-page from breaking with external shares and fixes the share types on incoming share resources.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/ocis/issues/9735

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

