### PR TITLE
[tests-only] [ full-ci]adding code to get bearer token in keycloak

### DIFF
--- a/tests/e2e/cucumber/environment/index.ts
+++ b/tests/e2e/cucumber/environment/index.ts
@@ -28,7 +28,7 @@ import { Group, User } from '../../support/types'
 import { getTokenFromLogin, setAccessToken } from '../../support/utils/tokenHelper'
 import { createdTokenStore, keycloakTokenStore } from '../../support/store/token'
 import { removeTempUploadDirectory } from '../../support/utils/runtimeFs'
-import { refreshToken, setupKeycloakAdminUser } from '../../support/api/keycloak'
+import { getAccessToken, refreshToken, setupKeycloakAdminUser } from '../../support/api/keycloak'
 import { closeSSEConnections } from '../../support/environment/sse'
 
 export { World }
@@ -73,11 +73,10 @@ Before(async function (this: World, { pickle }: ITestCaseHookParameter) {
     }
   })
   if (!config.basicAuth) {
-    // Currently, access token are received for keycloak via login
-    // Todo: Make keycloak get it's access token via api
     if (config.keycloak) {
+      // In keycloak setup with oCIS, access token is received via login to the browser directly.
       await setAdminTokenFromLogin(state.browser)
-      await setKeycloakAdminToken(state.browser)
+      await setKeycloakAdminTokenfromApi(this.usersEnvironment.getUser({ key: 'admin' }))
     } else {
       await setAdminToken(this.usersEnvironment.getUser({ key: 'admin' }))
     }
@@ -235,10 +234,6 @@ const setAdminTokenFromLogin = async (browser: Browser) => {
   return await getTokenFromLogin({ browser })
 }
 
-const setKeycloakAdminToken = async (browser: Browser) => {
-  return await getTokenFromLogin({
-    browser,
-    url: config.keycloakLoginUrl,
-    tokenType: 'keycloak'
-  })
+const setKeycloakAdminTokenfromApi = async (user: User) => {
+  return await getAccessToken(user)
 }


### PR DESCRIPTION
## Description
This PR adds code for getting **access token** from keycloak using `password grant type` flow.

For now in keycloak, one has to log in manually to be authenticated which isn't possible if one wants to get an access token without login. 

Note: **Password Grant flow** isn't recommended by OIDC due to security issue https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#section-2.4
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/web/issues/11307



## How Has This Been Tested?
- locally and CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
