### PR TITLE
feat: hide version panel with insufficient permissions

### DIFF
--- a/changelog/unreleased/enhancement-hide-versions-panel
+++ b/changelog/unreleased/enhancement-hide-versions-panel
@@ -1,0 +1,6 @@
+Enhancement: Hide versions panel with insufficient permissions
+
+Users that have insufficient permissions to view file versions don't see the versions sidebar panel anymore. This currently affects regular share receivers, space viewers and space editors without the permission to view versions.
+
+https://github.com/owncloud/web/pull/11484
+https://github.com/owncloud/web/issues/11359

--- a/packages/web-app-files/src/composables/extensions/useFileSideBars.ts
+++ b/packages/web-app-files/src/composables/extensions/useFileSideBars.ts
@@ -19,16 +19,11 @@ import {
   SidebarPanelExtension,
   useIsFilesAppActive,
   useGetMatchingSpace,
-  useUserStore,
   useCapabilityStore,
-  useCanListShares
+  useCanListShares,
+  useCanListVersions
 } from '@ownclouders/web-pkg'
-import {
-  isPersonalSpaceResource,
-  isProjectSpaceResource,
-  isSpaceResource,
-  SpaceResource
-} from '@ownclouders/web-client'
+import { isProjectSpaceResource, SpaceResource } from '@ownclouders/web-client'
 import { Resource } from '@ownclouders/web-client'
 import { useGettext } from 'vue3-gettext'
 import { unref } from 'vue'
@@ -43,7 +38,7 @@ export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resourc
   const isFilesAppActive = useIsFilesAppActive()
   const { isPersonalSpaceRoot } = useGetMatchingSpace()
   const { canListShares } = useCanListShares()
-  const userStore = useUserStore()
+  const { canListVersions } = useCanListVersions()
 
   return [
     {
@@ -251,23 +246,7 @@ export const useSideBarPanels = (): SidebarPanelExtension<SpaceResource, Resourc
           if (items?.length !== 1) {
             return false
           }
-          if (isProjectSpaceResource(items[0])) {
-            // project space roots don't support versions
-            return false
-          }
-
-          const userIsSpaceMember =
-            (isProjectSpaceResource(root) && root.isMember(userStore.user)) ||
-            (isPersonalSpaceResource(root) && root.isOwner(userStore.user))
-
-          if (
-            isLocationTrashActive(router, 'files-trash-generic') ||
-            !userIsSpaceMember ||
-            isSpaceResource(items[0])
-          ) {
-            return false
-          }
-          return items[0].type !== 'folder'
+          return canListVersions({ space: root, resource: items[0] })
         }
       }
     },

--- a/packages/web-client/src/helpers/share/types.ts
+++ b/packages/web-client/src/helpers/share/types.ts
@@ -12,9 +12,11 @@ export enum GraphSharePermission {
   readChildren = 'libre.graph/driveItem/children/read',
   readDeleted = 'libre.graph/driveItem/deleted/read',
   readPermissions = 'libre.graph/driveItem/permissions/read',
+  readVersions = 'libre.graph/driveItem/versions/read',
   updatePath = 'libre.graph/driveItem/path/update',
   updateDeleted = 'libre.graph/driveItem/deleted/update',
   updatePermissions = 'libre.graph/driveItem/permissions/update',
+  updateVersions = 'libre.graph/driveItem/versions/update',
   deleteStandard = 'libre.graph/driveItem/standard/delete',
   deleteDeleted = 'libre.graph/driveItem/deleted/delete',
   deletePermissions = 'libre.graph/driveItem/permissions/delete'

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -8,6 +8,7 @@ import {
 } from '../resource'
 import {
   isPersonalSpaceResource,
+  isPublicSpaceResource,
   PublicSpaceResource,
   ShareSpaceResource,
   SpaceMember,
@@ -296,6 +297,12 @@ export function buildSpace(
         GraphSharePermission.deletePermissions
       )
     },
+    canListVersions: function ({ user }: { user?: User } = {}) {
+      if (isPersonalSpaceResource(this) && this.isOwner(user)) {
+        return true
+      }
+      return getPermissionsForSpaceMember(this, user).includes(GraphSharePermission.readVersions)
+    },
     canCreate: function () {
       return true
     },
@@ -325,6 +332,9 @@ export function buildSpace(
       return urlJoin(webDavTrashUrl, path)
     },
     isMember(user: User): boolean {
+      if (isPublicSpaceResource(this)) {
+        return false
+      }
       if (this.isOwner(user) || !!this.members[user.id]) {
         return true
       }

--- a/packages/web-client/src/helpers/space/types.ts
+++ b/packages/web-client/src/helpers/space/types.ts
@@ -42,6 +42,7 @@ export interface SpaceResource extends Resource {
   canRestore(args?: { user?: User; ability?: Ability }): boolean
   canDeleteFromTrashBin(args?: { user?: User }): boolean
   canRestoreFromTrashbin(args?: { user?: User }): boolean
+  canListVersions(args?: { user?: User }): boolean
 
   getWebDavUrl({ path }: { path: string }): string
   getWebDavTrashUrl({ path }: { path: string }): string

--- a/packages/web-pkg/src/composables/resources/index.ts
+++ b/packages/web-pkg/src/composables/resources/index.ts
@@ -1,3 +1,4 @@
 export * from './useCanBeOpenedWithSecureView'
+export * from './useCanListVersions'
 export * from './useGetResourceContext'
 export * from './useResourceContents'

--- a/packages/web-pkg/src/composables/resources/useCanListVersions.ts
+++ b/packages/web-pkg/src/composables/resources/useCanListVersions.ts
@@ -1,0 +1,23 @@
+import { useUserStore } from '../piniaStores'
+import { isSpaceResource, isTrashResource, Resource, SpaceResource } from '@ownclouders/web-client'
+
+export const useCanListVersions = () => {
+  const userStore = useUserStore()
+
+  const canListVersions = ({ space, resource }: { space: SpaceResource; resource: Resource }) => {
+    if (resource.type === 'folder') {
+      return false
+    }
+    if (isSpaceResource(resource)) {
+      return false
+    }
+    if (isTrashResource(resource)) {
+      return false
+    }
+    return space.canListVersions({ user: userStore.user })
+  }
+
+  return {
+    canListVersions
+  }
+}

--- a/packages/web-pkg/tests/unit/components/sidebar/FileSideBar.spec.ts
+++ b/packages/web-pkg/tests/unit/components/sidebar/FileSideBar.spec.ts
@@ -23,6 +23,9 @@ const InnerSideBarComponent = defineComponent({
 })
 
 vi.mock('../../../../src/composables/selection', () => ({ useSelectedResources: vi.fn() }))
+vi.mock('../../../../src/composables/resources/useCanListVersions', () => ({
+  useCanListVersions: () => ({ canListVersions: vi.fn() })
+}))
 
 const selectors = {
   sideBar: '.files-side-bar',

--- a/packages/web-pkg/tests/unit/composables/resources/useCanListVersions.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/resources/useCanListVersions.spec.ts
@@ -1,0 +1,72 @@
+import { getComposableWrapper } from 'web-test-helpers'
+import { mock } from 'vitest-mock-extended'
+import { Resource, SpaceResource, TrashResource } from '@ownclouders/web-client'
+import { useCanListVersions } from '../../../../src/composables/resources'
+
+describe('useCanListVersions', () => {
+  describe('canListVersions', () => {
+    it('returns true for files when user has sufficient permissions in space', () => {
+      getWrapper({
+        setup: ({ canListVersions }) => {
+          const space = mock<SpaceResource>({ canListVersions: () => true })
+          const resource = mock<Resource>({ type: 'file' })
+          const canList = canListVersions({ space, resource })
+          expect(canList).toBeTruthy()
+        }
+      })
+    })
+    it('returns false for folders', () => {
+      getWrapper({
+        setup: ({ canListVersions }) => {
+          const space = mock<SpaceResource>({ canListVersions: () => true })
+          const resource = mock<Resource>({ type: 'folder' })
+          const canList = canListVersions({ space, resource })
+          expect(canList).toBeFalsy()
+        }
+      })
+    })
+    it('returns false for space resources', () => {
+      getWrapper({
+        setup: ({ canListVersions }) => {
+          const space = mock<SpaceResource>({ canListVersions: () => true })
+          const resource = mock<SpaceResource>({ type: 'space' })
+          const canList = canListVersions({ space, resource })
+          expect(canList).toBeFalsy()
+        }
+      })
+    })
+    it('returns false for trash resources', () => {
+      getWrapper({
+        setup: ({ canListVersions }) => {
+          const space = mock<SpaceResource>({ canListVersions: () => true })
+          const resource = mock<TrashResource>({ type: 'file', ddate: '' })
+          const canList = canListVersions({ space, resource })
+          expect(canList).toBeFalsy()
+        }
+      })
+    })
+    it('returns false when user does not have sufficient permissions in space', () => {
+      getWrapper({
+        setup: ({ canListVersions }) => {
+          const space = mock<SpaceResource>({ canListVersions: () => false })
+          const resource = mock<Resource>({ type: 'file' })
+          const canList = canListVersions({ space, resource })
+          expect(canList).toBeFalsy()
+        }
+      })
+    })
+  })
+})
+
+function getWrapper({
+  setup
+}: {
+  setup: (instance: ReturnType<typeof useCanListVersions>) => void
+}) {
+  return {
+    wrapper: getComposableWrapper(() => {
+      const instance = useCanListVersions()
+      setup(instance)
+    })
+  }
+}

--- a/tests/e2e/cucumber/features/spaces/project.feature
+++ b/tests/e2e/cucumber/features/spaces/project.feature
@@ -152,7 +152,7 @@ Feature: spaces.personal
 
     When "Carol" logs in
     And "Carol" navigates to the project space "team.1"
-    And "Carol" should not see the version of the file
+    And "Carol" should not see the version panel for the file
       | resource     | to     |
       | textfile.txt | parent |
     And "Carol" logs out


### PR DESCRIPTION
## Description
Users that have insufficient permissions to view file versions don't see the version sidebar panel anymore. This currently affects regular share receivers, space viewers and space editors without the `versions/read` permission.

Also introduces a helper `useCanListVersions`.

To enable Space Viewers without version permissions, start the latest oCIS with this env var: `GRAPH_AVAILABLE_ROLES="b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5,a8d5fe5e-96e3-418d-825b-534dbdf22b99,fb6c3e19-e378-47e5-b277-9732f9de6e21,58c63c02-1d89-4572-916a-870abc5a1b7d,2d00ce52-1fc2-4dbc-8b95-a73b73395f5a,1c996275-f1c9-4e71-abdf-a42f6495e960,312c0871-5ef7-4b3a-85b6-0e4074c64049,aa97fe03-7980-45ac-9e50-b325749fd7e6,3284f2d5-0070-4ad8-ac40-c247f7c1fb27"`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Closes https://github.com/owncloud/web/issues/11359

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
