### PR TITLE
feat: support `a` as component type in actions

### DIFF
--- a/changelog/unreleased/enhancement-action-a-tags
+++ b/changelog/unreleased/enhancement-action-a-tags
@@ -1,0 +1,5 @@
+Enhancement: Support a tags in actions
+
+We've added support for `a` tags in actions. This allows developers to create action extensions for e.g. opening file-specific URLs from the context menu.
+
+https://github.com/owncloud/web/pull/11502

--- a/docs/extension-system/extension-types/actions.md
+++ b/docs/extension-system/extension-types/actions.md
@@ -36,9 +36,9 @@ The most important configuration options are:
 - `icon` - The icon to be displayed, can be picked from https://owncloud.design/#/Design%20Tokens/IconList
 - `name` - The name of the action (not displayed in the UI)
 - `label` - The text to be displayed
-- `route` - The string/route to navigate to, if the nav item should be a `<router-link>`
-- `handler` - The action to perform upon click, if the nav item should be a `<button>`
-- `componentType` - Either `'button'` or `'router-link'`, depending on whether the action should be a link or button
+- `route` - The string/route to navigate to. The nav item will be a `<router-link>` tag.
+- `href` - The URL to navigate to. The nav item will be a `<a>`tag.
+- `handler` - The action to perform upon click. The nav item will be a `<button>` tag.
 - `isVisible` - Determines whether the action is displayed to the user
 
 Please check the [`Action` type](https://github.com/owncloud/web/blob/236c185540fc6758dc7bd84985c8834fa4145530/packages/web-pkg/src/composables/actions/types.ts#L6) for a full list of configuration options.
@@ -58,7 +58,6 @@ export const useDownloadFilesExtension = () => {
     action: {
       name: 'download-files',
       icon: 'download',
-      componentType: 'button',
       class: 'oc-files-actions-download-files',
       label: () => $gettext('Download'),
       isVisible: ({ space, resources }) => {

--- a/packages/web-app-admin-settings/src/composables/actions/general/useGeneralActionsResetLogo.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/general/useGeneralActionsResetLogo.ts
@@ -38,7 +38,6 @@ export const useGeneralActionsResetLogo = () => {
         return ability.can('update-all', 'Logo')
       },
       handler,
-      componentType: 'button',
       class: 'oc-general-actions-reset-logo-trigger'
     }
   ])

--- a/packages/web-app-admin-settings/src/composables/actions/general/useGeneralActionsUploadLogo.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/general/useGeneralActionsUploadLogo.ts
@@ -57,7 +57,6 @@ export const useGeneralActionsUploadLogo = ({ imageInput }: { imageInput: VNodeR
       handler: () => {
         unref(imageInput).click()
       },
-      componentType: 'button',
       class: 'oc-general-actions-upload-logo-trigger'
     }
   ])

--- a/packages/web-app-admin-settings/src/composables/actions/groups/useGroupActionsCreateGroup.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/groups/useGroupActionsCreateGroup.ts
@@ -11,7 +11,6 @@ export const useGroupActionsCreateGroup = () => {
     {
       name: 'create-group',
       icon: 'add',
-      componentType: 'button',
       class: 'oc-groups-actions-create-group',
       label: () => $gettext('New group'),
       isVisible: () => true,

--- a/packages/web-app-admin-settings/src/composables/actions/groups/useGroupActionsDelete.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/groups/useGroupActionsDelete.ts
@@ -114,7 +114,6 @@ export const useGroupActionsDelete = () => {
       isVisible: ({ resources }) => {
         return !!resources.length && !resources.some((r) => r.groupTypes?.includes('ReadOnly'))
       },
-      componentType: 'button',
       class: 'oc-groups-actions-delete-trigger'
     }
   ])

--- a/packages/web-app-admin-settings/src/composables/actions/groups/useGroupActionsEdit.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/groups/useGroupActionsEdit.ts
@@ -16,7 +16,6 @@ export const useGroupActionsEdit = () => {
       isVisible: ({ resources }) => {
         return resources.length === 1 && !resources[0].groupTypes?.includes('ReadOnly')
       },
-      componentType: 'button',
       class: 'oc-groups-actions-edit-trigger'
     }
   ])

--- a/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsAddToGroups.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsAddToGroups.ts
@@ -32,7 +32,6 @@ export const useUserActionsAddToGroups = ({ groups }: { groups: Ref<Group[]> }) 
     {
       name: 'add-to-groups',
       icon: 'add',
-      componentType: 'button',
       class: 'oc-users-actions-add-to-groups-trigger',
       label: () => $gettext('Add to groups'),
       isVisible: ({ resources }) => {

--- a/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsCreateUser.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsCreateUser.ts
@@ -13,7 +13,6 @@ export const useUserActionsCreateUser = () => {
     {
       name: 'create-user',
       icon: 'add',
-      componentType: 'button',
       class: 'oc-users-actions-create-user',
       label: () => $gettext('New user'),
       isVisible: () => !capabilityStore.graphUsersCreateDisabled,

--- a/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsDelete.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsDelete.ts
@@ -116,7 +116,6 @@ export const useUserActionsDelete = () => {
       isVisible: ({ resources }) => {
         return !!resources.length && !capabilityStore.graphUsersDeleteDisabled
       },
-      componentType: 'button',
       class: 'oc-users-actions-delete-trigger'
     }
   ])

--- a/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsEdit.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsEdit.ts
@@ -16,7 +16,6 @@ export const useUserActionsEdit = () => {
       isVisible: ({ resources }) => {
         return resources.length === 1
       },
-      componentType: 'button',
       class: 'oc-users-actions-edit-trigger'
     }
   ])

--- a/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsEditLogin.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsEditLogin.ts
@@ -30,7 +30,6 @@ export const useUserActionsEditLogin = () => {
     {
       name: 'edit-login',
       icon: 'login-circle',
-      componentType: 'button',
       class: 'oc-users-actions-edit-login-trigger',
       label: () => $gettext('Edit login'),
       isVisible: ({ resources }) => {

--- a/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsEditQuota.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsEditQuota.ts
@@ -96,7 +96,6 @@ export const useUserActionsEditQuota = () => {
 
         return ability.can('set-quota-all', 'Drive')
       },
-      componentType: 'button',
       class: 'oc-users-actions-edit-quota-trigger'
     }
   ])

--- a/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsRemoveFromGroups.ts
+++ b/packages/web-app-admin-settings/src/composables/actions/users/useUserActionsRemoveFromGroups.ts
@@ -32,7 +32,6 @@ export const useUserActionsRemoveFromGroups = ({ groups }: { groups: Ref<Group[]
     {
       name: 'remove-users-from-groups',
       icon: 'subtract',
-      componentType: 'button',
       class: 'oc-users-actions-remove-from-groups-trigger',
       label: () => $gettext('Remove from groups'),
       isVisible: ({ resources }) => {

--- a/packages/web-app-app-store/src/composables/actions/useAppActionsDownload.ts
+++ b/packages/web-app-app-store/src/composables/actions/useAppActionsDownload.ts
@@ -24,7 +24,6 @@ export const useAppActionsDownload = () => {
     isVisible: () => {
       return true
     },
-    componentType: 'button',
     appearance: 'outline'
   }
 

--- a/packages/web-app-files/src/composables/actions/spaces/useSpaceActionsUploadImage.ts
+++ b/packages/web-app-files/src/composables/actions/spaces/useSpaceActionsUploadImage.ts
@@ -118,7 +118,6 @@ export const useSpaceActionsUploadImage = ({ spaceImageInput }: { spaceImageInpu
 
         return resources[0].canEditImage({ user: userStore.user })
       },
-      componentType: 'button',
       class: 'oc-files-actions-upload-space-image-trigger'
     }
   ])

--- a/packages/web-app-files/tests/unit/components/SideBar/Actions/FileActions.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Actions/FileActions.spec.ts
@@ -21,28 +21,24 @@ const fileActions: Record<string, ActionWithSelector> = {
   copy: mock<ActionWithSelector>({
     handler: vi.fn(),
     label: () => 'Copy',
-    componentType: 'button',
     class: 'oc-files-actions-copy-trigger',
     selector: '.oc-files-actions-copy-trigger'
   }),
   move: mock<ActionWithSelector>({
     handler: vi.fn(),
     label: () => 'Move',
-    componentType: 'button',
     class: 'oc-files-actions-move-trigger',
     selector: '.oc-files-actions-move-trigger'
   }),
   download: mock<ActionWithSelector>({
     handler: vi.fn(),
     label: () => 'Download',
-    componentType: 'button',
     class: 'oc-files-actions-download-file-trigger',
     selector: '.oc-files-actions-download-file-trigger'
   }),
   'text-editor': mock<ActionWithSelector>({
     handler: vi.fn(),
     label: () => 'Open in Text Editor',
-    componentType: 'button',
     class: 'oc-files-actions-text-editor-trigger',
     selector: '.oc-files-actions-text-editor-trigger'
   })

--- a/packages/web-app-importer/src/extensions.ts
+++ b/packages/web-app-importer/src/extensions.ts
@@ -147,7 +147,6 @@ export const extensions = ({ applicationConfig }: ApplicationSetupOptions) => {
         },
         isDisabled: () => !!Object.keys(uppyService.getCurrentUploads()).length,
         disabledTooltip: () => $gettext('Please wait until all imports have finished'),
-        componentType: 'button',
         class: 'oc-files-actions-import'
       }
     }

--- a/packages/web-app-ocm/src/extensions.ts
+++ b/packages/web-app-ocm/src/extensions.ts
@@ -69,7 +69,6 @@ export const extensions = (appInfo: ApplicationInformation) => {
             resources[0]?.storageId?.startsWith(OCM_PROVIDER_ID)
           )
         },
-        componentType: 'button',
         class: 'oc-files-actions-open-file-remote'
       }
     },

--- a/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
+++ b/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
@@ -448,13 +448,10 @@ export default defineComponent({
           disabledTooltip: () => '',
           isVisible: () => unref(isEditor),
           isDisabled: () => isReadOnly.value || !isDirty.value,
-          componentType: 'button',
           icon: 'save',
           id: 'app-save-action',
           label: () => 'Save',
-          handler: () => {
-            save()
-          }
+          handler: save
         }
       ]
     })

--- a/packages/web-pkg/src/composables/actions/files/useFileActions.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActions.ts
@@ -113,7 +113,6 @@ export const useFileActions = () => {
             iconFillType: appInfo.iconFillType
           }),
           img: appInfo.img,
-          componentType: 'router-link',
           route: ({ space, resources }) => {
             return getEditorRoute({
               appFileExtension: fileExtension,

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCopy.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCopy.ts
@@ -91,7 +91,6 @@ export const useFileActionsCopy = () => {
           // a user always has their home dir with write access
           return true
         },
-        componentType: 'button',
         class: 'oc-files-actions-copy-trigger'
       }
     ]

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCopyQuicklink.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCopyQuicklink.ts
@@ -72,7 +72,6 @@ export const useFileActionsCopyQuickLink = () => {
 
         return canShare({ space, resource: resources[0] })
       },
-      componentType: 'button',
       class: 'oc-files-actions-copy-quicklink-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCreateLink.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCreateLink.ts
@@ -153,7 +153,6 @@ export const useFileActionsCreateLink = ({
           return $gettext('Create links')
         },
         isVisible,
-        componentType: 'button',
         class: 'oc-files-actions-create-links'
       },
       {
@@ -164,7 +163,6 @@ export const useFileActionsCreateLink = ({
           return $gettext('Create links')
         },
         isVisible,
-        componentType: 'button',
         class: 'oc-files-actions-create-quick-links'
       }
     ]

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCreateNewFile.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCreateNewFile.ts
@@ -181,7 +181,6 @@ export const useFileActionsCreateNewFile = ({ space }: { space?: Ref<SpaceResour
         isVisible: () => {
           return unref(currentFolder)?.canUpload({ user: userStore.user })
         },
-        componentType: 'button',
         class: 'oc-files-actions-create-new-file',
         ext: appFileExtension.extension,
         isExternal: appFileExtension.app?.startsWith('external-')

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCreateNewFolder.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCreateNewFolder.ts
@@ -128,7 +128,6 @@ export const useFileActionsCreateNewFolder = ({ space }: { space?: Ref<SpaceReso
         isVisible: () => {
           return unref(currentFolder)?.canCreate()
         },
-        componentType: 'button',
         class: 'oc-files-actions-create-new-folder'
       }
     ]

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCreateNewShortcut.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCreateNewShortcut.ts
@@ -31,7 +31,6 @@ export const useFileActionsCreateNewShortcut = ({ space }: { space: Ref<SpaceRes
         isVisible: () => {
           return unref(currentFolder)?.canCreate()
         },
-        componentType: 'button',
         class: 'oc-files-actions-create-new-shortcut'
       }
     ]

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCreateSpaceFromResource.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCreateSpaceFromResource.ts
@@ -131,7 +131,6 @@ export const useFileActionsCreateSpaceFromResource = () => {
 
           return true
         },
-        componentType: 'button',
         class: 'oc-files-actions-create-space-from-resource-trigger'
       }
     ]

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsDelete.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsDelete.ts
@@ -80,7 +80,6 @@ export const useFileActionsDelete = () => {
         })
         return !deleteDisabled
       },
-      componentType: 'button',
       class: 'oc-files-actions-delete-trigger'
     },
     {
@@ -106,7 +105,6 @@ export const useFileActionsDelete = () => {
 
         return resources.length > 0
       },
-      componentType: 'button',
       class: 'oc-files-actions-delete-permanent-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsDisableSync.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsDisableSync.ts
@@ -101,7 +101,6 @@ export const useFileActionsDisableSync = () => {
 
         return resources.some((resource) => resource.syncEnabled)
       },
-      componentType: 'button',
       class: 'oc-files-actions-disable-sync-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadArchive.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadArchive.ts
@@ -137,7 +137,6 @@ export const useFileActionsDownloadArchive = () => {
           })
           return !downloadDisabled
         },
-        componentType: 'button',
         class: 'oc-files-actions-download-archive-trigger'
       }
     ]

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadFile.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadFile.ts
@@ -52,7 +52,6 @@ export const useFileActionsDownloadFile = () => {
         }
         return resources[0].canDownload()
       },
-      componentType: 'button',
       class: 'oc-files-actions-download-file-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsEmptyTrashBin.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsEmptyTrashBin.ts
@@ -80,7 +80,6 @@ export const useFileActionsEmptyTrashBin = () => {
       isDisabled: () => {
         return resourcesStore.activeResources.length === 0
       },
-      componentType: 'button',
       class: 'oc-files-actions-empty-trash-bin-trigger',
       variation: 'danger',
       appearance: 'filled'

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsEnableSync.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsEnableSync.ts
@@ -103,7 +103,6 @@ export const useFileActionsEnableSync = () => {
 
         return resources.some((resource) => !resource.syncEnabled)
       },
-      componentType: 'button',
       class: 'oc-files-actions-enable-sync-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsFavorite.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsFavorite.ts
@@ -63,7 +63,6 @@ export const useFileActionsFavorite = () => {
 
         return capabilityStore.filesFavorites && ability.can('create', 'Favorite')
       },
-      componentType: 'button',
       class: 'oc-files-actions-favorite-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsMove.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsMove.ts
@@ -67,7 +67,6 @@ export const useFileActionsMove = () => {
         })
         return !moveDisabled
       },
-      componentType: 'button',
       class: 'oc-files-actions-move-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsNavigate.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsNavigate.ts
@@ -60,7 +60,6 @@ export const useFileActionsNavigate = () => {
 
         return true
       },
-      componentType: 'router-link',
       route: ({ space, resources }) => {
         return merge(
           {},

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsOpenShortcut.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsOpenShortcut.ts
@@ -89,7 +89,6 @@ export const useFileActionsOpenShortcut = () => {
         }
         return resources[0].canDownload()
       },
-      componentType: 'button',
       class: 'oc-files-actions-open-short-cut-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsOpenWithApp.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsOpenWithApp.ts
@@ -43,7 +43,6 @@ export const useFileActionsOpenWithApp = ({ appId }: { appId: string }) => {
       isVisible: () => {
         return !unref(isFilesAppActive)
       },
-      componentType: 'button',
       class: 'oc-files-actions-open-with-app-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsPaste.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsPaste.ts
@@ -169,7 +169,6 @@ export const useFileActionsPaste = () => {
         // a user always has their home dir with write access
         return true
       },
-      componentType: 'button',
       class: 'oc-files-actions-copy-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsRename.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsRename.ts
@@ -246,7 +246,6 @@ export const useFileActionsRename = () => {
         })
         return !renameDisabled
       },
-      componentType: 'button',
       class: 'oc-files-actions-rename-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsRestore.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsRestore.ts
@@ -234,7 +234,6 @@ export const useFileActionsRestore = () => {
 
         return resources.length > 0
       },
-      componentType: 'button',
       class: 'oc-files-actions-restore-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsSetImage.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsSetImage.ts
@@ -97,7 +97,6 @@ export const useFileActionsSetImage = () => {
 
         return space.canEditImage({ user: userStore.user })
       },
-      componentType: 'button',
       class: 'oc-files-actions-set-space-image-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsShowActions.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsShowActions.ts
@@ -37,7 +37,6 @@ export const useFileActionsShowActions = () => {
         // return hardcoded `true` in all cases once we have them.
         return resources.length === 1
       },
-      componentType: 'button',
       class: 'oc-files-actions-show-actions-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsShowDetails.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsShowDetails.ts
@@ -17,7 +17,6 @@ export const useFileActionsShowDetails = () => {
     {
       name: 'show-details',
       icon: 'information',
-      componentType: 'button',
       class: 'oc-files-actions-show-details-trigger',
       label: () => $gettext('Details'),
       // we don't have details in the trashbin, yet.

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsShowShares.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsShowShares.ts
@@ -37,7 +37,6 @@ export const useFileActionsShowShares = () => {
         }
         return canShare({ space, resource: resources[0] })
       },
-      componentType: 'button',
       class: 'oc-files-actions-show-shares-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsToggleHideShare.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsToggleHideShare.ts
@@ -84,7 +84,6 @@ export const useFileActionsToggleHideShare = () => {
 
         return isLocationSharesActive(router, 'files-shares-with-me')
       },
-      componentType: 'button',
       class: 'oc-files-actions-hide-share-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsDelete.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsDelete.ts
@@ -121,7 +121,6 @@ export const useSpaceActionsDelete = () => {
       isVisible: ({ resources }) => {
         return !!filterResourcesToDelete(resources).length
       },
-      componentType: 'button',
       class: 'oc-files-actions-delete-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsDisable.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsDisable.ts
@@ -119,7 +119,6 @@ export const useSpaceActionsDisable = () => {
       isVisible: ({ resources }) => {
         return !!filterResourcesToDisable(resources).length
       },
-      componentType: 'button',
       class: 'oc-files-actions-disable-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsDuplicate.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsDuplicate.ts
@@ -152,7 +152,6 @@ export const useSpaceActionsDuplicate = () => {
 
         return ability.can('create-all', 'Drive')
       },
-      componentType: 'button',
       class: 'oc-files-actions-duplicate-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditDescription.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditDescription.ts
@@ -75,7 +75,6 @@ export const useSpaceActionsEditDescription = () => {
 
         return resources[0].canEditDescription({ user: userStore.user, ability })
       },
-      componentType: 'button',
       class: 'oc-files-actions-edit-description-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditQuota.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditQuota.ts
@@ -52,7 +52,6 @@ export const useSpaceActionsEditQuota = () => {
         }
         return ability.can('set-quota-all', 'Drive')
       },
-      componentType: 'button',
       class: 'oc-files-actions-edit-quota-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditReadmeContent.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsEditReadmeContent.ts
@@ -80,7 +80,6 @@ export const useSpaceActionsEditReadmeContent = () => {
 
         return resources[0].canEditReadme({ user: userStore.user })
       },
-      componentType: 'button',
       class: 'oc-files-actions-edit-readme-content-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsNavigateToTrash.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsNavigateToTrash.ts
@@ -40,7 +40,6 @@ export const useSpaceActionsNavigateToTrash = () => {
 
         return true
       },
-      componentType: 'button',
       class: 'oc-files-actions-navigate-to-trash-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsRename.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsRename.ts
@@ -77,7 +77,6 @@ export const useSpaceActionsRename = () => {
 
         return resources[0].canRename({ user: userStore.user, ability })
       },
-      componentType: 'button',
       class: 'oc-files-actions-rename-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsRestore.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsRestore.ts
@@ -128,7 +128,6 @@ export const useSpaceActionsRestore = () => {
       isVisible: ({ resources }) => {
         return !!filterResourcesToRestore(resources).length
       },
-      componentType: 'button',
       class: 'oc-files-actions-restore-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsSetIcon.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsSetIcon.ts
@@ -132,7 +132,6 @@ export const useSpaceActionsSetIcon = () => {
 
         return resources[0].canEditImage({ user: userStore.user })
       },
-      componentType: 'button',
       class: 'oc-files-actions-set-space-icon-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsShowMembers.ts
+++ b/packages/web-pkg/src/composables/actions/spaces/useSpaceActionsShowMembers.ts
@@ -21,7 +21,6 @@ export const useSpaceActionsShowMembers = () => {
       label: () => $gettext('Members'),
       handler,
       isVisible: ({ resources }) => resources.length === 1 && !resources[0].disabled,
-      componentType: 'button',
       class: 'oc-files-actions-show-details-trigger'
     }
   ])

--- a/packages/web-pkg/src/composables/actions/types.ts
+++ b/packages/web-pkg/src/composables/actions/types.ts
@@ -15,7 +15,6 @@ export interface Action<T = ActionOptions> {
   appearance?: string
   id?: string
   img?: string
-  componentType: 'button' | 'router-link' // FIXME: Should be determined by handler/route
   class?: string
   hasPriority?: boolean
   hideLabel?: boolean
@@ -34,6 +33,9 @@ export interface Action<T = ActionOptions> {
 
   // componentType: router-link
   route?(options?: T): RouteLocationRaw
+
+  // componentType: a
+  href?(options?: T): string
 
   // can be used to display the action in a disabled state in the UI
   isDisabled?(options?: T): boolean

--- a/packages/web-pkg/src/composables/actions/useActionsShowDetails.ts
+++ b/packages/web-pkg/src/composables/actions/useActionsShowDetails.ts
@@ -16,7 +16,6 @@ export const useActionsShowDetails = () => {
       isVisible: ({ resources }) => {
         return (resources as unknown[]).length > 0
       },
-      componentType: 'button',
       class: 'oc-admin-settings-show-details-trigger'
     }
   ])

--- a/packages/web-pkg/tests/unit/components/ContextActions/ActionMenuItem.spec.ts
+++ b/packages/web-pkg/tests/unit/components/ContextActions/ActionMenuItem.spec.ts
@@ -17,7 +17,6 @@ const fileActions = {
     icon: 'file-download',
     handler: vi.fn(),
     label: () => 'Download',
-    componentType: 'button',
     class: 'oc-files-actions-download-file-trigger'
   } as unknown as FileAction,
   navigate: {
@@ -25,8 +24,14 @@ const fileActions = {
     icon: 'folder-open',
     route: () => ({ name: 'files-personal' }),
     label: () => 'Open Folder',
-    componentType: 'router-link',
     class: 'oc-files-actions-navigate-trigger'
+  } as unknown as FileAction,
+  redirect: {
+    name: 'redirect',
+    icon: 'external',
+    href: () => 'https://owncloud.com',
+    label: () => 'Visit ownCloud',
+    class: 'oc-files-actions-redirect-trigger'
   } as unknown as FileAction
 }
 
@@ -81,6 +86,16 @@ describe('ActionMenuItem component', () => {
       // FIXME: to.name cannot be accessed, because the attributes().to holds a string containing `[object Object]`.
       // That doesn't allow checking the name of the router-link.
       // expect(link.attributes().href).toBe(action.route)
+    })
+  })
+  describe('component is of type a', () => {
+    it('has a href', () => {
+      const action = fileActions.redirect
+      const { wrapper } = getWrapper(action, mount)
+      const link = wrapper.find(selectors.handler)
+      expect(link.exists()).toBeTruthy()
+      expect(link.element.tagName).toBe('A')
+      expect(link.attributes().href).toBe(action.href())
     })
   })
 })


### PR DESCRIPTION
## Description
`Action`s were only allowed to be of type `button` or `router-link`. This PR adds support for `a` tags and at the same time fixes a FIXME by determining the component type implicitly in a fallback chain by presence of certain callbacks.

## Related Issue
- Pre-requisite for https://github.com/owncloud/enterprise/issues/6850

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
