### PR TITLE
bugfix(ocm): fix invitation JSON body

### DIFF
--- a/changelog/unreleased/bugfix-ocm-invite-body
+++ b/changelog/unreleased/bugfix-ocm-invite-body
@@ -1,0 +1,6 @@
+Bugfix: OCM invite generation body format
+
+We've fixed the issue where the body of the OCM invite generation was not formatted correctly.
+
+https://github.com/owncloud/web/pull/11512
+https://github.com/owncloud/ocis/issues/9583

--- a/packages/web-app-ocm/src/views/OutgoingInvitations.vue
+++ b/packages/web-app-ocm/src/views/OutgoingInvitations.vue
@@ -202,15 +202,12 @@ export default defineComponent({
       if (unref(descriptionErrorMessage)) {
         return
       }
-
       try {
         const { data: tokenInfo } = await clientService.httpAuthenticated.post(
           '/sciencemesh/generate-invite',
           {
-            params: {
-              ...(description && { description }),
-              ...(recipient && { recipient })
-            }
+            ...(description && { description }),
+            ...(recipient && { recipient })
           },
           {
             schema: inviteSchema


### PR DESCRIPTION
## Description
this pr adds the email and description json param top level instead of having it nested inside a params key.

## Related Issue
- https://github.com/cs3org/reva/pull/4832
- https://github.com/owncloud/ocis/issues/9583
- https://github.com/owncloud/ocis/pull/9966

## How Has This Been Tested?
- since this is a ongoing ocm optimization currently only via my local installation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)