### PR TITLE
fix: logout when token renewal fails

### DIFF
--- a/changelog/unreleased/bugfix-logut-on-token-failure
+++ b/changelog/unreleased/bugfix-logut-on-token-failure
@@ -1,0 +1,6 @@
+Bugfix: Logout on access token renewal failure
+
+We've fixed the issue with the user being able to navigate the Web UI after a failed token renewal. Instead, the user is now properly being logged out.
+
+https://github.com/owncloud/web/pull/11526
+https://github.com/owncloud/web/issues/11478

--- a/packages/web-pkg/src/composables/authContext/useAuthService.ts
+++ b/packages/web-pkg/src/composables/authContext/useAuthService.ts
@@ -5,6 +5,7 @@ export interface AuthServiceInterface {
   handleAuthError(route: any): any
   signinSilent(): Promise<unknown>
   logoutUser(): Promise<void | NavigationFailure>
+  getRefreshToken(): Promise<string>
 }
 
 export const useAuthService = (): AuthServiceInterface => {

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -350,6 +350,11 @@ export class AuthService implements AuthServiceInterface {
     this.authStore.clearUserContext()
   }
 
+  public async getRefreshToken() {
+    const user = await this.userManager.getUser()
+    return user?.refresh_token
+  }
+
   private handleDelegatedTokenUpdate(event: MessageEvent) {
     if (
       this.configStore.options.embed?.delegateAuthenticationOrigin &&


### PR DESCRIPTION



## Description
Adds a logout when the token renewal fails for some reason. This fixes the issue with the user being able to access the Web UI without a valid token, leading to a broken state.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/11478

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

