### PR TITLE
bugfix(ocm): exclude the local instance in the inviter select

### DIFF
--- a/changelog/unreleased/bugfix-ocm-local-instance-check
+++ b/changelog/unreleased/bugfix-ocm-local-instance-check
@@ -1,0 +1,5 @@
+Bugfix: OCM local instance check
+
+We've fixed the issue where the current instance was not recognized as a local instance in inviter select.
+
+https://github.com/owncloud/web/pull/11560

--- a/packages/web-app-ocm/src/views/IncomingInvitations.vue
+++ b/packages/web-app-ocm/src/views/IncomingInvitations.vue
@@ -35,7 +35,7 @@
                 <span class="option" v-text="domain" />
               </div>
             </template>
-            <template #no-options> No institutions found with this name </template>
+            <template #no-options> No institutions found with this name</template>
             <template #selected-option="{ full_name, domain }">
               <div class="options-wrapper oc-text-break">
                 <strong class="oc-mr-s oc-text-break" v-text="full_name" />
@@ -155,7 +155,22 @@ export default defineComponent({
       }
     }
     const isMyProviderSelectedProvider = (p: ProviderSchema) => {
-      return p.domain === new URL(configStore.serverUrl).hostname
+      // the protocol is not important, we just need the host and port, it's there to make it compatible with URL
+      const toURL = (purl: string) =>
+        new URL(purl.split('://').length === 1 ? `https://${purl}` : purl)
+      const { host: configStoreHost, port: configStorePort } = toURL(configStore.serverUrl)
+      const { host: providerSchemaHost, port: providerSchemaPort } = toURL(p.domain)
+
+      return [
+        // ensure that the config store host is not empty, minimal check
+        !!configStoreHost,
+        // ensure that the provider schema host is not empty, minimal check
+        !!providerSchemaHost,
+        // check if the host is the same
+        configStoreHost === providerSchemaHost,
+        // also check the port, multiple instances can run on the same host but not on the same port...
+        configStorePort === providerSchemaPort
+      ].every((c) => c)
     }
 
     const handleParams = (to: RouteLocationNormalized) => {


### PR DESCRIPTION
## Description
this fixes a bug where the local instance was listed in the inviter select.

## Motivation and Context
reduce confusion by removing the current (users instance) from the inviter select.

## Screenshots (if appropriate):

### the current user is on https://ocis.ocm.i2:10200/
![Screenshot 2024-09-10 at 10 03 20](https://github.com/user-attachments/assets/de1e1d57-9fd6-43ee-b3b2-2a56b95ed9bf)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
