### PR TITLE
feat: add blob to csp connect-src

### DIFF
--- a/dev/docker/ocis/csp.yaml
+++ b/dev/docker/ocis/csp.yaml
@@ -3,6 +3,7 @@ directives:
     - '''self'''
   connect-src:
     - '''self'''
+    - 'blob:'
     - 'https://raw.githubusercontent.com/owncloud/awesome-ocis/'
   default-src:
     - '''none'''


### PR DESCRIPTION
I added `blob:` to the default csp rules in ocis with https://github.com/owncloud/ocis/pull/9993

Doing the same here for the dev stack.