### PR TITLE
feat: add custom date range filter

### DIFF
--- a/packages/design-system/src/components/OcDatepicker/OcDatepicker.vue
+++ b/packages/design-system/src/components/OcDatepicker/OcDatepicker.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, PropType, ref, unref, watch } from 'vue'
+import { computed, defineComponent, PropType, ref, unref, watch } from 'vue'
 import { useGettext } from 'vue3-gettext'
 import { DateTime } from 'luxon'
 export default defineComponent({
@@ -56,11 +56,18 @@ export default defineComponent({
       return ''
     })
 
-    onMounted(() => {
-      if (props.currentDate) {
-        dateInputString.value = props.currentDate.toISODate()
-      }
-    })
+    watch(
+      () => props.currentDate,
+      () => {
+        if (props.currentDate) {
+          dateInputString.value = props.currentDate.toISODate()
+          return
+        }
+
+        dateInputString.value = undefined
+      },
+      { immediate: true }
+    )
 
     watch(
       date,

--- a/packages/design-system/src/components/OcFilterChip/OcFilterChip.vue
+++ b/packages/design-system/src/components/OcFilterChip/OcFilterChip.vue
@@ -25,6 +25,7 @@
     </oc-button>
     <oc-drop
       v-if="!isToggle"
+      ref="dropRef"
       :toggle="'#' + id"
       class="oc-filter-chip-drop"
       mode="click"
@@ -49,8 +50,9 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, PropType } from 'vue'
+import { computed, defineComponent, PropType, ref, unref } from 'vue'
 import uniqueId from '../../utils/uniqueId'
+import OcDrop from '../OcDrop/OcDrop.vue'
 
 export default defineComponent({
   name: 'OcFilterChip',
@@ -107,14 +109,23 @@ export default defineComponent({
     }
   },
   emits: ['clearFilter', 'hideDrop', 'showDrop', 'toggleFilter'],
-  setup(props) {
+  setup(props, { expose }) {
+    const dropRef = ref<typeof OcDrop>()
+
     const filterActive = computed(() => {
       if (props.isToggle) {
         return props.isToggleActive
       }
       return !!props.selectedItemNames.length
     })
-    return { filterActive }
+
+    const hideDrop = () => {
+      unref(dropRef)?.hide()
+    }
+
+    expose({ hideDrop })
+
+    return { filterActive, dropRef }
   }
 })
 </script>

--- a/packages/web-pkg/src/components/Filters/DateFilter.vue
+++ b/packages/web-pkg/src/components/Filters/DateFilter.vue
@@ -1,0 +1,390 @@
+<template>
+  <div class="date-filter oc-flex" :class="`date-filter-${filterName}`">
+    <oc-filter-chip
+      ref="filterChip"
+      :filter-label="filterLabel"
+      :selected-item-names="selectedItem ? [selectedItem[displayNameAttribute]] : undefined"
+      @clear-filter="clearFilter"
+      @show-drop="onShowDrop"
+      @hide-drop="onHideDrop"
+    >
+      <template #default>
+        <oc-list class="date-filter-list" :class="{ 'date-filter-list-hidden': dateRangeClicked }">
+          <li v-for="(item, index) in displayedItems" :key="index" class="oc-my-xs">
+            <oc-button
+              class="date-filter-list-item oc-flex oc-flex-between oc-flex-middle oc-width-1-1 oc-p-xs"
+              :class="{
+                'date-filter-list-item-active': isItemSelected(item)
+              }"
+              justify-content="space-between"
+              appearance="raw"
+              :data-testid="item[displayNameAttribute as keyof Item]"
+              @click="toggleItemSelection(item)"
+            >
+              <div class="oc-flex oc-flex-middle oc-text-truncate">
+                <div class="oc-text-truncate oc-ml-s">
+                  <slot name="item" :item="item" />
+                </div>
+              </div>
+              <div class="oc-flex">
+                <oc-icon v-if="isItemSelected(item)" name="check" />
+              </div>
+            </oc-button>
+          </li>
+          <li class="oc-my-xs">
+            <oc-button
+              class="date-filter-list-item oc-flex oc-flex-between oc-flex-middle oc-width-1-1 oc-p-xs"
+              :class="{
+                'date-filter-list-item-active': dateRangeApplied
+              }"
+              justify-content="space-between"
+              appearance="raw"
+              data-testid="custom-date-range"
+              @click="dateRangeClicked = true"
+            >
+              <div class="oc-flex oc-flex-middle oc-text-truncate">
+                <div class="oc-text-truncate oc-ml-s">
+                  <span v-text="$gettext('Custom date range')" />
+                </div>
+              </div>
+              <div class="oc-flex">
+                <oc-icon v-if="dateRangeApplied" name="check" />
+              </div>
+            </oc-button>
+          </li>
+        </oc-list>
+        <div
+          class="date-filter-range-panel oc-py-s"
+          :class="{ 'date-filter-range-panel-active': dateRangeClicked }"
+        >
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-mb-m">
+            <oc-button
+              appearance="raw"
+              class="date-filter-range-panel-back"
+              :aria-label="$gettext('Go back to filter options')"
+              @click="dateRangeClicked = false"
+            >
+              <oc-icon name="arrow-left-s" fill-type="line" />
+            </oc-button>
+            <span v-text="$gettext('Custom date range')" />
+            <oc-button
+              appearance="raw"
+              class="date-filter-range-panel-close"
+              :aria-label="$gettext('Close filter')"
+              @click="filterChip.hideDrop()"
+            >
+              <oc-icon name="close" />
+            </oc-button>
+          </div>
+          <div class="oc-mt-s">
+            <oc-datepicker
+              :label="$gettext('From')"
+              type="date"
+              :is-clearable="true"
+              :current-date="fromDate"
+              @date-changed="(value) => setDateRangeDate(value, 'from')"
+            />
+            <oc-datepicker
+              :label="$gettext('To')"
+              type="date"
+              :is-clearable="true"
+              :current-date="toDate"
+              :min-date="fromDate ? fromDate : undefined"
+              @date-changed="(value) => setDateRangeDate(value, 'to')"
+            />
+          </div>
+          <div class="date-filter-apply-btn">
+            <oc-button
+              appearance="outline"
+              variation="passive"
+              size="small"
+              :disabled="!dateRangeValid"
+              @click="applyDateRangeFilter"
+            >
+              {{ $gettext('Apply') }}
+            </oc-button>
+          </div>
+        </div>
+      </template>
+    </oc-filter-chip>
+  </div>
+</template>
+
+<script lang="ts">
+import { PropType, computed, defineComponent, onMounted, ref, unref } from 'vue'
+import omit from 'lodash-es/omit'
+import { useRoute, useRouteQuery, useRouter } from '../../composables'
+import { formatDateFromDateTime } from '../../helpers'
+import { queryItemAsString } from '../../composables/appDefaults'
+import { DateTime } from 'luxon'
+import { useGettext } from 'vue3-gettext'
+import { OcFilterChip } from 'design-system/src/components'
+
+type Item = Record<string, string>
+
+export default defineComponent({
+  name: 'DateFilter',
+  props: {
+    filterLabel: {
+      type: String,
+      required: true
+    },
+    filterName: {
+      type: String,
+      required: true
+    },
+    items: {
+      type: Array as PropType<Item[]>,
+      required: true
+    },
+    idAttribute: {
+      type: String,
+      required: false,
+      default: 'id'
+    },
+    displayNameAttribute: {
+      type: String,
+      required: false,
+      default: 'name'
+    }
+  },
+  emits: ['selectionChange'],
+  setup: function (props, { emit, expose }) {
+    const router = useRouter()
+    const { current: currentLanguage } = useGettext()
+    const currentRoute = useRoute()
+    const selectedItem = ref<Item>()
+    const displayedItems = ref(props.items)
+    const fromDate = ref<DateTime>()
+    const toDate = ref<DateTime>()
+    const dateRangeClicked = ref(false)
+    const filterChip = ref<typeof OcFilterChip>()
+
+    const queryParam = `q_${props.filterName}`
+    const currentRouteQuery = useRouteQuery(queryParam)
+
+    const getId = (item: Item) => {
+      return item[props.idAttribute as keyof Item]
+    }
+
+    const setRouteQuery = () => {
+      return router.push({
+        query: {
+          ...omit(unref(currentRoute).query, [queryParam]),
+          ...(unref(selectedItem) && {
+            [queryParam]: getId(unref(selectedItem))
+          })
+        }
+      })
+    }
+
+    const isItemSelected = (item: Item) => {
+      return unref(selectedItem) && getId(unref(selectedItem)) === getId(item)
+    }
+
+    const resetDateRange = () => {
+      fromDate.value = undefined
+      toDate.value = undefined
+    }
+
+    const toggleItemSelection = async (item: Item) => {
+      resetDateRange()
+      if (isItemSelected(item)) {
+        selectedItem.value = undefined
+      } else {
+        selectedItem.value = item
+        unref(filterChip).hideDrop()
+      }
+      await setRouteQuery()
+      emit('selectionChange', unref(selectedItem))
+    }
+
+    const clearFilter = () => {
+      selectedItem.value = undefined
+      dateRangeClicked.value = false
+      resetDateRange()
+      emit('selectionChange', unref(selectedItem))
+      setRouteQuery()
+    }
+
+    const onShowDrop = () => {
+      displayedItems.value = props.items
+    }
+
+    const onHideDrop = () => {
+      dateRangeClicked.value = false
+    }
+
+    const setSelectedItemsBasedOnQuery = () => {
+      const id = queryItemAsString(unref(currentRouteQuery))
+      if (!id) {
+        return
+      }
+
+      const selected = props.items.find((s) => getId(s) === id)
+      if (selected) {
+        selectedItem.value = selected
+        return
+      }
+
+      if (unref(dateRangeApplied)) {
+        const dateRange = id.replace('range:', '')
+        const from = Number(dateRange.split(' - ')[0])
+        const to = Number(dateRange.split(' - ')[1])
+        fromDate.value = DateTime.fromMillis(from)
+        toDate.value = DateTime.fromMillis(to)
+        selectedItem.value = unref(dateRangeOption)
+      }
+    }
+
+    const dateRangeApplied = computed(() =>
+      queryItemAsString(unref(currentRouteQuery))?.startsWith('range:')
+    )
+
+    const dateRangeValid = computed(() => {
+      if (!unref(fromDate) || !unref(toDate)) {
+        return false
+      }
+      return unref(fromDate) <= unref(toDate)
+    })
+
+    const dateRangeOption = computed(() => {
+      if (!unref(fromDate) || !unref(toDate)) {
+        return null
+      }
+
+      const from = formatDateFromDateTime(unref(fromDate), currentLanguage, DateTime.DATE_SHORT)
+      const to = formatDateFromDateTime(unref(toDate), currentLanguage, DateTime.DATE_SHORT)
+      const fromDateMillis = unref(fromDate).toMillis()
+      const toDateMillis = unref(toDate).toMillis()
+
+      return {
+        [props.idAttribute]: `range:${fromDateMillis} - ${toDateMillis}`,
+        [props.displayNameAttribute]: `${from} - ${to}`
+      }
+    })
+
+    const applyDateRangeFilter = async () => {
+      selectedItem.value = unref(dateRangeOption)
+      await setRouteQuery()
+      unref(filterChip).hideDrop()
+      emit('selectionChange', unref(selectedItem))
+    }
+
+    const setDateRangeDate = (
+      { date, error }: { date: DateTime; error: Error },
+      type: 'from' | 'to'
+    ) => {
+      if (error) {
+        console.error(error)
+        return
+      }
+
+      const prop = type === 'from' ? fromDate : toDate
+
+      if (!date) {
+        prop.value = undefined
+        return
+      }
+
+      const formattedDate = type === 'from' ? date.startOf('day') : date.endOf('day')
+      prop.value = formattedDate
+    }
+
+    expose({ setSelectedItemsBasedOnQuery })
+
+    onMounted(() => {
+      setSelectedItemsBasedOnQuery()
+    })
+
+    return {
+      clearFilter,
+      displayedItems,
+      isItemSelected,
+      selectedItem,
+      onShowDrop,
+      onHideDrop,
+      filterChip,
+      toggleItemSelection,
+      setSelectedItemsBasedOnQuery,
+      fromDate,
+      toDate,
+      dateRangeValid,
+      applyDateRangeFilter,
+      dateRangeApplied,
+      setDateRangeDate,
+      dateRangeClicked,
+
+      // for unit tests
+      queryParam
+    }
+  }
+})
+</script>
+
+<style lang="scss">
+.date-filter {
+  overflow: hidden;
+
+  &-list {
+    li {
+      &:first-child {
+        margin-top: 0 !important;
+      }
+      &:last-child {
+        margin-bottom: 0 !important;
+      }
+    }
+
+    &-item {
+      line-height: 1.5;
+      gap: 8px;
+
+      &:hover,
+      &-active {
+        background-color: var(--oc-color-background-hover) !important;
+      }
+    }
+
+    &-hidden {
+      min-height: 225px;
+      visibility: hidden;
+      transition: visibility 0.4s 0s;
+    }
+  }
+
+  &-apply-btn {
+    text-align: end;
+  }
+
+  &-range-panel {
+    transform: translateX(100%);
+    transition:
+      transform 0.4s ease,
+      visibility 0.4s 0s;
+    visibility: hidden;
+    position: absolute;
+    width: calc(100% - var(--oc-space-medium));
+    background: #fff;
+    top: 0;
+    color: var(--oc-color-swatch-passive-default);
+
+    &-active {
+      visibility: unset;
+      transform: translateX(0);
+
+      .oc-card {
+        overflow: unset;
+      }
+    }
+  }
+
+  .oc-card {
+    overflow: hidden;
+  }
+
+  .oc-date-picker label {
+    font-size: var(--oc-font-size-small);
+  }
+}
+</style>

--- a/packages/web-pkg/src/components/Filters/index.ts
+++ b/packages/web-pkg/src/components/Filters/index.ts
@@ -1,2 +1,3 @@
+export { default as DateFilter } from './DateFilter.vue'
 export { default as ItemFilterInline } from './ItemFilterInline.vue'
 export * from './types'

--- a/packages/web-pkg/tests/unit/components/Filters/DateFilter.spec.ts
+++ b/packages/web-pkg/tests/unit/components/Filters/DateFilter.spec.ts
@@ -1,0 +1,155 @@
+import DateFilter from '../../../../src/components/Filters/DateFilter.vue'
+import {
+  PartialComponentProps,
+  defaultComponentMocks,
+  defaultPlugins,
+  mount
+} from 'web-test-helpers'
+import { queryItemAsString } from '../../../../src/composables/appDefaults'
+import { DateTime } from 'luxon'
+
+vi.mock('../../../../src/composables/appDefaults')
+
+const filterItems = [
+  { id: '1', name: 'today' },
+  { id: '2', name: 'yesterday' }
+]
+
+const selectors = {
+  filterListItem: '.date-filter-list-item',
+  filterChipLabel: '.oc-filter-chip-label',
+  activeFilterListItemSpan: '.date-filter-list-item-active .oc-text-truncate span',
+  customDateRangeBtn: '[data-testid="custom-date-range"]',
+  customDateRangePanel: '.date-filter-range-panel',
+  customDateRangeApplyBtn: '.date-filter-apply-btn button',
+  customDateRangeBackBtn: '.date-filter-range-panel-back'
+}
+
+describe('DateFilter', () => {
+  it('renders all items', () => {
+    const { wrapper } = getWrapper()
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+  it('can use a custom attribute as display name', () => {
+    const filterItems = [
+      { id: '1', displayName: 'today' },
+      { id: '2', displayName: 'yesterday' }
+    ]
+    const { wrapper } = getWrapper({
+      props: { displayNameAttribute: 'displayName', items: filterItems }
+    })
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
+  describe('route query', () => {
+    it('sets the selected item as route query param', async () => {
+      const { wrapper, mocks } = getWrapper()
+      const item = wrapper.findAll(selectors.filterListItem).at(0)
+      expect(mocks.$router.push).not.toHaveBeenCalled()
+      await item.trigger('click')
+      expect(mocks.$router.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({ [wrapper.vm.queryParam]: '1' })
+        })
+      )
+    })
+    it('sets the selected items initially when given via query param', () => {
+      const { wrapper } = getWrapper({ initialQuery: '1' })
+      expect(wrapper.vm.selectedItem).toEqual(filterItems[0])
+    })
+  })
+
+  describe('custom date range', () => {
+    it('shows the option and panel for picking a custom date range', () => {
+      const { wrapper } = getWrapper()
+      expect(wrapper.find(selectors.customDateRangeBtn).exists()).toBeTruthy()
+      expect(wrapper.find(selectors.customDateRangePanel).exists()).toBeTruthy()
+    })
+    it('shows the custom date range as filter chip label when selected', async () => {
+      const fromDate = DateTime.now().minus({ days: 1 })
+      const toDate = DateTime.now()
+      const { wrapper } = getWrapper({
+        initialQuery: `range:${fromDate.toMillis()} - ${toDate.toMillis()}`
+      })
+      await wrapper.vm.$nextTick()
+      const filterChipLabel = wrapper.find(selectors.filterChipLabel)
+      expect(filterChipLabel.text()).toContain(
+        `${fromDate.setLocale('en').toLocaleString()} - ${toDate.setLocale('en').toLocaleString()}`
+      )
+    })
+    it('correctly marks the "Custom date range"-option as selected', async () => {
+      const fromDate = DateTime.now().minus({ days: 1 })
+      const toDate = DateTime.now()
+      const { wrapper } = getWrapper({
+        initialQuery: `range:${fromDate.toMillis()} - ${toDate.toMillis()}`
+      })
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find(selectors.activeFilterListItemSpan).text()).toEqual('Custom date range')
+    })
+    it('back button should close the custom date range panel', async () => {
+      const { wrapper } = getWrapper()
+      wrapper.vm.dateRangeClicked = true
+      await wrapper.vm.$nextTick()
+      const backBtn = wrapper.find(selectors.customDateRangeBackBtn)
+      await backBtn.trigger('click')
+      expect(wrapper.vm.dateRangeClicked).toBeFalsy()
+    })
+    describe('apply button', () => {
+      it('is not clickable without dates entered', async () => {
+        const { wrapper } = getWrapper()
+        const applyBtn = wrapper.find(selectors.customDateRangeApplyBtn)
+        await applyBtn.trigger('click')
+        expect(wrapper.emitted('selectionChange')).not.toBeDefined()
+      })
+      it('is not clickable when from date is after to date', async () => {
+        const { wrapper } = getWrapper()
+        wrapper.vm.fromDate = DateTime.now().plus({ days: 1 })
+        wrapper.vm.toDate = DateTime.now()
+        await wrapper.vm.$nextTick()
+        const applyBtn = wrapper.find(selectors.customDateRangeApplyBtn)
+        await applyBtn.trigger('click')
+        expect(wrapper.emitted('selectionChange')).not.toBeDefined()
+      })
+      it('emits a selection change on click with today entered as date', async () => {
+        const { wrapper } = getWrapper()
+        wrapper.vm.fromDate = DateTime.now()
+        wrapper.vm.toDate = DateTime.now()
+        await wrapper.vm.$nextTick()
+        const applyBtn = wrapper.find(selectors.customDateRangeApplyBtn)
+        await applyBtn.trigger('click')
+        expect(wrapper.emitted('selectionChange')).toBeDefined()
+      })
+    })
+  })
+})
+
+function getWrapper({
+  props = {},
+  initialQuery = ''
+}: { props?: PartialComponentProps<typeof DateFilter>; initialQuery?: string } = {}) {
+  vi.mocked(queryItemAsString).mockImplementation(() => initialQuery)
+  const mocks = defaultComponentMocks()
+
+  return {
+    mocks,
+    wrapper: mount(DateFilter, {
+      props: {
+        filterLabel: 'Users',
+        filterName: 'users',
+        items: filterItems,
+        ...props
+      },
+      slots: {
+        item(data) {
+          return props.displayNameAttribute ? data.item[props.displayNameAttribute] : data.item.name
+        }
+      },
+      global: {
+        plugins: [...defaultPlugins()],
+        mocks,
+        provide: mocks,
+        stubs: { OcCheckbox: true }
+      }
+    })
+  }
+}

--- a/packages/web-pkg/tests/unit/components/Filters/__snapshots__/DateFilter.spec.ts.snap
+++ b/packages/web-pkg/tests/unit/components/Filters/__snapshots__/DateFilter.spec.ts.snap
@@ -1,0 +1,167 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`DateFilter > can use a custom attribute as display name 1`] = `
+"<div class="date-filter oc-flex date-filter-users">
+  <div class="oc-filter-chip oc-flex"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-filter-chip-button oc-pill" id="oc-filter-chip-5">
+      <!--v-if-->
+      <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive oc-filter-check-icon-inactive"><!----></span> <span class="oc-text-truncate oc-filter-chip-label">Users</span>
+      <!--v-if--> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span>
+    </button>
+    <div id="oc-drop-6" class="oc-drop oc-box-shadow-medium oc-rounded oc-filter-chip-drop">
+      <div class="oc-card oc-card-body oc-background-secondary oc-p-s">
+        <ul class="oc-list oc-my-rm oc-mx-rm date-filter-list">
+          <li class="oc-my-xs"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-space-between oc-button-gap-m oc-button-passive oc-button-passive-raw date-filter-list-item oc-flex oc-flex-between oc-flex-middle oc-width-1-1 oc-p-xs" data-testid="today">
+              <!--v-if-->
+              <!-- @slot Content of the button -->
+              <div class="oc-flex oc-flex-middle oc-text-truncate">
+                <div class="oc-text-truncate oc-ml-s">today</div>
+              </div>
+              <div class="oc-flex">
+                <!--v-if-->
+              </div>
+            </button></li>
+          <li class="oc-my-xs"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-space-between oc-button-gap-m oc-button-passive oc-button-passive-raw date-filter-list-item oc-flex oc-flex-between oc-flex-middle oc-width-1-1 oc-p-xs" data-testid="yesterday">
+              <!--v-if-->
+              <!-- @slot Content of the button -->
+              <div class="oc-flex oc-flex-middle oc-text-truncate">
+                <div class="oc-text-truncate oc-ml-s">yesterday</div>
+              </div>
+              <div class="oc-flex">
+                <!--v-if-->
+              </div>
+            </button></li>
+          <li class="oc-my-xs"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-space-between oc-button-gap-m oc-button-passive oc-button-passive-raw date-filter-list-item oc-flex oc-flex-between oc-flex-middle oc-width-1-1 oc-p-xs" data-testid="custom-date-range">
+              <!--v-if-->
+              <!-- @slot Content of the button -->
+              <div class="oc-flex oc-flex-middle oc-text-truncate">
+                <div class="oc-text-truncate oc-ml-s"><span>Custom date range</span></div>
+              </div>
+              <div class="oc-flex">
+                <!--v-if-->
+              </div>
+            </button></li>
+        </ul>
+        <div class="date-filter-range-panel oc-py-s">
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-mb-m"><button type="button" aria-label="Go back to filter options" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw date-filter-range-panel-back">
+              <!--v-if-->
+              <!-- @slot Content of the button --> <span class="oc-icon oc-icon-m oc-icon-passive"><!----></span>
+            </button> <span>Custom date range</span> <button type="button" aria-label="Close filter" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw date-filter-range-panel-close">
+              <!--v-if-->
+              <!-- @slot Content of the button --> <span class="oc-icon oc-icon-m oc-icon-passive"><!----></span>
+            </button></div>
+          <div class="oc-mt-s">
+            <div class="oc-date-picker"><label class="oc-label" for="oc-textinput-7">From</label>
+              <div class="oc-position-relative">
+                <!--v-if--> <input id="oc-textinput-7" aria-invalid="false" class="oc-text-input oc-input oc-rounded" type="date" value="">
+                <!--v-if-->
+              </div>
+              <div class="oc-text-input-message">
+                <!--v-if--> <span id="oc-textinput-7-message" class=""></span>
+              </div>
+              <!--v-if-->
+            </div>
+            <div class="oc-date-picker"><label class="oc-label" for="oc-textinput-8">To</label>
+              <div class="oc-position-relative">
+                <!--v-if--> <input id="oc-textinput-8" aria-invalid="false" class="oc-text-input oc-input oc-rounded" type="date" value="">
+                <!--v-if-->
+              </div>
+              <div class="oc-text-input-message">
+                <!--v-if--> <span id="oc-textinput-8-message" class=""></span>
+              </div>
+              <!--v-if-->
+            </div>
+          </div>
+          <div class="date-filter-apply-btn"><button type="button" disabled="" class="oc-button oc-rounded oc-button-s oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-outline">
+              <!--v-if-->
+              <!-- @slot Content of the button --> Apply
+            </button></div>
+        </div>
+      </div>
+    </div>
+    <!--v-if-->
+  </div>
+</div>"
+`;
+
+exports[`DateFilter > renders all items 1`] = `
+"<div class="date-filter oc-flex date-filter-users">
+  <div class="oc-filter-chip oc-flex"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-filter-chip-button oc-pill" id="oc-filter-chip-1">
+      <!--v-if-->
+      <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive oc-filter-check-icon-inactive"><!----></span> <span class="oc-text-truncate oc-filter-chip-label">Users</span>
+      <!--v-if--> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span>
+    </button>
+    <div id="oc-drop-2" class="oc-drop oc-box-shadow-medium oc-rounded oc-filter-chip-drop">
+      <div class="oc-card oc-card-body oc-background-secondary oc-p-s">
+        <ul class="oc-list oc-my-rm oc-mx-rm date-filter-list">
+          <li class="oc-my-xs"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-space-between oc-button-gap-m oc-button-passive oc-button-passive-raw date-filter-list-item oc-flex oc-flex-between oc-flex-middle oc-width-1-1 oc-p-xs" data-testid="today">
+              <!--v-if-->
+              <!-- @slot Content of the button -->
+              <div class="oc-flex oc-flex-middle oc-text-truncate">
+                <div class="oc-text-truncate oc-ml-s">today</div>
+              </div>
+              <div class="oc-flex">
+                <!--v-if-->
+              </div>
+            </button></li>
+          <li class="oc-my-xs"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-space-between oc-button-gap-m oc-button-passive oc-button-passive-raw date-filter-list-item oc-flex oc-flex-between oc-flex-middle oc-width-1-1 oc-p-xs" data-testid="yesterday">
+              <!--v-if-->
+              <!-- @slot Content of the button -->
+              <div class="oc-flex oc-flex-middle oc-text-truncate">
+                <div class="oc-text-truncate oc-ml-s">yesterday</div>
+              </div>
+              <div class="oc-flex">
+                <!--v-if-->
+              </div>
+            </button></li>
+          <li class="oc-my-xs"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-space-between oc-button-gap-m oc-button-passive oc-button-passive-raw date-filter-list-item oc-flex oc-flex-between oc-flex-middle oc-width-1-1 oc-p-xs" data-testid="custom-date-range">
+              <!--v-if-->
+              <!-- @slot Content of the button -->
+              <div class="oc-flex oc-flex-middle oc-text-truncate">
+                <div class="oc-text-truncate oc-ml-s"><span>Custom date range</span></div>
+              </div>
+              <div class="oc-flex">
+                <!--v-if-->
+              </div>
+            </button></li>
+        </ul>
+        <div class="date-filter-range-panel oc-py-s">
+          <div class="oc-flex oc-flex-middle oc-flex-between oc-mb-m"><button type="button" aria-label="Go back to filter options" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw date-filter-range-panel-back">
+              <!--v-if-->
+              <!-- @slot Content of the button --> <span class="oc-icon oc-icon-m oc-icon-passive"><!----></span>
+            </button> <span>Custom date range</span> <button type="button" aria-label="Close filter" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw date-filter-range-panel-close">
+              <!--v-if-->
+              <!-- @slot Content of the button --> <span class="oc-icon oc-icon-m oc-icon-passive"><!----></span>
+            </button></div>
+          <div class="oc-mt-s">
+            <div class="oc-date-picker"><label class="oc-label" for="oc-textinput-3">From</label>
+              <div class="oc-position-relative">
+                <!--v-if--> <input id="oc-textinput-3" aria-invalid="false" class="oc-text-input oc-input oc-rounded" type="date" value="">
+                <!--v-if-->
+              </div>
+              <div class="oc-text-input-message">
+                <!--v-if--> <span id="oc-textinput-3-message" class=""></span>
+              </div>
+              <!--v-if-->
+            </div>
+            <div class="oc-date-picker"><label class="oc-label" for="oc-textinput-4">To</label>
+              <div class="oc-position-relative">
+                <!--v-if--> <input id="oc-textinput-4" aria-invalid="false" class="oc-text-input oc-input oc-rounded" type="date" value="">
+                <!--v-if-->
+              </div>
+              <div class="oc-text-input-message">
+                <!--v-if--> <span id="oc-textinput-4-message" class=""></span>
+              </div>
+              <!--v-if-->
+            </div>
+          </div>
+          <div class="date-filter-apply-btn"><button type="button" disabled="" class="oc-button oc-rounded oc-button-s oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-outline">
+              <!--v-if-->
+              <!-- @slot Content of the button --> Apply
+            </button></div>
+        </div>
+      </div>
+    </div>
+    <!--v-if-->
+  </div>
+</div>"
+`;


### PR DESCRIPTION
## Description
Adds a filter for custom date ranges. This is needed for the soon to come activities app.

The filter stores the custom dates in a query param as milliseconds because that's a nice format for URLs. That means the implementing party might need to convert it to an actual date when working with the filter.

<img width="329" alt="image" src="https://github.com/user-attachments/assets/25e3a34e-5c95-49f6-8098-56d17d343e1e">

<img width="324" alt="image" src="https://github.com/user-attachments/assets/803a17a4-fa23-4d73-9b95-dbdd4601e19a">

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Closes https://github.com/owncloud/web/issues/11546

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
