### PR TITLE
[full-ci] bump ocis- run all e2e tests

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=91969e6434471b49e64d3c2b97da62d7c94789f0
+OCIS_COMMITID=19a7e945738eec4d6be2946570d7980570f69df4
 OCIS_BRANCH=master


### PR DESCRIPTION
part of release process 