### PR TITLE
feat: add min oCIS to app releases table

### DIFF
--- a/changelog/unreleased/enhancement-app-store-min-ocis-version
+++ b/changelog/unreleased/enhancement-app-store-min-ocis-version
@@ -1,0 +1,5 @@
+Enhancement: Show min oCIS version in app details (app store)
+
+We're now showing the minimum required oCIS version of apps in the app releases of the app store.
+
+https://github.com/owncloud/web/pull/11580

--- a/packages/web-app-app-store/src/components/AppVersions.vue
+++ b/packages/web-app-app-store/src/components/AppVersions.vue
@@ -1,11 +1,5 @@
 <template>
-  <oc-table
-    class="oc-width-1-1"
-    :data="data"
-    :fields="fields"
-    padding-x="remove"
-    :has-header="false"
-  >
+  <oc-table class="oc-width-1-1" :data="data" :fields="fields" padding-x="remove">
     <template #version="{ item }">
       v{{ item.version }}
       <oc-tag v-if="item.version === app.mostRecentVersion.version" size="small" class="oc-ml-s">
@@ -41,6 +35,7 @@ export default defineComponent({
       return props.app.versions.map((version) => {
         return {
           ...version,
+          minOCIS: version.minOCIS ? `v${version.minOCIS}` : '-',
           id: version.version
         }
       })
@@ -48,17 +43,26 @@ export default defineComponent({
     const fields = computed(() => {
       return [
         {
+          name: 'minOCIS',
+          type: 'raw',
+          width: 'shrink',
+          wrap: 'nowrap',
+          title: $gettext('oCIS Version')
+        },
+        {
           name: 'version',
           type: 'slot',
           width: 'expand',
-          wrap: 'truncate'
+          wrap: 'truncate',
+          title: $gettext('App Version')
         },
         {
           name: 'actions',
           type: 'slot',
           alignH: 'right',
           width: 'shrink',
-          wrap: 'nowrap'
+          wrap: 'nowrap',
+          title: ''
         }
       ]
     })

--- a/packages/web-app-app-store/src/types.ts
+++ b/packages/web-app-app-store/src/types.ts
@@ -12,6 +12,7 @@ export const AppStoreConfigSchema = z.object({
 
 export const AppVersionSchema = z.object({
   version: z.string(),
+  minOCIS: z.string().optional(),
   url: z.string(),
   filename: z.string().optional()
 })


### PR DESCRIPTION
## Description
This PR adds a `minOCIS` field to the app version schema and displays its value in the app releases table in the app store app details.

## Motivation and Context
Show min required ocis version to admins.

## Screenshots (if appropriate):

<img width="602" alt="Screenshot 2024-09-13 at 15 42 57" src="https://github.com/user-attachments/assets/ee7a79de-3a78-44c3-911a-5b451a835c46">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
