### PR TITLE
fix: idp logout issues when token renewal fails

### DIFF
--- a/changelog/unreleased/bugfix-logout-issues-token-renewal-failure
+++ b/changelog/unreleased/bugfix-logout-issues-token-renewal-failure
@@ -1,0 +1,9 @@
+Bugfix: Logout issues on token renewal failure
+
+When token renewal fails for any reason, we now retry the user login one more time. If this fails, the user gets logged out and redirected to the login page.
+
+This solves an issue where a logged out user was still able to access and navigate the UI in a broken state.
+
+https://github.com/owncloud/web/pull/11584
+https://github.com/owncloud/web/issues/11478
+https://github.com/owncloud/ocis/issues/10038

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -340,8 +340,8 @@ export function buildSpace(
       }
       return user.memberOf?.some((group) => !!this.members[group.id])
     },
-    isOwner({ id }: User): boolean {
-      return id === this.owner?.id
+    isOwner(user: User): boolean {
+      return user?.id === this.owner?.id
     }
   } satisfies SpaceResource
   Object.defineProperty(s, 'nodeId', {

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -145,7 +145,7 @@ export class AuthService implements AuthServiceInterface {
             this.handleAuthError(unref(this.router.currentRoute), { forceLogout: true })
           }
 
-          // retry silent signin once, force logoout if it fails
+          // retry silent signin once, force logout if it fails
           this.userManager.signinSilent().catch(handleExpirationError)
         })
 


### PR DESCRIPTION
## Description
Adds a silent signIn retry when token renewal fails for some reasons. If the retry fails again, then force the user to logout. This is the "old" behavior from `stable-8.0` for the most part, expect for the forced logout.

We might want to force the logout in other scenarios as well, e.g. when the webfinger app receives a `401` status code from the server. This might solve the webfinger issues we have on newer instances, although I can't confirm that.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/11478
- Fixes https://github.com/owncloud/ocis/issues/10038

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
