### PR TITLE
fix(a11y): contrast, checkbox focus and space member search label

### DIFF
--- a/changelog/unreleased/enhancement-a11y-improvements
+++ b/changelog/unreleased/enhancement-a11y-improvements
@@ -11,3 +11,4 @@ https://github.com/owncloud/web/pull/11574
 https://github.com/owncloud/web/pull/11591
 https://github.com/owncloud/web/issues/10725
 https://github.com/owncloud/web/issues/10729
+https://github.com/owncloud/web/issues/10724

--- a/changelog/unreleased/enhancement-a11y-improvements
+++ b/changelog/unreleased/enhancement-a11y-improvements
@@ -3,6 +3,9 @@ Enhancement: Accessibility improvements
 The following accessibility improvements have been made:
 
 - Contextual helpers now have a focus trap, meaning the user can't focus elements in the background while the contextual helper is showing.
+- An issue where the current focus would not change when navigating the resource table/tiles with the keyboard has been fixed.
 
 https://github.com/owncloud/web/pull/11574
+https://github.com/owncloud/web/pull/11591
 https://github.com/owncloud/web/issues/10725
+https://github.com/owncloud/web/issues/10729

--- a/changelog/unreleased/enhancement-a11y-improvements
+++ b/changelog/unreleased/enhancement-a11y-improvements
@@ -4,6 +4,8 @@ The following accessibility improvements have been made:
 
 - Contextual helpers now have a focus trap, meaning the user can't focus elements in the background while the contextual helper is showing.
 - An issue where the current focus would not change when navigating the resource table/tiles with the keyboard has been fixed.
+- The contrasts of input borders have been aligned with the official WCAG requirements.
+- The space member search in the right sidebar now has a label. Also, the search has been moved from the top of the sharing panel to the members section where all members are listed.
 
 https://github.com/owncloud/web/pull/11574
 https://github.com/owncloud/web/pull/11591

--- a/packages/design-system/src/components/OcCheckbox/OcCheckbox.spec.ts
+++ b/packages/design-system/src/components/OcCheckbox/OcCheckbox.spec.ts
@@ -65,11 +65,4 @@ describe('OcCheckbox', () => {
       expect(checkbox.element.checked).toBeTruthy()
     })
   })
-  describe('set outline', () => {
-    it('should show outline', async () => {
-      const wrapper = await getWrapperWithProps({ outline: true })
-      const checkbox = wrapper.find(`${checkboxSelector}.oc-checkbox-outline`)
-      expect(checkbox.exists()).toBeTruthy()
-    })
-  })
 })

--- a/packages/design-system/src/components/OcCheckbox/OcCheckbox.vue
+++ b/packages/design-system/src/components/OcCheckbox/OcCheckbox.vue
@@ -118,7 +118,6 @@ export default defineComponent({
         'oc-checkbox',
         'oc-rounded',
         'oc-checkbox-' + getSizeClass(this.size),
-        { 'oc-checkbox-outline': this.outline },
         { 'oc-checkbox-checked': this.isChecked }
       ]
     },
@@ -162,10 +161,6 @@ export default defineComponent({
   vertical-align: middle;
   background-color: transparent;
   outline: none;
-
-  &-outline {
-    outline: solid 2px var(--oc-color-swatch-passive-default);
-  }
 
   &-s {
     @include oc-form-check-size(0.7);

--- a/packages/design-system/src/components/_OcTableRow/_OcTableRow.vue
+++ b/packages/design-system/src/components/_OcTableRow/_OcTableRow.vue
@@ -1,7 +1,6 @@
 <template>
   <tr
     ref="observerTarget"
-    tabindex="-1"
     @click="$emit('click', $event)"
     @contextmenu="$emit('contextmenu', $event)"
     @dragstart="$emit('dragstart', $event)"

--- a/packages/design-system/src/styles/theme/oc-form.scss
+++ b/packages/design-system/src/styles/theme/oc-form.scss
@@ -290,7 +290,7 @@ $internal-form-checkbox-indeterminate-image: "data:image/svg+xml;charset=UTF-8,%
 .oc-select:focus,
 .oc-textarea:focus {
   outline: none;
-  border-color: var(--oc-color-swatch-passive-default);
+  border-color: var(--oc-color-input-text-default);
   color: $form-focus-color;
 }
 

--- a/packages/web-app-admin-settings/src/composables/keyboardActions/useKeyboardTableNavigation.ts
+++ b/packages/web-app-admin-settings/src/composables/keyboardActions/useKeyboardTableNavigation.ts
@@ -1,6 +1,6 @@
 import { useScrollTo } from '@ownclouders/web-pkg'
 import { Ref, unref } from 'vue'
-import { Key, KeyboardActions, Modifier } from '@ownclouders/web-pkg'
+import { Key, KeyboardActions, Modifier, focusCheckbox } from '@ownclouders/web-pkg'
 import { find, findIndex } from 'lodash-es'
 import { Item } from '@ownclouders/web-client'
 
@@ -55,6 +55,7 @@ export const useKeyboardTableNavigation = (
       (resource) => resource.id === nextResource.id
     )
 
+    focusCheckbox(nextResource.id)
     keyActions.resetSelectionCursor()
     selectedRows.value = [nextResource]
     lastSelectedRowIndex.value = nextResourceIndex
@@ -86,6 +87,7 @@ export const useKeyboardTableNavigation = (
       selectedRows.value.push(nextResource)
     }
 
+    focusCheckbox(nextResource.id)
     lastSelectedRowIndex.value = nextResourceIndex
     lastSelectedRowId.value = String(nextResource.id)
     keyActions.selectionCursor.value = unref(keyActions.selectionCursor) - 1
@@ -121,6 +123,7 @@ export const useKeyboardTableNavigation = (
       selectedRows.value.push(nextResource)
     }
 
+    focusCheckbox(nextResource.id)
     lastSelectedRowIndex.value = nextResourceIndex
     lastSelectedRowId.value = String(nextResource.id)
     keyActions.selectionCursor.value = unref(keyActions.selectionCursor) + 1

--- a/packages/web-app-admin-settings/tests/unit/components/Spaces/__snapshots__/SpacesList.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/components/Spaces/__snapshots__/SpacesList.spec.ts.snap
@@ -14,7 +14,7 @@ exports[`SpacesList > should render all spaces in a table 1`] = `
   </div>
   <table class="oc-table oc-table-hover oc-table-sticky has-item-context-menu spaces-table">
     <thead class="oc-thead">
-      <tr tabindex="-1" class="oc-table-header-row">
+      <tr class="oc-table-header-row">
         <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-select oc-pl-s" style="top: 0px;">
           <div><span class="oc-table-thead-content"><oc-checkbox-stub id="oc-checkbox-1" disabled="false" modelvalue="false" label="Select all spaces" labelhidden="true" size="large" outline="false" class="oc-ml-s"></oc-checkbox-stub></span></div>
         </th>
@@ -58,7 +58,7 @@ exports[`SpacesList > should render all spaces in a table 1`] = `
       </tr>
     </thead>
     <tbody class="has-item-context-menu">
-      <tr tabindex="-1" class="oc-tbody-tr oc-tbody-tr-1" data-item-id="1" draggable="false">
+      <tr class="oc-tbody-tr oc-tbody-tr-1" data-item-id="1" draggable="false">
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-select oc-pl-s">
           <oc-checkbox-stub id="oc-checkbox-2" disabled="false" modelvalue="false" option="undefined" label="Select 1 Some space" labelhidden="true" size="large" outline="false" class="oc-ml-s"></oc-checkbox-stub>
         </td>
@@ -84,7 +84,7 @@ exports[`SpacesList > should render all spaces in a table 1`] = `
             </button></div>
         </td>
       </tr>
-      <tr tabindex="-1" class="oc-tbody-tr oc-tbody-tr-2" data-item-id="2" draggable="false">
+      <tr class="oc-tbody-tr oc-tbody-tr-2" data-item-id="2" draggable="false">
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-select oc-pl-s">
           <oc-checkbox-stub id="oc-checkbox-3" disabled="false" modelvalue="false" option="undefined" label="Select 2 Another space" labelhidden="true" size="large" outline="false" class="oc-ml-s"></oc-checkbox-stub>
         </td>

--- a/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Users.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Users.spec.ts.snap
@@ -89,7 +89,7 @@ exports[`Users view > list view > renders list initially 1`] = `
         <div>
           <table class="oc-table oc-table-hover oc-table-sticky has-item-context-menu users-table">
             <thead class="oc-thead">
-              <tr tabindex="-1" class="oc-table-header-row">
+              <tr class="oc-table-header-row">
                 <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-select oc-pl-s" style="top: 0px;">
                   <div><span class="oc-table-thead-content"><span class="oc-ml-s"><input id="oc-checkbox-1" type="checkbox" name="checkbox" class="oc-checkbox oc-rounded oc-checkbox-l" aria-label="Select all users"> <!--v-if--></span></span></div>
                 </th>
@@ -117,7 +117,7 @@ exports[`Users view > list view > renders list initially 1`] = `
               </tr>
             </thead>
             <tbody class="has-item-context-menu">
-              <tr tabindex="-1" class="oc-tbody-tr oc-tbody-tr-1" data-item-id="1" draggable="false">
+              <tr class="oc-tbody-tr oc-tbody-tr-1" data-item-id="1" draggable="false">
                 <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-select oc-pl-s"><span class="oc-ml-s"><input id="oc-checkbox-2" type="checkbox" name="checkbox" class="oc-checkbox oc-rounded oc-checkbox-l" aria-label="Select Admin" value="[object Object]"> <!--v-if--></span></td>
                 <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-avatar">
                   <avatar-image width="32" userid="1" user-name="Admin"></avatar-image>

--- a/packages/web-app-files/src/composables/keyboardActions/useKeyboardTableNavigation.ts
+++ b/packages/web-app-files/src/composables/keyboardActions/useKeyboardTableNavigation.ts
@@ -1,7 +1,7 @@
 import { QueryValue, useResourcesStore, FolderViewModeConstants } from '@ownclouders/web-pkg'
 import { useScrollTo } from '@ownclouders/web-pkg'
 import { Ref, ref, unref, nextTick, watchEffect } from 'vue'
-import { Key, KeyboardActions, Modifier } from '@ownclouders/web-pkg'
+import { Key, KeyboardActions, Modifier, focusCheckbox } from '@ownclouders/web-pkg'
 import { Resource } from '@ownclouders/web-client'
 import { findIndex } from 'lodash-es'
 import { storeToRefs } from 'pinia'
@@ -19,9 +19,9 @@ export const useKeyboardTableNavigation = (
   const resourcesStore = useResourcesStore()
   const { latestSelectedId } = storeToRefs(resourcesStore)
 
-  const bindKeyActionsIds = ref([])
-  const tileViewStart = ref(null)
-  const tileViewDirection = ref(null)
+  const bindKeyActionsIds: Ref<string[]> = ref([])
+  const tileViewStart = ref<string>(null)
+  const tileViewDirection = ref<Direction>(null)
 
   keyActions.bindKeyAction({ modifier: Modifier.Ctrl, primary: Key.A }, () =>
     handleSelectAllAction()
@@ -123,6 +123,7 @@ export const useKeyboardTableNavigation = (
     await nextTick()
     resourcesStore.addSelection(nextId)
     await nextTick()
+    focusCheckbox(nextId)
     scrollToResource(nextId, { topbarElement: 'files-app-bar' })
   }
 
@@ -237,6 +238,7 @@ export const useKeyboardTableNavigation = (
         ? resourcesStore.addSelection(id)
         : resourcesStore.removeSelection(id)
     }
+    focusCheckbox(vp.lastSelectedFileId)
     resourcesStore.setLastSelectedId(vp.lastSelectedFileId)
   }
   const handleTilesShiftDownAction = () => {
@@ -254,6 +256,7 @@ export const useKeyboardTableNavigation = (
         ? resourcesStore.addSelection(id)
         : resourcesStore.removeSelection(id)
     }
+    focusCheckbox(vp.lastSelectedFileId)
     resourcesStore.setLastSelectedId(vp.lastSelectedFileId)
   }
 
@@ -281,6 +284,7 @@ export const useKeyboardTableNavigation = (
     if (tileViewDirection.value === direction) {
       resourcesStore.addSelection(nextResourceId)
     }
+    focusCheckbox(nextResourceId)
   }
 
   const handleShiftUpAction = (movedBy = 1) => {
@@ -294,6 +298,7 @@ export const useKeyboardTableNavigation = (
     } else {
       resourcesStore.addSelection(nextResourceId)
     }
+    focusCheckbox(nextResourceId)
     scrollToResource(nextResourceId, { topbarElement: 'files-app-bar' })
     keyActions.selectionCursor.value = unref(keyActions.selectionCursor) - 1
   }
@@ -308,6 +313,7 @@ export const useKeyboardTableNavigation = (
     } else {
       resourcesStore.addSelection(nextResourceId)
     }
+    focusCheckbox(nextResourceId)
     scrollToResource(nextResourceId, { topbarElement: 'files-app-bar' })
     keyActions.selectionCursor.value = unref(keyActions.selectionCursor) + 1
   }

--- a/packages/web-app-files/tests/unit/views/trash/__snapshots__/Overview.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/views/trash/__snapshots__/Overview.spec.ts.snap
@@ -17,7 +17,7 @@ exports[`TrashOverview > view states > should render spaces list 1`] = `
       </div>
       <table class="oc-table oc-table-hover oc-table-sticky has-item-context-menu spaces-table">
         <thead class="oc-thead">
-          <tr tabindex="-1" class="oc-table-header-row">
+          <tr class="oc-table-header-row">
             <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-icon oc-pl-s" style="top: 0px;">
               <div><span class="oc-table-thead-content header-text"></span></div>
             </th>
@@ -28,19 +28,19 @@ exports[`TrashOverview > view states > should render spaces list 1`] = `
           </tr>
         </thead>
         <tbody class="has-item-context-menu">
-          <tr tabindex="-1" class="oc-tbody-tr oc-tbody-tr-1" data-item-id="1" draggable="false">
+          <tr class="oc-tbody-tr oc-tbody-tr-1" data-item-id="1" draggable="false">
             <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-icon oc-pl-s"><span class="oc-icon oc-icon-m oc-icon-passive oc-pl-m"><!----></span></td>
             <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-name oc-pr-s">
               <router-link-stub to="[object Object]" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-display-block trash-bin-route"></router-link-stub>
             </td>
           </tr>
-          <tr tabindex="-1" class="oc-tbody-tr oc-tbody-tr-2" data-item-id="2" draggable="false">
+          <tr class="oc-tbody-tr oc-tbody-tr-2" data-item-id="2" draggable="false">
             <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-icon oc-pl-s"><span class="oc-icon oc-icon-m oc-icon-passive oc-pl-m"><!----></span></td>
             <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-name oc-pr-s">
               <router-link-stub to="[object Object]" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-display-block trash-bin-route"></router-link-stub>
             </td>
           </tr>
-          <tr tabindex="-1" class="oc-tbody-tr oc-tbody-tr-3" data-item-id="3" draggable="false">
+          <tr class="oc-tbody-tr oc-tbody-tr-3" data-item-id="3" draggable="false">
             <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-td oc-table-data-cell oc-table-data-cell-icon oc-pl-s"><span class="oc-icon oc-icon-m oc-icon-passive oc-pl-m"><!----></span></td>
             <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td oc-table-data-cell oc-table-data-cell-name oc-pr-s">
               <router-link-stub to="[object Object]" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-display-block trash-bin-route"></router-link-stub>

--- a/packages/web-pkg/src/helpers/ui/index.ts
+++ b/packages/web-pkg/src/helpers/ui/index.ts
@@ -1,2 +1,3 @@
+export * from './resourceCheckbox'
 export * from './resourceTable'
 export * from './resourceTiles'

--- a/packages/web-pkg/src/helpers/ui/resourceCheckbox.ts
+++ b/packages/web-pkg/src/helpers/ui/resourceCheckbox.ts
@@ -1,0 +1,8 @@
+export const focusCheckbox = (id: string) => {
+  const checkbox = document.querySelectorAll(
+    `[data-item-id="${id}"] input[type=checkbox]`
+  )?.[0] as HTMLInputElement
+  if (checkbox) {
+    checkbox.focus()
+  }
+}

--- a/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.ts.snap
+++ b/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.ts.snap
@@ -8,30 +8,30 @@ exports[`account page > account information section > displays basic user inform
   </div>
   <table class="oc-table-simple">
     <thead class="oc-thead oc-invisible-sr">
-      <tr tabindex="-1">
+      <tr>
         <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th">Information name</th>
         <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th">Information value</th>
       </tr>
     </thead>
     <tbody>
-      <tr tabindex="-1" class="account-page-info-username">
+      <tr class="account-page-info-username">
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td">Username</td>
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td">some-username</td>
       </tr>
-      <tr tabindex="-1" class="account-page-info-displayname">
+      <tr class="account-page-info-displayname">
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td">First and last name</td>
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td">some-displayname</td>
       </tr>
-      <tr tabindex="-1" class="account-page-info-email">
+      <tr class="account-page-info-email">
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td">Email</td>
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td">some-email</td>
       </tr>
       <!--v-if-->
-      <tr tabindex="-1" class="account-page-info-groups">
+      <tr class="account-page-info-groups">
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td">Group memberships</td>
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td" data-testid="group-names"><span data-testid="group-names-empty">You are not part of any group</span></td>
       </tr>
-      <tr tabindex="-1" class="account-page-logout-all-devices">
+      <tr class="account-page-logout-all-devices">
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td">Logout from active devices</td>
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td" data-testid="logout"><a href="https://account-manager/logout" target="_blank" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" data-testid="account-page-logout-url-btn">
             <!--v-if-->
@@ -61,14 +61,14 @@ exports[`account page > public link context > should render a limited view 1`] =
       <h2 class="account-table-title">Preferences</h2>
       <table class="oc-table-simple">
         <thead class="oc-thead oc-invisible-sr">
-          <tr tabindex="-1">
+          <tr>
             <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th">Preference name</th>
             <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th">Preference description</th>
             <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th">Preference value</th>
           </tr>
         </thead>
         <tbody>
-          <tr tabindex="-1" class="account-page-info-language">
+          <tr class="account-page-info-language">
             <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td">Language</td>
             <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td">
               <div class="oc-flex"><span>Select your language.</span> <a href="https://explore.transifex.com/owncloud-org/owncloud-web/" target="_blank">
@@ -99,7 +99,7 @@ exports[`account page > public link context > should render a limited view 1`] =
             </td>
           </tr>
           <!--v-if-->
-          <tr tabindex="-1" class="account-page-info-theme">
+          <tr class="account-page-info-theme">
             <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td">Theme</td>
             <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td"><span>Select your favorite theme</span></td>
             <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td" data-testid="theme">


### PR DESCRIPTION
## Description
* Fixes the issue where the current focus would not change when navigating the resource table/tiles with the keyboard.
* Fixes the border color contrast for focused inputs. The border colors for the inputs in general need a color token change and therefore need a change in ocis (see https://github.com/owncloud/ocis/pull/10076).
* Redesigns the space member search in the right sidebar so it has a label. Also moves the search from the top of the sharing panel to the members section where all members are listed.

<img width="403" alt="image" src="https://github.com/user-attachments/assets/4ee250ed-8c93-4295-b167-24e4e7d3715e">

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- refs https://github.com/owncloud/web/issues/10729
- fixes https://github.com/owncloud/web/issues/10724

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
