### PR TITLE
fix(a11y): keyboard navigation

### DIFF
--- a/changelog/unreleased/enhancement-a11y-improvements
+++ b/changelog/unreleased/enhancement-a11y-improvements
@@ -6,9 +6,12 @@ The following accessibility improvements have been made:
 - An issue where the current focus would not change when navigating the resource table/tiles with the keyboard has been fixed.
 - The contrasts of input borders have been aligned with the official WCAG requirements.
 - The space member search in the right sidebar now has a label. Also, the search has been moved from the top of the sharing panel to the members section where all members are listed.
+- Leaving dropdown menus via the keyboard navigation now closes them.
 
 https://github.com/owncloud/web/pull/11574
 https://github.com/owncloud/web/pull/11591
+https://github.com/owncloud/web/pull/11600
 https://github.com/owncloud/web/issues/10725
 https://github.com/owncloud/web/issues/10729
 https://github.com/owncloud/web/issues/10724
+https://github.com/owncloud/web/issues/10733

--- a/changelog/unreleased/enhancement-a11y-improvements
+++ b/changelog/unreleased/enhancement-a11y-improvements
@@ -7,6 +7,7 @@ The following accessibility improvements have been made:
 - The contrasts of input borders have been aligned with the official WCAG requirements.
 - The space member search in the right sidebar now has a label. Also, the search has been moved from the top of the sharing panel to the members section where all members are listed.
 - Leaving dropdown menus via the keyboard navigation now closes them.
+- When the sidebar is open and uses 100% of the screen width (mobile view), it is no longer possible to focus elements in the background.
 
 https://github.com/owncloud/web/pull/11574
 https://github.com/owncloud/web/pull/11591

--- a/packages/design-system/src/components/OcDrop/OcDrop.spec.ts
+++ b/packages/design-system/src/components/OcDrop/OcDrop.spec.ts
@@ -16,7 +16,7 @@ const dom = ({ position = 'auto', mode = 'click', paddingSize = 'medium' } = {})
     }
   )
   const drop = wrapper.findComponent({ name: 'oc-drop' })
-  const tippy = drop.vm.$data.tippy
+  const tippy = drop.vm.tippy
 
   return { wrapper, drop, tippy }
 }

--- a/packages/web-app-admin-settings/src/views/Users.vue
+++ b/packages/web-app-admin-settings/src/views/Users.vue
@@ -345,14 +345,20 @@ export default defineComponent({
     const filterGroups = (groups: Group[]) => {
       filters.groups.ids.value = groups.map((g) => g.id)
       loadUsersTask.perform()
-      userSettingsStore.setSelectedUsers([])
+      if (userSettingsStore.selectedUsers.length) {
+        // only reset selection if there are selected users because is messes with the focus otherwise
+        userSettingsStore.setSelectedUsers([])
+      }
       additionalUserDataLoadedForUserIds.value = []
       return resetPagination()
     }
     const filterRoles = (roles: AppRole[]) => {
       filters.roles.ids.value = roles.map((r) => r.id)
       loadUsersTask.perform()
-      userSettingsStore.setSelectedUsers([])
+      if (userSettingsStore.selectedUsers.length) {
+        // only reset selection if there are selected users because is messes with the focus otherwise
+        userSettingsStore.setSelectedUsers([])
+      }
       additionalUserDataLoadedForUserIds.value = []
       return resetPagination()
     }

--- a/packages/web-pkg/src/components/ItemFilter.vue
+++ b/packages/web-pkg/src/components/ItemFilter.vue
@@ -198,7 +198,7 @@ export default defineComponent({
     const showDrop = async () => {
       setDisplayedItems(props.items)
       await nextTick()
-      unref(filterInputRef).focus()
+      unref(filterInputRef)?.focus()
     }
 
     watch(filterTerm, () => {

--- a/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -9,7 +9,7 @@
         v-if="appMenuExtensions.length && !isEmbedModeEnabled"
         :menu-items="appMenuExtensions"
       />
-      <router-link v-if="!hideLogo" ref="navigationSidebarLogo" :to="homeLink" class="oc-width-1-1">
+      <router-link v-if="!hideLogo" :to="homeLink" class="oc-width-1-1 oc-logo-href">
         <oc-img
           v-oc-tooltip="$gettext('Back to home')"
           :src="currentTheme.logo.topbar"

--- a/tests/e2e/support/objects/app-admin-settings/users/actions.ts
+++ b/tests/e2e/support/objects/app-admin-settings/users/actions.ts
@@ -246,6 +246,10 @@ export const filterUsers = async (args: {
   values: string[]
 }): Promise<void> => {
   const { page, filter, values } = args
+  if (await page.locator(closeEditPanel).count()) {
+    // close potentially open sidebar panel to avoid focus jumping
+    await page.locator(closeEditPanel).click()
+  }
   await page.locator(util.format(userFilter, filter)).click()
   for (const value of values) {
     await Promise.all([


### PR DESCRIPTION
## Description
* Automatically closes drops when leaving them via keyboard navigation.
* Prevents background elements form being focused when the sidebar takes 100% screen width (mobile view).
* Fixes an issue where selecting a filter would cause a focus jump to the sidebar on the users page.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10733

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
