### PR TITLE
fix: right sidebar focus

### DIFF
--- a/changelog/unreleased/enhancement-a11y-improvements
+++ b/changelog/unreleased/enhancement-a11y-improvements
@@ -8,11 +8,14 @@ The following accessibility improvements have been made:
 - The space member search in the right sidebar now has a label. Also, the search has been moved from the top of the sharing panel to the members section where all members are listed.
 - Leaving dropdown menus via the keyboard navigation now closes them.
 - When the sidebar is open and uses 100% of the screen width (mobile view), it is no longer possible to focus elements in the background.
+- Focus issues with the right sidebar have been fixed.
 
 https://github.com/owncloud/web/pull/11574
 https://github.com/owncloud/web/pull/11591
 https://github.com/owncloud/web/pull/11600
+https://github.com/owncloud/web/pull/11609
 https://github.com/owncloud/web/issues/10725
 https://github.com/owncloud/web/issues/10729
 https://github.com/owncloud/web/issues/10724
 https://github.com/owncloud/web/issues/10733
+https://github.com/owncloud/web/issues/10618

--- a/packages/web-pkg/src/components/SideBar/FileSideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/FileSideBar.vue
@@ -3,7 +3,6 @@
     v-if="isOpen"
     ref="sidebar"
     class="files-side-bar"
-    tabindex="-1"
     :is-open="isOpen"
     :active-panel="activePanel"
     :available-panels="availablePanels"

--- a/packages/web-runtime/src/components/Topbar/ApplicationsMenu.vue
+++ b/packages/web-runtime/src/components/Topbar/ApplicationsMenu.vue
@@ -6,7 +6,6 @@
   >
     <oc-button
       id="_appSwitcherButton"
-      ref="menuButton"
       v-oc-tooltip="applicationSwitcherLabel"
       appearance="raw-inverse"
       variation="brand"
@@ -52,7 +51,7 @@
 
 <script lang="ts">
 import { defineComponent, PropType, ref, computed, unref, useTemplateRef } from 'vue'
-import { OcButton, OcDrop } from 'design-system/src/components'
+import { OcDrop } from 'design-system/src/components'
 import OcApplicationIcon from 'design-system/src/components/OcApplicationIcon/OcApplicationIcon.vue'
 import { useGettext } from 'vue3-gettext'
 import * as uuid from 'uuid'
@@ -74,7 +73,6 @@ export default defineComponent({
     const { $gettext } = useGettext()
     const appIconKey = ref('')
 
-    const menuButton = useTemplateRef<typeof OcButton>('menuButton')
     const menu = useTemplateRef<typeof OcDrop>('menu')
 
     const activeRoutePath = computed(() => unref(router.currentRoute).path)
@@ -116,7 +114,6 @@ export default defineComponent({
 
     return {
       menu,
-      menuButton,
       sortedMenuItems,
       appIconKey,
       updateAppIcons,
@@ -128,14 +125,6 @@ export default defineComponent({
   },
   mounted() {
     this.menu?.tippy?.setProps({
-      onHidden: () => {
-        if (document.activeElement?.classList.contains('oc-logo-href')) {
-          // logo is the next element, which means the user is navigating away and the
-          // drop closed. we don't want to re-focus the app switcher in this case.
-          return
-        }
-        this.menuButton.$el.focus()
-      },
       onShown: () => this.menu.$el.querySelector('a:first-of-type').focus()
     })
   }

--- a/tests/e2e/support/objects/app-admin-settings/users/actions.ts
+++ b/tests/e2e/support/objects/app-admin-settings/users/actions.ts
@@ -246,10 +246,6 @@ export const filterUsers = async (args: {
   values: string[]
 }): Promise<void> => {
   const { page, filter, values } = args
-  if (await page.locator(closeEditPanel).count()) {
-    // close potentially open sidebar panel to avoid focus jumping
-    await page.locator(closeEditPanel).click()
-  }
   await page.locator(util.format(userFilter, filter)).click()
   for (const value of values) {
     await Promise.all([

--- a/tests/e2e/support/objects/runtime/application.ts
+++ b/tests/e2e/support/objects/runtime/application.ts
@@ -9,7 +9,8 @@ const notificationsDrop = `#oc-notifications-drop`
 const notificationsLoading = `#oc-notifications-drop .oc-notifications-loading`
 const markNotificationsAsReadButton = `#oc-notifications-drop .oc-notifications-mark-all`
 const notificationItemsMessages = `#oc-notifications-drop .oc-notifications-item .oc-notifications-message`
-const closeSidebarBtn = `#app-sidebar .header__close`
+const closeSidebarRootPanelBtn = `#app-sidebar .is-active-root-panel .header__close`
+const closeSidebarSubPanelBtn = `#app-sidebar .is-active-sub-panel .header__close`
 
 export class Application {
   #page: Page
@@ -70,9 +71,11 @@ export class Application {
   }
 
   async closeSidebar(): Promise<void> {
-    const sideBarIsOpen = await this.#page.locator(closeSidebarBtn).isVisible()
-    if (sideBarIsOpen) {
-      await this.#page.locator(closeSidebarBtn).click()
+    const isSubPanelActive = await this.#page.locator(closeSidebarSubPanelBtn).isVisible()
+    if (isSubPanelActive) {
+      await this.#page.locator(closeSidebarSubPanelBtn).click()
+    } else {
+      await this.#page.locator(closeSidebarRootPanelBtn).click()
     }
   }
 


### PR DESCRIPTION
## Description
Fixes 2 main issues with the right sidebar focus:

* Prevents the sidebar from stealing the focus when loading the page with the sidebar being initially opened.
* Sets the focus on the sidebar when necessary (e.g. when opening/closing a specific sidebar panel).

I decided to get rid of the visibility- and the hidden-observer because it's painful to tweak them right and they weren't working as supposed anyway. The simple solution I went for sets the focus when opening the sidebar or a specific panel, or when closing a sub-panel and returning to the root panel.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10618

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
