### PR TITLE
fix: use Infinite Scale instead of oCIS because it's user facing

### DIFF
--- a/packages/web-app-app-store/src/components/AppVersions.vue
+++ b/packages/web-app-app-store/src/components/AppVersions.vue
@@ -43,18 +43,18 @@ export default defineComponent({
     const fields = computed(() => {
       return [
         {
-          name: 'minOCIS',
-          type: 'raw',
-          width: 'shrink',
-          wrap: 'nowrap',
-          title: $gettext('oCIS Version')
-        },
-        {
           name: 'version',
           type: 'slot',
           width: 'expand',
           wrap: 'truncate',
           title: $gettext('App Version')
+        },
+        {
+          name: 'minOCIS',
+          type: 'raw',
+          width: 'shrink',
+          wrap: 'nowrap',
+          title: $gettext('Infinite Scale Version')
         },
         {
           name: 'actions',


### PR DESCRIPTION
## Description
Using `Infinite Scale Version` instead of `oCIS Version` in the app store details versions table because it's user facing................... 👍
Also switched the order of app version and min ocis version to make it look less horrible with such a long table header cell.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
- [x] Whatever
