### PR TITLE
[tests-only] [full-ci] bump ocis stable commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=30e24469357366d0b925a88429764ffd3ada0be2
+OCIS_COMMITID=39dfdea21887a56a80af16fe1873181dc5897d48
 OCIS_BRANCH=stable-5.0


### PR DESCRIPTION
## Description
Bump latest ocis stable commit id.
Part of: https://github.com/owncloud/QA/issues/862