### PR TITLE
fix: force logout after token expiry retry (backport)

### DIFF
--- a/changelog/unreleased/bugfix-logout-issues-token-renewal-failure
+++ b/changelog/unreleased/bugfix-logout-issues-token-renewal-failure
@@ -1,0 +1,5 @@
+Bugfix: Force logout after token expiry retry
+
+When the access token has expired and the retry to re-login the user didn't work for some reason, we now force a logout.
+
+https://github.com/owncloud/ocis/issues/11620

--- a/packages/web-app-webfinger/src/views/Resolve.vue
+++ b/packages/web-app-webfinger/src/views/Resolve.vue
@@ -62,7 +62,7 @@ export default defineComponent({
       } catch (e) {
         console.error(e)
         if (e.response?.status === 401) {
-          return authService.handleAuthError(unref(route))
+          return authService.handleAuthError(unref(route), { forceLogout: true })
         }
         hasError.value = true
       }

--- a/packages/web-pkg/src/composables/authContext/useAuthService.ts
+++ b/packages/web-pkg/src/composables/authContext/useAuthService.ts
@@ -1,7 +1,7 @@
 import { useService } from '../service'
 
 export interface AuthServiceInterface {
-  handleAuthError(route: any): any
+  handleAuthError(route: any, options?: { forceLogout?: boolean }): any
 }
 
 export const useAuthService = (): AuthServiceInterface => {


### PR DESCRIPTION
## Description
This restores some of the behavior we had before https://github.com/owncloud/web/pull/10881.

It is a partial backport of https://github.com/owncloud/web/pull/11584.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
