### PR TITLE
[tests-only][full-ci] fix activity message

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=cb64d5cb51b9a87f3145eb8dd50586abd1f2eaf0
+OCIS_COMMITID=10a67114f1866c3cc5ad6da9e435e6fdfcd36543
 OCIS_BRANCH=master

--- a/tests/e2e/cucumber/features/smoke/activity.feature
+++ b/tests/e2e/cucumber/features/smoke/activity.feature
@@ -29,7 +29,7 @@ Feature: Users can see all activities of the resources and spaces
     And "Alice" navigates to the project space "team.1"
     Then "Alice" should see activity of the space
       | activity                      |
-      | alice added readme.md to team |
+      | alice added readme.md to .space |
     And "Alice" logs out
 
     # see activity in the shared resources
@@ -37,5 +37,5 @@ Feature: Users can see all activities of the resources and spaces
     And "Brian" navigates to the shared with me page
     Then "Brian" should see activity of the following resource
       | resource               | activity                              |
-      | sharedFolder/subFolder | alice added subFolder to Alice Hansen |
+      | sharedFolder/subFolder | alice added subFolder to sharedFolder |
     And "Brian" logs out


### PR DESCRIPTION
## Description
Bumped ocis commit-id and fixed the activity messages.
The activity message was changed in ocis (https://github.com/owncloud/ocis/pull/10049)

## Related Issue
- Fixes https://github.com/owncloud/web/issues/11625
- https://github.com/owncloud/QA/issues/862


## How Has This Been Tested?
- test environment: :raised_back_of_hand: 

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
