### PR TITLE
[tests-only][full-ci] sharee cannot see activity

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=10a67114f1866c3cc5ad6da9e435e6fdfcd36543
+OCIS_COMMITID=8ba090e1e26b18dd997e054880afc7f5cf09f2a7
 OCIS_BRANCH=master

--- a/tests/e2e/cucumber/features/smoke/activity.feature
+++ b/tests/e2e/cucumber/features/smoke/activity.feature
@@ -34,7 +34,7 @@ Feature: Users can see all activities of the resources and spaces
     # see activity in the shared resources
     When "Brian" logs in
     And "Brian" navigates to the shared with me page
-    Then "Brian" should see activity of the following resource
+    Then "Brian" should not see any activity of the following resource
       | resource               | activity                              |
       | sharedFolder/subFolder | alice added subFolder to sharedFolder |
     And "Brian" logs out

--- a/tests/e2e/cucumber/features/smoke/activity.feature
+++ b/tests/e2e/cucumber/features/smoke/activity.feature
@@ -35,6 +35,6 @@ Feature: Users can see all activities of the resources and spaces
     When "Brian" logs in
     And "Brian" navigates to the shared with me page
     Then "Brian" should not see any activity of the following resource
-      | resource               | activity                              |
-      | sharedFolder/subFolder | alice added subFolder to sharedFolder |
+      | resource               |
+      | sharedFolder/subFolder |
     And "Brian" logs out

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -979,7 +979,7 @@ Then(
     const resourceObject = new objects.applicationFiles.Resource({ page })
 
     for (const info of stepTable.hashes()) {
-      await resourceObject.checkEmptyActivity({ resource: info.resource, activity: info.activity })
+      await resourceObject.checkEmptyActivity({ resource: info.resource })
     }
   }
 )

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -971,3 +971,15 @@ Then(
     }
   }
 )
+
+Then(
+  '{string} should not see any activity of the following resource(s)',
+  async function (this: World, stepUser: string, stepTable: DataTable): Promise<void> {
+    const { page } = this.actorsEnvironment.getActor({ key: stepUser })
+    const resourceObject = new objects.applicationFiles.Resource({ page })
+
+    for (const info of stepTable.hashes()) {
+      await resourceObject.checkEmptyActivity({ resource: info.resource, activity: info.activity })
+    }
+  }
+)

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -2077,3 +2077,21 @@ export const checkActivity = async ({
   await expect(page.getByTestId(activitySidebarPanel)).toBeVisible()
   await expect(page.locator(activitySidebarPanelBodyContent)).toContainText(activity)
 }
+
+export const checkEmptyActivity = async ({
+  page,
+  resource
+}: {
+  page: Page
+  resource: string
+}): Promise<void> => {
+  const paths = resource.split('/')
+  const finalResource = paths.pop()
+  for (const path of paths) {
+    await clickResource({ page, path })
+  }
+  await sidebar.open({ page: page, resource: finalResource })
+  await sidebar.openPanel({ page: page, name: 'activities' })
+  await expect(page.getByTestId(activitySidebarPanel)).toBeVisible()
+  await expect(page.locator(activitySidebarPanelBodyContent)).toContainText('No activities')
+}

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -360,4 +360,8 @@ export class Resource {
   }): Promise<void> {
     await po.checkActivity({ page: this.#page, resource, activity })
   }
+
+  async checkEmptyActivity({ resource }: { resource: string }): Promise<void> {
+    await po.checkEmptyActivity({ page: this.#page, resource })
+  }
 }


### PR DESCRIPTION
## Description
Checking activity by sharee is not possible with latest ocis.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/11635

## How Has This Been Tested?
- test environment: :raised_back_of_hand: 

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
