### PR TITLE
fix: remove share type filter for project spaces

### DIFF
--- a/changelog/unreleased/bugfix-hide-share-type-switch-project-spaces
+++ b/changelog/unreleased/bugfix-hide-share-type-switch-project-spaces
@@ -1,0 +1,6 @@
+Bugfix: Hide share type switch for project spaces
+
+We've hidden the share type switch when adding members to project spaces because they currently don't support external shares.
+
+https://github.com/owncloud/web/pull/11653
+https://github.com/owncloud/web/issues/11579

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -56,7 +56,7 @@
             size="small"
           />
           <oc-filter-chip
-            v-if="shareRoleTypes.length > 1"
+            v-if="showShareTypeFilter"
             :filter-label="currentShareRoleType.label"
             class="invite-form-share-role-type"
             raw
@@ -495,6 +495,10 @@ export default defineComponent({
       return $gettext('No users or groups found.')
     })
 
+    const showShareTypeFilter = computed(
+      () => unref(shareRoleTypes).length > 1 && !isProjectSpaceResource(unref(resource))
+    )
+
     return {
       minSearchLength: capabilityRefs.sharingSearchMinLength,
       isRunningOnEos: computed(() => configStore.options.runningOnEos),
@@ -519,6 +523,7 @@ export default defineComponent({
       focusShareInput,
       noOptionsLabel,
       DateTime,
+      showShareTypeFilter,
 
       // CERN
       accountType,

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.spec.ts
@@ -164,6 +164,13 @@ describe('InviteCollaboratorForm', () => {
       const roleDropdown = wrapper.findComponent<typeof RoleDropdown>('role-dropdown-stub')
       expect(roleDropdown.props('isExternal')).toBeTruthy()
     })
+    it('is not present for project space resources', () => {
+      const space = mock<SpaceResource>({ driveType: 'project' })
+      const externalRoles = [mock<ShareRole>()]
+      const { wrapper } = getWrapper({ externalShareRoles: externalRoles, resource: space })
+
+      expect(wrapper.find('.invite-form-share-role-type').exists()).toBeFalsy()
+    })
   })
 })
 


### PR DESCRIPTION
## Description
Hides the share type switch when adding members to project spaces because they currently don't support external shares.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/11579

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
