### PR TITLE
refactor: use request interceptors in client service 

### DIFF
--- a/packages/web-client/README.md
+++ b/packages/web-client/README.md
@@ -22,44 +22,74 @@ $ yarn add @ownclouders/web-client
 
 ## Usage
 
-To utilize the `web-client`, you must instantiate it with a base URI corresponding to your oCIS deployment and an axios instance. The axios instance, or at least its headers, is being used for all requests, requiring the inclusion of all relevant headers such as authorization.
+### Graph
+
+The graph client needs to be instantiated with a base URI corresponding to your oCIS deployment and an axios instance. The axios instance is being used for all requests, which means it needs to include all relevant headers either statically or via interceptor.
 
 ```
 import axios from axios
-import { client } from '@ownclouders/web-client'
+import { graph } from '@ownclouders/web-client'
 
 const accessToken = 'some_access_token'
-const baseUri = 'some_base_uri'
+const baseURI = 'some_base_uri'
 
 const axiosClient = axios.create({
 	headers: { Authorization: accessToken }
 })
 
-const { graph, ocs, webdav } = client({ axiosClient, baseURI })
+const graphClient = graph(baseURI, axiosClient)
 ```
 
-### Graph
-
-The following example demonstrates how to retrieve all spaces accessible to the user. A `SpaceResource` can then be used to e.g. fetch files and folders (see example down below).
+The following example demonstrates how to retrieve all spaces accessible to the user. A `SpaceResource` can then be used to e.g. fetch files and folders (see webdav example down below).
 
 ```
-const mySpaces = await graph.drives.listMyDrives()
+const mySpaces = await graphClient.drives.listMyDrives()
 ```
 
 ### OCS
 
+The ocs client needs to be instantiated with a base URI corresponding to your oCIS deployment and an axios instance. The axios instance is being used for all requests, which means it needs to include all relevant headers either statically or via interceptor.
+
+```
+import axios from axios
+import { ocs } from '@ownclouders/web-client'
+
+const accessToken = 'some_access_token'
+const baseURI = 'some_base_uri'
+
+const axiosClient = axios.create({
+	headers: { Authorization: accessToken }
+})
+
+const ocsClient = ocs(baseURI, axiosClient)
+```
+
 The following examples demonstrate how to fetch capabilities and sign URLs.
 
 ```
-const capablities = await ocs.getCapabilities()
+const capabilities = await ocsClient.getCapabilities()
 
-const signedUrl = await ocs.signUrl('some_url_to_sign', 'your_username')
+const signedUrl = await ocsClient.signUrl('some_url_to_sign', 'your_username')
 ```
 
-### WebDAV
+### WebDav
+
+The webdav client needs to be instantiated with a base URI corresponding to your oCIS deployment. You can also pass a header callback which will be called with every dav request.
+
+```
+import { webdav } from '@ownclouders/web-client'
+
+const accessToken = 'some_access_token'
+const baseURI = 'some_base_uri'
+
+const webDavClient = webdav(
+	baseURI,
+	() => ({ Authorization: accessToken })
+)
+```
 
 The following example demonstrates how to list all resources of a given `SpaceResource` (see above how to fetch space resources).
 
 ```
-const { resource, children } = await webdav.listFiles(spaceResource)
+const { resource, children } = await webDavClient.listFiles(spaceResource)
 ```

--- a/packages/web-client/src/index.ts
+++ b/packages/web-client/src/index.ts
@@ -7,6 +7,8 @@ export * from './errors'
 export * from './helpers'
 export * from './utils'
 
+export { graph, ocs, webdav }
+
 interface Client {
   graph: Graph
   ocs: OCS
@@ -18,10 +20,23 @@ type ClientOptions = {
   baseURI: string
 }
 
+/** @deprecated use `graph()`, `ocs()` and `webdav()` to initialize and use clients */
 export const client = ({ axiosClient, baseURI }: ClientOptions): Client => {
+  const webDavHeaders = () => {
+    const authHeader = axiosClient.defaults?.headers?.Authorization
+    const languageHeader = axiosClient.defaults?.headers?.['Accept-Language']
+    const initiatorIdHeader = axiosClient.defaults?.headers?.['Initiator-ID']
+
+    return {
+      ...(authHeader && { Authorization: authHeader.toString() }),
+      ...(languageHeader && { 'Accept-Language': languageHeader.toString() }),
+      ...(initiatorIdHeader && { 'Initiator-ID': initiatorIdHeader.toString() })
+    }
+  }
+
   return {
     graph: graph(baseURI, axiosClient),
     ocs: ocs(baseURI, axiosClient),
-    webdav: webdav({ axiosClient, baseUrl: baseURI })
+    webdav: webdav(baseURI, webDavHeaders)
   }
 }

--- a/packages/web-client/src/webdav/index.ts
+++ b/packages/web-client/src/webdav/index.ts
@@ -1,4 +1,6 @@
-import { WebDAV, WebDavOptions } from './types'
+import axios from 'axios'
+import { Headers } from 'webdav'
+import { WebDAV } from './types'
 import { CopyFilesFactory } from './copyFiles'
 import { CreateFolderFactory } from './createFolder'
 import { GetFileContentsFactory } from './getFileContents'
@@ -25,8 +27,17 @@ export * from './types'
 export type { ListFilesOptions, ListFilesResult } from './listFiles'
 export type { GetFileContentsResponse } from './getFileContents'
 
-export const webdav = (options: WebDavOptions): WebDAV => {
-  const dav = new DAV({ axiosClient: options.axiosClient, baseUrl: options.baseUrl })
+export const webdav = (baseURI: string, headers?: () => Headers): WebDAV => {
+  const axiosClient = axios.create()
+  if (headers) {
+    axiosClient.interceptors.request.use((config) => {
+      Object.assign(config.headers, headers())
+      return config
+    })
+  }
+
+  const options = { axiosClient, baseUrl: baseURI, headers }
+  const dav = new DAV({ baseUrl: baseURI, headers })
 
   const pathForFileIdFactory = GetPathForFileIdFactory(dav, options)
   const { getPathForFileId } = pathForFileIdFactory

--- a/packages/web-client/src/webdav/types.ts
+++ b/packages/web-client/src/webdav/types.ts
@@ -17,10 +17,12 @@ import { GetPathForFileIdFactory } from './getPathForFileId'
 import { SetFavoriteFactory } from './setFavorite'
 import { ListFavoriteFilesFactory } from './listFavoriteFiles'
 import { AxiosInstance } from 'axios'
+import { Headers } from 'webdav'
 
 export interface WebDavOptions {
   axiosClient: AxiosInstance
   baseUrl: string
+  headers?: () => Headers
 }
 
 export interface WebDAV {

--- a/packages/web-pkg/src/http/client.ts
+++ b/packages/web-pkg/src/http/client.ts
@@ -1,4 +1,10 @@
-import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, CancelTokenSource } from 'axios'
+import axios, {
+  AxiosInstance,
+  AxiosRequestConfig,
+  AxiosResponse,
+  CancelTokenSource,
+  InternalAxiosRequestConfig
+} from 'axios'
 import merge from 'lodash-es/merge'
 import { z } from 'zod'
 
@@ -9,9 +15,17 @@ export class HttpClient {
   private readonly instance: AxiosInstance
   private readonly cancelToken: CancelTokenSource
 
-  constructor(config?: AxiosRequestConfig) {
+  constructor(
+    config?: AxiosRequestConfig,
+    interceptor?: (
+      value: InternalAxiosRequestConfig<any>
+    ) => InternalAxiosRequestConfig<any> | Promise<InternalAxiosRequestConfig<any>>
+  ) {
     this.cancelToken = axios.CancelToken.source()
     this.instance = axios.create(config)
+    if (interceptor) {
+      this.instance.interceptors.request.use(interceptor)
+    }
   }
 
   public cancel(msg?: string): void {

--- a/packages/web-pkg/tests/unit/composables/webWorkers/deleteWorker/worker.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/webWorkers/deleteWorker/worker.spec.ts
@@ -38,7 +38,7 @@ describe('delete worker', () => {
 
     vi.doMock('@ownclouders/web-client', async (importOriginal) => ({
       ...(await importOriginal<any>()),
-      client: () => ({ webdav: webDavMock, ocs: undefined, graph: undefined })
+      webdav: () => webDavMock
     }))
   })
 

--- a/packages/web-pkg/tests/unit/composables/webWorkers/pasteWorker/worker.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/webWorkers/pasteWorker/worker.spec.ts
@@ -50,7 +50,7 @@ describe('paste worker', () => {
 
     vi.doMock('@ownclouders/web-client', async (importOriginal) => ({
       ...(await importOriginal<any>()),
-      client: () => ({ webdav: webDavMock, ocs: undefined, graph: undefined })
+      webdav: () => webDavMock
     }))
   })
 

--- a/packages/web-pkg/tests/unit/composables/webWorkers/restoreWorker/worker.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/webWorkers/restoreWorker/worker.spec.ts
@@ -38,7 +38,7 @@ describe('delete worker', () => {
 
     vi.doMock('@ownclouders/web-client', async (importOriginal) => ({
       ...(await importOriginal<any>()),
-      client: () => ({ webdav: webDavMock, ocs: undefined, graph: undefined })
+      webdav: () => webDavMock
     }))
   })
 

--- a/packages/web-pkg/tests/unit/services/client.spec.ts
+++ b/packages/web-pkg/tests/unit/services/client.spec.ts
@@ -1,13 +1,14 @@
 import { HttpClient } from '../../../src/http'
 import { ClientService, useAuthStore, useConfigStore } from '../../../src/'
 import { Language } from 'vue3-gettext'
-import { client as _client } from '@ownclouders/web-client'
+import { graph, ocs, webdav } from '@ownclouders/web-client'
 import { Graph } from '@ownclouders/web-client/graph'
 import { OCS } from '@ownclouders/web-client/ocs'
+import { WebDAV } from '@ownclouders/web-client/webdav'
 import { createTestingPinia, writable } from 'web-test-helpers'
 import axios from 'axios'
+import { mock } from 'vitest-mock-extended'
 
-const getters = { 'runtime/auth/accessToken': 'token' }
 const language = { current: 'en' }
 const serverUrl = 'someUrl'
 
@@ -16,136 +17,96 @@ const getClientServiceMock = () => {
   const configStore = useConfigStore()
   writable(configStore).serverUrl = serverUrl
 
-  return {
-    clientService: new ClientService({
-      configStore,
-      language: language as Language,
-      authStore
-    }),
+  return new ClientService({
+    configStore,
+    language: language as Language,
     authStore
-  }
+  })
 }
 const v4uuid = '00000000-0000-0000-0000-000000000000'
 vi.mock('uuid', () => ({ v4: () => v4uuid }))
 vi.mock('@ownclouders/web-client', async (importOriginal) => ({
   ...(await importOriginal<any>()),
-  client: vi.fn(() => ({ graph: {}, ocs: {} }))
+  graph: vi.fn(),
+  ocs: vi.fn(),
+  webdav: vi.fn()
 }))
 
 describe('ClientService', () => {
   beforeEach(() => {
     createTestingPinia({ initialState: { auth: { accessToken: 'token' } } })
-    language.current = 'en'
   })
-  it('initializes a http authenticated client', () => {
-    const createSpy = vi.spyOn(axios, 'create')
-    const { clientService, authStore } = getClientServiceMock()
-    const client = clientService.httpAuthenticated
-    expect(client).toBeInstanceOf(HttpClient)
-    expect(createSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        headers: {
-          'Accept-Language': language.current,
-          Authorization: `Bearer ${getters['runtime/auth/accessToken']}`,
-          'X-Requested-With': 'XMLHttpRequest',
-          'X-Request-ID': v4uuid,
-          'Initiator-ID': v4uuid
-        }
+  describe('http authenticated', () => {
+    it('initializes an http client', () => {
+      const clientService = getClientServiceMock()
+      expect(clientService.httpAuthenticated).toBeInstanceOf(HttpClient)
+    })
+    it('initializes the http client with baseURL and static headers', () => {
+      vi.mock('../../../src/http')
+      const mocky = vi.mocked(HttpClient)
+      getClientServiceMock()
+
+      expect(mocky).toHaveBeenCalledWith(
+        {
+          baseURL: serverUrl,
+          headers: { 'Initiator-ID': v4uuid, 'X-Requested-With': 'XMLHttpRequest' }
+        },
+        expect.anything()
+      )
+    })
+  })
+  describe('http unauthenticated', () => {
+    it('initializes an http client', () => {
+      const clientService = getClientServiceMock()
+      expect(clientService.httpUnAuthenticated).toBeInstanceOf(HttpClient)
+    })
+    it('initializes the http client with baseURL and static headers', () => {
+      vi.mock('../../../src/http')
+      const mocky = vi.mocked(HttpClient)
+      getClientServiceMock()
+
+      expect(mocky).toHaveBeenCalledWith(
+        {
+          baseURL: serverUrl,
+          headers: { 'Initiator-ID': v4uuid, 'X-Requested-With': 'XMLHttpRequest' }
+        },
+        expect.anything()
+      )
+    })
+  })
+  describe('graph', () => {
+    it('initializes an axios client with static headers', () => {
+      const graphMock = mock<Graph>()
+      const graphSpy = vi.mocked(graph).mockReturnValue(graphMock)
+      const createSpy = vi.spyOn(axios, 'create')
+      const clientService = getClientServiceMock()
+      expect(createSpy).toHaveBeenCalledWith({
+        headers: { 'Initiator-ID': v4uuid, 'X-Requested-With': 'XMLHttpRequest' }
       })
-    )
-    expect(createSpy).toHaveBeenCalledTimes(1)
-    // test re-instantiation on token and language change
-    clientService.httpAuthenticated
-    expect(createSpy).toHaveBeenCalledTimes(1)
-    authStore.accessToken = 'changedToken'
-    clientService.httpAuthenticated
-    expect(createSpy).toHaveBeenCalledTimes(2)
-    language.current = 'de'
-    clientService.httpAuthenticated
-    expect(createSpy).toHaveBeenCalledTimes(3)
+      expect(graphSpy).toHaveBeenCalledWith(serverUrl, expect.anything())
+      expect(clientService.graphAuthenticated).toEqual(graphMock)
+    })
   })
-  it('initializes a http unauthenticated client', () => {
-    const createSpy = vi.spyOn(axios, 'create')
-    const { clientService } = getClientServiceMock()
-    const client = clientService.httpUnAuthenticated
-    expect(client).toBeInstanceOf(HttpClient)
-    expect(createSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        headers: {
-          'Accept-Language': language.current,
-          'X-Requested-With': 'XMLHttpRequest',
-          'X-Request-ID': v4uuid,
-          'Initiator-ID': v4uuid
-        }
+  describe('ocs', () => {
+    it('initializes an axios client with static headers', () => {
+      const ocsMock = mock<OCS>()
+      const ocsSpy = vi.mocked(ocs).mockReturnValue(ocsMock)
+      const createSpy = vi.spyOn(axios, 'create')
+      const clientService = getClientServiceMock()
+      expect(createSpy).toHaveBeenCalledWith({
+        headers: { 'Initiator-ID': v4uuid, 'X-Requested-With': 'XMLHttpRequest' }
       })
-    )
-    expect(createSpy).toHaveBeenCalledTimes(1)
-    // test re-instantiation on token and language change
-    clientService.httpUnAuthenticated
-    expect(createSpy).toHaveBeenCalledTimes(1)
-    clientService.httpUnAuthenticated
-    language.current = 'de'
-    clientService.httpUnAuthenticated
-    expect(createSpy).toHaveBeenCalledTimes(2)
-  })
-  it('initializes an graph client', () => {
-    const graphClient = {} as Graph
-    vi.mocked(_client).mockImplementation(() => {
-      return { graph: graphClient, ocs: {} } as ReturnType<typeof _client>
+      expect(ocsSpy).toHaveBeenCalledWith(serverUrl, expect.anything())
+      expect(clientService.ocs).toEqual(ocsMock)
     })
-    const { clientService, authStore } = getClientServiceMock()
-    const client = clientService.graphAuthenticated
-    expect(_client).toHaveBeenCalledWith(expect.objectContaining({ baseURI: serverUrl }))
-    expect(_client).toHaveBeenCalledTimes(1)
-    expect(graphClient).toEqual(client)
-    // test re-instantiation on token and language change
-    clientService.graphAuthenticated
-    expect(_client).toHaveBeenCalledTimes(1)
-    authStore.accessToken = 'changedToken'
-    clientService.graphAuthenticated
-    expect(_client).toHaveBeenCalledTimes(2)
-    language.current = 'de'
-    clientService.graphAuthenticated
-    expect(_client).toHaveBeenCalledTimes(3)
   })
-  it('initializes an ocs user client', () => {
-    const ocsClient = {} as OCS
-    vi.mocked(_client).mockImplementation(() => {
-      return { graph: {}, ocs: ocsClient } as ReturnType<typeof _client>
+  describe('webdav', () => {
+    it('initializes a webdav client', () => {
+      const webDavMock = mock<WebDAV>()
+      const webDavSpy = vi.mocked(webdav).mockReturnValue(webDavMock)
+      const clientService = getClientServiceMock()
+      expect(webDavSpy).toHaveBeenCalledWith(serverUrl, expect.anything())
+      expect(clientService.webdav).toEqual(webDavMock)
     })
-    const { clientService, authStore } = getClientServiceMock()
-    const client = clientService.ocsUserContext
-    expect(_client).toHaveBeenCalledWith(expect.objectContaining({ baseURI: serverUrl }))
-    expect(_client).toHaveBeenCalledTimes(1)
-    expect(ocsClient).toEqual(client)
-    // test re-instantiation on token and language change
-    clientService.ocsUserContext
-    expect(_client).toHaveBeenCalledTimes(1)
-    authStore.accessToken = 'changedToken'
-    clientService.ocsUserContext
-    expect(_client).toHaveBeenCalledTimes(2)
-    language.current = 'de'
-    clientService.ocsUserContext
-    expect(_client).toHaveBeenCalledTimes(3)
-  })
-  it('initializes an ocs public link client', () => {
-    const ocsClient = {} as OCS
-    vi.mocked(_client).mockImplementation(() => {
-      return { graph: {}, ocs: ocsClient } as ReturnType<typeof _client>
-    })
-    const { clientService, authStore } = getClientServiceMock()
-    const client = clientService.ocsPublicLinkContext()
-    expect(_client).toHaveBeenCalledWith(expect.objectContaining({ baseURI: serverUrl }))
-    expect(_client).toHaveBeenCalledTimes(1)
-    expect(ocsClient).toEqual(client)
-    // test re-instantiation on token and language change
-    clientService.ocsPublicLinkContext()
-    expect(_client).toHaveBeenCalledTimes(1)
-    authStore.accessToken = 'changedToken'
-    clientService.ocsPublicLinkContext()
-    expect(_client).toHaveBeenCalledTimes(2)
-    language.current = 'de'
-    clientService.ocsPublicLinkContext()
-    expect(_client).toHaveBeenCalledTimes(3)
   })
 })


### PR DESCRIPTION
## Description
Removes the old way of re-initializing clients in the client service when they needed to. The client service now uses request interceptors for the dynamic headers such as `Authorization`.

This a) is more developer friendly since the client service can now be destructured and b) removes the overhead of re-initializing the clients over and over again.

A few (non-breaking) changes needed to be done in the `web-client` package for this. It now exposes the 3 individual client init methods for initializing clients via the `web-client` package:

* `graph()`
* `ocs()`
* `webdav()`

This also deprecates the `client()` method which initializes all 3 clients at the same time because it's intransparent to the user. E.g. you pass an `axios` instance to this method, but the webdav client doesn't use it. So users might run into scenarios where they wonder why specific things don't work (e.g. request interceptors).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- closes https://github.com/owncloud/web/issues/11107

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
