### PR TITLE
fix(admin-settings): user filters after page reload

### DIFF
--- a/changelog/unreleased/bugfix-user-filters-after-page-reload
+++ b/changelog/unreleased/bugfix-user-filters-after-page-reload
@@ -1,0 +1,6 @@
+Bugfix: User filters after page reload
+
+We've fixed an issue where applied user filters would not be visible after page reload.
+
+https://github.com/owncloud/web/issues/11604
+https://github.com/owncloud/web/pull/11666

--- a/packages/web-app-admin-settings/src/views/Users.vue
+++ b/packages/web-app-admin-settings/src/views/Users.vue
@@ -45,6 +45,7 @@
                 <span v-text="$gettext('Filter:')" />
               </div>
               <item-filter
+                v-if="groups.length"
                 :allow-multiple="true"
                 :filter-label="$gettext('Groups')"
                 :filterable-attributes="['displayName']"
@@ -64,6 +65,7 @@
                 </template>
               </item-filter>
               <item-filter
+                v-if="roles.length"
                 :allow-multiple="true"
                 :filter-label="$gettext('Roles')"
                 :filterable-attributes="['displayName']"

--- a/packages/web-app-admin-settings/tests/unit/views/Users.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/views/Users.spec.ts
@@ -3,7 +3,7 @@ import { ItemFilter, OptionsConfig, UserAction, useAppDefaults } from '@owncloud
 import { mock, mockDeep } from 'vitest-mock-extended'
 import { defaultComponentMocks, defaultPlugins, mount, shallowMount } from 'web-test-helpers'
 import { ClientService, queryItemAsString } from '@ownclouders/web-pkg'
-import { User } from '@ownclouders/web-client/graph/generated'
+import { Group, User } from '@ownclouders/web-client/graph/generated'
 import { useAppDefaultsMock } from 'web-test-helpers/src/mocks/useAppDefaultsMock'
 import { useUserActionsCreateUser } from '../../../src/composables/actions/users/useUserActionsCreateUser'
 import { ref } from 'vue'
@@ -74,7 +74,7 @@ const getClientService = () => {
   clientService.graphAuthenticated.users.listUsers.mockResolvedValue([mock<User>(getDefaultUser())])
   clientService.graphAuthenticated.users.getUser.mockResolvedValue(mock<User>(getDefaultUser()))
   clientService.graphAuthenticated.users.editUser.mockResolvedValue(mock<User>(getDefaultUser()))
-  clientService.graphAuthenticated.groups.listGroups.mockResolvedValue([])
+  clientService.graphAuthenticated.groups.listGroups.mockResolvedValue([mock<Group>()])
   clientService.graphAuthenticated.applications.listApplications.mockResolvedValue(
     getDefaultApplications()
   )

--- a/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Users.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Users.spec.ts.snap
@@ -23,7 +23,7 @@ exports[`Users view > list view > renders initially warning if filters are manda
         <div class="user-filters oc-flex oc-flex-between oc-flex-wrap oc-flex-bottom oc-mx-m oc-mb-m">
           <div data-v-32efd9c6="" class="oc-flex oc-flex-middle">
             <div data-v-32efd9c6="" class="oc-mr-m oc-flex oc-flex-middle"><span data-v-32efd9c6="" class="oc-icon oc-icon-m oc-icon-passive oc-mr-xs"><!----></span> <span data-v-32efd9c6="">Filter:</span></div>
-            <item-filter-stub data-v-32efd9c6="" filterlabel="Groups" items="" filtername="groups" optionfilterlabel="Filter groups" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false" class="oc-mr-s"></item-filter-stub>
+            <item-filter-stub data-v-32efd9c6="" filterlabel="Groups" items="undefined" filtername="groups" optionfilterlabel="Filter groups" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false" class="oc-mr-s"></item-filter-stub>
             <item-filter-stub data-v-32efd9c6="" filterlabel="Roles" items="[object Object],[object Object],[object Object],[object Object]" filtername="roles" optionfilterlabel="Filter roles" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false"></item-filter-stub>
           </div>
           <div data-v-32efd9c6="" class="oc-flex oc-flex-middle">
@@ -71,7 +71,7 @@ exports[`Users view > list view > renders list initially 1`] = `
         <div class="user-filters oc-flex oc-flex-between oc-flex-wrap oc-flex-bottom oc-mx-m oc-mb-m">
           <div data-v-32efd9c6="" class="oc-flex oc-flex-middle">
             <div data-v-32efd9c6="" class="oc-mr-m oc-flex oc-flex-middle"><span data-v-32efd9c6="" class="oc-icon oc-icon-m oc-icon-passive oc-mr-xs"><!----></span> <span data-v-32efd9c6="">Filter:</span></div>
-            <item-filter-stub data-v-32efd9c6="" filterlabel="Groups" items="" filtername="groups" optionfilterlabel="Filter groups" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false" class="oc-mr-s"></item-filter-stub>
+            <item-filter-stub data-v-32efd9c6="" filterlabel="Groups" items="undefined" filtername="groups" optionfilterlabel="Filter groups" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false" class="oc-mr-s"></item-filter-stub>
             <item-filter-stub data-v-32efd9c6="" filterlabel="Roles" items="[object Object],[object Object],[object Object],[object Object]" filtername="roles" optionfilterlabel="Filter roles" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false"></item-filter-stub>
           </div>
           <div data-v-32efd9c6="" class="oc-flex oc-flex-middle">


### PR DESCRIPTION
## Description
Fixes an issue where applied user filters would not be visible after page reload.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/11604

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
