### PR TITLE
feat: add abort signals

### DIFF
--- a/packages/web-app-admin-settings/src/views/Spaces.vue
+++ b/packages/web-app-admin-settings/src/views/Spaces.vue
@@ -121,10 +121,14 @@ export default defineComponent({
 
     const loadResourcesTask = useTask(function* (signal) {
       const drives = yield* call(
-        clientService.graphAuthenticated.drives.listAllDrives(sharesStore.graphRoles, {
-          orderBy: 'name asc',
-          filter: 'driveType eq project'
-        })
+        clientService.graphAuthenticated.drives.listAllDrives(
+          sharesStore.graphRoles,
+          {
+            orderBy: 'name asc',
+            filter: 'driveType eq project'
+          },
+          { signal }
+        )
       )
       spaceSettingsStore.setSpaces(drives)
     })

--- a/packages/web-app-admin-settings/src/views/Users.vue
+++ b/packages/web-app-admin-settings/src/views/Users.vue
@@ -306,7 +306,7 @@ export default defineComponent({
         return
       }
 
-      const data = yield clientService.graphAuthenticated.users.getUser(user.id)
+      const data = yield clientService.graphAuthenticated.users.getUser(user.id, {}, { signal })
       unref(additionalUserDataLoadedForUserIds).push(user.id)
 
       Object.assign(user, data)

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -130,7 +130,8 @@ export default defineComponent({
 
         const url = `${baseUrl}?${query}`
         const response = yield makeRequest('POST', url, {
-          validateStatus: () => true
+          validateStatus: () => true,
+          signal
         })
 
         if (response.status !== 200) {

--- a/packages/web-app-files/src/services/folder/loaderFavorites.ts
+++ b/packages/web-app-files/src/services/folder/loaderFavorites.ts
@@ -22,7 +22,8 @@ export class FolderLoaderFavorites implements FolderLoader {
       resourcesStore.setAncestorMetaData({})
 
       let resources = yield clientService.webdav.listFavoriteFiles({
-        username: userStore.user?.onPremisesSamAccountName
+        username: userStore.user?.onPremisesSamAccountName,
+        signal: signal1
       })
 
       resources = resources.map(buildResource)

--- a/packages/web-app-files/src/services/folder/loaderSharedViaLink.ts
+++ b/packages/web-app-files/src/services/folder/loaderSharedViaLink.ts
@@ -22,10 +22,15 @@ export class FolderLoaderSharedViaLink implements FolderLoader {
       resourcesStore.setAncestorMetaData({})
 
       if (configStore.options.routing.fullShareOwnerPaths) {
-        yield spacesStore.loadMountPoints({ graphClient: clientService.graphAuthenticated })
+        yield spacesStore.loadMountPoints({
+          graphClient: clientService.graphAuthenticated,
+          signal: signal1
+        })
       }
 
-      const value = yield* call(clientService.graphAuthenticated.driveItems.listSharedByMe())
+      const value = yield* call(
+        clientService.graphAuthenticated.driveItems.listSharedByMe({ signal: signal1 })
+      )
 
       const resources = value
         .filter((s) => s.permissions.some(({ link }) => !!link))

--- a/packages/web-app-files/src/services/folder/loaderSharedWithMe.ts
+++ b/packages/web-app-files/src/services/folder/loaderSharedWithMe.ts
@@ -22,10 +22,15 @@ export class FolderLoaderSharedWithMe implements FolderLoader {
       resourcesStore.setAncestorMetaData({})
 
       if (configStore.options.routing.fullShareOwnerPaths) {
-        yield spacesStore.loadMountPoints({ graphClient: clientService.graphAuthenticated })
+        yield spacesStore.loadMountPoints({
+          graphClient: clientService.graphAuthenticated,
+          signal: signal1
+        })
       }
 
-      const value = yield* call(clientService.graphAuthenticated.driveItems.listSharedWithMe())
+      const value = yield* call(
+        clientService.graphAuthenticated.driveItems.listSharedWithMe({ signal: signal1 })
+      )
 
       const resources = value.map((driveItem) =>
         buildIncomingShareResource({ driveItem, graphRoles: sharesStore.graphRoles })

--- a/packages/web-app-files/src/services/folder/loaderSharedWithOthers.ts
+++ b/packages/web-app-files/src/services/folder/loaderSharedWithOthers.ts
@@ -22,10 +22,15 @@ export class FolderLoaderSharedWithOthers implements FolderLoader {
       resourcesStore.setAncestorMetaData({})
 
       if (configStore.options.routing.fullShareOwnerPaths) {
-        yield spacesStore.loadMountPoints({ graphClient: clientService.graphAuthenticated })
+        yield spacesStore.loadMountPoints({
+          graphClient: clientService.graphAuthenticated,
+          signal: signal1
+        })
       }
 
-      const value = yield* call(clientService.graphAuthenticated.driveItems.listSharedByMe())
+      const value = yield* call(
+        clientService.graphAuthenticated.driveItems.listSharedByMe({ signal: signal1 })
+      )
 
       const resources = value
         .filter((s) => s.permissions.some(({ link }) => !link))

--- a/packages/web-app-files/src/services/folder/loaderTrashbin.ts
+++ b/packages/web-app-files/src/services/folder/loaderTrashbin.ts
@@ -26,7 +26,7 @@ export class FolderLoaderTrashbin implements FolderLoader {
       const { resource, children } = yield webdav.listFiles(
         space,
         {},
-        { depth: 1, davProperties: DavProperties.Trashbin, isTrash: true }
+        { depth: 1, davProperties: DavProperties.Trashbin, isTrash: true, signal: signal1 }
       )
 
       resourcesStore.initResourceList({ currentFolder: resource, resources: children })

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -251,10 +251,13 @@ export default defineComponent({
     const { setSelection, initResourceList, clearResourceList, setAncestorMetaData } =
       useResourcesStore()
 
-    const loadResourcesTask = useTask(function* () {
+    const loadResourcesTask = useTask(function* (signal) {
       clearResourceList()
       setAncestorMetaData({})
-      yield spacesStore.reloadProjectSpaces({ graphClient: clientService.graphAuthenticated })
+      yield spacesStore.reloadProjectSpaces({
+        graphClient: clientService.graphAuthenticated,
+        signal
+      })
       initResourceList({ currentFolder: null, resources: unref(spaces) })
     })
 

--- a/packages/web-app-files/src/views/trash/Overview.vue
+++ b/packages/web-app-files/src/views/trash/Overview.vue
@@ -121,9 +121,12 @@ export default defineComponent({
       )
     )
 
-    const loadResourcesTask = useTask(function* () {
+    const loadResourcesTask = useTask(function* (signal) {
       resourcesStore.clearResourceList()
-      yield spacesStore.reloadProjectSpaces({ graphClient: clientService.graphAuthenticated })
+      yield spacesStore.reloadProjectSpaces({
+        graphClient: clientService.graphAuthenticated,
+        signal
+      })
       resourcesStore.initResourceList({ currentFolder: null, resources: unref(spaces) })
     })
 

--- a/packages/web-pkg/src/composables/appDefaults/useAppFileHandling.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppFileHandling.ts
@@ -14,10 +14,10 @@ interface AppFileHandlingOptions {
   clientService: ClientService
 }
 
-export type FileContentOptions = { responseType?: 'arraybuffer' | 'blob' | 'text' } & Record<
-  string,
-  any
->
+export type FileContentOptions = {
+  responseType?: 'arraybuffer' | 'blob' | 'text'
+  signal?: AbortSignal
+} & Record<string, any>
 export type UrlForResourceOptions = Omit<Parameters<WebDAV['getFileUrl']>[2], 'isUrlSigningEnabled'>
 
 export interface AppFileHandlingResult {
@@ -61,7 +61,10 @@ export function useAppFileHandling({
   // TODO: support query parameters
   const getFileContents = (
     fileContext: MaybeRef<FileContext>,
-    options: { responseType?: 'arraybuffer' | 'blob' | 'text' } & Record<string, any>
+    options: { responseType?: 'arraybuffer' | 'blob' | 'text'; signal?: AbortSignal } & Record<
+      string,
+      any
+    >
   ) => {
     return clientService.webdav.getFileContents(
       unref(unref(fileContext).space),
@@ -90,7 +93,7 @@ export function useAppFileHandling({
 
   const putFileContents = (
     fileContext: MaybeRef<FileContext>,
-    options: { content?: string } & Record<string, any>
+    options: { content?: string; signal?: AbortSignal } & Record<string, any>
   ) => {
     return clientService.webdav.putFileContents(unref(unref(fileContext).space), {
       path: unref(unref(fileContext).item),

--- a/packages/web-pkg/src/composables/piniaStores/resources.ts
+++ b/packages/web-pkg/src/composables/piniaStores/resources.ts
@@ -224,11 +224,13 @@ export const useResourcesStore = defineStore('resources', () => {
   const loadAncestorMetaData = ({
     folder,
     space,
-    client
+    client,
+    signal
   }: {
     folder: Resource
     space: SpaceResource
     client: WebDAV
+    signal?: AbortSignal
   }) => {
     const data: AncestorMetaData = {
       [folder.path]: {
@@ -274,15 +276,17 @@ export const useResourcesStore = defineStore('resources', () => {
       }
 
       promises.push(
-        client.listFiles(space, { path }, { depth: 0, davProperties }).then(({ resource }) => {
-          data[path] = {
-            id: resource.fileId,
-            shareTypes: resource.shareTypes,
-            parentFolderId: resource.parentFolderId,
-            spaceId: space.id,
-            path
-          }
-        })
+        client
+          .listFiles(space, { path }, { depth: 0, davProperties, signal })
+          .then(({ resource }) => {
+            data[path] = {
+              id: resource.fileId,
+              shareTypes: resource.shareTypes,
+              parentFolderId: resource.parentFolderId,
+              spaceId: space.id,
+              path
+            }
+          })
       )
     }
 

--- a/packages/web-pkg/tests/unit/composables/piniaStores/spaces.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/piniaStores/spaces.spec.ts
@@ -188,7 +188,8 @@ describe('spaces', () => {
             {
               orderBy: 'name asc',
               filter: 'driveType eq personal'
-            }
+            },
+            expect.anything()
           )
           expect(graphClient.drives.listMyDrives).toHaveBeenNthCalledWith(
             2,
@@ -196,7 +197,8 @@ describe('spaces', () => {
             {
               orderBy: 'name asc',
               filter: 'driveType eq project'
-            }
+            },
+            expect.anything()
           )
           expect(instance.spaces.length).toBe(2)
           expect(instance.spacesLoading).toBeFalsy()
@@ -220,7 +222,8 @@ describe('spaces', () => {
             {
               orderBy: 'name asc',
               filter: 'driveType eq mountpoint'
-            }
+            },
+            expect.anything()
           )
           expect(instance.spaces.length).toBe(1)
           expect(instance.mountPointsInitialized).toBeTruthy()
@@ -243,7 +246,8 @@ describe('spaces', () => {
             {
               orderBy: 'name asc',
               filter: 'driveType eq project'
-            }
+            },
+            expect.anything()
           )
           expect(instance.spaces.length).toBe(1)
         }

--- a/packages/web-runtime/src/components/Account/GdprExport.vue
+++ b/packages/web-runtime/src/components/Account/GdprExport.vue
@@ -74,11 +74,13 @@ export default defineComponent({
     const exportFile = ref<Resource>()
     const exportInProgress = ref(false)
 
-    const loadExportTask = useTask(function* () {
+    const loadExportTask = useTask(function* (signal) {
       try {
-        const resource = yield clientService.webdav.getFileInfo(spacesStore.personalSpace, {
-          path: `/${GDPR_EXPORT_FILE_NAME}`
-        })
+        const resource = yield clientService.webdav.getFileInfo(
+          spacesStore.personalSpace,
+          { path: `/${GDPR_EXPORT_FILE_NAME}` },
+          { signal }
+        )
 
         if (resource.processing) {
           exportInProgress.value = true

--- a/packages/web-runtime/src/components/Topbar/Notifications.vue
+++ b/packages/web-runtime/src/components/Topbar/Notifications.vue
@@ -176,7 +176,8 @@ export default {
       try {
         const response = yield* call(
           clientService.httpAuthenticated.get<{ ocs: { data: Notification[] } }>(
-            'ocs/v2.php/apps/notifications/api/v1/notifications'
+            'ocs/v2.php/apps/notifications/api/v1/notifications',
+            { signal }
           )
         )
 
@@ -198,7 +199,8 @@ export default {
       try {
         yield clientService.httpAuthenticated.delete(
           'ocs/v2.php/apps/notifications/api/v1/notifications',
-          { data: { ids } }
+          { data: { ids } },
+          { signal }
         )
       } catch (e) {
         console.error(e)

--- a/packages/web-runtime/src/pages/account.vue
+++ b/packages/web-runtime/src/pages/account.vue
@@ -305,7 +305,7 @@ export default defineComponent({
     )
     const showLogout = computed(() => authStore.userContextReady && configStore.options.logoutUrl)
 
-    const loadValuesListTask = useTask(function* () {
+    const loadValuesListTask = useTask(function* (signal) {
       if (!authStore.userContextReady || !unref(isSettingsServiceSupported)) {
         return
       }
@@ -316,7 +316,8 @@ export default defineComponent({
         } = yield* call(
           clientService.httpAuthenticated.post<{ values: SettingsValue[] }>(
             '/api/v0/settings/values-list',
-            { account_uuid: 'me' }
+            { account_uuid: 'me' },
+            { signal }
           )
         )
         valuesList.value = values || []
@@ -330,7 +331,7 @@ export default defineComponent({
       }
     }).restartable()
 
-    const loadAccountBundleTask = useTask(function* () {
+    const loadAccountBundleTask = useTask(function* (signal) {
       if (!authStore.userContextReady || !unref(isSettingsServiceSupported)) {
         return
       }
@@ -341,7 +342,8 @@ export default defineComponent({
         } = yield* call(
           clientService.httpAuthenticated.post<{ bundles: SettingsBundle[] }>(
             '/api/v0/settings/bundles-list',
-            {}
+            {},
+            { signal }
           )
         )
         accountBundle.value = bundles?.find((b) => b.extension === 'ocis-accounts')
@@ -355,13 +357,13 @@ export default defineComponent({
       }
     }).restartable()
 
-    const loadGraphUserTask = useTask(function* () {
+    const loadGraphUserTask = useTask(function* (signal) {
       if (!authStore.userContextReady) {
         return
       }
 
       try {
-        graphUser.value = yield* call(clientService.graphAuthenticated.users.getMe())
+        graphUser.value = yield* call(clientService.graphAuthenticated.users.getMe({}, { signal }))
       } catch (e) {
         console.error(e)
         showErrorMessage({

--- a/packages/web-runtime/src/pages/resolvePublicLink.vue
+++ b/packages/web-runtime/src/pages/resolvePublicLink.vue
@@ -135,9 +135,13 @@ export default defineComponent({
     const isPasswordRequired = ref(false)
     const isInternalLink = ref(false)
 
-    const loadPublicSpaceTask = useTask(function* () {
+    const loadPublicSpaceTask = useTask(function* (signal) {
       try {
-        loadedSpace.value = yield clientService.webdav.getFileInfo(unref(publicLinkSpace))
+        loadedSpace.value = yield clientService.webdav.getFileInfo(
+          unref(publicLinkSpace),
+          {},
+          { signal }
+        )
       } catch (error) {
         const err = error as DavHttpError
 
@@ -159,9 +163,13 @@ export default defineComponent({
       }
     })
 
-    const verifyPasswordTask = useTask(function* () {
+    const verifyPasswordTask = useTask(function* (signal) {
       try {
-        loadedSpace.value = yield clientService.webdav.getFileInfo(unref(publicLinkSpace))
+        loadedSpace.value = yield clientService.webdav.getFileInfo(
+          unref(publicLinkSpace),
+          {},
+          { signal }
+        )
         if (!isPublicSpaceResource(unref(loadedSpace))) {
           const e: any = new Error($gettext('The resource is not a public link.'))
           e.resource = unref(loadedSpace)


### PR DESCRIPTION
Adds abort signals to (almost) all requests that are running in a task. This way they get cancelled properly when a task is being cancelled or restarted.

Also wraps the search call in a task so it can benefit from this functionality.

closes https://github.com/owncloud/web/issues/11650