### PR TITLE
fix: error parsing in delete- and paste-worker

### DIFF
--- a/changelog/unreleased/bugfix-undefined-request-ids
+++ b/changelog/unreleased/bugfix-undefined-request-ids
@@ -1,0 +1,6 @@
+Bugfix: Undefined request IDs
+
+Request IDs from failing copy, move and delete requests are no longer undefined.
+
+https://github.com/owncloud/web/issues/11678
+https://github.com/owncloud/web/pull/11684

--- a/packages/web-pkg/src/composables/actions/helpers/useFileActionsDeleteResources.ts
+++ b/packages/web-pkg/src/composables/actions/helpers/useFileActionsDeleteResources.ts
@@ -193,9 +193,9 @@ export const useFileActionsDeleteResources = () => {
               messageStore.showMessage({ title })
             }
 
-            failed.forEach(({ status, resource }) => {
+            failed.forEach(({ error, resource }) => {
               let title = $gettext('Failed to delete "%{resource}"', { resource: resource.name })
-              if (status === 423) {
+              if (error.statusCode === 423) {
                 title = $gettext('Failed to delete "%{resource}" - the file is locked', {
                   resource: resource.name
                 })

--- a/packages/web-pkg/tests/unit/composables/webWorkers/deleteWorker/worker.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/webWorkers/deleteWorker/worker.spec.ts
@@ -113,6 +113,9 @@ describe('delete worker', () => {
   })
 
   it('returns failed files', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    webDavMock.deleteFile.mockRejectedValue({ response: {} })
+
     unref(worker.worker).onmessage = (e: MessageEvent) => {
       const { failed } = JSON.parse(e.data)
       expect(failed.length).toBe(1)

--- a/packages/web-pkg/tests/unit/composables/webWorkers/pasteWorker/worker.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/webWorkers/pasteWorker/worker.spec.ts
@@ -109,7 +109,8 @@ describe('paste worker', () => {
   })
 
   it('returns failed files', async () => {
-    webDavMock.copyFiles.mockRejectedValue(undefined)
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    webDavMock.copyFiles.mockRejectedValue({ response: {} })
 
     unref(worker.worker).onmessage = (e: MessageEvent) => {
       const { failed } = JSON.parse(e.data)


### PR DESCRIPTION
Errors in workers need to be constructed manually in the main thread since they can't be serialized and passed from the worker to the main thread.

This also fixes the issue with the missing request ids in failing copy, move and delete requests.

fixes https://github.com/owncloud/web/issues/11678