### PR TITLE
feat: add insufficient quota info to file copy

### DIFF
--- a/packages/web-app-files/src/HandleUpload.ts
+++ b/packages/web-app-files/src/HandleUpload.ts
@@ -250,9 +250,9 @@ export class HandleUpload extends BasePlugin {
         }
 
         this.messageStore.showErrorMessage({
-          title: $gettext('Not enough quota'),
+          title: $gettext('Insufficient quota'),
           desc: $gettext(
-            'There is not enough quota on %{spaceName}, you need additional %{missingSpace} to upload these files',
+            'Insufficient quota on %{spaceName}. You need additional %{missingSpace} to upload these files',
             {
               spaceName,
               missingSpace: filesize<FileSizeOptionsString>(

--- a/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
+++ b/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
@@ -385,7 +385,7 @@ export default defineComponent({
             if (space) {
               errorPopup(
                 new HttpError(
-                  $gettext('There is not enough quota on "%{spaceName}" to save this file', {
+                  $gettext('Insufficient quota on "%{spaceName}" to save this file', {
                     spaceName: space.name
                   }),
                   e.response
@@ -394,7 +394,7 @@ export default defineComponent({
               break
             }
             errorPopup(
-              new HttpError($gettext('There is not enough quota to save this file'), e.response)
+              new HttpError($gettext('Insufficient quota for saving this file'), e.response)
             )
             break
           default:

--- a/packages/web-pkg/src/helpers/resource/conflictHandling/transfer.ts
+++ b/packages/web-pkg/src/helpers/resource/conflictHandling/transfer.ts
@@ -7,6 +7,7 @@ import type { ClientService } from '../../../services'
 import { useMessages } from '../../../composables'
 import { Ref, unref } from 'vue'
 import type { Language } from 'vue3-gettext'
+import { HttpError } from '@ownclouders/web-client'
 
 export class ResourceTransfer extends ConflictDialog {
   constructor(
@@ -90,8 +91,16 @@ export class ResourceTransfer extends ConflictDialog {
           ? this.$gettext('Failed to copy "%{name}"', { name: errors[0]?.resourceName }, true)
           : this.$gettext('Failed to move "%{name}"', { name: errors[0]?.resourceName }, true)
     }
+    let description = ''
+    if (errors.some(({ error }) => error instanceof HttpError && error.statusCode === 507)) {
+      description = this.$gettext('Insufficient quota')
+    }
     const messageStore = useMessages()
-    messageStore.showErrorMessage({ title, errors: errors.map(({ error }) => error) })
+    messageStore.showErrorMessage({
+      title,
+      ...(description && { desc: description }),
+      errors: errors.map(({ error }) => error)
+    })
   }
 
   /**

--- a/tests/e2e/cucumber/features/smoke/upload.feature
+++ b/tests/e2e/cucumber/features/smoke/upload.feature
@@ -41,8 +41,8 @@ Feature: Upload
       | simple.pdf     |
       | testavatar.jpg |
     And "Alice" tries to upload the following resource
-      | resource      | error            |
-      | lorem-big.txt | Not enough quota |
+      | resource      | error              |
+      | lorem-big.txt | Insufficient quota |
     And "Alice" downloads the following resources using the sidebar panel
       | resource      | type   |
       | PARENT        | folder |


### PR DESCRIPTION
## Description
Adding an "insufficient quota" message detail to the file/folder copy and move error messages. Additionally I've tried to streamline the quota error messages a bit. Would be good to get some native language speaker feedback. Trying to spawn @phil-davis for that 😁 

## Issues
Relates to all the confusion in https://github.com/owncloud/enterprise/issues/6857 and trying to ease some of it.

## Motivation and Context
More details in error messages for normal users.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
- [ ] changelog item