### PR TITLE
fix: add missing resource tags on 'Shared with me' page

### DIFF
--- a/changelog/unreleased/bugfix-tags-shared-with-me-page
+++ b/changelog/unreleased/bugfix-tags-shared-with-me-page
@@ -1,0 +1,6 @@
+Bugfix: Missing tags on "Shared with me" page
+
+Missing resource tags on the "Shared with me" page have been added.
+
+https://github.com/owncloud/web/issues/11677
+https://github.com/owncloud/web/pull/11703

--- a/packages/web-pkg/src/components/SideBar/FileSideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/FileSideBar.vue
@@ -383,13 +383,17 @@ export default defineComponent({
 
         // shared resources look different, hence we need to fetch the actual resource here
         try {
-          let fullResource = await clientService.webdav.getFileInfo(props.space, {
+          const webDavResource = await clientService.webdav.getFileInfo(props.space, {
             path: resource.path
           })
 
-          // make sure props from the share (=resource) are available on the full resource as well
-          fullResource = { ...fullResource, ...resource }
-          loadedResource.value = fullResource
+          // make sure props from the share (=resource) are available on the merged resource
+          const mergedResource = {
+            ...webDavResource,
+            ...resource,
+            tags: webDavResource.tags // tags are always [] in Graph API, hence take them from webdav
+          }
+          loadedResource.value = mergedResource
         } catch (error) {
           loadedResource.value = resource
           console.error(error)


### PR DESCRIPTION
Tags are currently not available on the Graph API, hence we need to manually take them from the webdav response.

fixes https://github.com/owncloud/web/issues/11677