### PR TITLE
fix: deleting federated connections

### DIFF
--- a/changelog/unreleased/bugfix-delete-federated-connections
+++ b/changelog/unreleased/bugfix-delete-federated-connections
@@ -1,0 +1,6 @@
+Bugfix: Deleting federated connections
+
+We've fixed an issue where federated connections could not be deleted.
+
+https://github.com/owncloud/web/issues/11688
+https://github.com/owncloud/web/pull/11734

--- a/packages/web-app-ocm/src/views/ConnectionsPanel.vue
+++ b/packages/web-app-ocm/src/views/ConnectionsPanel.vue
@@ -155,11 +155,8 @@ export default defineComponent({
 
     const deleteConnection = async (user: FederatedConnection) => {
       try {
-        await clientService.httpAuthenticated.delete('/sciencemesh/delete-accepted-user', null, {
-          params: {
-            user_id: user.user_id,
-            idp: user.idp
-          }
+        await clientService.httpAuthenticated.delete('/sciencemesh/delete-accepted-user', {
+          data: { user_id: user.user_id, idp: user.idp }
         })
 
         const updatedConnections = props.connections.filter(


### PR DESCRIPTION
Fixes deleting federated connections in the science mesh app.

fixes https://github.com/owncloud/web/issues/11688