### PR TITLE
fix: various small a11y issues 

### DIFF
--- a/packages/design-system/src/components/OcModal/OcModal.vue
+++ b/packages/design-system/src/components/OcModal/OcModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="oc-modal-background" aria-labelledby="oc-modal-title">
+  <div class="oc-modal-background">
     <focus-trap :active="true" :initial-focus="initialFocusRef" :tabbable-options="tabbableOptions">
       <div
         :id="elementId"
@@ -8,6 +8,7 @@
         tabindex="0"
         role="dialog"
         aria-modal="true"
+        aria-labelledby="oc-modal-title"
         @keydown.esc="cancelModalAction"
       >
         <div class="oc-modal-title">

--- a/packages/design-system/src/components/OcModal/__snapshots__/OcModal.spec.ts.snap
+++ b/packages/design-system/src/components/OcModal/__snapshots__/OcModal.spec.ts.snap
@@ -1,9 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`OcModal > displays input 1`] = `
-"<div class="oc-modal-background" aria-labelledby="oc-modal-title">
+"<div class="oc-modal-background">
   <focus-trap-stub tabbableoptions="[object Object]" active="true" escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true" clickoutsidedeactivates="false" initialfocus="[Function]" delayinitialfocus="true" preventscroll="false" setreturnfocus="false">
-    <div class="oc-modal oc-modal-passive" tabindex="0" role="dialog" aria-modal="true">
+    <div class="oc-modal oc-modal-passive" tabindex="0" role="dialog" aria-modal="true" aria-labelledby="oc-modal-title">
       <div class="oc-modal-title">
         <!--v-if-->
         <h2 id="oc-modal-title" class="oc-text-truncate">Create new folder</h2>
@@ -25,9 +25,9 @@ exports[`OcModal > displays input 1`] = `
 `;
 
 exports[`OcModal > displays loading state 1`] = `
-"<div class="oc-modal-background" aria-labelledby="oc-modal-title">
+"<div class="oc-modal-background">
   <focus-trap-stub tabbableoptions="[object Object]" active="true" escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true" clickoutsidedeactivates="false" initialfocus="[Function]" delayinitialfocus="true" preventscroll="false" setreturnfocus="false">
-    <div class="oc-modal oc-modal-passive" tabindex="0" role="dialog" aria-modal="true">
+    <div class="oc-modal oc-modal-passive" tabindex="0" role="dialog" aria-modal="true" aria-labelledby="oc-modal-title">
       <div class="oc-modal-title">
         <!--v-if-->
         <h2 id="oc-modal-title" class="oc-text-truncate">Example title</h2>
@@ -49,9 +49,9 @@ exports[`OcModal > displays loading state 1`] = `
 `;
 
 exports[`OcModal > hides icon if not specified 1`] = `
-"<div class="oc-modal-background" aria-labelledby="oc-modal-title">
+"<div class="oc-modal-background">
   <focus-trap-stub tabbableoptions="[object Object]" active="true" escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true" clickoutsidedeactivates="false" initialfocus="[Function]" delayinitialfocus="true" preventscroll="false" setreturnfocus="false">
-    <div class="oc-modal oc-modal-passive" tabindex="0" role="dialog" aria-modal="true">
+    <div class="oc-modal oc-modal-passive" tabindex="0" role="dialog" aria-modal="true" aria-labelledby="oc-modal-title">
       <div class="oc-modal-title">
         <!--v-if-->
         <h2 id="oc-modal-title" class="oc-text-truncate">Example title</h2>
@@ -73,9 +73,9 @@ exports[`OcModal > hides icon if not specified 1`] = `
 `;
 
 exports[`OcModal > matches snapshot 1`] = `
-"<div class="oc-modal-background" aria-labelledby="oc-modal-title">
+"<div class="oc-modal-background">
   <focus-trap-stub tabbableoptions="[object Object]" active="true" escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true" clickoutsidedeactivates="false" initialfocus="[Function]" delayinitialfocus="true" preventscroll="false" setreturnfocus="false">
-    <div class="oc-modal oc-modal-passive" tabindex="0" role="dialog" aria-modal="true">
+    <div class="oc-modal oc-modal-passive" tabindex="0" role="dialog" aria-modal="true" aria-labelledby="oc-modal-title">
       <div class="oc-modal-title">
         <oc-icon-stub name="info" filltype="fill" accessiblelabel="" type="span" size="medium" variation="passive" color=""></oc-icon-stub>
         <h2 id="oc-modal-title" class="oc-text-truncate">Example title</h2>
@@ -97,9 +97,9 @@ exports[`OcModal > matches snapshot 1`] = `
 `;
 
 exports[`OcModal > overrides props message with slot 1`] = `
-"<div class="oc-modal-background" aria-labelledby="oc-modal-title">
+"<div class="oc-modal-background">
   <focus-trap-stub tabbableoptions="[object Object]" active="true" escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true" clickoutsidedeactivates="false" initialfocus="[Function]" delayinitialfocus="true" preventscroll="false" setreturnfocus="false">
-    <div class="oc-modal oc-modal-passive" tabindex="0" role="dialog" aria-modal="true">
+    <div class="oc-modal oc-modal-passive" tabindex="0" role="dialog" aria-modal="true" aria-labelledby="oc-modal-title">
       <div class="oc-modal-title">
         <!--v-if-->
         <h2 id="oc-modal-title" class="oc-text-truncate">Example title</h2>

--- a/packages/design-system/src/components/OcPageSize/OcPageSize.vue
+++ b/packages/design-system/src/components/OcPageSize/OcPageSize.vue
@@ -4,6 +4,7 @@
       class="oc-page-size-label"
       :for="selectId"
       data-testid="oc-page-size-label"
+      :aria-hidden="true"
       v-text="label"
     />
     <oc-select

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/EditDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/EditDropdown.vue
@@ -38,6 +38,15 @@
         </li>
       </oc-list>
     </oc-drop>
+    <oc-info-drop
+      ref="accessDetailsDrop"
+      class="share-access-details-drop"
+      v-bind="{
+        title: $gettext('Access details'),
+        list: accessDetails
+      }"
+      mode="manual"
+    />
   </div>
 </template>
 
@@ -53,6 +62,8 @@ import { useGettext } from 'vue3-gettext'
 import DatePickerModal from '../../../Modals/DatePickerModal.vue'
 import { RouteLocationNamedRaw } from 'vue-router'
 import ContextMenuItem from './ContextMenuItem.vue'
+import { ContextualHelperDataListItem } from 'design-system/src/helpers'
+import OcInfoDrop from 'design-system/src/components/OcInfoDrop/OcInfoDrop.vue'
 
 export type EditOption = {
   icon: string
@@ -86,6 +97,10 @@ export default defineComponent({
       type: Boolean,
       required: true
     },
+    accessDetails: {
+      type: Array as PropType<ContextualHelperDataListItem[]>,
+      required: true
+    },
     isShareDenied: {
       type: Boolean,
       default: false
@@ -103,19 +118,14 @@ export default defineComponent({
       default: undefined
     }
   },
-  emits: [
-    'expirationDateChanged',
-    'removeShare',
-    'showAccessDetails',
-    'setDenyShare',
-    'notifyShare'
-  ],
+  emits: ['expirationDateChanged', 'removeShare', 'setDenyShare', 'notifyShare'],
   setup(props, { emit }) {
     const language = useGettext()
     const { $gettext } = language
     const configStore = useConfigStore()
     const { dispatchModal } = useModals()
     const expirationDateDrop = useTemplateRef<typeof OcDrop>('expirationDateDrop')
+    const accessDetailsDrop = useTemplateRef<typeof OcInfoDrop>('accessDetailsDrop')
 
     const resource = inject<Ref<Resource>>('resource')
 
@@ -160,6 +170,7 @@ export default defineComponent({
       configStore,
       resource,
       expirationDateDrop,
+      accessDetailsDrop,
       toggleShareDenied,
       dropButtonTooltip,
       dispatchModal,
@@ -172,7 +183,7 @@ export default defineComponent({
       const result: EditOption[] = [
         {
           title: this.$gettext('Access details'),
-          method: this.showAccessDetails,
+          method: () => this.accessDetailsDrop.$refs.drop.show(),
           icon: 'information',
           class: 'show-access-details'
         }
@@ -253,9 +264,6 @@ export default defineComponent({
       this.$emit('expirationDateChanged', { expirationDateTime: null })
       this.expirationDateDrop.hide()
     },
-    showAccessDetails() {
-      this.$emit('showAccessDetails')
-    },
     showDatePickerModal() {
       const currentDate = DateTime.fromISO(this.expirationDate)
 
@@ -289,6 +297,21 @@ export default defineComponent({
     justify-content: flex-start;
     color: var(--oc-color-swatch-passive-default);
     gap: var(--oc-space-small);
+  }
+}
+.share-access-details-drop {
+  dl {
+    display: grid;
+    grid-template-columns: max-content auto;
+    column-gap: var(--oc-space-medium);
+    row-gap: var(--oc-space-xsmall);
+  }
+  dt {
+    grid-column-start: 1;
+  }
+  dd {
+    grid-column-start: 2;
+    margin-left: var(--oc-space-medium);
   }
 }
 </style>

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
@@ -99,7 +99,6 @@
           class="files-collaborators-collaborator-shared-via oc-mx-xs"
         />
         <edit-dropdown
-          :id="`edit-drop-down-${editDropDownToggleId}`"
           class="files-collaborators-collaborator-edit oc-ml-xs"
           data-testid="collaborator-edit"
           :expiration-date="share.expirationDateTime ? share.expirationDateTime : null"
@@ -109,18 +108,11 @@
           :is-locked="isLocked"
           :deniable="deniable"
           :shared-parent-route="!isShareDenied ? sharedParentRoute : undefined"
+          :access-details="accessDetails"
           @expiration-date-changed="shareExpirationChanged"
           @remove-share="removeShare"
           @set-deny-share="setDenyShare"
-          @show-access-details="showAccessDetails"
           @notify-share="showNotifyShareModal"
-        />
-        <oc-info-drop
-          ref="accessDetailsDrop"
-          class="share-access-details-drop"
-          v-bind="accessDetailsProps"
-          mode="manual"
-          :target="`#edit-drop-down-${editDropDownToggleId}`"
         />
       </div>
     </div>
@@ -144,10 +136,8 @@ import {
 } from '@ownclouders/web-pkg'
 import { Resource, extractDomSelector } from '@ownclouders/web-client'
 import { computed, defineComponent, inject, PropType, Ref, unref } from 'vue'
-import * as uuid from 'uuid'
 import { formatDateFromDateTime } from '@ownclouders/web-pkg'
 import { useClientService } from '@ownclouders/web-pkg'
-import { OcInfoDrop, OcDrop } from 'design-system/src/components'
 import { RouteLocationNamedRaw } from 'vue-router'
 import { useGettext } from 'vue3-gettext'
 import { SpaceResource } from '@ownclouders/web-client'
@@ -331,14 +321,10 @@ export default defineComponent({
         this.$language.current
       )
     },
-
-    editDropDownToggleId() {
-      return uuid.v4()
-    },
     shareOwnerDisplayName() {
       return this.share.sharedBy.displayName
     },
-    accessDetailsProps() {
+    accessDetails() {
       const list: ContextualHelperDataListItem[] = []
 
       list.push({ text: this.$gettext('Name'), headline: true }, { text: this.shareDisplayName })
@@ -357,22 +343,12 @@ export default defineComponent({
         )
       }
 
-      return {
-        title: this.$gettext('Access details'),
-        list
-      }
+      return list
     }
   },
   methods: {
     removeShare() {
       this.$emit('onDelete', this.share)
-    },
-
-    showAccessDetails() {
-      ;(
-        (this.$refs.accessDetailsDrop as InstanceType<typeof OcInfoDrop>).$refs
-          .drop as InstanceType<typeof OcDrop>
-      ).show()
     },
 
     async shareRoleChanged(role: ShareRole) {
@@ -440,22 +416,6 @@ export default defineComponent({
 <style lang="scss" scoped>
 .sharee-avatar {
   min-width: 36px;
-}
-
-.share-access-details-drop {
-  dl {
-    display: grid;
-    grid-template-columns: max-content auto;
-  }
-
-  dt {
-    grid-column-start: 1;
-  }
-
-  dd {
-    grid-column-start: 2;
-    margin-left: var(--oc-space-medium);
-  }
 }
 
 .files-collaborators-collaborator-navigation {

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/EditDropdown.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/EditDropdown.spec.ts
@@ -73,6 +73,7 @@ function getWrapper(props: PartialComponentProps<typeof EditDropdown> = {}) {
       props: {
         canEditOrDelete: true,
         shareCategory: 'user',
+        accessDetails: [],
         ...props
       },
       global: {

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/ListItem.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/ListItem.spec.ts
@@ -19,25 +19,11 @@ import { mock } from 'vitest-mock-extended'
 import { Resource, SpaceResource } from '@ownclouders/web-client'
 import { RouteLocationNamedRaw } from 'vue-router'
 
-vi.mock('@ownclouders/web-client', async (importOriginal) => ({
-  ...(await importOriginal<any>()),
-  buildSpace: vi.fn((space) => space)
-}))
-
-vi.mock('uuid', () => ({
-  v4: () => {
-    return '00000000-0000-0000-0000-000000000000'
-  }
-}))
-
 const selectors = {
   userAvatarImage: 'avatar-image-stub.files-collaborators-collaborator-indicator',
   notUserAvatar: 'oc-avatar-item-stub.files-collaborators-collaborator-indicator',
-  collaboratorAdditionalInfo: '.files-collaborators-collaborator-additional-info',
   collaboratorName: '.files-collaborators-collaborator-name',
-  accessDetailsButton: '.files-collaborators-collaborator-access-details-button',
   collaboratorRole: '.files-collaborators-collaborator-role',
-  collaboratorEdit: '.files-collaborators-collaborator-edit',
   shareInheritanceIndicators: '.files-collaborators-collaborator-shared-via',
   expirationDateIcon: '[data-testid="recipient-info-expiration-date"]',
   externalContextHelper: '.files-collaborators-collaborator-name-wrapper .oc-contextual-helper'

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/ListItem.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/ListItem.spec.ts.snap
@@ -21,8 +21,7 @@ exports[`Collaborator ListItem component > share inheritance indicators > show w
     <div data-v-ccf14be2="" class="oc-flex oc-flex-middle oc-width-1-3 files-collaborators-collaborator-navigation">
       <!--v-if-->
       <oc-icon-stub data-v-ccf14be2="" name="folder-shared" fill-type="line" class="files-collaborators-collaborator-shared-via oc-mx-xs"></oc-icon-stub>
-      <edit-dropdown-stub data-v-ccf14be2="" sharecategory="user" caneditordelete="true" issharedenied="false" deniable="false" islocked="false" sharedparentroute="[object Object]" id="edit-drop-down-00000000-0000-0000-0000-000000000000" class="files-collaborators-collaborator-edit oc-ml-xs" data-testid="collaborator-edit"></edit-dropdown-stub>
-      <oc-info-drop-stub data-v-ccf14be2="" class="share-access-details-drop" title="Access details" list="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" mode="manual" target="#edit-drop-down-00000000-0000-0000-0000-000000000000"></oc-info-drop-stub>
+      <edit-dropdown-stub data-v-ccf14be2="" accessdetails="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" sharecategory="user" caneditordelete="true" issharedenied="false" deniable="false" islocked="false" sharedparentroute="[object Object]" class="files-collaborators-collaborator-edit oc-ml-xs" data-testid="collaborator-edit"></edit-dropdown-stub>
     </div>
   </div>
 </div>"

--- a/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
@@ -13,38 +13,16 @@
         @click.stop="toggleSelectionAll"
       />
       <div v-if="sortFields.length" class="oc-tile-sorting oc-ml-m">
-        <span v-text="$gettext('Sort by:')" />
-        <oc-button id="oc-tiles-sort-btn" appearance="raw" gap-size="none">
-          <span v-text="$gettext(currentSortField.label)" />
-          <oc-icon name="arrow-down-s" />
-        </oc-button>
-        <oc-drop
-          ref="sortDrop"
-          toggle="#oc-tiles-sort-btn"
-          class="oc-tiles-sort-drop"
-          mode="click"
-          padding-size="small"
-          close-on-click
-        >
-          <oc-list class="oc-tiles-sort-list">
-            <li v-for="(field, index) in sortFields" :key="index" class="oc-my-xs">
-              <oc-button
-                justify-content="space-between"
-                class="oc-tiles-sort-list-item oc-p-s oc-width-1-1"
-                :class="{
-                  'oc-background-primary-gradient': isSortFieldSelected(field),
-                  selected: isSortFieldSelected(field)
-                }"
-                :appearance="isSortFieldSelected(field) ? 'raw-inverse' : 'raw'"
-                :variation="isSortFieldSelected(field) ? 'primary' : 'passive'"
-                @click="selectSorting(field)"
-              >
-                <span v-text="$gettext(field.label)" />
-                <oc-icon v-if="isSortFieldSelected(field)" name="check" variation="inherit" />
-              </oc-button>
-            </li>
-          </oc-list>
-        </oc-drop>
+        <oc-select
+          class="oc-tiles-sort-select oc-flex oc-flex-middle"
+          :model-value="currentSortField"
+          :label="$gettext('Sort by')"
+          :options="sortFields"
+          :clearable="false"
+          :searchable="false"
+          :position-fixed="true"
+          @update:model-value="selectSorting"
+        />
       </div>
     </div>
     <oc-list class="oc-tiles oc-flex">
@@ -661,7 +639,7 @@ export default defineComponent({
 })
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 .oc-tiles {
   column-gap: 1rem;
   display: grid;
@@ -684,17 +662,15 @@ export default defineComponent({
     padding: var(--oc-space-xsmall);
   }
 
-  &-sort-drop {
-    width: 200px;
-  }
+  &-sort-select {
+    min-width: var(--oc-size-width-xsmall);
 
-  &-sort-list {
-    &-item {
-      &:hover,
-      &:focus {
-        background-color: var(--oc-color-background-hover);
-        text-decoration: none;
-      }
+    .v-select {
+      flex: 1;
+      margin-left: var(--oc-space-small);
+    }
+    .vs__dropdown-menu {
+      min-width: var(--oc-size-width-small);
     }
   }
 }

--- a/packages/web-pkg/src/components/QuotaSelect.vue
+++ b/packages/web-pkg/src/components/QuotaSelect.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="quota-select-batch-action-form">
     <oc-select
       ref="select"
       :model-value="selectedOption"

--- a/packages/web-pkg/src/components/Spaces/QuotaModal.vue
+++ b/packages/web-pkg/src/components/Spaces/QuotaModal.vue
@@ -1,6 +1,5 @@
 <template>
   <quota-select
-    id="quota-select-batch-action-form"
     :total-quota="selectedOption"
     :max-quota="maxQuota"
     :position-fixed="true"

--- a/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTiles.spec.ts.snap
+++ b/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTiles.spec.ts.snap
@@ -1,24 +1,24 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`ResourceTiles component > renders a footer slot 1`] = `
-"<div data-v-67d39700="" id="tiles-view" class="oc-px-m oc-pt-l">
-  <div data-v-67d39700="" class="oc-flex oc-flex-middle oc-mb-m oc-pb-s oc-tiles-controls"><span data-v-67d39700="" class="oc-ml-s"><input id="tiles-view-select-all" type="checkbox" name="checkbox" class="oc-checkbox oc-rounded oc-checkbox-l" disabled="" aria-label="Select all"> <!--v-if--></span>
+"<div id="tiles-view" class="oc-px-m oc-pt-l">
+  <div class="oc-flex oc-flex-middle oc-mb-m oc-pb-s oc-tiles-controls"><span class="oc-ml-s"><input id="tiles-view-select-all" type="checkbox" name="checkbox" class="oc-checkbox oc-rounded oc-checkbox-l" disabled="" aria-label="Select all"> <!--v-if--></span>
     <!--v-if-->
   </div>
-  <ul data-v-67d39700="" class="oc-list oc-my-rm oc-mx-rm oc-tiles oc-flex"> </ul>
+  <ul class="oc-list oc-my-rm oc-mx-rm oc-tiles oc-flex"> </ul>
   <!--v-if-->
-  <div data-v-67d39700="" class="oc-tiles-footer">Hello, ResourceTiles footer!</div>
+  <div class="oc-tiles-footer">Hello, ResourceTiles footer!</div>
 </div>"
 `;
 
 exports[`ResourceTiles component > renders an array of spaces correctly 1`] = `
-"<div data-v-67d39700="" id="tiles-view" class="oc-px-m oc-pt-l">
-  <div data-v-67d39700="" class="oc-flex oc-flex-middle oc-mb-m oc-pb-s oc-tiles-controls"><span data-v-67d39700="" class="oc-ml-s"><input id="tiles-view-select-all" type="checkbox" name="checkbox" class="oc-checkbox oc-rounded oc-checkbox-l" aria-label="Select all"> <!--v-if--></span>
+"<div id="tiles-view" class="oc-px-m oc-pt-l">
+  <div class="oc-flex oc-flex-middle oc-mb-m oc-pb-s oc-tiles-controls"><span class="oc-ml-s"><input id="tiles-view-select-all" type="checkbox" name="checkbox" class="oc-checkbox oc-rounded oc-checkbox-l" aria-label="Select all"> <!--v-if--></span>
     <!--v-if-->
   </div>
-  <ul data-v-67d39700="" class="oc-list oc-my-rm oc-mx-rm oc-tiles oc-flex">
-    <li data-v-67d39700="" class="oc-tiles-item has-item-context-menu">
-      <div data-v-67d39700="" class="oc-tile-card oc-card oc-card-default oc-rounded" data-item-id="1" draggable="false"><a attrs="[object Object]" target="_self" draggable="false" class="oc-resource-link oc-card-media-top oc-flex oc-flex-center oc-flex-middle oc-m-rm" tabindex="-1"></a>
+  <ul class="oc-list oc-my-rm oc-mx-rm oc-tiles oc-flex">
+    <li class="oc-tiles-item has-item-context-menu">
+      <div class="oc-tile-card oc-card oc-card-default oc-rounded" data-item-id="1" draggable="false"><a attrs="[object Object]" target="_self" draggable="false" class="oc-resource-link oc-card-media-top oc-flex oc-flex-center oc-flex-middle oc-m-rm" tabindex="-1"></a>
         <div class="oc-card-body oc-p-s">
           <div class="oc-flex oc-flex-between oc-flex-middle">
             <div class="oc-flex oc-flex-middle oc-text-truncate resource-name-wrapper">
@@ -34,7 +34,7 @@ exports[`ResourceTiles component > renders an array of spaces correctly 1`] = `
             <div class="oc-flex oc-flex-middle">
               <!-- Slot for indicators !-->
               <!-- Slot for individual actions -->
-              <!-- Slot for contextmenu --> <button data-v-67d39700="" type="button" aria-label="Show context menu" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw resource-tiles-btn-action-dropdown" id="context-menu-trigger-1">
+              <!-- Slot for contextmenu --> <button type="button" aria-label="Show context menu" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw resource-tiles-btn-action-dropdown" id="context-menu-trigger-1">
                 <!--v-if-->
                 <!-- @slot Content of the button --> <span class="oc-icon oc-icon-m oc-icon-passive"><!----></span>
                 <div id="context-menu-drop-1" class="oc-drop oc-box-shadow-medium oc-rounded oc-overflow-hidden">
@@ -47,8 +47,8 @@ exports[`ResourceTiles component > renders an array of spaces correctly 1`] = `
         </div>
       </div>
     </li>
-    <li data-v-67d39700="" class="oc-tiles-item has-item-context-menu">
-      <div data-v-67d39700="" class="oc-tile-card oc-card oc-card-default oc-rounded" data-item-id="2" draggable="false"><a attrs="[object Object]" target="_self" draggable="false" class="oc-resource-link oc-card-media-top oc-flex oc-flex-center oc-flex-middle oc-m-rm" tabindex="-1"></a>
+    <li class="oc-tiles-item has-item-context-menu">
+      <div class="oc-tile-card oc-card oc-card-default oc-rounded" data-item-id="2" draggable="false"><a attrs="[object Object]" target="_self" draggable="false" class="oc-resource-link oc-card-media-top oc-flex oc-flex-center oc-flex-middle oc-m-rm" tabindex="-1"></a>
         <div class="oc-card-body oc-p-s">
           <div class="oc-flex oc-flex-between oc-flex-middle">
             <div class="oc-flex oc-flex-middle oc-text-truncate resource-name-wrapper">
@@ -64,7 +64,7 @@ exports[`ResourceTiles component > renders an array of spaces correctly 1`] = `
             <div class="oc-flex oc-flex-middle">
               <!-- Slot for indicators !-->
               <!-- Slot for individual actions -->
-              <!-- Slot for contextmenu --> <button data-v-67d39700="" type="button" aria-label="Show context menu" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw resource-tiles-btn-action-dropdown" id="context-menu-trigger-2">
+              <!-- Slot for contextmenu --> <button type="button" aria-label="Show context menu" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw resource-tiles-btn-action-dropdown" id="context-menu-trigger-2">
                 <!--v-if-->
                 <!-- @slot Content of the button --> <span class="oc-icon oc-icon-m oc-icon-passive"><!----></span>
                 <div id="context-menu-drop-2" class="oc-drop oc-box-shadow-medium oc-rounded oc-overflow-hidden">
@@ -77,13 +77,13 @@ exports[`ResourceTiles component > renders an array of spaces correctly 1`] = `
         </div>
       </div>
     </li>
-    <li data-v-67d39700="" class="ghost-tile" aria-hidden="true"></li>
-    <li data-v-67d39700="" class="ghost-tile" aria-hidden="true"></li>
-    <li data-v-67d39700="" class="ghost-tile" aria-hidden="true"></li>
-    <li data-v-67d39700="" class="ghost-tile" aria-hidden="true"></li>
-    <li data-v-67d39700="" class="ghost-tile" aria-hidden="true"></li>
+    <li class="ghost-tile" aria-hidden="true"></li>
+    <li class="ghost-tile" aria-hidden="true"></li>
+    <li class="ghost-tile" aria-hidden="true"></li>
+    <li class="ghost-tile" aria-hidden="true"></li>
+    <li class="ghost-tile" aria-hidden="true"></li>
   </ul>
   <!--v-if-->
-  <div data-v-67d39700="" class="oc-tiles-footer"></div>
+  <div class="oc-tiles-footer"></div>
 </div>"
 `;

--- a/packages/web-runtime/src/components/MobileNav.vue
+++ b/packages/web-runtime/src/components/MobileNav.vue
@@ -1,6 +1,6 @@
 <template>
   <nav id="mobile-nav">
-    <oc-button id="mobile-nav-button" appearance="raw">
+    <oc-button id="mobile-nav-button" appearance="raw" aria-current="page">
       {{ activeNavItem.name }}
       <oc-icon name="arrow-drop-down" />
     </oc-button>
@@ -12,7 +12,12 @@
       close-on-click
     >
       <oc-list>
-        <li v-for="(item, index) in navItems" :key="index" class="mobile-nav-item oc-width-1-1">
+        <li
+          v-for="(item, index) in navItems"
+          :key="index"
+          class="mobile-nav-item oc-width-1-1"
+          :aria-current="item.active ? 'page' : null"
+        >
           <oc-button
             type="router-link"
             :appearance="item.active ? 'raw-inverse' : 'raw'"

--- a/tests/e2e/support/objects/app-admin-settings/users/actions.ts
+++ b/tests/e2e/support/objects/app-admin-settings/users/actions.ts
@@ -25,7 +25,7 @@ const quotaInput = '#quota-select-form .vs__search'
 const quotaValueDropDown = 'ul.vs__dropdown-menu'
 const userCheckboxSelector = `[data-item-id="%s"] input[type=checkbox]`
 const editQuotaBtn = '.oc-users-actions-edit-quota-trigger'
-const quotaInputBatchAction = '#quota-select-batch-action-form .vs__search'
+const quotaInputBatchAction = '.quota-select-batch-action-form .vs__search'
 const userInput = '#%s-input'
 const roleValueDropDown = `.vs__dropdown-menu :text-is("%s")`
 const groupsInput = '#user-group-select-form .vs__search'


### PR DESCRIPTION
* transforms the select dropdown in the tiles view to a select input to be a11y compliant.
* hides the visible label in the `OcPageSize` component for screen readers since the combobox has its own label.
* removes a duplicated DOM id in quota select
* sets `aria-current` props in mobile nav
* moves the `aria-labelledby` property in modals to the modal body where `role="dialog"` sits.
* removes the `aria-expanded` property on the div that surrounds the share actions because it's invalid on a div-element. This was happening because the access details drop was placed in a wrong position in the DOM.




fixes https://github.com/owncloud/web/issues/10739