### PR TITLE
chore(eslint-config): prepare 10.3.0 release

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -8,7 +8,7 @@ export default [
   ...tseslint.configs.recommended,
   ...pluginVue.configs['flat/recommended'],
   eslintConfigPrettier,
-
+  { ignores: ['**/node_modules/', '.git/', '**/dist/'] },
   {
     languageOptions: {
       ecmaVersion: 5,

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -2,7 +2,7 @@
   "name": "@ownclouders/eslint-config",
   "main": "index.js",
   "private": false,
-  "version": "0.0.1",
+  "version": "10.3.0",
   "license": "AGPL-3.0",
   "type": "module",
   "author": "ownCloud GmbH <devops@owncloud.com>",
@@ -27,7 +27,7 @@
     "eslint-plugin-vuejs-accessibility": "^2.2.0",
     "globals": "^15.0.0",
     "typescript-eslint": "^8.4.0",
-    "typescript": "5.6.3"
+    "typescript": "^5.6.3"
   },
   "peerDependencies": {
     "eslint": "^9.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -472,7 +472,7 @@ importers:
         specifier: ^15.0.0
         version: 15.11.0
       typescript:
-        specifier: 5.6.3
+        specifier: ^5.6.3
         version: 5.6.3
       typescript-eslint:
         specifier: ^8.4.0
@@ -10232,7 +10232,7 @@ snapshots:
       '@cucumber/ci-environment': 9.1.0
       '@cucumber/cucumber-expressions': 16.1.1
       '@cucumber/gherkin': 26.0.3
-      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@21.0.1))(@cucumber/messages@21.0.1)
+      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@26.0.1))(@cucumber/messages@21.0.1)
       '@cucumber/gherkin-utils': 8.0.2
       '@cucumber/html-formatter': 20.2.1(@cucumber/messages@21.0.1)
       '@cucumber/message-streams': 4.0.1(@cucumber/messages@21.0.1)
@@ -10270,7 +10270,7 @@ snapshots:
       yaml: 2.5.1
       yup: 0.32.11
 
-  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@21.0.1))(@cucumber/messages@21.0.1)':
+  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@26.0.1))(@cucumber/messages@21.0.1)':
     dependencies:
       '@cucumber/gherkin': 26.0.3
       '@cucumber/message-streams': 4.0.1(@cucumber/messages@21.0.1)


### PR DESCRIPTION
Prepares the `10.3.0` release for `eslint-config` and adds some ignore patterns in the course of this.

closes https://github.com/owncloud/web/issues/11743