### PR TITLE
fix: ocm folder issues

### DIFF
--- a/changelog/unreleased/bugfix-navigating-into-external-folders
+++ b/changelog/unreleased/bugfix-navigating-into-external-folders
@@ -1,0 +1,6 @@
+Bugfix: Navigating into folders that have been shared externally
+
+We've fixed an issue where navigating into folders that have been shared externally would not work.
+
+https://github.com/owncloud/web/pull/11758
+https://github.com/owncloud/web/issues/11753

--- a/packages/web-app-files/src/index.ts
+++ b/packages/web-app-files/src/index.ts
@@ -92,6 +92,7 @@ export const navItems = (context: ComponentCustomProperties): AppNavigationItem[
       },
       activeFor: [
         { path: `/${appInfo.id}/spaces/share` },
+        { path: `/${appInfo.id}/spaces/ocm-share` },
         { path: `/${appInfo.id}/spaces/personal` }
       ],
       isVisible() {

--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -531,7 +531,10 @@ export default defineComponent({
     const capabilityStore = useCapabilityStore()
     const { getMatchingSpace } = useGetMatchingSpace()
     const { canBeOpenedWithSecureView } = useCanBeOpenedWithSecureView()
-    const { getFolderLink } = useFolderLink()
+    const folderLinkUtils = useFolderLink({
+      space: ref(props.space),
+      targetRouteCallback: computed(() => props.targetRouteCallback)
+    })
     const { isSticky } = useIsTopBarSticky()
     const {
       isLocationPicker,
@@ -622,7 +625,7 @@ export default defineComponent({
 
     const getResourceLink = (resource: Resource) => {
       if (resource.isFolder) {
-        return getFolderLink(resource)
+        return folderLinkUtils.getFolderLink(resource)
       }
 
       let space = props.space
@@ -665,10 +668,7 @@ export default defineComponent({
         },
         context
       ),
-      ...useFolderLink({
-        space: ref(props.space),
-        targetRouteCallback: computed(() => props.targetRouteCallback)
-      }),
+      ...folderLinkUtils,
       postMessage,
       isFilePicker,
       isLocationPicker,

--- a/packages/web-pkg/src/composables/appDefaults/useAppFolderHandling.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppFolderHandling.ts
@@ -56,7 +56,7 @@ export function useAppFolderHandling({
       })
 
       const isSpaceRoot = spacesStore.spaces.some(
-        (s) => isMountPointSpaceResource(s) && s.root.remoteItem.id === pathResource.id
+        (s) => isMountPointSpaceResource(s) && s.root.remoteItem?.id === pathResource.id
       )
 
       if (isSpaceRoot) {

--- a/packages/web-pkg/src/composables/spaces/useGetMatchingSpace.ts
+++ b/packages/web-pkg/src/composables/spaces/useGetMatchingSpace.ts
@@ -40,7 +40,7 @@ export const useGetMatchingSpace = (options?: GetMatchingSpaceOptions) => {
 
     const space = getInternalSpace(storageId)
 
-    if (space) {
+    if (space && !isMountPointSpaceResource(space)) {
       return space
     }
 


### PR DESCRIPTION
When retrieving a matching space via `getMatchingSpace`, we must not use a `mountpoint` space as internal space. This was happening for OCM shares, leading to them being inaccessible.

Also fixes the active nav item marker after navigating into an OCM share.

fixes https://github.com/owncloud/web/issues/11753
fixes https://github.com/owncloud/ocis/issues/10271