### PR TITLE
fix: tile sizing by removing unnecessary class

### DIFF
--- a/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
@@ -25,7 +25,7 @@
         />
       </div>
     </div>
-    <oc-list class="oc-tiles oc-flex">
+    <oc-list class="oc-tiles">
       <li
         v-for="resource in resources"
         :key="resource.id"

--- a/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTiles.spec.ts.snap
+++ b/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceTiles.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`ResourceTiles component > renders a footer slot 1`] = `
   <div class="oc-flex oc-flex-middle oc-mb-m oc-pb-s oc-tiles-controls"><span class="oc-ml-s"><input id="tiles-view-select-all" type="checkbox" name="checkbox" class="oc-checkbox oc-rounded oc-checkbox-l" disabled="" aria-label="Select all"> <!--v-if--></span>
     <!--v-if-->
   </div>
-  <ul class="oc-list oc-my-rm oc-mx-rm oc-tiles oc-flex"> </ul>
+  <ul class="oc-list oc-my-rm oc-mx-rm oc-tiles"> </ul>
   <!--v-if-->
   <div class="oc-tiles-footer">Hello, ResourceTiles footer!</div>
 </div>"
@@ -16,7 +16,7 @@ exports[`ResourceTiles component > renders an array of spaces correctly 1`] = `
   <div class="oc-flex oc-flex-middle oc-mb-m oc-pb-s oc-tiles-controls"><span class="oc-ml-s"><input id="tiles-view-select-all" type="checkbox" name="checkbox" class="oc-checkbox oc-rounded oc-checkbox-l" aria-label="Select all"> <!--v-if--></span>
     <!--v-if-->
   </div>
-  <ul class="oc-list oc-my-rm oc-mx-rm oc-tiles oc-flex">
+  <ul class="oc-list oc-my-rm oc-mx-rm oc-tiles">
     <li class="oc-tiles-item has-item-context-menu">
       <div class="oc-tile-card oc-card oc-card-default oc-rounded" data-item-id="1" draggable="false"><a attrs="[object Object]" target="_self" draggable="false" class="oc-resource-link oc-card-media-top oc-flex oc-flex-center oc-flex-middle oc-m-rm" tabindex="-1"></a>
         <div class="oc-card-body oc-p-s">


### PR DESCRIPTION
## Description
Apparently without the `scoped` styles in the tiles view, the `oc-flex` class on the `<ul>` overwrites the `display: grid` style from the `oc-tiles` class. 🤔 
Even weirder: was only happening in the `production` build, not with `pnpm vite`.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/11757

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
