### PR TITLE
chore: move peers to regular dependencies

### DIFF
--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -81,9 +81,16 @@
     "postpublish": "rm -rf ./package"
   },
   "dependencies": {
-    "fast-xml-parser": "4.5.0",
-    "webdav": "5.7.1",
-    "xml-js": "^1.6.11"
+    "@casl/ability": "^6.7.1",
+    "@microsoft/fetch-event-source": "^2.0.1",
+    "axios": "^1.7.7",
+    "fast-xml-parser": "^4.5.0",
+    "lodash-es": "^4.17.21",
+    "luxon": "^3.5.0",
+    "uuid": "^10.0.0",
+    "webdav": "^5.7.1",
+    "xml-js": "^1.6.11",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/luxon": "3.4.2",
@@ -92,14 +99,5 @@
     "vite-plugin-dts": "4.2.3",
     "vite-plugin-node-polyfills": "0.22.0",
     "vite": "5.4.8"
-  },
-  "peerDependencies": {
-    "@casl/ability": "6.7.1",
-    "@microsoft/fetch-event-source": "^2.0.1",
-    "axios": "1.7.7",
-    "lodash-es": "^4.17.21",
-    "luxon": "3.5.0",
-    "uuid": "10.0.0",
-    "zod": "3.23.8"
   }
 }

--- a/packages/web-test-helpers/README.md
+++ b/packages/web-test-helpers/README.md
@@ -7,11 +7,11 @@ This packages provides utilities for unit testing within the ownCloud app ecosys
 Depending on your package manager, run one of the following commands:
 
 ```
-$ npm install @ownclouders/web-test-helpers
+$ npm install @ownclouders/web-test-helpers --save-dev
 
-$ pnpm add @ownclouders/web-test-helpers
+$ pnpm add -D @ownclouders/web-test-helpers
 
-$ yarn add @ownclouders/web-test-helpers
+$ yarn add @ownclouders/web-test-helpers --dev
 ```
 
-Make sure that you have `vue`, `@vue/test-utils`, `@ownclouders/web-client` and `@ownclouders/web-pkg` as dependency of your app since those are peer dependencies of this package.
+Make sure that you have `vue`, `@vue/test-utils`, and `@ownclouders/web-pkg` as dev dependencies of your app since those are peer dependencies of this package.

--- a/packages/web-test-helpers/package.json
+++ b/packages/web-test-helpers/package.json
@@ -36,7 +36,6 @@
     "postpublish": "rm -rf ./package"
   },
   "peerDependencies": {
-    "@ownclouders/web-client": "^10.3.0",
     "@ownclouders/web-pkg": "^10.3.0",
     "@vue/test-utils": "^2.4.6",
     "vue": "^3.5.10"
@@ -51,7 +50,8 @@
   "dependencies": {
     "@casl/ability": "^6.7.1",
     "@casl/vue": "^2.2.2",
-    "@ownclouders/design-system": "workspace:*",
+    "@ownclouders/design-system": "workspace:^",
+    "@ownclouders/web-client": "workspace:^",
     "@pinia/testing": "^0.1.3",
     "axios": "1.7.7",
     "pinia": "2.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -878,34 +878,34 @@ importers:
   packages/web-client:
     dependencies:
       '@casl/ability':
-        specifier: 6.7.1
+        specifier: ^6.7.1
         version: 6.7.1
       '@microsoft/fetch-event-source':
         specifier: ^2.0.1
         version: 2.0.1
       axios:
-        specifier: 1.7.7
+        specifier: ^1.7.7
         version: 1.7.7
       fast-xml-parser:
-        specifier: 4.5.0
+        specifier: ^4.5.0
         version: 4.5.0
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
       luxon:
-        specifier: 3.5.0
+        specifier: ^3.5.0
         version: 3.5.0
       uuid:
-        specifier: 10.0.0
+        specifier: ^10.0.0
         version: 10.0.0
       webdav:
-        specifier: 5.7.1
+        specifier: ^5.7.1
         version: 5.7.1
       xml-js:
         specifier: ^1.6.11
         version: 1.6.11
       zod:
-        specifier: 3.23.8
+        specifier: ^3.23.8
         version: 3.23.8
     devDependencies:
       '@types/luxon':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1198,14 +1198,14 @@ importers:
         specifier: ^2.2.2
         version: 2.2.2(@casl/ability@6.7.1)(vue@3.5.11(typescript@5.6.3))
       '@ownclouders/design-system':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../design-system
       '@ownclouders/web-client':
-        specifier: ^10.3.0
-        version: 10.3.0(@casl/ability@6.7.1)(@microsoft/fetch-event-source@2.0.1)(axios@1.7.7)(lodash-es@4.17.21)(luxon@3.5.0)(uuid@10.0.0)(zod@3.23.8)
+        specifier: workspace:^
+        version: link:../web-client
       '@ownclouders/web-pkg':
         specifier: ^10.3.0
-        version: 10.3.0(@casl/ability@6.7.1)(@casl/vue@2.2.2(@casl/ability@6.7.1)(vue@3.5.11(typescript@5.6.3)))(@microsoft/fetch-event-source@2.0.1)(@ownclouders/web-client@10.3.0(@casl/ability@6.7.1)(@microsoft/fetch-event-source@2.0.1)(axios@1.7.7)(lodash-es@4.17.21)(luxon@3.5.0)(uuid@10.0.0)(zod@3.23.8))(@sentry/vue@8.33.1(vue@3.5.11(typescript@5.6.3)))(@vue/shared@3.5.11)(@vueuse/core@11.1.0(vue@3.5.11(typescript@5.6.3)))(axios@1.7.7)(deepmerge@4.3.1)(dompurify@3.1.7)(filesize@10.1.6)(fuse.js@7.0.0)(lodash-es@4.17.21)(luxon@3.5.0)(mark.js@8.11.1)(oidc-client-ts@3.1.0)(p-queue@8.0.1)(pinia@2.2.4(typescript@5.6.3)(vue@3.5.11(typescript@5.6.3)))(portal-vue@3.0.0(patch_hash=bogvb64kjdufpa4744k4xkam7u)(vue@3.5.11(typescript@5.6.3)))(qs@6.13.0)(semver@7.6.3)(uuid@10.0.0)(vue-concurrency@5.0.1(vue@3.5.11(typescript@5.6.3)))(vue-router@4.2.5(vue@3.5.11(typescript@5.6.3)))(vue3-gettext@2.4.0(patch_hash=x32qkm4z6srz5xuveescagpdyu)(@vue/compiler-sfc@3.5.11)(vue@3.5.11(typescript@5.6.3)))(zod@3.23.8)
+        version: 10.3.0(@casl/ability@6.7.1)(@casl/vue@2.2.2(@casl/ability@6.7.1)(vue@3.5.11(typescript@5.6.3)))(@microsoft/fetch-event-source@2.0.1)(@ownclouders/web-client@packages+web-client)(@sentry/vue@8.33.1(vue@3.5.11(typescript@5.6.3)))(@vue/shared@3.5.11)(@vueuse/core@11.1.0(vue@3.5.11(typescript@5.6.3)))(axios@1.7.7)(deepmerge@4.3.1)(dompurify@3.1.7)(filesize@10.1.6)(fuse.js@7.0.0)(lodash-es@4.17.21)(luxon@3.5.0)(mark.js@8.11.1)(oidc-client-ts@3.1.0)(p-queue@8.0.1)(pinia@2.2.4(typescript@5.6.3)(vue@3.5.11(typescript@5.6.3)))(portal-vue@3.0.0(patch_hash=bogvb64kjdufpa4744k4xkam7u)(vue@3.5.11(typescript@5.6.3)))(qs@6.13.0)(semver@7.6.3)(uuid@10.0.0)(vue-concurrency@5.0.1(vue@3.5.11(typescript@5.6.3)))(vue-router@4.2.5(vue@3.5.11(typescript@5.6.3)))(vue3-gettext@2.4.0(patch_hash=x32qkm4z6srz5xuveescagpdyu)(@vue/compiler-sfc@3.5.11)(vue@3.5.11(typescript@5.6.3)))(zod@3.23.8)
       '@pinia/testing':
         specifier: ^0.1.3
         version: 0.1.6(pinia@2.2.4(typescript@5.6.3)(vue@3.5.11(typescript@5.6.3)))(vue@3.5.11(typescript@5.6.3))
@@ -2342,17 +2342,6 @@ packages:
 
   '@one-ini/wasm@0.1.1':
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
-
-  '@ownclouders/web-client@10.3.0':
-    resolution: {integrity: sha512-DNceOEMI4JSSg9v4H2TWz1BID7CM4MeyzkLWA4iSnyEfsIucv+rwB3ywUVVec6iEfz9iQrCQ/mOtthIXTneUGQ==}
-    peerDependencies:
-      '@casl/ability': 6.7.1
-      '@microsoft/fetch-event-source': ^2.0.1
-      axios: 1.7.7
-      lodash-es: ^4.17.21
-      luxon: 3.5.0
-      uuid: 10.0.0
-      zod: 3.23.8
 
   '@ownclouders/web-pkg@10.3.0':
     resolution: {integrity: sha512-b/SEp9mM8VLLmV9NIeUWDzRcoGNOYz2OBwkgXQpcoPJBoCGHU5ACmjmlFxDwvOdNEbqxkxiPqylRdJvHOq1BPA==}
@@ -10643,25 +10632,12 @@ snapshots:
 
   '@one-ini/wasm@0.1.1': {}
 
-  '@ownclouders/web-client@10.3.0(@casl/ability@6.7.1)(@microsoft/fetch-event-source@2.0.1)(axios@1.7.7)(lodash-es@4.17.21)(luxon@3.5.0)(uuid@10.0.0)(zod@3.23.8)':
-    dependencies:
-      '@casl/ability': 6.7.1
-      '@microsoft/fetch-event-source': 2.0.1
-      axios: 1.7.7
-      fast-xml-parser: 4.5.0
-      lodash-es: 4.17.21
-      luxon: 3.5.0
-      uuid: 10.0.0
-      webdav: 5.7.1
-      xml-js: 1.6.11
-      zod: 3.23.8
-
-  '@ownclouders/web-pkg@10.3.0(@casl/ability@6.7.1)(@casl/vue@2.2.2(@casl/ability@6.7.1)(vue@3.5.11(typescript@5.6.3)))(@microsoft/fetch-event-source@2.0.1)(@ownclouders/web-client@10.3.0(@casl/ability@6.7.1)(@microsoft/fetch-event-source@2.0.1)(axios@1.7.7)(lodash-es@4.17.21)(luxon@3.5.0)(uuid@10.0.0)(zod@3.23.8))(@sentry/vue@8.33.1(vue@3.5.11(typescript@5.6.3)))(@vue/shared@3.5.11)(@vueuse/core@11.1.0(vue@3.5.11(typescript@5.6.3)))(axios@1.7.7)(deepmerge@4.3.1)(dompurify@3.1.7)(filesize@10.1.6)(fuse.js@7.0.0)(lodash-es@4.17.21)(luxon@3.5.0)(mark.js@8.11.1)(oidc-client-ts@3.1.0)(p-queue@8.0.1)(pinia@2.2.4(typescript@5.6.3)(vue@3.5.11(typescript@5.6.3)))(portal-vue@3.0.0(patch_hash=bogvb64kjdufpa4744k4xkam7u)(vue@3.5.11(typescript@5.6.3)))(qs@6.13.0)(semver@7.6.3)(uuid@10.0.0)(vue-concurrency@5.0.1(vue@3.5.11(typescript@5.6.3)))(vue-router@4.2.5(vue@3.5.11(typescript@5.6.3)))(vue3-gettext@2.4.0(patch_hash=x32qkm4z6srz5xuveescagpdyu)(@vue/compiler-sfc@3.5.11)(vue@3.5.11(typescript@5.6.3)))(zod@3.23.8)':
+  '@ownclouders/web-pkg@10.3.0(@casl/ability@6.7.1)(@casl/vue@2.2.2(@casl/ability@6.7.1)(vue@3.5.11(typescript@5.6.3)))(@microsoft/fetch-event-source@2.0.1)(@ownclouders/web-client@packages+web-client)(@sentry/vue@8.33.1(vue@3.5.11(typescript@5.6.3)))(@vue/shared@3.5.11)(@vueuse/core@11.1.0(vue@3.5.11(typescript@5.6.3)))(axios@1.7.7)(deepmerge@4.3.1)(dompurify@3.1.7)(filesize@10.1.6)(fuse.js@7.0.0)(lodash-es@4.17.21)(luxon@3.5.0)(mark.js@8.11.1)(oidc-client-ts@3.1.0)(p-queue@8.0.1)(pinia@2.2.4(typescript@5.6.3)(vue@3.5.11(typescript@5.6.3)))(portal-vue@3.0.0(patch_hash=bogvb64kjdufpa4744k4xkam7u)(vue@3.5.11(typescript@5.6.3)))(qs@6.13.0)(semver@7.6.3)(uuid@10.0.0)(vue-concurrency@5.0.1(vue@3.5.11(typescript@5.6.3)))(vue-router@4.2.5(vue@3.5.11(typescript@5.6.3)))(vue3-gettext@2.4.0(patch_hash=x32qkm4z6srz5xuveescagpdyu)(@vue/compiler-sfc@3.5.11)(vue@3.5.11(typescript@5.6.3)))(zod@3.23.8)':
     dependencies:
       '@casl/ability': 6.7.1
       '@casl/vue': 2.2.2(@casl/ability@6.7.1)(vue@3.5.11(typescript@5.6.3))
       '@microsoft/fetch-event-source': 2.0.1
-      '@ownclouders/web-client': 10.3.0(@casl/ability@6.7.1)(@microsoft/fetch-event-source@2.0.1)(axios@1.7.7)(lodash-es@4.17.21)(luxon@3.5.0)(uuid@10.0.0)(zod@3.23.8)
+      '@ownclouders/web-client': link:packages/web-client
       '@sentry/vue': 8.33.1(vue@3.5.11(typescript@5.6.3))
       '@toast-ui/editor': 3.2.2
       '@toast-ui/editor-plugin-code-syntax-highlight': 3.1.0


### PR DESCRIPTION
Moves peers of `web-client` and `web-test-helpers` to regular dependencies where it makes sense so users of these packages are not forced to provide them.
