### PR TITLE
chore: fix ods build and mark it external in other packages

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -51,23 +51,23 @@
     "linkDirectory": false,
     "exports": {
       ".": {
-        "default": "./dist/design-system.js",
-        "require": "./dist/design-system.cjs",
+        "default": "./dist/design-system.mjs",
+        "require": "./dist/design-system.js",
         "types": "./dist/src/index.d.ts"
       },
       "./components": {
-        "default": "./dist/design-system/components.js",
-        "require": "./dist/design-system/components.cjs",
+        "default": "./dist/design-system/components.mjs",
+        "require": "./dist/design-system/components.js",
         "types": "./dist/src/components/index.d.ts"
       },
       "./composables": {
-        "default": "./dist/design-system/composables.js",
-        "require": "./dist/design-system/composables.cjs",
+        "default": "./dist/design-system/composables.mjs",
+        "require": "./dist/design-system/composables.js",
         "types": "./dist/src/composables/index.d.ts"
       },
       "./helpers": {
-        "default": "./dist/design-system/helpers.js",
-        "require": "./dist/design-system/helpers.cjs",
+        "default": "./dist/design-system/helpers.mjs",
+        "require": "./dist/design-system/helpers.js",
         "types": "./dist/src/helpers/index.d.ts"
       }
     }

--- a/packages/design-system/vite.config.ts
+++ b/packages/design-system/vite.config.ts
@@ -15,6 +15,12 @@ export default defineConfig({
       }
     }
   },
+  resolve: {
+    alias: {
+      // this is a hack to mock it for the tests... won't be a problem if you don't plan to use the ODS standalone
+      webfontloader: resolve(__dirname, './../../tests/unit/stubs/webfontloader.ts')
+    }
+  },
   build: {
     lib: {
       entry: {
@@ -26,7 +32,13 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
-        ...Object.keys(pkg.dependencies),
+        ...Object.keys(pkg.dependencies).filter(
+          (dep) =>
+            // include vue-select because there is something off with its module type
+            dep !== 'vue-select' &&
+            // include webfontloader to mock it for the tests... won't be a problem if you don't plan to use the ODS standalone
+            dep !== 'webfontloader'
+        ),
         ...Object.keys(pkg.peerDependencies),
         '**/tests',
         '**/*.spec.ts'

--- a/packages/web-pkg/package.json
+++ b/packages/web-pkg/package.json
@@ -37,6 +37,7 @@
     "@casl/ability": "^6.7.1",
     "@casl/vue": "^2.2.2",
     "@microsoft/fetch-event-source": "^2.0.1",
+    "@ownclouders/design-system": "workspace:^",
     "@ownclouders/web-client": "workspace:^",
     "@sentry/vue": "^8.33.1",
     "@toast-ui/editor-plugin-code-syntax-highlight": "^3.1.0",
@@ -79,8 +80,5 @@
     "clean-publish": "5.0.0",
     "vite-plugin-dts": "4.2.4",
     "vite-plugin-node-polyfills": "0.22.0"
-  },
-  "peerDependencies": {
-    "@ownclouders/design-system": "workspace:^"
   }
 }

--- a/packages/web-pkg/vite.config.ts
+++ b/packages/web-pkg/vite.config.ts
@@ -6,7 +6,7 @@ import vue from '@vitejs/plugin-vue'
 import pkg from './package.json' assert { type: 'json' }
 
 const projectRootDir = searchForWorkspaceRoot(process.cwd())
-const external = [...Object.keys(pkg.dependencies), ...Object.keys(pkg.peerDependencies)]
+const external = [...Object.keys(pkg.dependencies)]
 
 export default defineConfig({
   resolve: {
@@ -17,7 +17,7 @@ export default defineConfig({
   css: {
     preprocessorOptions: {
       scss: {
-        additionalData: `@import "design-system/src/styles/styles";`,
+        additionalData: `@import "${projectRootDir}/packages/design-system/src/styles/styles";`,
         silenceDeprecations: ['legacy-js-api']
       }
     }
@@ -31,8 +31,6 @@ export default defineConfig({
     rollupOptions: {
       external: external.filter(
         (e) =>
-          // we need to include the ODS in the bundle because we don't publish it on npm
-          e !== 'design-system' &&
           // something is off with this lib, see https://github.com/ahmadjoya/generate-password-lite/issues/8
           e !== 'js-generate-password'
       )

--- a/packages/web-test-helpers/.npmrc
+++ b/packages/web-test-helpers/.npmrc
@@ -1,2 +1,0 @@
-# needed for "bundledDependencies" to work
-node-linker=hoisted

--- a/packages/web-test-helpers/package.json
+++ b/packages/web-test-helpers/package.json
@@ -27,9 +27,6 @@
       }
     }
   },
-  "bundledDependencies": [
-    "@ownclouders/design-system"
-  ],
   "scripts": {
     "vite": "vite",
     "prepublishOnly": "rm -rf ./package && clean-publish && find package && cat package/package.json",
@@ -44,7 +41,6 @@
     "@vitejs/plugin-vue": "5.1.4",
     "clean-publish": "^5.0.0",
     "vite-plugin-dts": "^4.2.3",
-    "vite-plugin-node-polyfills": "^0.22.0",
     "vite": "^5.4.8"
   },
   "dependencies": {

--- a/packages/web-test-helpers/vite.config.ts
+++ b/packages/web-test-helpers/vite.config.ts
@@ -1,29 +1,10 @@
 import { resolve } from 'path'
 import { defineConfig } from 'vite'
 import dts from 'vite-plugin-dts'
-import { nodePolyfills } from 'vite-plugin-node-polyfills'
 import pkg from './package.json' assert { type: 'json' }
 import vue from '@vitejs/plugin-vue'
 
-const external = [...Object.keys(pkg.dependencies), ...Object.keys(pkg.peerDependencies)]
-
 export default defineConfig({
-  css: {
-    preprocessorOptions: {
-      scss: {
-        additionalData: `@import "@ownclouders/design-system/src/styles/styles";`,
-        silenceDeprecations: ['legacy-js-api']
-      }
-    }
-  },
-  resolve: {
-    alias: {
-      // stub ODS stuff for tests. only needed because we need to include the ODS in the bundle
-      'vue-inline-svg': resolve(__dirname, './../../tests/unit/stubs/empty.ts'),
-      'js-generate-password': resolve(__dirname, './../../tests/unit/stubs/empty.ts'),
-      webfontloader: resolve(__dirname, './../../tests/unit/stubs/webfontloader.ts')
-    }
-  },
   build: {
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),
@@ -31,26 +12,8 @@ export default defineConfig({
       fileName: (format) => `web-test-helpers.${format}.js`
     },
     rollupOptions: {
-      // we need to include the ODS in the bundle because we don't publish it on npm
-      external: external.filter((e) => e !== '@ownclouders/design-system')
+      external: [...Object.keys(pkg.dependencies), ...Object.keys(pkg.peerDependencies)]
     }
   },
-  plugins: [
-    vue(),
-    nodePolyfills({
-      exclude: ['crypto']
-    }),
-    dts(),
-    {
-      name: '@ownclouders/vite-plugin-docs',
-      transform(src, id) {
-        if (id.includes('type=docs')) {
-          return {
-            code: 'export default {}',
-            map: null
-          }
-        }
-      }
-    }
-  ]
+  plugins: [vue(), dts()]
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1262,9 +1262,6 @@ importers:
       vite-plugin-dts:
         specifier: ^4.2.3
         version: 4.2.4(@types/node@22.7.4)(rollup@4.24.0)(typescript@5.6.3)(vite@5.4.8(@types/node@22.7.4)(sass@1.79.5)(terser@5.34.1))
-      vite-plugin-node-polyfills:
-        specifier: ^0.22.0
-        version: 0.22.0(rollup@4.24.0)(vite@5.4.8(@types/node@22.7.4)(sass@1.79.5)(terser@5.34.1))
     publishDirectory: package
 
   tests/e2e:
@@ -4909,7 +4906,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
+    deprecated: Upgrade to fsevents v2 to mitigate potential security issues
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}


### PR DESCRIPTION
`design-system`:
* Fixes the published exports since esm and cjs were mixed up.
* Stubs `webfontloader` and removes it from the external deps to avoid loading fonts in a unit testing context. This would only be a problem when using the ODS standalone, which basically noone does.
* Removes `vue-select` from the external deps because there seems to be something wrong with their package type.

`web-pkg` and `web-test-helpers`:
* Removes the pre-bundling of the design-system and mark it external since it's now published.

