### PR TITLE
chore: fix unmet peer warnings when using extension-sdk and eslint-config

### DIFF
--- a/dev/scripts/bump_versions.sh
+++ b/dev/scripts/bump_versions.sh
@@ -5,7 +5,7 @@
 #
 # NOTE: only run this if all packages are supposed to get the same version!
 
-apps=("design-system" "eslint-config" "web-pkg" "web-client" "web-test-helpers")
+apps=("design-system" "eslint-config" "extension-sdk" "web-pkg" "web-client" "web-test-helpers")
 
 NEW_VERSION="$1"
 

--- a/dev/scripts/create_and_push_tags.sh
+++ b/dev/scripts/create_and_push_tags.sh
@@ -2,7 +2,7 @@
 
 # This script creates and pushes tags for the main app and all published packages.
 
-APPS=("design-system" "eslint-config" "web-pkg" "web-client" "web-test-helpers")
+APPS=("design-system" "eslint-config" "extension-sdk" "web-pkg" "web-client" "web-test-helpers")
 
 cd "$(dirname "$0")/../.."
 VERSION=$(node -p "require('./package.json').version")

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -16,7 +16,7 @@
     ".": "./index.js"
   },
   "dependencies": {
-    "@babel/eslint-parser": "^7.23.3",
+    "@babel/eslint-parser": "^7.25.8",
     "@typescript-eslint/parser": "^8.0.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-n": "^17.0.0",

--- a/packages/extension-sdk/package.json
+++ b/packages/extension-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ownclouders/extension-sdk",
-  "version": "0.0.7",
+  "version": "11.0.0-alpha.1",
   "description": "ownCloud Web Extension SDK",
   "license": "AGPL-3.0",
   "main": "index.mjs",
@@ -19,6 +19,6 @@
   },
   "peerDependencies": {
     "vite": "^5",
-    "sass": "1.79.5"
+    "sass": "^1.79.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -506,7 +506,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       sass:
-        specifier: 1.79.5
+        specifier: ^1.79.5
         version: 1.79.5
       vite:
         specifier: ^5
@@ -10180,7 +10180,7 @@ snapshots:
       '@cucumber/ci-environment': 9.1.0
       '@cucumber/cucumber-expressions': 16.1.1
       '@cucumber/gherkin': 26.0.3
-      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@21.0.1))(@cucumber/messages@21.0.1)
+      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@26.0.1))(@cucumber/messages@21.0.1)
       '@cucumber/gherkin-utils': 8.0.2
       '@cucumber/html-formatter': 20.2.1(@cucumber/messages@21.0.1)
       '@cucumber/message-streams': 4.0.1(@cucumber/messages@21.0.1)
@@ -10218,7 +10218,7 @@ snapshots:
       yaml: 2.6.0
       yup: 0.32.11
 
-  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@21.0.1))(@cucumber/messages@21.0.1)':
+  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@26.0.1))(@cucumber/messages@21.0.1)':
     dependencies:
       '@cucumber/gherkin': 26.0.3
       '@cucumber/message-streams': 4.0.1(@cucumber/messages@21.0.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,7 +458,7 @@ importers:
   packages/eslint-config:
     dependencies:
       '@babel/eslint-parser':
-        specifier: ^7.23.3
+        specifier: ^7.25.8
         version: 7.25.8(@babel/core@7.25.8)(eslint@9.12.0(jiti@1.21.0))
       '@typescript-eslint/parser':
         specifier: ^8.0.0


### PR DESCRIPTION
* `extension-sdk`: Aligns the extension-sdk version with the one of the mono repo and its packages. Also adds a version range to the `sass` dependency so users of this package don't need to provide the pinned version exactly.
* `eslint-config`: Inscreases the minimum version of `@babel/eslint-parser` to `7.25.8` because this ensures compatibility with eslint v9. The previous, older version didn't do that.
