### PR TITLE
fix: sharing label for locked files

### DIFF
--- a/changelog/unreleased/bugfix-sharing-label-for-locked-files
+++ b/changelog/unreleased/bugfix-sharing-label-for-locked-files
@@ -1,0 +1,5 @@
+Bugfix: Sharing label for locked files
+
+We've fixed a bug where a locked file would be falsely labelled as shared in the right sidebar.
+
+https://github.com/owncloud/web/pull/11795

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -260,7 +260,7 @@ export default defineComponent({
         resource: unref(resource),
         ancestorMetaData: unref(ancestorMetaData),
         user: unref(user)
-      })
+      }).filter(({ category }) => category === 'sharing')
     })
 
     const hasAnyShares = computed(() => {

--- a/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Details/FileDetails.spec.ts
@@ -222,7 +222,7 @@ function createWrapper({
           ...mocks,
           versions,
           resource,
-          space: mockDeep<SpaceResource>()
+          space: mockDeep<SpaceResource>({ driveType: 'personal', isOwner: () => true })
         },
         plugins: [
           ...defaultPlugins({


### PR DESCRIPTION
Fixes an issue where a locked file would be falsely labelled as shared in the right sidebar.

refs https://github.com/owncloud/enterprise/issues/6915