### PR TITLE
fix: add missing translations

### DIFF
--- a/changelog/unreleased/bugfix-missing-translations
+++ b/changelog/unreleased/bugfix-missing-translations
@@ -1,0 +1,5 @@
+Bugfix: Add missing translations
+
+Missing translations for the tile sort options and the editor "Save"-button have been added.
+
+https://github.com/owncloud/web/pull/11804

--- a/packages/web-app-files/src/composables/resourcesViewDefaults/useResourcesViewDefaults.ts
+++ b/packages/web-app-files/src/composables/resourcesViewDefaults/useResourcesViewDefaults.ts
@@ -13,7 +13,8 @@ import { useSideBar } from '@ownclouders/web-pkg'
 import { queryItemAsString, useRouteQuery } from '@ownclouders/web-pkg'
 import {
   determineResourceTableSortFields,
-  determineResourceTilesSortFields
+  determineResourceTilesSortFields,
+  translateSortFields
 } from '@ownclouders/web-pkg'
 import { Task } from 'vue-concurrency'
 import { Resource } from '@ownclouders/web-client'
@@ -27,6 +28,7 @@ import {
 } from '@ownclouders/web-pkg'
 
 import { ScrollToResult, useScrollTo } from '@ownclouders/web-pkg'
+import { useGettext } from 'vue3-gettext'
 
 interface ResourcesViewDefaultsOptions<T, U extends any[]> {
   loadResourcesTask?: Task<T, U>
@@ -64,6 +66,7 @@ export const useResourcesViewDefaults = <T extends Resource, TT, TU extends any[
     return loadResourcesTask.isRunning || !loadResourcesTask.last
   })
 
+  const language = useGettext()
   const resourcesStore = useResourcesStore()
   const storeItems = computed(() => resourcesStore.activeResources) as unknown as Ref<T[]>
 
@@ -83,7 +86,7 @@ export const useResourcesViewDefaults = <T extends Resource, TT, TU extends any[
 
   const sortFields = computed((): SortField[] => {
     if (unref(viewMode) === FolderViewModeConstants.name.tiles) {
-      return determineResourceTilesSortFields(unref(storeItems)[0])
+      return translateSortFields(determineResourceTilesSortFields(unref(storeItems)[0]), language)
     }
     return determineResourceTableSortFields(unref(storeItems)[0])
   })

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -208,7 +208,7 @@ import FilesViewWrapper from '../../components/FilesViewWrapper.vue'
 import { ResourceTable, ResourceTiles } from '@ownclouders/web-pkg'
 import { eventBus } from '@ownclouders/web-pkg'
 import { SideBarEventTopics, useSideBar } from '@ownclouders/web-pkg'
-import { sortFields as availableSortFields } from '@ownclouders/web-pkg'
+import { sortFields as availableSortFields, translateSortFields } from '@ownclouders/web-pkg'
 import { defaultFuseOptions, formatFileSize, ResourceIcon } from '@ownclouders/web-pkg'
 import { useGettext } from 'vue3-gettext'
 import { useKeyboardActions } from '@ownclouders/web-pkg'
@@ -294,7 +294,7 @@ export default defineComponent({
       'mdate'
     ]
 
-    const sortFields = availableSortFields
+    const sortFields = translateSortFields(availableSortFields, language)
     const {
       sortBy,
       sortDir,

--- a/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
+++ b/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
@@ -505,7 +505,7 @@ export default defineComponent({
           isDisabled: () => isReadOnly.value || !isDirty.value,
           icon: 'save',
           id: 'app-save-action',
-          label: () => 'Save',
+          label: () => $gettext('Save'),
           handler: save
         }
       ]

--- a/packages/web-pkg/src/helpers/ui/resourceTiles.ts
+++ b/packages/web-pkg/src/helpers/ui/resourceTiles.ts
@@ -1,5 +1,6 @@
 import { Resource } from '@ownclouders/web-client'
 import { SortDir, SortField } from '../../composables/sort'
+import { Language } from 'vue3-gettext'
 
 // just a dummy function to trick gettext tools
 function $gettext(msg: string) {
@@ -74,4 +75,8 @@ export const determineResourceTilesSortFields = (firstResource: Resource): SortF
   return sortFields.filter((field) =>
     Object.prototype.hasOwnProperty.call(firstResource, field.name)
   )
+}
+
+export const translateSortFields = (fields: SortField[], { $gettext }: Language): SortField[] => {
+  return fields.map((field) => ({ ...field, label: $gettext(field.label) }))
 }


### PR DESCRIPTION
Adds missing translations for the tile sort options and the editor "Save"-button.