### PR TITLE
fix: preview image retry

### DIFF
--- a/changelog/unreleased/bugfix-preview-retries
+++ b/changelog/unreleased/bugfix-preview-retries
@@ -1,0 +1,6 @@
+Bugfix: Preview image retries
+
+We've added a retry mechanism to preview loading in case the server is being overrun with too many requests.
+
+https://github.com/owncloud/web/pull/11813
+https://github.com/owncloud/web/issues/11798


### PR DESCRIPTION
Adds a retry mechanism to preview loading when the server responds with `429` status codes.

fixes https://github.com/owncloud/web/issues/11798