### PR TITLE
fix: setting post logout redirect url

### DIFF
--- a/changelog/unreleased/bugfix-respect-post-logout-url
+++ b/changelog/unreleased/bugfix-respect-post-logout-url
@@ -1,0 +1,6 @@
+Bugfix: Respect post logout url
+
+We've fixed a bug where setting the `post_logout_redirect_url` in the oidc config had no effect.
+
+https://github.com/owncloud/web/pull/11817
+https://github.com/owncloud/web/issues/11816

--- a/packages/web-pkg/src/composables/piniaStores/config/types.ts
+++ b/packages/web-pkg/src/composables/piniaStores/config/types.ts
@@ -24,6 +24,7 @@ const OpenIdConnectConfigSchema = z.object({
   client_secret: z.string().optional(),
   dynamic: z.string().optional(),
   metadata_url: z.string().optional(),
+  post_logout_redirect_uri: z.string().optional(),
   response_type: z.string().optional(),
   scope: z.string().optional()
 })

--- a/packages/web-pkg/src/composables/piniaStores/config/types.ts
+++ b/packages/web-pkg/src/composables/piniaStores/config/types.ts
@@ -18,16 +18,18 @@ const OAuth2ConfigSchema = z.object({
 
 export type OAuth2Config = z.infer<typeof OAuth2ConfigSchema>
 
-const OpenIdConnectConfigSchema = z.object({
-  authority: z.string().optional(),
-  client_id: z.string().optional(),
-  client_secret: z.string().optional(),
-  dynamic: z.string().optional(),
-  metadata_url: z.string().optional(),
-  post_logout_redirect_uri: z.string().optional(),
-  response_type: z.string().optional(),
-  scope: z.string().optional()
-})
+const OpenIdConnectConfigSchema = z
+  .object({
+    authority: z.string().optional(),
+    client_id: z.string().optional(),
+    client_secret: z.string().optional(),
+    dynamic: z.string().optional(),
+    metadata_url: z.string().optional(),
+    post_logout_redirect_uri: z.string().optional(),
+    response_type: z.string().optional(),
+    scope: z.string().optional()
+  })
+  .passthrough()
 
 export type OpenIdConnectConfig = z.infer<typeof OpenIdConnectConfigSchema>
 


### PR DESCRIPTION
The parameter was simply missing in our `zod` schema, hence it was not loaded into the config object.

fixes https://github.com/owncloud/web/issues/11816
