### PR TITLE
fix: files wrongly appearing in the file list

### DIFF
--- a/changelog/unreleased/bugfix-files-appearing-in-file-list
+++ b/changelog/unreleased/bugfix-files-appearing-in-file-list
@@ -1,0 +1,6 @@
+Bugfix: Files appearing in file list
+
+We've fixed a bug where files would wrongly appear in the current file list during an ongoing upload.
+
+https://github.com/owncloud/web/issues/11803
+https://github.com/owncloud/web/pull/11824

--- a/packages/web-runtime/src/container/sse/files.ts
+++ b/packages/web-runtime/src/container/sse/files.ts
@@ -113,7 +113,11 @@ export const onSSEProcessingFinishedEvent = async ({
         path: '',
         fileId: sseData.itemid
       })
-      resourcesStore.upsertResource(resource)
+
+      // check again for the current folder in case the user has navigated away in the meantime
+      if (isItemInCurrentFolder({ resourcesStore, parentFolderId: sseData.parentitemid })) {
+        resourcesStore.upsertResource(resource)
+      }
     })
   }
 


### PR DESCRIPTION
Fixes the issue with files wrongly appearing in the file list during an upload. This was happening because of SSE since a check for the current folder was missing.

fixes https://github.com/owncloud/web/issues/11803