### PR TITLE
fix: clear ancestor data in app wrapper

### DIFF
--- a/changelog/unreleased/bugfix-sidebar-showing-wrong-shares
+++ b/changelog/unreleased/bugfix-sidebar-showing-wrong-shares
@@ -1,0 +1,6 @@
+Bugfix: Sidebar showing wrong shares
+
+We've fixed a bug where the right sidebar would display wrong shares when being inside a space and opening a file from another space (e.g. via the search results).
+
+https://github.com/owncloud/web/pull/11831
+https://github.com/owncloud/web/issues/11787

--- a/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
+++ b/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
@@ -455,6 +455,14 @@ export default defineComponent({
 
     let autosaveIntervalId: ReturnType<typeof setInterval> = null
     onMounted(() => {
+      if (resourcesStore.ancestorMetaData?.['/'] && unref(space)) {
+        const clearAncestorData = resourcesStore.ancestorMetaData['/'].spaceId !== unref(space).id
+        if (clearAncestorData) {
+          // clear ancestor data in case the user switched spaces (e.g. by opening a file via search results)
+          resourcesStore.setAncestorMetaData({})
+        }
+      }
+
       if (!unref(isEditor)) {
         return
       }


### PR DESCRIPTION
This fixes an issue where the right sidebar would display wrong shares when being inside a space and opening a file from another space (e.g. via the search results).

fixes https://github.com/owncloud/web/issues/11787
