### PR TITLE
Add resource_name to TX definition

### DIFF
--- a/changelog/unreleased/enhancement-resource-name
+++ b/changelog/unreleased/enhancement-resource-name
@@ -1,0 +1,7 @@
+Enhancement: Add resource_name to translation definition
+
+Add a reasource_name property to each Transifex definition.
+This eases identifying where the resource belongs to.
+
+https://github.com/owncloud/web/pull/11841
+https://github.com/owncloud/web/issues/11839

--- a/changelog/unreleased/enhancement-resource-name
+++ b/changelog/unreleased/enhancement-resource-name
@@ -1,7 +1,0 @@
-Enhancement: Add resource_name to translation definition
-
-Add a reasource_name property to each Transifex definition.
-This eases identifying where the resource belongs to.
-
-https://github.com/owncloud/web/pull/11841
-https://github.com/owncloud/web/issues/11839

--- a/packages/design-system/l10n/.tx/config
+++ b/packages/design-system/l10n/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:web-design-system]
+[o:owncloud-org:p:owncloud-web:r:design-system]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
 resource_name = web-design-system

--- a/packages/design-system/l10n/.tx/config
+++ b/packages/design-system/l10n/.tx/config
@@ -1,9 +1,10 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:design-system]
+[o:owncloud-org:p:owncloud-web:r:web-design-system]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
+resource_name = web-design-system
 source_file = template.pot
 source_lang = en
 type = PO

--- a/packages/web-app-activities/l10n/.tx/config
+++ b/packages/web-app-activities/l10n/.tx/config
@@ -1,9 +1,10 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:activities]
+[o:owncloud-org:p:owncloud-web:r:web-activities]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
+resource_name = web-activities
 source_file = template.pot
 source_lang = en
 type = PO

--- a/packages/web-app-activities/l10n/.tx/config
+++ b/packages/web-app-activities/l10n/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:web-activities]
+[o:owncloud-org:p:owncloud-web:r:activities]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
 resource_name = web-activities

--- a/packages/web-app-admin-settings/l10n/.tx/config
+++ b/packages/web-app-admin-settings/l10n/.tx/config
@@ -1,9 +1,10 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:admin-settings]
+[o:owncloud-org:p:owncloud-web:r:web-admin-settings]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
+resource_name = web-admin-settings
 source_file = template.pot
 source_lang = en
 type = PO

--- a/packages/web-app-admin-settings/l10n/.tx/config
+++ b/packages/web-app-admin-settings/l10n/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:web-admin-settings]
+[o:owncloud-org:p:owncloud-web:r:admin-settings]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
 resource_name = web-admin-settings

--- a/packages/web-app-app-store/l10n/.tx/config
+++ b/packages/web-app-app-store/l10n/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:web-app-store]
+[o:owncloud-org:p:owncloud-web:r:app-store]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
 resource_name = web-app-store

--- a/packages/web-app-app-store/l10n/.tx/config
+++ b/packages/web-app-app-store/l10n/.tx/config
@@ -1,9 +1,10 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:app-store]
+[o:owncloud-org:p:owncloud-web:r:web-app-store]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
+resource_name = web-app-store
 source_file = template.pot
 source_lang = en
 type = PO

--- a/packages/web-app-epub-reader/l10n/.tx/config
+++ b/packages/web-app-epub-reader/l10n/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:web-epub-reader]
+[o:owncloud-org:p:owncloud-web:r:epub-reader]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
 resource_name = web-epub-reader

--- a/packages/web-app-epub-reader/l10n/.tx/config
+++ b/packages/web-app-epub-reader/l10n/.tx/config
@@ -1,9 +1,10 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:epub-reader]
+[o:owncloud-org:p:owncloud-web:r:web-epub-reader]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
+resource_name = web-epub-reader
 source_file = template.pot
 source_lang = en
 type = PO

--- a/packages/web-app-external/l10n/.tx/config
+++ b/packages/web-app-external/l10n/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:web-external]
+[o:owncloud-org:p:owncloud-web:r:external]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
 resource_name = web-exteral

--- a/packages/web-app-external/l10n/.tx/config
+++ b/packages/web-app-external/l10n/.tx/config
@@ -1,9 +1,10 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:external]
+[o:owncloud-org:p:owncloud-web:r:web-external]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
+resource_name = web-exteral
 source_file = template.pot
 source_lang = en
 type = PO

--- a/packages/web-app-files/l10n/.tx/config
+++ b/packages/web-app-files/l10n/.tx/config
@@ -1,9 +1,10 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:files]
+[o:owncloud-org:p:owncloud-web:r:web-files]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
+resource_name = web-files
 source_file = template.pot
 source_lang = en
 type = PO

--- a/packages/web-app-files/l10n/.tx/config
+++ b/packages/web-app-files/l10n/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:web-files]
+[o:owncloud-org:p:owncloud-web:r:files]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
 resource_name = web-files

--- a/packages/web-app-ocm/l10n/.tx/config
+++ b/packages/web-app-ocm/l10n/.tx/config
@@ -1,9 +1,10 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:ocm]
+[o:owncloud-org:p:owncloud-web:r:web-ocm]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
+resource_name = web-ocm
 source_file = template.pot
 source_lang = en
 type = PO

--- a/packages/web-app-ocm/l10n/.tx/config
+++ b/packages/web-app-ocm/l10n/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:web-ocm]
+[o:owncloud-org:p:owncloud-web:r:ocm]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
 resource_name = web-ocm

--- a/packages/web-app-pdf-viewer/l10n/.tx/config
+++ b/packages/web-app-pdf-viewer/l10n/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:web-pdf-viewer]
+[o:owncloud-org:p:owncloud-web:r:pdf-viewer]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
 resource_name = web-pdf-viewer

--- a/packages/web-app-pdf-viewer/l10n/.tx/config
+++ b/packages/web-app-pdf-viewer/l10n/.tx/config
@@ -1,9 +1,10 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:pdf-viewer]
+[o:owncloud-org:p:owncloud-web:r:web-pdf-viewer]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
+resource_name = web-pdf-viewer
 source_file = template.pot
 source_lang = en
 type = PO

--- a/packages/web-app-preview/l10n/.tx/config
+++ b/packages/web-app-preview/l10n/.tx/config
@@ -1,9 +1,10 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:preview]
+[o:owncloud-org:p:owncloud-web:r:web-preview]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
+resource_name = web-preview
 source_file = template.pot
 source_lang = en
 type = PO

--- a/packages/web-app-preview/l10n/.tx/config
+++ b/packages/web-app-preview/l10n/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:web-preview]
+[o:owncloud-org:p:owncloud-web:r:preview]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
 resource_name = web-preview

--- a/packages/web-app-search/l10n/.tx/config
+++ b/packages/web-app-search/l10n/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:web-search]
+[o:owncloud-org:p:owncloud-web:r:search]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
 resource_name = web-search

--- a/packages/web-app-search/l10n/.tx/config
+++ b/packages/web-app-search/l10n/.tx/config
@@ -1,9 +1,10 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:search]
+[o:owncloud-org:p:owncloud-web:r:web-search]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
+resource_name = web-search
 source_file = template.pot
 source_lang = en
 type = PO

--- a/packages/web-app-text-editor/l10n/.tx/config
+++ b/packages/web-app-text-editor/l10n/.tx/config
@@ -1,9 +1,10 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:text-editor]
+[o:owncloud-org:p:owncloud-web:r:web-text-editor]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
+resource_name = web-text-editor
 source_file = template.pot
 source_lang = en
 type = PO

--- a/packages/web-app-text-editor/l10n/.tx/config
+++ b/packages/web-app-text-editor/l10n/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:web-text-editor]
+[o:owncloud-org:p:owncloud-web:r:text-editor]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
 resource_name = web-text-editor

--- a/packages/web-app-webfinger/l10n/.tx/config
+++ b/packages/web-app-webfinger/l10n/.tx/config
@@ -1,9 +1,10 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:webfinger]
+[o:owncloud-org:p:owncloud-web:r:web-webfinger]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
+resource_name = web-webfinger
 source_file = template.pot
 source_lang = en
 type = PO

--- a/packages/web-app-webfinger/l10n/.tx/config
+++ b/packages/web-app-webfinger/l10n/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:web-webfinger]
+[o:owncloud-org:p:owncloud-web:r:webfinger]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
 resource_name = web-webfinger

--- a/packages/web-client/l10n/.tx/config
+++ b/packages/web-client/l10n/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:web-client]
+[o:owncloud-org:p:owncloud-web:r:client]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
 resource_name = web-client

--- a/packages/web-client/l10n/.tx/config
+++ b/packages/web-client/l10n/.tx/config
@@ -1,9 +1,10 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:client]
+[o:owncloud-org:p:owncloud-web:r:web-client]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
+resource_name = web-client
 source_file = template.pot
 source_lang = en
 type = PO

--- a/packages/web-pkg/l10n/.tx/config
+++ b/packages/web-pkg/l10n/.tx/config
@@ -1,9 +1,10 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:pkg]
+[o:owncloud-org:p:owncloud-web:r:web-pkg]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
+resource_name = web-pkg
 source_file = template.pot
 source_lang = en
 type = PO

--- a/packages/web-pkg/l10n/.tx/config
+++ b/packages/web-pkg/l10n/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:web-pkg]
+[o:owncloud-org:p:owncloud-web:r:pkg]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
 resource_name = web-pkg

--- a/packages/web-runtime/l10n/.tx/config
+++ b/packages/web-runtime/l10n/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:runtime]
+[o:owncloud-org:p:owncloud-web:r:core]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
 resource_name = web-runtime

--- a/packages/web-runtime/l10n/.tx/config
+++ b/packages/web-runtime/l10n/.tx/config
@@ -1,10 +1,10 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:web-core]
+[o:owncloud-org:p:owncloud-web:r:web-runtime]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
-resource_name = web-core
+resource_name = web-runtime
 source_file = template.pot
 source_lang = en
 type = PO

--- a/packages/web-runtime/l10n/.tx/config
+++ b/packages/web-runtime/l10n/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:web-runtime]
+[o:owncloud-org:p:owncloud-web:r:runtime]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
 resource_name = web-runtime

--- a/packages/web-runtime/l10n/.tx/config
+++ b/packages/web-runtime/l10n/.tx/config
@@ -1,9 +1,10 @@
 [main]
 host = https://www.transifex.com
 
-[o:owncloud-org:p:owncloud-web:r:core]
+[o:owncloud-org:p:owncloud-web:r:web-core]
 file_filter = locale/<lang>/app.po
 minimum_perc = 0
+resource_name = web-core
 source_file = template.pot
 source_lang = en
 type = PO


### PR DESCRIPTION
Fixes: #11839 (Harmonize naming translations resources)

Add a `resorce_name` property to each TX definition (`packages/xxx/.tx/config`)

`activities` --> `web-activities` (`<repo-name>-<resource-name>`

Now, we can destinguish by the name in TX where the source is located:
`web-yyy`
`web-extension-yyy`
...