### PR TITLE
chore: include product var into collaboration-oo stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -222,6 +222,7 @@ services:
       MICRO_REGISTRY_ADDRESS: ocis:9233
       COLLABORATION_WOPI_SRC: https://${WOPISERVER_ONLYOFFICE_DOMAIN:-host.docker.internal:9302}
       COLLABORATION_APP_NAME: OnlyOffice
+      COLLABORATION_APP_PRODUCT: OnlyOffice
       COLLABORATION_APP_ADDR: https://${ONLYOFFICE_DOMAIN:-host.docker.internal:9981}
       COLLABORATION_APP_ICON: https://${ONLYOFFICE_DOMAIN:-host.docker.internal:9981}/web-apps/apps/documenteditor/main/resources/img/favicon.ico
       COLLABORATION_APP_INSECURE: ${INSECURE:-true}


### PR DESCRIPTION
## Description
The backend introduced a new env var for the collaboration app product (was falsely relying on the app name before, but since the app name needs to be customizable to customer needs we can't do string comparisons on strings like `collabora` or `onlyoffice` in the backend on that variable. Hence the `product` variable was introduced. See https://github.com/owncloud/ocis/pull/10335

## Related Issue
- Relates to https://github.com/owncloud/ocis/issues/10479

## Motivation and Context
Keep our dev stack working...

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [x] Maintenance (e.g. dependency updates or tooling)