### PR TITLE
fix: lock owner in file details

### DIFF
--- a/changelog/unreleased/bugfix-lock-information
+++ b/changelog/unreleased/bugfix-lock-information
@@ -1,0 +1,6 @@
+Bugfix: Show lock information in file details
+
+We fixed showing the lock owner in the file details whenever a file is locked.
+
+https://github.com/owncloud/web/issues/11008
+https://github.com/owncloud/web/pull/11859

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -55,9 +55,10 @@
           </td>
         </tr>
         <tr v-if="resource.locked" data-testid="locked-by">
-          <th scope="col" class="oc-pr-s oc-font-semibold" v-text="$gettext('Locked by')" />
+          <th scope="col" class="oc-pr-s oc-font-semibold" v-text="$gettext('Locked via')" />
           <td>
-            <span>{{ resource.lockOwnerName }} ({{ formatDateRelative(resource.lockTime) }})</span>
+            <span>{{ resource.lockOwner }}</span>
+            <span v-if="resource.lockTime">({{ formatDateRelative(resource.lockTime) }})</span>
           </td>
         </tr>
         <tr v-if="showSharedVia" data-testid="shared-via">

--- a/packages/web-client/src/helpers/resource/functions.ts
+++ b/packages/web-client/src/helpers/resource/functions.ts
@@ -102,11 +102,11 @@ export function buildResource(resource: WebDavResponseResource): Resource {
   const extension = extractExtensionFromFile({ ...resource, id, name, path: resourcePath })
 
   const lock = resource.props[DavProperty.LockDiscovery]
-  let activeLock: { [DavProperty.LockOwnerName]?: string; [DavProperty.LockTime]?: string }
-  let lockOwnerName: string, lockTime: string
+  let activeLock: { [DavProperty.LockOwner]?: string; [DavProperty.LockTime]?: string }
+  let lockOwner: string, lockTime: string
   if (lock) {
     activeLock = lock[DavProperty.ActiveLock]
-    lockOwnerName = activeLock[DavProperty.LockOwnerName]
+    lockOwner = activeLock[DavProperty.LockOwner]
     lockTime = activeLock[DavProperty.LockTime]
   }
 
@@ -131,7 +131,7 @@ export function buildResource(resource: WebDavResponseResource): Resource {
     type: isFolder ? 'folder' : resource.type,
     isFolder,
     locked: !!activeLock,
-    lockOwnerName,
+    lockOwner,
     lockTime,
     processing: resource.processing || false,
     mdate: resource.props[DavProperty.LastModifiedDate],

--- a/packages/web-client/src/helpers/resource/types.ts
+++ b/packages/web-client/src/helpers/resource/types.ts
@@ -64,7 +64,7 @@ export interface Resource {
   thumbnail?: string
   processing?: boolean
   locked?: boolean
-  lockOwnerName?: string
+  lockOwner?: string
   lockTime?: string
   mimeType?: string
   isFolder?: boolean

--- a/packages/web-client/src/webdav/constants/dav.ts
+++ b/packages/web-client/src/webdav/constants/dav.ts
@@ -81,7 +81,7 @@ const DavPropertyMapping = {
   MimeType: defString('getcontenttype' as const),
   ResourceType: defStringArray('resourcetype' as const),
   LockDiscovery: { value: 'lockdiscovery', type: null as Record<string, unknown> },
-  LockOwnerName: defString('ownername' as const),
+  LockOwner: defString('owner' as const),
   LockTime: defString('locktime' as const),
   ActiveLock: {
     value: 'activelock',

--- a/packages/web-test-helpers/package.json
+++ b/packages/web-test-helpers/package.json
@@ -33,7 +33,7 @@
     "postpublish": "rm -rf ./package"
   },
   "peerDependencies": {
-    "@ownclouders/web-pkg": "^11.0.0",
+    "@ownclouders/web-pkg": "workspace:^",
     "@vue/test-utils": "^2.4.6",
     "vue": "^3.5.10"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1232,8 +1232,8 @@ importers:
         specifier: workspace:^
         version: link:../web-client
       '@ownclouders/web-pkg':
-        specifier: ^11.0.0
-        version: 11.0.1(@vue/compiler-sfc@3.5.12)(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))
+        specifier: workspace:^
+        version: link:../web-pkg
       '@pinia/testing':
         specifier: ^0.1.3
         version: 0.1.7(pinia@2.2.6(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))(vue@3.5.12(typescript@5.6.3))
@@ -2295,17 +2295,6 @@ packages:
 
   '@one-ini/wasm@0.1.1':
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
-
-  '@ownclouders/design-system@11.0.1':
-    resolution: {integrity: sha512-IKxF5Xxw0LuJMnW++MZg4qC8z8Ti962TMHwo+KfPvQBN54JFXLtcL3XCmzgWVNm5j5YPC/q2LKEvbLNWnbf1MQ==}
-    peerDependencies:
-      vue: ^3.5.11
-
-  '@ownclouders/web-client@11.0.1':
-    resolution: {integrity: sha512-zkKQ5M7du0cLF/TmaT9eAI+yu2PLItVUMRoK/3nQyJ1XdnLm2MiF/MIeUnlL5z2MNgClaONW2pf09pX7RsTxWg==}
-
-  '@ownclouders/web-pkg@11.0.1':
-    resolution: {integrity: sha512-S0XK5WkoqemlQvC7SsaChRLDwyj9CF9Ddu7HvPvO0zcK1oZecRSEv1P+oXJNd6/qdsZguoyaumRSa9M2rdVPoA==}
 
   '@panzoom/panzoom@4.5.1':
     resolution: {integrity: sha512-QOr/t7314XTwgAUDazR+RDcTAWSbkpjDnZJddd9f56jSUA8ptUsyDblAb+sp/O5O1o5Fiu9KpWxVHKuhGUgp5w==}
@@ -4895,7 +4884,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: Upgrade to fsevents v2 to mitigate potential security issues
+    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -10184,7 +10173,7 @@ snapshots:
       '@cucumber/ci-environment': 9.1.0
       '@cucumber/cucumber-expressions': 16.1.1
       '@cucumber/gherkin': 26.0.3
-      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@21.0.1))(@cucumber/messages@21.0.1)
+      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@27.0.0))(@cucumber/messages@21.0.1)
       '@cucumber/gherkin-utils': 8.0.2
       '@cucumber/html-formatter': 20.2.1(@cucumber/messages@21.0.1)
       '@cucumber/message-streams': 4.0.1(@cucumber/messages@21.0.1)
@@ -10222,7 +10211,7 @@ snapshots:
       yaml: 2.6.0
       yup: 0.32.11
 
-  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@21.0.1))(@cucumber/messages@21.0.1)':
+  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@27.0.0))(@cucumber/messages@21.0.1)':
     dependencies:
       '@cucumber/gherkin': 26.0.3
       '@cucumber/message-streams': 4.0.1(@cucumber/messages@21.0.1)
@@ -10594,88 +10583,6 @@ snapshots:
       rimraf: 3.0.2
 
   '@one-ini/wasm@0.1.1': {}
-
-  '@ownclouders/design-system@11.0.1(@vue/compiler-sfc@3.5.12)(vue@3.5.12(typescript@5.6.3))':
-    dependencies:
-      '@emoji-mart/data': 1.2.1
-      '@popperjs/core': 2.11.8
-      deepmerge: 4.3.1
-      emoji-mart: 5.6.0
-      focus-trap: 7.6.0
-      focus-trap-vue: 4.0.3(focus-trap@7.6.0)(vue@3.5.12(typescript@5.6.3))
-      fuse.js: 7.0.0
-      lodash-es: 4.17.21
-      luxon: 3.5.0
-      tippy.js: 6.3.7
-      vue: 3.5.12(typescript@5.6.3)
-      vue-inline-svg: 3.1.4(vue@3.5.12(typescript@5.6.3))
-      vue-router: 4.2.5(vue@3.5.12(typescript@5.6.3))
-      vue-select: 4.0.0-beta.6(vue@3.5.12(typescript@5.6.3))
-      vue3-gettext: 2.4.0(patch_hash=x32qkm4z6srz5xuveescagpdyu)(@vue/compiler-sfc@3.5.12)(vue@3.5.12(typescript@5.6.3))
-      webfontloader: 1.6.28
-    transitivePeerDependencies:
-      - '@vue/compiler-sfc'
-
-  '@ownclouders/web-client@11.0.1':
-    dependencies:
-      '@casl/ability': 6.7.2
-      '@microsoft/fetch-event-source': 2.0.1
-      axios: 1.7.7
-      fast-xml-parser: 4.5.0
-      lodash-es: 4.17.21
-      luxon: 3.5.0
-      uuid: 11.0.2
-      webdav: 5.7.1
-      xml-js: 1.6.11
-      zod: 3.23.8
-    transitivePeerDependencies:
-      - debug
-
-  '@ownclouders/web-pkg@11.0.1(@vue/compiler-sfc@3.5.12)(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))':
-    dependencies:
-      '@casl/ability': 6.7.2
-      '@casl/vue': 2.2.2(@casl/ability@6.7.2)(vue@3.5.12(typescript@5.6.3))
-      '@microsoft/fetch-event-source': 2.0.1
-      '@ownclouders/design-system': 11.0.1(@vue/compiler-sfc@3.5.12)(vue@3.5.12(typescript@5.6.3))
-      '@ownclouders/web-client': 11.0.1
-      '@sentry/vue': 8.35.0(pinia@2.2.6(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3)))(vue@3.5.12(typescript@5.6.3))
-      '@toast-ui/editor': 3.2.2
-      '@toast-ui/editor-plugin-code-syntax-highlight': 3.1.0
-      '@uppy/core': https://github.com/owncloud/uppy/releases/download/v3.12.13-owncloud/uppy-core.tgz
-      '@uppy/drop-target': https://github.com/owncloud/uppy/releases/download/v3.12.13-owncloud/uppy-drop-target.tgz(@uppy/core@https://github.com/owncloud/uppy/releases/download/v3.12.13-owncloud/uppy-core.tgz)
-      '@uppy/tus': https://github.com/owncloud/uppy/releases/download/v3.12.13-owncloud/uppy-tus.tgz(@uppy/core@https://github.com/owncloud/uppy/releases/download/v3.12.13-owncloud/uppy-core.tgz)
-      '@uppy/utils': https://github.com/owncloud/uppy/releases/download/v3.12.13-owncloud/uppy-utils.tgz
-      '@uppy/xhr-upload': https://github.com/owncloud/uppy/releases/download/v3.12.13-owncloud/uppy-xhr-upload.tgz(@uppy/core@https://github.com/owncloud/uppy/releases/download/v3.12.13-owncloud/uppy-core.tgz)
-      '@vue/shared': 3.5.12
-      '@vueuse/core': 11.1.0(vue@3.5.12(typescript@5.6.3))
-      axios: 1.7.7
-      deepmerge: 4.3.1
-      dompurify: 3.1.7
-      filesize: 10.1.6
-      fuse.js: 7.0.0
-      js-generate-password: 1.0.0
-      lodash-es: 4.17.21
-      luxon: 3.5.0
-      mark.js: 8.11.1
-      oidc-client-ts: 3.1.0
-      p-queue: 8.0.1
-      password-sheriff: 1.1.1
-      pinia: 2.2.6(typescript@5.6.3)(vue@3.5.12(typescript@5.6.3))
-      portal-vue: 3.0.0(patch_hash=bogvb64kjdufpa4744k4xkam7u)(vue@3.5.12(typescript@5.6.3))
-      prismjs: 1.29.0
-      qs: 6.13.0
-      semver: 7.6.3
-      uuid: 11.0.2
-      vue-concurrency: 5.0.1(vue@3.5.12(typescript@5.6.3))
-      vue-router: 4.2.5(vue@3.5.12(typescript@5.6.3))
-      vue3-gettext: 2.4.0(patch_hash=x32qkm4z6srz5xuveescagpdyu)(@vue/compiler-sfc@3.5.12)(vue@3.5.12(typescript@5.6.3))
-      zod: 3.23.8
-    transitivePeerDependencies:
-      - '@vue/compiler-sfc'
-      - '@vue/composition-api'
-      - debug
-      - typescript
-      - vue
 
   '@panzoom/panzoom@4.5.1': {}
 


### PR DESCRIPTION
## Description
We were showing ` ()` for for the `Locked by` field in the file details for two reasons:
1. the lock owner propfind info was referencing the wrong field name
2. the `()` were shown if there was no lock time

Fixing this by
1. Referencing the correct field (after the backend prettified the string in that field)
2. Showing `(<lockTime>)` only if there is a lockTime and hiding the parentheses entirely if there is no lockTime info

## Related Issue
- Fixes https://github.com/owncloud/web/issues/11008

## Screenshots (if appropriate):
<img width="1624" alt="Screenshot 2024-11-06 at 10 09 18" src="https://github.com/user-attachments/assets/305dd2e9-5b30-43f8-9b18-9f4263153ea3">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
