### PR TITLE
chore: don't use global sass functions in oc-form.scss

### DIFF
--- a/packages/design-system/src/styles/theme/oc-form.scss
+++ b/packages/design-system/src/styles/theme/oc-form.scss
@@ -9,13 +9,16 @@
 //
 // ========================================================================
 
+@use "sass:string";
+@use "sass:meta";
+
 /* stylelint-disable */
 
 @function str-replace($string, $search, $replace: "") {
-  $index: str-index($string, $search);
+  $index: string.index($string, $search);
 
   @if $index {
-    @return str-slice($string, 1, $index - 1) + $replace + str-replace(str-slice($string, $index + str-length($search)), $search, $replace);
+    @return string.slice($string, 1, $index - 1) + $replace + str-replace(string.slice($string, $index + string.length($search)), $search, $replace);
   }
 
   @return $string;
@@ -25,8 +28,9 @@
 
   $replace-src: str-replace($src, $color-default, $color-new) !default;
   $replace-src: str-replace($replace-src, "#", "%23");
+  $replace-src: string.quote($replace-src);
 
-  background-image: url(quote($replace-src));
+  background-image: url($replace-src);
 }
 
 // Variables
@@ -232,7 +236,7 @@ $internal-form-checkbox-indeterminate-image: "data:image/svg+xml;charset=UTF-8,%
   /* 2 */
   width: 100%;
 
-  @if (mixin-exists(hook-form)) { @include hook-form(); }
+  @if (meta.mixin-exists(hook-form)) { @include hook-form(); }
 }
 
 /*

--- a/packages/design-system/vite.config.ts
+++ b/packages/design-system/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     preprocessorOptions: {
       scss: {
         additionalData: `@import "${projectRootDir}/packages/design-system/src/styles/styles";`,
-        silenceDeprecations: ['legacy-js-api']
+        silenceDeprecations: ['legacy-js-api', 'import']
       }
     }
   },

--- a/packages/web-pkg/vite.config.ts
+++ b/packages/web-pkg/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     preprocessorOptions: {
       scss: {
         additionalData: `@import "${projectRootDir}/packages/design-system/src/styles/styles";`,
-        silenceDeprecations: ['legacy-js-api']
+        silenceDeprecations: ['legacy-js-api', 'import']
       }
     }
   },

--- a/tests/unit/config/vitest.config.ts
+++ b/tests/unit/config/vitest.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
   css: {
     preprocessorOptions: {
       scss: {
-        silenceDeprecations: ['legacy-js-api']
+        silenceDeprecations: ['legacy-js-api', 'import']
       }
     }
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -173,7 +173,7 @@ export default defineConfig(({ mode, command }) => {
         preprocessorOptions: {
           scss: {
             additionalData: `@import "${projectRootDir}/packages/design-system/src/styles/styles";${stripScssMarker}`,
-            silenceDeprecations: ['legacy-js-api']
+            silenceDeprecations: ['legacy-js-api', 'import']
           }
         }
       },


### PR DESCRIPTION
## Description
With sass > 1.80.0 imports and global functions have been deprecated.
Replacing the global functions in `oc-form.scss` in this PR. Import statements are a different story and more complicated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [x] Maintenance (e.g. dependency updates or tooling)
