### PR TITLE
fix: preview loading retry after 425 status code

### DIFF
--- a/changelog/unreleased/bugfix-preview-retries-postprocessing
+++ b/changelog/unreleased/bugfix-preview-retries-postprocessing
@@ -1,0 +1,6 @@
+Bugfix: Preview image retries postprocessing
+
+Requests for preview images are now being retried when the images could not be loaded due to postprocessing.
+
+https://github.com/owncloud/web/issues/11870
+https://github.com/owncloud/web/pull/11874

--- a/packages/web-pkg/src/services/preview/previewService.ts
+++ b/packages/web-pkg/src/services/preview/previewService.ts
@@ -181,7 +181,7 @@ export class PreviewService {
       })
       return window.URL.createObjectURL(data)
     } catch (e) {
-      if (e.status === 429) {
+      if ([425, 429].includes(e.status)) {
         const retryAfter = e.response?.headers?.['retry-after'] || 5
         await new Promise((resolve) => setTimeout(resolve, retryAfter * 1000))
         return this.privatePreviewBlob(options, cached, silenceErrors, signal)
@@ -218,7 +218,7 @@ export class PreviewService {
         return previewUrl
       }
     } catch (e) {
-      if (e.status === 429) {
+      if ([425, 429].includes(e.status)) {
         const retryAfter = e.response?.headers?.['retry-after'] || 5
         await new Promise((resolve) => setTimeout(resolve, retryAfter * 1000))
         return this.publicPreviewUrl(options, signal)

--- a/packages/web-pkg/tests/unit/services/previewService.spec.ts
+++ b/packages/web-pkg/tests/unit/services/previewService.spec.ts
@@ -87,7 +87,7 @@ describe('PreviewService', () => {
       })
       expect(preview).toEqual(undefined)
     })
-    it('retries when the server returns a 429 status code', async () => {
+    it.each([425, 429])('retries when the server returns a %s status code', async (status) => {
       const supportedMimeTypes = ['image/png']
       const { previewService, clientService } = getWrapper({
         supportedMimeTypes,
@@ -96,7 +96,7 @@ describe('PreviewService', () => {
 
       clientService.httpAuthenticated.get.mockRejectedValueOnce({
         response: { headers: { 'retry-after': 0.1 } },
-        status: 429
+        status: status
       })
       clientService.httpAuthenticated.get.mockResolvedValueOnce(undefined)
 


### PR DESCRIPTION
Adds a retry mechanism for preview requests when the images could not be loaded due to postprocessing.

fixes https://github.com/owncloud/web/issues/11870