### PR TITLE
[tests-only][full-ci]Run app-store e2e tests on CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -91,6 +91,7 @@ config = {
                 "navigation",
                 "user-settings",
                 "file-action",
+                "app-store",
             ],
         },
         "app-provider": {

--- a/tests/drone/config-ocis.json
+++ b/tests/drone/config-ocis.json
@@ -7,5 +7,5 @@
     "client_id": "web",
     "response_type": "code"
   },
-  "apps": ["files", "text-editor", "preview", "pdf-viewer", "search", "admin-settings", "ocm"]
+  "apps": ["files", "text-editor", "preview", "pdf-viewer", "search", "admin-settings", "ocm", "app-store"]
 }


### PR DESCRIPTION
## Description
PR https://github.com/owncloud/web/pull/11664 introduced app-store test suite has been added to cover app-store feature but never run in CI. This PR setup drone to run `app-store` on CI

## Related Issue
- https://github.com/owncloud/web/issues/11837

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
