### PR TITLE
[full-ci]fix thumbnails in federated ocis. enable tests after fixing bugs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,9 +68,6 @@ x-ocis-server: &ocis-service
     OCM_OCM_INVITE_MANAGER_INSECURE: 'true'
     OCM_OCM_SHARE_PROVIDER_INSECURE: 'true'
     OCM_OCM_STORAGE_PROVIDER_INSECURE: 'true'
-    OCM_DEBUG_ADDR: '127.0.0.1:10281'
-    OCM_HTTP_ADDR: '127.0.0.1:10280'
-    OCM_GRPC_ADDR: '127.0.0.1:10282'
 
   extra_hosts:
     - host.docker.internal:${DOCKER_HOST:-host-gateway}

--- a/tests/e2e/cucumber/features/ocm/ocm.feature
+++ b/tests/e2e/cucumber/features/ocm/ocm.feature
@@ -49,20 +49,28 @@ Feature: federation management
     And "Brian" opens the "files" app
     When "Brian" navigates to the shared with me page
 
-    # should be work after fixing https://github.com/owncloud/ocis/issues/10272
-    # Then "Brian" should see thumbnail and preview for file "testavatar.jpg"
-    # And "Brian" should see thumbnail and preview for file "sampleGif.gif"
-    # When "Brian" opens the following file in mediaviewer
-    #   | resource       |
-    #   | testavatar.jpg |
-    # Then "Brian" is in a media-viewer
-    # And "Brian" navigates to the next media resource
-    # When "Brian" closes the file viewer
+    Then "Brian" should see thumbnail and preview for file "testavatar.jpg"
+    And "Brian" should see thumbnail and preview for file "sampleGif.gif"
+    When "Brian" opens the following file in mediaviewer
+      | resource       |
+      | testavatar.jpg |
+    Then "Brian" is in a media-viewer
 
+    # should be work after fixing https://github.com/owncloud/web/issues/11883
+    # And "Brian" navigates to the next media resource
+    And "Brian" closes the file viewer
     And "Brian" downloads the following resources using the sidebar panel
       | resource       | type   |
       | folderPublic   | folder |
-      # should be work after fixing https://github.com/owncloud/ocis/issues/11821
-      # | sampleGif.gif  | file   |
-      # | testavatar.jpg | file   |
+      | sampleGif.gif  | file   |
+      | testavatar.jpg | file   |
+    When "Brian" uploads the following resources
+      | resource       | to           |
+      | testavatar.png | folderPublic |
+    And "Brian" opens folder "folderPublic"
+    Then "Brian" should see thumbnail and preview for file "testavatar.png"
+    When "Brian" opens the following file in mediaviewer
+      | resource       |
+      | testavatar.png |
+    Then "Brian" is in a media-viewer
     And "Brian" logs out


### PR DESCRIPTION
- [x] fixed docker-compose.yml to make all thumbnails works. previosly was 500
- [x] enabled ocm test after fixing bugs
- [x] found and created new bug https://github.com/owncloud/web/issues/11883