### PR TITLE
[tests-only][full-ci] do proper response check with click action

### DIFF
--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -1129,13 +1129,15 @@ export const deleteResource = async (args: deleteResourceArgs): Promise<void> =>
       for (const resource of resourcesWithInfo) {
         await sidebar.open({ page, resource: resource.name })
         await sidebar.openPanel({ page, name: 'actions' })
-        await page.locator(deleteButtonSidebar).first().click()
-        await page.waitForResponse(
-          (resp) =>
-            resp.url().includes(encodeURIComponent(resource.name)) &&
-            resp.status() === 204 &&
-            resp.request().method() === 'DELETE'
-        )
+        await Promise.all([
+          page.waitForResponse(
+            (resp) =>
+              resp.url().includes(encodeURIComponent(resource.name)) &&
+              resp.status() === 204 &&
+              resp.request().method() === 'DELETE'
+          ),
+          page.locator(deleteButtonSidebar).first().click()
+        ])
         await sidebar.close({ page })
       }
       break


### PR DESCRIPTION
## Description
Response check MUST always be done using `Promise.all` along with the action that triggers the response. If not the assertion will become flaky. 

## Related Issue
- Failing test: https://drone.owncloud.com/owncloud/ocis/40977/4/14

## Motivation and Context

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
