### PR TITLE
fix: file picker when embed delegate authentication is enabled

### DIFF
--- a/changelog/unreleased/bugfix-save-as-open-action-embed-delegate-authentication
+++ b/changelog/unreleased/bugfix-save-as-open-action-embed-delegate-authentication
@@ -1,0 +1,6 @@
+Bugfix: "Save as" / "Open" when embed delegate authentication is enabled
+
+We've fixed the "Save as" / "Open" actions when embed delegate authentication is enabled on the server side.
+
+https://github.com/owncloud/web/issues/11897
+https://github.com/owncloud/web/pull/11899

--- a/packages/web-pkg/src/components/Modals/FilePickerModal.vue
+++ b/packages/web-pkg/src/components/Modals/FilePickerModal.vue
@@ -58,6 +58,7 @@ export default defineComponent({
     iframeUrl.searchParams.append('hide-logo', 'true')
     iframeUrl.searchParams.append('embed', 'true')
     iframeUrl.searchParams.append('embed-target', 'file')
+    iframeUrl.searchParams.append('embed-delegate-authentication', 'false')
     iframeUrl.searchParams.append('embed-file-types', availableFileTypes.join(','))
 
     const onLoad = () => {

--- a/packages/web-pkg/src/components/Modals/SaveAsModal.vue
+++ b/packages/web-pkg/src/components/Modals/SaveAsModal.vue
@@ -63,6 +63,7 @@ export default defineComponent({
     iframeUrl.searchParams.append('embed', 'true')
     iframeUrl.searchParams.append('embed-target', 'location')
     iframeUrl.searchParams.append('embed-choose-file-name', 'true')
+    iframeUrl.searchParams.append('embed-delegate-authentication', 'false')
     iframeUrl.searchParams.append('embed-choose-file-name-suggestion', props.originalResource.name)
 
     const onLoad = () => {

--- a/packages/web-pkg/tests/unit/components/Modals/FilePickerModal.spec.ts
+++ b/packages/web-pkg/tests/unit/components/Modals/FilePickerModal.spec.ts
@@ -12,7 +12,7 @@ describe('FilePickerModal', () => {
     it('sets the iframe src correctly', () => {
       const { wrapper } = getWrapper()
       expect(wrapper.vm.iframeSrc).toEqual(
-        'http://localhost:3000/files-spaces-generic?hide-logo=true&embed=true&embed-target=file&embed-file-types=text%2Cmd%2Ctext%2Frtf'
+        'http://localhost:3000/files-spaces-generic?hide-logo=true&embed=true&embed-target=file&embed-delegate-authentication=false&embed-file-types=text%2Cmd%2Ctext%2Frtf'
       )
     })
     it('sets the iframe title correctly', () => {

--- a/packages/web-pkg/tests/unit/components/Modals/SaveAsModal.spec.ts
+++ b/packages/web-pkg/tests/unit/components/Modals/SaveAsModal.spec.ts
@@ -18,7 +18,7 @@ describe('SaveAsModal', () => {
     it('sets the iframe src correctly', () => {
       const { wrapper } = getWrapper()
       expect(wrapper.vm.iframeSrc).toEqual(
-        'http://localhost:3000/files-spaces-generic?hide-logo=true&embed=true&embed-target=location&embed-choose-file-name=true&embed-choose-file-name-suggestion=test.txt'
+        'http://localhost:3000/files-spaces-generic?hide-logo=true&embed=true&embed-target=location&embed-choose-file-name=true&embed-delegate-authentication=false&embed-choose-file-name-suggestion=test.txt'
       )
     })
     it('sets the iframe title correctly', () => {


### PR DESCRIPTION
Fixes the "Open" and "Save as" actions when the server has enabled `embed.delegateAuthentication`. This flag needs to be ignored for these 2 actions since Web is basically embedding itself and always needs authentication.

fixes https://github.com/owncloud/web/issues/11897