### PR TITLE
Fix: always, show location in top bar, make file picker work in various locations, file picker width too narrow

### DIFF
--- a/changelog/unreleased/bugfix-app-top-bar-does-not-show-location-when-shared-file-is-opened
+++ b/changelog/unreleased/bugfix-app-top-bar-does-not-show-location-when-shared-file-is-opened
@@ -1,0 +1,6 @@
+Bugfix: App top bar does not show location when shared file is opened
+
+We've fixed an issue where the app top bar did not show the location when a shared file was opened.
+
+https://github.com/owncloud/web/pull/11900
+https://github.com/owncloud/web/issues/11896

--- a/changelog/unreleased/bugfix-open-from-app-and-save-as-feature-broken-when-opened-via-shared-file
+++ b/changelog/unreleased/bugfix-open-from-app-and-save-as-feature-broken-when-opened-via-shared-file
@@ -1,0 +1,6 @@
+Bugfix: Open from app and Save As feature broken when opened via shared file
+
+We've fixed an issue where the Open from app and Save As feature was broken when opened via a shared file.
+
+https://github.com/owncloud/web/pull/11900
+https://github.com/owncloud/web/issues/11895

--- a/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
+++ b/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
@@ -281,7 +281,12 @@ export default defineComponent({
           yield addMissingDriveAliasAndItem()
         }
         space.value = unref(unref(currentFileContext).space)
-        resource.value = yield getFileInfo(currentFileContext, { signal })
+        resource.value = yield getFileInfo(unref(currentFileContext), { signal })
+
+        //FIXME: As soon the backend exposes oc-remote-id via webdav, remove the assignment below
+        if (isShareSpaceResource(unref(space))) {
+          unref(resource).remoteItemId = unref(space).id
+        }
         resourcesStore.initResourceList({ currentFolder: null, resources: [unref(resource)] })
         selectedResources.value = [unref(resource)]
       } catch (e) {

--- a/packages/web-pkg/src/components/AppTopBar.vue
+++ b/packages/web-pkg/src/components/AppTopBar.vue
@@ -8,11 +8,11 @@
             id="app-top-bar-resource"
             :is-thumbnail-displayed="false"
             :is-extension-displayed="areFileExtensionsShown"
-            :path-prefix="pathPrefix"
+            :path-prefix="getPathPrefix(resource)"
             :resource="resource"
-            :parent-folder-name="parentFolderName"
+            :parent-folder-name="getParentFolderName(resource)"
             :parent-folder-link-icon-additional-attributes="
-              parentFolderLinkIconAdditionalAttributes
+              getParentFolderLinkIconAdditionalAttributes(resource)
             "
             :is-path-displayed="isPathDisplayed"
           />
@@ -99,7 +99,7 @@ import {
   useResourcesStore
 } from '../composables'
 import ResourceListItem from './FilesList/ResourceListItem.vue'
-import { Resource, isPublicSpaceResource, isShareSpaceResource } from '@ownclouders/web-client'
+import { isPublicSpaceResource, Resource } from '@ownclouders/web-client'
 import { Duration } from 'luxon'
 
 export default defineComponent({
@@ -140,9 +140,9 @@ export default defineComponent({
   emits: ['close'],
   setup(props) {
     const { $gettext, current: currentLanguage } = useGettext()
-    const { getMatchingSpace } = useGetMatchingSpace()
     const resourcesStore = useResourcesStore()
     const configStore = useConfigStore()
+    const { getMatchingSpace } = useGetMatchingSpace()
 
     const areFileExtensionsShown = computed(() => resourcesStore.areFileExtensionsShown)
     const contextMenuLabel = computed(() => $gettext('Show context menu'))
@@ -158,38 +158,20 @@ export default defineComponent({
       return $gettext(`Autosave (every %{ duration })`, { duration: duration.toHuman() })
     })
 
-    const { getParentFolderName, getParentFolderLinkIconAdditionalAttributes, getPathPrefix } =
-      useFolderLink()
-
     const space = computed(() => getMatchingSpace(props.resource))
 
-    //FIXME: We currently have problems to display the parent folder name of a shared file, so we disabled it for now
     const isPathDisplayed = computed(() => {
-      return !isShareSpaceResource(unref(space)) && !isPublicSpaceResource(unref(space))
-    })
-
-    const pathPrefix = computed(() => {
-      return props.resource ? getPathPrefix(props.resource) : null
-    })
-
-    const parentFolderName = computed(() => {
-      return props.resource ? getParentFolderName(props.resource) : null
-    })
-
-    const parentFolderLinkIconAdditionalAttributes = computed(() => {
-      return props.resource ? getParentFolderLinkIconAdditionalAttributes(props.resource) : null
+      return !isPublicSpaceResource(unref(space))
     })
 
     return {
-      pathPrefix,
-      isPathDisplayed,
       contextMenuLabel,
       closeButtonLabel,
-      parentFolderName,
-      parentFolderLinkIconAdditionalAttributes,
       areFileExtensionsShown,
       hasAutosave,
-      autoSaveTooltipText
+      autoSaveTooltipText,
+      isPathDisplayed,
+      ...useFolderLink()
     }
   }
 })

--- a/packages/web-pkg/src/components/Modals/FilePickerModal.vue
+++ b/packages/web-pkg/src/components/Modals/FilePickerModal.vue
@@ -122,7 +122,7 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-.open-with-app-modal {
+.oc-modal.open-with-app-modal {
   max-width: 80vw;
   border: none;
   overflow: hidden;

--- a/packages/web-pkg/src/components/Modals/SaveAsModal.vue
+++ b/packages/web-pkg/src/components/Modals/SaveAsModal.vue
@@ -188,7 +188,7 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-.save-as-modal {
+.oc-modal.save-as-modal {
   max-width: 80vw;
   border: none;
   overflow: hidden;

--- a/packages/web-pkg/src/composables/folderLink/useFolderLink.ts
+++ b/packages/web-pkg/src/composables/folderLink/useFolderLink.ts
@@ -69,7 +69,8 @@ export const useFolderLink = (options: ResourceRouteResolverOptions = {}) => {
     })
 
     //FIXME: As soon the backend exposes oc-share-root via webdav, only use isShareRoot fn
-    const shareRoot = isShareRoot(resource) || resource.id === space.id
+    const shareRoot =
+      isShareRoot(resource) || (resource.id === space.id && isShareSpaceResource(space))
     if (shareRoot || !parentFolderAccessible) {
       return $gettext('Shared with me')
     }

--- a/packages/web-pkg/src/composables/folderLink/useFolderLink.ts
+++ b/packages/web-pkg/src/composables/folderLink/useFolderLink.ts
@@ -67,7 +67,10 @@ export const useFolderLink = (options: ResourceRouteResolverOptions = {}) => {
       space,
       path: dirname(resource.path)
     })
-    if (isShareRoot(resource) || !parentFolderAccessible) {
+
+    //FIXME: As soon the backend exposes oc-share-root via webdav, only use isShareRoot fn
+    const shareRoot = isShareRoot(resource) || resource.id === space.id
+    if (shareRoot || !parentFolderAccessible) {
       return $gettext('Shared with me')
     }
     const parentFolder = extractParentFolderName(resource)

--- a/packages/web-pkg/tests/unit/composables/folderLink/useFolderLink.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/folderLink/useFolderLink.spec.ts
@@ -75,7 +75,8 @@ describe('useFolderLink', () => {
       const resource = {
         path: '/My share/test.txt',
         remoteItemPath: '/My share',
-        remoteItemId: '1'
+        remoteItemId: '1',
+        storageId: '1'
       } as Resource
 
       const wrapper = createWrapper()


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #11895 
- Fixes #11896 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
