### PR TITLE
fix: show extension actions in right sidebar actions panel

### DIFF
--- a/changelog/unreleased/bugfix-extension-actions-right-sidebar
+++ b/changelog/unreleased/bugfix-extension-actions-right-sidebar
@@ -1,0 +1,6 @@
+Bugfix: Extension actions in right sidebar
+
+Extension actions (e.g. "Extract here") are now correctly showing in the actions panel of the right sidebar.
+
+https://github.com/owncloud/web/pull/11924
+https://github.com/owncloud/web/issues/11898

--- a/packages/web-pkg/src/composables/actions/files/useFileActions.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActions.ts
@@ -1,4 +1,5 @@
 import kebabCase from 'lodash-es/kebabCase'
+import isNil from 'lodash-es/isNil'
 import { isShareSpaceResource } from '@ownclouders/web-client'
 import { routeToContextQuery } from '../../appDefaults'
 import { isLocationTrashActive } from '../../../router'
@@ -96,6 +97,13 @@ export const useFileActions = () => {
       extensionType: 'action'
     })
     return contextActionExtensions.map((extension) => extension.action)
+  })
+
+  const extensionActions = computed(() => {
+    return requestExtensions<ActionExtension>({
+      id: 'global.files.context-actions',
+      extensionType: 'action'
+    }).map((e) => e.action)
   })
 
   const editorActions = computed(() => {
@@ -260,7 +268,15 @@ export const useFileActions = () => {
       ? []
       : unref(systemActions).filter(filterCallback)
 
-    return [...primaryActions, ...secondaryActions]
+    return [
+      ...primaryActions,
+      ...secondaryActions,
+      ...unref(extensionActions).filter(
+        (a) =>
+          a.isVisible(options as FileActionOptions) &&
+          (a.category === 'actions' || isNil(a.category))
+      )
+    ]
   }
 
   return {


### PR DESCRIPTION
fixes https://github.com/owncloud/web/issues/11898