### PR TITLE
[tests-only][full-ci]Cache playwright chromium

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1903,9 +1903,9 @@ def cachePlaywright():
         "image": MINIO_MC,
         "environment": minio_mc_environment,
         "commands": [
-            ". ./.drone.env",
+            "playwright_version=$(grep '\"@playwright/test\":' \"package.json\" | cut -d':' -f2 | tr -d '\", ')",
             "mc alias set s3 $MC_HOST $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY",
-            "mc cp -a %s/.playwright s3/$CACHE_BUCKET/web/$version/" % dir["web"],
+            "mc cp -r -a %s/.playwright s3/$CACHE_BUCKET/web/$playwright_version/" % dir["web"],
             "mc ls --recursive s3/$CACHE_BUCKET/web",
         ],
     }]

--- a/tests/drone/script.sh
+++ b/tests/drone/script.sh
@@ -48,7 +48,7 @@ get_playwright_version() {
 check_chromium_cache() {
     get_playwright_version
 
-    playwright_cache=$(mc find s3/$CACHE_BUCKET/web/$playwright_version/.playwright 2>&1 | grep 'Object does not exist')
+    playwright_cache=$(mc find s3/$CACHE_BUCKET/web/$playwright_version/playwright-chromium.tar.gz 2>&1 | grep 'Object does not exist')
 
     if [[ "$playwright_cache" != "" ]]
     then

--- a/tests/drone/script.sh
+++ b/tests/drone/script.sh
@@ -31,25 +31,23 @@ check_ocis_cache() {
 
 # get playwright version from package.json
 get_playwright_version() {
-    # Ensure package.json exists
     if [[ ! -f "package.json" ]]; then
         echo "Error: package.json file not found."
     fi
 
-    # Extract Playwright version from package.json
     playwright_version=$(grep '"@playwright/test":' "package.json" | cut -d':' -f2 | tr -d '", ')
     if [[ -z "$playwright_version" ]]; then
-        echo "Error: Playwright package not found in package.json."
+        echo "Error: Playwright package not found in package.json." >&2
+        exit 78
     fi
 
-    echo "Checking Playwright cache for version: $playwright_version"
+    echo "$playwright_version"
 }
 
 # Function to check if the cache exists for the given commit ID
 check_playwright_cache() {
     get_playwright_version
 
-    # Check cache using MinIO
     playwright_cache=$(mc find s3/$CACHE_BUCKET/web/$playwright_version/.playwright 2>&1 | grep 'Object does not exist')
 
     if [[ "$playwright_cache" != "" ]]

--- a/tests/drone/script.sh
+++ b/tests/drone/script.sh
@@ -45,14 +45,18 @@ get_playwright_version() {
 }
 
 # Function to check if the cache exists for the given commit ID
-check_chromium_cache() {
+check_browsers_cache() {
     get_playwright_version
 
-    playwright_cache=$(mc find s3/$CACHE_BUCKET/web/$playwright_version/playwright-chromium.tar.gz 2>&1 | grep 'Object does not exist')
+    playwright_cache=$(mc find s3/$CACHE_BUCKET/web/browsers-cache/$playwright_version/playwright-browsers.tar.gz 2>&1 | grep 'Object does not exist')
 
     if [[ "$playwright_cache" != "" ]]
     then
-        echo "Playwright v$playwright_version supported chromium doesn't exist in cache."
+        echo "Playwright v$playwright_version supported browsers doesn't exist in cache."
+
+        # Remove everything inside the 'browsers-cache' directory to avoid multiple browsers version
+        echo "Clearing all contents inside the 'browsers-cache' directory..."
+        mc rm --recursive --force s3/$CACHE_BUCKET/web/browsers-cache/
         exit 0
     fi
     exit 78
@@ -65,7 +69,7 @@ if [[ "$1" == "" ]]; then
     echo -e "  get_latest_ocis_commit_id \t get the latest oCIS commit ID"
     echo -e "  check_ocis_cache \t\t check if the cache exists for the given commit ID"
     echo -e "  get_playwright_version \t get the playwright version from package.json"
-    echo -e "  check_chromium_cache \t check if the chromium cache exists for the given playwright version"
+    echo -e "  check_browsers_cache \t check if the browsers cache exists for the given playwright version"
     exit 1
 fi
 

--- a/tests/drone/script.sh
+++ b/tests/drone/script.sh
@@ -53,10 +53,6 @@ check_browsers_cache() {
     if [[ "$playwright_cache" != "" ]]
     then
         echo "Playwright v$playwright_version supported browsers doesn't exist in cache."
-
-        # Remove everything inside the 'browsers-cache' directory to avoid multiple browsers version
-        echo "Clearing all contents inside the 'browsers-cache' directory..."
-        mc rm --recursive --force s3/$CACHE_BUCKET/web/browsers-cache/
         exit 0
     fi
     exit 78

--- a/tests/drone/script.sh
+++ b/tests/drone/script.sh
@@ -45,14 +45,14 @@ get_playwright_version() {
 }
 
 # Function to check if the cache exists for the given commit ID
-check_playwright_cache() {
+check_chromium_cache() {
     get_playwright_version
 
     playwright_cache=$(mc find s3/$CACHE_BUCKET/web/$playwright_version/.playwright 2>&1 | grep 'Object does not exist')
 
     if [[ "$playwright_cache" != "" ]]
     then
-        echo "Playwright $playwright_version Chromium exists in cache."
+        echo "Playwright v$playwright_version supported chromium doesn't exist in cache."
         exit 0
     fi
     exit 78
@@ -64,7 +64,8 @@ if [[ "$1" == "" ]]; then
     echo "Commands:"
     echo -e "  get_latest_ocis_commit_id \t get the latest oCIS commit ID"
     echo -e "  check_ocis_cache \t\t check if the cache exists for the given commit ID"
-    echo -e "  check_playwright_cache \t check if the cache exists for the given commit ID"
+    echo -e "  get_playwright_version \t get the playwright version from package.json"
+    echo -e "  check_chromium_cache \t check if the chromium cache exists for the given playwright version"
     exit 1
 fi
 

--- a/tests/drone/script.sh
+++ b/tests/drone/script.sh
@@ -29,8 +29,8 @@ check_ocis_cache() {
     exit 78
 }
 
-# Function to check if the cache exists for the given commit ID
-check_playwright_cache() {
+# get playwright version from package.json
+get_playwright_version() {
     # Ensure package.json exists
     if [[ ! -f "package.json" ]]; then
         echo "Error: package.json file not found."
@@ -43,6 +43,11 @@ check_playwright_cache() {
     fi
 
     echo "Checking Playwright cache for version: $playwright_version"
+}
+
+# Function to check if the cache exists for the given commit ID
+check_playwright_cache() {
+    get_playwright_version
 
     # Check cache using MinIO
     playwright_cache=$(mc find s3/$CACHE_BUCKET/web/$playwright_version/.playwright 2>&1 | grep 'Object does not exist')

--- a/tests/drone/script.sh
+++ b/tests/drone/script.sh
@@ -29,11 +29,39 @@ check_ocis_cache() {
     exit 78
 }
 
+# Function to check if the cache exists for the given commit ID
+check_playwright_cache() {
+    # Ensure package.json exists
+    if [[ ! -f "package.json" ]]; then
+        echo "Error: package.json file not found."
+    fi
+
+    # Extract Playwright version from package.json
+    playwright_version=$(grep '"@playwright/test":' "package.json" | cut -d':' -f2 | tr -d '", ')
+    if [[ -z "$playwright_version" ]]; then
+        echo "Error: Playwright package not found in package.json."
+    fi
+
+    echo "Checking Playwright cache for version: $playwright_version"
+
+    # Check cache using MinIO
+    playwright_cache=$(mc find s3/$CACHE_BUCKET/web/$playwright_version/.playwright 2>&1 | grep 'Object does not exist')
+
+    if [[ "$playwright_cache" != "" ]]
+    then
+        echo "Playwright $playwright_version Chromium exists in cache."
+        exit 0
+    fi
+    exit 78
+}
+
+
 if [[ "$1" == "" ]]; then
     echo "Usage: $0 [COMMAND]"
     echo "Commands:"
     echo -e "  get_latest_ocis_commit_id \t get the latest oCIS commit ID"
     echo -e "  check_ocis_cache \t\t check if the cache exists for the given commit ID"
+    echo -e "  check_playwright_cache \t check if the cache exists for the given commit ID"
     exit 1
 fi
 

--- a/tests/e2e/cucumber/environment/index.ts
+++ b/tests/e2e/cucumber/environment/index.ts
@@ -100,6 +100,7 @@ BeforeAll(async (): Promise<void> => {
 
   state.browser = await browsers[config.browser]()
 
+  console.log(state.browser.version())
   // setup keycloak admin user
   if (config.keycloak) {
     const usersEnvironment = new environment.UsersEnvironment()

--- a/tests/e2e/cucumber/environment/index.ts
+++ b/tests/e2e/cucumber/environment/index.ts
@@ -100,7 +100,6 @@ BeforeAll(async (): Promise<void> => {
 
   state.browser = await browsers[config.browser]()
 
-  console.log(state.browser.version())
   // setup keycloak admin user
   if (config.keycloak) {
     const usersEnvironment = new environment.UsersEnvironment()


### PR DESCRIPTION
## Description
This PR 
- update `PLUGINS_S3 = "plugins/s3:1.5"` version
- cache chromium with respect to playwright version
- Use cached chromium to run e2e tests
- add script to get playwright version to store cache 

## Note
- can't upgrade minio version because some command are not available in the latest minio image 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/11921

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
