### PR TITLE
fix: do not load version when sidebar is closed

### DIFF
--- a/changelog/unreleased/bugfix-do-not-load-versions-when-sidebar-is-closed
+++ b/changelog/unreleased/bugfix-do-not-load-versions-when-sidebar-is-closed
@@ -1,0 +1,6 @@
+Bugfix: Do not load version when sidebar is closed
+
+We've fixed the the loading of file versions which was triggered even when sidebar was closed. File version will now be loaded only when the sidebar is opened.
+
+https://github.com/owncloud/web/pull/11998
+https://github.com/owncloud/web/issues/11979

--- a/packages/web-pkg/src/components/SideBar/FileSideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/FileSideBar.vue
@@ -334,6 +334,12 @@ export default defineComponent({
         if (unref(panelContext).items?.length !== 1) {
           return
         }
+
+        if (!props.isOpen) {
+          versions.value = []
+          return
+        }
+
         const resource = unref(panelContext).items[0]
 
         if (loadVersionsTask.isRunning) {

--- a/packages/web-pkg/tests/unit/components/sidebar/FileSideBar.spec.ts
+++ b/packages/web-pkg/tests/unit/components/sidebar/FileSideBar.spec.ts
@@ -214,6 +214,34 @@ describe('FileSideBar', () => {
         expect(sharesStore.setCollaboratorShares).toHaveBeenCalledWith([])
       })
     })
+    describe('loadVersionsTask', () => {
+      beforeEach(() => {
+        vi.mock('../../../../src/composables/resources/useCanListVersions', () => ({
+          useCanListVersions: () => ({ canListVersions: vi.fn().mockReturnValue(true) })
+        }))
+      })
+
+      it('is called when resource is selected and sidebar is opened', () => {
+        const resource = mock<Resource>({ id: 'some-image', path: '/someImage.jpg' })
+        const { mocks } = createWrapper({
+          item: resource
+        })
+
+        expect(mocks.$clientService.webdav.listFileVersions).toHaveBeenCalledWith('some-image', {
+          signal: expect.any(AbortSignal)
+        })
+      })
+
+      it('is not called if resource is selected and sidebar is not opened', () => {
+        const resource = mock<Resource>({ id: 'some-image', path: '/someImage.jpg' })
+        const { mocks } = createWrapper({
+          item: resource,
+          isOpen: false
+        })
+
+        expect(mocks.$clientService.webdav.listFileVersions).not.toHaveBeenCalled()
+      })
+    })
   })
 })
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
We've fixed the the loading of file versions which was triggered even when sidebar was closed. File version will now be loaded only when the sidebar is opened.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/11979

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Do not perform requests when not needed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: unit & local
- test case 1: added unit tests
- test case 2: follow reproduction steps from the issue
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
