### PR TITLE
fix: pass only space as space prop to sidebar

### DIFF
--- a/changelog/unreleased/bugfix-use-only-space-as-space-into-sidebar
+++ b/changelog/unreleased/bugfix-use-only-space-as-space-into-sidebar
@@ -1,0 +1,6 @@
+Bugfix: Use only space resource with `driveType` "project" as space in sidebar
+
+We've fixed the issue where any selected resource got passed to the sidebar as a space in Spaces page. Now only space resource with `driveType` "project" will be passed as a space.
+
+https://github.com/owncloud/web/pull/12000
+https://github.com/owncloud/web/issues/11978

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -275,7 +275,10 @@ export default defineComponent({
       return spacesStore.spaces.filter(isProjectSpaceResource) || []
     })
     const selectedSpace = computed(() => {
-      if (unref(selectedResources).length === 1) {
+      if (
+        unref(selectedResources).length === 1 &&
+        isProjectSpaceResource(unref(selectedResources)[0])
+      ) {
         return unref(selectedResources)[0] as ProjectSpaceResource
       }
       return null

--- a/packages/web-app-files/tests/unit/views/spaces/Projects.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/Projects.spec.ts
@@ -13,7 +13,8 @@ import {
   mount,
   defaultComponentMocks,
   defaultStubs,
-  RouteLocation
+  RouteLocation,
+  PiniaMockOptions
 } from '@ownclouders/web-test-helpers'
 import { AbilityRule, SpaceResource } from '@ownclouders/web-client'
 import {
@@ -120,6 +121,22 @@ describe('Projects view', () => {
     })
     expect(wrapper.find('create-space-stub').exists()).toBeTruthy()
   })
+  it('should not pass selected resource as space to sidebar when driveType is not "project"', () => {
+    const resource = mock<SpaceResource>({ id: 'selected-resource', driveType: 'personal' })
+    const { wrapper } = getMountedWrapper({
+      store: { resourcesStore: { resources: [resource], selectedIds: ['selected-resource'] } }
+    })
+
+    expect(wrapper.vm.selectedSpace).toStrictEqual(null)
+  })
+  it('should pass selected resource as space to sidebar when driveType is "project"', () => {
+    const resource = mock<SpaceResource>({ id: 'selected-resource', driveType: 'project' })
+    const { wrapper } = getMountedWrapper({
+      store: { resourcesStore: { resources: [resource], selectedIds: ['selected-resource'] } }
+    })
+
+    expect(wrapper.vm.selectedSpace.id).toStrictEqual('selected-resource')
+  })
 })
 
 function getMountedWrapper({
@@ -127,15 +144,17 @@ function getMountedWrapper({
   spaces = [],
   abilities = [],
   stubAppBar = true,
-  includeDisabled = false
+  includeDisabled = false,
+  store = {}
 }: {
   mocks?: Record<string, unknown>
   spaces?: SpaceResource[]
   abilities?: AbilityRule[]
   stubAppBar?: boolean
   includeDisabled?: boolean
+  store?: PiniaMockOptions
 } = {}) {
-  const plugins = defaultPlugins({ abilities, piniaOptions: { spacesState: { spaces } } })
+  const plugins = defaultPlugins({ abilities, piniaOptions: { spacesState: { spaces }, ...store } })
 
   vi.mocked(queryItemAsString).mockImplementation(() => includeDisabled.toString())
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
We've fixed the issue where any selected resource got passed to the sidebar as a space in Spaces page. Now only space resource with `driveType` "project" will be passed as a space.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/11978

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
So that our app does not crash and console is clean of errors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: unit & local
- test case 1: added unit tests
- test case 2: repeat issue reproduction steps
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
