### PR TITLE
fix: add missing activities on Shared with me page

### DIFF
--- a/changelog/unreleased/bugfix-missing-activities-shared-with-me-page
+++ b/changelog/unreleased/bugfix-missing-activities-shared-with-me-page
@@ -1,0 +1,5 @@
+Bugfix: Missing activities on Shared with me page
+
+We've added the missing activities on the Shared with me page.
+
+https://github.com/owncloud/web/pull/12008

--- a/packages/web-app-files/src/components/SideBar/ActivitiesPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/ActivitiesPanel.vue
@@ -70,7 +70,7 @@ export default defineComponent({
     const loadActivitiesTask = useTask(function* (signal) {
       activities.value = yield* call(
         clientService.graphAuthenticated.activities.listActivities(
-          `itemid:${unref(resource).id} AND limit:${activitiesLimit} AND sort:desc`,
+          `itemid:${unref(resource).fileId} AND limit:${activitiesLimit} AND sort:desc`,
           { signal }
         )
       )


### PR DESCRIPTION
We need to use the resource's `fileId` to load the activities since the regular `id` won't work for share resources.