### PR TITLE
feat: add notifications settings

### DIFF
--- a/changelog/unreleased/enhancement-add-notifications-settings
+++ b/changelog/unreleased/enhancement-add-notifications-settings
@@ -1,0 +1,6 @@
+Enhancement: Add notifications settings
+
+We've added a new notifications settings section into the account screen. This section allows users to configure what notifications they wish to receive either in-app or via email, when to receive email notifications, and drops the previous notifications toggle.
+
+https://github.com/owncloud/web/pull/12010
+https://github.com/owncloud/web/issues/9248

--- a/packages/web-client/src/ocs/capabilities.ts
+++ b/packages/web-client/src/ocs/capabilities.ts
@@ -72,6 +72,7 @@ export interface Capabilities {
     }
     notifications?: {
       'ocs-endpoints'?: string[]
+      configurable?: boolean
     }
     core: {
       pollinterval?: number

--- a/packages/web-runtime/src/components/Account/AccountTable.vue
+++ b/packages/web-runtime/src/components/Account/AccountTable.vue
@@ -4,9 +4,18 @@
       <h2 class="account-table-title" v-text="title" />
     </slot>
     <oc-table-simple>
-      <oc-thead class="oc-invisible-sr">
+      <oc-thead :class="{ 'oc-invisible-sr': !showHead }">
         <oc-tr>
-          <oc-th v-for="field in fields" :key="field">{{ field }}</oc-th>
+          <template v-for="field in fields" :key="typeof field === 'string' ? field : field.label">
+            <oc-th v-if="typeof field === 'string'">{{ field }}</oc-th>
+            <oc-th
+              v-else
+              :align-h="field.alignH || 'left'"
+              :class="{ 'oc-invisible-sr': field.hidden }"
+            >
+              {{ field.label }}
+            </oc-th>
+          </template>
         </oc-tr>
       </oc-thead>
       <oc-tbody>
@@ -19,6 +28,12 @@
 <script lang="ts">
 import { defineComponent } from 'vue'
 
+type AccountTableCell = {
+  label: string
+  alignH?: string
+  hidden?: boolean
+}
+
 export default defineComponent({
   name: 'AccountTable',
   props: {
@@ -27,15 +42,16 @@ export default defineComponent({
       required: true
     },
     fields: {
-      type: Array<string>,
+      type: Array<string | AccountTableCell>,
       required: true
-    }
+    },
+    showHead: { type: Boolean, required: false, default: false }
   }
 })
 </script>
 
 <style lang="scss">
-@media (max-width: 800px) {
+@media (max-width: $oc-breakpoint-small-max) {
   .account-table {
     tr {
       display: block;
@@ -85,11 +101,13 @@ export default defineComponent({
     }
   }
 
-  td:nth-child(3) {
-    display: flex;
-    justify-content: end;
-    align-items: center;
-    min-height: var(--oc-size-height-table-row);
+  @media (min-width: $oc-breakpoint-medium-default) {
+    td > .checkbox-cell-wrapper {
+      display: flex;
+      justify-content: end;
+      align-items: center;
+      min-height: var(--oc-size-height-table-row);
+    }
   }
 }
 </style>

--- a/packages/web-runtime/src/composables/notificationsSettings/index.ts
+++ b/packages/web-runtime/src/composables/notificationsSettings/index.ts
@@ -1,0 +1,1 @@
+export * from './useNotificationsSettings'

--- a/packages/web-runtime/src/composables/notificationsSettings/useNotificationsSettings.ts
+++ b/packages/web-runtime/src/composables/notificationsSettings/useNotificationsSettings.ts
@@ -1,0 +1,65 @@
+import { computed, Ref, unref } from 'vue'
+import {
+  getSettingsValue,
+  SETTINGS_EMAIL_NOTIFICATION_BUNDLE_IDS,
+  SETTINGS_NOTIFICATION_BUNDLE_IDS,
+  SettingsBundle,
+  SettingsValue
+} from '../../helpers/settings'
+
+export const useNotificationsSettings = (
+  valueList: Ref<SettingsValue[]>,
+  bundle: Ref<SettingsBundle>
+) => {
+  const values = computed(() => {
+    if (!unref(bundle)) {
+      return {}
+    }
+
+    return unref(bundle).settings.reduce((acc, curr) => {
+      if (!SETTINGS_NOTIFICATION_BUNDLE_IDS.includes(curr.id)) {
+        return acc
+      }
+
+      acc[curr.id] = getSettingsValue(curr, unref(valueList))
+
+      return acc
+    }, {})
+  })
+
+  const options = computed<SettingsBundle['settings']>(() => {
+    if (!unref(bundle)) {
+      return []
+    }
+
+    return unref(bundle).settings.filter(({ id }) => SETTINGS_NOTIFICATION_BUNDLE_IDS.includes(id))
+  })
+
+  const emailOptions = computed<SettingsBundle['settings']>(() => {
+    if (!unref(bundle)) {
+      return []
+    }
+
+    return unref(bundle).settings.filter(({ id }) =>
+      SETTINGS_EMAIL_NOTIFICATION_BUNDLE_IDS.includes(id)
+    )
+  })
+
+  const emailValues = computed(() => {
+    if (!unref(bundle)) {
+      return {}
+    }
+
+    return unref(bundle).settings.reduce((acc, curr) => {
+      if (!SETTINGS_EMAIL_NOTIFICATION_BUNDLE_IDS.includes(curr.id)) {
+        return acc
+      }
+
+      acc[curr.id] = getSettingsValue(curr, unref(valueList))
+
+      return acc
+    }, {})
+  })
+
+  return { values, options, emailOptions, emailValues }
+}

--- a/packages/web-runtime/src/helpers/settings.ts
+++ b/packages/web-runtime/src/helpers/settings.ts
@@ -1,3 +1,5 @@
+import { captureException } from '@sentry/vue'
+
 export interface SettingsValue {
   identifier: {
     bundle: string
@@ -18,7 +20,40 @@ export interface SettingsValue {
         stringValue: string
       }[]
     }
+    collectionValue?: {
+      values: {
+        key: string
+        boolValue: boolean
+      }[]
+    }
+    stringValue?: string
   }
+}
+
+interface SettingsBundleSetting {
+  description: string
+  displayName: string
+  id: string
+  name: string
+  resource: {
+    type: string
+  }
+  singleChoiceValue?: {
+    options: Record<string, any>[]
+  }
+  multiChoiceCollectionValue?: {
+    options: {
+      value: {
+        boolValue: {
+          default?: boolean
+        }
+      }
+      key: string
+      displayValue: string
+      attribute?: 'disabled'
+    }[]
+  }
+  boolValue?: Record<string, any>
 }
 
 export interface SettingsBundle {
@@ -29,19 +64,7 @@ export interface SettingsBundle {
   resource: {
     type: string
   }
-  settings: {
-    description: string
-    displayName: string
-    id: string
-    name: string
-    resource: {
-      type: string
-    }
-    singleChoiceValue?: {
-      options: Record<string, any>[]
-    }
-    boolValue?: Record<string, any>
-  }[]
+  settings: SettingsBundleSetting[]
   type: string
   roleId?: string
 }
@@ -49,4 +72,100 @@ export interface SettingsBundle {
 export interface LanguageOption {
   label: string
   value: string
+}
+
+/** IDs of notifications setting bundles */
+export enum SettingsNotificationBundle {
+  ShareCreated = '872d8ef6-6f2a-42ab-af7d-f53cc81d7046',
+  ShareRemoved = 'd7484394-8321-4c84-9677-741ba71e1f80',
+  ShareExpired = 'e1aa0b7c-1b0f-4072-9325-c643c89fee4e',
+  SpaceShared = '694d5ee1-a41c-448c-8d14-396b95d2a918',
+  SpaceUnshared = '26c20e0e-98df-4483-8a77-759b3a766af0',
+  SpaceMembershipExpired = '7275921e-b737-4074-ba91-3c2983be3edd',
+  SpaceDisabled = 'eb5c716e-03be-42c6-9ed1-1105d24e109f',
+  SpaceDeleted = '094ceca9-5a00-40ba-bb1a-bbc7bccd39ee',
+  PostprocessingStepFinished = 'fe0a3011-d886-49c8-b797-33d02fa426ef',
+  ScienceMeshInviteTokenGenerated = 'b441ffb1-f5ee-4733-a08f-48d03f6e7f22'
+}
+
+/** IDs of email notifications setting bundles */
+export enum SettingsEmailNotificationBundle {
+  EmailSendingInterval = '08dec2fe-3f97-42a9-9d1b-500855e92f25'
+}
+
+// We need the type specified here because e.g. includes method would otherwise complain about it
+export const SETTINGS_NOTIFICATION_BUNDLE_IDS: string[] = [
+  SettingsNotificationBundle.ShareCreated,
+  SettingsNotificationBundle.ShareRemoved,
+  SettingsNotificationBundle.ShareExpired,
+  SettingsNotificationBundle.SpaceShared,
+  SettingsNotificationBundle.SpaceUnshared,
+  SettingsNotificationBundle.SpaceMembershipExpired,
+  SettingsNotificationBundle.SpaceDisabled,
+  SettingsNotificationBundle.SpaceDeleted,
+  SettingsNotificationBundle.PostprocessingStepFinished,
+  SettingsNotificationBundle.ScienceMeshInviteTokenGenerated
+]
+
+export const SETTINGS_EMAIL_NOTIFICATION_BUNDLE_IDS: string[] = [
+  SettingsEmailNotificationBundle.EmailSendingInterval
+]
+
+function getSettingsDefaultValue(setting: SettingsBundleSetting) {
+  if (setting.singleChoiceValue) {
+    const [option] = setting.singleChoiceValue.options
+
+    return {
+      value: option.value.stringValue,
+      displayValue: option.displayValue
+    }
+  }
+
+  if (setting.multiChoiceCollectionValue) {
+    return setting.multiChoiceCollectionValue.options.reduce((acc, curr) => {
+      acc[curr.key] = curr.value.boolValue.default
+
+      return acc
+    }, {})
+  }
+
+  const error = new Error('Unsupported setting value')
+
+  console.error(error)
+  captureException(error)
+
+  return null
+}
+
+export function getSettingsValue(
+  setting: SettingsBundleSetting,
+  valueList: SettingsValue[]
+): boolean | string | null | { [key: string]: boolean } | { value: string; displayValue: string } {
+  const { value } = valueList.find((v) => v.identifier.setting === setting.name) || {}
+
+  if (!value) {
+    return getSettingsDefaultValue(setting)
+  }
+
+  if (value.collectionValue) {
+    return setting.multiChoiceCollectionValue.options.reduce((acc, curr) => {
+      const val = value.collectionValue.values.find((v) => v.key === curr.key)
+
+      if (val) {
+        acc[curr.key] = val.boolValue
+        return acc
+      }
+
+      acc[curr.key] = curr.value.boolValue.default
+      return acc
+    }, {})
+  }
+
+  if (value.stringValue) {
+    const option = setting.singleChoiceValue.options.find(
+      (o) => o.value.stringValue === value.stringValue
+    )
+
+    return { value: value.stringValue, displayValue: option?.displayValue || value.stringValue }
+  }
 }

--- a/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.ts.snap
+++ b/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.ts.snap
@@ -134,6 +134,7 @@ exports[`account page > public link context > should render a limited view 1`] =
     </div>
     <!--v-if-->
     <!--v-if-->
+    <!--v-if-->
   </div>
 </main>"
 `;

--- a/packages/web-runtime/tests/unit/pages/account.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/account.spec.ts
@@ -2,9 +2,9 @@ import account from '../../../src/pages/account.vue'
 import {
   defaultComponentMocks,
   defaultPlugins,
+  mockAxiosReject,
   mockAxiosResolve,
-  mount,
-  mockAxiosReject
+  mount
 } from '@ownclouders/web-test-helpers'
 import { mock } from 'vitest-mock-extended'
 import {
@@ -160,7 +160,9 @@ describe('account page', () => {
       const { wrapper, mocks } = getWrapper()
       await blockLoadingState(wrapper)
 
-      mocks.$clientService.httpAuthenticated.post.mockResolvedValueOnce(mockAxiosResolve({}))
+      mocks.$clientService.httpAuthenticated.post.mockResolvedValueOnce(
+        mockAxiosResolve({ value: { id: 'settings-language' } })
+      )
       await wrapper.vm.updateDisableEmailNotifications(true)
       const { showMessage } = useMessages()
       expect(showMessage).toHaveBeenCalled()
@@ -267,6 +269,68 @@ describe('account page', () => {
       await blockLoadingState(wrapper)
 
       expect(wrapper.find(selectors.extensionsSection).exists()).toBeTruthy()
+    })
+  })
+
+  describe('Method "updateMultiChoiceSettingsValue"', () => {
+    it('should show a message on success', async () => {
+      const { wrapper, mocks } = getWrapper({})
+      await blockLoadingState(wrapper)
+
+      mocks.$clientService.httpAuthenticated.post.mockResolvedValueOnce(
+        mockAxiosResolve({
+          value: { identifier: { setting: 'setting-id' }, value: { id: 'value-id' } }
+        })
+      )
+      await wrapper.vm.updateMultiChoiceSettingsValue('setting-id', 'setting-key', true)
+      const { showMessage } = useMessages()
+      expect(showMessage).toHaveBeenCalled()
+    })
+
+    it('should show a message on error', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+      const { wrapper, mocks } = getWrapper({})
+      await blockLoadingState(wrapper)
+
+      mocks.$clientService.httpAuthenticated.post.mockImplementation(() => mockAxiosReject('err'))
+      await wrapper.vm.updateMultiChoiceSettingsValue('setting-id', 'setting-key', true)
+      const { showErrorMessage } = useMessages()
+      expect(showErrorMessage).toHaveBeenCalled()
+    })
+  })
+
+  describe('Method "updateSingleChoiceValue"', () => {
+    it('should show a message on success', async () => {
+      const { wrapper, mocks } = getWrapper({})
+      await blockLoadingState(wrapper)
+
+      mocks.$clientService.httpAuthenticated.post.mockResolvedValueOnce(
+        mockAxiosResolve({
+          value: { identifier: { setting: 'setting-id' }, value: { id: 'value-id' } }
+        })
+      )
+      await wrapper.vm.updateSingleChoiceValue('setting-id', {
+        displayValue: 'Daily',
+        value: { stringValue: 'daily' }
+      })
+      const { showMessage } = useMessages()
+      expect(showMessage).toHaveBeenCalled()
+    })
+
+    it('should show a message on error', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+      const { wrapper, mocks } = getWrapper({})
+      await blockLoadingState(wrapper)
+
+      mocks.$clientService.httpAuthenticated.post.mockImplementation(() => mockAxiosReject('err'))
+      await wrapper.vm.updateSingleChoiceValue('setting-id', {
+        displayValue: 'Daily',
+        value: { stringValue: 'daily' }
+      })
+      const { showErrorMessage } = useMessages()
+      expect(showErrorMessage).toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
We've added a new notifications settings section into the account screen. This section allows users to configure what notifications they wish to receive either in-app or via email, when to receive email notifications, and drops the previous notifications toggle.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/9248

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Give more control to users to decide what notifications they wish to receive.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: local & unit
- test case 1: add unit tests
- test case 2: test in the browser

## Screenshots (if appropriate):

![host docker internal_9201_web-oidc-callback_code=tIgOFL3PbrHgrYTW3F7luscuS1x9lQvj scope=email%20openid%20profile session_state=b76325f6ae0240cdc6ac1f37c624fb1afda7be95b9d5885eeb881f1eb9000841 LQhHRvT0L20gbR1Me3rUY3QxLO0IE-chrnPJgQ8Fbvs stat](https://github.com/user-attachments/assets/a2620429-ebff-4f6d-99b6-ff984b6f8c37)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
