### PR TITLE
fix: disable paste button in same folder

### DIFF
--- a/changelog/unreleased/bugfix-disable-paste-action-in-same-folder.md
+++ b/changelog/unreleased/bugfix-disable-paste-action-in-same-folder.md
@@ -1,0 +1,6 @@
+Bugfix: Disable paste action in same folder
+
+We've fixed the state of the "paste files" action when copied resources are from the same folder. The button will be disabled in such case and a tooltip with explanation message displayed.
+
+https://github.com/owncloud/web/pull/12044
+https://github.com/owncloud/web/issues/12021

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -420,7 +420,7 @@ export default defineComponent({
 
     const pasteHereButtonTooltip = computed(() => {
       if (unref(uploadOrFileCreationBlocked)) {
-        return $gettext('You have no permission to paste files here!')
+        return $gettext('You have no permission to paste files here.')
       }
 
       if (unref(isPastingIntoSameFolder)) {

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -424,7 +424,7 @@ export default defineComponent({
       }
 
       if (unref(isPastingIntoSameFolder)) {
-        return $gettext('You cannot paste resources into the same folder where you copied them.')
+        return $gettext('You cannot paste resources into the same folder.')
       }
 
       return ''

--- a/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.ts
+++ b/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.ts
@@ -104,6 +104,34 @@ describe('CreateAndUpload component', () => {
       const clipboardStore = useClipboardStore()
       expect(clipboardStore.clearClipboard).toHaveBeenCalled()
     })
+    it('should disable the "paste files"-action when clipboardResources are from same folder', () => {
+      const { wrapper } = getWrapper({
+        clipboardResources: [mock<Resource>({ parentFolderId: 'current-folder' })],
+        currentFolder: mock<Resource>({
+          id: 'current-folder',
+          canUpload: vi.fn().mockReturnValue(true)
+        })
+      })
+      expect(
+        wrapper.findComponent<typeof OcButton>(elSelector.pasteFilesBtn).vm.disabled
+      ).toStrictEqual(true)
+    })
+
+    it('should not disable the "paste files"-action when at least one clipboardResources is not from same folder', () => {
+      const { wrapper } = getWrapper({
+        clipboardResources: [
+          mock<Resource>({ parentFolderId: 'current-folder' }),
+          mock<Resource>({ parentFolderId: 'another-folder' })
+        ],
+        currentFolder: mock<Resource>({
+          id: 'current-folder',
+          canUpload: vi.fn().mockReturnValue(true)
+        })
+      })
+      expect(
+        wrapper.findComponent<typeof OcButton>(elSelector.pasteFilesBtn).vm.disabled
+      ).toStrictEqual(false)
+    })
   })
   describe('method "onUploadComplete"', () => {
     it.each([

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -51,7 +51,7 @@ const uploadInfoCloseButton = '#close-upload-info-btn'
 const uploadErrorCloseButton = '.oc-notification-message-danger button[aria-label="Close"]'
 const filesBatchAction = '.files-app-bar-actions .oc-files-actions-%s-trigger'
 const pasteButton = '.paste-files-btn'
-const breadcrumbRoot = '//nav[contains(@class, "oc-breadcrumb")]/ol/li[1]'
+const breadcrumbRoot = '//nav[@id="files-breadcrumb"]//li[1]'
 const fileRenameInput = '.oc-text-input'
 const deleteButtonSidebar = '#oc-files-actions-sidebar .oc-files-actions-delete-trigger'
 const actionConfirmationButton =
@@ -881,6 +881,11 @@ export const pasteResource = async (args: moveOrCopyResourceArgs): Promise<void>
   }
 }
 
+const selectBatchAction = async (page: Page, action: string): Promise<void> => {
+  await page.locator(util.format(filesBatchAction, action)).click()
+  await page.mouse.move(0, 0)
+}
+
 export const moveOrCopyMultipleResources = async (
   args: moveOrCopyMultipleResourceArgs
 ): Promise<void> => {
@@ -922,7 +927,7 @@ export const moveOrCopyMultipleResources = async (
       break
     }
     case 'batch-action': {
-      await page.locator(util.format(filesBatchAction, action)).click()
+      await selectBatchAction(page, action)
 
       await page.locator(breadcrumbRoot).click()
       const newLocationPath = newLocation.split('/')
@@ -994,7 +999,7 @@ export const moveOrCopyResource = async (args: moveOrCopyResourceArgs): Promise<
     }
     case 'batch-action': {
       await page.locator(util.format(checkBox, resourceBase)).click()
-      await page.locator(util.format(filesBatchAction, action)).click()
+      await selectBatchAction(page, action)
       await pasteResource({ page, resource: resourceBase, newLocation, action, method, option })
       break
     }


### PR DESCRIPTION
## Description

We've fixed the state of the "paste files" action when copied resources are from the same folder. The button will be disabled in such case and a tooltip with explanation message displayed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/12021

## Motivation and Context

Prevent overwrite action.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: chrome & 🤖 
- test case 1: added unit tests
- test case 2: try to paste resources in chrome into same folder

## Screenshots (if appropriate):

![Snímek obrazovky 2024-12-18 v 9 51 41](https://github.com/user-attachments/assets/74ad4d0e-f395-4be8-bbdb-1dde7e07c277)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
