### PR TITLE
feat: add delete queue

### DIFF
--- a/changelog/unreleased/enhancement-disable-resources-in-delete-queue.md
+++ b/changelog/unreleased/enhancement-disable-resources-in-delete-queue.md
@@ -1,0 +1,6 @@
+Enhancement: Disable resources in delete queue
+
+We've added a new delete queue which is used to disable resources that are being currently deleted. When the resource is in delete queue, it also replaces select checkbox with a spinner to better hint that there is an action in progress.
+
+https://github.com/owncloud/web/pull/12046
+https://github.com/owncloud/web/issues/11956

--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -52,7 +52,14 @@
       </div>
     </template>
     <template v-if="!isLocationPicker && !isFilePicker" #select="{ item }">
+      <oc-spinner
+        v-if="isResourceInDeleteQueue(item.id)"
+        class="resource-table-activity-indicator"
+        size="medium"
+      />
+
       <oc-checkbox
+        v-else
         :id="`resource-table-select-${resourceDomSelector(item)}`"
         :label="getResourceCheckboxLabel(item)"
         :label-hidden="true"
@@ -307,6 +314,7 @@ import CollapsibleOcTable from './../../cern/components/CollapsibleOcTable.vue'
 import { storeToRefs } from 'pinia'
 import { OcButton, OcTable } from '@ownclouders/design-system/components'
 import { FieldType } from '@ownclouders/design-system/helpers'
+import { OcSpinner } from '@ownclouders/design-system/components'
 
 const TAGS_MINIMUM_SCREEN_WIDTH = 850
 
@@ -317,7 +325,8 @@ export default defineComponent({
     ResourceGhostElement,
     ResourceListItem,
     ResourceSize,
-    OcTable
+    OcTable,
+    OcSpinner
   },
   props: {
     /**
@@ -555,7 +564,7 @@ export default defineComponent({
     const { userContextReady } = storeToRefs(authStore)
 
     const resourcesStore = useResourcesStore()
-    const { areFileExtensionsShown, latestSelectedId } = storeToRefs(resourcesStore)
+    const { areFileExtensionsShown, latestSelectedId, deleteQueue } = storeToRefs(resourcesStore)
 
     const dragItem = ref<Resource>()
     const ghostElement = ref()
@@ -581,7 +590,7 @@ export default defineComponent({
           !resource.isFolder
         )
       }
-      return resource.processing === true
+      return resource.processing === true || isResourceInDeleteQueue(resource.id)
     }
 
     const disabledResources: ComputedRef<Array<Resource['id']>> = computed(() => {
@@ -643,6 +652,10 @@ export default defineComponent({
       return action.route({ space, resources: [resource] })
     }
 
+    const isResourceInDeleteQueue = (id: string): boolean => {
+      return unref(deleteQueue).includes(id)
+    }
+
     return {
       router,
       configOptions,
@@ -680,7 +693,8 @@ export default defineComponent({
       latestSelectedId,
       isResourceClickable,
       getResourceLink,
-      isSticky
+      isSticky,
+      isResourceInDeleteQueue
     }
   },
   data() {
@@ -1252,7 +1266,8 @@ export default defineComponent({
     vertical-align: text-bottom;
   }
 
-  &-edit-name {
+  &-edit-name,
+  &-activity-indicator {
     display: inline-flex;
     margin-left: var(--oc-space-xsmall);
 

--- a/packages/web-pkg/src/composables/piniaStores/resources.ts
+++ b/packages/web-pkg/src/composables/piniaStores/resources.ts
@@ -22,6 +22,7 @@ export const useResourcesStore = defineStore('resources', () => {
   const resources = ref<Resource[]>([]) as Ref<Resource[]>
   const currentFolder = ref<Resource>()
   const ancestorMetaData = ref<AncestorMetaData>({})
+  const deleteQueue = ref<string[]>([])
 
   const activeResources = computed(() => {
     let res = unref(resources)
@@ -313,6 +314,16 @@ export const useResourcesStore = defineStore('resources', () => {
     return Object.values(unref(ancestorMetaData)).find((a) => id === a.id)
   }
 
+  const addResourcesIntoDeleteQueue = (ids: string[]): void => {
+    deleteQueue.value = deleteQueue.value.concat(
+      ids.filter((id) => !unref(deleteQueue).includes(id))
+    )
+  }
+
+  const removeResourcesFromDeleteQueue = (ids: string[]): void => {
+    deleteQueue.value = deleteQueue.value.filter((id) => !ids.includes(id))
+  }
+
   return {
     resources,
     currentFolder,
@@ -355,7 +366,11 @@ export const useResourcesStore = defineStore('resources', () => {
     setAncestorMetaData,
     updateAncestorField,
     loadAncestorMetaData,
-    getAncestorById
+    getAncestorById,
+
+    deleteQueue,
+    addResourcesIntoDeleteQueue,
+    removeResourcesFromDeleteQueue
   }
 })
 

--- a/packages/web-pkg/tests/unit/composables/actions/helpers/useFileActionsDeleteResources.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/helpers/useFileActionsDeleteResources.spec.ts
@@ -8,6 +8,7 @@ import {
 } from '@ownclouders/web-test-helpers'
 import { useDeleteWorker } from '../../../../../src/composables/webWorkers/deleteWorker'
 import { useGetMatchingSpace } from '../../../../../src/composables/spaces/useGetMatchingSpace'
+import { useResourcesStore } from '../../../../../src/composables/piniaStores'
 
 vi.mock('../../../../../src/composables/webWorkers/deleteWorker')
 vi.mock('../../../../../src/composables/spaces/useGetMatchingSpace')
@@ -43,6 +44,20 @@ describe('deleteResources', () => {
           expect(router.push).toHaveBeenCalledTimes(1)
         }
       })
+    })
+
+    it('should push resources into delete queue', () => {
+      const filesToDelete = [{ id: '2', path: '/folder/fileToDelete.txt' }]
+      getWrapper({
+        currentFolder,
+        result: filesToDelete,
+        setup: ({ filesList_delete }) => {
+          filesList_delete(filesToDelete)
+        }
+      })
+
+      const { addResourcesIntoDeleteQueue } = useResourcesStore()
+      expect(addResourcesIntoDeleteQueue).toHaveBeenCalledWith(['2'])
     })
   })
 })

--- a/packages/web-test-helpers/src/mocks/pinia.ts
+++ b/packages/web-test-helpers/src/mocks/pinia.ts
@@ -64,6 +64,7 @@ export type PiniaMockOptions = {
     selectedIds?: string[]
     areFileExtensionsShown?: boolean
     areHiddenFilesShown?: boolean
+    deleteQueue?: string[]
   }
   sharesState?: {
     collaboratorShares?: CollaboratorShare[]


### PR DESCRIPTION
## Description

We've added a new delete queue which is used to disable resources that are being currently deleted. When the resource is in delete queue, it also replaces select checkbox with a spinner to better hint that there is an action in progress.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/11956

## Motivation and Context

Understand better that resource is being deleted and prevent trying to delete it again.

## How Has This Been Tested?
- test environment: chrome & 🤖 
- test case 1: delete resources in chrome
- test case 2: unit tests

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/6eed6bec-d2d9-44fb-b2da-00f792955d26



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
