### PR TITLE
[tests-only][full-ci]Bump stable7.0 ocis commit id on web stable11.0

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=6866f5a664891bbb04316584a788edb4777e5f44
-OCIS_BRANCH=master
+OCIS_COMMITID=63ecc7f9886fbc2c50e9bb9c0c8b022af90c9644
+OCIS_BRANCH=stable-7.0


### PR DESCRIPTION
This PR bump latest ocis commit id of stable7.0 branch 

Part of 
- https://github.com/owncloud/QA/issues/870