### PR TITLE
fix: show indirect shares in search results

### DIFF
--- a/changelog/unreleased/bugfix-show-indirect-shares-on-search-page.md
+++ b/changelog/unreleased/bugfix-show-indirect-shares-on-search-page.md
@@ -1,0 +1,6 @@
+Bugfix: Show indirect shares on search page
+
+We've fixed an issue where the indirect shares of resources were not displayed in the sidebar when user is on search page.
+
+https://github.com/owncloud/web/pull/12050
+https://github.com/owncloud/web/issues/10939

--- a/packages/web-pkg/src/components/SideBar/FileSideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/FileSideBar.vue
@@ -276,6 +276,15 @@ export default defineComponent({
         })
       }
 
+      if (isLocationCommonActive(router, 'files-common-search')) {
+        yield resourcesStore.loadAncestorMetaData({
+          folder: unref(resource),
+          space: unref(props.space),
+          client: clientService.webdav,
+          signal
+        })
+      }
+
       // gather all ancestors we need to load shares for (indirect shares, space members)
       const cachedIds = [...collaboratorCache, ...linkCache].map(({ resourceId }) => resourceId)
       const ancestorIds = Object.values(resourcesStore.ancestorMetaData)

--- a/packages/web-pkg/tests/unit/components/sidebar/FileSideBar.spec.ts
+++ b/packages/web-pkg/tests/unit/components/sidebar/FileSideBar.spec.ts
@@ -161,6 +161,22 @@ describe('FileSideBar', () => {
         mocks.$clientService.graphAuthenticated.permissions.listPermissions
       ).toHaveBeenCalledTimes(2)
     })
+
+    it('should load ancestor meta data to get indirect shares when on search page', async () => {
+      const resource = mock<Resource>()
+      const { wrapper, mocks } = createWrapper({ currentRouteName: 'files-common-search' })
+      const { loadAncestorMetaData } = useResourcesStore()
+
+      mocks.$clientService.graphAuthenticated.permissions.listPermissions.mockResolvedValue({
+        shares: [],
+        allowedActions: [],
+        allowedRoles: []
+      })
+
+      await wrapper.vm.loadSharesTask.perform(resource)
+      expect(loadAncestorMetaData).toHaveBeenCalled()
+    })
+
     describe('cache', () => {
       it('is being used in non-flat file lists', async () => {
         const resource = mock<Resource>()


### PR DESCRIPTION
## Description

We've fixed an issue where the indirect shares of resources were not displayed in the sidebar when user is on search page.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/10939

## Motivation and Context

🐛less code

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: chrome & 🤖 
- test case 1: add unit tests to check whether ancestors metadata are loaded on search page
- test case 2: follow reproduction steps in chrome

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [x] add tests
- [x] add changelog item
