### PR TITLE
feat: use more generic private link error message

### DIFF
--- a/changelog/unreleased/enhancement-use-generic-private-link-error.md
+++ b/changelog/unreleased/enhancement-use-generic-private-link-error.md
@@ -1,0 +1,6 @@
+Enhancement: Use generic private link error
+
+We've added a more generic error message to the unavailable private links as the previous message was confusing.
+
+https://github.com/owncloud/web/pull/12054
+https://github.com/owncloud/web/issues/12009

--- a/packages/web-runtime/src/pages/resolvePrivateLink.vue
+++ b/packages/web-runtime/src/pages/resolvePrivateLink.vue
@@ -21,10 +21,6 @@
         </div>
         <div class="oc-card-body oc-link-resolve-error-message">
           <p class="oc-text-xlarge">{{ errorMessage }}</p>
-          <p
-            v-if="isUnacceptedShareError"
-            v-text="$gettext('You can reload this page after you have enabled syncing the share.')"
-          />
         </div>
       </template>
     </div>
@@ -170,18 +166,9 @@ export default defineComponent({
 
     const errorMessage = computed(() => {
       if (unref(isUnacceptedShareError)) {
-        if (!unref(sharedParentResource)) {
-          return $gettext(
-            'This file or folder has been shared with you. Enable the sync in "Shares" > "Shared with me" to view it.'
-          )
-        } else {
-          return $gettext(
-            'This file or folder has been shared with you via "%{parentShareName}". Enable the sync for the share "%{parentShareName}" in "Shares" > "Shared with me" to view it.',
-            {
-              parentShareName: unref(sharedParentResource).name
-            }
-          )
-        }
+        return $gettext(
+          'The link you are trying to access is invalid or you do not have permission to view the content. Please check the link for any errors or contact the person who shared it for assistance.'
+        )
       }
 
       if (resolvePrivateLinkTask.isError) {


### PR DESCRIPTION
## Description

Use more generic error message when resolution of private link fails.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/12009

## Motivation and Context

Prevent confusing errors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: chrome
- test case 1: Open private link of unshared resource with another user

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/15734eed-c9f6-4938-b91c-c95dbd27211c)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
