### PR TITLE
fix: add more padding to input with text

### DIFF
--- a/changelog/unreleased/bugfix-add-more-padding-to-input-when-clear-actions-is-visible.md
+++ b/changelog/unreleased/bugfix-add-more-padding-to-input-when-clear-actions-is-visible.md
@@ -1,0 +1,6 @@
+Bugfix: Add more padding to input when clear action is visible
+
+We've fixed the issue where the clear action of the text input would overlap the text entered into the input. When the clear action becomes visible, the right padding of the input will be increased by the size of the clear action.
+
+https://github.com/owncloud/web/pull/12055
+https://github.com/owncloud/web/issues/11543

--- a/packages/design-system/src/components/OcTextInput/OcTextInput.vue
+++ b/packages/design-system/src/components/OcTextInput/OcTextInput.vue
@@ -20,7 +20,8 @@
         :class="{
           'oc-text-input-warning': !!warningMessage,
           'oc-text-input-danger': !!errorMessage,
-          'oc-pl-l': !!readOnly
+          'oc-pl-l': !!readOnly,
+          'clear-action-visible': showClearButton
         }"
         :type="type"
         :value="displayValue"
@@ -407,6 +408,10 @@ export default defineComponent({
     align-items: center;
     margin-top: var(--oc-space-xsmall);
     min-height: $oc-font-size-default * 1.5;
+  }
+
+  &.clear-action-visible {
+    padding-right: ($oc-size-icon-default * 0.7) + 7px;
   }
 }
 </style>


### PR DESCRIPTION
## Description

We've fixed the issue where the clear action of the text input would overlap the text entered into the input. When the clear action becomes visible, the right padding of the input will be increased by the size of the clear action.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/11543

## Motivation and Context

Text and clear action are not overlapping each other and everything is clearly visible.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: chrome 
- test case 1: Enter long enough string into the input

## Screenshots (if appropriate):


https://github.com/user-attachments/assets/91f89322-9e9c-4c44-91c8-ac2910b21f10


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
