### PR TITLE
[tests-only][full-ci] bump ocis stable 7.0 commit

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=63ecc7f9886fbc2c50e9bb9c0c8b022af90c9644
+OCIS_COMMITID=b89dff3dda3795201bf7984e5bd113c17478f5cc
 OCIS_BRANCH=stable-7.0


### PR DESCRIPTION
## Description
This pr bumps latest ocis stable-7.0 commit id.

Part of:  https://github.com/owncloud/QA/issues/870