### PR TITLE
fix: use local state in sidebar in embed mode

### DIFF
--- a/changelog/unreleased/bugfix-use-local-state-in-sidebar-in-embed-mode.md
+++ b/changelog/unreleased/bugfix-use-local-state-in-sidebar-in-embed-mode.md
@@ -1,0 +1,6 @@
+Bugfix: Use local state in sidebar in embed mode
+
+We've fixed an issue where the sidebar would be overlapping the content of embed mode iframe when opened due to shared local storage. We now use own local state for the sidebar in embed mode instead of relying on the local storage.
+
+https://github.com/owncloud/web/pull/12058
+https://github.com/owncloud/web/issues/11875


### PR DESCRIPTION
## Description

When embed mode is enabled, use local state instead of local storage in sidebar to prevent overlapping the content when the embed iframe is opened.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/11875

## Motivation and Context

Content is visible when embed iframe is opened.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: chrome & 🤖 
- test case 1: added unit tests
- test case 2: open embed iframe while sidebar is opened in the "regular" app

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
