### PR TITLE
fix: reload sidebar preloaded resource

### DIFF
--- a/changelog/unreleased/bugfix-reload-preloaded-resource-in-sidebar.md
+++ b/changelog/unreleased/bugfix-reload-preloaded-resource-in-sidebar.md
@@ -1,0 +1,6 @@
+Bugfix: Reload preloaded resource in sidebar
+
+We've fixed an issue where actions were not being updated on a resource. We are now reloading metadata of the resource even in the case when it is already preloaded so that we get up to date information.
+
+https://github.com/owncloud/web/pull/12059
+https://github.com/owncloud/web/issues/10748

--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -1130,6 +1130,11 @@ export default defineComponent({
       if (isCheckboxClicked) {
         return
       }
+
+      if (this.isResourceSelected(resource)) {
+        return
+      }
+
       return this.emitSelect([resource.id])
     },
     formatDate(date: string) {

--- a/packages/web-pkg/src/components/SideBar/FileSideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/FileSideBar.vue
@@ -381,12 +381,6 @@ export default defineComponent({
           return
         }
         const resource = unref(panelContext).items[0]
-
-        if (unref(loadedResource)?.id === resource.id) {
-          // current resource is already loaded
-          return
-        }
-
         isMetaDataLoading.value = true
         if (canListShares({ space: props.space, resource })) {
           try {

--- a/packages/web-pkg/tests/unit/components/FilesList/ResourceTable.spec.ts
+++ b/packages/web-pkg/tests/unit/components/FilesList/ResourceTable.spec.ts
@@ -508,6 +508,14 @@ describe('ResourceTable', () => {
       const { wrapper } = getMountedWrapper()
       expect(wrapper.find('.oc-tbody-tr-in-delete-queue.oc-table-disabled').exists()).toBe(true)
     })
+
+    it('should not emit select event when clicking on the row of an already selected resource', async () => {
+      const { wrapper } = getMountedWrapper({ props: { selectedIds: ['forest'] } })
+      const tableRow = wrapper.find('.oc-tbody-tr-forest .oc-table-data-cell-size')
+      await tableRow.trigger('click')
+
+      expect(wrapper.emitted('update:selectedIds')).toBeUndefined()
+    })
   })
 
   describe('context menu', () => {


### PR DESCRIPTION
## Description

We've fixed an issue where actions were not being updated on a resource. We are now reloading metadata of the resource even in the case when it is already preloaded so that we get up to date information. To prevent reloading currently selected resource, prevent selecting it.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/10748

## Motivation and Context

Preloaded resource in the sidebar can easily become stale e.g. by hiding it in shares and then directly opening the sidebar again while having hidden filter set. In order to always get up to date information, always reload the resource.

## How Has This Been Tested?

- test environment: chrome & 🤖 
- test case 1: added unit test
- test case 2: follow reproduction steps in the issue

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
