### PR TITLE
fix: lower disabled checkbox opacity

### DIFF
--- a/changelog/unreleased/bugfix-change-opacity-of-disabled-checkboxes.md
+++ b/changelog/unreleased/bugfix-change-opacity-of-disabled-checkboxes.md
@@ -1,0 +1,6 @@
+Bugfix: Change opacity of disabled checkboxes
+
+We've fixed an issue where disabled checkbox was not clearly distinguishable from enabled ones by lowering it's opacity.
+
+https://github.com/owncloud/web/pull/12063
+https://github.com/owncloud/web/issues/12060

--- a/packages/design-system/src/components/OcCheckbox/OcCheckbox.vue
+++ b/packages/design-system/src/components/OcCheckbox/OcCheckbox.vue
@@ -198,6 +198,8 @@ export default defineComponent({
 
   &:disabled {
     background-color: $form-radio-disabled-background;
+    cursor: default;
+    opacity: 0.4;
   }
 
   &:disabled:checked {


### PR DESCRIPTION
## Description

We've fixed an issue where disabled checkbox was not clearly distinguishable from enabled ones by lowering it's opacity.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/12060

## Motivation and Context

Clearly distinguishable checkbox states.

## How Has This Been Tested?

- test environment: chrome
- test case 1: check disabled and enabled checkboxes

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/33a8239a-13a4-4bdc-ad23-ada9ccae2496)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
