### PR TITLE
fix: refetch settings bundle on locale change

### DIFF
--- a/changelog/unreleased/bugfix-refetch-notifications-settings-on-locale-change.md
+++ b/changelog/unreleased/bugfix-refetch-notifications-settings-on-locale-change.md
@@ -1,0 +1,6 @@
+Bugfix: Refetch notifications settings on locale change
+
+We've fixed an issue where the notification settings section did not update any strings when users changed their locale. The settings bundle is now fetched again when locale changes to make sure that the oCIS server can return strings in the correct locale.
+
+https://github.com/owncloud/web/pull/12074
+https://github.com/owncloud/web/issues/12064

--- a/packages/web-runtime/src/pages/account.vue
+++ b/packages/web-runtime/src/pages/account.vue
@@ -557,6 +557,11 @@ export default defineComponent({
           }
         }
 
+        if (loadAccountBundleTask.isRunning) {
+          loadAccountBundleTask.cancelAll()
+        }
+
+        loadAccountBundleTask.perform()
         showMessage({ title: $gettext('Preference saved.') })
       } catch (e) {
         console.error(e)

--- a/packages/web-runtime/tests/unit/pages/account.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/account.spec.ts
@@ -201,6 +201,19 @@ describe('account page', () => {
       const { showErrorMessage } = useMessages()
       expect(showErrorMessage).toHaveBeenCalled()
     })
+
+    it('should refetch settings bundles', async () => {
+      const { wrapper, mocks } = getWrapper({})
+      await blockLoadingState(wrapper)
+
+      mocks.$clientService.graphAuthenticated.users.editMe.mockResolvedValueOnce(undefined)
+      await wrapper.vm.updateSelectedLanguage({ value: 'en' } as LanguageOption)
+      expect(mocks.$clientService.httpAuthenticated.post).toHaveBeenCalledWith(
+        '/api/v0/settings/bundles-list',
+        {},
+        { signal: expect.any(AbortSignal) }
+      )
+    })
   })
 
   describe('Method "updateViewOptionsWebDavDetails', () => {


### PR DESCRIPTION
## Description

To make sure that the server returns settings bundle strings in the correct locale, refetch it after a locale is changed via the UI.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/12064

## Motivation and Context

Correct translations

## How Has This Been Tested?

- test environment: chrome & 🤖 
- test case 1: switch locale in the account settings
- test case 2: added unit tests

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/564a62fa-3fe0-45a1-890f-3e7891ac8958


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
