### PR TITLE
[tests-only][full-ci]Bump ocis stable to web stable

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=b89dff3dda3795201bf7984e5bd113c17478f5cc
+OCIS_COMMITID=965a7fc00e29d32372f8669e64ad31b4aecd0f49
 OCIS_BRANCH=stable-7.0


### PR DESCRIPTION
### Description
Bump latest `stable-7.0-ocis` commit to `web-11.0-stable`

Part of:
https://github.com/owncloud/QA/issues/872