### PR TITLE
Update account.vue: fix gettext values

### DIFF
--- a/packages/web-runtime/src/pages/account.vue
+++ b/packages/web-runtime/src/pages/account.vue
@@ -621,7 +621,7 @@ export default defineComponent({
       { label: $gettext('Event') },
       { label: $gettext('Event description'), hidden: true },
       { label: $gettext('In-App'), alignH: 'right' },
-      { label: $gettext('Mail'), alignH: 'right' }
+      { label: $gettext('Email'), alignH: 'right' }
     ])
 
     const emailNotificationsOptionsFields = computed(() => [

--- a/packages/web-runtime/src/pages/account.vue
+++ b/packages/web-runtime/src/pages/account.vue
@@ -205,7 +205,7 @@
           </oc-tr>
         </account-table>
         <account-table
-          :title="$gettext('Mail notification options')"
+          :title="$gettext('Email notification options')"
           :fields="emailNotificationsOptionsFields"
           :show-head="!isMobileWidth"
           class="oc-mt-m"


### PR DESCRIPTION
`Mail` --> `Email`
(we dont send snail mails 🤣 )

Just a small fix that relates to:
https://github.com/owncloud/ocis/pull/10835 ([docs-only] Update settings source strings for translation)

Should be part of the upcoming 7.1 release, needs manual translation sync up/down and a port