### PR TITLE
[tests-only][full-ci]Bump latest ocis stable-7.0 commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=965a7fc00e29d32372f8669e64ad31b4aecd0f49
+OCIS_COMMITID=73a6ee77083aaa397c2a26d4df12429791860c77
 OCIS_BRANCH=stable-7.0


### PR DESCRIPTION
## Description
Bumps ocis stable-7.0 commit id.

Part of: https://github.com/owncloud/QA/issues/872