### PR TITLE
fix: add missing User Light role translations definition

### DIFF
--- a/changelog/unreleased/bugfix-missing-user-light-translations.md
+++ b/changelog/unreleased/bugfix-missing-user-light-translations.md
@@ -1,0 +1,6 @@
+Bugfix: Missing User Light translations
+
+We've added a missing "User Light" string definition into our translations in order to get this role translated.
+
+https://github.com/owncloud/web/pull/12101
+https://github.com/owncloud/web/issues/12100

--- a/packages/web-runtime/src/helpers/additionalTranslations.ts
+++ b/packages/web-runtime/src/helpers/additionalTranslations.ts
@@ -3,11 +3,17 @@ function $gettext(msg: string): string {
   return msg
 }
 
+/**
+ * These translation strings are used to translate text which is not directly part of the code here.
+ * E.g. the role display names coming from oCIS via API call.
+ * Please note that when searching for the original strings, use the actual string passed to the $gettext function and not the key.
+ * TODO: Move these translations into oCIS
+ */
 export const additionalTranslations = {
   admin: $gettext('Admin'),
   spaceAdmin: $gettext('Space Admin'),
   user: $gettext('User'),
-  guest: $gettext('Guest'),
+  userLight: $gettext('User Light'),
   activities: $gettext('Activities'),
   noActivities: $gettext('No activities'),
   virusDetectedActivity: $gettext(


### PR DESCRIPTION
## Description

We've added a missing "User Light" string definition into our translations in order to get this role translated.

## Related Issue

- refs https://github.com/owncloud/web/issues/12100!
- refs https://github.com/owncloud/ocis/issues/10870!

## Motivation and Context

Translatable UI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
