### PR TITLE
[tests-only][full-ci] Bump ocis commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=73a6ee77083aaa397c2a26d4df12429791860c77
+OCIS_COMMITID=dbc536baea71c7fac72627d8027054bfafbabe31
 OCIS_BRANCH=stable-7.0


### PR DESCRIPTION
## Description
Bumps ocis stable-7.0 commit id.

Part of: https://github.com/owncloud/QA/issues/872