### PR TITLE
feat: handle editor-less extensions

### DIFF
--- a/changelog/unreleased/enhancement-handle-extensions-without-editor.md
+++ b/changelog/unreleased/enhancement-handle-extensions-without-editor.md
@@ -1,0 +1,5 @@
+Enhancement: Handle extensions without editor
+
+We've added a new property to extensions that asserts whether is has an editor or not. This property is computed by checking whether the extension exposes any routes.
+
+https://github.com/owncloud/web/pull/12105

--- a/packages/web-pkg/src/apps/types.ts
+++ b/packages/web-pkg/src/apps/types.ts
@@ -86,6 +86,8 @@ export interface ApplicationInformation {
   translations?: Translations
   /** @deprecated */
   applicationMenu?: ApplicationMenuItem
+  /** Asserts whether the app has any route which works as an editor */
+  hasEditor?: boolean
 }
 
 /**
@@ -99,7 +101,7 @@ export interface ApplicationTranslations {
 
 /** ClassicApplicationScript reflects classic application script structure */
 export interface ClassicApplicationScript {
-  appInfo?: ApplicationInformation
+  appInfo?: Omit<ApplicationInformation, 'hasEditor'>
   routes?: ((args: ComponentCustomProperties) => RouteRecordRaw[]) | RouteRecordRaw[]
   navItems?: ((args: ComponentCustomProperties) => AppNavigationItem[]) | AppNavigationItem[]
   translations?: ApplicationTranslations

--- a/packages/web-pkg/src/composables/actions/files/useFileActions.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActions.ts
@@ -112,6 +112,7 @@ export const useFileActions = () => {
     }
 
     return appsStore.fileExtensions
+      .filter((fileExtension) => appsStore.apps[fileExtension.app]?.hasEditor)
       .map((fileExtension): FileAction => {
         const appInfo = appsStore.apps[fileExtension.app]
 

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActions.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActions.spec.ts
@@ -90,13 +90,22 @@ function getWrapper({ setup }: { setup: (instance: ReturnType<typeof useFileActi
                     {
                       extension: 'txt'
                     }
-                  ]
+                  ],
+                  hasEditor: true
                 },
                 external: {
                   defaultExtension: '',
                   icon: 'check_box_outline_blank',
                   name: 'External',
-                  id: 'external'
+                  id: 'external',
+                  hasEditor: true
+                },
+                'editor-less': {
+                  defaultExtension: '',
+                  icon: 'check_box_outline_blank',
+                  name: 'Editor Less',
+                  id: 'editor-less',
+                  hasEditor: false
                 }
               },
               fileExtensions: [

--- a/packages/web-runtime/src/container/application/classic.ts
+++ b/packages/web-runtime/src/container/application/classic.ts
@@ -110,7 +110,10 @@ export const convertClassicApplication = ({
   })
 
   const appsStore = useAppsStore()
-  appsStore.registerApp(applicationScript.appInfo, applicationScript.translations)
+  appsStore.registerApp(
+    { ...applicationScript.appInfo, hasEditor: applicationScript.routes?.length > 0 },
+    applicationScript.translations
+  )
 
   if (applicationScript.extensions) {
     extensionRegistry.registerExtensions(applicationScript.extensions)


### PR DESCRIPTION
## Description

When an app does not expose any routes, mark it as editor-less so that we do not try to load editor actions for such extension.

## Motivation and Context

Extension without editor does not break the app.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: chrome & 🤖 
- test case 1: manually add extension without any routes and open sidebar
- test case 2: extend existing unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
