### PR TITLE
fix(web-pkg): hide sidebar editor action when the editor is already opened

### DIFF
--- a/changelog/unreleased/enhancement-hide-active-editor-action.md
+++ b/changelog/unreleased/enhancement-hide-active-editor-action.md
@@ -1,0 +1,6 @@
+Enhancement: Hide active editor action
+
+We've hidden the sidebar file action of a currently opened editor. This prevents confusion where user might try to re-open the current editor.
+
+https://github.com/owncloud/web/pull/12110
+https://github.com/owncloud/web/issues/12108

--- a/packages/web-pkg/src/composables/actions/files/useFileActions.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActions.ts
@@ -41,6 +41,7 @@ import { Resource, SpaceResource } from '@ownclouders/web-client'
 import { storeToRefs } from 'pinia'
 import { useEmbedMode } from '../../embedMode'
 import { RouteRecordName } from 'vue-router'
+import { isLocationActive } from '../../../router/utils'
 
 export const EDITOR_MODE_EDIT = 'edit'
 export const EDITOR_MODE_CREATE = 'create'
@@ -156,6 +157,10 @@ export const useFileActions = () => {
             }
 
             if (!unref(isSearchActive) && isLocationTrashActive(router, 'files-trash-generic')) {
+              return false
+            }
+
+            if (isLocationActive(router, { name: fileExtension.routeName || fileExtension.app })) {
               return false
             }
 


### PR DESCRIPTION
## Description

When an editor is already opened and the user clicks on the Open in ... action, it pushes the same editor route into the history causing a bug where the user needs to click twice on the close button to actually close the editor. This change hides the editor action if an editor with matching route name is already opened which prevents this behaviour.

## Related Issue

- refs https://github.com/owncloud/web/issues/12108

## Motivation and Context

No confusion with re-opening the active editor.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: chrome & 🤖 
- test case 1: added unit test
- test case 2: open an image in the preview app and open sidebar

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
