### PR TITLE
fix(web-app-preview): optionally access route query

### DIFF
--- a/changelog/unreleased/bugfix-optionally-access-preview-app-route-query.md
+++ b/changelog/unreleased/bugfix-optionally-access-preview-app-route-query.md
@@ -1,0 +1,7 @@
+Bugfix: Optionally access preview app route query
+
+We've fixed an issue where loading of preview app would fail due to missing route query. The route query is now accessed optionally meaning even when it undefined, the app still loads as expected.
+
+https://github.com/owncloud/web/pull/12112
+https://github.com/owncloud/web/issues/12108
+https://github.com/owncloud/web/issues/12106

--- a/packages/web-app-preview/src/App.vue
+++ b/packages/web-app-preview/src/App.vue
@@ -181,14 +181,14 @@ export default defineComponent({
 
       const files = props.activeFiles.filter((file) => {
         if (
-          unref(props.currentFileContext.routeQuery)['q_share-visibility'] === 'hidden' &&
+          unref(props.currentFileContext.routeQuery)?.['q_share-visibility'] === 'hidden' &&
           !(file as IncomingShareResource).hidden
         ) {
           return false
         }
 
         if (
-          unref(props.currentFileContext.routeQuery)['q_share-visibility'] !== 'hidden' &&
+          unref(props.currentFileContext.routeQuery)?.['q_share-visibility'] !== 'hidden' &&
           (file as IncomingShareResource).hidden
         ) {
           return false

--- a/packages/web-app-preview/tests/unit/app.spec.ts
+++ b/packages/web-app-preview/tests/unit/app.spec.ts
@@ -126,6 +126,13 @@ describe('Preview app', () => {
       })
       expect(wrapper.vm.filteredFiles.length).toStrictEqual(2)
     })
+
+    it('should filter files even when routeQuery is undefined', () => {
+      const { wrapper } = createShallowMountWrapper({
+        currentFileContext: { routeQuery: undefined }
+      })
+      expect(wrapper.vm.filteredFiles.length).toStrictEqual(7)
+    })
   })
 })
 


### PR DESCRIPTION
## Description

When filtering out files in preview app, access route query optionally in case it is undefined to prevent broken loading.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/12108
- resolves https://github.com/owncloud/web/issues/12106

## Motivation and Context

The app loads even when the route query got somehow lost.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: chrome & 🤖 
- test case 1: added unit test
- test case 2: open the editor without the route query

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
