### PR TITLE
fix(design-system): use earth icon for federated shares

### DIFF
--- a/changelog/unreleased/bugfix-change-federated-share-icon.md
+++ b/changelog/unreleased/bugfix-change-federated-share-icon.md
@@ -1,0 +1,6 @@
+Bugfix: Change federated share icon
+
+We've changed the icon we are using for federated shares in the Shared with others list from "cloud" into "earth".
+
+https://github.com/owncloud/web/pull/12118
+https://github.com/owncloud/web/issues/12117

--- a/changelog/unreleased/bugfix-improve-federated-share-icon-contrast.md
+++ b/changelog/unreleased/bugfix-improve-federated-share-icon-contrast.md
@@ -1,0 +1,6 @@
+Bugfix: Improve federated share icon contrast
+
+We've made the color of the federated share icon slightly lighter in order to have a sufficient contrast compared to the icon background.
+
+https://github.com/owncloud/web/pull/12118
+https://github.com/owncloud/web/issues/12117

--- a/packages/design-system/src/components/OcAvatarFederated/OcAvatarFederated.vue
+++ b/packages/design-system/src/components/OcAvatarFederated/OcAvatarFederated.vue
@@ -2,9 +2,9 @@
   <oc-avatar-item
     :width="width"
     :icon-size="iconSize"
-    icon="cloud"
+    icon="earth"
     icon-fill-type="line"
-    icon-color="#5AAB9F"
+    icon-color="#85C1BA"
     :name="name"
     :accessible-label="accessibleLabel"
   />


### PR DESCRIPTION
## Description

Use "earth" icon instead of "cloud" and make the icon lighter not to fail contrast check.

## Related Issue

- refs https://github.com/owncloud/web/issues/12117

## Motivation and Context

Good a11y and same icon as in other places.

## How Has This Been Tested?

- test environment: chrome
- test case 1: share file with federated user

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/3bfb926f-bd6a-4b37-95a9-380344e22165)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
