### PR TITLE
fix(web-app-files): show external shares indicator

### DIFF
--- a/changelog/unreleased/bugfix-show-external-share-indicator.md
+++ b/changelog/unreleased/bugfix-show-external-share-indicator.md
@@ -1,0 +1,6 @@
+Bugfix: Show external share indicator
+
+We've fixed the condition that was preventing the external share indicator from showing up when a permissions indicator was visible.
+
+https://github.com/owncloud/web/pull/12119
+https://github.com/owncloud/web/issues/12117

--- a/packages/design-system/src/styles/theme/oc-flex.scss
+++ b/packages/design-system/src/styles/theme/oc-flex.scss
@@ -178,3 +178,30 @@
   */
 
 .oc-flex-1 { flex: 1; }
+
+/* Spacing
+  ========================================================================== */
+
+.oc-gap-xs {
+  gap: $oc-space-xsmall;
+}
+
+.oc-gap-s {
+  gap: $oc-space-small;
+}
+
+.oc-gap-m {
+  gap: $oc-space-medium;
+}
+
+.oc-gap-l {
+  gap: $oc-space-large;
+}
+
+.oc-gap-xl {
+  gap: $oc-space-xlarge;
+}
+
+.oc-gap-xxl {
+  gap: $oc-space-xxlarge;
+}

--- a/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
+++ b/packages/web-app-files/src/components/Shares/SharedWithMeSection.vue
@@ -33,7 +33,7 @@
       <template #syncEnabled="{ resource }">
         <div
           :key="resource.getDomSelector()"
-          class="oc-text-nowrap oc-flex oc-flex-middle oc-flex-right"
+          class="oc-text-nowrap oc-flex oc-flex-middle oc-flex-right oc-gap-s"
         >
           <oc-icon
             v-if="resource.shareRoles?.length"
@@ -44,7 +44,7 @@
             size="small"
           />
           <oc-icon
-            v-else-if="isExternalShare(resource)"
+            v-if="isExternalShare(resource)"
             v-oc-tooltip="ShareTypes.remote.label"
             :accessible-label="ShareTypes.remote.label"
             :name="ShareTypes.remote.icon"
@@ -56,7 +56,7 @@
             v-oc-tooltip="$gettext('Synced with your devices')"
             :accessible-label="$gettext('Synced with your devices')"
             name="loop-right"
-            class="sync-enabled oc-ml-s"
+            class="sync-enabled"
             size="small"
           />
         </div>


### PR DESCRIPTION
## Description

The external shares indicator was hidden when permissions indicator was displayed. This prevents users from understanding quickly that the share is actually external. This changes the condition to include both indicators independently.

## Related Issue

- refs https://github.com/owncloud/web/issues/12117

## Motivation and Context

Quickly understandable shares.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: chrome
- test case 1: share resource with external user

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/762aa46c-733c-498d-8509-acfb1832c5c9)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
