### PR TITLE
test: convert report generator to mjs

### DIFF
--- a/tests/e2e/cucumber/report/index.mjs
+++ b/tests/e2e/cucumber/report/index.mjs
@@ -1,8 +1,10 @@
-const { program } = require('commander')
-const getRepoInfo = require('git-repo-info')
-const pkg = require('../../../../package.json')
-const reporter = require('cucumber-html-reporter')
-const os = require('os')
+import { Command } from 'commander'
+import getRepoInfo from 'git-repo-info'
+import reporter from 'cucumber-html-reporter'
+import os from 'os'
+import pkg from '../../../../package.json' with { type: 'json' }
+
+const program = new Command()
 
 program
   .option('--backend-version <semver>', 'version of used backend')
@@ -36,7 +38,7 @@ reporter.generate({
     'web-version': pkg.version,
     platform: os.platform(),
     repository: `${repoInfo.branch}`,
-    ...(backendVersion && { [`${backendName}-version`]: backendVersion }),
+    ...(backendVersion && { ['ocis-version']: backendVersion }),
     ...(environment && { environment: environment })
   }
 })


### PR DESCRIPTION
## Description
Convert report generate script to mjs so that it can be used from within the repo.
```bash
node tests/e2e/cucumber/report/index.mjs
```

## How Has This Been Tested?
- test environment: :raised_hands: 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
