### PR TITLE
chore: specify linux/amd64 platform in tika

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -334,6 +334,7 @@ services:
   tika:
     image: apache/tika:3.0.0.0
     container_name: web_tika
+    platform: linux/amd64
     ports:
       - 9998:9998
     restart: unless-stopped


### PR DESCRIPTION
With recent update of docker on my Apple Silicon MacBook, the tika container started crashing immediatelly after starting. That then caused random 502 responses when doing requests to oCIS. Adding linux/amd64 seems to fix this. Tika container starts again and 502 responses are gone = I am a happy dev with working env again :).