### PR TITLE
chore: sign main tag

### DIFF
--- a/dev/scripts/create_and_push_tags.sh
+++ b/dev/scripts/create_and_push_tags.sh
@@ -8,7 +8,7 @@ cd "$(dirname "$0")/../.."
 VERSION=$(node -p "require('./package.json').version")
 TAG="v${VERSION}"
 
-git tag "$TAG"
+git tag -s -a "$TAG" -m "$TAG"
 git push origin "$TAG"
 echo "v$VERSION has been created and pushed"
 


### PR DESCRIPTION
## Description

The signing of the main tag was missed out. This adds the signing flag so that it has the same behaviour as tagging single packages.

## Motivation and Context

Sign tags via script.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: macos
- test case 1: run the script to tag https://github.com/owncloud/web/tree/v11.1.2

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [x] Maintenance (e.g. dependency updates or tooling)
