### PR TITLE
feat(password-protected-folders): open folder in an iframe

### DIFF
--- a/changelog/unreleased/enhancement-add-password-protected-folders-handler.md
+++ b/changelog/unreleased/enhancement-add-password-protected-folders-handler.md
@@ -1,0 +1,6 @@
+Enhancement: Add password protected folders handler
+
+We've added a new file action used to handle password protected folders. When a password protected folder is opened, a popup is opened prompting the user to enter the password. After successfully entering the password, content of the folder is displayed inside of the popup.
+
+https://github.com/owncloud/web/pull/12142
+https://github.com/owncloud/web/issues/12039

--- a/changelog/unreleased/enhancement-control-more-elements-visibility-via-url-query.md
+++ b/changelog/unreleased/enhancement-control-more-elements-visibility-via-url-query.md
@@ -1,0 +1,9 @@
+Enhancement: Control more elements visibility via URL query
+
+We've added new params into the URL query that allows configuring elements visibility. The following params can be used:
+
+- `hide-app-switcher`: hides the application switcher in the top bar
+- `hide-account-menu`: hides the feedback action, notifications bell, and user menu
+- `hide-navigation`: hides the navigation sidebar and mobile navigation
+
+https://github.com/owncloud/web/pull/12142

--- a/dev/docker/ocis/csp.yaml
+++ b/dev/docker/ocis/csp.yaml
@@ -11,6 +11,8 @@ directives:
     - '''self'''
   frame-ancestors:
     - '''self'''
+    - 'https://host.docker.internal:9200'
+    - 'https://host.docker.internal:9201'
   frame-src:
     - '''self'''
     - 'blob:'

--- a/packages/web-app-password-protected-folders/src/components/FolderViewModal.vue
+++ b/packages/web-app-password-protected-folders/src/components/FolderViewModal.vue
@@ -1,0 +1,68 @@
+<template>
+  <div class="oc-height-1-1" tabindex="0">
+    <app-loading-spinner v-if="isLoading" />
+    <iframe
+      v-show="!isLoading"
+      id="iframe-folder-view"
+      ref="iframeRef"
+      class="oc-width-1-1 oc-height-1-1"
+      :title="iframeTitle"
+      :src="iframeUrl.href"
+      tabindex="0"
+      @load="onLoad"
+    ></iframe>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+import { Modal, useThemeStore } from '@ownclouders/web-pkg/src/composables'
+import AppLoadingSpinner from '@ownclouders/web-pkg/src/components/AppLoadingSpinner.vue'
+import { unref } from 'vue'
+
+const props = defineProps<{
+  modal: Modal
+  publicLink: string
+}>()
+
+const iframeRef = ref<HTMLIFrameElement>()
+const isLoading = ref(true)
+const themeStore = useThemeStore()
+
+const iframeTitle = themeStore.currentTheme.common?.name
+const iframeUrl = new URL(props.publicLink)
+iframeUrl.searchParams.append('hide-logo', 'true')
+iframeUrl.searchParams.append('hide-app-switcher', 'true')
+iframeUrl.searchParams.append('hide-account-menu', 'true')
+iframeUrl.searchParams.append('hide-navigation', 'true')
+
+const onLoad = () => {
+  isLoading.value = false
+  unref(iframeRef).contentWindow.focus()
+}
+</script>
+
+<style lang="scss">
+.oc-modal.folder-view-modal {
+  max-width: 80vw;
+  border: none;
+  overflow: hidden;
+
+  .oc-modal-title {
+    display: none;
+  }
+
+  .oc-modal-body {
+    padding: 0;
+
+    &-message {
+      height: 60vh;
+      margin: 0;
+    }
+  }
+
+  .oc-modal-body-actions {
+    background-color: var(--oc-color-swatch-brand-default);
+  }
+}
+</style>

--- a/packages/web-app-password-protected-folders/src/composables/useCreateFileHandler.ts
+++ b/packages/web-app-password-protected-folders/src/composables/useCreateFileHandler.ts
@@ -28,7 +28,7 @@ export const useCreateFileHandler = () => {
     const folder = await clientService.webdav.createFolder(unref(space), { path: folderPath })
     upsertResource(folder)
 
-    await addLink({
+    const share = await addLink({
       clientService,
       space,
       resource: folder,
@@ -37,7 +37,10 @@ export const useCreateFileHandler = () => {
 
     const path = urlJoin(currentFolder.path, fileName + '.psec')
 
-    const file = await clientService.webdav.putFileContents(unref(space), { path })
+    const file = await clientService.webdav.putFileContents(unref(space), {
+      path,
+      content: btoa(share.webUrl)
+    })
     upsertResource(file)
   }
 

--- a/packages/web-app-password-protected-folders/src/composables/useOpenFolderAction.ts
+++ b/packages/web-app-password-protected-folders/src/composables/useOpenFolderAction.ts
@@ -1,16 +1,31 @@
-import { FileAction } from '@ownclouders/web-pkg'
+import { FileAction, useClientService, useModals } from '@ownclouders/web-pkg'
 import { computed } from 'vue'
 import { useGettext } from 'vue3-gettext'
+import FolderViewModal from '../components/FolderViewModal.vue'
 
 export const useOpenFolderAction = () => {
   const { $gettext } = useGettext()
+  const { dispatchModal } = useModals()
+  const clientService = useClientService()
 
   const action = computed<FileAction>(() => ({
     name: 'open-password-protected-folder',
     icon: 'external-link',
-    handler: () => {
-      // TODO: add handler
-      console.warn('NOT IMPLEMENTED')
+    async handler({ resources, space }) {
+      const [file] = resources
+      const { body } = await clientService.webdav.getFileContents(space, file)
+      const publicLink = atob(body)
+
+      dispatchModal({
+        title: resources.at(0).name,
+        elementClass: 'folder-view-modal',
+        customComponent: FolderViewModal,
+        customComponentAttrs: () => ({
+          publicLink
+        }),
+        hideConfirmButton: true,
+        cancelText: $gettext('Close folder')
+      })
     },
     label: () => $gettext('Open folder'),
     isDisabled: () => false,

--- a/packages/web-app-password-protected-folders/tests/unit/components/FolderViewModal.spec.ts
+++ b/packages/web-app-password-protected-folders/tests/unit/components/FolderViewModal.spec.ts
@@ -1,0 +1,38 @@
+import { defaultComponentMocks, defaultPlugins, shallowMount } from '@ownclouders/web-test-helpers'
+import FolderViewModal from '../../../src/components/FolderViewModal.vue'
+import { Modal } from '@ownclouders/web-pkg'
+import { mock } from 'vitest-mock-extended'
+
+const SELECTORS = Object.freeze({
+  iframe: '#iframe-folder-view'
+})
+
+describe('FolderViewModal', () => {
+  it('should set iframe src', () => {
+    const { wrapper } = getWrapper()
+    const iframe = wrapper.find(SELECTORS.iframe)
+
+    expect(iframe.attributes('src')).toEqual(
+      'https://example.org/public-link?hide-logo=true&hide-app-switcher=true&hide-account-menu=true&hide-navigation=true'
+    )
+  })
+})
+
+function getWrapper() {
+  const mocks = defaultComponentMocks()
+
+  return {
+    mocks,
+    wrapper: shallowMount(FolderViewModal, {
+      props: {
+        modal: mock<Modal>(),
+        publicLink: 'https://example.org/public-link'
+      },
+      global: {
+        plugins: defaultPlugins(),
+        mocks,
+        provide: mocks
+      }
+    })
+  }
+}

--- a/packages/web-app-password-protected-folders/tests/unit/composables/useOpenFolderAction.spec.ts
+++ b/packages/web-app-password-protected-folders/tests/unit/composables/useOpenFolderAction.spec.ts
@@ -1,0 +1,60 @@
+import { defaultComponentMocks, getComposableWrapper } from '@ownclouders/web-test-helpers'
+import { useOpenFolderAction } from '../../../src/composables/useOpenFolderAction'
+import { unref } from 'vue'
+import { mock } from 'vitest-mock-extended'
+import { Resource, SpaceResource } from '@ownclouders/web-client'
+import { useModals } from '@ownclouders/web-pkg'
+import { MockedFunction } from 'vitest'
+import FolderViewModal from '../../../src/components/FolderViewModal.vue'
+
+describe('openFolderAction', () => {
+  it('should open a modal with the public link', () => {
+    getWrapper({
+      async setup(instance) {
+        const { dispatchModal } = useModals()
+
+        await unref(instance).handler({
+          resources: [mock<Resource>()],
+          space: mock<SpaceResource>()
+        })
+
+        const modalConfig = (dispatchModal as MockedFunction<typeof dispatchModal>).mock.calls
+          .at(0)
+          .at(0)
+        const attrs = modalConfig.customComponentAttrs()
+
+        expect(dispatchModal).toHaveBeenCalledWith(
+          expect.objectContaining({ customComponent: FolderViewModal })
+        )
+        expect(attrs).toStrictEqual({ publicLink: 'https://example.org/public-link' })
+      }
+    })
+  })
+})
+
+function getWrapper({
+  setup
+}: {
+  setup: (
+    instance: ReturnType<typeof useOpenFolderAction>,
+    mocks: ReturnType<typeof defaultComponentMocks>
+  ) => void
+}) {
+  const mocks = defaultComponentMocks()
+  mocks.$clientService.webdav.getFileContents.mockResolvedValue({
+    body: btoa('https://example.org/public-link')
+  })
+
+  return {
+    wrapper: getComposableWrapper(
+      () => {
+        const instance = useOpenFolderAction()
+        setup(instance, mocks)
+      },
+      {
+        mocks,
+        provide: mocks
+      }
+    )
+  }
+}

--- a/packages/web-pkg/src/composables/piniaStores/config/types.ts
+++ b/packages/web-pkg/src/composables/piniaStores/config/types.ts
@@ -122,7 +122,10 @@ const OptionsConfigSchema = z.object({
     })
     .optional(),
   userListRequiresFilter: z.boolean().optional(),
-  hideLogo: z.boolean().optional()
+  hideLogo: z.boolean().optional(),
+  hideAppSwitcher: z.boolean().optional(),
+  hideAccountMenu: z.boolean().optional(),
+  hideNavigation: z.boolean().optional()
 })
 
 export type OptionsConfig = z.infer<typeof OptionsConfigSchema>

--- a/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -6,7 +6,7 @@
   >
     <div class="oc-topbar-left oc-flex oc-flex-middle oc-flex-start">
       <applications-menu
-        v-if="appMenuExtensions.length && !isEmbedModeEnabled"
+        v-if="appMenuExtensions.length && !isEmbedModeEnabled && !hideAppSwitcher"
         :menu-items="appMenuExtensions"
       />
       <router-link v-if="!hideLogo" :to="homeLink" class="oc-width-1-1 oc-logo-href">
@@ -21,12 +21,15 @@
     </div>
     <template v-if="!isEmbedModeEnabled">
       <portal to="app.runtime.header.right" :order="50">
-        <feedback-link v-if="isFeedbackLinkEnabled" v-bind="feedbackLinkOptions" />
+        <feedback-link
+          v-if="isFeedbackLinkEnabled && !hideAccountMenu"
+          v-bind="feedbackLinkOptions"
+        />
       </portal>
       <portal to="app.runtime.header.right" :order="100">
-        <notifications v-if="isNotificationBellEnabled" />
+        <notifications v-if="isNotificationBellEnabled && !hideAccountMenu" />
         <side-bar-toggle v-if="isSideBarToggleVisible" :disabled="isSideBarToggleDisabled" />
-        <user-menu />
+        <user-menu v-if="!hideAccountMenu" />
       </portal>
     </template>
     <portal-target name="app.runtime.header.left" @change="updateLeftPortal" />
@@ -92,6 +95,8 @@ export default {
 
     const logoWidth = ref('150px')
     const hideLogo = computed(() => unref(configOptions).hideLogo)
+    const hideAppSwitcher = computed(() => unref(configOptions).hideAppSwitcher)
+    const hideAccountMenu = computed(() => unref(configOptions).hideAccountMenu)
 
     const isNotificationBellEnabled = computed(() => {
       return (
@@ -157,7 +162,9 @@ export default {
       isSideBarToggleDisabled,
       homeLink,
       topBarCenterExtensionPoint,
-      appMenuExtensions
+      appMenuExtensions,
+      hideAppSwitcher,
+      hideAccountMenu
     }
   },
   computed: {

--- a/packages/web-runtime/src/container/bootstrap.ts
+++ b/packages/web-runtime/src/container/bootstrap.ts
@@ -162,7 +162,10 @@ export const announceConfiguration = async ({
   rawConfig.options = {
     ...rawConfig.options,
     embed: { ...rawConfig.options?.embed, ...embedConfigFromQuery },
-    hideLogo: getQueryParam('hide-logo') === 'true'
+    hideLogo: getQueryParam('hide-logo') === 'true',
+    hideAppSwitcher: getQueryParam('hide-app-switcher') === 'true',
+    hideAccountMenu: getQueryParam('hide-account-menu') === 'true',
+    hideNavigation: getQueryParam('hide-navigation') === 'true'
   }
 
   configStore.loadConfig(rawConfig)

--- a/packages/web-runtime/src/layouts/Application.vue
+++ b/packages/web-runtime/src/layouts/Application.vue
@@ -21,7 +21,10 @@
             @update:nav-bar-closed="setNavBarClosed"
           />
           <portal to="app.runtime.mobile.nav">
-            <mobile-nav v-if="isMobileWidth && navItems.length" :nav-items="navItems" />
+            <mobile-nav
+              v-if="isMobileWidth && navItems.length && !hideNavigation"
+              :nav-items="navItems"
+            />
           </portal>
           <router-view
             v-for="name in ['default', 'app', 'fullscreen']"
@@ -51,6 +54,7 @@ import {
   ExtensionPoint,
   useAppsStore,
   useAuthStore,
+  useConfigStore,
   useExtensionRegistry,
   useLocalStorage
 } from '@ownclouders/web-pkg'
@@ -103,6 +107,9 @@ export default defineComponent({
 
     const appsStore = useAppsStore()
     const { apps } = storeToRefs(appsStore)
+
+    const configStore = useConfigStore()
+    const { options: configOptions } = storeToRefs(configStore)
 
     const extensionNavItems = computed(() =>
       getExtensionNavItems({ extensionRegistry, appId: unref(activeApp) })
@@ -177,8 +184,9 @@ export default defineComponent({
       )
     })
 
+    const hideNavigation = computed(() => unref(configOptions).hideNavigation)
     const isSidebarVisible = computed(() => {
-      return unref(navItems).length && !unref(isMobileWidth)
+      return unref(navItems).length && !unref(isMobileWidth) && !unref(hideNavigation)
     })
 
     const navBarClosed = useLocalStorage(`oc_navBarClosed`, false)
@@ -232,6 +240,7 @@ export default defineComponent({
       navItems,
       isMobileWidth,
       navBarClosed,
+      hideNavigation,
       setNavBarClosed
     }
   },

--- a/packages/web-runtime/tests/unit/components/Topbar/TopBar.spec.ts
+++ b/packages/web-runtime/tests/unit/components/Topbar/TopBar.spec.ts
@@ -7,7 +7,12 @@ import {
 import { mock } from 'vitest-mock-extended'
 import { computed } from 'vue'
 import TopBar from '../../../../src/components/Topbar/TopBar.vue'
-import { defaultComponentMocks, defaultPlugins, shallowMount } from '@ownclouders/web-test-helpers'
+import {
+  defaultComponentMocks,
+  defaultPlugins,
+  PiniaMockOptions,
+  shallowMount
+} from '@ownclouders/web-test-helpers'
 
 const mockUseEmbedMode = vi.fn().mockReturnValue({ isEnabled: computed(() => false) })
 
@@ -17,9 +22,15 @@ vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
 }))
 
 describe('Top Bar component', () => {
-  it('Displays applications menu', () => {
-    const { wrapper } = getWrapper()
-    expect(wrapper.find('applications-menu-stub').exists()).toBeTruthy()
+  describe('applications menu', () => {
+    it('Displays applications menu', () => {
+      const { wrapper } = getWrapper()
+      expect(wrapper.find('applications-menu-stub').exists()).toBeTruthy()
+    })
+    it('should not display when hideAppSwitcher is "true"', () => {
+      const { wrapper } = getWrapper({ options: { hideAppSwitcher: true } })
+      expect(wrapper.find('applications-menu-stub').exists()).toBeFalsy()
+    })
   })
   describe('notifications bell', () => {
     it('should display in authenticated context if announced via capabilities', () => {
@@ -72,14 +83,23 @@ describe('Top Bar component', () => {
       expect(wrapper.find(`${componentName}-stub`).exists()).toBeTruthy()
     }
   )
+  it.each(['feedback-link', 'notifications', 'user-menu'])(
+    'should hide %s when hideAccountMenu is "true"',
+    (componentName) => {
+      const { wrapper } = getWrapper({ options: { hideAccountMenu: true } })
+      expect(wrapper.find(`${componentName}-stub`).exists()).toBeFalsy()
+    }
+  )
 })
 
 const getWrapper = ({
   capabilities = {},
-  userContextReady = true
+  userContextReady = true,
+  options
 }: {
   capabilities?: Partial<Capabilities['capabilities']>
   userContextReady?: boolean
+  options?: PiniaMockOptions['configState']['options']
 } = {}) => {
   const mocks = { ...defaultComponentMocks() }
 
@@ -87,7 +107,7 @@ const getWrapper = ({
     piniaOptions: {
       authState: { userContextReady },
       capabilityState: { capabilities },
-      configState: { options: { disableFeedbackLink: false } }
+      configState: { options: { disableFeedbackLink: false, ...options } }
     }
   })
 


### PR DESCRIPTION
## Description

Add modal rendering an iframe with the public link content using a limited UI.

## Related Issue

- refs https://github.com/owncloud/web/issues/12039

## Motivation and Context

Give users a way to open password protected folders

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: chrome & 🤖 
- test case 1: open a folder in the browser
- test case 2: extended unit tests

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/36ffa532-2661-4379-8916-de1da9f34b29)

![image](https://github.com/user-attachments/assets/edc5fe22-8b4f-45a9-9002-779029031f3e)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:

- [x] merge previous PRs
- [x] add changelog
- [x] fill out PR description
- [x] rebase
