### PR TITLE
feat(password-protected-folders): hide extension and actions

### DIFF
--- a/changelog/unreleased/enhancement-display-default-actions-in-context-menu.md
+++ b/changelog/unreleased/enhancement-display-default-actions-in-context-menu.md
@@ -1,0 +1,6 @@
+Enhancement: Display default actions in context menu
+
+We've added default actions into the context menu so that the user can use that action when accessing the resource through it.
+
+https://github.com/owncloud/web/pull/12145
+https://github.com/owncloud/web/issues/12039

--- a/changelog/unreleased/enhancement-hide-password-protected-folders-actions.md
+++ b/changelog/unreleased/enhancement-hide-password-protected-folders-actions.md
@@ -1,0 +1,6 @@
+Enhancement: Hide password protected folders action
+
+We've hidden all actions on password protected folders except delete.
+
+https://github.com/owncloud/web/pull/12145
+https://github.com/owncloud/web/issues/12039

--- a/changelog/unreleased/enhancement-hide-password-protected-folders-extension.md
+++ b/changelog/unreleased/enhancement-hide-password-protected-folders-extension.md
@@ -1,0 +1,6 @@
+Enhancement: Hide password protected folders extension
+
+We've hidden the password protected folder ".psec" extension.
+
+https://github.com/owncloud/web/pull/12145
+https://github.com/owncloud/web/issues/12039

--- a/packages/web-app-password-protected-folders/src/composables/useExtensions.ts
+++ b/packages/web-app-password-protected-folders/src/composables/useExtensions.ts
@@ -8,7 +8,7 @@ export const useExtensions = () => {
   const actionExtension = computed<ActionExtension>(() => ({
     id: 'com.github.owncloud.web-extensions.password-protected-folders',
     type: 'action',
-    extensionPointIds: ['global.files.context-actions', 'global.files.default-actions'],
+    extensionPointIds: ['global.files.default-actions'],
     action: unref(action)
   }))
 

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -83,6 +83,7 @@
   "dependencies": {
     "@casl/ability": "^6.7.1",
     "@microsoft/fetch-event-source": "^2.0.1",
+    "@ownclouders/web-pkg": "workspace:*",
     "axios": "^1.7.7",
     "fast-xml-parser": "^4.5.0",
     "lodash-es": "^4.17.21",

--- a/packages/web-client/src/helpers/resource/functions.ts
+++ b/packages/web-client/src/helpers/resource/functions.ts
@@ -9,6 +9,7 @@ import {
   WebDavResponseResource
 } from './types'
 import { camelCase } from 'lodash-es'
+import { HIDDEN_FILE_EXTENSIONS } from '@ownclouders/web-pkg/src/constants'
 
 const fileExtensions = {
   complex: ['tar.bz2', 'tar.gz', 'tar.xz']
@@ -170,17 +171,26 @@ export function buildResource(resource: WebDavResponseResource): Resource {
       return this.permissions.indexOf(DavPermission.FolderCreateable) >= 0
     },
     canDownload: function () {
-      return this.permissions.indexOf(DavPermission.SecureView) === -1
+      return (
+        // TODO: we should later on separate this from the hidden extensions and use some better logic
+        !HIDDEN_FILE_EXTENSIONS.includes(this.extension) &&
+        this.permissions.indexOf(DavPermission.SecureView) === -1
+      )
     },
     canBeDeleted: function () {
       return this.permissions.indexOf(DavPermission.Deletable) >= 0
     },
     canRename: function () {
-      return this.permissions.indexOf(DavPermission.Renameable) >= 0
+      return (
+        !HIDDEN_FILE_EXTENSIONS.includes(this.extension) &&
+        this.permissions.indexOf(DavPermission.Renameable) >= 0
+      )
     },
     canShare: function ({ ability }) {
       return (
-        ability.can('create-all', 'Share') && this.permissions.indexOf(DavPermission.Shareable) >= 0
+        !HIDDEN_FILE_EXTENSIONS.includes(this.extension) &&
+        ability.can('create-all', 'Share') &&
+        this.permissions.indexOf(DavPermission.Shareable) >= 0
       )
     },
     canCreate: function () {
@@ -188,8 +198,9 @@ export function buildResource(resource: WebDavResponseResource): Resource {
     },
     canEditTags: function () {
       return (
-        this.permissions.indexOf(DavPermission.Updateable) >= 0 ||
-        this.permissions.indexOf(DavPermission.FileUpdateable) >= 0
+        !HIDDEN_FILE_EXTENSIONS.includes(this.extension) &&
+        (this.permissions.indexOf(DavPermission.Updateable) >= 0 ||
+          this.permissions.indexOf(DavPermission.FileUpdateable) >= 0)
       )
     },
     isMounted: function () {

--- a/packages/web-pkg/src/components/FilesList/ContextActions.vue
+++ b/packages/web-pkg/src/components/FilesList/ContextActions.vue
@@ -42,7 +42,7 @@ export default defineComponent({
     }
   },
   setup(props) {
-    const { editorActions } = useFileActions()
+    const { editorActions, defaultActions } = useFileActions()
 
     const { actions: enableSyncActions } = useFileActionsEnableSync()
     const { actions: hideShareActions } = useFileActionsToggleHideShare()
@@ -110,6 +110,7 @@ export default defineComponent({
 
     const menuItemsContext = computed(() => {
       return [
+        ...unref(defaultActions),
         ...unref(editorActions),
         ...unref(extensionsContextActions).filter((a) => a.category === 'context')
       ]

--- a/packages/web-pkg/src/components/FilesList/ResourceListItem.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceListItem.vue
@@ -44,7 +44,9 @@
           :type="resource.type"
           :full-path="resource.path"
           :is-path-displayed="isPathDisplayed"
-          :is-extension-displayed="isExtensionDisplayed"
+          :is-extension-displayed="
+            isExtensionDisplayed && !HIDDEN_EXTENSIONS.includes(resource.extension)
+          "
         />
       </resource-link>
       <div class="oc-resource-indicators">
@@ -69,7 +71,7 @@ import ResourceIcon from './ResourceIcon.vue'
 import ResourceLink from './ResourceLink.vue'
 import ResourceName from './ResourceName.vue'
 import { RouteLocationRaw } from 'vue-router'
-
+import { HIDDEN_FILE_EXTENSIONS } from '../../constants'
 /**
  * Displays a resource together with the resource type icon or thumbnail
  */
@@ -166,6 +168,11 @@ export default defineComponent({
     }
   },
   emits: ['click'],
+
+  setup() {
+    return { HIDDEN_EXTENSIONS: HIDDEN_FILE_EXTENSIONS }
+  },
+
   computed: {
     parentFolderComponentType() {
       return this.parentFolderLink ? 'router-link' : 'span'

--- a/packages/web-pkg/src/components/SideBar/Files/FileInfo.vue
+++ b/packages/web-pkg/src/components/SideBar/Files/FileInfo.vue
@@ -25,11 +25,12 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, inject } from 'vue'
+import { computed, defineComponent, inject, unref } from 'vue'
 import { Resource } from '@ownclouders/web-client'
 import { useResourcesStore } from '../../../composables'
 import ResourceIcon from '../../FilesList/ResourceIcon.vue'
 import ResourceName from '../../FilesList/ResourceName.vue'
+import { HIDDEN_FILE_EXTENSIONS } from '../../../constants'
 
 export default defineComponent({
   name: 'FileInfo',
@@ -44,7 +45,11 @@ export default defineComponent({
     const resourcesStore = useResourcesStore()
 
     const resource = inject<Resource>('resource')
-    const areFileExtensionsShown = computed(() => resourcesStore.areFileExtensionsShown)
+    const areFileExtensionsShown = computed(
+      () =>
+        resourcesStore.areFileExtensionsShown &&
+        !HIDDEN_FILE_EXTENSIONS.includes(unref(resource).extension)
+    )
 
     return {
       resource,

--- a/packages/web-pkg/src/composables/actions/files/useFileActions.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActions.ts
@@ -286,6 +286,7 @@ export const useFileActions = () => {
   return {
     editorActions,
     systemActions,
+    defaultActions,
     getDefaultAction,
     getAllAvailableActions,
     getEditorRouteOpts,

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsCreateSpaceFromResource.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsCreateSpaceFromResource.ts
@@ -17,6 +17,7 @@ import {
   useResourcesStore,
   useSpacesStore
 } from '../../piniaStores'
+import { HIDDEN_FILE_EXTENSIONS } from '../../../constants'
 
 export const useFileActionsCreateSpaceFromResource = () => {
   const { showMessage, showErrorMessage } = useMessages()
@@ -126,6 +127,10 @@ export const useFileActionsCreateSpaceFromResource = () => {
             !isLocationSpacesActive(router, 'files-spaces-generic') ||
             !isPersonalSpaceResource(space)
           ) {
+            return false
+          }
+
+          if (HIDDEN_FILE_EXTENSIONS.includes(resources[0].extension)) {
             return false
           }
 

--- a/packages/web-pkg/src/constants.ts
+++ b/packages/web-pkg/src/constants.ts
@@ -14,3 +14,9 @@ export abstract class ImageType {
   static readonly Preview: string = 'preview'
   static readonly Avatar: string = 'avatar'
 }
+
+/**
+ * List of file extensions that should be hidden from the user.
+ * Hiding the extension currently leads to hiding all actions except delete.
+ */
+export const HIDDEN_FILE_EXTENSIONS = ['psec']

--- a/packages/web-pkg/tests/unit/components/FilesList/ResourceListItem.spec.ts
+++ b/packages/web-pkg/tests/unit/components/FilesList/ResourceListItem.spec.ts
@@ -1,6 +1,12 @@
-import { defaultPlugins, mount } from '@ownclouders/web-test-helpers'
+import { defaultComponentMocks, defaultPlugins, mount } from '@ownclouders/web-test-helpers'
 import ResourceListItem from '../../../../src/components/FilesList/ResourceListItem.vue'
 import { Resource } from '@ownclouders/web-client'
+import { HIDDEN_FILE_EXTENSIONS } from '../../../../src/constants'
+import { mock } from 'vitest-mock-extended'
+
+const SELECTORS = Object.freeze({
+  resourceName: '.oc-resource-basename'
+})
 
 const fileResource = {
   name: 'forest.jpg',
@@ -146,4 +152,34 @@ describe('OcResource', () => {
     expect(wrapper.find('oc-resource-thumbnail').exists()).toBeFalsy()
     expect(wrapper.find('oc-resource-icon').exists()).toBeFalsy()
   })
+
+  it.each(HIDDEN_FILE_EXTENSIONS)(
+    'should not show the file extension when it equals "%s"',
+    (extension) => {
+      const { wrapper } = getWrapper({
+        props: {
+          resource: mock<Resource>({ extension, name: 'forest.' + extension }),
+          isExtensionDisplayed: true
+        }
+      })
+
+      expect(wrapper.find(SELECTORS.resourceName).text()).toStrictEqual('forest')
+    }
+  )
 })
+
+function getWrapper({ props }: { props: { resource: Resource; isExtensionDisplayed?: boolean } }) {
+  const mocks = defaultComponentMocks()
+
+  return {
+    mocks,
+    wrapper: mount(ResourceListItem, {
+      props,
+      global: {
+        mocks,
+        provide: mocks,
+        plugins: [...defaultPlugins()]
+      }
+    })
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -915,6 +915,9 @@ importers:
       '@microsoft/fetch-event-source':
         specifier: ^2.0.1
         version: 2.0.1
+      '@ownclouders/web-pkg':
+        specifier: workspace:*
+        version: link:../web-pkg
       axios:
         specifier: ^1.7.7
         version: 1.7.9
@@ -10199,7 +10202,7 @@ snapshots:
       '@cucumber/ci-environment': 9.1.0
       '@cucumber/cucumber-expressions': 16.1.1
       '@cucumber/gherkin': 26.0.3
-      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@21.0.1))(@cucumber/messages@21.0.1)
+      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@27.0.2))(@cucumber/messages@21.0.1)
       '@cucumber/gherkin-utils': 8.0.2
       '@cucumber/html-formatter': 20.2.1(@cucumber/messages@21.0.1)
       '@cucumber/message-streams': 4.0.1(@cucumber/messages@21.0.1)
@@ -10237,7 +10240,7 @@ snapshots:
       yaml: 2.6.0
       yup: 0.32.11
 
-  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@21.0.1))(@cucumber/messages@21.0.1)':
+  '@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@26.0.3)(@cucumber/message-streams@4.0.1(@cucumber/messages@27.0.2))(@cucumber/messages@21.0.1)':
     dependencies:
       '@cucumber/gherkin': 26.0.3
       '@cucumber/message-streams': 4.0.1(@cucumber/messages@21.0.1)


### PR DESCRIPTION
## Description

Hide .psec extensions, hide all actions except delete, and display default actions in context menu.

## Related Issue

- refs https://github.com/owncloud/web/issues/12039

## Motivation and Context

Make the file look more like a folder

## How Has This Been Tested?

- test environment: chrome & 🤖 
- test case 1: create a folder, open context menu and see available actions
- test case 2: create a folder, open sidebar and see available actions

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/6ba02825-6c9e-470b-91bd-cd2f608ef3fa)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
