### PR TITLE
fix(password-protected-folders): create folder in the personal space

### DIFF
--- a/changelog/unreleased/bugfix-create-password-protected-folder-in-personal-space.md
+++ b/changelog/unreleased/bugfix-create-password-protected-folder-in-personal-space.md
@@ -1,0 +1,6 @@
+Bugfix: Create password protected folder in personal space
+
+We've fixed an issue where the password protected folder was created in current space instead of users personal space.
+
+https://github.com/owncloud/web/pull/12146
+https://github.com/owncloud/web/issues/12039

--- a/changelog/unreleased/enhancement-recursive-folder-creation.md
+++ b/changelog/unreleased/enhancement-recursive-folder-creation.md
@@ -1,0 +1,5 @@
+Enhancement: Recursive folder creation
+
+We've extended the `CreateFolderFactory` in web-client to allow creating folders recursively. Simply pass `recursive: true` into options and all parent folders will be created.
+
+https://github.com/owncloud/web/pull/12146

--- a/packages/web-app-password-protected-folders/tests/unit/components/CreateFolderModal.spec.ts
+++ b/packages/web-app-password-protected-folders/tests/unit/components/CreateFolderModal.spec.ts
@@ -11,7 +11,7 @@ vi.mock('../../../src/composables/useCreateFileHandler', () => ({
 }))
 
 const currentFolder = mock<Resource>()
-const currentSpace = mock<SpaceResource>()
+const currentSpace = mock<SpaceResource>({ driveType: 'personal' })
 
 const SELECTORS = Object.freeze({
   inputFolderName: '#input-folder-name',
@@ -36,7 +36,8 @@ describe('CreateFolderModal', () => {
     expect(useCreateFileHandler().createFileHandler).toHaveBeenCalledWith({
       fileName: 'name',
       password: 'password',
-      space: currentSpace,
+      personalSpace: currentSpace,
+      currentSpace: currentSpace,
       currentFolder,
       type: SharingLinkType.Edit
     })
@@ -62,7 +63,7 @@ function getWrapper() {
         plugins: defaultPlugins({
           piniaOptions: {
             resourcesStore: { currentFolder },
-            spacesState: { currentSpace }
+            spacesState: { currentSpace, spaces: [currentSpace] }
           }
         }),
         mocks,

--- a/packages/web-app-password-protected-folders/tests/unit/composables/useCreateFileHandler.spec.ts
+++ b/packages/web-app-password-protected-folders/tests/unit/composables/useCreateFileHandler.spec.ts
@@ -6,7 +6,8 @@ import { useSharesStore } from '@ownclouders/web-pkg'
 import { SharingLinkType } from '@ownclouders/web-client/graph/generated'
 import { MockedFunction } from 'vitest'
 
-const space = mock<SpaceResource>()
+const space = mock<SpaceResource>({ name: 'With psec file' })
+const personalSpace = mock<SpaceResource>({ driveType: 'personal' })
 const currentFolder = mock<Resource>({ path: '/current/folder' })
 const createdFolder = mock<Resource>()
 
@@ -24,18 +25,20 @@ describe('createFileHandler', () => {
 
         await instance.createFileHandler({
           fileName: 'protected',
-          space,
+          personalSpace: personalSpace,
           currentFolder,
+          currentSpace: space,
           password: 'Pass$123',
           type: SharingLinkType.Edit
         })
 
-        expect(mocks.$clientService.webdav.createFolder).toHaveBeenCalledWith(space, {
-          path: '/.protected'
+        expect(mocks.$clientService.webdav.createFolder).toHaveBeenCalledWith(personalSpace, {
+          path: '/.PasswordProtectedFolders/projects/With psec file/current/folder/protected',
+          recursive: true
         })
         expect(addLink).toHaveBeenCalledWith({
           clientService: mocks.$clientService,
-          space,
+          space: personalSpace,
           resource: createdFolder,
           options: { password: 'Pass$123', type: SharingLinkType.Edit }
         })

--- a/packages/web-client/src/webdav/createFolder.ts
+++ b/packages/web-client/src/webdav/createFolder.ts
@@ -3,12 +3,14 @@ import { GetFileInfoFactory } from './getFileInfo'
 import { DAV, DAVRequestOptions } from './client/dav'
 import { WebDavOptions } from './types'
 import { getWebDavPath } from './utils'
+import { DavHttpError } from '../errors'
 
 type CreateFolderOptions = {
   path: string
   parentFolderId?: string
   folderName?: string
   fetchFolder?: boolean
+  recursive?: boolean
 } & DAVRequestOptions
 
 export const CreateFolderFactory = (
@@ -21,6 +23,26 @@ export const CreateFolderFactory = (
       space: SpaceResource,
       { path, parentFolderId, folderName, fetchFolder = true, ...opts }: CreateFolderOptions
     ): Promise<FolderResource> {
+      if (opts.recursive) {
+        const pathParts = path.split('/').filter(Boolean)
+        pathParts.pop()
+
+        let currentPath = ''
+
+        for (const part of pathParts) {
+          try {
+            currentPath += `/${part}`
+            await this.createFolder(space, { path: currentPath, fetchFolder: false })
+          } catch (error) {
+            if (error instanceof DavHttpError && error.statusCode === 405) {
+              continue
+            }
+
+            throw error
+          }
+        }
+      }
+
       const webDavPath = getWebDavPath(space, { fileId: parentFolderId, path, name: folderName })
       await dav.mkcol(webDavPath)
 

--- a/packages/web-pkg/src/composables/actions/helpers/useFileActionsDeleteResources.ts
+++ b/packages/web-pkg/src/composables/actions/helpers/useFileActionsDeleteResources.ts
@@ -1,6 +1,6 @@
 import { cloneStateObject } from '../../../helpers/store'
 import { isSameResource } from '../../../helpers/resource'
-import { DavHttpError, Resource, SpaceResource } from '@ownclouders/web-client'
+import { DavHttpError, Resource, SpaceResource, urlJoin } from '@ownclouders/web-client'
 import { isLocationSpacesActive } from '../../../router'
 import { dirname } from 'path'
 import { createFileRouteOptions } from '../../../helpers'
@@ -163,7 +163,14 @@ export const useFileActionsDeleteResources = () => {
       }
 
       try {
-        const folderPath = '/.' + resource.name.replace('.psec', '')
+        const matchingSpace = getMatchingSpace(resource)
+
+        const folderPath = urlJoin(
+          '/.PasswordProtectedFolders/projects/',
+          matchingSpace.name,
+          resource.path.replace(resource.name, ''),
+          resource.name.replace('.psec', '')
+        )
         const passwordProtectedFolder = await clientService.webdav.getFileInfo(
           unref(personalSpace),
           {


### PR DESCRIPTION
## Description

Create the hidden folder in users personal space

## Related Issue

- refs https://github.com/owncloud/web/issues/12039

## Motivation and Context

Other users cannot access the folder without the pass

## How Has This Been Tested?

- test environment: chrome & 🤖 
- test case 1: Create a password protected folder in users personal space
- test case 2: Create a password protected folder in created space

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
