### PR TITLE
feat(password-protected-folders): delete protected folder

### DIFF
--- a/changelog/unreleased/enhancement-delete-password-protected-folders.md
+++ b/changelog/unreleased/enhancement-delete-password-protected-folders.md
@@ -1,0 +1,6 @@
+Enhancement: Delete password protected folders
+
+We've extended the delete resources handler to also delete the hidden folder acting as the password protected folder when deleting a `.psec` files.
+
+https://github.com/owncloud/web/pull/12152
+https://github.com/owncloud/web/issues/12039

--- a/packages/web-app-password-protected-folders/src/index.ts
+++ b/packages/web-app-password-protected-folders/src/index.ts
@@ -1,6 +1,9 @@
 import { useGettext } from 'vue3-gettext'
 import translations from '../l10n/translations.json'
-import { defineWebApplication } from '@ownclouders/web-pkg'
+import {
+  defineWebApplication,
+  PASSWORD_PROTECTED_FOLDER_FILE_EXTENSION
+} from '@ownclouders/web-pkg'
 import { useExtensions } from './composables/useExtensions'
 import { useCustomHandler } from './composables/useCustomHandler'
 
@@ -17,7 +20,7 @@ export default defineWebApplication({
         extensions: [
           {
             newFileMenu: { menuTitle: () => $gettext('Password Protected Folder') },
-            extension: 'psec',
+            extension: PASSWORD_PROTECTED_FOLDER_FILE_EXTENSION,
             customHandler
           }
         ]

--- a/packages/web-pkg/src/composables/webWorkers/deleteWorker/worker.ts
+++ b/packages/web-pkg/src/composables/webWorkers/deleteWorker/worker.ts
@@ -1,7 +1,6 @@
 import PQueue from 'p-queue'
 import { type Resource, webdav as _webdav, type SpaceResource } from '@ownclouders/web-client'
 import type { DeleteWorkerTopic, DeleteWorkerReturnData } from './useDeleteWorker'
-
 type MessageData = {
   baseUrl?: string
   accessToken?: string
@@ -41,7 +40,7 @@ self.onmessage = async (e: MessageEvent) => {
   const failed: DeleteWorkerReturnData['failed'] = []
   const queue = new PQueue({ concurrency: concurrentRequests })
 
-  const doDelete = (r: Resource) => {
+  const doDelete = (r: Pick<Resource, 'extension' | 'path' | 'id'>) => {
     if (topic === 'fileListDelete') {
       return webdav.deleteFile(space, { path: r.path })
     }

--- a/packages/web-pkg/src/constants.ts
+++ b/packages/web-pkg/src/constants.ts
@@ -15,8 +15,10 @@ export abstract class ImageType {
   static readonly Avatar: string = 'avatar'
 }
 
+export const PASSWORD_PROTECTED_FOLDER_FILE_EXTENSION = 'psec'
+
 /**
  * List of file extensions that should be hidden from the user.
  * Hiding the extension currently leads to hiding all actions except delete.
  */
-export const HIDDEN_FILE_EXTENSIONS = ['psec']
+export const HIDDEN_FILE_EXTENSIONS = [PASSWORD_PROTECTED_FOLDER_FILE_EXTENSION]


### PR DESCRIPTION
## Description

When deleting `.psec` files, try to get also the related hidden folder and delete it as well. If the folder is not found or user does not have enough permissions, output a warning in the console and ignore it.

## Related Issue

- refs https://github.com/owncloud/web/issues/12039

## Motivation and Context

Clean files list

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: chrome & unit
- test case 1: delete a psec file in personal space
- test case 2: delete a psec file in space
- test case 3: delete a psec file in space as non-owner

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
