### PR TITLE
fix: do not render default actions in context menu

### DIFF
--- a/changelog/unreleased/bugfix-do-not-render-default-actions-in-context-menu.md
+++ b/changelog/unreleased/bugfix-do-not-render-default-actions-in-context-menu.md
@@ -1,0 +1,6 @@
+Bugfix: Do not render default actions in context menu
+
+We've fixed an issue where the default action was rendered in the context menu leading into duplicate actions being shown. The default action was originally introduced into the context menu to show "Open folder" action of password protected folders extension but we fixed this to use the correct category in the extension which renders the action as expected.
+
+https://github.com/owncloud/web/pull/12175
+https://github.com/owncloud/web/issues/12154

--- a/packages/web-app-password-protected-folders/src/composables/useExtensions.ts
+++ b/packages/web-app-password-protected-folders/src/composables/useExtensions.ts
@@ -8,7 +8,7 @@ export const useExtensions = () => {
   const actionExtension = computed<ActionExtension>(() => ({
     id: 'com.github.owncloud.web-extensions.password-protected-folders',
     type: 'action',
-    extensionPointIds: ['global.files.default-actions'],
+    extensionPointIds: ['global.files.context-actions', 'global.files.default-actions'],
     action: unref(action)
   }))
 

--- a/packages/web-app-password-protected-folders/src/composables/useOpenFolderAction.ts
+++ b/packages/web-app-password-protected-folders/src/composables/useOpenFolderAction.ts
@@ -10,6 +10,7 @@ export const useOpenFolderAction = () => {
 
   const action = computed<FileAction>(() => ({
     name: 'open-password-protected-folder',
+    category: 'context',
     icon: 'external-link',
     async handler({ resources, space }) {
       const [file] = resources

--- a/packages/web-pkg/src/components/FilesList/ContextActions.vue
+++ b/packages/web-pkg/src/components/FilesList/ContextActions.vue
@@ -42,7 +42,7 @@ export default defineComponent({
     }
   },
   setup(props) {
-    const { editorActions, defaultActions } = useFileActions()
+    const { editorActions } = useFileActions()
 
     const { actions: enableSyncActions } = useFileActionsEnableSync()
     const { actions: hideShareActions } = useFileActionsToggleHideShare()
@@ -110,7 +110,6 @@ export default defineComponent({
 
     const menuItemsContext = computed(() => {
       return [
-        ...unref(defaultActions),
         ...unref(editorActions),
         ...unref(extensionsContextActions).filter((a) => a.category === 'context')
       ]


### PR DESCRIPTION
## Description

We've fixed an issue where the default action was rendered in the context menu leading into duplicate actions being shown. The default action was originally introduced into the context menu to show "Open folder" action of password protected folders extension but we fixed this to use the correct category in the extension which renders the action as expected.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/12154

## Motivation and Context

No duplicate actions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: chrome
- test case 1: open context menu on template file
- test case 2: open context menu on psec file

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/1336eb36-4b05-4c0b-804f-2716ff21ebb8)

![image](https://github.com/user-attachments/assets/15b46fe6-9222-409b-a83f-70709bf6ce99)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
