### PR TITLE
fix: open password protected folder when clicking its name

### DIFF
--- a/changelog/unreleased/bugfix-open-password-protected-folder-when-clicking-on-its-name.md
+++ b/changelog/unreleased/bugfix-open-password-protected-folder-when-clicking-on-its-name.md
@@ -1,0 +1,6 @@
+Bugfix: Open password protected folder when clicking on its name
+
+We've fixed an issue where clicking on the password protected folder name in the list did not do anything. Clicking on the name name will open the folder.
+
+https://github.com/owncloud/web/pull/12177
+https://github.com/owncloud/web/issues/12176

--- a/packages/web-client/src/helpers/resource/functions.ts
+++ b/packages/web-client/src/helpers/resource/functions.ts
@@ -3,7 +3,10 @@ import { urlJoin } from '../../utils'
 import { DavPermission, DavProperty } from '../../webdav/constants'
 import { Resource, SearchResource, TrashResource, WebDavResponseResource } from './types'
 import { camelCase } from 'lodash-es'
-import { HIDDEN_FILE_EXTENSIONS } from '@ownclouders/web-pkg/src/constants'
+import {
+  HIDDEN_FILE_EXTENSIONS,
+  PASSWORD_PROTECTED_FOLDER_FILE_EXTENSION
+} from '@ownclouders/web-pkg/src/constants'
 
 const fileExtensions = {
   complex: ['tar.bz2', 'tar.gz', 'tar.xz']
@@ -274,4 +277,8 @@ export function buildDeletedResource(resource: WebDavResponseResource): TrashRes
     isReceivedShare: () => false,
     getDomSelector: () => extractDomSelector(id)
   }
+}
+
+export function isPasswordProtectedFolderFileResource(resourceName: string): boolean {
+  return resourceName.endsWith(PASSWORD_PROTECTED_FOLDER_FILE_EXTENSION)
 }

--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -262,6 +262,7 @@ import {
 import { useWindowSize } from '@vueuse/core'
 import {
   IncomingShareResource,
+  isPasswordProtectedFolderFileResource,
   isProjectSpaceResource,
   Resource,
   TrashResource
@@ -611,7 +612,7 @@ export default defineComponent({
         return false
       }
 
-      if (!resource.isFolder) {
+      if (!resource.isFolder && !isPasswordProtectedFolderFileResource(resource.name)) {
         if (!resource.canDownload() && !canBeOpenedWithSecureView(resource)) {
           return false
         }

--- a/packages/web-pkg/tests/unit/components/FilesList/ResourceTable.spec.ts
+++ b/packages/web-pkg/tests/unit/components/FilesList/ResourceTable.spec.ts
@@ -484,6 +484,28 @@ describe('ResourceTable', () => {
       await tr.trigger('click')
       expect(wrapper.emitted().fileClick).toBeUndefined()
     })
+
+    it('should emit "fileClick" when psec file is clicked', async () => {
+      const resource = mock<Resource>({
+        id: 'psec-file',
+        name: 'psec-file.psec',
+        path: '/psec-file.psec',
+        remoteItemPath: '/psec-file.psec',
+        canDownload: () => false,
+        isFolder: false,
+        getDomSelector: () => extractDomSelector('psec-file')
+      })
+
+      const { wrapper } = getMountedWrapper({
+        canBeOpenedWithSecureView: false,
+        resources: [resource]
+      })
+      await wrapper.find('.oc-tbody-tr-psec-file .oc-resource-name').trigger('click')
+
+      expect(
+        wrapper.emitted<{ resources: Resource[] }[]>('fileClick')[0][0].resources[0].name
+      ).toMatch('psec-file.psec')
+    })
   })
 
   describe('resource details', () => {


### PR DESCRIPTION
## Description

Since all the necessary permissions to allow clickable resource name are missing on password protected folders and we cannot affect what mimetype the file will have, we added a psec file specific condition to skip check of these permissions.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/12176

## Motivation and Context

Users can click the file to open it

## How Has This Been Tested?

- test environment: chrome & 🤖 
- test case 1: open the password protected folder by clicking on psec file name

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
