### PR TITLE
fix(files): check files view presence in upload dropzone init

### DIFF
--- a/changelog/unreleased/bugfix-skip-upload-dropzone-init-when-files-view-is-missing.md
+++ b/changelog/unreleased/bugfix-skip-upload-dropzone-init-when-files-view-is-missing.md
@@ -1,0 +1,6 @@
+Bugfix: Skip upload dropzone init when files view is missing
+
+We've fixed an issue where the drag & drop upload zone was being initialized even though the target files view element was missing. The initialization will be skipped now in such case.
+
+https://github.com/owncloud/web/pull/12178
+https://github.com/owncloud/web/issues/12150

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -444,12 +444,15 @@ export default defineComponent({
 
     watch(
       canUpload,
-      () => {
-        if (unref(canUpload)) {
-          uppyService.useDropTarget({ targetSelector: '#files-view' })
-        } else {
+      (canUpload) => {
+        const el = document.getElementById('files-view')
+
+        if (!el || !canUpload) {
           uppyService.removeDropTarget()
+          return
         }
+
+        uppyService.useDropTarget({ targetSelector: '#files-view' })
       },
       { immediate: true }
     )

--- a/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.ts
+++ b/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.ts
@@ -168,12 +168,21 @@ describe('CreateAndUpload component', () => {
   })
   describe('drop target', () => {
     it('is being initialized when user can upload', () => {
+      document.getElementById = vi.fn().mockReturnValue(document.createElement('div'))
+
       const { mocks } = getWrapper()
       expect(mocks.$uppyService.useDropTarget).toHaveBeenCalled()
     })
     it('is not being initialized when user can not upload', () => {
       const currentFolder = mock<Resource>({ canUpload: () => false })
       const { mocks } = getWrapper({ currentFolder })
+      expect(mocks.$uppyService.useDropTarget).not.toHaveBeenCalled()
+    })
+    it('should not be initialized when the files view element is not found', () => {
+      document.getElementById = vi.fn().mockReturnValue(null)
+
+      const { mocks } = getWrapper()
+      expect(document.getElementById).toHaveBeenCalledWith('files-view')
       expect(mocks.$uppyService.useDropTarget).not.toHaveBeenCalled()
     })
   })


### PR DESCRIPTION
## Description

When initializing the uppy upload dropzone, first check whether the target files view element is present to prevent the app from crashing due to the non-existing target.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/12150

## Motivation and Context

Non-crashing app

## How Has This Been Tested?

- test environment: chrome & 🤖 
- test case 1: navigate into any space and then back to personal space

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
