### PR TITLE
feat(external): allow camera

### DIFF
--- a/changelog/unreleased/enhancement-allow-camera-in-external-app-iframe.md
+++ b/changelog/unreleased/enhancement-allow-camera-in-external-app-iframe.md
@@ -1,0 +1,6 @@
+Enhancement: Allow camera in external app iframe
+
+We've added the `allow` attribute with value `camera` to iframe in external app so that we allow using camera in external apps. We are not specifying any allowed origins and allow it everywhere as we are already allowing only certain origins to be loaded inside of the iframe.
+
+https://github.com/owncloud/web/pull/12188
+https://github.com/owncloud/web/issues/12121

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -5,6 +5,7 @@
     class="oc-width-1-1 oc-height-1-1"
     :title="iFrameTitle"
     allowfullscreen
+    allow="camera"
   />
   <div v-if="appUrl && method === 'POST' && formParameters" class="oc-height-1-1 oc-width-1-1">
     <form :action="appUrl" target="app-iframe" method="post">
@@ -18,6 +19,7 @@
       class="oc-width-1-1 oc-height-1-1"
       :title="iFrameTitle"
       allowfullscreen
+      allow="camera"
     />
   </div>
 </template>

--- a/packages/web-app-external/tests/unit/__snapshots__/app.spec.ts.snap
+++ b/packages/web-app-external/tests/unit/__snapshots__/app.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`The app provider extension > should be able to load an iFrame via get 1`] = `
-"<iframe src="https://example.test/d12ab86/loe009157-MzBw" class="oc-width-1-1 oc-height-1-1" title="&quot;example-app&quot; app content area" allowfullscreen=""></iframe>
+"<iframe src="https://example.test/d12ab86/loe009157-MzBw" class="oc-width-1-1 oc-height-1-1" title="&quot;example-app&quot; app content area" allowfullscreen="" allow="camera"></iframe>
 
 <!--v-if-->"
 `;
@@ -13,7 +13,7 @@ exports[`The app provider extension > should be able to load an iFrame via post 
   <form action="https://example.test/d12ab86/loe009157-MzBw" target="app-iframe" method="post"><input type="submit" class="oc-hidden" value="[object Object]">
     <div><input name="access_token" type="hidden" value="asdfsadfsadf"></div>
     <div><input name="access_token_ttl" type="hidden" value="123456"></div>
-  </form> <iframe name="app-iframe" class="oc-width-1-1 oc-height-1-1" title="&quot;example-app&quot; app content area" allowfullscreen=""></iframe>
+  </form> <iframe name="app-iframe" class="oc-width-1-1 oc-height-1-1" title="&quot;example-app&quot; app content area" allowfullscreen="" allow="camera"></iframe>
 </div>"
 `;
 


### PR DESCRIPTION
## Description

We've added the  attribute into the external app iframe so that users can use their cameras in external apps.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/12121

## Motivation and Context

Users can use their cameras

## How Has This Been Tested?

- test environment: chrome
- test case 1: Check whether the attribute is present (we unfortunately cannot run geogebra locally)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
