### PR TITLE
fix: display shared file versions

### DIFF
--- a/changelog/unreleased/bugfix-display-shared-file-versions.md
+++ b/changelog/unreleased/bugfix-display-shared-file-versions.md
@@ -1,0 +1,6 @@
+Bugfix: Display shared file versions
+
+We've fixed an issue where versions were not displayed in the sidebar for a shared file even when shared with necessary permissions. If a resource is an incoming share, we are now checking permission directly on the resource object instead of space.
+
+https://github.com/owncloud/web/pull/12194
+https://github.com/owncloud/web/issues/12168

--- a/packages/web-client/src/helpers/share/functions.ts
+++ b/packages/web-client/src/helpers/share/functions.ts
@@ -162,6 +162,7 @@ export function buildIncomingShareResource({
     canCreate: () => sharePermissions.includes(GraphSharePermission.createChildren),
     canBeDeleted: () => sharePermissions.includes(GraphSharePermission.deleteStandard),
     canEditTags: () => sharePermissions.includes(GraphSharePermission.createChildren),
+    canListVersions: () => sharePermissions.includes(GraphSharePermission.readVersions),
     isMounted: () => false,
     isReceivedShare: () => true,
     canShare: () => false,

--- a/packages/web-client/src/helpers/share/types.ts
+++ b/packages/web-client/src/helpers/share/types.ts
@@ -41,6 +41,7 @@ export interface IncomingShareResource extends ShareResource {
   syncEnabled: boolean
   shareRoles: UnifiedRoleDefinition[]
   sharePermissions: GraphSharePermission[]
+  canListVersions?(): boolean
 }
 
 export interface ShareRole extends UnifiedRoleDefinition {

--- a/packages/web-pkg/src/composables/resources/useCanListVersions.ts
+++ b/packages/web-pkg/src/composables/resources/useCanListVersions.ts
@@ -1,5 +1,11 @@
 import { useUserStore } from '../piniaStores'
-import { isSpaceResource, isTrashResource, Resource, SpaceResource } from '@ownclouders/web-client'
+import {
+  IncomingShareResource,
+  isSpaceResource,
+  isTrashResource,
+  Resource,
+  SpaceResource
+} from '@ownclouders/web-client'
 
 export const useCanListVersions = () => {
   const userStore = useUserStore()
@@ -14,6 +20,14 @@ export const useCanListVersions = () => {
     if (isTrashResource(resource)) {
       return false
     }
+
+    if (
+      resource.isReceivedShare() &&
+      typeof (resource as IncomingShareResource).canListVersions === 'function'
+    ) {
+      return (resource as IncomingShareResource).canListVersions()
+    }
+
     return space?.canListVersions({ user: userStore.user })
   }
 

--- a/packages/web-pkg/tests/unit/components/FilesList/ResourceTable.spec.ts
+++ b/packages/web-pkg/tests/unit/components/FilesList/ResourceTable.spec.ts
@@ -188,14 +188,14 @@ const resourcesWithAllFields = [
     shareTypes: [],
     canRename: vi.fn(),
     getDomSelector: () => extractDomSelector('documents'),
-    canDownload: () => true
+    canDownload: () => true,
+    canListVersions: () => true
   },
   {
     id: 'another-one==',
     driveId: 'another-one==',
     name: 'Another one',
     path: '/Another one',
-    indicators,
     isFolder: true,
     type: 'folder',
     size: '237895',
@@ -213,14 +213,14 @@ const resourcesWithAllFields = [
     tags: [],
     canRename: vi.fn(),
     getDomSelector: () => extractDomSelector('another-one=='),
-    canDownload: () => true
+    canDownload: () => true,
+    canListVersions: () => true
   },
   {
     id: 'in-delete-queue==',
     driveId: 'another-one==',
     name: 'In delete queue',
     path: '/In delete queue',
-    indicators,
     isFolder: true,
     type: 'folder',
     size: '237895',
@@ -238,7 +238,8 @@ const resourcesWithAllFields = [
     tags: [],
     canRename: vi.fn(),
     getDomSelector: () => extractDomSelector('in-delete-queue=='),
-    canDownload: () => true
+    canDownload: () => true,
+    canListVersions: () => true
   }
 ] as IncomingShareResource[]
 
@@ -270,6 +271,7 @@ const processingResourcesWithAllFields = [
     canRename: vi.fn(),
     getDomSelector: () => extractDomSelector('forest'),
     canDownload: () => true,
+    canListVersions: () => true,
     processing: true
   },
   {
@@ -296,6 +298,7 @@ const processingResourcesWithAllFields = [
     canRename: vi.fn(),
     getDomSelector: () => extractDomSelector('notes'),
     canDownload: () => true,
+    canListVersions: () => true,
     processing: true
   }
 ] as IncomingShareResource[]

--- a/packages/web-pkg/tests/unit/composables/resources/useCanListVersions.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/resources/useCanListVersions.spec.ts
@@ -1,6 +1,11 @@
 import { getComposableWrapper } from '@ownclouders/web-test-helpers'
 import { mock } from 'vitest-mock-extended'
-import { Resource, SpaceResource, TrashResource } from '@ownclouders/web-client'
+import {
+  IncomingShareResource,
+  Resource,
+  SpaceResource,
+  TrashResource
+} from '@ownclouders/web-client'
 import { useCanListVersions } from '../../../../src/composables/resources'
 
 describe('useCanListVersions', () => {
@@ -52,6 +57,21 @@ describe('useCanListVersions', () => {
           const resource = mock<Resource>({ type: 'file' })
           const canList = canListVersions({ space, resource })
           expect(canList).toBeFalsy()
+        }
+      })
+    })
+
+    it('should use resource permissions instead of space permissions for received shares', () => {
+      getWrapper({
+        setup: ({ canListVersions }) => {
+          const space = mock<SpaceResource>({ canListVersions: () => false })
+          const resource = mock<IncomingShareResource>({
+            type: 'file',
+            isReceivedShare: () => true,
+            canListVersions: () => true
+          })
+          const canList = canListVersions({ space, resource })
+          expect(canList).toBeTruthy()
         }
       })
     })


### PR DESCRIPTION
## Description

Instead of checking permissions of the space, check permissions directly on the resource object if it is an incoming share because the space is manually built there without permissions.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/12168

## Motivation and Context

Versions are visible when shared with correct permissions.

## How Has This Been Tested?

- test environment: chrome & 🤖 
- test case 1: share a file with sufficient permissions

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/7b295324-e770-4d7d-a728-8194432fc399)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
