### PR TITLE
[tests-only][full-ci] test: bump ocis stable-7.0 commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=afb1b4016005a8bff14dd758eb61ca8e09590cd7
+OCIS_COMMITID=d647c8ec1ca41ee6596a23851da7db91e31885e3
 OCIS_BRANCH=stable-7.0


### PR DESCRIPTION

## Description
This pr bumps ocis stable-7.0 latest commit id.

## Related Issue
https://github.com/owncloud/QA/issues/877