### PR TITLE
fix(files): reenable OCM shares editing

### DIFF
--- a/changelog/unreleased/bugfix-enable-external-shares-editing.md
+++ b/changelog/unreleased/bugfix-enable-external-shares-editing.md
@@ -1,0 +1,6 @@
+Bugfix: Enable external shares editing
+
+We've reenabled external shares editing. It was previously disabled due to missing implementation of OCM shares editing in the backend. That has been implemented in the meantime.
+
+https://github.com/owncloud/web/pull/12204
+https://github.com/owncloud/web/issues/12201

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/EditDropdown.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/EditDropdown.vue
@@ -27,7 +27,7 @@
         </li>
       </oc-list>
       <oc-list
-        v-if="canRemove"
+        v-if="canEdit"
         class="collaborator-edit-dropdown-options-list collaborator-edit-dropdown-options-list-remove"
       >
         <li
@@ -92,10 +92,6 @@ export default defineComponent({
       }
     },
     canEdit: {
-      type: Boolean,
-      required: true
-    },
-    canRemove: {
       type: Boolean,
       required: true
     },

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
@@ -104,7 +104,6 @@
           :expiration-date="share.expirationDateTime ? share.expirationDateTime : null"
           :share-category="shareCategory"
           :can-edit="modifiable"
-          :can-remove="removable"
           :is-share-denied="isShareDenied"
           :is-locked="isLocked"
           :deniable="deniable"
@@ -163,10 +162,6 @@ export default defineComponent({
       default: false
     },
     modifiable: {
-      type: Boolean,
-      default: false
-    },
-    removable: {
       type: Boolean,
       default: false
     },

--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -43,7 +43,6 @@
             :resource-name="resource.name"
             :deniable="isShareDeniable(collaborator)"
             :modifiable="isShareModifiable(collaborator)"
-            :removable="isShareRemovable(collaborator)"
             :is-share-denied="isShareDenied(collaborator)"
             :shared-parent-route="getSharedParentRoute(collaborator)"
             :is-locked="resource.locked"
@@ -436,17 +435,6 @@ export default defineComponent({
     },
 
     isShareModifiable(collaborator: CollaboratorShare) {
-      if (collaborator.indirect || collaborator.shareType === ShareTypes.remote.value) {
-        return false
-      }
-
-      if (isProjectSpaceResource(this.space) || isShareSpaceResource(this.space)) {
-        return this.space.canShare({ user: this.user })
-      }
-
-      return true
-    },
-    isShareRemovable(collaborator: CollaboratorShare) {
       if (collaborator.indirect) {
         return false
       }

--- a/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
@@ -65,7 +65,6 @@
           <collaborator-list-item
             :share="collaborator"
             :modifiable="isModifiable(collaborator)"
-            :removable="isModifiable(collaborator)"
             :is-space-share="true"
             @on-delete="deleteMemberConfirm(collaborator)"
           />

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/EditDropdown.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/EditDropdown.spec.ts
@@ -28,12 +28,12 @@ describe('EditDropdown', () => {
     })
   })
   describe('remove share action', () => {
-    it('is being rendered when canRemove is true', () => {
-      const { wrapper } = getWrapper({ canRemove: true })
+    it('is being rendered when canEdit is true', () => {
+      const { wrapper } = getWrapper({ canEdit: true })
       expect(wrapper.find(selectors.removeShareSection).exists()).toBeTruthy()
     })
-    it('is not being rendered when canRemove is false', () => {
-      const { wrapper } = getWrapper({ canRemove: false })
+    it('is not being rendered when canEdit is false', () => {
+      const { wrapper } = getWrapper({ canEdit: false })
       expect(wrapper.find(selectors.removeShareSection).exists()).toBeFalsy()
     })
   })
@@ -72,7 +72,6 @@ function getWrapper(props: PartialComponentProps<typeof EditDropdown> = {}) {
     wrapper: shallowMount(EditDropdown, {
       props: {
         canEdit: true,
-        canRemove: true,
         shareCategory: 'user',
         accessDetails: [],
         ...props

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/ListItem.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/__snapshots__/ListItem.spec.ts.snap
@@ -21,7 +21,7 @@ exports[`Collaborator ListItem component > share inheritance indicators > show w
     <div data-v-ccf14be2="" class="oc-flex oc-flex-middle oc-width-1-3 files-collaborators-collaborator-navigation">
       <!--v-if-->
       <oc-icon-stub data-v-ccf14be2="" name="folder-shared" fill-type="line" class="files-collaborators-collaborator-shared-via oc-mx-xs"></oc-icon-stub>
-      <edit-dropdown-stub data-v-ccf14be2="" accessdetails="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" sharecategory="user" canedit="true" canremove="false" issharedenied="false" deniable="false" islocked="false" sharedparentroute="[object Object]" class="files-collaborators-collaborator-edit oc-ml-xs" data-testid="collaborator-edit"></edit-dropdown-stub>
+      <edit-dropdown-stub data-v-ccf14be2="" accessdetails="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" sharecategory="user" canedit="true" issharedenied="false" deniable="false" islocked="false" sharedparentroute="[object Object]" class="files-collaborators-collaborator-edit oc-ml-xs" data-testid="collaborator-edit"></edit-dropdown-stub>
     </div>
   </div>
 </div>"

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/FileShares.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/FileShares.spec.ts.snap
@@ -16,16 +16,16 @@ exports[`FileShares > collaborators list > renders sharedWithLabel and sharee li
   <portal-target data-v-5d17c3fa="" name="app.files.sidebar.sharing.shared-with.top" slot-props="[object Object]" multiple="true"></portal-target>
   <ul data-v-5d17c3fa="" id="files-collaborators-list" class="oc-list oc-list-divider oc-m-rm" aria-label="Share receivers">
     <li data-v-5d17c3fa="">
-      <collaborator-list-item-stub data-v-5d17c3fa="" share="[object Object]" issharedenied="false" modifiable="true" removable="true" resourcename="[Function]" deniable="false" islocked="[Function]" isspaceshare="false"></collaborator-list-item-stub>
+      <collaborator-list-item-stub data-v-5d17c3fa="" share="[object Object]" issharedenied="false" modifiable="true" resourcename="[Function]" deniable="false" islocked="[Function]" isspaceshare="false"></collaborator-list-item-stub>
     </li>
     <li data-v-5d17c3fa="">
-      <collaborator-list-item-stub data-v-5d17c3fa="" share="[object Object]" issharedenied="false" modifiable="true" removable="true" resourcename="[Function]" deniable="false" islocked="[Function]" isspaceshare="false"></collaborator-list-item-stub>
+      <collaborator-list-item-stub data-v-5d17c3fa="" share="[object Object]" issharedenied="false" modifiable="true" resourcename="[Function]" deniable="false" islocked="[Function]" isspaceshare="false"></collaborator-list-item-stub>
     </li>
     <li data-v-5d17c3fa="">
-      <collaborator-list-item-stub data-v-5d17c3fa="" share="[object Object]" issharedenied="false" modifiable="true" removable="true" resourcename="[Function]" deniable="false" islocked="[Function]" isspaceshare="false"></collaborator-list-item-stub>
+      <collaborator-list-item-stub data-v-5d17c3fa="" share="[object Object]" issharedenied="false" modifiable="true" resourcename="[Function]" deniable="false" islocked="[Function]" isspaceshare="false"></collaborator-list-item-stub>
     </li>
     <li data-v-5d17c3fa="">
-      <collaborator-list-item-stub data-v-5d17c3fa="" share="[object Object]" issharedenied="false" modifiable="true" removable="true" resourcename="[Function]" deniable="false" islocked="[Function]" isspaceshare="false"></collaborator-list-item-stub>
+      <collaborator-list-item-stub data-v-5d17c3fa="" share="[object Object]" issharedenied="false" modifiable="true" resourcename="[Function]" deniable="false" islocked="[Function]" isspaceshare="false"></collaborator-list-item-stub>
     </li>
     <portal-target data-v-5d17c3fa="" name="app.files.sidebar.sharing.shared-with.bottom" slot-props="[object Object]" multiple="true"></portal-target>
   </ul>
@@ -53,7 +53,7 @@ exports[`FileShares > current space > loads space members if a space is given an
   <portal-target data-v-5d17c3fa="" name="app.files.sidebar.sharing.shared-with.top" slot-props="[object Object]" multiple="true"></portal-target>
   <ul data-v-5d17c3fa="" id="files-collaborators-list" class="oc-list oc-list-divider oc-mb-l" aria-label="Share receivers">
     <li data-v-5d17c3fa="">
-      <collaborator-list-item-stub data-v-5d17c3fa="" share="[object Object]" issharedenied="false" modifiable="false" removable="false" resourcename="[Function]" deniable="false" islocked="[Function]" isspaceshare="false"></collaborator-list-item-stub>
+      <collaborator-list-item-stub data-v-5d17c3fa="" share="[object Object]" issharedenied="false" modifiable="false" resourcename="[Function]" deniable="false" islocked="[Function]" isspaceshare="false"></collaborator-list-item-stub>
     </li>
     <portal-target data-v-5d17c3fa="" name="app.files.sidebar.sharing.shared-with.bottom" slot-props="[object Object]" multiple="true"></portal-target>
   </ul>
@@ -63,10 +63,10 @@ exports[`FileShares > current space > loads space members if a space is given an
   </div>
   <ul data-v-5d17c3fa="" id="space-collaborators-list" class="oc-list oc-list-divider oc-overflow-hidden oc-m-rm" aria-label="Space members">
     <li data-v-5d17c3fa="">
-      <collaborator-list-item-stub data-v-5d17c3fa="" share="[object Object]" issharedenied="false" modifiable="false" removable="false" resourcename="[Function]" deniable="false" islocked="false" isspaceshare="true"></collaborator-list-item-stub>
+      <collaborator-list-item-stub data-v-5d17c3fa="" share="[object Object]" issharedenied="false" modifiable="false" resourcename="[Function]" deniable="false" islocked="false" isspaceshare="true"></collaborator-list-item-stub>
     </li>
     <li data-v-5d17c3fa="">
-      <collaborator-list-item-stub data-v-5d17c3fa="" share="[object Object]" issharedenied="false" modifiable="false" removable="false" resourcename="[Function]" deniable="false" islocked="false" isspaceshare="true"></collaborator-list-item-stub>
+      <collaborator-list-item-stub data-v-5d17c3fa="" share="[object Object]" issharedenied="false" modifiable="false" resourcename="[Function]" deniable="false" islocked="false" isspaceshare="true"></collaborator-list-item-stub>
     </li>
   </ul>
   <!--v-if-->


### PR DESCRIPTION
## Description

OCM shares editing was previously disabled due to missing backend implementation. That has been done in the meantime. We're dropping the separate canRemove prop and we are no longer checking for external shares in the canEdit prop.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/12201

## Motivation and Context

OCM shares can be edited again.

## How Has This Been Tested?

- test environment: chrome & 🤖 
- test case 1: add OCM share and try to change permission

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/364606be-db56-41b3-a641-ce74c8c0c175)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
