### PR TITLE
fix(pkg): prevent move of psec files

### DIFF
--- a/changelog/unreleased/bugfix-prevent-password-protected-folder-move.md
+++ b/changelog/unreleased/bugfix-prevent-password-protected-folder-move.md
@@ -1,0 +1,6 @@
+Bugfix: Prevent password protected folder move
+
+We've fixed permissions on password protected folders so that the name of the resource is checked and if it ends with `.psec`, it cannot be moved.
+
+https://github.com/owncloud/web/pull/12205
+https://github.com/owncloud/web/issues/12198

--- a/packages/web-pkg/src/helpers/permissions.ts
+++ b/packages/web-pkg/src/helpers/permissions.ts
@@ -1,4 +1,4 @@
-import { Resource } from '@ownclouders/web-client'
+import { isPasswordProtectedFolderFileResource, Resource } from '@ownclouders/web-client'
 
 /**
  * Asserts whether given resource can be moved
@@ -11,6 +11,10 @@ export function canBeMoved(resource: Resource, parentPath: string) {
   // TODO: Find a way to disable move action when shares are mounted in different folder then root
   const isExternal = resource.isReceivedShare() || resource.isMounted()
   const isMountedInRoot = parentPath === '' && isExternal
+
+  if (isPasswordProtectedFolderFileResource(resource.name)) {
+    return false
+  }
 
   return resource.canBeDeleted() && !isMountedInRoot
 }

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsMove.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsMove.spec.ts
@@ -13,12 +13,19 @@ describe('move', () => {
     describe('move isVisible property of returned element', () => {
       it.each([
         {
-          resources: [{ isReceivedShare: () => true, canBeDeleted: () => true }] as Resource[],
+          resources: [
+            { name: 'forest.jpg', isReceivedShare: () => true, canBeDeleted: () => true }
+          ] as Resource[],
           expectedStatus: true
         },
         {
           resources: [
-            { isReceivedShare: () => true, canBeDeleted: () => true, locked: true }
+            {
+              name: 'forest.jpg',
+              isReceivedShare: () => true,
+              canBeDeleted: () => true,
+              locked: true
+            }
           ] as Resource[],
           expectedStatus: false
         }

--- a/packages/web-pkg/tests/unit/helpers/permissions.spec.ts
+++ b/packages/web-pkg/tests/unit/helpers/permissions.spec.ts
@@ -4,10 +4,34 @@ import { canBeMoved } from '../../../src/helpers/permissions'
 describe('permissions helper', () => {
   describe('canBeMoved function', () => {
     it.each([
-      { isReceivedShare: false, isMounted: false, canBeDeleted: true, parentPath: '' },
-      { isReceivedShare: false, isMounted: false, canBeDeleted: true, parentPath: 'folder' },
-      { isReceivedShare: true, isMounted: false, canBeDeleted: true, parentPath: 'folder' },
-      { isReceivedShare: false, isMounted: true, canBeDeleted: true, parentPath: 'folder' }
+      {
+        name: 'forest.jpg',
+        isReceivedShare: false,
+        isMounted: false,
+        canBeDeleted: true,
+        parentPath: ''
+      },
+      {
+        name: 'forest.jpg',
+        isReceivedShare: false,
+        isMounted: false,
+        canBeDeleted: true,
+        parentPath: 'folder'
+      },
+      {
+        name: 'forest.jpg',
+        isReceivedShare: true,
+        isMounted: false,
+        canBeDeleted: true,
+        parentPath: 'folder'
+      },
+      {
+        name: 'forest.jpg',
+        isReceivedShare: false,
+        isMounted: true,
+        canBeDeleted: true,
+        parentPath: 'folder'
+      }
     ])(
       'should return true if the given resource can be deleted and if it is not mounted in root',
       (input) => {
@@ -16,6 +40,7 @@ describe('permissions helper', () => {
         expect(
           canBeMoved(
             {
+              name: input.name,
               isReceivedShare: () => input.isReceivedShare,
               isMounted: () => input.isMounted,
               canBeDeleted: () => input.canBeDeleted
@@ -26,19 +51,69 @@ describe('permissions helper', () => {
       }
     )
     it.each([
-      { isReceivedShare: false, isMounted: false, canBeDeleted: false, parentPath: '' },
-      { isReceivedShare: false, isMounted: false, canBeDeleted: false, parentPath: 'folder' },
-      { isReceivedShare: true, isMounted: false, canBeDeleted: false, parentPath: 'folder' },
-      { isReceivedShare: false, isMounted: true, canBeDeleted: false, parentPath: 'folder' },
-      { isReceivedShare: false, isMounted: true, canBeDeleted: true, parentPath: '' },
-      { isReceivedShare: true, isMounted: false, canBeDeleted: true, parentPath: '' },
-      { isReceivedShare: true, isMounted: true, canBeDeleted: true, parentPath: '' }
+      {
+        name: 'forest.jpg',
+        isReceivedShare: false,
+        isMounted: false,
+        canBeDeleted: false,
+        parentPath: ''
+      },
+      {
+        name: 'forest.jpg',
+        isReceivedShare: false,
+        isMounted: false,
+        canBeDeleted: false,
+        parentPath: 'folder'
+      },
+      {
+        name: 'forest.jpg',
+        isReceivedShare: true,
+        isMounted: false,
+        canBeDeleted: false,
+        parentPath: 'folder'
+      },
+      {
+        name: 'forest.jpg',
+        isReceivedShare: false,
+        isMounted: true,
+        canBeDeleted: false,
+        parentPath: 'folder'
+      },
+      {
+        name: 'forest.jpg',
+        isReceivedShare: false,
+        isMounted: true,
+        canBeDeleted: true,
+        parentPath: ''
+      },
+      {
+        name: 'forest.jpg',
+        isReceivedShare: true,
+        isMounted: false,
+        canBeDeleted: true,
+        parentPath: ''
+      },
+      {
+        name: 'forest.jpg',
+        isReceivedShare: true,
+        isMounted: true,
+        canBeDeleted: true,
+        parentPath: ''
+      },
+      {
+        name: 'forest.psec',
+        isReceivedShare: false,
+        isMounted: false,
+        canBeDeleted: true,
+        parentPath: ''
+      }
     ])(
       'should return false if the given resource cannot be deleted or if it is mounted in root',
       (input) => {
         expect(
           canBeMoved(
             {
+              name: input.name,
               isReceivedShare: () => input.isReceivedShare,
               isMounted: () => input.isMounted,
               canBeDeleted: () => input.canBeDeleted


### PR DESCRIPTION
## Description

To prevent moving password protected folders, check whether the resource is password protected folder and if yes, disable move.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/12198

## Motivation and Context

Only delete action is available for password protected folders.

## How Has This Been Tested?

- test environment: chrome & 🤖 
- test case 1: try to move psec file
- test case 2: try to move anything else


## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/5134dba5-8190-40ad-bd7f-5eea5d6ac2dc)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
