### PR TITLE
[tests-only][full-ci] retry logon until timeout if the server responds with 502

### DIFF
--- a/tests/e2e/cucumber/environment/index.ts
+++ b/tests/e2e/cucumber/environment/index.ts
@@ -120,16 +120,19 @@ After(async function (this: World, { result, willBeRetried, pickle }: ITestCaseH
 
   await this.actorsEnvironment.close()
 
+  const adminUser = this.usersEnvironment.getUser({ key: 'admin' })
+  await api.token.refreshAccessToken(adminUser)
+
   // refresh keycloak admin access token
   if (config.keycloak) {
-    const user = this.usersEnvironment.getUser({ key: 'admin' })
-    await api.keycloak.refreshAccessTokenForKeycloakUser(user)
-    await api.keycloak.refreshAccessTokenForKeycloakOcisUser(user)
+    await api.keycloak.refreshAccessTokenForKeycloakUser(adminUser)
+    await api.keycloak.refreshAccessTokenForKeycloakOcisUser(adminUser)
   }
 
   if (isOcm(pickle)) {
     // need to set federatedServer config to true to delete federated oCIS users
     config.federatedServer = true
+    await api.token.refreshAccessToken(adminUser)
     await cleanUpUser(store.federatedUserStore, this.usersEnvironment.getUser({ key: 'admin' }))
     config.federatedServer = false
   }

--- a/tests/e2e/cucumber/environment/index.ts
+++ b/tests/e2e/cucumber/environment/index.ts
@@ -121,12 +121,13 @@ After(async function (this: World, { result, willBeRetried, pickle }: ITestCaseH
   await this.actorsEnvironment.close()
 
   const adminUser = this.usersEnvironment.getUser({ key: 'admin' })
-  await api.token.refreshAccessToken(adminUser)
 
   // refresh keycloak admin access token
   if (config.keycloak) {
     await api.keycloak.refreshAccessTokenForKeycloakUser(adminUser)
     await api.keycloak.refreshAccessTokenForKeycloakOcisUser(adminUser)
+  } else {
+    await api.token.refreshAccessToken(adminUser)
   }
 
   if (isOcm(pickle)) {

--- a/tests/e2e/cucumber/features/admin-settings/users.feature
+++ b/tests/e2e/cucumber/features/admin-settings/users.feature
@@ -151,7 +151,7 @@ Feature: users management
       | user  |
       | David |
     When "Admin" deletes the following users using the batch actions
-      | id    |
+      | user  |
       | Alice |
       | Brian |
     And "Admin" deletes the following user using the context menu

--- a/tests/e2e/cucumber/steps/ui/adminSettings.ts
+++ b/tests/e2e/cucumber/steps/ui/adminSettings.ts
@@ -346,7 +346,7 @@ When(
     const userIds = []
     switch (actionType) {
       case 'batch actions':
-        for (const { id: user } of stepTable.hashes()) {
+        for (const { user } of stepTable.hashes()) {
           userIds.push(usersObject.getUUID({ key: user }))
           await usersObject.selectUser({ key: user })
         }

--- a/tests/e2e/support/api/graph/userManagement.ts
+++ b/tests/e2e/support/api/graph/userManagement.ts
@@ -46,15 +46,14 @@ export const createUser = async ({ user, admin }: { user: User; admin: User }): 
 }
 
 export const deleteUser = async ({ user, admin }: { user: User; admin: User }): Promise<User> => {
-  await request({
+  const response = await request({
     method: 'DELETE',
     path: join('graph', 'v1.0', 'users', user.id),
     user: admin
   })
-  try {
-    const usersEnvironment = new UsersEnvironment()
-    usersEnvironment.removeCreatedUser({ key: user.id })
-  } catch {}
+  checkResponseStatus(response, `Failed to delete user: ${user.id}`)
+  const usersEnvironment = new UsersEnvironment()
+  usersEnvironment.removeCreatedUser({ key: user.id })
   return user
 }
 

--- a/tests/e2e/support/api/graph/userManagement.ts
+++ b/tests/e2e/support/api/graph/userManagement.ts
@@ -51,7 +51,10 @@ export const deleteUser = async ({ user, admin }: { user: User; admin: User }): 
     path: join('graph', 'v1.0', 'users', user.id),
     user: admin
   })
-  checkResponseStatus(response, `Failed to delete user: ${user.id}`)
+  // do not throw error if user is not found
+  if (response.status !== 204 && response.status !== 404) {
+    throw Error(`Failed to delete user: ${user.id}, Status: ${response.status}`)
+  }
   const usersEnvironment = new UsersEnvironment()
   usersEnvironment.removeCreatedUser({ key: user.id })
   return user

--- a/tests/e2e/support/api/keycloak/user.ts
+++ b/tests/e2e/support/api/keycloak/user.ts
@@ -127,7 +127,10 @@ export const deleteUser = async ({ user, admin }: { user: User; admin: User }): 
     path: join(realmBasePath, 'users', keyclockUser.uuid),
     user: admin
   })
-  checkResponseStatus(response, 'Failed to delete keycloak user: ' + user.id)
+  // do not throw error if user is not found
+  if (response.status !== 204 && response.status !== 404) {
+    throw Error(`Failed to delete keycloak user: ${user.id}, Status: ${response.status}`)
+  }
   if (response.ok) {
     try {
       const usersEnvironment = new UsersEnvironment()

--- a/tests/e2e/support/api/token/index.ts
+++ b/tests/e2e/support/api/token/index.ts
@@ -1,1 +1,1 @@
-export { setAccessAndRefreshToken } from './utils'
+export * from './utils'

--- a/tests/e2e/support/api/token/utils.ts
+++ b/tests/e2e/support/api/token/utils.ts
@@ -1,7 +1,7 @@
+import fetch, { Response } from 'node-fetch'
 import { checkResponseStatus, request } from '../http'
 import { TokenEnvironmentFactory } from '../../environment'
 import { config } from '../../../config'
-import fetch, { Response } from 'node-fetch'
 import { User } from '../../types'
 
 const logonUrl = '/signin/v1/identifier/_/logon'
@@ -13,8 +13,8 @@ interface Token {
   refresh_token: string
 }
 
-const getAuthorizedEndPoint = async (user: User): Promise<Array<string>> => {
-  const logonResponse = await fetch(config.baseUrl + logonUrl, {
+const logonRequest = (username: string, password: string): Promise<Response> => {
+  return fetch(config.baseUrl + logonUrl, {
     method: 'POST',
     headers: {
       'Kopano-Konnect-XSRF': '1',
@@ -22,7 +22,7 @@ const getAuthorizedEndPoint = async (user: User): Promise<Array<string>> => {
       'Content-Type': 'application/json'
     },
     body: JSON.stringify({
-      params: [user.id, user.password, '1'],
+      params: [username, password, '1'],
       hello: {
         scope: 'openid profile email',
         client_id: 'web',
@@ -31,10 +31,31 @@ const getAuthorizedEndPoint = async (user: User): Promise<Array<string>> => {
       }
     })
   })
-  if (logonResponse.status !== 200) {
-    throw new Error(
-      `Logon failed: Expected status code be 200 but received ${logonResponse.status} Message: ${logonResponse.statusText}`
-    )
+}
+
+const getAuthorizedEndPoint = async (user: User): Promise<Array<string>> => {
+  const timeout = 5000 // 5 seconds timeout
+  const startTime = Date.now()
+  let retry = true
+  let logonResponse: Response
+
+  // server may return 502 Bad Gateway if the request is too early
+  // retry until timeout
+  while (retry) {
+    logonResponse = await logonRequest(user.id, user.password)
+    const elapsedTime = Date.now() - startTime
+    retry = elapsedTime < timeout
+
+    if (logonResponse.status === 502 && retry) {
+      console.info('[INFO] Failed with 502 Bad Gateway. Retrying logon request...')
+      // wait for 1 second before retrying
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+      continue
+    } else if (logonResponse.status !== 200) {
+      throw new Error(
+        `Logon failed: Expected status code be 200 but received ${logonResponse.status} Message: ${logonResponse.statusText}`
+      )
+    }
   }
 
   const cookies = logonResponse.headers.raw()['set-cookie']?.[0] || ''


### PR DESCRIPTION
## Description
The error https://github.com/owncloud/web/issues/11669 can occur if the request is too early, so I have added a retry mechanism with a timeout if that happens.

- Fix user deletion in after hook: refresh admin token before trying to delete user
- Retry logon if the server returns 502 

## Related Issue
- Fixes https://github.com/owncloud/web/issues/11669

## How Has This Been Tested?
- test environment: :raised_hands: 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
