### PR TITLE
chore: extend version bump script to sonar

### DIFF
--- a/dev/scripts/bump_versions.sh
+++ b/dev/scripts/bump_versions.sh
@@ -27,3 +27,23 @@ for app in "${apps[@]}"; do
 done
 
 echo "package.json files have been updated to version $NEW_VERSION"
+
+SONAR_PROPERTIES_FILE="sonar-project.properties"
+
+if [ ! -f "$SONAR_PROPERTIES_FILE" ]; then
+    echo "Error: $SONAR_PROPERTIES_FILE file not found!"
+    exit 1
+fi
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' "s/sonar\.projectVersion=[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*/sonar.projectVersion=$NEW_VERSION/" "$SONAR_PROPERTIES_FILE"
+else
+    sed -i "s/sonar\.projectVersion=[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*/sonar.projectVersion=$NEW_VERSION/" "$SONAR_PROPERTIES_FILE"
+fi
+
+if grep -q "sonar.projectVersion=$NEW_VERSION" "$SONAR_PROPERTIES_FILE"; then
+    echo "Sonar project version successfully updated to $NEW_VERSION"
+else
+    echo "Failed to update Sonar project version. Please check the file format."
+    exit 1
+fi


### PR DESCRIPTION
## Description

In the bump versions script, include also a script to bump the project version in sonar properties file.

## Motivation and Context

No need to do it manually - removes user error

## How Has This Been Tested?

- test environment: macOS + zsh
- test case 1: run the bump script and check the sonar properties file

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [x] Maintenance (e.g. dependency updates or tooling)
