### PR TITLE
[tests-only][full-ci] bump ocis stable-7.0 commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=d647c8ec1ca41ee6596a23851da7db91e31885e3
+OCIS_COMMITID=c5e4b0ee289df2b61da714e5dc0613788f9c2693
 OCIS_BRANCH=stable-7.0


### PR DESCRIPTION
## Description
This pr bumps commit id of ocis stable-7.0

## Related Issue
Part of: https://github.com/owncloud/QA/issues/877