### PR TITLE
bugfix: show correct window title when opening a public link

### DIFF
--- a/changelog/unreleased/bugfix-broken-title-for-public-files-link.md
+++ b/changelog/unreleased/bugfix-broken-title-for-public-files-link.md
@@ -1,0 +1,6 @@
+Bugfix: broken title for public files link
+
+We've fixed the issue of showing an incorrect/broken window title when user opens a public files link
+
+https://github.com/owncloud/web/pull/12225
+https://github.com/owncloud/web/issues/12220

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -282,9 +282,15 @@ export default defineComponent({
     const isCurrentFolderEmpty = computed(
       () => unref(resourcesViewDefaults.paginatedResources).length < 1
     )
+    const hasNoSpaceName = (spaceData: SpaceResource) => !unref(spaceData).name
 
     const titleSegments = computed(() => {
-      const segments = [unref(space).name]
+      const title =
+        isPublicSpaceResource(unref(space)) && hasNoSpaceName(unref(space))
+          ? $gettext('Public files')
+          : unref(space).name
+
+      const segments = [title]
       if (props.item !== '/') {
         segments.unshift(basename(props.item))
       }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Currently, the window title is incorrectly shown when user opens a public link.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/12220

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
