### PR TITLE
fix: disable psec creation in public links

### DIFF
--- a/changelog/unreleased/bugfix-disable-password-protected-folders-creation-inside-public-links.md
+++ b/changelog/unreleased/bugfix-disable-password-protected-folders-creation-inside-public-links.md
@@ -1,0 +1,6 @@
+Bugfix: Disable password protected folders creation inside public links
+
+We've disabled the option to create password protected folders creation inside of folders that are shared via a public link.
+
+https://github.com/owncloud/web/pull/12226
+https://github.com/owncloud/web/issues/12190

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -314,11 +314,15 @@ export default defineComponent({
 
     const createFileActionsGroups = computed(() => {
       const result = []
-      const externalFileActions = unref(createNewFileActions).filter(({ isExternal }) => isExternal)
+      const externalFileActions = unref(createNewFileActions).filter(
+        ({ isExternal, isVisible }) => isExternal && isVisible()
+      )
       if (externalFileActions.length) {
         result.push(externalFileActions)
       }
-      const appFileActions = unref(createNewFileActions).filter(({ isExternal }) => !isExternal)
+      const appFileActions = unref(createNewFileActions).filter(
+        ({ isExternal, isVisible }) => !isExternal && isVisible()
+      )
       if (appFileActions.length) {
         result.push(appFileActions)
       }

--- a/packages/web-app-files/tests/unit/components/AppBar/__snapshots__/CreateAndUpload.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/AppBar/__snapshots__/CreateAndUpload.spec.ts.snap
@@ -1,44 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`CreateAndUpload component > action buttons > should show and be enabled if file creation is possible 1`] = `
-"<div class="create-and-upload-actions oc-flex-inline oc-mr-s"><span><button type="button" aria-label="Create new files or folders" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-primary oc-button-primary-filled" id="new-file-menu-btn"><!--v-if--> <!-- @slot Content of the button --> <oc-icon-stub name="add" filltype="fill" accessiblelabel="" type="span" size="medium" variation="passive" color=""></oc-icon-stub> <span>New</span></button></span>
-  <oc-drop-stub dropid="new-file-menu-drop" popperoptions="[object Object]" toggle="#new-file-menu-btn" position="bottom-start" mode="click" closeonclick="true" isnested="false" paddingsize="small" class="oc-width-auto">
-    <oc-list-stub raw="false" id="create-list" class="">
-      <li class="create-list-folder oc-menu-item-hover"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-passive oc-button-passive-raw oc-width-1-1" id="new-folder-btn">
-          <!--v-if-->
-          <!-- @slot Content of the button -->
-          <resource-icon-stub resource="[object Object]" size="medium"></resource-icon-stub> <span>Folder</span>
-        </button></li>
-    </oc-list-stub>
-    <oc-list-stub raw="false">
-      <li class="create-list-file oc-menu-item-hover"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-passive oc-button-passive-raw oc-width-1-1 new-file-btn-txt">
-          <!--v-if-->
-          <!-- @slot Content of the button -->
-          <resource-icon-stub resource="[object Object]" size="medium"></resource-icon-stub> <span class="create-list-file-item-text">Plain text file</span>
-          <!--v-if-->
-        </button></li>
-      <li class="create-list-file oc-menu-item-hover"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-passive oc-button-passive-raw oc-width-1-1 new-file-btn-md">
-          <!--v-if-->
-          <!-- @slot Content of the button -->
-          <resource-icon-stub resource="[object Object]" size="medium"></resource-icon-stub> <span class="create-list-file-item-text">Mark-down file</span>
-          <!--v-if-->
-        </button></li>
-      <li class="create-list-file oc-menu-item-hover"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-passive oc-button-passive-raw oc-width-1-1 new-file-btn-drawio">
-          <!--v-if-->
-          <!-- @slot Content of the button -->
-          <resource-icon-stub resource="[object Object]" size="medium"></resource-icon-stub> <span class="create-list-file-item-text">Draw.io document</span>
-          <!--v-if-->
-        </button></li>
-    </oc-list-stub>
-    <oc-list-stub raw="false">
-      <li class="create-list-shortcut oc-menu-item-hover"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-passive oc-button-passive-raw oc-width-1-1" id="new-shortcut-btn">
-          <!--v-if-->
-          <!-- @slot Content of the button -->
-          <oc-icon-stub name="external-link" filltype="fill" accessiblelabel="" type="span" size="medium" variation="passive" color=""></oc-icon-stub> <span>Shortcut</span>
-          <!--v-if-->
-        </button></li>
-    </oc-list-stub>
-  </oc-drop-stub> <span><button type="button" aria-label="Upload files or folders" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-outline" id="upload-menu-btn"><!--v-if--> <!-- @slot Content of the button --> <oc-icon-stub name="upload" filltype="line" accessiblelabel="" type="span" size="medium" variation="passive" color=""></oc-icon-stub> <span>Upload</span></button></span>
+"<div class="create-and-upload-actions oc-flex-inline oc-mr-s"><span><button type="button" aria-label="New folder" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-primary oc-button-primary-filled" id="new-folder-btn"><!--v-if--> <!-- @slot Content of the button --> <oc-icon-stub name="resource-type-folder" filltype="fill" accessiblelabel="" type="span" size="medium" variation="passive" color=""></oc-icon-stub> <span>New Folder</span></button></span> <span><button type="button" aria-label="Upload files or folders" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-outline" id="upload-menu-btn"><!--v-if--> <!-- @slot Content of the button --> <oc-icon-stub name="upload" filltype="line" accessiblelabel="" type="span" size="medium" variation="passive" color=""></oc-icon-stub> <span>Upload</span></button></span>
   <oc-drop-stub dropid="upload-menu-drop" popperoptions="[object Object]" toggle="#upload-menu-btn" position="bottom-start" mode="click" closeonclick="true" isnested="false" paddingsize="small" class="oc-width-auto">
     <oc-list-stub raw="false" id="upload-list">
       <li class="oc-menu-item-hover">
@@ -55,44 +18,7 @@ exports[`CreateAndUpload component > action buttons > should show and be enabled
 `;
 
 exports[`CreateAndUpload component > file handlers > should show entries for all new file handlers 1`] = `
-"<div class="create-and-upload-actions oc-flex-inline oc-mr-s"><span><button type="button" aria-label="Create new files or folders" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-primary oc-button-primary-filled" id="new-file-menu-btn"><!--v-if--> <!-- @slot Content of the button --> <oc-icon-stub name="add" filltype="fill" accessiblelabel="" type="span" size="medium" variation="passive" color=""></oc-icon-stub> <span>New</span></button></span>
-  <oc-drop-stub dropid="new-file-menu-drop" popperoptions="[object Object]" toggle="#new-file-menu-btn" position="bottom-start" mode="click" closeonclick="true" isnested="false" paddingsize="small" class="oc-width-auto">
-    <oc-list-stub raw="false" id="create-list" class="">
-      <li class="create-list-folder oc-menu-item-hover"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-passive oc-button-passive-raw oc-width-1-1" id="new-folder-btn">
-          <!--v-if-->
-          <!-- @slot Content of the button -->
-          <resource-icon-stub resource="[object Object]" size="medium"></resource-icon-stub> <span>Folder</span>
-        </button></li>
-    </oc-list-stub>
-    <oc-list-stub raw="false">
-      <li class="create-list-file oc-menu-item-hover"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-passive oc-button-passive-raw oc-width-1-1 new-file-btn-txt">
-          <!--v-if-->
-          <!-- @slot Content of the button -->
-          <resource-icon-stub resource="[object Object]" size="medium"></resource-icon-stub> <span class="create-list-file-item-text">Plain text file</span>
-          <!--v-if-->
-        </button></li>
-      <li class="create-list-file oc-menu-item-hover"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-passive oc-button-passive-raw oc-width-1-1 new-file-btn-md">
-          <!--v-if-->
-          <!-- @slot Content of the button -->
-          <resource-icon-stub resource="[object Object]" size="medium"></resource-icon-stub> <span class="create-list-file-item-text">Mark-down file</span>
-          <!--v-if-->
-        </button></li>
-      <li class="create-list-file oc-menu-item-hover"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-passive oc-button-passive-raw oc-width-1-1 new-file-btn-drawio">
-          <!--v-if-->
-          <!-- @slot Content of the button -->
-          <resource-icon-stub resource="[object Object]" size="medium"></resource-icon-stub> <span class="create-list-file-item-text">Draw.io document</span>
-          <!--v-if-->
-        </button></li>
-    </oc-list-stub>
-    <oc-list-stub raw="false">
-      <li class="create-list-shortcut oc-menu-item-hover"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-m oc-button-passive oc-button-passive-raw oc-width-1-1" id="new-shortcut-btn">
-          <!--v-if-->
-          <!-- @slot Content of the button -->
-          <oc-icon-stub name="external-link" filltype="fill" accessiblelabel="" type="span" size="medium" variation="passive" color=""></oc-icon-stub> <span>Shortcut</span>
-          <!--v-if-->
-        </button></li>
-    </oc-list-stub>
-  </oc-drop-stub> <span><button type="button" aria-label="Upload files or folders" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-outline" id="upload-menu-btn"><!--v-if--> <!-- @slot Content of the button --> <oc-icon-stub name="upload" filltype="line" accessiblelabel="" type="span" size="medium" variation="passive" color=""></oc-icon-stub> <span>Upload</span></button></span>
+"<div class="create-and-upload-actions oc-flex-inline oc-mr-s"><span><button type="button" aria-label="New folder" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-primary oc-button-primary-filled" id="new-folder-btn"><!--v-if--> <!-- @slot Content of the button --> <oc-icon-stub name="resource-type-folder" filltype="fill" accessiblelabel="" type="span" size="medium" variation="passive" color=""></oc-icon-stub> <span>New Folder</span></button></span> <span><button type="button" aria-label="Upload files or folders" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-outline" id="upload-menu-btn"><!--v-if--> <!-- @slot Content of the button --> <oc-icon-stub name="upload" filltype="line" accessiblelabel="" type="span" size="medium" variation="passive" color=""></oc-icon-stub> <span>Upload</span></button></span>
   <oc-drop-stub dropid="upload-menu-drop" popperoptions="[object Object]" toggle="#upload-menu-btn" position="bottom-start" mode="click" closeonclick="true" isnested="false" paddingsize="small" class="oc-width-auto">
     <oc-list-stub raw="false" id="upload-list">
       <li class="oc-menu-item-hover">

--- a/packages/web-app-password-protected-folders/src/composables/useApplicationFileExtensions.ts
+++ b/packages/web-app-password-protected-folders/src/composables/useApplicationFileExtensions.ts
@@ -1,0 +1,20 @@
+import { PASSWORD_PROTECTED_FOLDER_FILE_EXTENSION } from '@ownclouders/web-pkg'
+import { useGettext } from 'vue3-gettext'
+import { shareType } from '../../../design-system/src/utils/shareType'
+import { useCustomHandler } from './useCustomHandler'
+
+export function useApplicationFileExtensions() {
+  const { $gettext } = useGettext()
+  const { customHandler } = useCustomHandler()
+
+  return [
+    {
+      newFileMenu: {
+        menuTitle: () => $gettext('Password Protected Folder'),
+        isVisible: ({ currentFolder }) => !currentFolder?.shareTypes?.includes(shareType.link)
+      },
+      extension: PASSWORD_PROTECTED_FOLDER_FILE_EXTENSION,
+      customHandler
+    }
+  ]
+}

--- a/packages/web-app-password-protected-folders/src/index.ts
+++ b/packages/web-app-password-protected-folders/src/index.ts
@@ -1,29 +1,20 @@
 import { useGettext } from 'vue3-gettext'
 import translations from '../l10n/translations.json'
-import {
-  defineWebApplication,
-  PASSWORD_PROTECTED_FOLDER_FILE_EXTENSION
-} from '@ownclouders/web-pkg'
+import { defineWebApplication } from '@ownclouders/web-pkg'
 import { useExtensions } from './composables/useExtensions'
-import { useCustomHandler } from './composables/useCustomHandler'
+import { useApplicationFileExtensions } from './composables/useApplicationFileExtensions'
 
 export default defineWebApplication({
   setup() {
     const { $gettext } = useGettext()
     const extensions = useExtensions()
-    const { customHandler } = useCustomHandler()
+    const applicationFileExtensions = useApplicationFileExtensions()
 
     return {
       appInfo: {
         name: $gettext('Password Protected Folders'),
         id: 'password-protected-folders',
-        extensions: [
-          {
-            newFileMenu: { menuTitle: () => $gettext('Password Protected Folder') },
-            extension: PASSWORD_PROTECTED_FOLDER_FILE_EXTENSION,
-            customHandler
-          }
-        ]
+        extensions: applicationFileExtensions
       },
       translations,
       extensions

--- a/packages/web-app-password-protected-folders/tests/unit/composables/useApplicationFileExtensions.spec.ts
+++ b/packages/web-app-password-protected-folders/tests/unit/composables/useApplicationFileExtensions.spec.ts
@@ -1,0 +1,49 @@
+import { defaultComponentMocks, getComposableWrapper } from '@ownclouders/web-test-helpers'
+import { mock } from 'vitest-mock-extended'
+import { Resource } from '@ownclouders/web-client'
+import { useApplicationFileExtensions } from '../../../src/composables/useApplicationFileExtensions'
+import { shareType } from '../../../../design-system/src/utils/shareType'
+
+describe('application file extensions', () => {
+  it('should hide the new file menu when the current folder is a link share', () => {
+    const currentFolder = mock<Resource>({ path: '/current/folder', shareTypes: [shareType.link] })
+    getWrapper({
+      setup(instance) {
+        expect(instance.at(0).newFileMenu.isVisible({ currentFolder })).toBe(false)
+      }
+    })
+  })
+
+  it('should not hide the new file menu when the current folder is not a link share', () => {
+    const currentFolder = mock<Resource>({ path: '/current/folder', shareTypes: [] })
+    getWrapper({
+      setup(instance) {
+        expect(instance.at(0).newFileMenu.isVisible({ currentFolder })).toBe(true)
+      }
+    })
+  })
+})
+
+function getWrapper({
+  setup
+}: {
+  setup: (
+    instance: ReturnType<typeof useApplicationFileExtensions>,
+    mocks: ReturnType<typeof defaultComponentMocks>
+  ) => void
+}) {
+  const mocks = defaultComponentMocks()
+
+  return {
+    wrapper: getComposableWrapper(
+      () => {
+        const instance = useApplicationFileExtensions()
+        setup(instance, mocks)
+      },
+      {
+        mocks,
+        provide: mocks
+      }
+    )
+  }
+}

--- a/packages/web-pkg/src/apps/types.ts
+++ b/packages/web-pkg/src/apps/types.ts
@@ -61,7 +61,10 @@ export interface ApplicationFileExtension {
   name?: string
   icon?: string
   mimeType?: string
-  newFileMenu?: { menuTitle: () => string }
+  newFileMenu?: {
+    menuTitle: () => string
+    isVisible?: ({ currentFolder }: { currentFolder: Resource }) => boolean
+  }
   routeName?: string
   secureView?: boolean
   customHandler?: (

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsCreateNewFile.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsCreateNewFile.spec.ts
@@ -82,6 +82,43 @@ describe('useFileActionsCreateNewFile', () => {
       })
     })
   })
+
+  describe('actions', () => {
+    it('should check if the new file menu is visible when the isVisible is a function', () => {
+      const isVisible = vi.fn().mockReturnValue(false)
+      const action = mock<ApplicationFileExtension>({
+        app: 'text-editor',
+        extension: '.txt',
+        newFileMenu: { menuTitle: vi.fn(), isVisible },
+        customHandler: null
+      })
+
+      getWrapper({
+        action,
+        setup(instance) {
+          expect(unref(instance.actions).at(0).isVisible()).toBe(false)
+          expect(isVisible).toHaveBeenCalled()
+        }
+      })
+    })
+
+    it('should not check if the new file menu is visible when the isVisible is not a function', () => {
+      const action = mock<ApplicationFileExtension>({
+        app: 'text-editor',
+        extension: '.txt',
+        newFileMenu: { menuTitle: vi.fn(), isVisible: undefined },
+        customHandler: null
+      })
+
+      getWrapper({
+        action,
+        currentFolder: mock<Resource>({ canUpload: () => true }),
+        setup(instance) {
+          expect(unref(instance.actions).at(0).isVisible()).toBe(true)
+        }
+      })
+    })
+  })
 })
 
 function getWrapper({
@@ -93,12 +130,14 @@ function getWrapper({
     extension: '.txt',
     newFileMenu: { menuTitle: vi.fn() },
     customHandler: null
-  })
+  }),
+  currentFolder = mock<Resource>({ id: '1', path: '/' })
 }: {
   resolveCreateFile?: boolean
   space?: SpaceResource
   setup: (instance: ReturnType<typeof useFileActionsCreateNewFile>) => void
   action?: ApplicationFileExtension
+  currentFolder?: Resource
 }) {
   const mocks = {
     ...defaultComponentMocks({
@@ -117,8 +156,6 @@ function getWrapper({
     }
     return Promise.reject('error')
   })
-
-  const currentFolder = mock<Resource>({ id: '1', path: '/' })
 
   return {
     wrapper: getComposableWrapper(


### PR DESCRIPTION
## Description

To prevent all kinds of issues with nested password protected folders, disable their creation inside of folders shared via public link.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/12190
- resolves https://github.com/owncloud/web/issues/12182

## Motivation and Context

Password protected folders are opened via public links. This mainly prevents creation of password protected folders within another password protected folder.

## How Has This Been Tested?

- test environment: chrome & 🤖 
- test case 1: open a password protected folder via the psec file and try to create a new one
- test case 2: open a password protected folder via its hidden folder and try to create a new one

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
