### PR TITLE
fix(pkg): make psec files clickable

### DIFF
--- a/changelog/unreleased/bugfix-make-password-protected-folder-tile-clickable.md
+++ b/changelog/unreleased/bugfix-make-password-protected-folder-tile-clickable.md
@@ -1,0 +1,6 @@
+Bugfix: Make password protected folder tile clickable
+
+We've fixed an issue where the password protected folder resource was not clickable when the files list is in "Tiles" view mode. Due to missing permissions on the resource, the click was disabled. We have added a new check that asserts whether the resource is a password protected folder and if yes, we allow the click.
+
+https://github.com/owncloud/web/pull/12227
+https://github.com/owncloud/web/issues/12193

--- a/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTiles.vue
@@ -126,7 +126,12 @@ import {
   watch
 } from 'vue'
 import { useGettext } from 'vue3-gettext'
-import { isSpaceResource, Resource, SpaceResource } from '@ownclouders/web-client'
+import {
+  isPasswordProtectedFolderFileResource,
+  isSpaceResource,
+  Resource,
+  SpaceResource
+} from '@ownclouders/web-client'
 
 // Constants should match what is being used in OcTable/ResourceTable
 // Alignment regarding naming would be an API-breaking change and can
@@ -342,7 +347,7 @@ export default defineComponent({
         return false
       }
 
-      if (resource.isFolder) {
+      if (resource.isFolder || isPasswordProtectedFolderFileResource(resource.name)) {
         return true
       }
 

--- a/packages/web-pkg/tests/unit/components/FilesList/ResourceTiles.spec.ts
+++ b/packages/web-pkg/tests/unit/components/FilesList/ResourceTiles.spec.ts
@@ -249,6 +249,68 @@ describe('ResourceTiles component', () => {
     )
   })
 
+  it('should make resource clickable when it is a password protected folder', async () => {
+    const { wrapper } = getWrapper({
+      props: {
+        resources: [
+          {
+            id: 'protected-folder',
+            driveId: 'protected-folder',
+            name: 'protected-folder.psec',
+            path: '/protected-folder.psec',
+            extension: 'psec',
+            isFolder: false,
+            indicators: [] as ResourceIndicator[],
+            type: 'file',
+            tags: ['space', 'tag', 'moon'],
+            size: '111000234',
+            hidden: false,
+            syncEnabled: true,
+            outgoing: false,
+            canRename: () => false,
+            getDomSelector: () => extractDomSelector('protected-folder'),
+            canDownload: () => false
+          }
+        ]
+      }
+    })
+
+    const resourceLink = wrapper.find('.oc-resource-link')
+    await resourceLink.trigger('click')
+
+    expect(wrapper.emitted('fileClick')).toBeTruthy()
+  })
+
+  it('should not make resource clickable when it is not a password protected folder and does not have enough permissions', () => {
+    const { wrapper } = getWrapper({
+      props: {
+        resources: [
+          {
+            id: 'forest',
+            driveId: 'forest',
+            name: 'forest.jpg',
+            path: 'images/nature/forest.jpg',
+            extension: 'jpg',
+            thumbnail: 'https://cdn.pixabay.com/photo/2015/09/09/16/05/forest-931706_960_720.jpg',
+            isFolder: false,
+            indicators: [] as ResourceIndicator[],
+            type: 'file',
+            tags: ['space', 'tag', 'moon'],
+            size: '111000234',
+            hidden: false,
+            syncEnabled: true,
+            outgoing: false,
+            canRename: false,
+            getDomSelector: () => extractDomSelector('forest'),
+            canDownload: () => false
+          }
+        ]
+      }
+    })
+
+    expect(wrapper.find('.oc-resource-link').exists()).toBeFalsy()
+  })
+
   function getWrapper({
     props = {},
     slots = {},


### PR DESCRIPTION
## Description

Due to missing permissions on the psec resource, check whether it is a password protected folder and then automatically allow it.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/12193

## Motivation and Context

Folder can be easily opened.

## How Has This Been Tested?

- test environment: chrome & 🤖 
- test case 1: in tiles view mode, click on psec file

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
