### PR TITLE
[tests-only][full-ci] harden weboffice tests

### DIFF
--- a/tests/e2e/cucumber/steps/ui/public.ts
+++ b/tests/e2e/cucumber/steps/ui/public.ts
@@ -68,18 +68,13 @@ Then(
 
 When(
   '{string} enters the text {string} in editor {string}',
-  async function (
-    this: World,
-    stepUser: string,
-    text: string,
-    editorToOpen: string
-  ): Promise<void> {
+  async function (this: World, stepUser: string, text: string, editor: string): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const pageObject = new objects.applicationFiles.page.Public({ page })
-    await pageObject.fillContentOfOpenDocumentOrMicrosoftWordDocument({
+    await pageObject.fillDocumentContent({
       page,
       text,
-      editorToOpen
+      editor
     })
   }
 )
@@ -90,13 +85,13 @@ When(
     this: World,
     stepUser: string,
     expectedContent: string,
-    editorToOpen: string
+    editor: string
   ): Promise<void> {
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
     const pageObject = new objects.applicationFiles.page.Public({ page })
-    const actualFileContent = await pageObject.getContentOfOpenDocumentOrMicrosoftWordDocument({
+    const actualFileContent = await pageObject.getDocumentContent({
       page,
-      editorToOpen
+      editor
     })
     expect(actualFileContent.trim()).toBe(expectedContent)
   }

--- a/tests/e2e/cucumber/steps/ui/resources.ts
+++ b/tests/e2e/cucumber/steps/ui/resources.ts
@@ -934,7 +934,7 @@ Then(
     const resourceObject = new objects.applicationFiles.Resource({ page })
 
     for (const info of stepTable.hashes()) {
-      const canEdit = await resourceObject.canEditContent({ type: info.type })
+      const canEdit = await resourceObject.canEditDocumentContent({ type: info.type })
       expect(canEdit).toBe(actionType === 'should')
     }
   }

--- a/tests/e2e/support/environment/actor/actor.ts
+++ b/tests/e2e/support/environment/actor/actor.ts
@@ -6,6 +6,11 @@ import { ActorOptions, buildBrowserContextOptions } from './shared'
 
 export class ActorEnvironment extends EventEmitter implements Actor {
   private readonly options: ActorOptions
+  private readonly localStorage: Record<string, any> = {
+    // disables copy-paste dialog in web office
+    clipboardApiAvailable: false
+  }
+
   public context: BrowserContext
   public page: Page
   public tabs: Page[] = []
@@ -32,6 +37,12 @@ export class ActorEnvironment extends EventEmitter implements Actor {
         expect(exception).not.toBeDefined()
       }
     })
+    // set local storage
+    await this.context.addInitScript((storage) => {
+      for (const [key, value] of Object.entries(storage)) {
+        localStorage.setItem(key, value)
+      }
+    }, this.localStorage)
   }
 
   public savePage(newPage: Page) {

--- a/tests/e2e/support/objects/app-files/page/public.ts
+++ b/tests/e2e/support/objects/app-files/page/public.ts
@@ -86,25 +86,19 @@ export class Public {
     await po.expectThatPublicLinkIsDeleted({ page: this.#page, url })
   }
 
-  async getContentOfOpenDocumentOrMicrosoftWordDocument({
-    page,
-    editorToOpen
-  }: {
-    page: Page
-    editorToOpen: string
-  }): Promise<string> {
-    return await po.openAndGetContentOfDocument({ page, editorToOpen })
+  async getDocumentContent({ page, editor }: { page: Page; editor: string }): Promise<string> {
+    return await po.getDocumentContent({ page, editor })
   }
 
-  async fillContentOfOpenDocumentOrMicrosoftWordDocument({
+  async fillDocumentContent({
     page,
     text,
-    editorToOpen
+    editor
   }: {
     page: Page
     text: string
-    editorToOpen: string
+    editor: string
   }): Promise<void> {
-    return await po.fillContentOfDocument({ page, text, editorToOpen })
+    return await po.fillDocumentContent({ page, text, editor })
   }
 }

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -449,6 +449,7 @@ export const fillDocumentContent = async ({
       throw new Error("Editor should be 'TextEditor' but found " + editor)
   }
 }
+
 export const getDocumentContent = async ({
   page,
   editor

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -224,7 +224,7 @@ export class Resource {
   }
 
   async editResource(args: Omit<po.editResourcesArgs, 'page'>): Promise<void> {
-    await po.editResources({ ...args, page: this.#page })
+    await po.editResource({ ...args, page: this.#page })
   }
 
   async openFileInViewer(args: Omit<po.openFileInViewerArgs, 'page'>): Promise<void> {
@@ -331,8 +331,8 @@ export class Resource {
     return await po.canManageResource({ ...args, page: this.#page })
   }
 
-  async canEditContent({ type }: { type: string }): Promise<boolean> {
-    return await po.canEditContent({ page: this.#page, type })
+  async canEditDocumentContent({ type }: { type: string }): Promise<boolean> {
+    return await po.canEditDocumentContent({ page: this.#page, type })
   }
 
   async getAllAvailableActions({ resource }: { resource: string }): Promise<string[]> {

--- a/tests/e2e/support/objects/app-files/resource/webOffice.ts
+++ b/tests/e2e/support/objects/app-files/resource/webOffice.ts
@@ -12,7 +12,6 @@ const onlyOfficeInnerFrameSelector = '[name="frameEditor"]'
 const onlyOfficeSaveButtonSelector = '#slot-btn-dt-save > button'
 const onlyofficeDocTextAreaSelector = '#area_id'
 const onlyOfficeCanvasEditorSelector = '#id_viewer_overlay'
-const copyPasteWarningPopup = '#copy_paste_warning-box'
 
 export const removeCollaboraWelcomeModal = async (page: Page) => {
   const editorMainFrame = page.frameLocator(externalEditorIframe)
@@ -50,6 +49,8 @@ export const focusOnlyOfficeEditor = async (page: Page) => {
 }
 
 export const getOfficeDocumentContent = async (page: Page) => {
+  // clear the clipboard
+  await page.evaluate("navigator.clipboard.writeText('')")
   // copying and getting the value with keyboard requires some time
   await page.keyboard.press('ControlOrMeta+A', { delay: 200 })
   await page.keyboard.press('ControlOrMeta+C', { delay: 200 })

--- a/tests/e2e/support/objects/app-files/resource/webOffice.ts
+++ b/tests/e2e/support/objects/app-files/resource/webOffice.ts
@@ -13,7 +13,7 @@ const onlyOfficeSaveButtonSelector = '#slot-btn-dt-save > button'
 const onlyofficeDocTextAreaSelector = '#area_id'
 const onlyOfficeCanvasEditorSelector = '#id_viewer_overlay'
 
-export const removeCollaboraWelcomeModal = async (page: Page) => {
+export const removeCollaboraWelcomeModal = async (page: Page): Promise<void> => {
   const editorMainFrame = page.frameLocator(externalEditorIframe)
   await editorMainFrame.locator('#document-header').waitFor()
   const versionSet = await editorMainFrame.locator('body').evaluate(() => {
@@ -25,30 +25,30 @@ export const removeCollaboraWelcomeModal = async (page: Page) => {
   }
 }
 
-export const waitForCollaboraEditor = async (page: Page) => {
+export const waitForCollaboraEditor = async (page: Page): Promise<void> => {
   const editorMainFrame = page.frameLocator(externalEditorIframe)
   await editorMainFrame.locator(collaboraDocTextAreaSelector).waitFor()
 }
 
-export const waitForOnlyOfficeEditor = async (page: Page) => {
+export const waitForOnlyOfficeEditor = async (page: Page): Promise<void> => {
   const editorMainFrame = page
     .frameLocator(externalEditorIframe)
     .frameLocator(onlyOfficeInnerFrameSelector)
   await editorMainFrame.locator(onlyofficeDocTextAreaSelector).waitFor()
 }
 
-export const focusCollaboraEditor = async (page: Page) => {
+export const focusCollaboraEditor = async (page: Page): Promise<void> => {
   const editorMainFrame = page.frameLocator(externalEditorIframe)
   await editorMainFrame.locator(collaboraCanvasEditorSelector).click()
 }
 
-export const focusOnlyOfficeEditor = async (page: Page) => {
+export const focusOnlyOfficeEditor = async (page: Page): Promise<void> => {
   const editorMainFrame = page.frameLocator(externalEditorIframe)
   const innerFrame = editorMainFrame.frameLocator(onlyOfficeInnerFrameSelector)
   await innerFrame.locator(onlyOfficeCanvasEditorSelector).click()
 }
 
-export const getOfficeDocumentContent = async (page: Page) => {
+export const getOfficeDocumentContent = async (page: Page): Promise<string> => {
   // clear the clipboard
   await page.evaluate("navigator.clipboard.writeText('')")
   // copying and getting the value with keyboard requires some time
@@ -57,7 +57,7 @@ export const getOfficeDocumentContent = async (page: Page) => {
   return page.evaluate(() => navigator.clipboard.readText())
 }
 
-export const fillCollaboraDocumentContent = async (page: Page, content: string) => {
+export const fillCollaboraDocumentContent = async (page: Page, content: string): Promise<void> => {
   await removeCollaboraWelcomeModal(page)
 
   const editorMainFrame = page.frameLocator(externalEditorIframe)
@@ -72,7 +72,7 @@ export const fillCollaboraDocumentContent = async (page: Page, content: string) 
   await page.waitForTimeout(500)
 }
 
-export const fillOnlyOfficeDocumentContent = async (page: Page, content: string) => {
+export const fillOnlyOfficeDocumentContent = async (page: Page, content: string): Promise<void> => {
   const editorMainFrame = page.frameLocator(externalEditorIframe)
   const innerIframe = editorMainFrame.frameLocator(onlyOfficeInnerFrameSelector)
   await innerIframe.locator(onlyofficeDocTextAreaSelector).focus()
@@ -82,7 +82,7 @@ export const fillOnlyOfficeDocumentContent = async (page: Page, content: string)
   await expect(saveButtonDisabledLocator).toHaveAttribute('disabled', 'disabled')
 }
 
-export const canEditCollaboraDocument = async (page: Page) => {
+export const canEditCollaboraDocument = async (page: Page): Promise<boolean> => {
   const editorMainFrame = page.frameLocator(externalEditorIframe)
   const collaboraDocPermissionModeLocator = editorMainFrame.locator(
     collaboraDocPermissionModeSelector
@@ -91,7 +91,7 @@ export const canEditCollaboraDocument = async (page: Page) => {
   return permissionMode === 'Edit'
 }
 
-export const canEditOnlyOfficeDocument = async (page: Page) => {
+export const canEditOnlyOfficeDocument = async (page: Page): Promise<boolean> => {
   const editorMainFrame = page.frameLocator(externalEditorIframe)
   const innerFrame = editorMainFrame.frameLocator(onlyOfficeInnerFrameSelector)
   try {

--- a/tests/e2e/support/objects/app-files/resource/webOffice.ts
+++ b/tests/e2e/support/objects/app-files/resource/webOffice.ts
@@ -53,18 +53,6 @@ export const getOfficeDocumentContent = async (page: Page) => {
   // copying and getting the value with keyboard requires some time
   await page.keyboard.press('ControlOrMeta+A', { delay: 200 })
   await page.keyboard.press('ControlOrMeta+C', { delay: 200 })
-  try {
-    const editorMainFrame = page.frameLocator(externalEditorIframe)
-    await editorMainFrame.locator(copyPasteWarningPopup).waitFor({ timeout: 1000 })
-    console.log('copy-paste warning popup found...')
-    // close popup
-    await page.keyboard.press('Escape')
-    // deselect text. otherwise the clipboard will be empty
-    await page.keyboard.press('Escape')
-    // select text again and copy text
-    await page.keyboard.press('ControlOrMeta+A', { delay: 200 })
-    await page.keyboard.press('ControlOrMeta+C', { delay: 200 })
-  } catch {}
   return page.evaluate(() => navigator.clipboard.readText())
 }
 

--- a/tests/e2e/support/objects/app-files/resource/webOffice.ts
+++ b/tests/e2e/support/objects/app-files/resource/webOffice.ts
@@ -26,6 +26,18 @@ export const removeCollaboraWelcomeModal = async (page: Page) => {
   }
 }
 
+export const waitForCollaboraEditor = async (page: Page) => {
+  const editorMainFrame = page.frameLocator(externalEditorIframe)
+  await editorMainFrame.locator(collaboraDocTextAreaSelector).waitFor()
+}
+
+export const waitForOnlyOfficeEditor = async (page: Page) => {
+  const editorMainFrame = page
+    .frameLocator(externalEditorIframe)
+    .frameLocator(onlyOfficeInnerFrameSelector)
+  await editorMainFrame.locator(onlyofficeDocTextAreaSelector).waitFor()
+}
+
 export const focusCollaboraEditor = async (page: Page) => {
   const editorMainFrame = page.frameLocator(externalEditorIframe)
   await editorMainFrame.locator(collaboraCanvasEditorSelector).click()

--- a/tests/e2e/support/objects/app-files/resource/webOffice.ts
+++ b/tests/e2e/support/objects/app-files/resource/webOffice.ts
@@ -1,0 +1,102 @@
+import { Page, expect } from '@playwright/test'
+
+const externalEditorIframe = '[name="app-iframe"]'
+// Collabora
+const collaboraDocPermissionModeSelector = '#permissionmode-container'
+const collaboraEditorSaveSelector = '.notebookbar-shortcuts-bar #save'
+const collaboraDocTextAreaSelector = '#clipboard-area'
+const collaboraWelcomeModal = '.iframe-welcome-modal'
+const collaboraCanvasEditorSelector = '.leaflet-layer'
+// OnlyOffice
+const onlyOfficeInnerFrameSelector = '[name="frameEditor"]'
+const onlyOfficeSaveButtonSelector = '#slot-btn-dt-save > button'
+const onlyofficeDocTextAreaSelector = '#area_id'
+const onlyOfficeCanvasEditorSelector = '#id_viewer_overlay'
+const copyPasteWarningPopup = '#copy_paste_warning-box'
+
+export const removeCollaboraWelcomeModal = async (page: Page) => {
+  const editorMainFrame = page.frameLocator(externalEditorIframe)
+  await editorMainFrame.locator('#document-header').waitFor()
+  const versionSet = await editorMainFrame.locator('body').evaluate(() => {
+    return localStorage.getItem('WSDWelcomeVersion')
+  })
+  if (!versionSet) {
+    await editorMainFrame.locator(collaboraWelcomeModal).waitFor()
+    await page.keyboard.press('Escape')
+  }
+}
+
+export const focusCollaboraEditor = async (page: Page) => {
+  const editorMainFrame = page.frameLocator(externalEditorIframe)
+  await editorMainFrame.locator(collaboraCanvasEditorSelector).click()
+}
+
+export const focusOnlyOfficeEditor = async (page: Page) => {
+  const editorMainFrame = page.frameLocator(externalEditorIframe)
+  const innerFrame = editorMainFrame.frameLocator(onlyOfficeInnerFrameSelector)
+  await innerFrame.locator(onlyOfficeCanvasEditorSelector).click()
+}
+
+export const getOfficeDocumentContent = async (page: Page) => {
+  // copying and getting the value with keyboard requires some time
+  await page.keyboard.press('ControlOrMeta+A', { delay: 200 })
+  await page.keyboard.press('ControlOrMeta+C', { delay: 200 })
+  try {
+    const editorMainFrame = page.frameLocator(externalEditorIframe)
+    await editorMainFrame.locator(copyPasteWarningPopup).waitFor({ timeout: 1000 })
+    console.log('copy-paste warning popup found...')
+    // close popup
+    await page.keyboard.press('Escape')
+    // deselect text. otherwise the clipboard will be empty
+    await page.keyboard.press('Escape')
+    // select text again and copy text
+    await page.keyboard.press('ControlOrMeta+A', { delay: 200 })
+    await page.keyboard.press('ControlOrMeta+C', { delay: 200 })
+  } catch {}
+  return page.evaluate(() => navigator.clipboard.readText())
+}
+
+export const fillCollaboraDocumentContent = async (page: Page, content: string) => {
+  await removeCollaboraWelcomeModal(page)
+
+  const editorMainFrame = page.frameLocator(externalEditorIframe)
+  await editorMainFrame.locator(collaboraDocTextAreaSelector).focus()
+  await page.keyboard.press('ControlOrMeta+A')
+  await editorMainFrame.locator(collaboraDocTextAreaSelector).fill(content)
+  const saveLocator = editorMainFrame.locator(collaboraEditorSaveSelector)
+  await expect(saveLocator).toHaveAttribute('class', /.*savemodified.*/)
+  await saveLocator.click()
+  await expect(saveLocator).not.toHaveAttribute('class', /.*savemodified.*/)
+  // allow the document to save
+  await page.waitForTimeout(500)
+}
+
+export const fillOnlyOfficeDocumentContent = async (page: Page, content: string) => {
+  const editorMainFrame = page.frameLocator(externalEditorIframe)
+  const innerIframe = editorMainFrame.frameLocator(onlyOfficeInnerFrameSelector)
+  await innerIframe.locator(onlyofficeDocTextAreaSelector).focus()
+  await page.keyboard.press('ControlOrMeta+A')
+  await innerIframe.locator(onlyofficeDocTextAreaSelector).fill(content)
+  const saveButtonDisabledLocator = innerIframe.locator(onlyOfficeSaveButtonSelector)
+  await expect(saveButtonDisabledLocator).toHaveAttribute('disabled', 'disabled')
+}
+
+export const canEditCollaboraDocument = async (page: Page) => {
+  const editorMainFrame = page.frameLocator(externalEditorIframe)
+  const collaboraDocPermissionModeLocator = editorMainFrame.locator(
+    collaboraDocPermissionModeSelector
+  )
+  const permissionMode = (await collaboraDocPermissionModeLocator.innerText()).trim()
+  return permissionMode === 'Edit'
+}
+
+export const canEditOnlyOfficeDocument = async (page: Page) => {
+  const editorMainFrame = page.frameLocator(externalEditorIframe)
+  const innerFrame = editorMainFrame.frameLocator(onlyOfficeInnerFrameSelector)
+  try {
+    await expect(innerFrame.locator(onlyOfficeSaveButtonSelector)).toBeVisible()
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Description
This PR hardens that weboffice e2e tests.
Notable changes:
- separate weboffice actions to own file
- use localStorage to disable some weboffice dialogs
- remove unnecessary try catch

## Related Issue

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
