### PR TITLE
fix: add password policies to psec

### DIFF
--- a/changelog/unreleased/bugfix-add-password-policies-to-password-protected-folders.md
+++ b/changelog/unreleased/bugfix-add-password-policies-to-password-protected-folders.md
@@ -1,0 +1,6 @@
+Bugfix: Add password policies to password protected folders
+
+We've added password policies to the password protected folders so that the creation of the folder does not fail with a generic error message and to prevent the user from even continuing with the creation of the folder if the password does not meet the policy.
+
+https://github.com/owncloud/web/pull/12240
+https://github.com/owncloud/web/issues/12223

--- a/packages/web-app-password-protected-folders/src/components/CreateFolderModal.vue
+++ b/packages/web-app-password-protected-folders/src/components/CreateFolderModal.vue
@@ -12,6 +12,7 @@
       type="password"
       :label="$gettext('Password')"
       class="oc-mt-s"
+      :password-policy="passwordPolicy"
     />
 
     <div class="oc-flex oc-flex-middle oc-mt-m">
@@ -32,6 +33,7 @@ import {
   LinkRoleDropdown,
   useLinkTypes,
   useMessages,
+  usePasswordPolicyService,
   useResourcesStore,
   useSpacesStore
 } from '@ownclouders/web-pkg'
@@ -51,6 +53,7 @@ const { createFileHandler } = useCreateFileHandler()
 const { currentFolder } = useResourcesStore()
 const { spaces, currentSpace } = useSpacesStore()
 const { defaultLinkType, getAvailableLinkTypes, getLinkRoleByType } = useLinkTypes()
+const passwordPolicyService = usePasswordPolicyService()
 
 const formData = reactive({
   folderName: '',
@@ -60,9 +63,15 @@ const formData = reactive({
 
 const folderNameError = ref('')
 
-const isFormValid = computed(() => formData.folderName !== '' && formData.password !== '')
+const isFormValid = computed(() => {
+  return formData.folderName !== '' && passwordPolicy.check(formData.password)
+})
 const availableLinkTypes = computed(() => getAvailableLinkTypes({ isFolder: true }))
 const selectedTypeIcon = computed(() => getLinkRoleByType(formData.selectedType).icon)
+
+const passwordPolicy = passwordPolicyService.getPolicy({
+  enforcePassword: true
+})
 
 const onConfirm = async () => {
   if (!unref(isFormValid)) {


### PR DESCRIPTION
## Description

Add password policies to the create password protected folder modal so that users are prevented from trying to create folders with invalid passwords.

## Related Issue

- refs https://github.com/owncloud/web/issues/12223

## Motivation and Context

Users are prevented from making an error.

## How Has This Been Tested?

- test environment: chrome
- test case 1: create a password protected folder

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/6956e4e0-da6c-41c8-b99c-52ea39536e0e)

![image](https://github.com/user-attachments/assets/9e91c5d1-cdc9-43bb-bfa3-991c7c440540)

![image](https://github.com/user-attachments/assets/ebd337bd-866a-41b8-92e7-2c59db55ca23)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
