### PR TITLE
fix(password-protected-folders): delete hidden folder when either link or file creation fails

### DIFF
--- a/changelog/unreleased/bugfix-revert-password-protected-folder-creation-on-error.md
+++ b/changelog/unreleased/bugfix-revert-password-protected-folder-creation-on-error.md
@@ -1,0 +1,6 @@
+Bugfix: Revert password protected folder creation on error
+
+We've fixed an issue where the hidden folder with password protected files was not being deleted in case of an error with link or file creation.
+
+https://github.com/owncloud/web/pull/12241
+https://github.com/owncloud/web/issues/12223


### PR DESCRIPTION
## Description

Hidden folder created during password protected folder gets deleted now in case its link or the psec file creation fails.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/12223

## Motivation and Context

There is no zombie folder left which prevents same name folder creation.

## How Has This Been Tested?

- test environment: chrome & 🤖 
- test case 1: create a folder with insufficient password

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
