### PR TITLE
bugfix: allow paste operation when destination folder is different fr…

### DIFF
--- a/changelog/unreleased/bugfix-disable-cutting-and-pasting-into-same-folder.md
+++ b/changelog/unreleased/bugfix-disable-cutting-and-pasting-into-same-folder.md
@@ -1,0 +1,6 @@
+Bugfix: Disable cutting and pasting into the same folder
+
+We've fixed the issue where users were allowed to cut and paste files into the same folder, either by clicking on the "Paste" button or by using keyboard paste shortcuts. This fix ensures that the paste operation is only allowed when the destination folder is different from the source folder, preventing invalid file operations.
+
+https://github.com/owncloud/web/pull/12265
+https://github.com/owncloud/web/issues/12021

--- a/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
+++ b/packages/web-app-files/src/components/AppBar/CreateAndUpload.vue
@@ -299,7 +299,7 @@ export default defineComponent({
 
     let uploadCompletedSub: string
 
-    const { actions: pasteFileActions } = useFileActionsPaste()
+    const { actions: pasteFileActions, isCuttingAndPastingIntoSameFolder } = useFileActionsPaste()
     const pasteFileAction = () => {
       return unref(pasteFileActions)[0].handler({ space: unref(space) })
     }
@@ -408,18 +408,8 @@ export default defineComponent({
       return !unref(canUpload)
     })
 
-    const isPastingIntoSameFolder = computed(() => {
-      if (!unref(clipboardResources) || unref(clipboardResources).length < 1) {
-        return false
-      }
-
-      return !unref(clipboardResources).some(
-        (resource) => resource.parentFolderId !== unref(currentFolder).id
-      )
-    })
-
     const isPasteHereButtonDisabled = computed(() => {
-      return unref(uploadOrFileCreationBlocked) || unref(isPastingIntoSameFolder)
+      return unref(uploadOrFileCreationBlocked) || unref(isCuttingAndPastingIntoSameFolder)
     })
 
     const pasteHereButtonTooltip = computed(() => {
@@ -427,8 +417,8 @@ export default defineComponent({
         return $gettext('You have no permission to paste files here.')
       }
 
-      if (unref(isPastingIntoSameFolder)) {
-        return $gettext('You cannot paste resources into the same folder.')
+      if (unref(isCuttingAndPastingIntoSameFolder)) {
+        return $gettext('You cannot cut and paste resources into the same folder.')
       }
 
       return ''

--- a/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.ts
+++ b/packages/web-app-files/tests/unit/components/AppBar/CreateAndUpload.spec.ts
@@ -107,12 +107,14 @@ describe('CreateAndUpload component', () => {
     })
     it('should disable the "paste files"-action when clipboardResources are from same folder', () => {
       const { wrapper } = getWrapper({
+        isCuttingAndPastingIntoSameFolder: true,
         clipboardResources: [mock<Resource>({ parentFolderId: 'current-folder' })],
         currentFolder: mock<Resource>({
           id: 'current-folder',
           canUpload: vi.fn().mockReturnValue(true)
         })
       })
+
       expect(
         wrapper.findComponent<typeof OcButton>(elSelector.pasteFilesBtn).vm.disabled
       ).toStrictEqual(true)
@@ -198,6 +200,7 @@ function getWrapper({
   itemId = undefined,
   newFileAction = false,
   areFileExtensionsShown = false,
+  isCuttingAndPastingIntoSameFolder = false,
   createActions = [
     mock<FileAction>({ label: () => 'Plain text file', ext: 'txt' }),
     mock<FileAction>({ label: () => 'Mark-down file', ext: 'md' }),
@@ -214,6 +217,7 @@ function getWrapper({
   newFileAction?: boolean
   areFileExtensionsShown?: boolean
   createActions?: FileAction[]
+  isCuttingAndPastingIntoSameFolder?: boolean
 } = {}) {
   const capabilities = {
     spaces: { enabled: true },
@@ -242,7 +246,12 @@ function getWrapper({
   const pasteActionHandler = vi.fn()
   vi.mocked(useFileActionsPaste).mockReturnValue(
     mock<ReturnType<typeof useFileActionsPaste>>({
-      actions: ref([mock<FileAction>({ handler: pasteActionHandler })])
+      isCuttingAndPastingIntoSameFolder: ref(isCuttingAndPastingIntoSameFolder),
+      actions: ref([
+        mock<FileAction>({
+          handler: pasteActionHandler
+        })
+      ])
     })
   )
 


### PR DESCRIPTION
allow paste operation when destination folder is different from source folder

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- Fixes https://github.com/owncloud/web/issues/12021

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
