### PR TITLE
fix(web-pkg): pass generate link password method as callback

### DIFF
--- a/changelog/unreleased/bugfix-generate-public-link-password-on-click.md
+++ b/changelog/unreleased/bugfix-generate-public-link-password-on-click.md
@@ -1,0 +1,5 @@
+Bugfix: Generate public link password on click
+
+We've fixed an issue where the password input was not generating a new password on click. The generate method was directly called instead of being passed as a callback.
+
+https://github.com/owncloud/web/pull/12266

--- a/packages/web-pkg/src/components/CreateLinkModal.vue
+++ b/packages/web-pkg/src/components/CreateLinkModal.vue
@@ -35,7 +35,7 @@
       :model-value="password.value"
       type="password"
       :password-policy="passwordPolicy"
-      :generate-password-method="passwordPolicyService.generatePassword()"
+      :generate-password-method="() => passwordPolicyService.generatePassword()"
       :error-message="password.error"
       :label="passwordEnforced ? `${$gettext('Password')}*` : $gettext('Password')"
       class="link-modal-password-input"


### PR DESCRIPTION
## Description

Directly calling the generate method caused the new password being passed instead of the method as callback. Also, needs to be passed using arrow function. Otherwise it looses the password rules.

## Motivation and Context

Users can generate passwords again.

## How Has This Been Tested?

- test environment: chrome
- test case 1: generate password when creating new link
- test case 2: generate password when editing existing link

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
