### PR TITLE
fix(web-app-password-protected-folders): add password generator

### DIFF
--- a/changelog/unreleased/bugfix-add-password-generator-into-password-protected-folders.md
+++ b/changelog/unreleased/bugfix-add-password-generator-into-password-protected-folders.md
@@ -1,0 +1,5 @@
+Bugfix: Add password generator into password protected folders
+
+We've added a password generator into the password protected folders modal. This allows users to generate a new password if they want to.
+
+https://github.com/owncloud/web/pull/12270

--- a/packages/web-app-password-protected-folders/src/components/CreateFolderModal.vue
+++ b/packages/web-app-password-protected-folders/src/components/CreateFolderModal.vue
@@ -13,6 +13,7 @@
       :label="$gettext('Password')"
       class="oc-mt-s"
       :password-policy="passwordPolicy"
+      :generate-password-method="() => passwordPolicyService.generatePassword()"
     />
 
     <div class="oc-flex oc-flex-middle oc-mt-m">


### PR DESCRIPTION
## Description

Add missing generate password method.

## Motivation and Context

Users can generate passwords instead of typing them manually.

## How Has This Been Tested?

- test environment: chrome
- test case 1: generate password when creating password protected folder

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/40a5a2d3-f9e5-402b-82dd-d370e5a9c330)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
