### PR TITLE
bugfix: create only one space/folder when user presses enter on modal

### DIFF
--- a/changelog/unreleased/bugfix-two-spaces-are-created-on-enter.md
+++ b/changelog/unreleased/bugfix-two-spaces-are-created-on-enter.md
@@ -1,0 +1,6 @@
+Bugfix: Two spaces are created at the same time when user tries to create a space
+
+This bugfix addresses an issue where pressing the Enter key in a modal to create a space or folder results in the creation of two spaces or folders instead of just one. The fix ensures that only a single space or folder is created when the Enter key is pressed.
+
+https://github.com/owncloud/web/pull/12297
+https://github.com/owncloud/web/issues/12276

--- a/packages/design-system/src/components/OcModal/OcModal.vue
+++ b/packages/design-system/src/components/OcModal/OcModal.vue
@@ -48,7 +48,7 @@
               :fix-message-line="true"
               :selection-range="inputSelectionRange"
               @update:model-value="inputOnInput"
-              @keydown.enter.prevent="confirm"
+              @enter-key-down="confirm"
             />
           </template>
         </div>

--- a/packages/design-system/src/components/OcTextInput/OcTextInput.vue
+++ b/packages/design-system/src/components/OcTextInput/OcTextInput.vue
@@ -32,6 +32,7 @@
         @password-challenge-completed="$emit('passwordChallengeCompleted')"
         @password-challenge-failed="$emit('passwordChallengeFailed')"
         @focus="onFocus($event.target)"
+        @keydown.enter="$emit('enterKeyDown')"
       />
       <oc-button
         v-if="showClearButton"
@@ -128,6 +129,7 @@ import { useGettext } from 'vue3-gettext'
  * @emits focus - Emitted when the input field is focused.
  * @emits passwordChallengeCompleted - Emitted when the password challenge is completed.
  * @emits passwordChallengeFailed - Emitted when the password challenge fails.
+ * @emits enterKeyDown - Emitted when enter key is pressed.
  */
 
 interface Props {
@@ -154,6 +156,7 @@ interface Emits {
   (e: 'focus', value: string): void
   (e: 'passwordChallengeCompleted'): void
   (e: 'passwordChallengeFailed'): void
+  (e: 'enterKeyDown'): void
 }
 
 defineOptions({


### PR DESCRIPTION
This bugfix addresses an issue where pressing the Enter key in a modal to create a space or folder results in the creation of two spaces or folders instead of just one. The fix ensures that only a single space or folder is created when the Enter key is pressed.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/12276

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
