### PR TITLE
[tests-only][full-ci] bump ocis commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=84a91b3ad713c2fe3d1bef8397136dbdc0a21ab7
+OCIS_COMMITID=027ffc822714232f0af0a2b409e9740a0cb0b4fe
 OCIS_BRANCH=master


### PR DESCRIPTION

## Description
This pr bumps latest commit id of ocis master.

## Related Issue
Part of: https://github.com/owncloud/QA/issues/879