### PR TITLE
[full-ci][tests-only] use manual elements drag-n-drop in the tests

### DIFF
--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -1022,7 +1022,7 @@ export const moveOrCopyResource = async (args: moveOrCopyResourceArgs): Promise<
             resp.status() === 201 &&
             resp.request().method() === 'MOVE'
         ),
-        source.dragTo(target)
+        utils.dragTo(page, source, target)
       ])
 
       await Promise.all([

--- a/tests/e2e/support/utils/dragDrop.ts
+++ b/tests/e2e/support/utils/dragDrop.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs'
-import { Page } from '@playwright/test'
+import { Locator, Page } from '@playwright/test'
 
 interface File {
   name: string
@@ -11,6 +11,7 @@ interface FileBuffer {
   bufferString: string
 }
 
+// drag and drop local files to a target element
 export const dragDropFiles = async (page: Page, resources: File[], targetSelector: string) => {
   const files = resources.map((file) => ({
     name: file.name,
@@ -34,4 +35,16 @@ export const dragDropFiles = async (page: Page, resources: File[], targetSelecto
     },
     [files, targetSelector]
   )
+}
+
+// drag and drop a element to another element
+export const dragTo = async (page: Page, sourceLocator: Locator, destinationLocator: Locator) => {
+  // playwright 'dragTo' can be flaky sometimes
+  // https://playwright.dev/docs/api/class-locator#locator-drag-to
+
+  // perform drag and drop manually
+  await sourceLocator.hover()
+  await page.mouse.down()
+  await destinationLocator.hover()
+  await page.mouse.up()
 }


### PR DESCRIPTION
## Description
Replacing playwright `dragTo` with a function that does the drag-n-drop manually.

I ran the tests with and without the fix and the manual one didn't show any failure whereas the tests can fail with the in-built `dragTo` function.

## Related Issue
- Fixes https://github.com/owncloud/web/issues/12233

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- test environment: :raised_back_of_hand: 

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
