### PR TITLE
fix: drop links advanced mode

### DIFF
--- a/changelog/unreleased/bugfix-do-not-reveal-generated-password.md
+++ b/changelog/unreleased/bugfix-do-not-reveal-generated-password.md
@@ -1,0 +1,6 @@
+Bugfix: Do not reveal generated password
+
+We've stopped revealing passwords in the password input when user clicks on the generate action. In order to preview the password, the user needs to click on the eye icon inside the input.
+
+https://github.com/owncloud/web/pull/12326
+https://github.com/owncloud/web/issues/12275

--- a/changelog/unreleased/bugfix-drop-advanced-mode-when-creating-links.md
+++ b/changelog/unreleased/bugfix-drop-advanced-mode-when-creating-links.md
@@ -1,0 +1,6 @@
+Bugfix: Drop advanced mode when creating links
+
+We've removed the advanced mode in the create public link dialog and we show the password and expiration date fields directly.
+
+https://github.com/owncloud/web/pull/12326
+https://github.com/owncloud/web/issues/12275

--- a/packages/design-system/src/components/OcTextInput/OcTextInput.spec.ts
+++ b/packages/design-system/src/components/OcTextInput/OcTextInput.spec.ts
@@ -69,12 +69,19 @@ describe('OcTextInput', () => {
       }
     }
 
-    return mount(OcTextInput, {
+    const wrapper = mount(OcTextInput, {
       ...options,
+      props: {
+        'onUpdate:modelValue': (e) => wrapper.setProps({ modelValue: e }),
+        modelValue: '',
+        ...options.props
+      },
       global: {
         plugins: [...defaultPlugins()]
       }
     })
+
+    return wrapper
   }
 
   const selectors = {
@@ -413,11 +420,8 @@ describe('OcTextInput', () => {
 
       await btn.trigger('click')
 
-      // value as data is supposed to be `null`
       expect(wrapper.emitted('update:modelValue')[0][0]).toEqual(null)
-      // value in DOM would be the empty string if two way binding was used
-      // by just passing in the value it should remain unchanged
-      expect((input.element as HTMLInputElement).value).toEqual('non-empty-value')
+      expect((input.element as HTMLInputElement).value).toEqual('')
       expect(document.activeElement.id).toBe(input.element.id)
     })
   })

--- a/packages/design-system/src/components/OcTextInput/__snapshots__/OcTextInput.spec.ts.snap
+++ b/packages/design-system/src/components/OcTextInput/__snapshots__/OcTextInput.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`OcTextInput > password input field > password policy > displays error s
 "<div class=""><label class="oc-label" for="oc-textinput-24">label</label>
   <div class="oc-position-relative">
     <!--v-if-->
-    <div class="oc-text-input-password-wrapper"><input id="oc-textinput-24" aria-invalid="false" class="oc-text-input oc-input oc-rounded" type="password"> <button type="button" aria-label="Show password" class="oc-button oc-rounded oc-button-s oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-text-input-show-password-toggle oc-px-s oc-background-default">
+    <div class="oc-text-input-password-wrapper"><input id="oc-textinput-24" aria-invalid="false" class="oc-text-input oc-input oc-rounded" type="password" value="pass"> <button type="button" aria-label="Show password" class="oc-button oc-rounded oc-button-s oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-text-input-show-password-toggle oc-px-s oc-background-default">
         <!--v-if-->
         <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span>
       </button> <button type="button" aria-label="Copy password" class="oc-button oc-rounded oc-button-s oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-text-input-copy-password-button oc-px-s oc-background-default">
@@ -31,7 +31,7 @@ exports[`OcTextInput > password input field > password policy > displays success
 "<div class=""><label class="oc-label" for="oc-textinput-25">label</label>
   <div class="oc-position-relative">
     <!--v-if-->
-    <div class="oc-text-input-password-wrapper"><input id="oc-textinput-25" aria-invalid="false" class="oc-text-input oc-input oc-rounded" type="password"> <button type="button" aria-label="Show password" class="oc-button oc-rounded oc-button-s oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-text-input-show-password-toggle oc-px-s oc-background-default">
+    <div class="oc-text-input-password-wrapper"><input id="oc-textinput-25" aria-invalid="false" class="oc-text-input oc-input oc-rounded" type="password" value="password123"> <button type="button" aria-label="Show password" class="oc-button oc-rounded oc-button-s oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-text-input-show-password-toggle oc-px-s oc-background-default">
         <!--v-if-->
         <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span>
       </button> <button type="button" aria-label="Copy password" class="oc-button oc-rounded oc-button-s oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-text-input-copy-password-button oc-px-s oc-background-default">

--- a/packages/web-pkg/src/components/CreateLinkModal.vue
+++ b/packages/web-pkg/src/components/CreateLinkModal.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="oc-flex oc-button-justify-content-space-between oc-pb-s">
-    <div v-if="isAdvancedMode" class="oc-flex oc-flex-middle">
+    <div class="oc-flex oc-flex-middle">
       <oc-icon class="oc-mr-s" :name="selectedTypeIcon" fill-type="line" />
       <link-role-dropdown
         :model-value="selectedType"
@@ -8,29 +8,9 @@
         @update:model-value="updateSelectedLinkType"
       />
     </div>
-    <div v-else class="oc-flex oc-flex-middle">
-      <oc-icon class="oc-mr-s" :name="selectedTypeIcon" fill-type="line" />
-      <div class="oc-flex oc-flex-column">
-        <span class="oc-text-bold" v-text="selectedTypeDisplayName" />
-        <span class="oc-text-small" v-text="selectedTypeDescription" />
-      </div>
-    </div>
-    <oc-button
-      v-if="!isAdvancedMode"
-      class="link-modal-advanced-mode-button"
-      gap-size="xsmall"
-      appearance="raw"
-      variation="primary"
-      data-testid="modal-advanced-mode-button"
-      @click="setAdvancedMode()"
-    >
-      <oc-icon name="settings-3" size="small" fill-type="fill" />
-      <span v-text="$gettext('Options')" />
-    </oc-button>
   </div>
   <div class="link-modal-password oc-mb-m">
     <oc-text-input
-      v-if="isAdvancedMode"
       :key="passwordInputKey"
       :model-value="password.value"
       type="password"
@@ -41,12 +21,7 @@
       class="link-modal-password-input"
       @update:model-value="updatePassword"
     />
-    <div v-else-if="password.value" class="link-modal-password-text oc-text-small oc-text-muted">
-      <span v-text="$gettext('Password:')" />
-      <span v-text="password.value" />
-    </div>
     <oc-datepicker
-      v-if="isAdvancedMode"
       class="oc-mt-s"
       :min-date="DateTime.now()"
       :label="$gettext('Expiry date')"
@@ -156,7 +131,6 @@ const { isEnabled: isEmbedEnabled, postMessage } = useEmbedMode()
 const { defaultLinkType, getAvailableLinkTypes, getLinkRoleByType, isPasswordEnforcedForLinkType } =
   useLinkTypes()
 const { addLink } = useSharesStore()
-const isAdvancedMode = ref(false)
 const isInvalidExpiryDate = ref(false)
 
 const isFolder = computed(() => resources.every(({ isFolder }) => isFolder))
@@ -176,14 +150,6 @@ const selectedExpiry = ref<DateTime>()
 const password = reactive({ value: '', error: undefined })
 const selectedType = ref(unref(defaultLinkType))
 
-const selectedTypeDescription = computed(() =>
-  $gettext(getLinkRoleByType(unref(selectedType)).description)
-)
-
-const selectedTypeDisplayName = computed(() =>
-  $gettext(getLinkRoleByType(unref(selectedType)).displayName)
-)
-
 const selectedTypeIcon = computed(() => getLinkRoleByType(unref(selectedType)).icon)
 
 const availableLinkTypes = computed(() => getAvailableLinkTypes({ isFolder: unref(isFolder) }))
@@ -192,10 +158,6 @@ const passwordEnforced = computed(() => isPasswordEnforcedForLinkType(unref(sele
 const passwordPolicy = passwordPolicyService.getPolicy({
   enforcePassword: unref(passwordEnforced)
 })
-
-const setAdvancedMode = () => {
-  isAdvancedMode.value = true
-}
 
 const onExpiryDateChanged = ({ date, error }: { date: DateTime; error: boolean }) => {
   selectedExpiry.value = date
@@ -276,9 +238,6 @@ const onConfirm = async (options: { copyPassword?: boolean } = {}) => {
 
 defineExpose({ onConfirm })
 
-const isSelectedLinkType = (type: SharingLinkType) => {
-  return unref(selectedType) === type
-}
 const updatePassword = (value: string) => {
   password.value = value
   password.error = undefined
@@ -295,7 +254,7 @@ onMounted(() => {
   }
 
   if (unref(passwordEnforced)) {
-    password.value = passwordPolicyService.generatePassword()
+    updatePassword(passwordPolicyService.generatePassword())
   }
 })
 </script>

--- a/packages/web-pkg/tests/unit/components/CreateLinkModal.spec.ts
+++ b/packages/web-pkg/tests/unit/components/CreateLinkModal.spec.ts
@@ -12,7 +12,7 @@ import { AbilityRule, LinkShare, Resource, ShareRole, SpaceResource } from '@own
 import { PasswordPolicy } from '@ownclouders/design-system/helpers'
 import { useEmbedMode } from '../../../src/composables/embedMode'
 import { useLinkTypes } from '../../../src/composables/links'
-import { nextTick, ref } from 'vue'
+import { ref } from 'vue'
 import { CapabilityStore, Modal, useSharesStore } from '../../../src/composables/piniaStores'
 import { SharingLinkType } from '@ownclouders/web-client/graph/generated'
 import { describe } from 'vitest'
@@ -30,64 +30,26 @@ const selectors = {
   contextMenuToggle: '#link-modal-context-menu-toggle',
   confirmBtn: '.link-modal-confirm',
   cancelBtn: '.link-modal-cancel',
-  linkRoleDropDownToggle: '.link-role-dropdown-toggle',
-  modalAdvancedModeButton: '[data-testid="modal-advanced-mode-button"]'
+  linkRoleDropDownToggle: '.link-role-dropdown-toggle'
 }
 
 describe('CreateLinkModal', () => {
   describe('password input', () => {
-    it('should not rendered when "isAdvancedMode" is not set', async () => {
+    it('should be rendered', () => {
       const { wrapper } = getWrapper()
-      await nextTick()
-      expect(wrapper.find(selectors.passwordInput).exists()).toBeFalsy()
-    })
-    it('should be rendered', async () => {
-      const { wrapper } = getWrapper()
-      wrapper.find(selectors.modalAdvancedModeButton).trigger('click')
-      await nextTick()
       expect(wrapper.find(selectors.passwordInput).exists()).toBeTruthy()
-    })
-    it('should not be rendered if user cannot create public links', () => {
-      const { wrapper } = getWrapper({
-        userCanCreatePublicLinks: false,
-        availableLinkTypes: [],
-        defaultLinkType: SharingLinkType.View
-      })
-      expect(wrapper.find(selectors.passwordInput).exists()).toBeFalsy()
     })
   })
   describe('datepicker', () => {
-    it('should not rendered when "isAdvancedMode" is not set', async () => {
+    it('should be rendered', () => {
       const { wrapper } = getWrapper()
-      await nextTick()
-      expect(wrapper.findComponent({ name: 'oc-datepicker' }).exists()).toBeFalsy()
-    })
-    it('should be rendered', async () => {
-      const { wrapper } = getWrapper()
-      wrapper.find(selectors.modalAdvancedModeButton).trigger('click')
-      await nextTick()
       expect(wrapper.findComponent({ name: 'oc-datepicker' }).exists()).toBeTruthy()
-    })
-    it('should not be rendered if user cannot create public links', () => {
-      const { wrapper } = getWrapper({
-        userCanCreatePublicLinks: false,
-        availableLinkTypes: [],
-        defaultLinkType: SharingLinkType.View
-      })
-      expect(wrapper.findComponent({ name: 'oc-datepicker' }).exists()).toBeFalsy()
     })
   })
   describe('link role drop', () => {
-    it('should not rendered when "isAdvancedMode" is not set', async () => {
-      const { wrapper } = getWrapper()
-      await nextTick()
-      expect(wrapper.find(selectors.linkRoleDropDownToggle).exists()).toBeFalsy()
-    })
     it('lists all types as roles', async () => {
       const availableLinkTypes = [SharingLinkType.View, SharingLinkType.Edit]
       const { wrapper } = getWrapper({ availableLinkTypes })
-      wrapper.find(selectors.modalAdvancedModeButton).trigger('click')
-      await nextTick()
       await wrapper.find(selectors.linkRoleDropDownToggle).trigger('click')
 
       expect(wrapper.findAll(selectors.roleElements).length).toBe(availableLinkTypes.length)
@@ -138,8 +100,6 @@ describe('CreateLinkModal', () => {
     describe('confirm button', () => {
       it('is disabled when password policy is not fulfilled', async () => {
         const { wrapper } = getWrapper({ passwordPolicyFulfilled: false })
-        wrapper.find(selectors.modalAdvancedModeButton).trigger('click')
-        await nextTick()
         expect(wrapper.find(selectors.confirmBtn).attributes('disabled')).toBeTruthy()
       })
     })

--- a/tests/e2e/support/objects/app-files/link/actions.ts
+++ b/tests/e2e/support/objects/app-files/link/actions.ts
@@ -96,7 +96,6 @@ const copyPasswordButton = '.oc-text-input-copy-password-button'
 const generatePasswordButton = '.oc-text-input-generate-password-button'
 const expectedRegexForGeneratedPassword = /^[A-Za-z0-9\s\S]{12}$/
 const passwordInputDescription = '.oc-text-input-description .oc-text-input-description'
-const advancedModeButton = '.link-modal-advanced-mode-button'
 const copyLinkButton =
   '//span[contains(@class, "files-links-name") and text()="%s"]//ancestor::li//button[contains(@class, "oc-files-public-link-copy-url")]'
 
@@ -122,7 +121,6 @@ export const createLink = async (args: createLinkArgs): Promise<string> => {
     await sidebar.openPanel({ page: page, name: 'sharing' })
   }
   await page.locator(addPublicLinkButton).click()
-  await page.locator(advancedModeButton).click()
 
   if (role) {
     await page.locator(publicLinkRoleToggle).click()


### PR DESCRIPTION
## Description

Drop the advanced mode and display password and expiration fields immediately. Also, stop revealing password inside of the password input after generating a password.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/12275

## Motivation and Context

Streamlined process and secure password generation

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: chrome & 🤖 
- test case 1: create new public link
- test case 2: generate password

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/f05eef64-5645-4b5e-a457-762bb51020a0)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
