### PR TITLE
fix: delete psec file when deleting password protected folder

### DIFF
--- a/changelog/unreleased/bugfix-delete-psec-file.md
+++ b/changelog/unreleased/bugfix-delete-psec-file.md
@@ -1,0 +1,6 @@
+Bugfix: Delete .psec file
+
+We've extended the deletion of resources to also delete `.psec` file when deleting its related folder in personal space. The deletion works only when the user has delete permissions on that `.psec` file and if the folder and path and name still match.
+
+https://github.com/owncloud/web/pull/12329
+https://github.com/owncloud/web/issues/12273

--- a/packages/web-app-password-protected-folders/README.md
+++ b/packages/web-app-password-protected-folders/README.md
@@ -28,6 +28,7 @@ Users can create password-protected folders by following these steps:
 1. The target folder for the PPF is ALWAYS created as **subfolder** mirroring the original path of the link folder in a hidden folder located in the root of the private space of the PPF creator. This means he normally does not see the target folder except if showing hidden files is enabled in his private space. Do not change or delete this folder unless you know what you are doing.
 1. The link file and target folder have the same name.
 1. If the **owner** of the PPF deletes the **link file**, it also deletes the target folder with its content automatically.
+1. If the **owner** of the PPF deletes the parent **folder(s)** containing the **link file**, it deletes the link file and related data automatically.
 1. The deletion of a PPF moves the link file and the target folder into the respective trashbin of the space.
 
 ## Considerations

--- a/packages/web-pkg/src/composables/piniaStores/spaces.ts
+++ b/packages/web-pkg/src/composables/piniaStores/spaces.ts
@@ -264,6 +264,11 @@ export const useSpacesStore = defineStore('spaces', () => {
     addSpaces(projectSpaces)
   }
 
+  const getSpacesByName = (name: string): SpaceResource[] => {
+    const matchingSpaces = unref(spaces).filter((s) => s.name === name)
+    return matchingSpaces
+  }
+
   return {
     spaces,
     spacesInitialized,
@@ -287,7 +292,8 @@ export const useSpacesStore = defineStore('spaces', () => {
     updateSpaceField,
     loadSpaces,
     loadMountPoints,
-    reloadProjectSpaces
+    reloadProjectSpaces,
+    getSpacesByName
   }
 })
 


### PR DESCRIPTION
## Description

Delete `.psec` file if it still matches path and name of the hidden folder.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/12273

## Motivation and Context

No zombie files

## How Has This Been Tested?

- test environment: chrome & 🤖 
- test case 1: Create password protected folder in space and then delete the actual folder

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
