### PR TITLE
fix: handle shares loading error

### DIFF
--- a/changelog/unreleased/bugfix-handle-shares-loading-error.md
+++ b/changelog/unreleased/bugfix-handle-shares-loading-error.md
@@ -1,0 +1,6 @@
+Bugfix: Handle shares loading error
+
+Display error message instead of showing the loader infinitely when we encounter an error during shares or space members loading.
+
+https://github.com/owncloud/web/pull/12336
+https://github.com/owncloud/ocis/issues/11119

--- a/packages/design-system/src/styles/theme/oc-text.scss
+++ b/packages/design-system/src/styles/theme/oc-text.scss
@@ -193,6 +193,10 @@ td.oc-text-break {
   color: var(--oc-color-text-muted);
 }
 
+.oc-text-danger {
+  color: var(--oc-color-swatch-danger-default)
+}
+
 /*
  * Transform text to all uppercase
  */

--- a/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
@@ -1,6 +1,12 @@
 <template>
   <div>
     <oc-loader v-if="sharesLoading" :aria-label="$gettext('Loading list of shares')" />
+    <div v-else-if="hasSharesLoadingFailed" class="oc-text-center oc-pt-xl">
+      <oc-icon name="group" variation="danger" size="xxlarge" />
+      <p class="oc-text-danger">
+        {{ errorMessage }}
+      </p>
+    </div>
     <template v-else>
       <space-members v-if="showSpaceMembers" class="oc-background-highlight oc-p-m oc-mb-s" />
       <file-shares v-else class="oc-background-highlight oc-p-m oc-mb-s" />
@@ -9,32 +15,37 @@
   </div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue'
+<script setup lang="ts">
+import { computed, unref } from 'vue'
 import FileLinks from './FileLinks.vue'
 import FileShares from './FileShares.vue'
 import SpaceMembers from './SpaceMembers.vue'
 import { useSharesStore } from '@ownclouders/web-pkg'
 import { storeToRefs } from 'pinia'
+import { useGettext } from 'vue3-gettext'
 
-export default defineComponent({
-  name: 'SharesPanel',
-  components: {
-    FileLinks,
-    FileShares,
-    SpaceMembers
-  },
-  props: {
-    showSpaceMembers: { type: Boolean, default: false },
-    showLinks: { type: Boolean, default: false }
-  },
-  setup() {
-    const sharesStore = useSharesStore()
-    const { loading: sharesLoading } = storeToRefs(sharesStore)
+defineOptions({ name: 'SharesPanel' })
 
-    return {
-      sharesLoading
-    }
+const { showSpaceMembers = false, showLinks = false } = defineProps<{
+  showSpaceMembers?: boolean
+  showLinks?: boolean
+}>()
+
+const { $gettext } = useGettext()
+
+const sharesStore = useSharesStore()
+const { loading: sharesLoading, hasLoadingFailed: hasSharesLoadingFailed } =
+  storeToRefs(sharesStore)
+
+const errorMessage = computed(() => {
+  if (!unref(hasSharesLoadingFailed)) {
+    return ''
   }
+
+  if (unref(showSpaceMembers)) {
+    return $gettext('Loading members failed. Try again later.')
+  }
+
+  return $gettext('Loading shares failed. Try again later.')
 })
 </script>

--- a/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
+++ b/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
@@ -27,6 +27,7 @@ export const useSharesStore = defineStore('shares', () => {
   const collaboratorShares = ref<CollaboratorShare[]>([]) as Ref<CollaboratorShare[]>
   const linkShares = ref<LinkShare[]>([]) as Ref<LinkShare[]>
   const graphRoles = ref<Record<string, ShareRole>>({}) as Ref<Record<string, ShareRole>>
+  const hasLoadingFailed = ref(false)
 
   const setGraphRoles = (values: UnifiedRoleDefinition[]) => {
     graphRoles.value = values.reduce<Record<string, ShareRole>>((acc, role) => {
@@ -269,6 +270,10 @@ export const useSharesStore = defineStore('shares', () => {
     updateFileShareTypes(resource.id)
   }
 
+  const setHasLoadingFailed = (value: boolean) => {
+    hasLoadingFailed.value = value
+  }
+
   return {
     loading,
     collaboratorShares,
@@ -288,7 +293,10 @@ export const useSharesStore = defineStore('shares', () => {
 
     addLink,
     updateLink,
-    deleteLink
+    deleteLink,
+
+    hasLoadingFailed,
+    setHasLoadingFailed
   }
 })
 


### PR DESCRIPTION
## Description

Add try catch to handle the error and display an error message instead of infinite loader.

## Related Issue

- refs https://github.com/owncloud/ocis/issues/11119

## Motivation and Context

Users know that the loading failed.

## How Has This Been Tested?

- test environment: chrome
- test case 1: Trigger an error during shares load

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/c7478993-f647-475a-b088-9ed5a70a1def)

![image](https://github.com/user-attachments/assets/13befe24-c2f5-4675-a16f-64d79e2e3b31)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
