### PR TITLE
deps(web-test-helpers): drop pinia

### DIFF
--- a/packages/web-test-helpers/package.json
+++ b/packages/web-test-helpers/package.json
@@ -40,8 +40,8 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "5.2.1",
     "clean-publish": "^5.0.0",
-    "vite-plugin-dts": "^4.2.3",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vite-plugin-dts": "^4.2.3"
   },
   "dependencies": {
     "@casl/ability": "^6.7.1",
@@ -50,7 +50,6 @@
     "@ownclouders/web-client": "workspace:^",
     "@pinia/testing": "^1.0.0",
     "axios": "1.8.3",
-    "pinia": "3.0.1",
     "vitest-mock-extended": "3.0.1",
     "vue-router": "4.2.5",
     "vue3-gettext": "2.4.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1176,9 +1176,6 @@ importers:
       axios:
         specifier: 1.8.3
         version: 1.8.3
-      pinia:
-        specifier: 3.0.1
-        version: 3.0.1(typescript@5.8.2)(vue@3.5.13(typescript@5.8.2))
       vitest-mock-extended:
         specifier: 3.0.1
         version: 3.0.1(typescript@5.8.2)(vitest@3.0.8(@types/node@22.13.10)(happy-dom@17.4.4)(jsdom@26.0.0)(sass@1.85.1)(terser@5.39.0)(yaml@2.7.0))


### PR DESCRIPTION
## Description

Since pinia in tests has been replaced with @pinia/testing, it seems that we no longer need the pinia dependency itself.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/12096

## Motivation and Context

No unused deps.

## How Has This Been Tested?

- test environment: 🤖 
- test case 1: run unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [x] Maintenance (e.g. dependency updates or tooling)
