### PR TITLE
chore: fix SASS round function deprecation

### DIFF
--- a/packages/design-system/src/components/OcButton/OcButton.vue
+++ b/packages/design-system/src/components/OcButton/OcButton.vue
@@ -200,7 +200,7 @@ export default defineComponent({
 
 <style lang="scss">
 @mixin oc-button-gap($factor) {
-  gap: round(calc($oc-space-small * $factor / 2)) * 2;
+  gap: math.round(calc($oc-space-small * $factor / 2)) * 2;
 }
 
 @mixin oc-button-line-height($factor) {

--- a/packages/design-system/src/components/OcSpinner/OcSpinner.vue
+++ b/packages/design-system/src/components/OcSpinner/OcSpinner.vue
@@ -56,8 +56,8 @@ export default defineComponent({
 
 <style lang="scss">
 @mixin oc-spinner-size($factor) {
-  height: round(calc($oc-size-icon-default * $factor / 2)) * 2;
-  width: round(calc($oc-size-icon-default * $factor / 2)) * 2;
+  height: math.round(calc($oc-size-icon-default * $factor / 2)) * 2;
+  width: math.round(calc($oc-size-icon-default * $factor / 2)) * 2;
 }
 
 .oc-spinner {

--- a/packages/design-system/vite.config.ts
+++ b/packages/design-system/vite.config.ts
@@ -10,7 +10,10 @@ export default defineConfig({
   css: {
     preprocessorOptions: {
       scss: {
-        additionalData: `@import "${projectRootDir}/packages/design-system/src/styles/styles";`,
+        additionalData: `
+          @use "sass:math";
+          @import "${projectRootDir}/packages/design-system/src/styles/styles";
+        `,
         silenceDeprecations: ['legacy-js-api', 'import']
       }
     }

--- a/packages/web-pkg/vite.config.ts
+++ b/packages/web-pkg/vite.config.ts
@@ -17,7 +17,10 @@ export default defineConfig({
   css: {
     preprocessorOptions: {
       scss: {
-        additionalData: `@import "${projectRootDir}/packages/design-system/src/styles/styles";`,
+        additionalData: `
+          @use "sass:math";
+          @import "${projectRootDir}/packages/design-system/src/styles/styles";
+        `,
         silenceDeprecations: ['legacy-js-api', 'import']
       }
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -174,7 +174,10 @@ export default defineConfig(({ mode, command }) => {
       css: {
         preprocessorOptions: {
           scss: {
-            additionalData: `@import "${projectRootDir}/packages/design-system/src/styles/styles";${stripScssMarker}`,
+            additionalData: `
+              @use "sass:math";
+              @import "${projectRootDir}/packages/design-system/src/styles/styles";${stripScssMarker}
+            `,
             silenceDeprecations: ['legacy-js-api', 'import']
           }
         }


### PR DESCRIPTION
## Description

Replace SASS `round` function with the correct `math.round` to keep using the SASS function.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/12314

## Motivation and Context

No deprecation warnings and consistent functions usage.

## How Has This Been Tested?

- test environment: 🤖 
- test case 1: Run `pnpm build`

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [x] Maintenance (e.g. dependency updates or tooling)
