### PR TITLE
[docs-only] ci: whitelist docs-only PRs in changelog

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -6,6 +6,7 @@ updateDocsComment: >
 
 updateDocsWhiteList:
   - Tests-only
+  - docs-only
 
 updateDocsTargetFiles:
   - changelog/unreleased/


### PR DESCRIPTION
## Description

Added `docs-only` tag into the changelog whitelist.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/10353

## Motivation and Context

We are not adding changelog items for docs

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [x] Maintenance (e.g. dependency updates or tooling)
