### PR TITLE
[tests-only][full-ci] bump ocis commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=39fe52d0fb0c59e4584cafe5c045deedd3bed32e
+OCIS_COMMITID=819b80b80245921bbb5d7c2c33447034bc513cf1
 OCIS_BRANCH=master


### PR DESCRIPTION
## Description
This pr bumps latest commit id of ocis master.

## Related Issue
Part of: https://github.com/owncloud/QA/issues/880