### PR TITLE
[tests-only][full-ci] bump ocis stable-7.1 commit-id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=051ad98d46ae662e49e25f3ab4b7271e5b15b559
+OCIS_COMMITID=f0ff233027fa2a9fe5b3ef9d8f6b0cd8480aa1fe
 OCIS_BRANCH=stable-7.1


### PR DESCRIPTION
## Description
This pr bumps latest commit id of ocis stable-7.1 branch.

## Related Issue
Part of: https://github.com/owncloud/QA/issues/880