### PR TITLE
Fix sorting in spaces view may crash the application

### DIFF
--- a/changelog/unreleased/bugfix-order-spaces-in-project-view
+++ b/changelog/unreleased/bugfix-order-spaces-in-project-view
@@ -1,0 +1,5 @@
+Bugfix: Fix sorting in spaces view that may crash the application
+
+Fixed a bug where the project/spaces view crashed when orderd by quota items.
+
+https://github.com/owncloud/web/pull/12351

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -323,7 +323,12 @@ export default defineComponent({
     const items = computed(() =>
       orderBy(
         filter(unref(spaces), unref(filterTerm)),
-        [(item: SpaceResource) => item[unref(sortBy)].toLowerCase()],
+        [
+          (item: SpaceResource) =>
+            typeof item[unref(sortBy)] === 'string'
+              ? item[unref(sortBy)].toLowerCase()
+              : item[unref(sortBy)]
+        ],
         unref(sortDir)
       )
     )


### PR DESCRIPTION
## Description
The order by function is broken in spaces view. Just go here: https://demo.owncloud.com/ and to spaces and try to sort via any quota. it breaks the view.

**Fix**: Test if value a string before committing it the toLowerCase function.

Please merge asap, because alot of user have a broken view when using the orderby in the spaces view. Thank you.