### PR TITLE
fix(web-pkg): move path tooltip to parent folder

### DIFF
--- a/changelog/unreleased/bugfix-show-path-tooltip-on-parent-folder.md
+++ b/changelog/unreleased/bugfix-show-path-tooltip-on-parent-folder.md
@@ -1,0 +1,6 @@
+Bugfix: Show path tooltip on parent folder
+
+Instead of displaying tooltip with resource path while hovering/focusing on the resource, display it on parent folder with parent folder path.
+
+https://github.com/owncloud/web/pull/12356
+https://github.com/owncloud/web/issues/7776

--- a/packages/web-pkg/src/components/FilesList/ResourceListItem.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceListItem.vue
@@ -39,7 +39,6 @@
         <resource-name
           :key="resource.name"
           :name="resource.name"
-          :path-prefix="pathPrefix"
           :extension="resource.extension"
           :type="resource.type"
           :full-path="resource.path"
@@ -53,6 +52,7 @@
         <component
           :is="parentFolderComponentType"
           v-if="isPathDisplayed"
+          v-oc-tooltip="parentFolderPathTooltip"
           :to="parentFolderLink"
           :style="parentFolderStyle"
           class="parent-folder oc-text-truncate"
@@ -65,13 +65,14 @@
   </div>
 </template>
 <script lang="ts">
-import { defineComponent, PropType } from 'vue'
+import { computed, defineComponent, PropType } from 'vue'
 import { Resource } from '@ownclouders/web-client'
 import ResourceIcon from './ResourceIcon.vue'
 import ResourceLink from './ResourceLink.vue'
 import ResourceName from './ResourceName.vue'
 import { RouteLocationRaw } from 'vue-router'
 import { HIDDEN_FILE_EXTENSIONS } from '../../constants'
+import { dirname, join } from 'node:path'
 /**
  * Displays a resource together with the resource type icon or thumbnail
  */
@@ -169,8 +170,22 @@ export default defineComponent({
   },
   emits: ['click'],
 
-  setup() {
-    return { HIDDEN_EXTENSIONS: HIDDEN_FILE_EXTENSIONS }
+  setup(props) {
+    const parentFolderPathTooltip = computed(() => {
+      if (!props.isPathDisplayed) {
+        return null
+      }
+
+      const parentFolderPath = dirname(props.resource.path)
+
+      if (props.pathPrefix) {
+        return join(props.pathPrefix, parentFolderPath).replaceAll('/', ' > ')
+      }
+
+      return parentFolderPath.replaceAll('/', ' > ')
+    })
+
+    return { HIDDEN_EXTENSIONS: HIDDEN_FILE_EXTENSIONS, parentFolderPathTooltip }
   },
 
   computed: {

--- a/packages/web-pkg/src/components/FilesList/ResourceName.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceName.vue
@@ -1,6 +1,5 @@
 <template>
   <span
-    v-oc-tooltip="tooltip"
     class="oc-resource-name"
     :class="[{ 'oc-display-inline-block': !truncateName }]"
     :data-test-resource-path="fullPath"
@@ -21,7 +20,6 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue'
-import path from 'path'
 
 export default defineComponent({
   name: 'ResourceName',
@@ -32,14 +30,6 @@ export default defineComponent({
     name: {
       type: String,
       required: true
-    },
-    /**
-     * The prefix that will be shown in the path
-     */
-    pathPrefix: {
-      type: String,
-      required: false,
-      default: ''
     },
     /**
      * The extension of the resource, if there is one
@@ -90,10 +80,6 @@ export default defineComponent({
   },
 
   computed: {
-    tooltip() {
-      return this.pathTooltip
-    },
-
     fullName() {
       return (this.displayPath || '') + this.name
     },
@@ -123,24 +109,7 @@ export default defineComponent({
       return `…/${pathSplit[pathSplit.length - 2]}/`
     },
 
-    pathTooltip() {
-      if (!this.isPathDisplayed) {
-        return null
-      }
-      if (this.displayPath === this.fullPath) {
-        return null
-      }
-      if (this.pathPrefix) {
-        return path.join(this.pathPrefix, this.fullPath)
-      }
-      return this.fullPath
-    },
-
     htmlTitle() {
-      if (this.tooltip) {
-        return
-      }
-
       if (this.isExtensionDisplayed) {
         return `${this.displayName}${this.displayExtension}`
       }

--- a/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceListItem.spec.ts.snap
+++ b/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceListItem.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`OcResource > displays parent folder name default if calculated name is 
   </button>
   <div class="oc-resource-details oc-text-overflow oc-pl-s"><button target="_self" type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-undefined oc-button-passive oc-button-passive-raw oc-resource-link oc-text-overflow" draggable="false">
       <!--v-if-->
-      <!-- @slot Content of the button --> <span class="oc-resource-name" data-test-resource-path="example.pdf" data-test-resource-name="example.pdf" data-test-resource-type="file"><span class="oc-text-truncate"><span class="oc-resource-basename">example</span></span><span class="oc-resource-extension">.pdf</span></span>
+      <!-- @slot Content of the button --> <span class="oc-resource-name" data-test-resource-path="example.pdf" data-test-resource-name="example.pdf" data-test-resource-type="file" title="example.pdf"><span class="oc-text-truncate"><span class="oc-resource-basename">example</span></span><span class="oc-resource-extension">.pdf</span></span>
     </button>
     <div class="oc-resource-indicators"><span style="cursor: default;" class="parent-folder oc-text-truncate"><span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="text oc-text-truncate">Example parent folder name</span></span></div>
   </div>

--- a/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceName.spec.ts.snap
+++ b/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceName.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`OcResourceName > does not show the name as HTML title if the path is being displayed 1`] = `
-"<span class="oc-resource-name" data-test-resource-path="folder" data-test-resource-name="folder" data-test-resource-type="folder"><span class="oc-text-truncate"><span class="oc-resource-basename">folder</span></span>
+"<span class="oc-resource-name" data-test-resource-path="folder" data-test-resource-name="folder" data-test-resource-type="folder" title="folder"><span class="oc-text-truncate"><span class="oc-resource-basename">folder</span></span>
 <!--v-if--></span>"
 `;
 


### PR DESCRIPTION
## Description

Instead of showing the path tooltip on the actual resource, show it on the parent folder using its path as a content.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/7776

## How Has This Been Tested?

- test environment: chrome
- test case 1: hover on the resource and on its parent folder

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/df5f2a29-4be7-495f-82f6-f2ff215dcef6)

![image](https://github.com/user-attachments/assets/c699d694-aead-45cd-88d1-25abcfa91a8b)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
