### PR TITLE
fix(web-pkg): display password screen when link auth fails in editors

### DIFF
--- a/changelog/unreleased/bugfix-handle-changed-public-link-password-in-file-editors.md
+++ b/changelog/unreleased/bugfix-handle-changed-public-link-password-in-file-editors.md
@@ -1,0 +1,6 @@
+Bugfix: Handle changed public link password in file editors
+
+Refreshing a file editor while having a file shared via public link opened will no longer display an error that username or password is incorrect when the public link password has been changed. Instead, it will correctly redirect to the public link password screen where user can enter new password and continue editing the file afterwards.
+
+https://github.com/owncloud/web/pull/12357
+https://github.com/owncloud/web/issues/12113

--- a/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
+++ b/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
@@ -96,6 +96,7 @@ import { useFileActionsOpenWithApp } from '../../composables/actions/files/useFi
 import { UnsavedChangesModal } from '../Modals'
 import { formatFileSize, getSharedDriveItem } from '../../helpers'
 import toNumber from 'lodash-es/toNumber'
+import { useAuthService } from '../../composables/authContext/useAuthService'
 
 export default defineComponent({
   name: 'AppWrapper',
@@ -149,6 +150,7 @@ export default defineComponent({
     const configStore = useConfigStore()
     const resourcesStore = useResourcesStore()
     const sharesStore = useSharesStore()
+    const authService = useAuthService()
 
     const { actions: openWithAppActions } = useFileActionsOpenWithApp({
       appId: props.applicationId
@@ -317,6 +319,10 @@ export default defineComponent({
         resourcesStore.initResourceList({ currentFolder: null, resources: [unref(resource)] })
         selectedResources.value = [unref(resource)]
       } catch (e) {
+        if (typeof e === 'object' && e.statusCode === 401) {
+          return authService.handleAuthError(unref(router.currentRoute))
+        }
+
         console.error(e)
         loadingError.value = e
         loading.value = false


### PR DESCRIPTION
## Description

If public link password is changed and any user with already opened file shared via that link inside of an editor refreshes the page, redirect to the link password screen instead of displaying an error.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/12113

## Motivation and Context

User can quickly enter the password again and continue editing instead of being confused by an error which even uses "username" in there...

## How Has This Been Tested?

- test environment: chrome
- test case 1: open public links shared .txt file, change password, refresh page

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
