### PR TITLE
[tests-only][full-ci] combine ocm provider configs using wildcards

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -608,6 +608,7 @@ def e2eTests(ctx):
             "FAIL_ON_UNCAUGHT_CONSOLE_ERR": "true",
             "PLAYWRIGHT_BROWSERS_PATH": ".playwright",
             "BROWSER": "chromium",
+            "FEDERATED_BASE_URL_OCIS": "federation-ocis:9200",
         }
 
         steps = skipIfUnchanged(ctx, "e2e-tests") + \
@@ -973,11 +974,12 @@ def ocisService(extra_env_config = {}, deploy_type = "ocis"):
     }
 
     if deploy_type == "federation":
-        environment["OCIS_URL"] = "https://federation-ocis:10200"
-        environment["PROXY_HTTP_ADDR"] = "federation-ocis:10200"
+        environment["OCIS_URL"] = "https://federation-ocis:9200"
+        environment["PROXY_HTTP_ADDR"] = "federation-ocis:9200"
         environment["WEB_UI_CONFIG_FILE"] = dir["federatedOcisConfig"]
+        environment["OCIS_LOG_LEVEL"] = "debug"
         container_name = "federation-ocis"
-        ocis_domain = "federation-ocis:10200"
+        ocis_domain = "federation-ocis:9200"
     else:
         container_name = "ocis"
         ocis_domain = "ocis:9200"

--- a/.drone.star
+++ b/.drone.star
@@ -977,7 +977,6 @@ def ocisService(extra_env_config = {}, deploy_type = "ocis"):
         environment["OCIS_URL"] = "https://federation-ocis:9200"
         environment["PROXY_HTTP_ADDR"] = "federation-ocis:9200"
         environment["WEB_UI_CONFIG_FILE"] = dir["federatedOcisConfig"]
-        environment["OCIS_LOG_LEVEL"] = "debug"
         container_name = "federation-ocis"
         ocis_domain = "federation-ocis:9200"
     else:

--- a/tests/drone/config-ocis-federated.json
+++ b/tests/drone/config-ocis-federated.json
@@ -1,9 +1,9 @@
 {
-  "server": "https://federation-ocis:10200",
-  "theme": "https://federation-ocis:10200/themes/owncloud/theme.json",
+  "server": "https://federation-ocis:9200",
+  "theme": "https://federation-ocis:9200/themes/owncloud/theme.json",
   "openIdConnect": {
-    "metadata_url": "https://federation-ocis:10200/.well-known/openid-configuration",
-    "authority": "https://federation-ocis:10200",
+    "metadata_url": "https://federation-ocis:9200/.well-known/openid-configuration",
+    "authority": "https://federation-ocis:9200",
     "client_id": "web",
     "response_type": "code"
   },

--- a/tests/drone/providers.json
+++ b/tests/drone/providers.json
@@ -1,45 +1,23 @@
 [
   {
     "name": "ocis",
-    "full_name": "first-ocis-instance",
-    "organization": "Owncloud",
-    "domain": "ocis:9200",
+    "full_name": "ocis server",
+    "organization": "ownCloud",
+    "domain": ".*ocis:9200",
     "homepage": "https://owncloud.com",
     "services": [
       {
         "endpoint": {
           "type": {
             "name": "OCM",
-            "description": "CERNBox Open Cloud Mesh API"
+            "description": "ownCloud Open Cloud Mesh API"
           },
-          "name": "CERNBox - OCM API",
-          "path": "https://ocis:9200/ocm/",
+          "name": "ownCloud - OCM API",
+          "path": "https://.*ocis:9200/ocm/",
           "is_monitored": true
         },
         "api_version": "0.0.1",
-        "host": "ocis:9200"
-      }
-    ]
-  },
-  {
-    "name": "federation-ocis",
-    "full_name": "Federation ocis",
-    "organization": "Owncloud",
-    "domain": "federation-ocis:10200",
-    "homepage": "https://owncloud.com",
-    "services": [
-      {
-        "endpoint": {
-          "type": {
-            "name": "OCM",
-            "description": "CERNBox Open Cloud Mesh API"
-          },
-          "name": "CERNBox - OCM API",
-          "path": "https://federation-ocis:10200/ocm/",
-          "is_monitored": true
-        },
-        "api_version": "0.0.1",
-        "host": "federation-ocis:10200"
+        "host": ".*ocis:9200"
       }
     ]
   }

--- a/tests/drone/providers.json
+++ b/tests/drone/providers.json
@@ -3,7 +3,7 @@
     "name": "ocis",
     "full_name": "ocis server",
     "organization": "ownCloud",
-    "domain": ".*ocis:9200",
+    "domain": ".*:9200",
     "homepage": "https://owncloud.com",
     "services": [
       {
@@ -13,11 +13,11 @@
             "description": "ownCloud Open Cloud Mesh API"
           },
           "name": "ownCloud - OCM API",
-          "path": "https://.*ocis:9200/ocm/",
+          "path": "https://.*:9200/ocm/",
           "is_monitored": true
         },
         "api_version": "0.0.1",
-        "host": ".*ocis:9200"
+        "host": ".*:9200"
       }
     ]
   }


### PR DESCRIPTION
## Description
Define ocm providers using patterns. Run tests with this ocm setup in the CI.

## Related Issue
- Cover issue: https://github.com/owncloud/enterprise/issues/7073
- https://github.com/cs3org/reva/pull/5061

## How Has This Been Tested?
- test environment: :raised_back_of_hand: :robot: 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
