### PR TITLE
[tests-only][full-ci] check lock before opening word document file 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,7 +181,8 @@ services:
 
   collabora:
     image: collabora/code:24.04.13.2.1
-    command: ['bash', '-c', 'coolconfig generate-proof-key ; /start-collabora-online.sh']
+    entrypoint: /bin/sh
+    command: ['-c', 'coolconfig generate-proof-key ; /start-collabora-online.sh']
     environment:
       DONT_GEN_SSL_CERT: YES
       extra_params: --o:ssl.enable=false --o:ssl.ssl_verification=false --o:ssl.termination=true --o:welcome.enable=false --o:net.frame_ancestors=${OCIS_URL:-https://host.docker.internal:9200}

--- a/tests/e2e/cucumber/features/app-provider/officeSuites.feature
+++ b/tests/e2e/cucumber/features/app-provider/officeSuites.feature
@@ -11,10 +11,10 @@ Feature: Integrate with online office suites like Collabora and OnlyOffice
       | Alice |
       | Brian |
     And "Alice" logs in
-    And "Alice" opens the "files" app
 
 
   Scenario: create an OpenDocument file with Collabora
+    Given "Alice" opens the "files" app
     When "Alice" creates the following resources
       | resource         | type         | content              |
       | OpenDocument.odt | OpenDocument | OpenDocument Content |
@@ -77,9 +77,11 @@ Feature: Integrate with online office suites like Collabora and OnlyOffice
 
 
   Scenario: create a Microsoft Word file with OnlyOffice
+    Given "Alice" opens the "files" app
     When "Alice" creates the following resources
       | resource           | type           | content                |
       | MicrosoftWord.docx | Microsoft Word | Microsoft Word Content |
+    And for "Alice" file "MicrosoftWord.docx" should not be locked
     And "Alice" creates a public link of following resource using the sidebar panel
       | resource           | role     | password |
       | MicrosoftWord.docx | Can edit | %public% |
@@ -172,6 +174,7 @@ Feature: Integrate with online office suites like Collabora and OnlyOffice
       | usingFolderLink.docx | Microsoft Word | Microsoft Word Content |
 
     When "Alice" navigates to the project space "marketing.1"
+    And for "Alice" file "usingSpaceLink.docx" should not be locked
     And "Alice" opens the following file in OnlyOffice
       | resource            |
       | usingSpaceLink.docx |
@@ -179,6 +182,7 @@ Feature: Integrate with online office suites like Collabora and OnlyOffice
     And "Alice" closes the file viewer
 
     When "Alice" opens folder "myfolder"
+    And for "Alice" file "usingFolderLink.docx" should not be locked
     And "Alice" opens the following file in OnlyOffice
       | resource             |
       | usingFolderLink.docx |
@@ -238,6 +242,7 @@ Feature: Integrate with online office suites like Collabora and OnlyOffice
       | localFile     | to            |
       | Template.dotx | Template.dotx |
       | Template.ott  | Template.ott  |
+    And "Alice" opens the "files" app
 
     When "Alice" creates a file from template file "Template.dotx" via "OnlyOffice" using the sidebar panel
     Then "Alice" should see the content "As a user I want to create a document by clicking on a template file" in editor "OnlyOffice"

--- a/tests/e2e/support/environment/actor/actor.ts
+++ b/tests/e2e/support/environment/actor/actor.ts
@@ -8,7 +8,9 @@ export class ActorEnvironment extends EventEmitter implements Actor {
   private readonly options: ActorOptions
   private readonly localStorage: Record<string, any> = {
     // disables copy-paste dialog in web office
-    clipboardApiAvailable: false
+    clipboardApiAvailable: false,
+    // disable help tip
+    'help-tip-rtl-dir': 1
   }
 
   public context: BrowserContext

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -3,7 +3,6 @@ import util from 'util'
 import path from 'path'
 import { resourceExists, waitForResources } from './utils'
 import {
-  removeCollaboraWelcomeModal,
   fillCollaboraDocumentContent,
   fillOnlyOfficeDocumentContent,
   canEditCollaboraDocument,
@@ -461,7 +460,6 @@ export const getDocumentContent = async ({
   await page.waitForURL(/.*\/external-.*/)
   switch (editor) {
     case 'Collabora':
-      await removeCollaboraWelcomeModal(page)
       await focusCollaboraEditor(page)
       break
     case 'OnlyOffice':
@@ -2005,7 +2003,6 @@ export const canEditDocumentContent = async ({
 }): Promise<boolean> => {
   switch (type) {
     case 'OpenDocument':
-      await removeCollaboraWelcomeModal(page)
       return canEditCollaboraDocument(page)
     case 'Microsoft Word':
       return canEditOnlyOfficeDocument(page)

--- a/tests/e2e/support/objects/app-files/resource/webOffice.ts
+++ b/tests/e2e/support/objects/app-files/resource/webOffice.ts
@@ -5,8 +5,10 @@ const externalEditorIframe = '[name="app-iframe"]'
 const collaboraDocPermissionModeSelector = '#permissionmode-container'
 const collaboraEditorSaveSelector = '.notebookbar-shortcuts-bar #save'
 const collaboraDocTextAreaSelector = '#clipboard-area'
-const collaboraWelcomeModal = '.iframe-welcome-modal'
 const collaboraCanvasEditorSelector = '.leaflet-layer'
+const collaboraWelcomeModal = '.iframe-welcome-modal'
+const collaboraWelcomeSlide = '.slider > a'
+const collaboraWelcomeClose = '//button[text()="Close"]'
 // OnlyOffice
 const onlyOfficeInnerFrameSelector = '[name="frameEditor"]'
 const onlyOfficeSaveButtonSelector = '#slot-btn-dt-save > button'
@@ -21,11 +23,14 @@ export const removeCollaboraWelcomeModal = async (page: Page): Promise<void> => 
   })
   if (!versionSet) {
     await editorMainFrame.locator(collaboraWelcomeModal).waitFor()
-    await page.keyboard.press('Escape')
+    const welcomeModal = editorMainFrame.frameLocator(collaboraWelcomeModal)
+    await welcomeModal.locator(collaboraWelcomeSlide).last().click()
+    await welcomeModal.locator(collaboraWelcomeClose).click()
   }
 }
 
 export const waitForCollaboraEditor = async (page: Page): Promise<void> => {
+  await removeCollaboraWelcomeModal(page)
   const editorMainFrame = page.frameLocator(externalEditorIframe)
   await editorMainFrame.locator(collaboraDocTextAreaSelector).waitFor()
 }
@@ -38,6 +43,7 @@ export const waitForOnlyOfficeEditor = async (page: Page): Promise<void> => {
 }
 
 export const focusCollaboraEditor = async (page: Page): Promise<void> => {
+  await removeCollaboraWelcomeModal(page)
   const editorMainFrame = page.frameLocator(externalEditorIframe)
   await editorMainFrame.locator(collaboraCanvasEditorSelector).click()
 }
@@ -83,6 +89,7 @@ export const fillOnlyOfficeDocumentContent = async (page: Page, content: string)
 }
 
 export const canEditCollaboraDocument = async (page: Page): Promise<boolean> => {
+  await removeCollaboraWelcomeModal(page)
   const editorMainFrame = page.frameLocator(externalEditorIframe)
   const collaboraDocPermissionModeLocator = editorMainFrame.locator(
     collaboraDocPermissionModeSelector


### PR DESCRIPTION
## Description
Check the lock status of the word document when created/edited in OnlyOffice.
The lock is released after sometime when opened in OnlyOffice. and when we open the file before the lock is released, there will be no content in the file leading to the flakiness.

## Related Issue
- Reduce failure like https://drone.owncloud.com/owncloud/web/51407/13/16

## How Has This Been Tested?
- :raised_hand_with_fingers_splayed: 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
