### PR TITLE
fix(web-app-files): show drive resolve error

### DIFF
--- a/changelog/unreleased/bugfix-add-space-not-found-message.md
+++ b/changelog/unreleased/bugfix-add-space-not-found-message.md
@@ -1,0 +1,11 @@
+Bugfix: Add space not found message
+
+We've added a space not found message. If users are trying to open a space that does not exist or users has not got access to it, the error message will be shown instead of users being redirected to their personal space.
+
+The error message will be shown in the following cases:
+
+- The space does not exist
+- The space exists but the user has no access to it
+
+https://github.com/owncloud/web/pull/12373
+https://github.com/owncloud/web/issues/11014

--- a/packages/web-app-files/tests/unit/views/spaces/DriveRedirect.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/DriveRedirect.spec.ts
@@ -8,6 +8,10 @@ import {
   RouteLocation
 } from '@ownclouders/web-test-helpers'
 
+const selectors = Object.freeze({
+  spaceNotFound: '#files-space-not-found'
+})
+
 describe('DriveRedirect view', () => {
   it('redirects to "projects" route if no personal space exist', () => {
     const { mocks } = getMountedWrapper()
@@ -15,9 +19,32 @@ describe('DriveRedirect view', () => {
       name: 'files-spaces-projects'
     })
   })
+
+  it('should show a message if the space is not found', () => {
+    const { mocks, wrapper } = getMountedWrapper({ props: { driveAliasAndItem: 'missing-space' } })
+
+    expect(wrapper.find(selectors.spaceNotFound).exists()).toBe(true)
+    expect(mocks.$router.replace).not.toHaveBeenCalledWith({
+      name: 'files-spaces-projects'
+    })
+  })
+
+  it('should redirect to personal space if the alias is personal drive', () => {
+    const { mocks } = getMountedWrapper({ props: { driveAliasAndItem: 'personal' } })
+    expect(mocks.$router.replace).toHaveBeenCalledWith({
+      name: 'files-spaces-projects'
+    })
+  })
+
+  it('should redirect to personal space if the alias is the fake personal drive alias', () => {
+    const { mocks } = getMountedWrapper({ props: { driveAliasAndItem: 'personal/home' } })
+    expect(mocks.$router.replace).toHaveBeenCalledWith({
+      name: 'files-spaces-projects'
+    })
+  })
 })
 
-function getMountedWrapper({ currentRouteName = 'files-spaces-generic' } = {}) {
+function getMountedWrapper({ currentRouteName = 'files-spaces-generic', props = {} } = {}) {
   const mocks = {
     ...defaultComponentMocks({ currentRoute: mock<RouteLocation>({ name: currentRouteName }) })
   }
@@ -25,8 +52,9 @@ function getMountedWrapper({ currentRouteName = 'files-spaces-generic' } = {}) {
   return {
     mocks,
     wrapper: mount(DriveRedirect, {
+      props,
       global: {
-        plugins: [...defaultPlugins()],
+        plugins: defaultPlugins(),
         stubs: defaultStubs,
         mocks,
         provide: mocks


### PR DESCRIPTION
## Description

Show an error message if the drive could not be resolved due to non-existent space or missing access instead of automatically redirecting to users personal space.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/11014

## Motivation and Context

Users are clearly told that the space could not be found.

## How Has This Been Tested?

- test environment: chrome & 🤖 
- test case 1: create a space with user `admin`, open the space, copy link, open the link with user `einstein`
- test case 2: open personal space and refresh page
- test case 3: open existing space and refresh page
- test case 4: open shares and refresh page
- test case 5: open trash and refresh page

## Screenshots (if appropriate):

![host docker internal_9201_files_spaces_project_new-space_fileId=8146d863-06f7-4130-8126-be2af45c909f%24882f6fb0-c121-458a-baa5-0bc04b331196%21882f6fb0-c121-458a-baa5-0bc04b331196 sort-by=name sort-dir=asc items-per-page=100 files-spaces-gen](https://github.com/user-attachments/assets/76715c87-a3cc-4859-a924-ab1fb58ab5c3)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
