### PR TITLE
fix: scroll to resource on share notification click

### DIFF
--- a/changelog/unreleased/bugfix-use-resource-id-in-share-notifications.md
+++ b/changelog/unreleased/bugfix-use-resource-id-in-share-notifications.md
@@ -1,0 +1,6 @@
+Bugfix: Use resource ID in share notifications
+
+When building a link to a resource in shared with me notifications, we now use the resource ID instead of share ID to correctly navigate and scroll to the resource.
+
+https://github.com/owncloud/web/pull/12385
+https://github.com/owncloud/web/issues/10398

--- a/changelog/unreleased/bugfix-watch-scroll-target-in-shared-list.md
+++ b/changelog/unreleased/bugfix-watch-scroll-target-in-shared-list.md
@@ -1,0 +1,6 @@
+Bugfix: Watch scroll target in shared list
+
+Inside of shared with me list, watch for changes of the scroll target so that we can react and scroll to the resource when user clicks on a notification while being already in the list.
+
+https://github.com/owncloud/web/pull/12385
+https://github.com/owncloud/web/issues/10398

--- a/packages/web-app-files/src/views/shares/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithMe.vue
@@ -175,6 +175,8 @@ export default defineComponent({
 
     const selectedShareTypesQuery = useRouteQuery('q_shareType')
     const selectedSharedByQuery = useRouteQuery('q_sharedBy')
+    const scrollToTarget = useRouteQuery('scrollTo')
+
     const filteredItems = computed(() => {
       let result = unref(currentItems)
 
@@ -270,6 +272,14 @@ export default defineComponent({
 
     onMounted(() => {
       performLoaderTask()
+    })
+
+    watch(scrollToTarget, (value) => {
+      if (!value) {
+        return
+      }
+
+      scrollToResourceFromRoute(unref(items), 'files-app-bar')
     })
 
     return {

--- a/packages/web-runtime/src/components/Topbar/Notifications.vue
+++ b/packages/web-runtime/src/components/Topbar/Notifications.vue
@@ -154,8 +154,8 @@ export default {
       if (object_type === 'share') {
         return {
           name: 'files-shares-with-me',
-          ...(!!messageRichParameters?.share?.id && {
-            query: { scrollTo: messageRichParameters.share.id }
+          ...(!!messageRichParameters?.resource.id && {
+            query: { scrollTo: messageRichParameters.resource.id }
           })
         }
       }

--- a/packages/web-runtime/tests/unit/components/Topbar/Notifications.spec.ts
+++ b/packages/web-runtime/tests/unit/components/Topbar/Notifications.spec.ts
@@ -149,7 +149,7 @@ describe('Notification component', () => {
           object_type: 'share',
           messageRichParameters: {
             user: { displayname: 'Albert Einstein' },
-            resource: { name: 'someFile.txt' },
+            resource: { name: 'someFile.txt', id: '1' },
             share: { id: '1' }
           },
           computedMessage: undefined,
@@ -166,7 +166,7 @@ describe('Notification component', () => {
           'files-shares-with-me'
         )
         expect((routerLink.props('to') as RouteLocationNamedRaw).query).toEqual({
-          scrollTo: notification.messageRichParameters.share.id
+          scrollTo: notification.messageRichParameters.resource.id
         })
       })
       it('renders notification as link for spaces', async () => {


### PR DESCRIPTION
## Description

Use resource ID instead of share ID to find the correct resource and watch for scroll target change to react to the click when the shared with me list is already opened.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/10398

## Motivation and Context

List correctly reacts to user action

## How Has This Been Tested?

- test environment: chrome & 🤖 
- test case 1: share a resource with einstein and click on the notification from personal space
- test case 2: share a resource with einstein and click on the notification from shared with me list

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
