### PR TITLE
fix(web-pkg): download archives directly

### DIFF
--- a/changelog/unreleased/bugfix-download-archives-directly.md
+++ b/changelog/unreleased/bugfix-download-archives-directly.md
@@ -1,0 +1,6 @@
+Bugfix: Download archives directly
+
+In authenticated context and inside public links without a password, download zip archives directly by opening the download URL instead of fetching it first. Fetching the archive first puts constraints on the size of the archive that can be downloaded because it is being saved into the devices memory. In case of a public link with a password, the archive is still being fetched because signed URLs are not supported for public links.
+
+https://github.com/owncloud/web/pull/12406
+https://github.com/owncloud/web/issues/12405

--- a/changelog/unreleased/bugfix-request-archive-as-blob.md
+++ b/changelog/unreleased/bugfix-request-archive-as-blob.md
@@ -1,0 +1,6 @@
+Bugfix: Request archive as blob
+
+When downloading an archive in public links with passwords, the archive is now being fetched as a blob instead of a signed URL. This allows for downloading larger archives in Chrome and Firefox.
+
+https://github.com/owncloud/web/pull/12406
+https://github.com/owncloud/web/issues/12405

--- a/packages/web-pkg/tests/unit/services/archiver.spec.ts
+++ b/packages/web-pkg/tests/unit/services/archiver.spec.ts
@@ -20,6 +20,11 @@ const getArchiverServiceInstance = (capabilities: Ref<ArchiverCapability[]>) => 
   } as unknown as AxiosResponse)
   clientServiceMock.ocsUserContext.signUrl.mockImplementation((url) => Promise.resolve(url))
 
+  Object.defineProperty(window, 'open', {
+    value: vi.fn(),
+    writable: true
+  })
+
   return new ArchiverService(clientServiceMock, userStore, serverUrl, capabilities)
 }
 
@@ -66,10 +71,9 @@ describe('archiver', () => {
     })
     it('returns a download url for a valid archive download trigger', async () => {
       const archiverService = getArchiverServiceInstance(capabilities)
-      window.URL.createObjectURL = vi.fn(() => '')
       const fileId = 'asdf'
       const url = await archiverService.triggerDownload({ fileIds: [fileId] })
-      expect(window.URL.createObjectURL).toHaveBeenCalled()
+      expect(window.open).toHaveBeenCalled()
       expect(url.startsWith(archiverUrl)).toBeTruthy()
       expect(url.indexOf(`id=${fileId}`)).toBeGreaterThan(-1)
     })
@@ -98,12 +102,11 @@ describe('archiver', () => {
     })
     it('returns a download url for a valid archive download trigger', async () => {
       const archiverService = getArchiverServiceInstance(capabilities)
-      window.URL.createObjectURL = vi.fn(() => '')
       const dir = '/some/path'
       const fileName = 'qwer'
       const url = await archiverService.triggerDownload({ dir, files: [fileName] })
 
-      expect(window.URL.createObjectURL).toHaveBeenCalled()
+      expect(window.open).toHaveBeenCalled()
       expect(url.startsWith(archiverUrl)).toBeTruthy()
       expect(url.indexOf(`files[]=${fileName}`)).toBeGreaterThan(-1)
       expect(url.indexOf(`dir=${encodeURIComponent(dir)}`)).toBeGreaterThan(-1)


### PR DESCRIPTION
## Description

When in authenticated context or inside public links without password, download the archive file directly by opening the download URL instead of fetching it. This gets around constrains on memory. In public links with password, we still need to request the file first due to missing public link signed URLs. At least we are now requesting the file as blob instead of arraybuffer which works at least with bigger limits in Chrome and Firefox.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/12405

## Motivation and Context

Users are able to download large archives without errors and their memory being nuked.

## How Has This Been Tested?

- test environment: chrome & safari & firefox
- test case 1: download archived folder with 2GB+ content
- test case 2: download several files with total size 2GB+

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
