### PR TITLE
chore(web-pkg): drop oC10 archiver handling

### DIFF
--- a/packages/web-pkg/package.json
+++ b/packages/web-pkg/package.json
@@ -65,7 +65,6 @@
     "portal-vue": "^3.0.0",
     "prismjs": "^1.29.0",
     "qs": "^6.13.0",
-    "semver": "^7.6.3",
     "uuid": "^11.0.0",
     "vue-concurrency": "^5.0.1",
     "vue-router": "^4.2.5",

--- a/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsDownloadArchive.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/actions/files/useFileActionsDownloadArchive.spec.ts
@@ -9,7 +9,6 @@ import {
 } from '@ownclouders/web-test-helpers'
 import { useArchiverService } from '../../../../../src/composables'
 import { ArchiverService } from '../../../../../src'
-import { ref } from 'vue'
 
 vi.mock('../../../../../src/composables/archiverService/useArchiverService')
 
@@ -64,7 +63,7 @@ function getWrapper({
   vi.mocked(useArchiverService).mockImplementation(() => {
     return {
       triggerDownload: triggerDownloadMock,
-      fileIdsSupported: ref(true)
+      fileIdsSupported: true
     } as ArchiverService
   })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -987,9 +987,6 @@ importers:
       qs:
         specifier: ^6.13.0
         version: 6.14.0
-      semver:
-        specifier: ^7.6.3
-        version: 7.7.1
       uuid:
         specifier: ^11.0.0
         version: 11.1.0
@@ -9126,7 +9123,7 @@ snapshots:
 
   '@vitest/web-worker@3.0.9(vitest@3.0.9(@types/node@22.13.15)(happy-dom@17.4.4)(jsdom@26.0.0)(sass@1.86.0)(terser@5.39.0)(yaml@2.7.0))':
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       vitest: 3.0.9(@types/node@22.13.15)(happy-dom@17.4.4)(jsdom@26.0.0)(sass@1.86.0)(terser@5.39.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
@@ -10041,6 +10038,10 @@ snapshots:
 
   de-indent@1.0.2: {}
 
+  debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.0(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -10815,7 +10816,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10824,7 +10825,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12925,7 +12926,7 @@ snapshots:
   vite-node@3.0.9(@types/node@22.13.15)(sass@1.86.0)(terser@5.39.0)(yaml@2.7.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
       vite: 6.2.4(@types/node@22.13.15)(sass@1.86.0)(terser@5.39.0)(yaml@2.7.0)
@@ -12950,7 +12951,7 @@ snapshots:
       '@volar/typescript': 2.4.12
       '@vue/language-core': 2.2.0(typescript@5.8.2)
       compare-versions: 6.1.1
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       kolorist: 1.8.0
       local-pkg: 1.1.1
       magic-string: 0.30.17
@@ -13016,7 +13017,7 @@ snapshots:
       '@vitest/spy': 3.0.9
       '@vitest/utils': 3.0.9
       chai: 5.2.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0
       expect-type: 1.2.0
       magic-string: 0.30.17
       pathe: 2.0.3


### PR DESCRIPTION
## Description

oC10 is not supported for several major versions. This drops archiver code specific to version 1 (oC10) archivers.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/12403

## Motivation and Context

Cleanup 🧹 

## How Has This Been Tested?

- test environment: chrome
- test case 1: download an archive with oCIS

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
