### PR TITLE
feat: limit tag chars

### DIFF
--- a/changelog/unreleased/enhancement-add-tag-characters-limit.md
+++ b/changelog/unreleased/enhancement-add-tag-characters-limit.md
@@ -1,0 +1,5 @@
+Enhancement: Add tag characters limit
+
+We now limit the number of characters in a tag. The limit is configured in the capabilities and defaults to 30.
+
+https://github.com/owncloud/web/pull/12474

--- a/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/EditPanel.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/EditPanel.spec.ts
@@ -181,7 +181,7 @@ function getWrapper({
 }: { readOnlyUserAttributes?: string[]; selectedGroups?: Group[]; groups?: Group[] } = {}) {
   const mocks = defaultComponentMocks()
   const capabilities = {
-    graph: { users: { read_only_attributes: readOnlyUserAttributes } }
+    graph: { users: { read_only_attributes: readOnlyUserAttributes }, tags: { max_tag_length: 30 } }
   } satisfies Partial<CapabilityStore['capabilities']>
 
   return {

--- a/packages/web-app-files/src/components/SideBar/Details/TagsSelect.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/TagsSelect.vue
@@ -77,6 +77,7 @@ import {
   eventBus,
   SideBarEventTopics,
   useAuthStore,
+  useCapabilityStore,
   useClientService,
   useMessages,
   useResourcesStore,
@@ -120,6 +121,9 @@ export default defineComponent({
     const authStore = useAuthStore()
     const { publicLinkContextReady } = storeToRefs(authStore)
 
+    const capabilitiesStore = useCapabilityStore()
+    const { graphTagsMaxTagLength } = storeToRefs(capabilitiesStore)
+
     const type = unref(publicLinkContextReady) ? 'span' : 'router-link'
     const resource = toRef(props, 'resource')
     const { $gettext } = useGettext()
@@ -158,13 +162,26 @@ export default defineComponent({
       selectedTags.value = unref(currentTags)
     }
     const createOption = (label: string): TagOption => {
-      if (!label.trim().length) {
+      const len = label.trim().length
+
+      if (!len) {
         return {
           label: label.toLowerCase().trim(),
           error: $gettext('Tag must not consist of blanks only'),
           selectable: false
         }
       }
+
+      if (len > unref(graphTagsMaxTagLength)) {
+        return {
+          label: label.toLowerCase().trim(),
+          error: $gettext('Tag must not be longer than %{max} characters', {
+            max: unref(graphTagsMaxTagLength).toString()
+          }),
+          selectable: false
+        }
+      }
+
       return { label: label.toLowerCase().trim() }
     }
     const isOptionSelectable = (option: TagOption) => {

--- a/packages/web-app-files/tests/unit/components/SideBar/TagsSelect.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/TagsSelect.spec.ts
@@ -2,8 +2,10 @@ import { defaultComponentMocks, mount, defaultPlugins } from '@ownclouders/web-t
 import TagsSelect from '../../../../src/components/SideBar/Details/TagsSelect.vue'
 import { mock, mockDeep } from 'vitest-mock-extended'
 import { Resource } from '@ownclouders/web-client'
-import { ClientService, eventBus, useMessages } from '@ownclouders/web-pkg'
+import { ClientService, eventBus, useCapabilityStore, useMessages } from '@ownclouders/web-pkg'
 import { OcSelect } from '@ownclouders/design-system/components'
+import { storeToRefs } from 'pinia'
+import { unref } from 'vue'
 
 describe('Tag Select', () => {
   it('show tags input form if loaded successfully', () => {
@@ -116,6 +118,18 @@ describe('Tag Select', () => {
   it('does not accept tags consisting of blanks only', () => {
     const { wrapper } = createWrapper(mock<Resource>({ tags: [] }))
     const option = wrapper.vm.createOption(' ')
+    expect(option.error).toBeDefined()
+    expect(option.selectable).toBeFalsy()
+  })
+
+  it('should not accept tags longer than max tag length', () => {
+    const { wrapper } = createWrapper(mock<Resource>({ tags: [] }))
+
+    const capabilitiesStore = useCapabilityStore()
+    const { graphTagsMaxTagLength } = storeToRefs(capabilitiesStore)
+
+    const option = wrapper.vm.createOption('a'.repeat(unref(graphTagsMaxTagLength) + 1))
+
     expect(option.error).toBeDefined()
     expect(option.selectable).toBeFalsy()
   })

--- a/packages/web-client/src/ocs/capabilities.ts
+++ b/packages/web-client/src/ocs/capabilities.ts
@@ -173,6 +173,9 @@ export interface Capabilities {
         delete_disabled?: boolean
         read_only_attributes?: string[]
       }
+      tags: {
+        max_tag_length: number
+      }
     }
   }
   version: {

--- a/packages/web-pkg/src/composables/piniaStores/capabilities.ts
+++ b/packages/web-pkg/src/composables/piniaStores/capabilities.ts
@@ -45,6 +45,9 @@ const defaultValues = {
       create_disabled: false,
       delete_disabled: false,
       read_only_attributes: [] as string[]
+    },
+    tags: {
+      max_tag_length: 30
     }
   },
   notifications: {
@@ -92,6 +95,8 @@ export const useCapabilityStore = defineStore('capabilities', () => {
   const graphUsersReadOnlyAttributes = computed(
     () => unref(capabilities).graph.users.read_only_attributes
   )
+
+  const graphTagsMaxTagLength = computed(() => unref(capabilities).graph.tags.max_tag_length)
 
   const filesAppProviders = computed(() => unref(capabilities).files.app_providers)
   const filesFavorites = computed(() => unref(capabilities).files.favorites)
@@ -157,6 +162,7 @@ export const useCapabilityStore = defineStore('capabilities', () => {
     graphUsersDeleteDisabled,
     graphUsersChangeSelfPasswordDisabled,
     graphUsersReadOnlyAttributes,
+    graphTagsMaxTagLength,
     filesAppProviders,
     filesFavorites,
     filesThumbnail,

--- a/packages/web-runtime/tests/unit/pages/account.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/account.spec.ts
@@ -136,7 +136,9 @@ describe('account page', () => {
     describe('change password button', () => {
       it('should be displayed if not disabled via capability', async () => {
         const { wrapper } = getWrapper({
-          capabilities: { graph: { users: { change_password_self_disabled: false } } }
+          capabilities: {
+            graph: { users: { change_password_self_disabled: false }, tags: { max_tag_length: 30 } }
+          }
         })
         await blockLoadingState(wrapper)
 
@@ -145,7 +147,9 @@ describe('account page', () => {
       })
       it('should not be displayed if disabled via capability', async () => {
         const { wrapper } = getWrapper({
-          capabilities: { graph: { users: { change_password_self_disabled: true } } }
+          capabilities: {
+            graph: { users: { change_password_self_disabled: true }, tags: { max_tag_length: 30 } }
+          }
         })
         await blockLoadingState(wrapper)
 

--- a/packages/web-test-helpers/src/mocks/pinia.ts
+++ b/packages/web-test-helpers/src/mocks/pinia.ts
@@ -146,6 +146,8 @@ export function createMockStore({
       spaceSettings: { spaces: [], selectedSpaces: [], ...spaceSettingsStore },
       user: { user: { ...mock<User>({ id: '1' }), ...(userState?.user && { ...userState.user }) } },
       capabilities: {
+        graphTagsMaxTagLength: 30,
+        ...capabilityState,
         isInitialized: capabilityState?.isInitialized ? capabilityState.isInitialized : true,
         capabilities: {
           ...mock<Capabilities['capabilities']>(),


### PR DESCRIPTION
## Description

Read limit set via config from capabilities and apply it to resource tags. Defaults to 30.

## Motivation and Context

Secure web app.

## How Has This Been Tested?

- test environment: chrome & 🤖 
- test case 1: set oCIS config to limit chars to 8 and try to create tag with >= 9 chars

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/81d77880-eef1-420e-aa53-add92d727457)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
