### PR TITLE
fix: use plural form of tags in chars limit message

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Details/TagsSelect.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/TagsSelect.vue
@@ -175,7 +175,7 @@ export default defineComponent({
       if (len > unref(graphTagsMaxTagLength)) {
         return {
           label: label.toLowerCase().trim(),
-          error: $gettext('Tag must not be longer than %{max} characters', {
+          error: $gettext('Tags must not be longer than %{max} characters', {
             max: unref(graphTagsMaxTagLength).toString()
           }),
           selectable: false


### PR DESCRIPTION
## Description

We are using plural form all over the UI. This just makes it consistent.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/12480

## Motivation and Context

Consistent UI.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
