### PR TITLE
feat(web-app-ocm): add explanatory tooltips

### DIFF
--- a/changelog/unreleased/enhancement-add-ocm-explanatory-tooltips.md
+++ b/changelog/unreleased/enhancement-add-ocm-explanatory-tooltips.md
@@ -1,0 +1,19 @@
+Enhancement: Add OCM explanatory tooltips
+
+We added two contextual helpers to the Connections panel in the OCM app.
+
+- The first one is for the "User" column header.
+- The second one is for the "Institution" column header.
+
+The contextual helpers are used to provide additional information about the columns.
+
+The "User" column header tooltip reads:
+
+> This is the user the federation is set up with, and the one you can share resources with.
+
+The "Institution" column header tooltip reads:
+
+> This URL represents the trusted partner's instance.
+
+https://github.com/owncloud/web/pull/12488
+https://github.com/owncloud/web/issues/11567

--- a/packages/web-app-ocm/src/views/ConnectionsPanel.vue
+++ b/packages/web-app-ocm/src/views/ConnectionsPanel.vue
@@ -42,6 +42,26 @@
           </template>
         </no-content-message>
         <oc-table v-else :fields="fields" :data="connections" :highlighted="highlightedConnections">
+          <template #display_nameHeader>
+            {{ $gettext('User') }}
+            <oc-contextual-helper
+              class="oc-pl-xs"
+              :title="$gettext('User')"
+              :text="
+                $gettext(
+                  'This is the user the federation is set up with, and the one you can share resources with.'
+                )
+              "
+            />
+          </template>
+          <template #idpHeader>
+            {{ $gettext('Institution') }}
+            <oc-contextual-helper
+              class="oc-pl-xs oc-text-left"
+              :title="$gettext('Institution')"
+              :text="$gettext('This URL represents the trusted partner\'s instance.')"
+            />
+          </template>
           <template #actions="{ item }">
             <oc-button
               appearance="raw"
@@ -111,7 +131,8 @@ export default defineComponent({
         {
           name: 'display_name',
           title: $gettext('User'),
-          alignH: 'left'
+          alignH: 'left',
+          headerType: 'slot'
         },
         {
           name: 'mail',
@@ -121,7 +142,8 @@ export default defineComponent({
         {
           name: 'idp',
           title: $gettext('Institution'),
-          alignH: 'right'
+          alignH: 'right',
+          headerType: 'slot'
         },
         {
           name: 'actions',

--- a/packages/web-app-ocm/src/views/ConnectionsPanel.vue
+++ b/packages/web-app-ocm/src/views/ConnectionsPanel.vue
@@ -49,7 +49,7 @@
               :title="$gettext('User')"
               :text="
                 $gettext(
-                  'This is the user the federation is set up with, and the one you can share resources with.'
+                  'This is the remote user with whom the federation is set up and resources can be shared.'
                 )
               "
             />
@@ -59,7 +59,7 @@
             <oc-contextual-helper
               class="oc-pl-xs oc-text-left"
               :title="$gettext('Institution')"
-              :text="$gettext('This URL represents the trusted partner\'s instance.')"
+              :text="$gettext('This URL represents the instance of the trusted partner.')"
             />
           </template>
           <template #actions="{ item }">


### PR DESCRIPTION
## Description

Add two tooltips to connections panel in OCM to better explain users and institutions.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/11567

## Motivation and Context

Better user understanding of the complex OCM topic.

## How Has This Been Tested?

- test environment: chrome
- test case 1: create connection and see tooltips

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/3ec61f47-7a94-4b4e-9b06-53f57954b51f)

![image](https://github.com/user-attachments/assets/12925619-43e6-47ef-bb42-55a378465c96)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
