### PR TITLE
[full-ci][tests-only] check domain detail of external collaborator

### DIFF
--- a/tests/e2e/cucumber/features/ocm/ocm.feature
+++ b/tests/e2e/cucumber/features/ocm/ocm.feature
@@ -43,6 +43,12 @@ Feature: federation management
       | folderPublic   | Brian     | user | Can edit without versions | folder       | external  |
       | sampleGif.gif  | Brian     | user | Can edit without versions | file         | external  |
       | testavatar.jpg | Brian     | user | Can view                  | file         | external  |
+    And "Alice" checks the following access details of share "folderPublic" for user "Brian"
+      | Name   | Brian Murphy |
+      | Type   | External     |
+    And "Alice" should see the following access details of share "folderPublic" for federated user "Brian"
+      | detail |
+      | Domain |
     And "Alice" logs out
 
     And using "FEDERATED" server


### PR DESCRIPTION
## Description
check `Domain` of external user in the share details

## Related Issue
- https://github.com/owncloud/web/issues/12184

## How Has This Been Tested?
- test environment:


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
