### PR TITLE
fix: rename languages link in md editor

### DIFF
--- a/packages/web-pkg/src/components/TextEditor/TextEditor.vue
+++ b/packages/web-pkg/src/components/TextEditor/TextEditor.vue
@@ -32,14 +32,24 @@
             href="https://imzbf.github.io/md-editor-v3/en-US/api#%F0%9F%AA%A1%20Shortcut%20keys"
             target="_blank"
             rel="noopener noreferrer"
-            >{{ $gettext('Keyboard shortcuts') }}</a
+            >{{
+              $pgettext(
+                'A link to a list of keyboard shortcuts that can be used in the markdown editor.',
+                'Keyboard shortcuts'
+              )
+            }}</a
           >
 
           <a
             href="https://highlightjs.readthedocs.io/en/latest/supported-languages.html"
             target="_blank"
             rel="noopener noreferrer"
-            >{{ $gettext('Supported languages') }}</a
+            >{{
+              $pgettext(
+                'A link to a list of supported programming languages that can be used in the markdown editor.',
+                'Supported programming languages'
+              )
+            }}</a
           >
         </span>
       </template>


### PR DESCRIPTION
## Description

This renames the label of supported languages link in the markdown to . This change should prevent
confusion with spoken languages. As a small bonus, add context to the translations so it is clear in Transifex as well.

## Motivation and Context

No confusion.

## How Has This Been Tested?

- test environment: chrome
- test case 1: Open the markdown editor and see links

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/c3069777-fd32-4290-9669-809d26e2377f)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
