### PR TITLE
feat: add loading spinner to submit button for password-protected public links

### DIFF
--- a/changelog/unreleased/enhancement-add-spinner.md
+++ b/changelog/unreleased/enhancement-add-spinner.md
@@ -1,0 +1,6 @@
+Enhancement: Add loading spinner to submit button
+
+We have enhanced the user experience by displaying a loading spinner and disabling the submit button when clicked on password-protected public links. This ensures users on slower connections receive clear feedback that their request is being processed.
+
+https://github.com/owncloud/web/pull/12513
+https://github.com/owncloud/enterprise/issues/7190

--- a/packages/web-runtime/src/pages/resolvePublicLink.vue
+++ b/packages/web-runtime/src/pages/resolvePublicLink.vue
@@ -33,7 +33,8 @@
               variation="primary"
               appearance="filled"
               class="oc-login-authorize-button"
-              :disabled="!password"
+              :disabled="!password || resolvePublicLinkTask.isRunning"
+              :show-spinner="resolvePublicLinkTask.isRunning"
               submit="submit"
             >
               <span v-text="$gettext('Continue')" />
@@ -58,7 +59,7 @@
   </div>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import { DavHttpError, SharePermissionBit } from '@ownclouders/web-client'
 import { authService } from '../services/auth'
 
@@ -75,7 +76,7 @@ import {
   useThemeStore
 } from '@ownclouders/web-pkg'
 import { useTask } from 'vue-concurrency'
-import { ref, unref, computed, defineComponent, onMounted } from 'vue'
+import { ref, unref, computed, onMounted } from 'vue'
 import {
   buildPublicSpaceResource,
   isPublicSpaceResource,
@@ -87,233 +88,210 @@ import { RouteLocationNamedRaw } from 'vue-router'
 import { dirname } from 'path'
 import { storeToRefs } from 'pinia'
 
-export default defineComponent({
-  name: 'ResolvePublicLink',
-  setup() {
-    const configStore = useConfigStore()
-    const clientService = useClientService()
-    const router = useRouter()
-    const route = useRoute()
-    const authStore = useAuthStore()
-    const { $gettext } = useGettext()
-    const token = useRouteParam('token')
-    const redirectUrl = useRouteQuery('redirectUrl')
-    const themeStore = useThemeStore()
-    const spacesStore = useSpacesStore()
+const configStore = useConfigStore()
+const clientService = useClientService()
+const router = useRouter()
+const route = useRoute()
+const authStore = useAuthStore()
+const { $gettext } = useGettext()
+const token = useRouteParam('token')
+const redirectUrl = useRouteQuery('redirectUrl')
+const themeStore = useThemeStore()
+const spacesStore = useSpacesStore()
 
-    const { currentTheme } = storeToRefs(themeStore)
-    const password = ref('')
+const { currentTheme } = storeToRefs(themeStore)
+const password = ref('')
 
-    const isOcmLink = computed(() => {
-      const split = unref(route).path.split('/')?.[1]
-      return split === 'o'
-    })
+const isOcmLink = computed(() => {
+  const split = unref(route).path.split('/')?.[1]
+  return split === 'o'
+})
 
-    const publicLinkType = computed(() => {
-      return unref(isOcmLink) ? 'ocm' : 'public-link'
-    })
+const publicLinkType = computed(() => (unref(isOcmLink) ? 'ocm' : 'public-link'))
 
-    const publicLinkSpace = computed(() =>
-      buildPublicSpaceResource({
-        id: unref(token),
-        driveType: 'public',
-        publicLinkType: unref(publicLinkType),
-        ...(unref(password) && { publicLinkPassword: unref(password) })
-      })
+const publicLinkSpace = computed(() =>
+  buildPublicSpaceResource({
+    id: unref(token),
+    driveType: 'public',
+    publicLinkType: unref(publicLinkType),
+    ...(unref(password) && { publicLinkPassword: unref(password) })
+  })
+)
+
+const item = computed(() => queryItemAsString(unref(route).params.driveAliasAndItem))
+
+const detailsQuery = useRouteQuery('details')
+const details = computed(() => queryItemAsString(unref(detailsQuery)))
+
+const loadedSpace = ref<PublicSpaceResource>()
+const isPasswordRequired = ref(false)
+const isInternalLink = ref(false)
+
+const loadPublicSpaceTask = useTask(function* (signal) {
+  try {
+    loadedSpace.value = yield clientService.webdav.getFileInfo(
+      unref(publicLinkSpace),
+      {},
+      { signal }
     )
+  } catch (error) {
+    const err = error as DavHttpError
 
-    const item = computed(() => {
-      return queryItemAsString(unref(route).params.driveAliasAndItem)
-    })
-
-    const detailsQuery = useRouteQuery('details')
-    const details = computed(() => {
-      return queryItemAsString(unref(detailsQuery))
-    })
-
-    const loadedSpace = ref<PublicSpaceResource>()
-    const isPasswordRequired = ref(false)
-    const isInternalLink = ref(false)
-
-    const loadPublicSpaceTask = useTask(function* (signal) {
-      try {
-        loadedSpace.value = yield clientService.webdav.getFileInfo(
-          unref(publicLinkSpace),
-          {},
-          { signal }
-        )
-      } catch (error) {
-        const err = error as DavHttpError
-
-        if (err.statusCode === 401) {
-          if (err.errorCode === 'ERR_MISSING_BASIC_AUTH') {
-            isPasswordRequired.value = true
-          }
-
-          if (err.errorCode === 'ERR_MISSING_BEARER_AUTH') {
-            isInternalLink.value = true
-          }
-
-          return
-        }
-        if (err.statusCode === 404) {
-          throw new Error($gettext('The resource could not be located, it may not exist anymore.'))
-        }
-        throw err
-      }
-    })
-
-    const verifyPasswordTask = useTask(function* (signal) {
-      try {
-        loadedSpace.value = yield clientService.webdav.getFileInfo(
-          unref(publicLinkSpace),
-          {},
-          { signal }
-        )
-        if (!isPublicSpaceResource(unref(loadedSpace))) {
-          const e: any = new Error($gettext('The resource is not a public link.'))
-          e.resource = unref(loadedSpace)
-          throw e
-        }
-      } catch (e) {
-        if (e.statusCode === 401) {
-          throw e
-        }
-        throw new Error($gettext('The resource could not be located, it may not exist anymore.'))
-      }
-    })
-    const wrongPassword = computed(() => {
-      if (verifyPasswordTask.isError) {
-        return verifyPasswordTask.last.error.statusCode === 401
-      }
-      return false
-    })
-
-    const resolvePublicLinkTask = useTask(function* (signal, passwordRequired: boolean) {
-      if (unref(isOcmLink) && !configStore.options.ocm.openRemotely) {
-        throw new Error($gettext('Opening files from remote is disabled'))
+    if (err.statusCode === 401) {
+      if (err.errorCode === 'ERR_MISSING_BASIC_AUTH') {
+        isPasswordRequired.value = true
       }
 
-      if (unref(isInternalLink)) {
-        router.push({ name: 'login', query: { redirectUrl: `/i/${unref(token)}` } })
-        return
+      if (err.errorCode === 'ERR_MISSING_BEARER_AUTH') {
+        isInternalLink.value = true
       }
 
-      yield authService.resolvePublicLink(
-        unref(token),
-        passwordRequired,
-        passwordRequired ? unref(password) : '',
-        unref(publicLinkType)
-      )
+      return
+    }
+    if (err.statusCode === 404) {
+      throw new Error($gettext('The resource could not be located, it may not exist anymore.'))
+    }
+    throw err
+  }
+})
 
-      if (passwordRequired) {
-        try {
-          yield verifyPasswordTask.perform()
-        } catch (e) {
-          authStore.clearPublicLinkContext()
-          console.error(e, e.resource)
-          throw e
-        }
-      }
+const verifyPasswordTask = useTask(function* (signal) {
+  try {
+    loadedSpace.value = yield clientService.webdav.getFileInfo(
+      unref(publicLinkSpace),
+      {},
+      { signal }
+    )
+    if (!isPublicSpaceResource(unref(loadedSpace))) {
+      const e: any = new Error($gettext('The resource is not a public link.'))
+      e.resource = unref(loadedSpace)
+      throw e
+    }
+  } catch (e) {
+    if (e.statusCode === 401) {
+      throw e
+    }
+    throw new Error($gettext('The resource could not be located, it may not exist anymore.'))
+  }
+})
+const wrongPassword = computed(() => {
+  if (verifyPasswordTask.isError) {
+    return verifyPasswordTask.last.error.statusCode === 401
+  }
+  return false
+})
 
-      const url = queryItemAsString(unref(redirectUrl))
-      if (url) {
-        router.push({ path: url })
-        return
-      }
+const resolvePublicLinkTask = useTask(function* (signal, passwordRequired: boolean) {
+  if (unref(isOcmLink) && !configStore.options.ocm.openRemotely) {
+    throw new Error($gettext('Opening files from remote is disabled'))
+  }
 
-      if (unref(loadedSpace).publicLinkPermission === SharePermissionBit.Create) {
-        router.push({
-          name: 'files-public-upload',
-          params: { token: unref(token) },
-          query: { fileId: unref(publicLinkSpace).fileId }
-        })
-        return
-      }
+  if (unref(isInternalLink)) {
+    router.push({ name: 'login', query: { redirectUrl: `/i/${unref(token)}` } })
+    return
+  }
 
-      let scrollTo: string
-      let fileId: string
-      let path: string
+  yield authService.resolvePublicLink(
+    unref(token),
+    passwordRequired,
+    passwordRequired ? unref(password) : '',
+    unref(publicLinkType)
+  )
 
-      if (['folder', 'space'].includes(unref(loadedSpace).type)) {
-        fileId = unref(loadedSpace).fileId
-        path = unref(item)
-      } else {
-        fileId = unref(loadedSpace).parentFolderId
-        scrollTo = unref(loadedSpace).fileId
-        path = dirname(unref(item))
-      }
-
-      spacesStore.upsertSpace(unref(loadedSpace))
-
-      const driveAliasAndItem = urlJoin(unref(isOcmLink) ? `ocm/` : `public/`, unref(token), path)
-      const targetLocation: RouteLocationNamedRaw = {
-        name: 'files-public-link',
-        query: {
-          openWithDefaultApp: 'true',
-          ...(!!fileId && { fileId }),
-          ...(!!scrollTo && { scrollTo }),
-          ...(unref(details) && { details: unref(details) })
-        },
-        params: {
-          driveAliasAndItem
-        }
-      }
-
-      router.push(targetLocation)
-    })
-
-    const errorMessage = computed<string>(() => {
-      if (resolvePublicLinkTask.isError && resolvePublicLinkTask.last.error.statusCode !== 401) {
-        return resolvePublicLinkTask.last.error.message
-      }
-
-      if (loadPublicSpaceTask.isError) {
-        return loadPublicSpaceTask.last.error.message
-      }
-      return null
-    })
-
-    onMounted(async () => {
-      try {
-        if (unref(isOcmLink)) {
-          await resolvePublicLinkTask.perform(false)
-          return
-        }
-
-        await loadPublicSpaceTask.perform()
-
-        if (!unref(isPasswordRequired)) {
-          await resolvePublicLinkTask.perform(false)
-        }
-      } catch (e) {
-        console.error(e)
-      }
-    })
-
-    const footerSlogan = computed(() => currentTheme.value.common.slogan)
-    const passwordFieldLabel = computed(() => {
-      return $gettext('Enter password for public link')
-    })
-    const wrongPasswordMessage = computed(() => {
-      if (unref(wrongPassword)) {
-        return $gettext('Incorrect password')
-      }
-      return null
-    })
-
-    return {
-      isPasswordRequired,
-      password,
-      wrongPassword,
-      passwordFieldLabel,
-      wrongPasswordMessage,
-      errorMessage,
-      footerSlogan,
-      resolvePublicLinkTask,
-      loadPublicSpaceTask
+  if (passwordRequired) {
+    try {
+      yield verifyPasswordTask.perform()
+    } catch (e) {
+      authStore.clearPublicLinkContext()
+      console.error(e, e.resource)
+      throw e
     }
   }
+
+  const url = queryItemAsString(unref(redirectUrl))
+  if (url) {
+    router.push({ path: url })
+    return
+  }
+
+  if (unref(loadedSpace).publicLinkPermission === SharePermissionBit.Create) {
+    router.push({
+      name: 'files-public-upload',
+      params: { token: unref(token) },
+      query: { fileId: unref(publicLinkSpace).fileId }
+    })
+    return
+  }
+
+  let scrollTo: string
+  let fileId: string
+  let path: string
+
+  if (['folder', 'space'].includes(unref(loadedSpace).type)) {
+    fileId = unref(loadedSpace).fileId
+    path = unref(item)
+  } else {
+    fileId = unref(loadedSpace).parentFolderId
+    scrollTo = unref(loadedSpace).fileId
+    path = dirname(unref(item))
+  }
+
+  spacesStore.upsertSpace(unref(loadedSpace))
+
+  const driveAliasAndItem = urlJoin(unref(isOcmLink) ? `ocm/` : `public/`, unref(token), path)
+  const targetLocation: RouteLocationNamedRaw = {
+    name: 'files-public-link',
+    query: {
+      openWithDefaultApp: 'true',
+      ...(!!fileId && { fileId }),
+      ...(!!scrollTo && { scrollTo }),
+      ...(unref(details) && { details: unref(details) })
+    },
+    params: {
+      driveAliasAndItem
+    }
+  }
+
+  router.push(targetLocation)
+})
+
+const errorMessage = computed<string>(() => {
+  if (resolvePublicLinkTask.isError && resolvePublicLinkTask.last.error.statusCode !== 401) {
+    return resolvePublicLinkTask.last.error.message
+  }
+
+  if (loadPublicSpaceTask.isError) {
+    return loadPublicSpaceTask.last.error.message
+  }
+  return null
+})
+
+onMounted(async () => {
+  try {
+    if (unref(isOcmLink)) {
+      await resolvePublicLinkTask.perform(false)
+      return
+    }
+
+    await loadPublicSpaceTask.perform()
+
+    if (!unref(isPasswordRequired)) {
+      await resolvePublicLinkTask.perform(false)
+    }
+  } catch (e) {
+    console.error(e)
+  }
+})
+
+const footerSlogan = computed(() => currentTheme.value.common.slogan)
+const passwordFieldLabel = computed(() => {
+  return $gettext('Enter password for public link')
+})
+const wrongPasswordMessage = computed(() => {
+  if (unref(wrongPassword)) {
+    return $gettext('Incorrect password')
+  }
+  return null
 })
 </script>
 

--- a/packages/web-runtime/tests/unit/pages/resolvePublicLink.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/resolvePublicLink.spec.ts
@@ -35,34 +35,43 @@ describe('resolvePublicLink', () => {
   describe('password required form', () => {
     it('should display if password is required', async () => {
       const { wrapper } = getWrapper({ passwordRequired: true })
-      await wrapper.vm.loadPublicSpaceTask.last
+      await (wrapper.vm as any).loadPublicSpaceTask.last
 
       expect(wrapper.find('form').html()).toMatchSnapshot()
     })
     describe('submit button', () => {
       it('should be set as disabled if "password" is empty', async () => {
         const { wrapper } = getWrapper({ passwordRequired: true })
-        await wrapper.vm.loadPublicSpaceTask.last
+        await (wrapper.vm as any).loadPublicSpaceTask.last
 
         expect(wrapper.find(selectors.submitButton).attributes().disabled).toBe('true')
       })
       it('should be set as enabled if "password" is not empty', async () => {
         const { wrapper } = getWrapper({ passwordRequired: true })
-        await wrapper.vm.loadPublicSpaceTask.last
-        wrapper.vm.password = 'password'
+        await (wrapper.vm as any).loadPublicSpaceTask.last
+        ;(wrapper.vm as any).password = 'password'
         await wrapper.vm.$nextTick()
 
         expect(wrapper.find(selectors.submitButton).attributes().disabled).toBe('false')
       })
+      it('should be disabled and showing spinner when submit button is clicked', async () => {
+        const { wrapper } = getWrapper({ passwordRequired: true })
+        ;(wrapper.vm as any).resolvePublicLinkTask.perform(true)
+        await (wrapper.vm as any).loadPublicSpaceTask.last
+        ;(wrapper.vm as any).password = 'password'
+        await wrapper.vm.$nextTick()
+        const submitButton = wrapper.find(selectors.submitButton)
+        expect(submitButton.attributes().disabled).toBe('true')
+        expect(submitButton.attributes().showspinner).toBe('true')
+      })
       it('should resolve the public link on click', async () => {
         const resolvePublicLinkSpy = vi.spyOn(authService, 'resolvePublicLink')
         const { wrapper } = getWrapper({ passwordRequired: true })
-        await wrapper.vm.loadPublicSpaceTask.last
-
-        wrapper.vm.password = 'password'
+        await (wrapper.vm as any).loadPublicSpaceTask.last
+        ;(wrapper.vm as any).password = 'password'
         await wrapper.vm.$nextTick()
         await wrapper.find(selectors.submitButton).trigger('submit')
-        await wrapper.vm.resolvePublicLinkTask.last
+        await (wrapper.vm as any).resolvePublicLinkTask.last
 
         expect(resolvePublicLinkSpy).toHaveBeenCalled()
       })
@@ -74,7 +83,7 @@ describe('resolvePublicLink', () => {
       const { wrapper } = getWrapper({ getFileInfoErrorStatusCode: 404 })
 
       try {
-        await wrapper.vm.loadPublicSpaceTask.last
+        await (wrapper.vm as any).loadPublicSpaceTask.last
       } catch {}
 
       expect(wrapper.find('.oc-link-resolve-error-message').text()).toContain(
@@ -86,7 +95,7 @@ describe('resolvePublicLink', () => {
       const { wrapper } = getWrapper({
         passwordRequired: true,
         getFileInfoErrorStatusCode: 404
-      })
+      }) as any
       await wrapper.vm.loadPublicSpaceTask.last
       await expect(wrapper.vm.resolvePublicLinkTask.perform(true)).rejects.toThrow()
 
@@ -98,7 +107,7 @@ describe('resolvePublicLink', () => {
   describe('internal link', () => {
     it('redirects the user to the login page', async () => {
       const { wrapper, mocks } = getWrapper({ isInternalLink: true })
-      await wrapper.vm.loadPublicSpaceTask.last
+      await (wrapper.vm as any).loadPublicSpaceTask.last
 
       expect(mocks.$router.push).toHaveBeenCalledWith({
         name: 'login',


### PR DESCRIPTION
add loading spinner to submit button for password-protected public links.

We have enhanced the user experience by displaying a loading spinner and disabling the submit button when clicked on password-protected public links. This ensures users on slower connections receive clear feedback that their request is being processed.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/7190

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
