### PR TITLE
[test-only][full-ci] bump ocis stable-7.1 commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=56f7645f0b11c9112e15ce46f6effd2fea01d6be
+OCIS_COMMITID=2c6bb688eeb60a929b7b9a16ae250e7cf47e405e
 OCIS_BRANCH=stable-7.1


### PR DESCRIPTION
Bump latest ocis stable-7.1 commit id.

Part of: https://github.com/owncloud/QA/issues/884