### PR TITLE
[tests-only][full-ci] set configs based on browser support

### DIFF
--- a/tests/e2e/cucumber/environment/index.ts
+++ b/tests/e2e/cucumber/environment/index.ts
@@ -18,6 +18,7 @@ import { state } from './shared'
 import { config } from '../../config'
 import { Group, User, UserState } from '../../support/types'
 import { api, environment, utils, store } from '../../support'
+import { getBrowserLaunchOptions } from '../../support/environment/actor/shared'
 
 export { World }
 
@@ -35,15 +36,7 @@ setDefaultTimeout(config.debug ? -1 : config.timeout * 1000)
 setWorldConstructor(World)
 
 BeforeAll(async (): Promise<void> => {
-  const browserConfiguration = {
-    slowMo: config.slowMo,
-    args: ['--use-fake-ui-for-media-stream', '--use-fake-device-for-media-stream'],
-    firefoxUserPrefs: {
-      'media.navigator.streams.fake': true,
-      'media.navigator.permission.disabled': true
-    },
-    headless: config.headless
-  }
+  const browserConfiguration = getBrowserLaunchOptions()
 
   const browsers: Record<string, () => Promise<Browser>> = {
     firefox: async (): Promise<Browser> => await firefox.launch(browserConfiguration),


### PR DESCRIPTION
## Description
some browser capabilities and permissions are not supported in all browsers (chromium, firebfox, webkit). Therefore, adding the correct browser configs based on their support.

## Related Issue


## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
