### PR TITLE
[test-only][full-ci] bump ocis stable-7.1 commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=2c6bb688eeb60a929b7b9a16ae250e7cf47e405e
+OCIS_COMMITID=ab5591184ce590c1f6b81c118255430df9b94bb2
 OCIS_BRANCH=stable-7.1


### PR DESCRIPTION
Bump latest ocis stable-7.1 commit id.

Part of: https://github.com/owncloud/QA/issues/885