### PR TITLE
feat: add configurable space members management

### DIFF
--- a/changelog/unreleased/enhancement-disable-space-membership-management-when-its-server-managed
+++ b/changelog/unreleased/enhancement-disable-space-membership-management-when-its-server-managed
@@ -1,0 +1,5 @@
+Enhancement: Disable space membership management when it's server-managed
+
+Hide the "Add members" section and member edit options in the "Members" panel in the space sidebar when the `spaces.server_managed` capability is `true`.
+
+https://github.com/owncloud/web/pull/12584

--- a/packages/web-client/src/ocs/capabilities.ts
+++ b/packages/web-client/src/ocs/capabilities.ts
@@ -164,6 +164,7 @@ export interface Capabilities {
       max_quota?: number
       projects?: boolean
       version?: string
+      server_managed?: boolean
     }
     graph?: {
       'personal-data-export'?: boolean

--- a/packages/web-pkg/src/composables/piniaStores/capabilities.ts
+++ b/packages/web-pkg/src/composables/piniaStores/capabilities.ts
@@ -63,7 +63,8 @@ const defaultValues = {
   spaces: {
     enabled: false,
     max_quota: 0,
-    projects: false
+    projects: false,
+    server_managed: false
   }
 } satisfies Partial<Capabilities['capabilities']>
 

--- a/packages/web-pkg/src/composables/shares/useCanShare.ts
+++ b/packages/web-pkg/src/composables/shares/useCanShare.ts
@@ -9,7 +9,7 @@ export const useCanShare = () => {
   const userStore = useUserStore()
 
   const canShare = ({ space, resource }: { space: SpaceResource; resource: Resource }) => {
-    if (!capabilityStore.sharingApiEnabled) {
+    if (!capabilityStore.sharingApiEnabled || capabilityStore.capabilities.spaces.server_managed) {
       return false
     }
 


### PR DESCRIPTION
## Description

Add a check to the canShare permissions check to assert on space whether the  capability is set. If it is , hide the "Add members" section and member edit options in the "Members" panel in space sidebar.

## Motivation and Context

Respect capabilities and allow space members to be maintained via OIDC claims.

## How Has This Been Tested?

- test environment: chrome
- test case 1: `server_managed` is `true`
- test case 2: `server_managed` is `failse`

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
