### PR TITLE
[full-ci] use same hostname for both ocis instances in docker compose setup

### DIFF
--- a/dev/docker/ocis.idp.config.yaml
+++ b/dev/docker/ocis.idp.config.yaml
@@ -11,23 +11,23 @@ clients:
       - https://host.docker.internal:9201/
       - https://host.docker.internal:9201/oidc-callback.html
       - https://host.docker.internal:9201/oidc-silent-redirect.html
-      - https://ocis.owncloud.test:10200/
-      - https://ocis.owncloud.test:10200/oidc-callback.html
-      - https://ocis.owncloud.test:10200/oidc-silent-redirect.html
-      - https://ocis.owncloud.test:10201/
-      - https://ocis.owncloud.test:10201/oidc-callback.html
-      - https://ocis.owncloud.test:10201/oidc-silent-redirect.html
+      - https://host.docker.internal:10200/
+      - https://host.docker.internal:10200/oidc-callback.html
+      - https://host.docker.internal:10200/oidc-silent-redirect.html
+      - https://host.docker.internal:10201/
+      - https://host.docker.internal:10201/oidc-callback.html
+      - https://host.docker.internal:10201/oidc-silent-redirect.html
     origins:
       - https://host.docker.internal:9200
       - https://host.docker.internal:9201
-      - https://ocis.owncloud.test:10200
-      - https://ocis.owncloud.test:10201
+      - https://host.docker.internal:10200
+      - https://host.docker.internal:10201
 
-  - id: "xdXOt13JKxym1B1QcEncf2XDkLAexMBFwiT9j6EfhhHFJhs2KM9jbjTmf8JBXE69"
+  - id: xdXOt13JKxym1B1QcEncf2XDkLAexMBFwiT9j6EfhhHFJhs2KM9jbjTmf8JBXE69
     name: ownCloud desktop client
-    application_type: "native"
+    application_type: native
     trusted: true
-    secret: "UBntmLjC2yYCeHwsyj73Uwo9TAaecAetRwMw0xYcvNL9yRdLSUi0hUAHfvCHFeFh"
+    secret: UBntmLjC2yYCeHwsyj73Uwo9TAaecAetRwMw0xYcvNL9yRdLSUi0hUAHfvCHFeFh
     redirect_uris:
       - http://localhost
       - http://127.0.0.1

--- a/dev/docker/ocis.storage.ocmproviders.json
+++ b/dev/docker/ocis.storage.ocmproviders.json
@@ -1,9 +1,9 @@
 [
   {
-    "name": "host.docker.internal:9200",
-    "full_name": "host.docker.internal 9200",
+    "name": "ocis",
+    "full_name": "ocis server",
     "organization": "ownCloud",
-    "domain": "host.docker.internal:9200",
+    "domain": "host.docker.internal:(9200|10200)",
     "homepage": "https://owncloud.com",
     "services": [
       {
@@ -13,33 +13,10 @@
             "description": "ownCloud Open Cloud Mesh API"
           },
           "name": "ownCloud - OCM API",
-          "path": "https://host.docker.internal:9200/ocm/",
+          "path": "https://host.docker.internal:(9200|10200)/ocm/",
           "is_monitored": true
         },
-        "api_version": "0.0.1",
-        "host": "host.docker.internal:9200"
-      }
-    ]
-  },
-  {
-    "name": "ocis.owncloud.test:10200",
-    "full_name": "ocis.owncloud.test 10200",
-    "organization": "ownCloud",
-    "domain": "ocis.owncloud.test:10200",
-    "homepage": "https://owncloud.com",
-    "services": [
-      {
-        "endpoint": {
-          "type": {
-            "name": "OCM",
-            "description": "ownCloud Open Cloud Mesh API"
-          },
-          "name": "ownCloud - OCM API",
-          "path": "https://ocis.owncloud.test:10200/ocm/",
-          "is_monitored": true
-        },
-        "api_version": "0.0.1",
-        "host": "ocis.owncloud.test:10200"
+        "host": "host.docker.internal:(9200|10200)"
       }
     ]
   }

--- a/dev/docker/ocis.web-federated.config.json
+++ b/dev/docker/ocis.web-federated.config.json
@@ -1,9 +1,9 @@
 {
-  "server": "https://ocis.owncloud.test:10200",
-  "theme": "https://ocis.owncloud.test:10200/themes/owncloud/theme.json",
+  "server": "https://host.docker.internal:10200",
+  "theme": "https://host.docker.internal:10200/themes/owncloud/theme.json",
   "openIdConnect": {
-    "metadata_url": "https://ocis.owncloud.test:10200/.well-known/openid-configuration",
-    "authority": "https://ocis.owncloud.test:10200",
+    "metadata_url": "https://host.docker.internal:10200/.well-known/openid-configuration",
+    "authority": "https://host.docker.internal:10200",
     "client_id": "web",
     "response_type": "code",
     "scope": "openid profile email"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -179,7 +179,7 @@ services:
     restart: always
 
   collabora:
-    image: collabora/code:25.04.2.1.1
+    image: collabora/code:24.04.10.2.1
     entrypoint: /bin/sh
     command: ['-c', 'coolconfig generate-proof-key ; /start-collabora-online.sh']
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,6 @@ x-ocis-server: &ocis-service
 
   extra_hosts:
     - host.docker.internal:${DOCKER_HOST:-host-gateway}
-    - ocis.owncloud.test:${DOCKER_HOST:-host-gateway}
   restart: unless-stopped
   depends_on:
     - traefik
@@ -121,13 +120,13 @@ services:
     container_name: web_ocis_federated
     environment:
       <<: *ocis-environment
-      OCIS_URL: https://ocis.owncloud.test:10200
-      OCIS_CORS_ALLOW_ORIGINS: https://ocis.owncloud.test:10201
-      OCM_WEBAPP_TEMPLATE: https://ocis.owncloud.test:10201/o/{{.Token}}/{relative-path-to-shared-resource}
+      OCIS_URL: https://host.docker.internal:10200
+      OCIS_CORS_ALLOW_ORIGINS: https://host.docker.internal:10201
+      OCM_WEBAPP_TEMPLATE: https://host.docker.internal:10201/o/{{.Token}}/{relative-path-to-shared-resource}
     labels:
       traefik.enable: true
       traefik.http.routers.ocis-federated.tls: true
-      traefik.http.routers.ocis-federated.rule: Host(`ocis.owncloud.test`) && PathPrefix(`/`)
+      traefik.http.routers.ocis-federated.rule: Host(`host.docker.internal`) && PathPrefix(`/`)
       traefik.http.routers.ocis-federated.entrypoints: ocis-federated
       traefik.http.services.ocis-federated.loadbalancer.server.port: 9200
       # workaround: https://github.com/owncloud/ocis/issues/5108

--- a/tests/e2e/config.js
+++ b/tests/e2e/config.js
@@ -30,7 +30,7 @@ export const config = {
     return withHttp(this.keycloakHost + '/admin/master/console')
   },
   // ocm config
-  federatedBaseUrlOcis: process.env.FEDERATED_BASE_URL_OCIS ?? 'federation-ocis:10200',
+  federatedBaseUrlOcis: process.env.FEDERATED_BASE_URL_OCIS ?? 'host.docker.internal:10200',
   federatedServer: false,
   get baseUrl() {
     return withHttp(this.federatedServer ? this.federatedBaseUrlOcis : this.baseUrlOcis)


### PR DESCRIPTION
## Description
Use the same hostname for both ocis instances:
```diff
host.docker.internal:9200
- ocis.owncloud.test:10200
+ host.docker.internal:10200
```

This reduces the need for adding many hosts in the system while using the `docker-compose.yml` setup.

Fix: `collabora/code:25.04.2.1.1` was not working, so replaced it with `collabora/code:24.04.10.2.1` (same as in the CI)

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
