### PR TITLE
[tests-only][full-ci] bump ocis latest commit id of ocis stable branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=ab5591184ce590c1f6b81c118255430df9b94bb2
+OCIS_COMMITID=62bac12a4c74c3ede3f6ef4814a25be0f1c9b358
 OCIS_BRANCH=stable-7.1


### PR DESCRIPTION
### Descriptiom

This PR bump latest commit id of ocis `stable-7.1` branch.

Part of: https://github.com/owncloud/QA/issues/885