### PR TITLE
fix(web-pkg): access result of favorites loader

### DIFF
--- a/changelog/unreleased/bugfix-access-correct-key-when-loading-favorites.md
+++ b/changelog/unreleased/bugfix-access-correct-key-when-loading-favorites.md
@@ -1,0 +1,7 @@
+Bugfix: Access correct key when loading favorites
+
+When loading favorites, we were trying to build resources by mapping the response object itself.
+This was throwing an error because the response object is not a list.
+We are now using the `results` property of the response object to access the list of favorite resources.
+
+https://github.com/owncloud/web/pull/12606

--- a/packages/web-pkg/src/services/folder/loaders/loaderFavorites.ts
+++ b/packages/web-pkg/src/services/folder/loaders/loaderFavorites.ts
@@ -26,12 +26,12 @@ export class FolderLoaderFavorites implements FolderLoader {
       resourcesStore.clearResourceList()
       resourcesStore.setAncestorMetaData({})
 
-      let resources = yield clientService.webdav.listFavoriteFiles({
+      const { results } = yield clientService.webdav.listFavoriteFiles({
         username: userStore.user?.onPremisesSamAccountName,
         signal: signal1
       })
 
-      resources = resources.map(buildResource)
+      const resources = results.map(buildResource)
       resourcesStore.initResourceList({ currentFolder: null, resources })
     })
   }


### PR DESCRIPTION
## Description

Do not map the response object itself which throws an error and access the result prop of the object holding the list of favorite resources instead.

## Motivation and Context

Code without errors.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
