### PR TITLE
fix(web-pkg): load ancestor space only when parent ID is returned

### DIFF
--- a/changelog/unreleased/bugfix-load-ancestor-space-only-when-parent-id-is-returned.md
+++ b/changelog/unreleased/bugfix-load-ancestor-space-only-when-parent-id-is-returned.md
@@ -1,0 +1,6 @@
+Bugfix: Load ancestor space only when parent id is returned
+
+When loading ancestor meta data, we were trying to load the space even when the parent ID was not returned by the API.
+We are now only loading the space when the parent ID is returned.
+
+https://github.com/owncloud/web/pull/12607

--- a/packages/web-pkg/src/composables/piniaStores/resources.ts
+++ b/packages/web-pkg/src/composables/piniaStores/resources.ts
@@ -277,18 +277,23 @@ export const useResourcesStore = defineStore('resources', () => {
       if (!Object.keys(data).includes('/')) {
         // add space as root element
         const cachedRoot = unref(ancestorMetaData)['/']
+
         if (cachedRoot?.spaceId === space.id) {
           data['/'] = cachedRoot
         } else {
           const { parentFolderId } = Object.values(data)[0]
-          const space = spacesStore.spaces.find(({ id }) => parentFolderId.startsWith(id))
-          if (space) {
-            data['/'] = {
-              id: space.id,
-              shareTypes: space.shareTypes,
-              parentFolderId: space.id,
-              spaceId: space.id,
-              path: '/'
+
+          if (parentFolderId) {
+            const space = spacesStore.spaces.find(({ id }) => parentFolderId.startsWith(id))
+
+            if (space) {
+              data['/'] = {
+                id: space.id,
+                shareTypes: space.shareTypes,
+                parentFolderId: space.id,
+                spaceId: space.id,
+                path: '/'
+              }
             }
           }
         }

--- a/packages/web-pkg/src/types.ts
+++ b/packages/web-pkg/src/types.ts
@@ -1,7 +1,7 @@
 export interface AncestorMetaDataValue {
   id: string
   shareTypes: number[]
-  parentFolderId: string
+  parentFolderId?: string
   spaceId: string
   path: string
 }


### PR DESCRIPTION
## Description

Resource parent ID is optionally but we were not treating it as such when loading ancestor metadata. We are now looking for space only if the parent ID is returned by the API. Based on https://github.com/owncloud/web/pull/11946/commits/40b72d3965de3648fc01291487b048fc0a4e86e4

## Motivation and Context

Do not treat optional props as required ones.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
