### PR TITLE
fix(web-pkg): do not crash when TUS is unsupported

### DIFF
--- a/changelog/unreleased/bugfix-do-not-crash-when-tus-is-unsupported.md
+++ b/changelog/unreleased/bugfix-do-not-crash-when-tus-is-unsupported.md
@@ -1,0 +1,6 @@
+Bugfix: Do not crash when tus is unsupported
+
+When TUS is not supported, we were not setting a fallback value. This was causing the app to crash.
+We're now setting an empty string as fallback value so that we can still call `includes` method and not crash the app.
+
+https://github.com/owncloud/web/pull/12608

--- a/packages/web-pkg/src/composables/piniaStores/capabilities.ts
+++ b/packages/web-pkg/src/composables/piniaStores/capabilities.ts
@@ -130,7 +130,7 @@ export const useCapabilityStore = defineStore('capabilities', () => {
   )
 
   const tusMaxChunkSize = computed(() => unref(capabilities).files.tus_support?.max_chunk_size)
-  const tusExtension = computed(() => unref(capabilities).files.tus_support?.extension)
+  const tusExtension = computed(() => unref(capabilities).files.tus_support?.extension || '')
   const tusHttpMethodOverride = computed(
     () => unref(capabilities).files.tus_support?.http_method_override
   )


### PR DESCRIPTION
## Description

When TUS is not supported, we were not setting a fallback value. This was causing the app to crash. We're now setting an empty string as fallback value so that we can still call `includes` method and not crash the app. Based on https://github.com/owncloud/web/pull/11946/commits/2a1319b5aa8de11bfffcd9c26f1d4eb9a21f4568.

## Motivation and Context

App without crashes.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
