### PR TITLE
fix(web-pkg): add label to rename button

### DIFF
--- a/changelog/unreleased/bugfix-add-missing-label-to-rename-button.md
+++ b/changelog/unreleased/bugfix-add-missing-label-to-rename-button.md
@@ -1,0 +1,5 @@
+Bugfix: Add missing label to rename button
+
+Set `aria-label` to the rename button in the resource table for folders and files.
+
+https://github.com/owncloud/web/pull/12646

--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -94,6 +94,7 @@
         />
         <oc-button
           v-if="hasRenameAction(item)"
+          :aria-label="getRenameButtonAriaLabel(item)"
           class="resource-table-edit-name"
           appearance="raw"
           @click="openRenameDialog(item)"
@@ -314,6 +315,7 @@ import { OcButton, OcTable } from '@ownclouders/design-system/components'
 import { FieldType } from '@ownclouders/design-system/helpers'
 import { OcSpinner } from '@ownclouders/design-system/components'
 import ResourceStatusIndicators from './ResourceStatusIndicators.vue'
+import { useGettext } from 'vue3-gettext'
 
 const TAGS_MINIMUM_SCREEN_WIDTH = 850
 
@@ -553,6 +555,8 @@ export default defineComponent({
       fileTypes: embedModeFileTypes
     } = useEmbedMode()
     const { getDefaultAction } = useFileActions()
+    const { $pgettext } = useGettext()
+
     const configStore = useConfigStore()
     const { options: configOptions } = storeToRefs(configStore)
 
@@ -655,6 +659,20 @@ export default defineComponent({
       return unref(deleteQueue).includes(id)
     }
 
+    const getRenameButtonAriaLabel = (resource: Resource): string => {
+      if (resource.isFolder) {
+        return $pgettext(
+          'The label of the rename button in the resource table for folders',
+          'Rename folder'
+        )
+      }
+
+      return $pgettext(
+        'The label of the rename button in the resource table for files',
+        'Rename file'
+      )
+    }
+
     return {
       router,
       configOptions,
@@ -693,7 +711,8 @@ export default defineComponent({
       isResourceClickable,
       getResourceLink,
       isSticky,
-      isResourceInDeleteQueue
+      isResourceInDeleteQueue,
+      getRenameButtonAriaLabel
     }
   },
   data() {


### PR DESCRIPTION
## Description

Set `aria-label` to the rename button in the resource table for folders and files.

## Motivation and Context

Accessible app.

## How Has This Been Tested?

- test environment: chrome
- test case 1: check the rendered html
- test case 2: focus the button while screen reader is turned on

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
