### PR TITLE
feat(web-runtime): add login error

### DIFF
--- a/changelog/unreleased/enhancement-add-login-error.md
+++ b/changelog/unreleased/enhancement-add-login-error.md
@@ -1,0 +1,5 @@
+Enhancement: Add login error
+
+When the login fails due to any kind of error, the user is now presented with an error message.
+
+https://github.com/owncloud/web/pull/12648

--- a/packages/web-runtime/src/pages/login.vue
+++ b/packages/web-runtime/src/pages/login.vue
@@ -1,14 +1,43 @@
 <template>
-  <div class="oc-width-1-1 oc-height-1-1">
-    <app-loading-spinner />
+  <div class="login">
+    <div v-if="hasFailed" class="oc-login-card error-msg">
+      <div class="oc-login-card-body">
+        <h2 class="oc-login-card-title oc-mb-m">
+          {{
+            $pgettext(
+              'The error message title displayed on login page when login fails due to any kind of error.',
+              'Something went wrong'
+            )
+          }}
+        </h2>
+        <p class="oc-m-rm">
+          {{
+            $pgettext(
+              'The error message displayed on login page when login fails due to any kind of error.',
+              "We're having trouble connecting to the login service. If the problem continues, please contact support."
+            )
+          }}
+        </p>
+        <oc-button variation="primary" class="oc-mt-l" @click="login">
+          {{
+            $pgettext(
+              'The action to retry the login on login page when login fails due to any kind of error.',
+              'Try again'
+            )
+          }}
+        </oc-button>
+      </div>
+    </div>
+    <app-loading-spinner v-else />
   </div>
 </template>
 
 <script lang="ts">
 import { authService } from '../services/auth'
 import { queryItemAsString, useRouteQuery } from '@ownclouders/web-pkg'
-import { defineComponent, unref } from 'vue'
+import { defineComponent, ref, unref } from 'vue'
 import { AppLoadingSpinner } from '@ownclouders/web-pkg'
+import { captureException } from '@sentry/vue'
 
 export default defineComponent({
   name: 'LoginPage',
@@ -17,9 +46,41 @@ export default defineComponent({
   },
   setup() {
     const redirectUrl = useRouteQuery('redirectUrl')
-    authService.loginUser(queryItemAsString(unref(redirectUrl)))
 
-    return {}
+    const hasFailed = ref(false)
+
+    const login = async () => {
+      hasFailed.value = false
+
+      try {
+        await authService.loginUser(queryItemAsString(unref(redirectUrl)))
+      } catch (e) {
+        console.error(e)
+        captureException(e)
+
+        hasFailed.value = true
+      }
+    }
+
+    login()
+
+    return {
+      hasFailed,
+      login
+    }
   }
 })
 </script>
+
+<style lang="scss" scoped>
+.login {
+  align-content: center;
+  min-height: 100vh;
+  width: 100%;
+}
+
+.error-msg {
+  margin-inline: auto;
+  width: min(100%, $width-xlarge-width);
+}
+</style>


### PR DESCRIPTION
## Description

When the login fails due to any kind of error, the user is now presented with an error message.

## Motivation and Context

User is not stuck in endless loading spinner loop.

## How Has This Been Tested?

- test environment: chrome
- test case 1: run ocis and kill idp

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/e8aca22b-d6e9-470b-8a3a-2a60cc861e48)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
