### PR TITLE
Update the docs makefile for improved handling and messaging

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,23 +2,15 @@ NAME := web
 HUGO := ${CURDIR}/hugo
 HDIR := ${CURDIR}/hugo/.git
 
-# for drone only, run necessary doc prep commands. drone uses an image for hugo, so do not execute hugo with docs-build
-# CURDIR will work for make only but not when running manually in the shell
-.PHONY: docs-drone
-docs-drone: docs-init docs-copy
-	@echo 'Linking directory hugo for drone.'
-	@ln -s $(HUGO) ../hugo
+hugo-exists:
+## if the directory exists, print that we do not need to prepare
+	@if [ -d $(HDIR) ]; then \
+		echo 'Build environment for hugo exists, nothing to setup, continuing.'; \
+	fi
 
-# run all necessary doc commands
-.PHONY: docs
-docs: docs-init docs-copy docs-build
-
-# order-only-prerequisites, always execute @echo 
-docs-init: | $(HDIR)
-	@echo 'Directory hugo exists, nothing to setup, continuing.'
-
-# if the directory does not extist, initialize and create the theme
 $(HDIR):
+## if the directory does not extist, initialize and create the theme
+	@echo 'Creating build environment for hugo.'
 	@mkdir -p $(HUGO)/content/
 	@mkdir -p $(HUGO)/extensions/
 	@cd $(HUGO) && git init
@@ -29,13 +21,32 @@ $(HDIR):
 	@cd $(HUGO) && git checkout origin/main -f
 	@cd $(HUGO) && make --no-print-directory theme
 
+# for drone only, run necessary doc prep commands. drone uses an image for hugo, so do not execute hugo with docs-build
+# CURDIR will work for make only but not when running manually in the shell
+.PHONY: docs-drone
+docs-drone: docs-init docs-copy
+	@echo 'Linking directory hugo for drone.'
+	@rm -f ../hugo
+	@ln -s $(HUGO) ../hugo
+
+# run all necessary doc commands
+.PHONY: docs
+docs: docs-init docs-copy docs-first-time-message docs-build
+
 # create the build environment 
 .PHONY: docs-init
+docs-init: hugo-exists $(HDIR)
+## if there is nothing to do, stop printing that
+## another way would be https://stackoverflow.com/questions/58039810/makefiles-what-is-an-order-only-prerequisite
+	@:
+
+# print a hint when doing a local build because it may fail if you have not run pnpm commands at least once
+docs-first-time-message:
+	@echo 'Note, on a fresh web clone, you need to run `pnpm install` and `pnpm build` once to create required directories.'
 
 # copy required resources into hugo
 .PHONY: docs-copy
 docs-copy:
-	@echo 'Note on a fresh clone, you need to run `pnpm install` and `pnpm build` once to create required directories.'
 	@echo 'Syncing required doc files and directories for the build process.'
 	@rsync --delete -ax --exclude=hugo/ --exclude=.gitignore ./ $(HUGO)/content/$(NAME)
 


### PR DESCRIPTION
This PR updates some `docs-xxx` steps for improved processing and error/step messaging.
This (hopefully) eases finding build errors in https://drone.owncloud.com/owncloud/owncloud.github.io when web triggers a build 