### PR TITLE
Fix the global owncloud.dev build process

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -927,7 +927,7 @@ def documentation(ctx):
                         "password": {
                             "from_secret": "github_token",
                         },
-                        "pages_directory": "docs/",
+                        "pages_directory": "docs/hugo/content/web/",
                         "copy_contents": "true",
                         "target_branch": "docs",
                         "delete": "true",

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -48,7 +48,7 @@ docs-first-time-message:
 .PHONY: docs-copy
 docs-copy:
 	@echo 'Syncing required doc files and directories for the build process.'
-	@rsync --delete -ax --exclude=hugo/ --exclude=.gitignore ./ $(HUGO)/content/$(NAME)
+	@rsync --delete -ax --exclude=hugo/ --exclude=Makefile ./ $(HUGO)/content/$(NAME)
 
 # create a docs build
 .PHONY: docs-build


### PR DESCRIPTION
This PR fixes the global build pipeline for owncloud.dev.

Compared to the `.drone.star` pipeline in ocis, this one copied the `docs` folder and not the `docs/hugo/content/web` folder causing a loophole within hugo when running a build via `owncloud.github.io`