### PR TITLE
[docs-only] Update the make docs-clean command

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -65,5 +65,10 @@ docs-serve:
 # clean up docs build artifacts (removing the hogo folder)
 .PHONY: docs-clean
 docs-clean:
-	@rm -rf $(HUGO)
-	@echo "Removed folder: $(HUGO)"
+# note that the whitespace at the begginning of the lines of ifneq/else/endif statements are intentionally!
+ 	ifneq ($(shell id -u), 0)
+		@echo "You need to run the clean command using sudo or as root because some doc files are created by root"
+ 	else
+		@rm -rf $(HUGO)
+		@echo "Removed folder: $(HUGO)"
+ 	endif


### PR DESCRIPTION
The `make docs-clean` command has been updated.

Because a doc build uses a docker image, files created by hugo are now from the root user in folder `docs/hugo` which needs elevated permissions to delete them.