### PR TITLE
fix(design-system): export ESM as .js

### DIFF
--- a/changelog/unreleased/bugfix-export-correct-design-system-files.md
+++ b/changelog/unreleased/bugfix-export-correct-design-system-files.md
@@ -1,0 +1,5 @@
+Bugfix: Export correct design system files
+
+We've fixed the export of the design system files to ensure they are correctly exported as ES modules.
+
+https://github.com/owncloud/web/pull/12717

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -48,23 +48,23 @@
     "linkDirectory": false,
     "exports": {
       ".": {
-        "default": "./dist/design-system.mjs",
-        "require": "./dist/design-system.js",
+        "default": "./dist/design-system.js",
+        "require": "./dist/design-system.cjs",
         "types": "./dist/src/index.d.ts"
       },
       "./components": {
-        "default": "./dist/design-system/components.mjs",
-        "require": "./dist/design-system/components.js",
+        "default": "./dist/design-system/components.js",
+        "require": "./dist/design-system/components.cjs",
         "types": "./dist/src/components/index.d.ts"
       },
       "./composables": {
-        "default": "./dist/design-system/composables.mjs",
-        "require": "./dist/design-system/composables.js",
+        "default": "./dist/design-system/composables.js",
+        "require": "./dist/design-system/composables.cjs",
         "types": "./dist/src/composables/index.d.ts"
       },
       "./helpers": {
-        "default": "./dist/design-system/helpers.mjs",
-        "require": "./dist/design-system/helpers.js",
+        "default": "./dist/design-system/helpers.js",
+        "require": "./dist/design-system/helpers.cjs",
         "types": "./dist/src/helpers/index.d.ts"
       }
     }


### PR DESCRIPTION
## Description

After recent changes, the built files changed and instead of exporting CommonJS modules as .js files, we are now exporting ESM as .js and CommonJS as .cjs. The exports field in package.json was not adjusted causing issues when installing the package. This uses correct file extensions.

## Motivation and Context

Correct files.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
