### PR TITLE
fix(web-app-files): reset selection only when path changes

### DIFF
--- a/changelog/unreleased/bugfix-reset-selection-only-when-path-changes.md
+++ b/changelog/unreleased/bugfix-reset-selection-only-when-path-changes.md
@@ -1,0 +1,12 @@
+Bugfix: Reset selection only when path changes
+
+We've changed the way we reset the selection when the route changes.
+
+Previously, we were resetting the selection when the route changed, but this was not
+working as expected. For example, when updating `scrollTo` route query, the selection
+was being unintentionally reset.
+
+Now, we're only resetting the selection when the path changes.
+
+https://github.com/owncloud/web/pull/12768
+https://github.com/owncloud/web/issues/10398

--- a/packages/web-app-files/src/App.vue
+++ b/packages/web-app-files/src/App.vue
@@ -5,15 +5,19 @@
   </main>
 </template>
 <script lang="ts">
-import { defineComponent, onBeforeUnmount, watch, ref } from 'vue'
+import { defineComponent, onBeforeUnmount, watch, ref, computed, unref } from 'vue'
 import { useRoute, eventBus, useResourcesStore } from '@ownclouders/web-pkg'
 
 export default defineComponent({
   setup() {
-    const dragareaEnabled = ref(false)
+    const route = useRoute()
     const { resetSelection } = useResourcesStore()
 
-    watch(useRoute(), () => {
+    const dragareaEnabled = ref(false)
+
+    const routePath = computed(() => unref(route).path)
+
+    watch(routePath, (value) => {
       resetSelection()
     })
 


### PR DESCRIPTION
## Description

We've changed the way we reset the selection when the route changes.

Previously, we were resetting the selection when the route changed, but this was not working as expected. For example, when updating `scrollTo` route query, the selection was being unintentionally reset.

Now, we're only resetting the selection when the path changes.

## Related Issue

- resolves https://github.com/owncloud/web/issues/10398

## Motivation and Context

Users can easily see the resource from the notification

## How Has This Been Tested?

- test environment: macOS
- test case 1: click on the resource from the notification while in shared with me list

## Screenshots (if appropriate):


https://github.com/user-attachments/assets/c5b8f200-feaf-4762-a3ad-4015c0ac1b3c



## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
