### PR TITLE
fix(web-app-admin-settings): [OCISDEV-138] handle direct admin settings access

### DIFF
--- a/changelog/unreleased/bugfix-handle-direct-admin-settings-access.md
+++ b/changelog/unreleased/bugfix-handle-direct-admin-settings-access.md
@@ -1,0 +1,7 @@
+Bugfix: Handle direct admin settings access
+
+Opening the admin settings directly by pasting the URL in the browser address bar or opening the app in a new tab now works correctly.
+The redirect was not correctly using the navigation guard leading to a mismatch in users permissions.
+We now redirect to the first available route and leave the route itself to handle the permissions navigation guard.
+
+https://github.com/owncloud/web/pull/12780

--- a/packages/web-app-admin-settings/src/index.ts
+++ b/packages/web-app-admin-settings/src/index.ts
@@ -22,23 +22,31 @@ function $gettext(msg: string) {
 
 const appId = 'admin-settings'
 
+function getAvailableRoute(ability: Ability) {
+  if (ability.can('read-all', 'Setting')) {
+    return { name: 'admin-settings-general' }
+  }
+
+  if (ability.can('read-all', 'Account')) {
+    return { name: 'admin-settings-users' }
+  }
+
+  if (ability.can('read-all', 'Group')) {
+    return { name: 'admin-settings-groups' }
+  }
+
+  if (ability.can('read-all', 'Drive')) {
+    return { name: 'admin-settings-spaces' }
+  }
+
+  throw Error('Insufficient permissions')
+}
+
 export const routes = ({ $ability }: { $ability: Ability }): RouteRecordRaw[] => [
   {
     path: '/',
     redirect: () => {
-      if ($ability.can('read-all', 'Setting')) {
-        return { name: 'admin-settings-general' }
-      }
-      if ($ability.can('read-all', 'Account')) {
-        return { name: 'admin-settings-users' }
-      }
-      if ($ability.can('read-all', 'Group')) {
-        return { name: 'admin-settings-groups' }
-      }
-      if ($ability.can('read-all', 'Drive')) {
-        return { name: 'admin-settings-spaces' }
-      }
-      throw Error('Insufficient permissions')
+      return { name: 'admin-settings-general' }
     }
   },
   {
@@ -47,7 +55,7 @@ export const routes = ({ $ability }: { $ability: Ability }): RouteRecordRaw[] =>
     component: General,
     beforeEnter: (to, from, next) => {
       if (!$ability.can('read-all', 'Setting')) {
-        next({ path: '/' })
+        return next(getAvailableRoute($ability))
       }
       next()
     },
@@ -62,7 +70,7 @@ export const routes = ({ $ability }: { $ability: Ability }): RouteRecordRaw[] =>
     component: Users,
     beforeEnter: (to, from, next) => {
       if (!$ability.can('read-all', 'Account')) {
-        next({ path: '/' })
+        return next(getAvailableRoute($ability))
       }
       next()
     },
@@ -77,7 +85,7 @@ export const routes = ({ $ability }: { $ability: Ability }): RouteRecordRaw[] =>
     component: Groups,
     beforeEnter: (to, from, next) => {
       if (!$ability.can('read-all', 'Group')) {
-        next({ path: '/' })
+        return next(getAvailableRoute($ability))
       }
       next()
     },
@@ -92,7 +100,7 @@ export const routes = ({ $ability }: { $ability: Ability }): RouteRecordRaw[] =>
     component: Spaces,
     beforeEnter: (to, from, next) => {
       if (!$ability.can('read-all', 'Drive')) {
-        next({ path: '/' })
+        return next(getAvailableRoute($ability))
       }
       next()
     },


### PR DESCRIPTION
## Description

Opening the admin settings directly by pasting the URL in the browser address bar or opening the app in a new tab now works correctly. The redirect was not correctly using the navigation guard leading to a mismatch in users permissions. We now redirect to the first available route and leave the route itself to handle the permissions navigation guard.

## Motivation and Context

Users can open admin settings by entering URL address.

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: open admin settings on new tab
- test case 2: open admin settings by entering URL

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
