### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on stable-12 branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=a51f90e2e7f632be51235ab01c95ef1f27c82d87
+OCIS_COMMITID=e6c3458206a7180883e2098d76cbbb6a7d1e71bc
 OCIS_BRANCH=stable-7.2


### PR DESCRIPTION
## Description
Bump latest ocis `stable-7.2` branch commit id.

Part of: https://github.com/owncloud/QA/issues/889