### PR TITLE
chore: [OCISDEV-205] bump md-editor-v3 to 5.8.1 that uses latest Katex version

### DIFF
--- a/packages/web-pkg/package.json
+++ b/packages/web-pkg/package.json
@@ -60,7 +60,7 @@
     "lodash-es": "^4.17.21",
     "luxon": "^3.5.0",
     "mark.js": "^8.11.1",
-    "md-editor-v3": "^5.7.1",
+    "md-editor-v3": "^5.8.1",
     "mermaid": "^11.6.0",
     "oidc-client-ts": "^3.3.0",
     "p-queue": "^8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -980,8 +980,8 @@ importers:
         specifier: ^8.11.1
         version: 8.11.1
       md-editor-v3:
-        specifier: ^5.7.1
-        version: 5.7.1(vue@3.5.17(typescript@5.8.3))
+        specifier: ^5.8.1
+        version: 5.8.1(vue@3.5.17(typescript@5.8.3))
       mermaid:
         specifier: ^11.6.0
         version: 11.7.0
@@ -5295,8 +5295,8 @@ packages:
   mathml-tag-names@2.1.3:
     resolution: {integrity: sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==}
 
-  md-editor-v3@5.7.1:
-    resolution: {integrity: sha512-QPqa+xKpd0MMG2G0aYZGr0X0xcc43KKv03PVEe49BrsOr9/rlTPAz1an2M7yZKrCkuE2YIBPaQSIhcLLpLawrA==}
+  md-editor-v3@5.8.1:
+    resolution: {integrity: sha512-XXJaxULwX4N2fX4Tg+LAjj0b1+29erDNto3DAJya494ZmRYoegDmaJS6e7th6k4rKXPztPTeCbg9lyPpQEz1tw==}
     peerDependencies:
       vue: ^3.5.3
 
@@ -11848,7 +11848,7 @@ snapshots:
 
   mathml-tag-names@2.1.3: {}
 
-  md-editor-v3@5.7.1(vue@3.5.17(typescript@5.8.3)):
+  md-editor-v3@5.8.1(vue@3.5.17(typescript@5.8.3)):
     dependencies:
       '@codemirror/autocomplete': 6.18.6
       '@codemirror/commands': 6.8.1


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes - JIRA OCISDEV-205

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [x] Maintenance (e.g. dependency updates or tooling)
