### PR TITLE
bugfix(web-client, web-pkg): [OCISDEV-208] space parent return invalid path when parent is spaces' root

### DIFF
--- a/packages/web-client/src/helpers/share/functions.ts
+++ b/packages/web-client/src/helpers/share/functions.ts
@@ -185,7 +185,10 @@ export function buildOutgoingShareResource({
   serverUrl: string
 }): OutgoingShareResource {
   const storageId = extractStorageId(driveItem.id)
-  const path = urlJoin(driveItem.parentReference.path, driveItem.name)
+  const path =
+    driveItem.parentReference.path === '.'
+      ? driveItem.parentReference.path
+      : urlJoin(driveItem.parentReference.path, driveItem.name)
 
   const resource: OutgoingShareResource = {
     id: driveItem.id,

--- a/packages/web-pkg/src/components/FilesList/ResourceListItem.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceListItem.vue
@@ -64,8 +64,9 @@
     </div>
   </div>
 </template>
-<script lang="ts">
-import { computed, defineComponent, PropType } from 'vue'
+<script lang="ts" setup>
+import { computed } from 'vue'
+import { useGettext } from 'vue3-gettext'
 import { Resource } from '@ownclouders/web-client'
 import ResourceIcon from './ResourceIcon.vue'
 import ResourceLink from './ResourceLink.vue'
@@ -73,168 +74,111 @@ import ResourceName from './ResourceName.vue'
 import { RouteLocationRaw } from 'vue-router'
 import { HIDDEN_FILE_EXTENSIONS } from '../../constants'
 import { dirname, join } from 'node:path'
+
+interface Props {
+  resource: Resource
+  pathPrefix?: string
+  link?: RouteLocationRaw | null
+  isPathDisplayed?: boolean
+  parentFolderLink?: RouteLocationRaw | null
+  parentFolderName?: string
+  parentFolderLinkIconAdditionalAttributes?: Record<string, any>
+  isExtensionDisplayed?: boolean
+  isThumbnailDisplayed?: boolean
+  isIconDisplayed?: boolean
+  isResourceClickable?: boolean
+}
+
+interface Emits {
+  (e: 'click'): void
+}
+const {
+  resource,
+  pathPrefix = '',
+  link = null,
+  isPathDisplayed = false,
+  parentFolderLink = null,
+  parentFolderName = '',
+  parentFolderLinkIconAdditionalAttributes = {},
+  isExtensionDisplayed = true,
+  isThumbnailDisplayed = true,
+  isIconDisplayed = true,
+  isResourceClickable = true
+} = defineProps<Props>()
+
+const emit = defineEmits<Emits>()
+const { $gettext } = useGettext()
+const HIDDEN_EXTENSIONS = HIDDEN_FILE_EXTENSIONS
+
 /**
- * Displays a resource together with the resource type icon or thumbnail
+ * Checks if a path has a valid second segment after splitting by '/'.
+ * Used for tooltip display - if true, shows "segment1 > segment2 > ...",
+ * otherwise just shows "segment1" without trailing ">".
+ *
+ * @param {string} value - The path to check
+ * @returns {boolean} - True if path has a valid second segment, false otherwise
  */
-export default defineComponent({
-  name: 'ResourceListItem',
-  components: { ResourceIcon, ResourceLink, ResourceName },
-  props: {
-    /**
-     * The resource to be displayed
-     */
-    resource: {
-      type: Object as PropType<Resource>,
-      required: true
-    },
-    /**
-     * The prefix that will be shown in the path
-     */
-    pathPrefix: {
-      type: String,
-      required: false,
-      default: ''
-    },
-    /**
-     * The resource link
-     */
-    link: {
-      type: Object as PropType<RouteLocationRaw>,
-      required: false,
-      default: null
-    },
-    /**
-     * Asserts whether the resource path should be displayed
-     */
-    isPathDisplayed: {
-      type: Boolean,
-      required: false,
-      default: false
-    },
-    /**
-     * The resource parent folder link path
-     */
-    parentFolderLink: {
-      type: Object,
-      required: false,
-      default: null
-    },
-    /**
-     * The resource parent folder name to be displayed
-     */
-    parentFolderName: {
-      type: String,
-      required: false,
-      default: ''
-    },
-    /**
-     * The resource parent folder link path icon additional attributes
-     */
-    parentFolderLinkIconAdditionalAttributes: {
-      type: Object,
-      required: false,
-      default: () => ({})
-    },
-    /**
-     * Asserts whether the resource extension should be displayed
-     */
-    isExtensionDisplayed: {
-      type: Boolean,
-      required: false,
-      default: true
-    },
-    /**
-     * Asserts whether the resource thumbnail should be displayed
-     */
-    isThumbnailDisplayed: {
-      type: Boolean,
-      required: false,
-      default: true
-    },
-    /**
-     * Asserts whether the resource thumbnail should be displayed
-     */
-    isIconDisplayed: {
-      type: Boolean,
-      required: false,
-      default: true
-    },
-    /**
-     * Asserts whether clicking on the resource name triggers any action
-     */
-    isResourceClickable: {
-      type: Boolean,
-      required: false,
-      default: true
-    }
-  },
-  emits: ['click'],
 
-  setup(props) {
-    const parentFolderPathTooltip = computed(() => {
-      if (!props.isPathDisplayed) {
-        return null
-      }
+function splitPathHasSecondSegment(value: string): boolean {
+  const result = value.split('/')
+  return result?.length > 1 && result[1].length > 0
+}
 
-      const parentFolderPath = dirname(props.resource.path)
+function emitClick() {
+  /**
+   * Triggered when the resource is a file and the name is clicked
+   */
+  emit('click')
+}
 
-      if (props.pathPrefix) {
-        return join(props.pathPrefix, parentFolderPath).replaceAll('/', ' > ')
-      }
-
-      return parentFolderPath.replaceAll('/', ' > ')
-    })
-
-    return { HIDDEN_EXTENSIONS: HIDDEN_FILE_EXTENSIONS, parentFolderPathTooltip }
-  },
-
-  computed: {
-    parentFolderComponentType() {
-      return this.parentFolderLink ? 'router-link' : 'span'
-    },
-
-    parentFolderStyle() {
-      return {
-        cursor: this.parentFolderLink ? 'pointer' : 'default'
-      }
-    },
-
-    parentFolderLinkIconAttrs() {
-      return {
-        'fill-type': 'line',
-        name: 'folder-2',
-        size: 'small',
-        ...this.parentFolderLinkIconAdditionalAttributes
-      }
-    },
-
-    hasThumbnail() {
-      return (
-        this.isThumbnailDisplayed &&
-        Object.prototype.hasOwnProperty.call(this.resource, 'thumbnail')
-      )
-    },
-
-    thumbnail() {
-      return this.resource.thumbnail
-    },
-
-    tooltipLabelIcon() {
-      if (this.resource.locked) {
-        return this.$gettext('This item is locked')
-      }
-      return null
-    }
-  },
-
-  methods: {
-    emitClick() {
-      /**
-       * Triggered when the resource is a file and the name is clicked
-       */
-      this.$emit('click')
-    }
+const parentFolderPathTooltip = computed(() => {
+  if (!isPathDisplayed) {
+    return null
   }
+
+  const parentFolderPath = dirname(resource.path)
+
+  if (pathPrefix) {
+    if (splitPathHasSecondSegment(parentFolderPath)) {
+      return join(pathPrefix, parentFolderPath).replaceAll('/', ' > ')
+    }
+    return pathPrefix.replace('/', ' > ')
+  }
+
+  return parentFolderPath.replaceAll('/', ' > ')
+})
+const parentFolderComponentType = computed(() => {
+  return parentFolderLink ? 'router-link' : 'span'
+})
+
+const parentFolderStyle = computed(() => {
+  return {
+    cursor: parentFolderLink ? 'pointer' : 'default'
+  }
+})
+
+const parentFolderLinkIconAttrs = computed(() => {
+  return {
+    'fill-type': 'line',
+    name: 'folder-2',
+    size: 'small',
+    ...parentFolderLinkIconAdditionalAttributes
+  }
+})
+
+const hasThumbnail = computed(() => {
+  return isThumbnailDisplayed && Object.prototype.hasOwnProperty.call(resource, 'thumbnail')
+})
+
+const thumbnail = computed(() => {
+  return resource.thumbnail
+})
+
+const tooltipLabelIcon = computed(() => {
+  if (resource.locked) {
+    return $gettext('This item is locked')
+  }
+  return null
 })
 </script>
 

--- a/packages/web-pkg/src/composables/folderLink/useFolderLink.ts
+++ b/packages/web-pkg/src/composables/folderLink/useFolderLink.ts
@@ -23,6 +23,9 @@ export const useFolderLink = (options: ResourceRouteResolverOptions = {}) => {
     const space = unref(options.space) || getMatchingSpace(resource)
 
     if (isProjectSpaceResource(space)) {
+      if (resource.path === '.') {
+        return $gettext('Spaces')
+      }
       return path.join($gettext('Spaces'), space.name)
     }
 
@@ -53,6 +56,9 @@ export const useFolderLink = (options: ResourceRouteResolverOptions = {}) => {
     if (isProjectSpaceResource(resource)) {
       return createLocationSpaces('files-spaces-projects')
     }
+    if (resource.path === '.') {
+      return createLocationSpaces('files-spaces-projects')
+    }
 
     return createFolderLink({
       path: dirname(resource.path),
@@ -76,6 +82,9 @@ export const useFolderLink = (options: ResourceRouteResolverOptions = {}) => {
     }
     const parentFolder = extractParentFolderName(resource)
     if (parentFolder) {
+      if (resource.path === '.' && parentFolder === '.') {
+        return $gettext('Spaces')
+      }
       return parentFolder
     }
 


### PR DESCRIPTION
Fixes an issue where a shared space incorrectly showed its own folder as the parent. Now, it correctly points to the root folder of the space. Also, the parent folder is now labeled as "Spaces" instead of ".".

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [x] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
