### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on stable-11.0 branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=70db6e8d3a9f0bbe94436f9c99d36b1f39db0013
+OCIS_COMMITID=e0cd0a70bf60b90dee865bc76d58915047751920
 OCIS_BRANCH=stable-7.1


### PR DESCRIPTION
## Description
Bump latest ocis `stable-7.1` branch commit id.

Part of: https://github.com/owncloud/QA/issues/890