### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on stable-11.0 branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=81da003f22b845a7f6ac388c50c5816c874a521c
+OCIS_COMMITID=db24f8db4f6ac729e1f575b96b47c27400dc77af
 OCIS_BRANCH=stable-7.1


### PR DESCRIPTION
### Description

Bump latest ocis `stable-7.1` branch commit id.

Part of: owncloud/QA#891