### PR TITLE
bugfix(web-pkg, web-runtime): [OCISDEV-186] fixes incorrect translation when user switches language

### DIFF
--- a/changelog/unreleased/bugfix-incorrect-translation-when-use-switches-language.md
+++ b/changelog/unreleased/bugfix-incorrect-translation-when-use-switches-language.md
@@ -1,0 +1,6 @@
+Bugfix: Incorrect translation when using switches language
+
+We have fixed an issue where the translation was incorrect when switching languages in the web interface. This ensures that the language displayed matches the selected language without inconsistencies by fetching the roles when use switches language.
+
+https://kiteworks.atlassian.net/browse/OCISDEV-186
+https://github.com/owncloud/web/pull/12889

--- a/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
+++ b/packages/web-pkg/src/composables/piniaStores/shares/shares.ts
@@ -274,6 +274,12 @@ export const useSharesStore = defineStore('shares', () => {
     hasLoadingFailed.value = value
   }
 
+  async function fetchShareRolesDefinitions({ clientService }): Promise<UnifiedRoleDefinition[]> {
+    const result = await clientService.graphAuthenticated.permissions.listRoleDefinitions()
+
+    return result
+  }
+
   return {
     loading,
     collaboratorShares,
@@ -296,7 +302,8 @@ export const useSharesStore = defineStore('shares', () => {
     deleteLink,
 
     hasLoadingFailed,
-    setHasLoadingFailed
+    setHasLoadingFailed,
+    fetchShareRolesDefinitions
   }
 })
 

--- a/packages/web-runtime/src/pages/account.vue
+++ b/packages/web-runtime/src/pages/account.vue
@@ -295,7 +295,8 @@ import {
   useModals,
   useResourcesStore,
   useSpacesStore,
-  useUserStore
+  useUserStore,
+  useSharesStore
 } from '@ownclouders/web-pkg'
 import { useTask } from 'vue-concurrency'
 import { useGettext } from 'vue3-gettext'
@@ -334,6 +335,7 @@ export default defineComponent({
     const clientService = useClientService()
     const resourcesStore = useResourcesStore()
     const appsStore = useAppsStore()
+    const sharesStore = useSharesStore()
 
     const valuesList = ref<SettingsValue[]>()
     const graphUser = ref<User>()
@@ -542,6 +544,15 @@ export default defineComponent({
           await clientService.graphAuthenticated.users.editMe({
             preferredLanguage: option.value
           } as User)
+
+          /*
+           * Refetch shared roles to update their translations when the user changes their preferred language.
+           * Otherwise, the roles will remain in the previous language (e.g., English) until the page is refreshed.
+           * */
+          const shareRolesDefinitions = await sharesStore.fetchShareRolesDefinitions({
+            clientService
+          })
+          sharesStore.setGraphRoles(shareRolesDefinitions)
 
           if (capabilityStore.supportSSE) {
             ;(clientService.sseAuthenticated as SSEAdapter).updateLanguage(language.current)

--- a/packages/web-runtime/tests/unit/pages/account.spec.ts
+++ b/packages/web-runtime/tests/unit/pages/account.spec.ts
@@ -13,6 +13,7 @@ import {
   OptionsConfig,
   useExtensionRegistry,
   useMessages,
+  useSharesStore,
   useResourcesStore
 } from '@ownclouders/web-pkg'
 import { LanguageOption, SettingsBundle, SettingsValue } from '../../../src/helpers/settings'
@@ -194,6 +195,19 @@ describe('account page', () => {
       const { showMessage } = useMessages()
       expect(showMessage).toHaveBeenCalled()
     })
+
+    it('should fetch share roles', async () => {
+      const { wrapper } = getWrapper({})
+      await blockLoadingState(wrapper)
+      const sharesStore = useSharesStore()
+
+      await wrapper.vm.updateSelectedLanguage({ value: 'en' } as LanguageOption)
+
+      expect(sharesStore.fetchShareRolesDefinitions).toHaveBeenCalled()
+
+      expect(sharesStore.setGraphRoles).toHaveBeenCalled()
+    })
+
     it('should show a message on error', async () => {
       vi.spyOn(console, 'error').mockImplementation(() => undefined)
 


### PR DESCRIPTION
We have fixed an issue where the translation was incorrect when switching languages in the web interface. This ensures that the language displayed matches the selected language without inconsistencies by fetching the roles when user switches language.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://kiteworks.atlassian.net/browse/OCISDEV-186

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
