### PR TITLE
bugfix(design-systems): [OCISDEV-194] fixes clipped german translation of deactivated spaces button

### DIFF
--- a/changelog/unreleased/bugfix-deactivated-spaces-clips-german-translated-word.md
+++ b/changelog/unreleased/bugfix-deactivated-spaces-clips-german-translated-word.md
@@ -1,0 +1,6 @@
+Bugfix: Deactivated Space button clips German translated word
+
+We have fixed an issue where the "Deactivated Space" button would clip the German translated word. The button now displays the full word without clipping.
+
+https://kiteworks.atlassian.net/browse/OCISDEV-194
+https://github.com/owncloud/web/pull/12890

--- a/packages/design-system/src/components/OcFilterChip/OcFilterChip.vue
+++ b/packages/design-system/src/components/OcFilterChip/OcFilterChip.vue
@@ -152,7 +152,7 @@ defineExpose({ hideDrop })
     text-decoration: none;
     font-size: var(--oc-font-size-xsmall);
     line-height: 1rem;
-    max-width: 150px;
+    max-width: 180px;
     padding: var(--oc-space-xsmall) var(--oc-space-small) !important;
     height: 100%;
   }


### PR DESCRIPTION
We have fixed an issue where the "Deactivated Space" button would clip the German translated word. The button now displays the full word without clipping.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
