### PR TITLE
feat: [OCISDEV-197] replace title only filter pill with toggle

### DIFF
--- a/changelog/unreleased/enhancement-use-switch-for-full-text-search-filter.md
+++ b/changelog/unreleased/enhancement-use-switch-for-full-text-search-filter.md
@@ -1,0 +1,6 @@
+Enhancement: Use switch for full text search filter
+
+We've replaced the "Title only" search filter pill with a toggle between "Title Only" and "Full Text Search".
+This change should improve the user experience as it's easier to understand the toggle.
+
+https://github.com/owncloud/web/pull/12915

--- a/packages/web-app-files/src/components/Search/List.vue
+++ b/packages/web-app-files/src/components/Search/List.vue
@@ -72,9 +72,9 @@
           </template>
         </item-filter>
 
-        <item-filter-toggle
+        <item-filter-inline
           v-if="fullTextSearchEnabled"
-          :filter-label="$gettext('Title only')"
+          :filter-options="searchTermScopeOptions"
           filter-name="titleOnly"
           class="files-search-filter-title-only oc-mr-s"
         />
@@ -182,7 +182,7 @@ import { useTask } from 'vue-concurrency'
 import { eventBus } from '@ownclouders/web-pkg'
 import { ItemFilter } from '@ownclouders/web-pkg'
 import { isLocationCommonActive } from '@ownclouders/web-pkg'
-import { ItemFilterToggle } from '@ownclouders/web-pkg'
+import { ItemFilterInline } from '@ownclouders/web-pkg'
 import { useKeyboardActions, ResourceIcon } from '@ownclouders/web-pkg'
 import {
   useKeyboardTableNavigation,
@@ -213,7 +213,7 @@ const emit = defineEmits<Emits>()
 const capabilityStore = useCapabilityStore()
 const router = useRouter()
 const route = useRoute()
-const { $gettext } = useGettext()
+const { $gettext, $pgettext } = useGettext()
 const { y: fileListHeaderY } = useFileListHeaderPosition()
 const clientService = useClientService()
 const { getMatchingSpace } = useGetMatchingSpace()
@@ -379,6 +379,23 @@ const breadcrumbs = computed(() => {
     }
   ]
 })
+
+const searchTermScopeOptions = computed(() => [
+  {
+    name: 'true',
+    label: $pgettext(
+      'Label of a search page filter used to search only for resources with the search term in their name.',
+      'Title only'
+    )
+  },
+  {
+    name: 'false',
+    label: $pgettext(
+      'Label of a search page filter used to search for resources with the search term in their name and content.',
+      'Full Text Search'
+    )
+  }
+])
 
 const resourceDomSelector = ({ id, remoteItemId }: Resource) => {
   let selectorStr = id.toString()

--- a/packages/web-app-search/src/portals/SearchBar.vue
+++ b/packages/web-app-search/src/portals/SearchBar.vue
@@ -374,7 +374,8 @@ const getSearchResultLocation = (providerId: string) => {
       term: unref(term),
       ...(unref(scope) && { scope: unref(scope) }),
       useScope: unref(useScope).toString(),
-      provider: providerId
+      provider: providerId,
+      ...(unref(fullTextSearchEnabled) && { q_titleOnly: 'false' })
     }
   })
 }

--- a/tests/e2e/support/objects/app-files/search/actions.ts
+++ b/tests/e2e/support/objects/app-files/search/actions.ts
@@ -12,9 +12,9 @@ const clearFilterSelector = '.item-filter-%s .oc-filter-chip-clear'
 const lastModifiedFilterSelector = '.item-filter-lastModified'
 const lastModifiedFilterItem = '[data-test-value="%s"]'
 const enableSearchTitleOnlySelector =
-  '//div[contains(@class,"files-search-filter-title-only")]//button[contains(@class,"oc-filter-chip-button")]'
+  '//div[contains(@class,"files-search-filter-title-only")]//button[contains(@class,"item-inline-filter-option") and contains(@id,"true")]'
 const disableSearchTitleOnlySelector =
-  '//div[contains(@class,"files-search-filter-title-only")]//button[contains(@class,"oc-filter-chip-clear")]'
+  '//div[contains(@class,"files-search-filter-title-only")]//button[contains(@class,"item-inline-filter-option") and contains(@id,"false")]'
 
 export const getSearchResultMessage = ({ page }: { page: Page }): Promise<string> => {
   return page.locator(searchResultMessageSelector).innerText()


### PR DESCRIPTION
## Description

We've replaced the "Title only" search filter pill with a toggle between "Title Only" and "Full Text Search". This change should improve the user experience as it's easier to understand the toggle.

## Motivation and Context

Better UX.

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: open search by typing a search term and hitting enter
- test case 2: switch between search modes

## Screenshots (if appropriate):

<img width="478" height="79" alt="image" src="https://github.com/user-attachments/assets/9de28e0d-06e4-4b57-8f42-59e242a6bab9" />

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
