### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on `master` branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=a46cd29cc9feccc1c9ac9ad3043fe110de9f84be
+OCIS_COMMITID=8abef52e47bbfffc70926f6fcd9817ab2c94d92b
 OCIS_BRANCH=master


### PR DESCRIPTION
## Description

Bump latest ocis `master` branch commit id.

Part of: [owncloud/QA#892](https://github.com/owncloud/QA/issues/892)