### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on`stable-12` branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=1cbea7fba3ef20b10484895f62ddeb48b8673ffa
+OCIS_COMMITID=42829c56cdc5946495807b09460f3e7f39f45c3d
 OCIS_BRANCH=stable-7.2


### PR DESCRIPTION
## Description

Bump latest ocis `stable-7.2` branch commit id.

Part of: [owncloud/QA#892](https://github.com/owncloud/QA/issues/892)