### PR TITLE
feat: [OCISDEV-249] add MFA capability

### DIFF
--- a/changelog/unreleased/enhancement-add-mfa-capability.md
+++ b/changelog/unreleased/enhancement-add-mfa-capability.md
@@ -1,0 +1,6 @@
+Enhancement: Add MFA capability
+
+We've added a capability to check if MFA is enabled.
+If the capability is enabled, we will require MFA when accessing the admin settings page.
+
+https://github.com/owncloud/web/pull/12925

--- a/dev/docker/ocis.web.config.json
+++ b/dev/docker/ocis.web.config.json
@@ -5,7 +5,8 @@
     "metadata_url": "https://host.docker.internal:9200/.well-known/openid-configuration",
     "authority": "https://host.docker.internal:9200",
     "client_id": "web",
-    "response_type": "code"
+    "response_type": "code",
+    "scope": "openid profile email acr"
   },
   "options": {
     "contextHelpersReadMore": true

--- a/packages/web-app-admin-settings/src/index.ts
+++ b/packages/web-app-admin-settings/src/index.ts
@@ -10,6 +10,8 @@ import {
   AppNavigationItem,
   defineWebApplication,
   useAbility,
+  useAuthService,
+  useCapabilityStore,
   useUserStore
 } from '@ownclouders/web-pkg'
 import { RouteRecordRaw } from 'vue-router'
@@ -22,7 +24,7 @@ function $gettext(msg: string) {
 
 const appId = 'admin-settings'
 
-function getAvailableRoute(ability: Ability) {
+function getNextAvailableRoute(ability: Ability) {
   if (ability.can('read-all', 'Setting')) {
     return { name: 'admin-settings-general' }
   }
@@ -42,6 +44,16 @@ function getAvailableRoute(ability: Ability) {
   throw Error('Insufficient permissions')
 }
 
+async function requireAcr(redirectUrl: string) {
+  const capabilityStore = useCapabilityStore()
+  if (!capabilityStore.authMfaEnabled) {
+    return
+  }
+
+  const authService = useAuthService()
+  await authService.requireAcr(capabilityStore.authMfaRequiredLevelname, redirectUrl)
+}
+
 export const routes = ({ $ability }: { $ability: Ability }): RouteRecordRaw[] => [
   {
     path: '/',
@@ -53,10 +65,13 @@ export const routes = ({ $ability }: { $ability: Ability }): RouteRecordRaw[] =>
     path: '/general',
     name: 'admin-settings-general',
     component: General,
-    beforeEnter: (to, from, next) => {
+    beforeEnter: async (to, from, next) => {
       if (!$ability.can('read-all', 'Setting')) {
-        return next(getAvailableRoute($ability))
+        return next(getNextAvailableRoute($ability))
       }
+
+      await requireAcr(to.fullPath)
+
       next()
     },
     meta: {
@@ -68,10 +83,13 @@ export const routes = ({ $ability }: { $ability: Ability }): RouteRecordRaw[] =>
     path: '/users',
     name: 'admin-settings-users',
     component: Users,
-    beforeEnter: (to, from, next) => {
+    beforeEnter: async (to, from, next) => {
       if (!$ability.can('read-all', 'Account')) {
-        return next(getAvailableRoute($ability))
+        return next(getNextAvailableRoute($ability))
       }
+
+      await requireAcr(to.fullPath)
+
       next()
     },
     meta: {
@@ -83,10 +101,13 @@ export const routes = ({ $ability }: { $ability: Ability }): RouteRecordRaw[] =>
     path: '/groups',
     name: 'admin-settings-groups',
     component: Groups,
-    beforeEnter: (to, from, next) => {
+    beforeEnter: async (to, from, next) => {
       if (!$ability.can('read-all', 'Group')) {
-        return next(getAvailableRoute($ability))
+        return next(getNextAvailableRoute($ability))
       }
+
+      await requireAcr(to.fullPath)
+
       next()
     },
     meta: {
@@ -98,10 +119,13 @@ export const routes = ({ $ability }: { $ability: Ability }): RouteRecordRaw[] =>
     path: '/spaces',
     name: 'admin-settings-spaces',
     component: Spaces,
-    beforeEnter: (to, from, next) => {
+    beforeEnter: async (to, from, next) => {
       if (!$ability.can('read-all', 'Drive')) {
-        return next(getAvailableRoute($ability))
+        return next(getNextAvailableRoute($ability))
       }
+
+      await requireAcr(to.fullPath)
+
       next()
     },
     meta: {

--- a/packages/web-client/src/ocs/capabilities.ts
+++ b/packages/web-client/src/ocs/capabilities.ts
@@ -50,8 +50,16 @@ export interface ArchiverCapability {
   max_size?: string
 }
 
+interface AuthCapability {
+  mfa: {
+    enabled?: boolean
+    levelnames?: string[]
+  }
+}
+
 export interface Capabilities {
   capabilities: {
+    auth: AuthCapability
     checksums?: {
       preferredUploadType?: string
       supportedTypes?: string[]

--- a/packages/web-pkg/src/composables/authContext/useAuthService.ts
+++ b/packages/web-pkg/src/composables/authContext/useAuthService.ts
@@ -6,6 +6,7 @@ export interface AuthServiceInterface {
   signinSilent(): Promise<unknown>
   logoutUser(): Promise<void | NavigationFailure>
   getRefreshToken(): Promise<string>
+  requireAcr(acrValue: string, redirectUrl: string): Promise<void>
 }
 
 export const useAuthService = (): AuthServiceInterface => {

--- a/packages/web-pkg/src/composables/piniaStores/capabilities.ts
+++ b/packages/web-pkg/src/composables/piniaStores/capabilities.ts
@@ -5,6 +5,12 @@ import merge from 'lodash-es/merge'
 import { SharePermissionBit } from '@ownclouders/web-client'
 
 const defaultValues = {
+  auth: {
+    mfa: {
+      enabled: false,
+      levelnames: ['advanced']
+    }
+  },
   core: {
     'support-sse': false,
     'support-url-signing': false
@@ -145,6 +151,9 @@ export const useCapabilityStore = defineStore('capabilities', () => {
   const searchMediaType = computed(() => unref(capabilities).search.property?.mediatype)
   const searchContent = computed(() => unref(capabilities).search.property?.content)
 
+  const authMfaEnabled = computed(() => unref(capabilities).auth.mfa.enabled)
+  const authMfaRequiredLevelname = computed(() => unref(capabilities).auth.mfa.levelnames.at(0))
+
   return {
     isInitialized,
     capabilities,
@@ -191,7 +200,9 @@ export const useCapabilityStore = defineStore('capabilities', () => {
     passwordPolicy,
     searchLastMofifiedDate,
     searchMediaType,
-    searchContent
+    searchContent,
+    authMfaEnabled,
+    authMfaRequiredLevelname
   }
 })
 

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -384,6 +384,30 @@ export class AuthService implements AuthServiceInterface {
     console.debug('[authService:handleDelegatedTokenUpdate] - going to update the access_token')
     return this.userManager.updateContext(event.data, false)
   }
+
+  /**
+   * Redirects to the login page if the user is not authenticated or if the ACR value is not the one required.
+   *
+   * @param acrValue - The ACR value to require.
+   * @param redirectUrl - The URL to redirect to after login.
+   *
+   * @throws {Error} In cases of wrong authentication.
+   */
+  public async requireAcr(acrValue: string, redirectUrl: string) {
+    const user = await this.userManager.getUser()
+    if (!user || user.expired) {
+      this.userManager.setPostLoginRedirectUrl(redirectUrl)
+      return this.userManager.signinRedirect({ acr_values: acrValue })
+    }
+
+    const { acr } = user.profile
+    if (acr === acrValue) {
+      return
+    }
+
+    this.userManager.setPostLoginRedirectUrl(redirectUrl)
+    return this.userManager.signinRedirect({ acr_values: acrValue })
+  }
 }
 
 export const authService = new AuthService()

--- a/packages/web-runtime/src/services/auth/userManager.ts
+++ b/packages/web-runtime/src/services/auth/userManager.ts
@@ -73,7 +73,10 @@ export class UserManager extends OidcUserManager {
       client_id: '',
 
       // we trigger the token renewal manually via a timer running in a web worker
-      automaticSilentRenew: false
+      automaticSilentRenew: false,
+
+      // do not filter acr
+      filterProtocolClaims: ['nbf', 'jti', 'auth_time', 'nonce', 'amr', 'azp', 'at_hash']
     }
 
     if (options.configStore.isOIDC) {


### PR DESCRIPTION
## Description

We've added a capability to check if MFA is enabled. If the capability is enabled, we will require MFA when accessing the admin settings page.

## Motivation and Context

Admin settings can be made available only to users with configured 2FA.

## How Has This Been Tested?

For easier testing, there is a Keycloak example with acr configured introduced in https://github.com/owncloud/ocis/pull/11592 and currently oCIS needs to be run with https://github.com/owncloud/ocis/pull/11603 and latest Reva.

- test environment: macos, chrome
- test case 1: open admin settings with only "regular" acr
- test case 2: open admin settings with "advanced" acr

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
