### PR TITLE
fix: [OCISDEV-147] sign public link archiver download URL

### DIFF
--- a/changelog/unreleased/bugfix-sign-public-link-archiver-download-url.md
+++ b/changelog/unreleased/bugfix-sign-public-link-archiver-download-url.md
@@ -1,0 +1,7 @@
+Bugfix: Sign public link archiver download URL
+
+We've started signing the archiver download URL in public link context in case the link is password protected.
+This allows users to download large archives without memory limits imposed by browsers.
+
+https://github.com/owncloud/web/pull/12943
+https://github.com/owncloud/web/issues/12811

--- a/packages/web-app-files/src/helpers/user/avatarUrl.ts
+++ b/packages/web-app-files/src/helpers/user/avatarUrl.ts
@@ -23,7 +23,7 @@ export const avatarUrl = async (options: AvatarUrlOptions, cached = false): Prom
     throw new Error(statusText)
   }
 
-  return options.clientService.ocs.signUrl(url, options.username)
+  return options.clientService.ocs.signUrl({ url, username: options.username })
 }
 
 const cacheFactory = async (options: AvatarUrlOptions): Promise<string> => {

--- a/packages/web-app-files/tests/unit/helpers/user/avatarUrl.spec.ts
+++ b/packages/web-app-files/tests/unit/helpers/user/avatarUrl.spec.ts
@@ -29,8 +29,8 @@ describe('avatarUrl', () => {
     defaultOptions.clientService.httpAuthenticated.head.mockResolvedValue({
       status: 200
     } as AxiosResponse)
-    defaultOptions.clientService.ocs.signUrl.mockImplementation((url) => {
-      return Promise.resolve(`${url}?signed=true`)
+    defaultOptions.clientService.ocs.signUrl.mockImplementation((payload) => {
+      return Promise.resolve(`${payload.url}?signed=true`)
     })
     const avatarUrlPromise = avatarUrl(defaultOptions)
     await expect(avatarUrlPromise).resolves.toBe(`${buildUrl(defaultOptions)}?signed=true`)
@@ -40,7 +40,9 @@ describe('avatarUrl', () => {
     defaultOptions.clientService.httpAuthenticated.head.mockResolvedValue({
       status: 200
     } as AxiosResponse)
-    defaultOptions.clientService.ocs.signUrl.mockImplementation((url) => Promise.resolve(url))
+    defaultOptions.clientService.ocs.signUrl.mockImplementation((payload) =>
+      Promise.resolve(payload.url)
+    )
 
     const avatarUrlPromiseUncached = avatarUrl(defaultOptions, true)
     await expect(avatarUrlPromiseUncached).resolves.toBe(buildUrl(defaultOptions))

--- a/packages/web-client/src/ocs/index.ts
+++ b/packages/web-client/src/ocs/index.ts
@@ -1,12 +1,12 @@
 import { Capabilities, GetCapabilitiesFactory } from './capabilities'
 import { AxiosInstance } from 'axios'
-import { UrlSign } from './urlSign'
+import { SignUrlPayload, UrlSign } from './urlSign'
 
 export * from './capabilities'
 
 export interface OCS {
   getCapabilities: () => Promise<Capabilities>
-  signUrl: (url: string, username: string) => Promise<string>
+  signUrl: (payload: SignUrlPayload) => Promise<string>
 }
 
 export const ocs = (baseURI: string, axiosClient: AxiosInstance): OCS => {
@@ -22,8 +22,8 @@ export const ocs = (baseURI: string, axiosClient: AxiosInstance): OCS => {
     getCapabilities: () => {
       return capabilitiesFactory.getCapabilities()
     },
-    signUrl: (url: string, username: string) => {
-      return urlSign.signUrl(url, username)
+    signUrl: (payload: SignUrlPayload) => {
+      return urlSign.signUrl(payload)
     }
   }
 }

--- a/packages/web-client/src/webdav/getFileUrl.ts
+++ b/packages/web-client/src/webdav/getFileUrl.ts
@@ -48,7 +48,7 @@ export const GetFileUrlFactory = (
         // sign url
         if (isUrlSigningEnabled && username) {
           const ocsClient = ocs(baseUrl, axiosClient)
-          downloadURL = await ocsClient.signUrl(downloadURL, username)
+          downloadURL = await ocsClient.signUrl({ url: downloadURL, username })
         } else {
           signed = false
         }

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadArchive.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadArchive.ts
@@ -42,13 +42,15 @@ export const useFileActionsDownloadArchive = () => {
           dir: path.dirname(first<Resource>(resources).path) || '/',
           files: resources.map((resource) => resource.name)
         }
+
     return archiverService
       .triggerDownload({
         ...fileOptions,
         ...(space &&
           isPublicSpaceResource(space) && {
             publicToken: space.id as string,
-            publicLinkPassword: authStore.publicLinkPassword
+            publicLinkPassword: authStore.publicLinkPassword,
+            publicLinkShareOwner: space.publicLinkShareOwner
           })
       })
       .catch((e) => {

--- a/packages/web-pkg/src/services/client/client.ts
+++ b/packages/web-pkg/src/services/client/client.ts
@@ -168,7 +168,8 @@ export class ClientService {
     return {
       'Accept-Language': this.currentLanguage,
       'X-Request-ID': uuidV4(),
-      ...(useAuth && { Authorization: 'Bearer ' + this.authStore.accessToken })
+      ...(useAuth &&
+        this.authStore.accessToken && { Authorization: 'Bearer ' + this.authStore.accessToken })
     }
   }
 


### PR DESCRIPTION
## Description

Start signing the archiver download URL in public link context in case the link is password protected. This allows users to download large archives without memory limits imposed by browsers.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/12811

## Motivation and Context

Users can download large archives.

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: share a folder with several files with total size 5 GB+ via link protected by password, access the link and try to download them as archive

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
