### PR TITLE
chore: [OCISDEV-272] fix packages type exports

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -50,22 +50,22 @@
       ".": {
         "default": "./dist/design-system.js",
         "require": "./dist/design-system.cjs",
-        "types": "./dist/src/index.d.ts"
+        "types": "./dist/types/index.d.ts"
       },
       "./components": {
         "default": "./dist/design-system/components.js",
         "require": "./dist/design-system/components.cjs",
-        "types": "./dist/src/components/index.d.ts"
+        "types": "./dist/types/components/index.d.ts"
       },
       "./composables": {
         "default": "./dist/design-system/composables.js",
         "require": "./dist/design-system/composables.cjs",
-        "types": "./dist/src/composables/index.d.ts"
+        "types": "./dist/types/composables/index.d.ts"
       },
       "./helpers": {
         "default": "./dist/design-system/helpers.js",
         "require": "./dist/design-system/helpers.cjs",
-        "types": "./dist/src/helpers/index.d.ts"
+        "types": "./dist/types/helpers/index.d.ts"
       }
     }
   },

--- a/packages/design-system/vite.config.ts
+++ b/packages/design-system/vite.config.ts
@@ -50,7 +50,12 @@ export default defineConfig({
   },
   plugins: [
     vue(),
-    dts({ exclude: ['**/tests', '**/*.spec.ts'] }),
+    dts({
+      exclude: ['**/tests', '**/*.spec.ts'],
+      include: ['src'],
+      outDir: 'dist/types',
+      insertTypesEntry: true
+    }),
     {
       name: '@ownclouders/vite-plugin-docs',
       transform(src, id) {

--- a/packages/web-client/package.json
+++ b/packages/web-client/package.json
@@ -22,32 +22,32 @@
       ".": {
         "default": "./dist/web-client.js",
         "require": "./dist/web-client.cjs",
-        "types": "./dist/src/index.d.ts"
+        "types": "./dist/types/index.d.ts"
       },
       "./graph": {
         "default": "./dist/web-client/graph.js",
         "require": "./dist/web-client/graph.cjs",
-        "types": "./dist/src/graph/index.d.ts"
+        "types": "./dist/types/graph/index.d.ts"
       },
       "./graph/generated": {
         "default": "./dist/web-client/graph/generated.js",
         "require": "./dist/web-client/graph/generated.cjs",
-        "types": "./dist/src/graph/generated/index.d.ts"
+        "types": "./dist/types/graph/generated/index.d.ts"
       },
       "./ocs": {
         "default": "./dist/web-client/ocs.js",
         "require": "./dist/web-client/ocs.cjs",
-        "types": "./dist/src/ocs/index.d.ts"
+        "types": "./dist/types/ocs/index.d.ts"
       },
       "./sse": {
         "default": "./dist/web-client/sse.js",
         "require": "./dist/web-client/sse.cjs",
-        "types": "./dist/src/sse/index.d.ts"
+        "types": "./dist/types/sse/index.d.ts"
       },
       "./webdav": {
         "default": "./dist/web-client/webdav.js",
         "require": "./dist/web-client/webdav.cjs",
-        "types": "./dist/src/webdav/index.d.ts"
+        "types": "./dist/types/webdav/index.d.ts"
       }
     }
   },

--- a/packages/web-client/vite.config.ts
+++ b/packages/web-client/vite.config.ts
@@ -27,6 +27,10 @@ export default defineConfig({
     nodePolyfills({
       exclude: ['crypto']
     }),
-    dts()
+    dts({
+      include: ['src'],
+      outDir: 'dist/types',
+      insertTypesEntry: true
+    })
   ]
 })

--- a/packages/web-pkg/package.json
+++ b/packages/web-pkg/package.json
@@ -24,7 +24,7 @@
       ".": {
         "import": "./dist/web-pkg.js",
         "require": "./dist/web-pkg.umd.cjs",
-        "types": "./dist/src/index.d.ts"
+        "types": "./dist/types/index.d.ts"
       }
     }
   },

--- a/packages/web-pkg/vite.config.ts
+++ b/packages/web-pkg/vite.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
     nodePolyfills({
       exclude: ['crypto']
     }),
-    dts({ exclude: ['**/tests'] }),
+    dts({ exclude: ['**/tests'], include: ['src'], outDir: 'dist/types', insertTypesEntry: true }),
     {
       name: '@ownclouders/vite-plugin-docs',
       transform(src, id) {

--- a/packages/web-test-helpers/package.json
+++ b/packages/web-test-helpers/package.json
@@ -23,7 +23,7 @@
       ".": {
         "import": "./dist/web-test-helpers.es.js",
         "require": "./dist/web-test-helpers.umd.cjs",
-        "types": "./dist/src/index.d.ts"
+        "types": "./dist/types/index.d.ts"
       }
     }
   },

--- a/packages/web-test-helpers/vite.config.ts
+++ b/packages/web-test-helpers/vite.config.ts
@@ -15,5 +15,5 @@ export default defineConfig({
       external: [...Object.keys(pkg.dependencies), ...Object.keys(pkg.peerDependencies)]
     }
   },
-  plugins: [vue(), dts()]
+  plugins: [vue(), dts({ include: ['src'], outDir: 'dist/types', insertTypesEntry: true })]
 })


### PR DESCRIPTION
## Description

Explicitly set export path for types and use that path in package exports.

## Motivation and Context

Seems that (probably during a dependency update) the types started being exported into a different directory (`/dist/packages`). This broke the exports in packages because they were pointing to non-existing directories. By hardcoding the `outDir`, we make sure that it stays in our desired directory.

## How Has This Been Tested?

- test environment: macos, node v22
- test case 1: build all the affected packages and check whether the paths match

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [x] Maintenance (e.g. dependency updates or tooling)
