### PR TITLE
fix(web-app-external): add clipboard permissions

### DIFF
--- a/changelog/unreleased/bugfix-add-clipboard-permissions.md
+++ b/changelog/unreleased/bugfix-add-clipboard-permissions.md
@@ -1,0 +1,5 @@
+Bugfix: Add clipboard permissions
+
+We've added clipboard permissions to the iframe in external apps to allow the external editor to read and write to the clipboard.
+
+https://github.com/owncloud/web/pull/12954

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -5,7 +5,7 @@
     class="oc-width-1-1 oc-height-1-1"
     :title="iFrameTitle"
     allowfullscreen
-    allow="camera"
+    allow="camera; clipboard-read; clipboard-write"
   />
   <div v-if="appUrl && method === 'POST' && formParameters" class="oc-height-1-1 oc-width-1-1">
     <form :action="appUrl" target="app-iframe" method="post">
@@ -20,7 +20,7 @@
       class="oc-width-1-1 oc-height-1-1"
       :title="iFrameTitle"
       allowfullscreen
-      allow="camera"
+      allow="camera; clipboard-read; clipboard-write"
     />
   </div>
 </template>

--- a/packages/web-app-external/tests/unit/__snapshots__/app.spec.ts.snap
+++ b/packages/web-app-external/tests/unit/__snapshots__/app.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`The app provider extension > should be able to load an iFrame via get 1`] = `
-"<iframe src="https://example.test/d12ab86/loe009157-MzBw" class="oc-width-1-1 oc-height-1-1" title="&quot;example-app&quot; app content area" allowfullscreen="" allow="camera"></iframe>
+"<iframe src="https://example.test/d12ab86/loe009157-MzBw" class="oc-width-1-1 oc-height-1-1" title="&quot;example-app&quot; app content area" allowfullscreen="" allow="camera; clipboard-read; clipboard-write"></iframe>
 
 <!--v-if-->"
 `;
@@ -13,7 +13,7 @@ exports[`The app provider extension > should be able to load an iFrame via post 
   <form action="https://example.test/d12ab86/loe009157-MzBw" target="app-iframe" method="post"><input type="submit" class="oc-hidden" value="[object Object]">
     <div><input name="access_token" type="hidden" value="asdfsadfsadf"></div>
     <div><input name="access_token_ttl" type="hidden" value="123456"></div>
-  </form> <iframe name="app-iframe" src="https://example.test/d12ab86/loe009157-MzBw" class="oc-width-1-1 oc-height-1-1" title="&quot;example-app&quot; app content area" allowfullscreen="" allow="camera"></iframe>
+  </form> <iframe name="app-iframe" src="https://example.test/d12ab86/loe009157-MzBw" class="oc-width-1-1 oc-height-1-1" title="&quot;example-app&quot; app content area" allowfullscreen="" allow="camera; clipboard-read; clipboard-write"></iframe>
 </div>"
 `;
 


### PR DESCRIPTION
## Description

Added clipboard permissions to the iframe in external apps to allow the external editor to read and write to the clipboard.

## Motivation and Context

With latest OnlyOffice version updated [here](https://github.com/owncloud/web/pull/12937), copying and pasting got broken due to missing permissions.

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: copy text inside onlyoffice
- test case 2: paste text inside onlyoffice

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
