### PR TITLE
chore: add vue group into renovate config

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -3,5 +3,12 @@
   "extends": ["github>owncloud-ops/renovate-presets:docker"],
   "prConcurrentLimit": 15,
   "ignoreDeps": ["@adobe/leonardo-contrast-colors"],
-  "postUpdateOptions": ["pnpmDedupe"]
+  "postUpdateOptions": ["pnpmDedupe"],
+  "rangeStrategy": "bump",
+  "packageRules": [
+    {
+      "matchPackageNames": ["vue", "@vue/shared", "@vue/compiler-dom", "@vue/compiler-sfc"],
+      "groupName": "vue monorepo"
+    }
+  ]
 }


### PR DESCRIPTION
## Description

Added a group matching all vue monorepo packages which needs to be updated together. As a bonus, add rangeStrategy to force package.json updates.

## Motivation and Context

Get around the need to manually update all the Vue packages in the bump PR and also manually bumping package.json files.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [x] Maintenance (e.g. dependency updates or tooling)
