### PR TITLE
bugfix(web-pkg): [OCISDEV-307] set md editor code head to have z-index of 0

### DIFF
--- a/changelog/unreleased/bugfix-md-editor-code-block-header-cuts-off-other-elements.md
+++ b/changelog/unreleased/bugfix-md-editor-code-block-header-cuts-off-other-elements.md
@@ -1,0 +1,6 @@
+Bugfix: Set md-editor code block header to have z-index of 0
+
+We have fixed an issue where the code block header in the markdown editor was cutting off other elements on the page. This has been resolved by setting the z-index of the code block header to 0.
+
+https://kiteworks.atlassian.net/browse/OCISDEV-307
+https://github.com/owncloud/web/pull/13075

--- a/packages/web-pkg/src/components/TextEditor/TextEditor.vue
+++ b/packages/web-pkg/src/components/TextEditor/TextEditor.vue
@@ -220,6 +220,9 @@ config({
   #text-editor-component-html-wrapper {
     margin-left: var(--oc-space-xsmall);
   }
+  .md-editor-code-head {
+    z-index: 0;
+  }
 }
 
 .toastui-editor-tabs {


### PR DESCRIPTION
We have fixed an issue where the code block header in the markdown editor was cutting off other elements on the page. This has been resolved by setting the z-index of the code block header to 0.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://kiteworks.atlassian.net/browse/OCISDEV-307

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
