### PR TITLE
fix: [OCISDEV-142] handle markdown to pdf export edge cases

### DIFF
--- a/packages/web-pkg/src/composables/webWorkers/exportAsPdfWorker/index.ts
+++ b/packages/web-pkg/src/composables/webWorkers/exportAsPdfWorker/index.ts
@@ -8,6 +8,7 @@ import { useConfigStore } from '../../piniaStores'
 import { useMermaid } from './useMermaid'
 import { useImages } from './useImages'
 import { useKaTeX } from './useKaTeX'
+import { sanitizeText } from './helpers'
 
 export type ExportAsPdfWorkerReturnData = {
   successful: Resource[]
@@ -55,7 +56,8 @@ export const useExportAsPdfWorker = () => {
         })
     )
 
-    let processedContent = await preprocessMermaidCharts(content)
+    let processedContent = sanitizeText(content)
+    processedContent = await preprocessMermaidCharts(processedContent)
     processedContent = await preprocessKaTeXFormulas(processedContent)
     processedContent = await preprocessImages(processedContent)
 

--- a/packages/web-pkg/src/composables/webWorkers/exportAsPdfWorker/pdfConfig.ts
+++ b/packages/web-pkg/src/composables/webWorkers/exportAsPdfWorker/pdfConfig.ts
@@ -36,7 +36,7 @@ export const PDF_THEME = Object.freeze({
     codeSpan: rgb(0.7, 0.1, 0.1),
     codeBlockBg: rgb(0.15625, 0.171875, 0.203125),
     codeBlockText: rgb(0.875, 0.875, 0.875),
-    blockquoteBar: rgb(0.7, 0.7, 0.7),
+    blockquoteBar: rgb(0.208, 0.702, 0.471),
     blockquoteText: rgb(0.3, 0.3, 0.3),
     tableHeaderBg: rgb(0.9, 0.9, 0.9),
     tableBorder: rgb(0.5, 0.5, 0.5),
@@ -60,7 +60,7 @@ export const PDF_THEME = Object.freeze({
   blockquote: {
     barWidth: 3,
     barXOffset: 10,
-    contentPadding: 40
+    nestedQuoteYOffset: 10
   },
   hr: {
     thickness: 1

--- a/packages/web-pkg/src/composables/webWorkers/exportAsPdfWorker/useImages.ts
+++ b/packages/web-pkg/src/composables/webWorkers/exportAsPdfWorker/useImages.ts
@@ -1,5 +1,7 @@
 import { useGettext } from 'vue3-gettext'
 
+const inMemoryCache = new Map<string, string>()
+
 /**
  * Converts an external image URL to a data URL by loading it into a canvas.
  *
@@ -12,6 +14,10 @@ import { useGettext } from 'vue3-gettext'
  * @throws Error if the image fails to load or canvas context cannot be obtained
  */
 function convertImageToDataURL(imageUrl: string): Promise<string> {
+  if (inMemoryCache.has(imageUrl)) {
+    return Promise.resolve(inMemoryCache.get(imageUrl)!)
+  }
+
   return new Promise((resolve, reject) => {
     const img = new Image()
     img.crossOrigin = 'anonymous'
@@ -27,7 +33,11 @@ function convertImageToDataURL(imageUrl: string): Promise<string> {
       }
 
       ctx.drawImage(img, 0, 0, img.width, img.height)
-      resolve(canvas.toDataURL('image/png'))
+
+      const dataURL = canvas.toDataURL('image/png')
+
+      inMemoryCache.set(imageUrl, dataURL)
+      resolve(dataURL)
     }
 
     img.onerror = (err) => {
@@ -39,11 +49,79 @@ function convertImageToDataURL(imageUrl: string): Promise<string> {
 }
 
 /**
+ * Helper function to identify code regions in markdown content.
+ * Returns an array of ranges [start, end] that represent code blocks and inline code.
+ */
+function getCodeRegions(markdownContent: string): Array<[number, number]> {
+  const codeRegions: Array<[number, number]> = []
+
+  const fencedCodeBlockRegex = /^```[^\n]*\n[\s\S]*?^```$/gm
+  let match: RegExpExecArray | null
+  while ((match = fencedCodeBlockRegex.exec(markdownContent)) !== null) {
+    codeRegions.push([match.index, match.index + match[0].length])
+  }
+
+  const lines = markdownContent.split('\n')
+  let inCodeBlock = false
+  let codeBlockStart = 0
+  let currentPos = 0
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const isIndentedLine = /^(?:    |\t)/.test(line)
+    const lineLength = line.length + 1
+
+    if (isIndentedLine && !inCodeBlock) {
+      inCodeBlock = true
+      codeBlockStart = currentPos
+    } else if (!isIndentedLine && inCodeBlock) {
+      codeRegions.push([codeBlockStart, currentPos])
+      inCodeBlock = false
+    }
+
+    currentPos += lineLength
+  }
+
+  if (inCodeBlock && codeBlockStart >= 0) {
+    codeRegions.push([codeBlockStart, markdownContent.length])
+  }
+
+  const inlineCodeRegex = /`[^`\n]+`/g
+  while ((match = inlineCodeRegex.exec(markdownContent)) !== null) {
+    codeRegions.push([match.index, match.index + match[0].length])
+  }
+
+  codeRegions.sort((a, b) => a[0] - b[0])
+
+  const mergedRegions: Array<[number, number]> = []
+  for (const [start, end] of codeRegions) {
+    if (mergedRegions.length === 0 || mergedRegions[mergedRegions.length - 1][1] < start) {
+      mergedRegions.push([start, end])
+    } else {
+      mergedRegions[mergedRegions.length - 1][1] = Math.max(
+        mergedRegions[mergedRegions.length - 1][1],
+        end
+      )
+    }
+  }
+
+  return mergedRegions
+}
+
+/**
+ * Helper function to check if a position is within any code region.
+ */
+function isInCodeRegion(position: number, codeRegions: Array<[number, number]>): boolean {
+  return codeRegions.some(([start, end]) => position >= start && position < end)
+}
+
+/**
  * Composable providing image preprocessing for PDF generation.
  *
  * This composable handles the conversion of external image URLs in markdown content
  * to data URLs that can be embedded directly in PDF documents. It processes all
  * external images (non-data URLs) and converts them to base64-encoded PNG data.
+ * Images within code blocks and inline code are excluded from processing.
  */
 export function useImages() {
   const { $pgettext } = useGettext()
@@ -51,39 +129,90 @@ export function useImages() {
   /**
    * Preprocesses markdown content to convert external image URLs into data URLs.
    *
-   * This function scans markdown content for image syntax with external URLs
-   * (excluding data URLs), converts each external image to a data URL using
+   * This function scans markdown content for both inline and reference-style image syntax
+   * with external URLs (excluding data URLs), converts each external image to a data URL using
    * canvas rendering, and replaces the original URL with the data URL.
+   * Images within code blocks and inline code are excluded from processing.
    * Failed conversions are replaced with error messages.
    *
    * @param markdownContent - The markdown content to preprocess
    * @returns Promise resolving to the content with image sources replaced by data URLs
    */
   async function preprocessImages(markdownContent: string): Promise<string> {
-    const imageRegex = /!\[([^\]]*)\]\((?!data:)([^)]+)\)/g
-    const matches = Array.from(markdownContent.matchAll(imageRegex))
+    const codeRegions = getCodeRegions(markdownContent)
 
-    if (matches.length === 0) {
+    const referenceRegex = /^\[([^\]]+)\]:\s*(.+?)(?:\s+"[^"]*")?\s*$/gm
+    const referenceMap = new Map<string, string>()
+
+    let match: RegExpExecArray | null
+    while ((match = referenceRegex.exec(markdownContent)) !== null) {
+      if (!isInCodeRegion(match.index, codeRegions)) {
+        const referenceId = match[1]
+        const imageUrl = match[2].trim()
+        referenceMap.set(referenceId, imageUrl)
+      }
+    }
+
+    const inlineImageRegex = /!\[([^\]]*)\]\((?!data:)([^"\s)]+)(?:\s+"[^"]*")?\)/g
+    const referenceImageRegex = /!\[([^\]]*)\]\[([^\]]*)\]/g
+
+    const inlineMatches = Array.from(markdownContent.matchAll(inlineImageRegex))
+    const referenceMatches = Array.from(markdownContent.matchAll(referenceImageRegex))
+
+    const filteredInlineMatches = inlineMatches.filter(
+      (match) => !isInCodeRegion(match.index, codeRegions)
+    )
+    const filteredReferenceMatches = referenceMatches.filter(
+      (match) => !isInCodeRegion(match.index, codeRegions)
+    )
+
+    if (filteredInlineMatches.length === 0 && filteredReferenceMatches.length === 0) {
       return markdownContent
     }
 
-    const conversionPromises = matches.map(async (match) => {
-      const imageUrl = match[2]
+    const imageUrls = new Set<string>()
 
-      try {
-        return await convertImageToDataURL(imageUrl)
-      } catch (error) {
-        console.error('Failed to convert image to data URL:', error)
-        return null
+    filteredInlineMatches.forEach((match) => {
+      const imageUrl = match[2]
+      if (!imageUrl.startsWith('data:')) {
+        imageUrls.add(imageUrl)
       }
     })
 
-    const results = await Promise.all(conversionPromises)
+    filteredReferenceMatches.forEach((match) => {
+      const referenceId = match[2]
+      const imageUrl = referenceMap.get(referenceId)
+      if (imageUrl && !imageUrl.startsWith('data:')) {
+        imageUrls.add(imageUrl)
+      }
+    })
 
-    let i = 0
-    return markdownContent.replace(imageRegex, (_, altText) => {
-      const dataURL = results[i++]
+    const conversionPromises = Array.from(imageUrls).map(async (imageUrl) => {
+      try {
+        const dataURL = await convertImageToDataURL(imageUrl)
+        return { imageUrl, dataURL }
+      } catch (error) {
+        console.error('Failed to convert image to data URL:', error)
+        return { imageUrl, dataURL: null }
+      }
+    })
 
+    const conversionResults = await Promise.all(conversionPromises)
+    const urlToDataUrlMap = new Map<string, string | null>()
+    conversionResults.forEach(({ imageUrl, dataURL }) => {
+      urlToDataUrlMap.set(imageUrl, dataURL)
+    })
+
+    let processedContent = markdownContent
+
+    let inlineMatchIndex = 0
+    processedContent = processedContent.replace(inlineImageRegex, (match, altText, imageUrl) => {
+      const currentMatch = inlineMatches[inlineMatchIndex++]
+      if (!currentMatch || isInCodeRegion(currentMatch.index, codeRegions)) {
+        return match
+      }
+
+      const dataURL = urlToDataUrlMap.get(imageUrl)
       if (dataURL) {
         return `![${altText}](${dataURL})`
       }
@@ -97,6 +226,45 @@ export function useImages() {
         '*'
       )
     })
+
+    let referenceMatchIndex = 0
+    processedContent = processedContent.replace(
+      referenceImageRegex,
+      (match, altText, referenceId) => {
+        const currentMatch = referenceMatches[referenceMatchIndex++]
+        if (!currentMatch || isInCodeRegion(currentMatch.index, codeRegions)) {
+          return match
+        }
+
+        const imageUrl = referenceMap.get(referenceId)
+        if (!imageUrl) {
+          return (
+            '*' +
+            $pgettext(
+              'Error message rendered in a PDF file when there is any error during the rendering of an image.',
+              'Failed to render image.'
+            ) +
+            '*'
+          )
+        }
+
+        const dataURL = urlToDataUrlMap.get(imageUrl)
+        if (dataURL) {
+          return `![${altText}](${dataURL})`
+        }
+
+        return (
+          '*' +
+          $pgettext(
+            'Error message rendered in a PDF file when there is any error during the rendering of an image.',
+            'Failed to render image.'
+          ) +
+          '*'
+        )
+      }
+    )
+
+    return processedContent
   }
 
   return {

--- a/packages/web-pkg/tests/unit/composables/webWorkers/exportAsPdfWorker/helpers.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/webWorkers/exportAsPdfWorker/helpers.spec.ts
@@ -53,7 +53,7 @@ describe('export as PDF worker helpers', () => {
       const text = 'verylongwordthatexceedsmaxwidth'
       const result = splitTextToFit(text, mockFont, 12, 50)
 
-      expect(result).toEqual(['verylongwordthatexceedsmaxwidth'])
+      expect(result).toEqual(['verylo', 'ngword', 'thatex', 'ceedsm', 'axwidt', 'h'])
     })
   })
 
@@ -69,7 +69,7 @@ describe('export as PDF worker helpers', () => {
       ]
 
       const result = extractTextFromTokens(tokens)
-      expect(result).toBe('Click here (https://example.com)')
+      expect(result).toBe('https://example.com')
     })
 
     it('should extract text from text tokens', () => {
@@ -113,60 +113,43 @@ describe('export as PDF worker helpers', () => {
       ]
 
       const result = extractTextFromTokens(tokens)
-      expect(result).toBe('Check out this link (https://example.com)')
+      expect(result).toBe('Check out https://example.com')
     })
   })
 
   describe('sanitizeText', () => {
     it('should replace typographic characters with ASCII equivalents', () => {
-      const input = 'Here\u2019s a \u201cquote\u201d with an em\u2014dash and ellipsis\u2026'
-      const expected = 'Here\'s a "quote" with an em--dash and ellipsis...'
-
-      const result = sanitizeText(input)
-      expect(result).toBe(expected)
+      expect(
+        sanitizeText('Here\u2019s a \u201cquote\u201d with an em\u2014dash and ellipsis\u2026')
+      ).toBe('Here\'s a "quote" with an em--dash and ellipsis...')
     })
 
     it('should replace all types of quotes', () => {
-      const input = '\u2018\u2019\u201c\u201d'
-      const expected = '\'\'"\"'
-
-      const result = sanitizeText(input)
-      expect(result).toBe(expected)
+      expect(sanitizeText('\u2018\u2019\u201c\u201d')).toBe('\'\'"\"')
     })
 
     it('should replace all types of dashes', () => {
-      const input = '\u2014\u2013\u2011'
-      const expected = '----'
-
-      const result = sanitizeText(input)
-      expect(result).toBe(expected)
+      expect(sanitizeText('\u2014\u2013\u2011')).toBe('----')
     })
 
     it('should replace non-breaking spaces', () => {
-      const input = 'word word'
-      const expected = 'word word'
-
-      const result = sanitizeText(input)
-      expect(result).toBe(expected)
+      expect(sanitizeText('word word')).toBe('word word')
     })
 
     it('should remove emojis', () => {
-      const input = 'Hello 😀 world 🌍'
-      const result = sanitizeText(input)
+      const result = sanitizeText('Hello 😀 world 🌍')
 
       expect(result).not.toContain('😀')
       expect(result).not.toContain('🌍')
     })
 
     it('should handle empty string', () => {
-      const result = sanitizeText('')
-      expect(result).toBe('')
+      expect(sanitizeText('')).toBe('')
     })
 
     it('should handle string with no special characters', () => {
       const input = 'Regular text with no special characters'
-      const result = sanitizeText(input)
-      expect(result).toBe(input)
+      expect(sanitizeText(input)).toBe(input)
     })
   })
 
@@ -330,7 +313,7 @@ describe('export as PDF worker helpers', () => {
 
       expect(result).toHaveLength(1)
       expect(result[0]).toEqual({
-        text: 'Link text (https://example.com)',
+        text: 'https://example.com',
         bold: false,
         italic: false,
         code: false,

--- a/packages/web-pkg/tests/unit/composables/webWorkers/exportAsPdfWorker/renderer.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/webWorkers/exportAsPdfWorker/renderer.spec.ts
@@ -333,7 +333,7 @@ describe('PDFRenderer', () => {
       const result = await renderer.renderAsArrayBuffer()
 
       expect(result).toBeInstanceOf(ArrayBuffer)
-      expect(mockPage.drawText).toHaveBeenCalledTimes(6)
+      expect(mockPage.drawText).toHaveBeenCalledTimes(5)
     })
   })
 })

--- a/packages/web-pkg/tests/unit/composables/webWorkers/exportAsPdfWorker/useImages.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/webWorkers/exportAsPdfWorker/useImages.spec.ts
@@ -188,8 +188,7 @@ describe('useImages', () => {
       await new Promise<void>((resolve, reject) => {
         getWrapper({
           setup: async ({ preprocessImages }) => {
-            const content = '![test](https://example.com/image.png)'
-
+            const content = '![test](https://example.com/canvas-failure.png)'
             mockCanvas.getContext.mockReturnValue(null)
 
             try {


### PR DESCRIPTION
## Description

This fixes a number of edge cases in the markdown to pdf export.

- We are no longer matching KaTeX formulas inside of code blocks and tables.
- We are no longer matching images inside of code blocks.
- We are now correctly handling image references.
- We are now caching images in memory to avoid duplicate conversions.
- We are now sanitizing codeblocks to prevent incorrect matching.
- We are now correctly rendering blockquotes.
- We are now downscaling images in case they cannot fit on the page.
- We are now breaking words in case they cannot fit on the page.
- We are now rendering links directly.

## Motivation and Context

Correct MD -> PDF conversion.

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: export [Full-Markdown.md](https://github.com/user-attachments/files/22251808/Full-Markdown.md) as PDF
- test case 2: export release plan file from JIRA ticket as PDF

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
