### PR TITLE
fix: make theme icons optional

### DIFF
--- a/packages/web-pkg/src/composables/piniaStores/theme.ts
+++ b/packages/web-pkg/src/composables/piniaStores/theme.ts
@@ -67,7 +67,7 @@ const ThemeDefaults = z.object({
   designTokens: DesignTokens,
   loginPage: LoginPage,
   logo: Logo,
-  icons: Icons
+  icons: Icons.optional()
 })
 
 const WebTheme = z.object({


### PR DESCRIPTION
## Description

Make the recently introduced icons object in theme optional. So far it only has icons for universal access which is not enabled by default. This prevents an error in the browser console.

## Motivation and Context

No errors in console.

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: open Web while the icons object is missing in the theme & open browser console

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
