### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on stable-12 branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=30b09db4b17cdb790b7a29cbf2f2bc457aa09cf8
+OCIS_COMMITID=5e6fdc2489196285822064716f93023e6105e1ac
 OCIS_BRANCH=stable-7.2


### PR DESCRIPTION
## Description
Bump latest ocis `stable-7.2` branch commit id.

Part of: https://github.com/owncloud/QA/issues/894