### PR TITLE
feat: [OCISDEV-316] use OCS v2 API

### DIFF
--- a/changelog/unreleased/enhancement-use-ocs-v2-api.md
+++ b/changelog/unreleased/enhancement-use-ocs-v2-api.md
@@ -1,0 +1,5 @@
+Enhancement: Use OCS v2 API
+
+We have updated the OCS API to version 2. This is not a breaking change because oCIS uses one implementation for both versions.
+
+https://github.com/owncloud/web/pull/13111

--- a/packages/web-client/src/ocs/index.ts
+++ b/packages/web-client/src/ocs/index.ts
@@ -11,10 +11,10 @@ export interface OCS {
 
 export const ocs = (baseURI: string, axiosClient: AxiosInstance): OCS => {
   const url = new URL(baseURI)
-  url.pathname = [...url.pathname.split('/'), 'ocs', 'v1.php'].filter(Boolean).join('/')
-  const ocsV1BaseURI = url.href
+  url.pathname = [...url.pathname.split('/'), 'ocs', 'v2.php'].filter(Boolean).join('/')
+  const ocsV2BaseURI = url.href
 
-  const capabilitiesFactory = GetCapabilitiesFactory(ocsV1BaseURI, axiosClient)
+  const capabilitiesFactory = GetCapabilitiesFactory(ocsV2BaseURI, axiosClient)
 
   const urlSign = new UrlSign({ baseURI, axiosClient })
 

--- a/packages/web-client/src/ocs/urlSign.ts
+++ b/packages/web-client/src/ocs/urlSign.ts
@@ -56,7 +56,7 @@ export class UrlSign {
     }
 
     const data = await this.axiosClient.get(
-      urlJoin(this.baseURI, 'ocs/v1.php/cloud/user/signing-key'),
+      urlJoin(this.baseURI, 'ocs/v2.php/cloud/user/signing-key'),
       {
         params: {
           ...(publicToken && { 'public-token': publicToken })

--- a/packages/web-runtime/src/services/auth/userManager.ts
+++ b/packages/web-runtime/src/services/auth/userManager.ts
@@ -280,7 +280,7 @@ export class UserManager extends OidcUserManager {
     try {
       console.log('CERNBox: login successful, exchange sso token with reva token')
       const httpClient = this.clientService.httpAuthenticated
-      const revaTokenReq = await httpClient.get('/ocs/v1.php/cloud/user')
+      const revaTokenReq = await httpClient.get('/ocs/v2.php/cloud/user')
       const revaToken = revaTokenReq.headers['x-access-token']
       const claims = JSON.parse(atob(revaToken.split('.')[1]))
       user.access_token = revaToken


### PR DESCRIPTION
## Description

We have updated the OCS API to version 2.
This is not a breaking change because oCIS uses one implementation for both versions.

## Motivation and Context

Support Kiteworks WebDAV bridge.

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: open the UI and check capabilities request
- test case 2: download an archive with pre-signed URL

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
