### PR TITLE
[full-ci] feat: [OCISDEV-330] drop `remote.php` from WebDAV paths

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=f9c7d914a877c7b0905023eb9ecd23dbe1de9448
+OCIS_COMMITID=c52ec807a688f7841a75204c6d2c79dea8e51555
 OCIS_BRANCH=master

--- a/changelog/unreleased/enhancement-drop-remote-php.md
+++ b/changelog/unreleased/enhancement-drop-remote-php.md
@@ -1,0 +1,6 @@
+Enhancement: Drop `remote.php` from WebDAV paths
+
+We have dropped the `remote.php` prefix from WebDAV paths.
+This is not a breaking change because oCIS strips this string from the path and it had been done in the past only to support ownCloud 10.
+
+https://github.com/owncloud/web/pull/13113

--- a/packages/web-app-files/src/helpers/user/avatarUrl.ts
+++ b/packages/web-app-files/src/helpers/user/avatarUrl.ts
@@ -15,7 +15,7 @@ export const avatarUrl = async (options: AvatarUrlOptions, cached = false): Prom
     return cacheFactory({ ...options, size })
   }
 
-  const url = [options.server, 'remote.php/dav/avatars/', options.username, `/${size}.png`].join('')
+  const url = [options.server, 'dav/avatars/', options.username, `/${size}.png`].join('')
 
   const { status, statusText } = await options.clientService.httpAuthenticated.head(url)
 

--- a/packages/web-app-files/tests/unit/helpers/user/avatarUrl.spec.ts
+++ b/packages/web-app-files/tests/unit/helpers/user/avatarUrl.spec.ts
@@ -70,5 +70,4 @@ const buildUrl = ({
   server: string
   username: string
   size?: number
-}) =>
-  [server, 'remote.php/dav/avatars/', username, `/${size || ImageDimension.Avatar}.png`].join('')
+}) => [server, 'dav/avatars/', username, `/${size || ImageDimension.Avatar}.png`].join('')

--- a/packages/web-client/src/helpers/space/functions.ts
+++ b/packages/web-client/src/helpers/space/functions.ts
@@ -157,11 +157,11 @@ export function buildSpace(
   const webDavPath = urlJoin(data.webDavPath || buildWebDavSpacesPath(data.id), {
     leadingSlash: true
   })
-  const webDavUrl = urlJoin(data.serverUrl, 'remote.php/dav', webDavPath)
+  const webDavUrl = urlJoin(data.serverUrl, 'dav', webDavPath)
   const webDavTrashPath = urlJoin(data.webDavTrashPath || buildWebDavSpacesTrashPath(data.id), {
     leadingSlash: true
   })
-  const webDavTrashUrl = urlJoin(data.serverUrl, 'remote.php/dav', webDavTrashPath)
+  const webDavTrashUrl = urlJoin(data.serverUrl, 'dav', webDavTrashPath)
 
   const members = data.root?.permissions?.reduce<Record<string, SpaceMember>>((acc, p) => {
     acc[(p.grantedToV2.user || p.grantedToV2.group).id] = {

--- a/packages/web-client/src/webdav/client/dav.ts
+++ b/packages/web-client/src/webdav/client/dav.ts
@@ -39,7 +39,7 @@ export class DAV {
   #onSetMaintenance: (value: boolean) => void
 
   constructor({ baseUrl, headers, onSetMaintenance }: DAVOptions) {
-    this.davPath = urlJoin(baseUrl, 'remote.php/dav')
+    this.davPath = urlJoin(baseUrl, 'dav')
     this.client = createClient(this.davPath, {})
     this.headers = headers
     this.extraProps = []

--- a/packages/web-client/src/webdav/client/parsers.ts
+++ b/packages/web-client/src/webdav/client/parsers.ts
@@ -28,9 +28,9 @@ export const parseTusHeaders = (headers: Headers) => {
 export const parseMultiStatus = async (xmlBody: string) => {
   const parseFileName = (name: string) => {
     const decoded = decodeURIComponent(name)
-    if (name?.startsWith('/remote.php/dav/')) {
-      // strip out '/remote.php/dav/' from the beginning
-      return urlJoin(decoded.replace('/remote.php/dav/', ''), {
+    if (name?.startsWith('/dav/')) {
+      // strip out '/dav/' from the beginning
+      return urlJoin(decoded.replace('/dav/', ''), {
         leadingSlash: true,
         trailingSlash: false
       })

--- a/packages/web-pkg/src/services/preview/previewService.ts
+++ b/packages/web-pkg/src/services/preview/previewService.ts
@@ -167,7 +167,7 @@ export class PreviewService {
 
     const url = [
       this.configStore.serverUrl,
-      'remote.php/dav',
+      'dav',
       encodePath(resource.webDavPath),
       '?',
       this.buildQueryString({ etag: resource.etag, dimensions, processor })

--- a/packages/web-runtime/src/components/Avatar.vue
+++ b/packages/web-runtime/src/components/Avatar.vue
@@ -97,7 +97,7 @@ export default defineComponent({
         this.loading = false
         return
       }
-      const url = this.serverUrl + 'remote.php/dav/avatars/' + userid + '/128.png'
+      const url = this.serverUrl + 'dav/avatars/' + userid + '/128.png'
       this.$clientService.httpAuthenticated
         .get<Blob>(url, { responseType: 'blob' })
         .then((response) => {

--- a/tests/e2e/support/api/davSpaces/spaces.ts
+++ b/tests/e2e/support/api/davSpaces/spaces.ts
@@ -35,7 +35,7 @@ const createFolder = async ({
 
   let parentFolder = ''
   for (const resource of paths) {
-    const path = join('remote.php', 'dav', webDavEndPathToRoot, parentFolder, resource)
+    const path = join('dav', webDavEndPathToRoot, parentFolder, resource)
     // check if the folder exists already or not
     const folderExist = await folderExists({ user, path })
     if (folderExist === false) {
@@ -66,7 +66,7 @@ const createFile = async ({
   const today = new Date()
   const response = await request({
     method: 'PUT',
-    path: join('remote.php', 'dav', webDavEndPathToRoot, pathToFile),
+    path: join('dav', webDavEndPathToRoot, pathToFile),
     body: content,
     user: user,
     header: mtimeDeltaDays
@@ -173,7 +173,6 @@ export const getDataOfFileInsideSpace = async ({
   const response = await request({
     method: 'PROPFIND',
     path: join(
-      'remote.php',
       'dav',
       'spaces',
       await getSpaceIdBySpaceName({ user, spaceType, spaceName }),
@@ -263,7 +262,7 @@ export const listSpaceResources = async ({
 
   const response = await request({
     method: 'PROPFIND',
-    path: join('remote.php', 'dav', 'spaces', spaceId, folder),
+    path: join('dav', 'spaces', spaceId, folder),
     body: propBody,
     user: user
   })
@@ -303,7 +302,7 @@ export const deleteSpaceResource = async ({
   folder?: string
   fileId?: string
 }): Promise<void> => {
-  const path = ['remote.php', 'dav', 'spaces']
+  const path = ['dav', 'spaces']
   let errMessage = `Failed to delete resource '${folder}'`
   if (!fileId) {
     const spaceId = await getSpaceIdBySpaceName({ user, spaceType, spaceName })
@@ -336,7 +335,7 @@ export const emptyTrashbin = async ({
 
   const response = await request({
     method: 'DELETE',
-    path: join('remote.php', 'dav', 'spaces', 'trash-bin', spaceId),
+    path: join('dav', 'spaces', 'trash-bin', spaceId),
     user: user
   })
 


### PR DESCRIPTION
## Description

We have dropped the `remote.php` prefix from WebDAV paths. This is not a breaking change because oCIS strips this string from the path and it had been done in the past only to support ownCloud 10.

## Motivation and Context

Support Kiteworks WebDAV bridge.

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: upload files & folders
- test case 2: delete files & folders
- test case 3: create files & folders
- test case 4: modify file contents
- test case 5: preview image and text file thumbnails
- test case 6: create a new space
- test case 7: browser folders in spaces

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
