### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on stable-11.0 branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=0e53869cc55c2bab17c3b3467068a12098e78945
+OCIS_COMMITID=00dd32495ef0a30bb214389ed31dfe0a610a1ef1
 OCIS_BRANCH=stable-7.1


### PR DESCRIPTION
## Description
Bump latest ocis `stable-7.1` branch commit id.

Part of: https://github.com/owncloud/QA/issues/895