### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on stable-12 branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=5e6fdc2489196285822064716f93023e6105e1ac
+OCIS_COMMITID=eeb72e7467cefe70fe6b98dd8efe201d254a51a3
 OCIS_BRANCH=stable-7.2


### PR DESCRIPTION
## Description
Bump latest ocis `stable-7.2` branch commit id.

Part of: https://github.com/owncloud/QA/issues/895