### PR TITLE
fix: [OCISDEV-267] make progress bar settings reactive

### DIFF
--- a/changelog/unreleased/bugfix-make-progress-bar-settings-reactive.md
+++ b/changelog/unreleased/bugfix-make-progress-bar-settings-reactive.md
@@ -1,0 +1,6 @@
+Bugfix: Make progress bar settings reactive
+
+We had a bug where the progress bar settings were not reactive. This caused labels to not be updated when the language changed.
+Adding reactivity to the progress bar settings fixes this issue.
+
+https://github.com/owncloud/web/pull/13126

--- a/packages/web-runtime/src/layouts/Application.vue
+++ b/packages/web-runtime/src/layouts/Application.vue
@@ -74,7 +74,6 @@ import {
   onMounted,
   provide,
   ref,
-  toRef,
   unref,
   watch
 } from 'vue'
@@ -203,7 +202,7 @@ export default defineComponent({
 
     const progressBarExtensionId = 'com.github.owncloud.web.runtime.default-progress-bar'
     const progressBarExtensionPointId = 'app.runtime.global-progress-bar'
-    const defaultProgressBarExtension: CustomComponentExtension = {
+    const defaultProgressBarExtension = computed<CustomComponentExtension>(() => ({
       id: progressBarExtensionId,
       type: 'customComponent',
       extensionPointIds: [progressBarExtensionPointId],
@@ -211,19 +210,24 @@ export default defineComponent({
       userPreference: {
         optionLabel: $gettext('Default progress bar')
       }
-    }
-    extensionRegistry.registerExtensions(toRef([defaultProgressBarExtension] satisfies Extension[]))
-    const progressBarExtensionPoint: ExtensionPoint<CustomComponentExtension> = {
+    }))
+
+    extensionRegistry.registerExtensions(
+      computed(() => [unref(defaultProgressBarExtension)] satisfies Extension[])
+    )
+    const progressBarExtensionPoint = computed<ExtensionPoint<CustomComponentExtension>>(() => ({
       id: progressBarExtensionPointId,
       extensionType: 'customComponent',
       multiple: false,
-      defaultExtensionId: defaultProgressBarExtension.id,
+      defaultExtensionId: unref(defaultProgressBarExtension).id,
       userPreference: {
         label: $gettext('Global progress bar'),
         description: $gettext('Customize your progress bar')
       }
-    }
-    const extensionPoints = computed<ExtensionPoint<Extension>[]>(() => [progressBarExtensionPoint])
+    }))
+    const extensionPoints = computed<ExtensionPoint<Extension>[]>(() => [
+      unref(progressBarExtensionPoint)
+    ])
     extensionRegistry.registerExtensionPoints(extensionPoints)
 
     onMounted(async () => {


### PR DESCRIPTION
## Description

We had a bug where the progress bar settings were not reactive. This caused labels to not be updated when the language changed. Adding reactivity to the progress bar settings fixes this issue.

## Motivation and Context

Fully reactive UI.

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: change locale in settings and watch progress bar strings

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/9f6acfcd-8493-40be-98d9-1db8154155c5

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
