### PR TITLE
fix: [OCISDEV-297] handle html upload error

### DIFF
--- a/changelog/unreleased/bugfix-handle-html-upload-error.md
+++ b/changelog/unreleased/bugfix-handle-html-upload-error.md
@@ -1,0 +1,6 @@
+Bugfix: Handle HTML upload error
+
+We had a bug where the upload error was not handled correctly when the server returned an HTML error.
+This caused the upload to fail and the user to not be able to see details about the upload.
+
+https://github.com/owncloud/web/pull/13127

--- a/packages/web-runtime/src/components/UploadBar.vue
+++ b/packages/web-runtime/src/components/UploadBar.vue
@@ -565,9 +565,8 @@ const getUploadItemMessage = (item: UploadResult) => {
     errorMessage: string | null
   } => {
     const responseCode = errorMessage.match(/response code: (\d+)/)?.[1]
-    const errorBody = JSON.parse(
-      errorMessage.match(/response text: ([\s\S]+?), request id/)?.[1] || '{}'
-    )
+    const responseText = errorMessage.match(/response text: ([\s\S]+?), request id/)?.[1]
+    const errorBody = JSON.parse(responseText?.startsWith('{') ? responseText : '{}')
 
     return {
       responseCode: responseCode ? parseInt(responseCode) : null,
@@ -756,6 +755,7 @@ onMounted(() => {
     uploads.value[file.meta.uploadId].status = 'error'
     errors.value[file.meta.uploadId] = error as HttpError
     filesInProgressCount.value -= 1
+    runningUploads.value -= 1
 
     if (file.meta.topLevelFolderId) {
       handleTopLevelFolderUpdate(file, 'error')


### PR DESCRIPTION
## Description

We had a bug where the upload error was not handled correctly when the server returned an HTML error. This caused the upload to fail and the user to not be able to see details about the upload.

## Motivation and Context

Handle all kinds of errors

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: force upload to fail with html error and upload a file

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
