### PR TITLE
test: click on the first tag

### DIFF
--- a/tests/e2e/support/objects/app-store/actions.ts
+++ b/tests/e2e/support/objects/app-store/actions.ts
@@ -14,7 +14,7 @@ const selectors = {
   appDetailsTitle: '//h2[contains(@class, "app-details-title")][text()="%s"]',
   appsFilter: '#apps-filter',
   tag: '//button[contains(@class,"oc-tag")][span[text()="%s"]]',
-  appTag: '//a[contains(.,"%s")]/following::button[contains(@class,"oc-tag")][span[text()="%s"]]'
+  appTag: '//a[contains(.,"%s")]/following::button[contains(@class,"oc-tag")][span[text()="%s"]][1]'
 }
 
 export const openAppStore = async (args: { page: Page }): Promise<void> => {


### PR DESCRIPTION
## Description

When testing app store, in the click on tag step, force the selector to use the first element. This fixes the issue where several same tags are present.

## Motivation and Context

Tests are green again.

## How Has This Been Tested?

- test environment: macos, chromium
- test case 1: run E2E tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
