### PR TITLE
feat: [OCISDEV-397] remove duplicate resource links

### DIFF
--- a/changelog/unreleased/bugfix-remove-duplicate-resource-links.md
+++ b/changelog/unreleased/bugfix-remove-duplicate-resource-links.md
@@ -1,0 +1,6 @@
+Bugfix: Remove duplicate resource links
+
+In the resources table, we had duplicate resource links. This has been fixed by removing the link from the resource icon.
+The icon is now treated solely as a decorative element and is hidden from screen readers.
+
+https://github.com/owncloud/web/pull/13203

--- a/packages/web-pkg/src/components/FilesList/ResourceListItem.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceListItem.vue
@@ -4,14 +4,7 @@
     class="oc-resource oc-text-overflow"
     :class="{ 'oc-resource-no-interaction': !isResourceClickable }"
   >
-    <resource-link
-      v-if="isIconDisplayed"
-      :resource="resource"
-      :link="link"
-      :is-resource-clickable="isResourceClickable"
-      class="oc-resource-icon-link"
-      @click="emitClick"
-    >
+    <span v-if="isIconDisplayed" class="oc-resource-icon-wrapper">
       <oc-img
         v-if="hasThumbnail"
         :key="thumbnail"
@@ -26,9 +19,10 @@
         v-else
         v-oc-tooltip="tooltipLabelIcon"
         :aria-label="tooltipLabelIcon"
+        :aria-hidden="tooltipLabelIcon !== null"
         :resource="resource"
       />
-    </resource-link>
+    </span>
     <div class="oc-resource-details oc-text-overflow" :class="{ 'oc-pl-s': isIconDisplayed }">
       <resource-link
         :resource="resource"

--- a/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceListItem.spec.ts.snap
+++ b/packages/web-pkg/tests/unit/components/FilesList/__snapshots__/ResourceListItem.spec.ts.snap
@@ -1,10 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`OcResource > displays parent folder name default if calculated name is empty 1`] = `
-"<div class="oc-resource oc-text-overflow"><button target="_self" type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-undefined oc-button-passive oc-button-passive-raw oc-resource-link oc-resource-icon-link" draggable="false">
-    <!--v-if-->
-    <!-- @slot Content of the button --> <span class="oc-icon oc-icon-l oc-icon-passive oc-resource-icon oc-resource-icon-file"><!----></span>
-  </button>
+"<div class="oc-resource oc-text-overflow"><span class="oc-resource-icon-wrapper"><span class="oc-icon oc-icon-l oc-icon-passive oc-resource-icon oc-resource-icon-file" aria-hidden="false"><!----></span></span>
   <div class="oc-resource-details oc-text-overflow oc-pl-s"><button target="_self" type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-undefined oc-button-passive oc-button-passive-raw oc-resource-link oc-text-overflow" draggable="false">
       <!--v-if-->
       <!-- @slot Content of the button --> <span class="oc-resource-name" data-test-resource-path="example.pdf" data-test-resource-name="example.pdf" data-test-resource-type="file" title="example.pdf"><span class="oc-text-truncate"><span class="oc-resource-basename">example</span></span><span class="oc-resource-extension">.pdf</span></span>

--- a/packages/web-pkg/tests/unit/components/Search/__snapshots__/ResourcePreview.spec.ts.snap
+++ b/packages/web-pkg/tests/unit/components/Search/__snapshots__/ResourcePreview.spec.ts.snap
@@ -1,10 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Preview component > should render preview component 1`] = `
-"<div class="oc-resource oc-text-overflow"><button target="_self" type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-undefined oc-button-passive oc-button-passive-raw oc-resource-link oc-resource-icon-link" draggable="false">
-    <!--v-if-->
-    <!-- @slot Content of the button --> <img src="blob:image" alt="" aria-hidden="true" loading="eager" class="oc-resource-thumbnail" width="40" height="40">
-  </button>
+"<div class="oc-resource oc-text-overflow"><span class="oc-resource-icon-wrapper"><img src="blob:image" alt="" aria-hidden="true" loading="eager" class="oc-resource-thumbnail" width="40" height="40"></span>
   <div class="oc-resource-details oc-text-overflow oc-pl-s"><button target="_self" type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-undefined oc-button-passive oc-button-passive-raw oc-resource-link oc-text-overflow" draggable="false">
       <!--v-if-->
       <!-- @slot Content of the button --> <span class="oc-resource-name" data-test-resource-path="/" data-test-resource-name="lorem.txt" title="lorem.txt"><span class="oc-text-truncate"><span class="oc-resource-basename">lorem.txt</span></span>

--- a/tests/e2e/support/objects/a11y/actions.ts
+++ b/tests/e2e/support/objects/a11y/actions.ts
@@ -4,7 +4,7 @@ import AxeBuilder from '@axe-core/playwright'
 export const selectors = {
   files: '#files',
   resourceTableEditName: '.resource-table-edit-name',
-  resourceIconLink: '.oc-resource-icon-link',
+  resourceIconWrapper: '.oc-resource-icon-wrapper',
   resourceTableCondensedIcon: '.resource-table-condensed',
   filesSpaceTableCondensed: '#files-space-table.condensed', // '.condensed.files-table',
   resourceTiles: '.resource-tiles',


### PR DESCRIPTION
## Description

In the resources table, we had duplicate resource links. This has been fixed by removing the link from the resource icon. The icon is now treated solely as a decorative element and is hidden from screen readers.

## Motivation and Context

Screen readers do not announce duplicate links.

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: check the icon in resource row

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
