### PR TITLE
fix: [OCISDEV-433] do not disable sharing of resources when managing spaces via claims

### DIFF
--- a/changelog/unreleased/bugfix-do-not-disable-sharing-of-resources-when-managing-spaces-via-claims.md
+++ b/changelog/unreleased/bugfix-do-not-disable-sharing-of-resources-when-managing-spaces-via-claims.md
@@ -1,0 +1,6 @@
+Bugfix: Do not disable sharing of resources when managing spaces via claims
+
+When managing spaces via claims, we were disabling sharing of resources when the server managed spaces capability was enabled.
+This was not correct, as we should only disable sharing of spaces.
+
+https://github.com/owncloud/web/pull/13213

--- a/packages/web-pkg/src/composables/shares/useCanShare.ts
+++ b/packages/web-pkg/src/composables/shares/useCanShare.ts
@@ -1,4 +1,4 @@
-import { Resource, SpaceResource } from '@ownclouders/web-client'
+import { isSpaceResource, Resource, SpaceResource } from '@ownclouders/web-client'
 import { useAbility } from '../ability'
 import { useCapabilityStore, useUserStore } from '../piniaStores'
 import { isProjectSpaceResource, isShareSpaceResource } from '@ownclouders/web-client'
@@ -9,7 +9,7 @@ export const useCanShare = () => {
   const userStore = useUserStore()
 
   const canShare = ({ space, resource }: { space: SpaceResource; resource: Resource }) => {
-    if (!capabilityStore.sharingApiEnabled || capabilityStore.capabilities.spaces.server_managed) {
+    if (!capabilityStore.sharingApiEnabled) {
       return false
     }
 
@@ -18,6 +18,10 @@ export const useCanShare = () => {
     }
 
     if (isProjectSpaceResource(space) && !space.canShare({ user: userStore.user })) {
+      return false
+    }
+
+    if (isSpaceResource(resource) && capabilityStore.capabilities.spaces.server_managed) {
       return false
     }
 

--- a/packages/web-pkg/tests/unit/composables/shares/useCanShare.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/shares/useCanShare.spec.ts
@@ -1,0 +1,62 @@
+import { getComposableWrapper } from '@ownclouders/web-test-helpers'
+import { mock } from 'vitest-mock-extended'
+import { Resource, SpaceResource } from '@ownclouders/web-client'
+import { useCanShare } from '../../../../src/composables/shares'
+import { useCapabilityStore } from '../../../../src/composables/piniaStores'
+
+describe('useCanShare', () => {
+  describe('canShare', () => {
+    describe('server managed spaces', () => {
+      it('should disable sharing of spaces when server managed spaces capability is enabled', () => {
+        getWrapper({
+          setup: ({ canShare }) => {
+            const space = mock<SpaceResource>()
+            const resource = mock<SpaceResource>({ type: 'space', canShare: vi.fn(() => true) })
+
+            const capabilityStore = useCapabilityStore()
+            vi.mocked(capabilityStore).capabilities.spaces.server_managed = true
+
+            expect(canShare({ space, resource })).toBeFalsy()
+          }
+        })
+      })
+
+      it('should not disable sharing of spaces when server managed spaces capability is disabled', () => {
+        getWrapper({
+          setup: ({ canShare }) => {
+            const space = mock<SpaceResource>()
+            const resource = mock<SpaceResource>({ type: 'space', canShare: vi.fn(() => true) })
+
+            const capabilityStore = useCapabilityStore()
+            vi.mocked(capabilityStore).capabilities.spaces.server_managed = false
+
+            expect(canShare({ space, resource })).toBeTruthy()
+          }
+        })
+      })
+
+      it('should not disable sharing of resources when server managed spaces capability is enabled', () => {
+        getWrapper({
+          setup: ({ canShare }) => {
+            const space = mock<SpaceResource>()
+            const resource = mock<Resource>({ canShare: vi.fn(() => true) })
+
+            const capabilityStore = useCapabilityStore()
+            vi.mocked(capabilityStore).capabilities.spaces.server_managed = true
+
+            expect(canShare({ space, resource })).toBeTruthy()
+          }
+        })
+      })
+    })
+  })
+})
+
+function getWrapper({ setup }: { setup: (instance: ReturnType<typeof useCanShare>) => void }) {
+  return {
+    wrapper: getComposableWrapper(() => {
+      const instance = useCanShare()
+      setup(instance)
+    })
+  }
+}


### PR DESCRIPTION
## Description

When managing spaces via claims, we were disabling sharing of resources when the server managed spaces capability was enabled. This was not correct, as we should only disable sharing of spaces.

## Motivation and Context

The capability should affect only spaces.

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: set `OCIS_CLAIM_MANAGED_SPACES_ENABLED` to `true` and try to share a resource
- test case 2: set `OCIS_CLAIM_MANAGED_SPACES_ENABLED` to `true` and try to add members into a space
- test case 3: set `OCIS_CLAIM_MANAGED_SPACES_ENABLED` to `false` and try to share a resource
- test case 4: set `OCIS_CLAIM_MANAGED_SPACES_ENABLED` to `false` and try to add members into a space

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
