### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on stable-12.1 branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=d0e963cf9c5597258c42535c5f0219a742be0254
+OCIS_COMMITID=4ead779a6dedbf6e0d4f9a8c8ba5a858428ff887
 OCIS_BRANCH=stable-7.3


### PR DESCRIPTION
## Description
Bump latest ocis `stable-7.3` branch commit id.

Part of: https://github.com/owncloud/QA/issues/900