### PR TITLE
feat(design-system): [OCISDEV-399] add table caption

### DIFF
--- a/changelog/unreleased/enhancement-add-table-caption.md
+++ b/changelog/unreleased/enhancement-add-table-caption.md
@@ -1,0 +1,10 @@
+Enhancement: Add table caption
+
+We added a caption to the `OcTable` component. It's content can be set via a newly introduced `caption` prop.
+The visibility of the caption can also be toggled via new `captionVisible` prop. By default, it is visible only to screen readers.
+If the `OcTable` includes any sortable columns, the caption will automatically include screen reader only explanation of sorting capabilities.
+This makes sure that screen readers are not overriding column headers with actions via `aria-label` and that it does not repeat the same action multiple times.
+All of this behavior is directly inspired by the ARIA Authoring Practices Guide (APG).
+
+https://www.w3.org/WAI/ARIA/apg/patterns/table/examples/sortable-table/
+https://github.com/owncloud/web/pull/13224

--- a/packages/design-system/src/components/OcTable/OcTable.sort.spec.ts
+++ b/packages/design-system/src/components/OcTable/OcTable.sort.spec.ts
@@ -3,7 +3,6 @@ import Table from './OcTable.vue'
 
 const ASC = 'ascending'
 const DESC = 'descending'
-const NONE = 'none'
 
 const tableFieldId = {
   name: 'id',
@@ -63,13 +62,13 @@ describe('OcTable.sort', () => {
       }
     })
     const headers = wrapper.findAll('thead th')
-    it('has any [aria-sort] attribute on all sortable column headers', () => {
+    it('should not have [aria-sort] on column headers with no sorting applied', () => {
       const sortableFields = tableFields.filter((f) => f.sortable).map((f) => f.name)
       tableFields.forEach((field, index) => {
         if (!sortableFields.includes(field.name)) {
           return
         }
-        expect(headers.at(index).attributes()['aria-sort']).toBeTruthy()
+        expect(headers.at(index).attributes()['aria-sort']).toBeFalsy()
       })
     })
     it('lacks an [aria-sort] attribute on non-sortable column headers', () => {
@@ -96,14 +95,6 @@ describe('OcTable.sort', () => {
           sortBy: tableFieldId.name,
           sortDir: 'desc' as 'asc' | 'desc',
           ariaSort: DESC
-        }
-      ],
-      [
-        NONE,
-        {
-          sortBy: tableFieldResource.name,
-          sortDir: 'asc' as 'asc' | 'desc',
-          ariaSort: NONE
         }
       ]
     ])(

--- a/packages/web-app-admin-settings/tests/unit/components/Spaces/__snapshots__/SpacesList.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/components/Spaces/__snapshots__/SpacesList.spec.ts.snap
@@ -13,6 +13,7 @@ exports[`SpacesList > should render all spaces in a table 1`] = `
     </div>
   </div>
   <table class="oc-table oc-table-hover oc-table-sticky has-item-context-menu spaces-table">
+    <caption class=""> <span class="oc-invisible-sr">Column headers with buttons are sortable.</span></caption>
     <thead class="oc-thead">
       <tr class="oc-table-header-row">
         <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-select oc-pl-s" style="top: 0px;">
@@ -21,34 +22,34 @@ exports[`SpacesList > should render all spaces in a table 1`] = `
         <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-icon" style="top: 0px;">
           <div><span class="oc-table-thead-content header-text"></span></div>
         </th>
-        <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-name" style="top: 0px;" aria-sort="ascending"><button type="button" aria-label="Sort by name" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-button-sort oc-width-1-1">
+        <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-name" style="top: 0px;" aria-sort="ascending"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-button-sort oc-width-1-1">
             <!--v-if-->
             <!-- @slot Content of the button --> <span class="oc-table-thead-content header-text">Name</span> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span>
           </button></th>
-        <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-status" style="top: 0px;" aria-sort="none"><button type="button" aria-label="Sort by status" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-button-sort oc-width-1-1">
+        <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-status" style="top: 0px;"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-button-sort oc-width-1-1">
             <!--v-if-->
             <!-- @slot Content of the button --> <span class="oc-table-thead-content header-text">Status</span> <span class="oc-icon oc-icon-s oc-icon-passive oc-invisible-sr"><!----></span>
           </button></th>
         <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-manager" style="top: 0px;">
           <div><span class="oc-table-thead-content header-text">Manager</span></div>
         </th>
-        <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-members" style="top: 0px;" aria-sort="none"><button type="button" aria-label="Sort by members" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-button-sort oc-width-1-1">
+        <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-members" style="top: 0px;"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-button-sort oc-width-1-1">
             <!--v-if-->
             <!-- @slot Content of the button --> <span class="oc-table-thead-content header-text">Members</span> <span class="oc-icon oc-icon-s oc-icon-passive oc-invisible-sr"><!----></span>
           </button></th>
-        <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-totalQuota" style="top: 0px;" aria-sort="none"><button type="button" aria-label="Sort by totalQuota" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-button-sort oc-width-1-1">
+        <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-totalQuota" style="top: 0px;"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-button-sort oc-width-1-1">
             <!--v-if-->
             <!-- @slot Content of the button --> <span class="oc-table-thead-content header-text">Total quota</span> <span class="oc-icon oc-icon-s oc-icon-passive oc-invisible-sr"><!----></span>
           </button></th>
-        <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-usedQuota" style="top: 0px;" aria-sort="none"><button type="button" aria-label="Sort by usedQuota" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-button-sort oc-width-1-1">
+        <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-usedQuota" style="top: 0px;"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-button-sort oc-width-1-1">
             <!--v-if-->
             <!-- @slot Content of the button --> <span class="oc-table-thead-content header-text">Used quota</span> <span class="oc-icon oc-icon-s oc-icon-passive oc-invisible-sr"><!----></span>
           </button></th>
-        <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-remainingQuota" style="top: 0px;" aria-sort="none"><button type="button" aria-label="Sort by remainingQuota" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-button-sort oc-width-1-1">
+        <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-remainingQuota" style="top: 0px;"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-button-sort oc-width-1-1">
             <!--v-if-->
             <!-- @slot Content of the button --> <span class="oc-table-thead-content header-text">Remaining quota</span> <span class="oc-icon oc-icon-s oc-icon-passive oc-invisible-sr"><!----></span>
           </button></th>
-        <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-mdate" style="top: 0px;" aria-sort="none"><button type="button" aria-label="Sort by mdate" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-button-sort oc-width-1-1">
+        <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-mdate" style="top: 0px;"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-button-sort oc-width-1-1">
             <!--v-if-->
             <!-- @slot Content of the button --> <span class="oc-table-thead-content header-text">Modified</span> <span class="oc-icon oc-icon-s oc-icon-passive oc-invisible-sr"><!----></span>
           </button></th>

--- a/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Users.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Users.spec.ts.snap
@@ -88,6 +88,7 @@ exports[`Users view > list view > renders list initially 1`] = `
         </div>
         <div>
           <table class="oc-table oc-table-hover oc-table-sticky has-item-context-menu users-table">
+            <caption class=""> <span class="oc-invisible-sr">Column headers with buttons are sortable.</span></caption>
             <thead class="oc-thead">
               <tr class="oc-table-header-row">
                 <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-select oc-pl-s" style="top: 0px;">
@@ -97,19 +98,19 @@ exports[`Users view > list view > renders list initially 1`] = `
                   <div><span class="oc-table-thead-content header-text"></span></div>
                 </th>
                 <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-onPremisesSamAccountName" style="top: 0px;" aria-sort="ascending">
-                  <oc-button-stub type="button" disabled="false" size="medium" arialabel="Sort by onPremisesSamAccountName" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" showspinner="false" class="oc-button-sort oc-width-1-1"></oc-button-stub>
+                  <oc-button-stub type="button" disabled="false" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" showspinner="false" class="oc-button-sort oc-width-1-1"></oc-button-stub>
                 </th>
-                <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-displayName" style="top: 0px;" aria-sort="none">
-                  <oc-button-stub type="button" disabled="false" size="medium" arialabel="Sort by displayName" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" showspinner="false" class="oc-button-sort oc-width-1-1"></oc-button-stub>
+                <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-displayName" style="top: 0px;">
+                  <oc-button-stub type="button" disabled="false" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" showspinner="false" class="oc-button-sort oc-width-1-1"></oc-button-stub>
                 </th>
-                <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-mail" style="top: 0px;" aria-sort="none">
-                  <oc-button-stub type="button" disabled="false" size="medium" arialabel="Sort by mail" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" showspinner="false" class="oc-button-sort oc-width-1-1"></oc-button-stub>
+                <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-mail" style="top: 0px;">
+                  <oc-button-stub type="button" disabled="false" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" showspinner="false" class="oc-button-sort oc-width-1-1"></oc-button-stub>
                 </th>
-                <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-role" style="top: 0px;" aria-sort="none">
-                  <oc-button-stub type="button" disabled="false" size="medium" arialabel="Sort by role" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" showspinner="false" class="oc-button-sort oc-width-1-1"></oc-button-stub>
+                <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-role" style="top: 0px;">
+                  <oc-button-stub type="button" disabled="false" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" showspinner="false" class="oc-button-sort oc-width-1-1"></oc-button-stub>
                 </th>
-                <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-accountEnabled" style="top: 0px;" aria-sort="none">
-                  <oc-button-stub type="button" disabled="false" size="medium" arialabel="Sort by accountEnabled" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" showspinner="false" class="oc-button-sort oc-width-1-1"></oc-button-stub>
+                <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-accountEnabled" style="top: 0px;">
+                  <oc-button-stub type="button" disabled="false" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" showspinner="false" class="oc-button-sort oc-width-1-1"></oc-button-stub>
                 </th>
                 <th class="oc-table-cell oc-table-cell-align-right oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-actions oc-pr-s" style="top: 0px;">
                   <div><span class="oc-table-thead-content header-text">Actions</span></div>

--- a/packages/web-app-files/tests/unit/views/trash/__snapshots__/Overview.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/views/trash/__snapshots__/Overview.spec.ts.snap
@@ -16,12 +16,13 @@ exports[`TrashOverview > view states > should render spaces list 1`] = `
         </div>
       </div>
       <table class="oc-table oc-table-hover oc-table-sticky has-item-context-menu spaces-table">
+        <caption class=""> <span class="oc-invisible-sr">Column headers with buttons are sortable.</span></caption>
         <thead class="oc-thead">
           <tr class="oc-table-header-row">
             <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-icon oc-pl-s" style="top: 0px;">
               <div><span class="oc-table-thead-content header-text"></span></div>
             </th>
-            <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-name oc-pr-s" style="top: 0px;" aria-sort="ascending"><button type="button" aria-label="Sort by name" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-button-sort oc-width-1-1">
+            <th class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-th oc-table-header-cell oc-table-header-cell-name oc-pr-s" style="top: 0px;" aria-sort="ascending"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-button-sort oc-width-1-1">
                 <!--v-if-->
                 <!-- @slot Content of the button --> <span class="oc-table-thead-content header-text">Name</span> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span>
               </button></th>


### PR DESCRIPTION
## Description

We added a caption to the `OcTable` component. It's content can be set via a newly introduced `caption` prop. The visibility of the caption can also be toggled via new `captionVisible` prop. By default, it is visible only to screen readers. If the `OcTable` includes any sortable columns, the caption will automatically include screen reader only explanation of sorting capabilities. This makes sure that screen readers are not overriding column headers with actions via `aria-label` and that it does not repeat the same action multiple times. All of this behavior is directly inspired by the [ARIA Authoring Practices Guide (APG)](https://www.w3.org/WAI/ARIA/apg/patterns/table/examples/sortable-table/).

## Motivation and Context

Adjustments after accessibility audit.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: macos, chrome
- test case 1: sort resources table in personal space
- test case 2: sort resources table in trash
- test case 3: sort spaces table in spaces

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
