### PR TITLE
feat(web-app-admin-settings): [OCISDEV-348] use api groups search

### DIFF
--- a/changelog/unreleased/enhancement-use-api-groups-search-in-admin.md
+++ b/changelog/unreleased/enhancement-use-api-groups-search-in-admin.md
@@ -1,0 +1,5 @@
+Enhancement: Use API groups search in admin settings
+
+We have changed the search behaviour in the admin settings. Instead of filtering the groups in the client, we now use the search parameter of the list groups API endpoint.
+
+https://github.com/owncloud/web/pull/13235

--- a/packages/web-app-admin-settings/tests/unit/components/Groups/GroupsList.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Groups/GroupsList.spec.ts
@@ -22,6 +22,11 @@ vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
   displayPositionedDropdown: vi.fn()
 }))
 
+vi.mock('vue-router', () => ({
+  useRoute: vi.fn().mockReturnValue({ query: {} }),
+  useRouter: vi.fn()
+}))
+
 describe('GroupsList', () => {
   describe('method "orderBy"', () => {
     it('should return an ascending ordered list while desc is set to false', () => {


### PR DESCRIPTION
## Description

This changes the search behaviour in the admin settings. Instead of filtering the groups in the client, we now use the search parameter of the list groups API endpoint.

## Motivation and Context

Leave the search to the API and don't slow down the browser.

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: search groups

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/e1fd4e0b-6faf-4449-ace7-bdf769b61706



## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
