### PR TITLE
fix(web-app-files): [OCISDEV-451] external share ID fallback

### DIFF
--- a/changelog/unreleased/bugfix-external-share-id-fallback.md
+++ b/changelog/unreleased/bugfix-external-share-id-fallback.md
@@ -1,0 +1,5 @@
+Bugfix: External share ID fallback
+
+We now fallback to the original ID if decoding the external share ID fails.
+
+https://github.com/owncloud/web/pull/13253

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/ListItem.vue
@@ -287,7 +287,14 @@ const shareOwnerDisplayName = computed(() => share.sharedBy.displayName)
 
 const externalShareDomainName = computed(() => {
   if (unref(isExternalShare)) {
-    const decodedId = atob(share.sharedWith.id)
+    let decodedId = ''
+
+    try {
+      decodedId = atob(share.sharedWith.id)
+    } catch (_) {
+      decodedId = share.sharedWith.id
+    }
+
     const [, serverUrl] = decodedId.split('@')
     const domain = new URL(serverUrl).hostname
 

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/ListItem.spec.ts
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/Collaborators/ListItem.spec.ts
@@ -206,6 +206,17 @@ describe('Collaborator ListItem component', () => {
 
       expect(el.text()).toEqual('www.lorem.com')
     })
+
+    it('should fallback to original ID if decoding fails', () => {
+      const share = getShareMock({
+        shareType: ShareTypes.remote.value,
+        sharedWith: { id: 'einstein@https://www.lorem.com', displayName: 'einstein' }
+      })
+      const { wrapper } = createWrapper({ share })
+      const el = wrapper.find('[data-testid="external-share-domain"]')
+
+      expect(el.text()).toEqual('www.lorem.com')
+    })
   })
 })
 


### PR DESCRIPTION
## Description

Fallback to original ID if decoding the external share ID fails.

## Motivation and Context

ID can be also a plain string instead of base64 encoded string.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: macos, chrome
- test case 1: run oCIS using `romanperekhod/ocis-ocm:dev` image, create a federated share and open shares

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
