### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on stable-12 branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=eeb72e7467cefe70fe6b98dd8efe201d254a51a3
+OCIS_COMMITID=995dde559bbc37464a59170160adc144b25e2b11
 OCIS_BRANCH=stable-7.2


### PR DESCRIPTION
## Description
Bump latest ocis `stable-7.2` branch commit id.

Part of: https://github.com/owncloud/QA/issues/910