### PR TITLE
[full-ci][tests-only] Run page beforeunload event handlers before closing page

### DIFF
--- a/tests/e2e/support/environment/actor/actor.ts
+++ b/tests/e2e/support/environment/actor/actor.ts
@@ -77,7 +77,7 @@ export class ActorEnvironment extends EventEmitter implements Actor {
       })
     }
 
-    await this.page?.close()
+    await this.page?.close({ runBeforeUnload: true })
     await this.context?.close()
 
     this.emit('closed')


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR adds beforeunload event handlers to run before the page is closed.
Some E2E tests were failing on `page.close()` step after user is logged out.

Hopefully fixex the issue: https://github.com/owncloud/web/issues/13267

Passed builds:
- https://drone.owncloud.com/owncloud/ocis/49066
- https://drone.owncloud.com/owncloud/ocis/49065

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)