### PR TITLE
fix(web-pkg): [OCISDEV-482] handle file info loading error

### DIFF
--- a/changelog/unreleased/bugfix-handle-file-loading-error.md
+++ b/changelog/unreleased/bugfix-handle-file-loading-error.md
@@ -1,0 +1,5 @@
+Bugfix: Handle file loading error
+
+Skip loading file content if getting the file info fails. This prevents an unexpected error when opening a file.
+
+https://github.com/owncloud/web/pull/13274

--- a/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
+++ b/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
@@ -313,6 +313,10 @@ const loadResourceTask = useTask(function* (signal) {
 }).restartable()
 
 const loadFileTask = useTask(function* (signal) {
+  if (!unref(resource)) {
+    return
+  }
+
   try {
     const newExtension = importResourceWithExtension(unref(resource))
     if (newExtension) {


### PR DESCRIPTION
## Description

Skip loading file content if getting the file info fails. This prevents an unexpected error when opening a file.

## Motivation and Context

Handle exceptions with user friendly messages.

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: open a .docx file and manually change the ID in the URL

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
