### PR TITLE
chore(web-pkg): [OCISDEV-477] move comment out of template

### DIFF
--- a/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
+++ b/packages/web-pkg/src/components/AppTemplates/AppWrapper.vue
@@ -1,6 +1,8 @@
+<!-- Keeping this comment out of the template because including it as a first element breaks the app -->
+<!-- eslint-disable vuejs-accessibility/no-static-element-interactions -->
 <template>
-  <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
   <main :id="applicationId" class="app-wrapper oc-height-1-1" @keydown.esc="closeApp">
+    <!-- eslint-enable vuejs-accessibility/no-static-element-interactions -->
     <h1 class="oc-invisible-sr" v-text="pageTitle" />
     <app-top-bar
       v-if="!loading && !loadingError && resource"


### PR DESCRIPTION
## Description

Keep the comment in app wrapper outside of the template to avoid breaking the app layout in dev server.

## Motivation and Context

Fixed layout.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: macos, chrome
- test case 1: open a file in onlyoffice

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [x] Maintenance (e.g. dependency updates or tooling)
