### PR TITLE
[full-ci][test-only] test: fill filename properly

### DIFF
--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -380,6 +380,7 @@ export const createNewFileOrFolder = async (args: createResourceArgs): Promise<v
     }
     case 'txtFile': {
       await page.locator(createNewTxtFileButton).click()
+      await page.locator(resourceNameInput).clear()
       await page.locator(resourceNameInput).fill(name)
       await Promise.all([
         page.waitForResponse((resp) => resp.status() === 201 && resp.request().method() === 'PUT'),
@@ -390,6 +391,7 @@ export const createNewFileOrFolder = async (args: createResourceArgs): Promise<v
     }
     case 'mdFile': {
       await page.locator(createNewMdFileButton).click()
+      await page.locator(resourceNameInput).clear()
       await page.locator(resourceNameInput).fill(name)
       await Promise.all([
         page.waitForResponse((resp) => resp.status() === 201 && resp.request().method() === 'PUT'),
@@ -429,6 +431,7 @@ const createDocumentFile = async (
     )
   }
   await page.locator(util.format(createNewOfficeDocumentFileButton, type)).click()
+  await page.locator(resourceNameInput).clear()
   await page.locator(resourceNameInput).fill(name)
   await Promise.all([
     page.waitForLoadState(),


### PR DESCRIPTION
This PR backports fix for filenames in tests implemented in https://github.com/owncloud/web/pull/13187