### PR TITLE
feat: share links and passwords in embed mode

### DIFF
--- a/changelog/unreleased/enhancement-embed-share-links-with-password.md
+++ b/changelog/unreleased/enhancement-embed-share-links-with-password.md
@@ -1,0 +1,9 @@
+Enhancement: Embed mode share links with password
+
+In embed mode, the "Copy link and password" button text has been changed to "Share link(s) and password(s)".
+When sharing links in embed mode, a new event `owncloud-embed:share-links` is now emitted that contains an array of objects with the link URL and optionally the password (when the "Share link(s) and password(s)" button is clicked).
+This allows parent applications to handle both the link and password programmatically.
+
+DEPRECATION NOTICE: This deprecates the `owncloud-embed:share` event. The existing event continues to be emitted for backward compatibility.
+
+https://github.com/owncloud/web/pull/13296

--- a/docs/embed-mode/_index.md
+++ b/docs/embed-mode/_index.md
@@ -35,10 +35,13 @@ To maintain uniformity and ease of handling, each event encapsulates the same st
 | Name | Data | Description |
 | --- | --- | --- |
 | **owncloud-embed:select** | Resource[] | Gets emitted when user selects resources or location via the select action |
-| **owncloud-embed:share** | string[] | Gets emitted when user selects resources and shares them via the "Share links" action |
+| **owncloud-embed:share** | string[] | **DEPRECATED**: Gets emitted when user selects resources and shares them via the "Share links" action. Use `owncloud-embed:share-links` instead. |
+| **owncloud-embed:share-links** | Array<{ url: string; password?: string }> | Gets emitted when user selects resources and shares them via the "Share link(s)" or "Share link(s) and password(s)" action. Each object contains the link URL and optionally the password (when shared with password). |
 | **owncloud-embed:cancel** | null | Gets emitted when user attempts to close the embedded instance via "Cancel" action |
 
 ### Example
+
+#### Selecting resources
 
 ```html
 <iframe src="https://my-owncloud-web-instance?embed=true"></iframe>
@@ -55,6 +58,28 @@ To maintain uniformity and ease of handling, each event encapsulates the same st
   }
 
   window.addEventListener('message', selectEventHandler)
+</script>
+```
+
+#### Sharing links with password
+
+```html
+<iframe src="https://my-owncloud-web-instance?embed=true"></iframe>
+
+<script>
+  function shareLinksEventHandler(event) {
+    if (event.data?.name !== 'owncloud-embed:share-links') {
+      return
+    }
+
+    const links = event.data.data // Array<{ url: string; password?: string }>
+
+    links.forEach(link => console.log("Link", link.url, "Password", link.password))
+
+    doSomethingWithSharedLinks(links)
+  }
+
+  window.addEventListener('message', shareLinksEventHandler)
 </script>
 ```
 

--- a/docs/releasing/deprecations.md
+++ b/docs/releasing/deprecations.md
@@ -18,6 +18,7 @@ The following features are deprecated and **will be removed** in the next major 
 
 | Component/Feature | Deprecated | Migration | Reference | Reasoning |
 |---|---|---|---|---|---|
+| `owncloud-embed:share` event | November 12, 2025 | Use `owncloud-embed:share-links` event instead | [PR #13296](https://github.com/owncloud/web/pull/13296) | New event provides structured data with both URL and optional password |
 
 ## Migration History
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Change the "copy link and password" action in CreateShareModal in embed mode to actually pass link(s) and password(s) to the parent application.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
In embed mode copying the links with passwords to clipboard is completely counterintuitive as it behaves completely different than "share links" and requires users to insert it themselves. Moreover the clipboard functionality is blocked by default in an inframe.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):
<img width="1777" height="852" alt="Screenshot_20251112_163410" src="https://github.com/user-attachments/assets/51a089cf-57a1-467d-89f3-5a1117a63f33" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
