### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on stable-12 branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=995dde559bbc37464a59170160adc144b25e2b11
+OCIS_COMMITID=e50392a97ce63093b69bda0defc9328e2142804c
 OCIS_BRANCH=stable-7.2


### PR DESCRIPTION
## Description
Bump latest ocis `stable-7.2` branch commit id.

Part of: https://github.com/owncloud/QA/issues/911