### PR TITLE
refactor(web-app-files): [OCISDEV-389] adjust sharing headings

### DIFF
--- a/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileLinks.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="oc-files-file-link" class="oc-position-relative">
     <div class="oc-flex oc-flex-middle">
-      <h3 class="oc-text-bold oc-text-medium oc-m-rm" v-text="$gettext('Public links')" />
+      <h4 class="oc-text-bold oc-text-medium oc-m-rm" v-text="$gettext('Public links')" />
       <oc-contextual-helper v-if="helpersEnabled" class="oc-pl-xs" v-bind="shareViaLinkHelp" />
     </div>
     <p v-if="!directLinks.length" class="files-links-empty oc-mt-m" v-text="noLinksLabel" />
@@ -49,14 +49,14 @@
     </div>
     <div v-if="indirectLinks.length" class="files-links-indirect oc-mt-m">
       <hr class="oc-my-m" />
-      <h4 class="oc-text-bold oc-text-medium oc-m-rm">
+      <h5 class="oc-text-bold oc-text-medium oc-m-rm">
         {{ indirectLinksHeading }}
         <oc-contextual-helper
           v-if="helpersEnabled"
           class="oc-pl-xs"
           v-bind="shareViaIndirectLinkHelp"
         />
-      </h4>
+      </h5>
       <div
         class="files-links-indirect-list"
         :class="{ 'files-links-indirect-list-open': !indirectLinkListCollapsed }"

--- a/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/FileShares.vue
@@ -2,7 +2,7 @@
   <div id="oc-files-sharing-sidebar" class="oc-position-relative">
     <div class="oc-flex oc-flex-between oc-flex-middle">
       <div class="oc-flex">
-        <h3 v-translate class="oc-text-bold oc-text-medium oc-m-rm">Share with people</h3>
+        <h4 v-translate class="oc-text-bold oc-text-medium oc-m-rm">Share with people</h4>
         <oc-contextual-helper
           v-if="helpersEnabled"
           class="oc-pl-xs"
@@ -24,7 +24,7 @@
     />
     <template v-if="hasSharees">
       <div id="files-collaborators-headline" class="oc-flex oc-flex-middle oc-flex-between">
-        <h4 class="oc-text-bold oc-my-rm" v-text="sharedWithLabel" />
+        <h5 class="oc-text-bold oc-text-medium oc-my-rm" v-text="sharedWithLabel" />
       </div>
       <portal-target
         name="app.files.sidebar.sharing.shared-with.top"
@@ -68,7 +68,7 @@
     </template>
     <template v-if="showSpaceMembers">
       <div class="oc-flex oc-flex-middle oc-flex-between">
-        <h4 class="oc-text-bold oc-my-s" v-text="spaceMemberLabel" />
+        <h5 class="oc-text-bold oc-text-medium oc-my-s" v-text="spaceMemberLabel" />
       </div>
       <ul
         id="space-collaborators-list"

--- a/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SpaceMembers.vue
@@ -2,7 +2,7 @@
   <div id="oc-files-sharing-sidebar" class="oc-position-relative">
     <div class="oc-flex">
       <div v-if="canShare({ space: resource, resource })" class="oc-flex oc-py-s">
-        <h3 class="oc-text-bold oc-text-medium oc-m-rm" v-text="$gettext('Add members')" />
+        <h4 class="oc-text-bold oc-text-medium oc-m-rm" v-text="$gettext('Add members')" />
         <oc-contextual-helper
           v-if="helpersEnabled"
           class="oc-pl-xs"
@@ -24,7 +24,7 @@
         class="oc-flex oc-flex-middle oc-flex-between oc-position-relative"
       >
         <div class="oc-flex">
-          <h4 class="oc-text-bold oc-my-rm" v-text="$gettext('Members')" />
+          <h5 class="oc-text-bold oc-text-medium oc-my-rm" v-text="$gettext('Members')" />
           <oc-button
             v-oc-tooltip="$gettext('Filter members')"
             class="open-filter-btn oc-ml-s"

--- a/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/FileShares.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/SideBar/Shares/__snapshots__/FileShares.spec.ts.snap
@@ -4,14 +4,14 @@ exports[`FileShares > collaborators list > renders sharedWithLabel and sharee li
 "<div data-v-89647fdf="" id="oc-files-sharing-sidebar" class="oc-position-relative">
   <div data-v-89647fdf="" class="oc-flex oc-flex-between oc-flex-middle">
     <div data-v-89647fdf="" class="oc-flex">
-      <h3 data-v-89647fdf="" class="oc-text-bold oc-text-medium oc-m-rm" data-msgid="Share with people" data-current-language="en">Share with people</h3>
+      <h4 data-v-89647fdf="" class="oc-text-bold oc-text-medium oc-m-rm" data-msgid="Share with people" data-current-language="en">Share with people</h4>
       <oc-contextual-helper-stub data-v-89647fdf="" title="Share with people" text="Use the input field to search for users and groups. Select them to share the item." list="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" endtext="" readmorelink="https://doc.owncloud.com/go?to=webui-users-sharing" class="oc-pl-xs"></oc-contextual-helper-stub>
     </div>
     <copy-private-link-stub data-v-89647fdf="" resource="undefined"></copy-private-link-stub>
   </div>
   <invite-collaborator-form-stub data-v-89647fdf="" invitelabel="" class="oc-my-s"></invite-collaborator-form-stub>
   <div data-v-89647fdf="" id="files-collaborators-headline" class="oc-flex oc-flex-middle oc-flex-between">
-    <h4 data-v-89647fdf="" class="oc-text-bold oc-my-rm">Shared with</h4>
+    <h5 data-v-89647fdf="" class="oc-text-bold oc-text-medium oc-my-rm">Shared with</h5>
   </div>
   <portal-target data-v-89647fdf="" name="app.files.sidebar.sharing.shared-with.top" slot-props="[object Object]" multiple="true"></portal-target>
   <ul data-v-89647fdf="" id="files-collaborators-list" class="oc-list oc-list-divider oc-m-rm" aria-label="Share receivers">
@@ -41,14 +41,14 @@ exports[`FileShares > current space > loads space members if a space is given an
 "<div data-v-89647fdf="" id="oc-files-sharing-sidebar" class="oc-position-relative">
   <div data-v-89647fdf="" class="oc-flex oc-flex-between oc-flex-middle">
     <div data-v-89647fdf="" class="oc-flex">
-      <h3 data-v-89647fdf="" class="oc-text-bold oc-text-medium oc-m-rm" data-msgid="Share with people" data-current-language="en">Share with people</h3>
+      <h4 data-v-89647fdf="" class="oc-text-bold oc-text-medium oc-m-rm" data-msgid="Share with people" data-current-language="en">Share with people</h4>
       <oc-contextual-helper-stub data-v-89647fdf="" title="Share with people" text="Use the input field to search for users and groups. Select them to share the item." list="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]" endtext="" readmorelink="https://doc.owncloud.com/go?to=webui-users-sharing" class="oc-pl-xs"></oc-contextual-helper-stub>
     </div>
     <copy-private-link-stub data-v-89647fdf="" resource="undefined"></copy-private-link-stub>
   </div>
   <invite-collaborator-form-stub data-v-89647fdf="" invitelabel="" class="oc-my-s"></invite-collaborator-form-stub>
   <div data-v-89647fdf="" id="files-collaborators-headline" class="oc-flex oc-flex-middle oc-flex-between">
-    <h4 data-v-89647fdf="" class="oc-text-bold oc-my-rm">Shared with</h4>
+    <h5 data-v-89647fdf="" class="oc-text-bold oc-text-medium oc-my-rm">Shared with</h5>
   </div>
   <portal-target data-v-89647fdf="" name="app.files.sidebar.sharing.shared-with.top" slot-props="[object Object]" multiple="true"></portal-target>
   <ul data-v-89647fdf="" id="files-collaborators-list" class="oc-list oc-list-divider oc-mb-l" aria-label="Share receivers">
@@ -59,7 +59,7 @@ exports[`FileShares > current space > loads space members if a space is given an
   </ul>
   <!--v-if-->
   <div data-v-89647fdf="" class="oc-flex oc-flex-middle oc-flex-between">
-    <h4 data-v-89647fdf="" class="oc-text-bold oc-my-s">Space members</h4>
+    <h5 data-v-89647fdf="" class="oc-text-bold oc-text-medium oc-my-s">Space members</h5>
   </div>
   <ul data-v-89647fdf="" id="space-collaborators-list" class="oc-list oc-list-divider oc-overflow-hidden oc-m-rm" aria-label="Space members">
     <li data-v-89647fdf="">


### PR DESCRIPTION
## Description

Adjust the heading structure in the sharing components displayed in the sidebar. The new structure improves the ordering of the sections.

## Motivation and Context

Sensible structure.

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: open sharing panels and check the heading levels
