### PR TITLE
refactor: [OCISDEV-389] use fieldsets for filter sections

### DIFF
--- a/packages/design-system/src/styles/styles.scss
+++ b/packages/design-system/src/styles/styles.scss
@@ -1,6 +1,7 @@
 // 1. Your custom variables and variable overwrites.
 @import "../assets/tokens/ods";
 @import "theme/variables";
+@import "theme/resets";
 
 // 2. Import Vendor.
 @import "../../node_modules/tippy.js/dist/tippy";

--- a/packages/design-system/src/styles/theme/resets.scss
+++ b/packages/design-system/src/styles/theme/resets.scss
@@ -1,0 +1,12 @@
+fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+  min-width: 0;
+}
+
+legend {
+  padding: 0;
+  width: auto;
+  margin: 0;
+}

--- a/packages/web-app-admin-settings/src/views/Users.vue
+++ b/packages/web-app-admin-settings/src/views/Users.vue
@@ -39,10 +39,12 @@
             <context-actions :items="selectedUsers" />
           </template>
           <template #filter>
-            <div class="oc-flex oc-flex-middle">
-              <div class="oc-mr-m oc-flex oc-flex-middle">
-                <oc-icon name="filter-2" class="oc-mr-xs" />
-                <span v-text="$gettext('Filter:')" />
+            <fieldset class="oc-flex oc-flex-middle">
+              <div>
+                <legend class="oc-mr-m oc-flex oc-flex-middle">
+                  <oc-icon name="filter-2" class="oc-mr-xs" />
+                  <span v-text="$gettext('Filter:')" />
+                </legend>
               </div>
               <item-filter
                 v-if="groups.length"
@@ -87,7 +89,7 @@
                   <div v-text="$gettext(item.displayName)" />
                 </template>
               </item-filter>
-            </div>
+            </fieldset>
             <div class="oc-flex oc-flex-middle">
               <oc-text-input
                 id="users-filter"

--- a/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Users.spec.ts.snap
+++ b/packages/web-app-admin-settings/tests/unit/views/__snapshots__/Users.spec.ts.snap
@@ -21,11 +21,13 @@ exports[`Users view > list view > renders initially warning if filters are manda
       </div>
       <div data-v-10ab5d2a="" id="user-list" class="">
         <div class="user-filters oc-flex oc-flex-between oc-flex-wrap oc-flex-bottom oc-mx-m oc-mb-m">
-          <div data-v-10ab5d2a="" class="oc-flex oc-flex-middle">
-            <div data-v-10ab5d2a="" class="oc-mr-m oc-flex oc-flex-middle"><span data-v-10ab5d2a="" class="oc-icon oc-icon-m oc-icon-passive oc-mr-xs"><!----></span> <span data-v-10ab5d2a="">Filter:</span></div>
+          <fieldset data-v-10ab5d2a="" class="oc-flex oc-flex-middle">
+            <div data-v-10ab5d2a="">
+              <legend data-v-10ab5d2a="" class="oc-mr-m oc-flex oc-flex-middle"><span data-v-10ab5d2a="" class="oc-icon oc-icon-m oc-icon-passive oc-mr-xs"><!----></span> <span data-v-10ab5d2a="">Filter:</span></legend>
+            </div>
             <item-filter-stub data-v-10ab5d2a="" filterlabel="Groups" items="undefined" filtername="groups" optionfilterlabel="Filter groups" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false" class="oc-mr-s"></item-filter-stub>
             <item-filter-stub data-v-10ab5d2a="" filterlabel="Roles" items="[object Object],[object Object],[object Object],[object Object]" filtername="roles" optionfilterlabel="Filter roles" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false"></item-filter-stub>
-          </div>
+          </fieldset>
           <div data-v-10ab5d2a="" class="oc-flex oc-flex-middle">
             <div data-v-10ab5d2a="" class="" modelmodifiers="[object Object]" autocomplete="off"><label class="oc-label" for="users-filter">Search</label>
               <div class="oc-position-relative">
@@ -69,11 +71,13 @@ exports[`Users view > list view > renders list initially 1`] = `
       </div>
       <div data-v-10ab5d2a="" id="user-list" class="">
         <div class="user-filters oc-flex oc-flex-between oc-flex-wrap oc-flex-bottom oc-mx-m oc-mb-m">
-          <div data-v-10ab5d2a="" class="oc-flex oc-flex-middle">
-            <div data-v-10ab5d2a="" class="oc-mr-m oc-flex oc-flex-middle"><span data-v-10ab5d2a="" class="oc-icon oc-icon-m oc-icon-passive oc-mr-xs"><!----></span> <span data-v-10ab5d2a="">Filter:</span></div>
+          <fieldset data-v-10ab5d2a="" class="oc-flex oc-flex-middle">
+            <div data-v-10ab5d2a="">
+              <legend data-v-10ab5d2a="" class="oc-mr-m oc-flex oc-flex-middle"><span data-v-10ab5d2a="" class="oc-icon oc-icon-m oc-icon-passive oc-mr-xs"><!----></span> <span data-v-10ab5d2a="">Filter:</span></legend>
+            </div>
             <item-filter-stub data-v-10ab5d2a="" filterlabel="Groups" items="undefined" filtername="groups" optionfilterlabel="Filter groups" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false" class="oc-mr-s"></item-filter-stub>
             <item-filter-stub data-v-10ab5d2a="" filterlabel="Roles" items="[object Object],[object Object],[object Object],[object Object]" filtername="roles" optionfilterlabel="Filter roles" showoptionfilter="true" allowmultiple="true" idattribute="id" displaynameattribute="displayName" filterableattributes="displayName" closeonclick="false"></item-filter-stub>
-          </div>
+          </fieldset>
           <div data-v-10ab5d2a="" class="oc-flex oc-flex-middle">
             <div data-v-10ab5d2a="" class="" modelmodifiers="[object Object]" autocomplete="off"><label class="oc-label" for="users-filter">Search</label>
               <div class="oc-position-relative">

--- a/packages/web-app-files/src/components/Search/List.vue
+++ b/packages/web-app-files/src/components/Search/List.vue
@@ -6,13 +6,15 @@
         :has-bulk-actions="true"
         :is-side-bar-open="isSideBarOpen"
       />
-      <div
+      <fieldset
         v-if="displayFilter"
         class="files-search-result-filter oc-flex oc-flex-wrap oc-mx-m oc-mb-m oc-mt-xs"
       >
-        <div class="oc-mr-m oc-flex oc-flex-middle">
-          <oc-icon name="filter-2" class="oc-mr-xs" />
-          <span v-text="$gettext('Filter:')" />
+        <div>
+          <legend class="oc-mr-m oc-flex oc-flex-middle">
+            <oc-icon name="filter-2" class="oc-mr-xs" />
+            <span v-text="$gettext('Filter:')" />
+          </legend>
         </div>
         <item-filter
           v-if="availableMediaTypeValues.length"
@@ -78,7 +80,7 @@
           filter-name="titleOnly"
           class="files-search-filter-title-only oc-mr-s"
         />
-      </div>
+      </fieldset>
       <app-loading-spinner v-if="loading" />
       <template v-else>
         <no-content-message

--- a/packages/web-app-files/src/views/shares/SharedWithMe.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithMe.vue
@@ -11,10 +11,12 @@
         <div
           class="shared-with-me-filters oc-flex oc-flex-between oc-flex-wrap oc-flex-bottom oc-mx-m oc-mb-m"
         >
-          <div class="oc-flex oc-flex-wrap">
-            <div class="oc-mr-m oc-flex oc-flex-middle">
-              <oc-icon name="filter-2" class="oc-mr-xs" />
-              <span v-text="$gettext('Filter:')" />
+          <fieldset class="oc-flex oc-flex-wrap">
+            <div>
+              <legend class="oc-mr-m oc-flex oc-flex-middle">
+                <oc-icon name="filter-2" class="oc-mr-xs" />
+                <span v-text="$gettext('Filter:')" />
+              </legend>
             </div>
             <item-filter-inline
               class="share-visibility-filter"
@@ -57,7 +59,7 @@
                 <span class="oc-ml-s" v-text="item.displayName" />
               </template>
             </item-filter>
-          </div>
+          </fieldset>
           <div>
             <oc-text-input
               v-model="filterTerm"

--- a/packages/web-app-files/src/views/shares/SharedWithOthers.vue
+++ b/packages/web-app-files/src/views/shares/SharedWithOthers.vue
@@ -8,10 +8,12 @@
       </app-bar>
       <app-loading-spinner v-if="areResourcesLoading" />
       <template v-else>
-        <div v-if="shareTypes.length > 1" class="oc-flex oc-m-m">
-          <div class="oc-mr-m oc-flex oc-flex-middle">
-            <oc-icon name="filter-2" class="oc-mr-xs" />
-            <span v-text="$gettext('Filter:')" />
+        <fieldset v-if="shareTypes.length > 1" class="oc-flex oc-m-m">
+          <div>
+            <legend class="oc-mr-m oc-flex oc-flex-middle">
+              <oc-icon name="filter-2" class="oc-mr-xs" />
+              <span v-text="$gettext('Filter:')" />
+            </legend>
           </div>
           <item-filter
             :allow-multiple="true"
@@ -29,7 +31,7 @@
               <span class="oc-ml-s" v-text="item.label" />
             </template>
           </item-filter>
-        </div>
+        </fieldset>
         <no-content-message
           v-if="isEmpty"
           id="files-shared-with-others-empty"

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -39,17 +39,19 @@
           <div
             class="spaces-list-filters oc-flex oc-flex-between oc-flex-wrap oc-flex-bottom oc-mx-m oc-mb-m"
           >
-            <div class="oc-flex">
-              <div class="oc-mr-m oc-flex oc-flex-middle">
-                <oc-icon name="filter-2" class="oc-mr-xs" />
-                <span v-text="$gettext('Filter:')" />
+            <fieldset class="oc-flex">
+              <div>
+                <legend class="oc-mr-m oc-flex oc-flex-middle">
+                  <oc-icon name="filter-2" class="oc-mr-xs" />
+                  <span v-text="$gettext('Filter:')" />
+                </legend>
               </div>
               <item-filter-toggle
                 :filter-label="$gettext('Include disabled')"
                 filter-name="includeDisabled"
                 class="spaces-list-filter-include-disabled oc-mr-s"
               />
-            </div>
+            </fieldset>
             <oc-text-input
               id="spaces-filter"
               v-model="filterTerm"

--- a/packages/web-app-files/tests/unit/views/spaces/__snapshots__/Projects.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/views/spaces/__snapshots__/Projects.spec.ts.snap
@@ -7,8 +7,10 @@ exports[`Projects view > different files view states > lists all available proje
       <app-bar-stub viewmodedefault="resource-tiles" breadcrumbs="[object Object]" breadcrumbscontextactionsitems="" viewmodes="[object Object]" hasbulkactions="true" hasviewoptions="true" hashiddenfiles="false" hasfileextensions="false" haspagination="false" issidebaropen="false"></app-bar-stub>
       <div class="spaces-list">
         <div class="spaces-list-filters oc-flex oc-flex-between oc-flex-wrap oc-flex-bottom oc-mx-m oc-mb-m">
-          <div class="oc-flex">
-            <div class="oc-mr-m oc-flex oc-flex-middle"><span class="oc-icon oc-icon-m oc-icon-passive oc-mr-xs"><!----></span> <span>Filter:</span></div>
+          <fieldset class="oc-flex">
+            <div>
+              <legend class="oc-mr-m oc-flex oc-flex-middle"><span class="oc-icon oc-icon-m oc-icon-passive oc-mr-xs"><!----></span> <span>Filter:</span></legend>
+            </div>
             <div class="item-filter oc-flex item-filter-includeDisabled spaces-list-filter-include-disabled oc-mr-s">
               <div class="oc-filter-chip oc-flex oc-filter-chip-toggle"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw oc-filter-chip-button oc-pill" id="oc-filter-chip-1">
                   <!--v-if-->
@@ -20,7 +22,7 @@ exports[`Projects view > different files view states > lists all available proje
                 <!--v-if-->
               </div>
             </div>
-          </div>
+          </fieldset>
           <div class="" autocomplete="off"><label class="oc-label" for="spaces-filter">Search</label>
             <div class="oc-position-relative">
               <!--v-if--> <input id="spaces-filter" autocomplete="off" aria-invalid="false" class="oc-text-input oc-input oc-rounded" type="text" value="">


### PR DESCRIPTION
## Description

Instead of using divs for filter sections, use fieldsets with legend. This semantically marks the section to assistive technologies.

## Motivation and Context

Better semantics.