### PR TITLE
[full-ci] test: add wcag22aa tag

### DIFF
--- a/packages/design-system/src/components/OcFilterChip/OcFilterChip.vue
+++ b/packages/design-system/src/components/OcFilterChip/OcFilterChip.vue
@@ -155,6 +155,7 @@ defineExpose({ hideDrop })
     max-width: 180px;
     padding: var(--oc-space-xsmall) var(--oc-space-small) !important;
     height: 100%;
+    min-height: 1.9591836735rem;
   }
   &-button-selected.oc-pill,
   &-button-selected.oc-pill:hover {

--- a/packages/design-system/src/components/OcSearchBar/OcSearchBar.vue
+++ b/packages/design-system/src/components/OcSearchBar/OcSearchBar.vue
@@ -26,7 +26,7 @@
         v-if="icon"
         v-oc-tooltip="$gettext('Search')"
         :aria-label="$gettext('Search')"
-        class="oc-position-small oc-position-center-right oc-mt-rm"
+        class="btn-search-icon oc-position-small oc-position-center-right oc-mt-rm"
         appearance="raw"
         @click.prevent.stop="$emit('advancedSearch', $event)"
       >
@@ -325,5 +325,10 @@ const loadingAccessibleLabelValue = computed(() => {
       }
     }
   }
+}
+
+.btn-search-icon {
+  height: 1.9591836735rem;
+  width: 1.9591836735rem;
 }
 </style>

--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -1094,7 +1094,7 @@ function getSharedWithAvatarItems(resource: Resource) {
   &-edit-name,
   &-activity-indicator {
     display: inline-flex;
-    margin-left: var(--oc-space-xsmall);
+    margin-left: var(--oc-space-small);
 
     svg {
       fill: var(--oc-color-text-muted);

--- a/tests/e2e/support/objects/a11y/actions.ts
+++ b/tests/e2e/support/objects/a11y/actions.ts
@@ -31,7 +31,7 @@ export const selectors = {
   appSidebar: '#app-sidebar'
 }
 
-const a11yRuleTags = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'best-practice']
+const a11yRuleTags = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'best-practice', 'wcag22aa']
 // decide which tags should be included in the default configuration of axebuilder
 
 export const analyzeAccessibilityConformityViolations = async (args: {


### PR DESCRIPTION
## Description

When checking accessibility in the tests, use also wcag22aa tag to run WCAG 2.2 Level AA checks.

## Motivation and Context

More coverage.

## How Has This Been Tested?

- test environment: 🤖 
