### PR TITLE
fix(web-app-files): use sticky header composable in deleted files

### DIFF
--- a/changelog/unreleased/bugfix-deleted-files-sticky-header.md
+++ b/changelog/unreleased/bugfix-deleted-files-sticky-header.md
@@ -1,0 +1,7 @@
+Bugfix: Use sticky header composable in deleted files
+
+The sticky header composable is now used in the deleted files view.
+This fixes the issue where the header was always sticky.
+On smaller screens, this breaks the layout and overlaps the content.
+
+https://github.com/owncloud/web/pull/13329

--- a/packages/web-app-files/src/views/trash/Overview.vue
+++ b/packages/web-app-files/src/views/trash/Overview.vue
@@ -34,7 +34,7 @@
             :fields="fields"
             :data="displaySpaces"
             :header-position="fileListHeaderY"
-            :sticky="true"
+            :sticky="isSticky"
             :hover="true"
             :has-icons-column="true"
             @sort="handleSort"
@@ -77,6 +77,7 @@ import {
   FileSideBar,
   SortDir,
   useClientService,
+  useIsTopBarSticky,
   useResourcesStore,
   useRouter,
   useSideBar,
@@ -105,6 +106,7 @@ const clientService = useClientService()
 const { y: fileListHeaderY } = useFileListHeaderPosition()
 const resourcesStore = useResourcesStore()
 const { isSideBarOpen, sideBarActivePanel } = useSideBar()
+const { isSticky } = useIsTopBarSticky()
 
 const sortBy = ref<keyof SpaceResource>('name')
 const sortDir = ref<SortDir>(SortDir.Asc)


### PR DESCRIPTION
## Description

The sticky header composable is now used in the deleted files view. This fixes the issue where the header was always sticky. On smaller screens, this breaks the layout and overlaps the content.

## Motivation and Context

Consistent behaviour with other tables.

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: scroll table with window height < 500 px
- test case 2: scroll table with window height > 500 px

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/fdd7e7b9-9d9e-49c4-b894-0f7350d6e608


https://github.com/user-attachments/assets/4f0f160e-c6f6-4b92-b2e3-9a05af211c89

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
