### PR TITLE
[tests-only] [full-ci] test: expect no severe violations in a11y feature tests

### DIFF
--- a/tests/e2e/cucumber/steps/ui/a11y.ts
+++ b/tests/e2e/cucumber/steps/ui/a11y.ts
@@ -12,24 +12,10 @@ Then(
 
     const a11yObject = new objects.a11y.Accessibility({ page })
 
-    const a11yViolations = await a11yObject.getAccessibilityConformityViolations(
+    const a11yViolations = await a11yObject.getSevereAccessibilityViolations(
       a11yObject.getSelectors().files
     )
-    expect(a11yViolations).not.toMatchObject([])
-
-    // expected to fail due to known accessibility issues, therefore exclude:
-    // selectors.resourceTableEditName --> buttons must have discernible text
-    // selectors.resourceIconLink --> buttons/links must have discernible text
-
-    const a11yViolationsWithExclusions =
-      await a11yObject.getAccessibilityConformityViolationsWithExclusions(
-        a11yObject.getSelectors().files,
-        [
-          a11yObject.getSelectors().resourceTableEditName,
-          a11yObject.getSelectors().resourceIconLink
-        ]
-      )
-    expect(a11yViolationsWithExclusions).toMatchObject([])
+    expect(a11yViolations).toMatchObject([])
   }
 )
 
@@ -50,24 +36,10 @@ Then(
 
     const a11yObject = new objects.a11y.Accessibility({ page })
 
-    const a11yViolations = await a11yObject.getAccessibilityConformityViolations(
+    const a11yViolations = await a11yObject.getSevereAccessibilityViolations(
       a11yObject.getSelectors().filesSpaceTable
     )
-    expect(a11yViolations).not.toMatchObject([])
-
-    // expected to fail due to known accessibility issues, therefore exclude:
-    // selectors.resourceTableEditName --> buttons must have discernible text
-    // selectors.resourceIconLink --> buttons/links must have discernible text
-
-    const a11yViolationsWithExclusions =
-      await a11yObject.getAccessibilityConformityViolationsWithExclusions(
-        a11yObject.getSelectors().filesSpaceTable,
-        [
-          a11yObject.getSelectors().resourceTableEditName,
-          a11yObject.getSelectors().resourceIconLink
-        ]
-      )
-    expect(a11yViolationsWithExclusions).toMatchObject([])
+    expect(a11yViolations).toMatchObject([])
   }
 )
 
@@ -77,7 +49,7 @@ Then(
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
 
     const a11yObject = new objects.a11y.Accessibility({ page })
-    const a11yViolations = await a11yObject.getAccessibilityConformityViolations(
+    const a11yViolations = await a11yObject.getSevereAccessibilityViolations(
       a11yObject.getSelectors().tilesView
     )
     expect(a11yViolations).toMatchObject([])
@@ -110,7 +82,7 @@ Then(
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
 
     const a11yObject = new objects.a11y.Accessibility({ page })
-    const a11yViolations = await a11yObject.getAccessibilityConformityViolations(
+    const a11yViolations = await a11yObject.getSevereAccessibilityViolations(
       a11yObject.getSelectors().displayOptionsMenu
     )
     expect(a11yViolations).toMatchObject([])
@@ -143,7 +115,7 @@ Then(
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
 
     const a11yObject = new objects.a11y.Accessibility({ page })
-    const a11yViolations = await a11yObject.getAccessibilityConformityViolations(
+    const a11yViolations = await a11yObject.getSevereAccessibilityViolations(
       a11yObject.getSelectors().filesContextMenu
     )
     expect(a11yViolations).toMatchObject([])
@@ -173,7 +145,7 @@ Then(
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
 
     const a11yObject = new objects.a11y.Accessibility({ page })
-    const a11yViolations = await a11yObject.getAccessibilityConformityViolations(
+    const a11yViolations = await a11yObject.getSevereAccessibilityViolations(
       a11yObject.getSelectors().newResourceContextMenu
     )
     expect(a11yViolations).toMatchObject([])
@@ -196,7 +168,7 @@ Then(
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
 
     const a11yObject = new objects.a11y.Accessibility({ page })
-    const a11yViolations = await a11yObject.getAccessibilityConformityViolations(
+    const a11yViolations = await a11yObject.getSevereAccessibilityViolations(
       a11yObject.getSelectors().ocModal
     )
     expect(a11yViolations).toMatchObject([])
@@ -226,7 +198,7 @@ Then(
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
 
     const a11yObject = new objects.a11y.Accessibility({ page })
-    const a11yViolations = await a11yObject.getAccessibilityConformityViolations(
+    const a11yViolations = await a11yObject.getSevereAccessibilityViolations(
       a11yObject.getSelectors().uploadContextMenu
     )
     expect(a11yViolations).toMatchObject([])
@@ -259,7 +231,7 @@ Then(
     const { page } = this.actorsEnvironment.getActor({ key: stepUser })
 
     const a11yObject = new objects.a11y.Accessibility({ page })
-    const a11yViolations = await a11yObject.getAccessibilityConformityViolations(
+    const a11yViolations = await a11yObject.getSevereAccessibilityViolations(
       a11yObject.getSelectors().appbarBatchActions
     )
     expect(a11yViolations).toMatchObject([])

--- a/tests/e2e/support/objects/a11y/actions.ts
+++ b/tests/e2e/support/objects/a11y/actions.ts
@@ -24,7 +24,7 @@ export const selectors = {
   ocModal: '.oc-modal',
   ocModalCancel: '.oc-modal-body-actions-cancel',
   uploadMenuBtn: '#upload-menu-btn',
-  uploadContextMenu: '.files-app-bar-actions .tippy-content',
+  uploadContextMenu: '#upload-menu-drop',
   appbarBatchActions: '#oc-appbar-batch-actions',
   filesSpaceTableCheckbox: '#files-space-table .oc-checkbox',
   uploadMenuDropdown: '#upload-menu-drop',


### PR DESCRIPTION
## Description

Instead of checking for any violations, we now only check for severe violations. Also, we now actually fail the test in case there are any severe violations.

## Motivation and Context

A11y feature matches behaviour of other a11y tests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: macos & 🤖 
- test case 1: run E2E tests locally
- test case 2: let the drone CI pass

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
