### PR TITLE
[full-ci] test: fix the modal selector

### DIFF
--- a/tests/e2e/support/objects/app-files/link/actions.ts
+++ b/tests/e2e/support/objects/app-files/link/actions.ts
@@ -128,7 +128,7 @@ export const createLink = async (args: createLinkArgs): Promise<string> => {
 
   const a11yObject = new objects.a11y.Accessibility({ page })
   const violations = await a11yObject.getSevereAccessibilityViolations(
-    a11yObject.getSelectors().modal
+    a11yObject.getSelectors().ocModal
   )
   expect(
     violations,

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -326,7 +326,7 @@ export const createNewFolder = async ({
 
   const a11yObject = new objects.a11y.Accessibility({ page })
   const violations = await a11yObject.getSevereAccessibilityViolations(
-    a11yObject.getSelectors().modal
+    a11yObject.getSelectors().ocModal
   )
   expect(
     violations,


### PR DESCRIPTION
## Description
Use the correct modal selector.

The a11y error was caused by other hidden elements in the UI, but in the test, we only want to check the accessibility of the current modal.

Fixes following errors:
```
✖ And "Alice" creates a public link of following resource using the sidebar panel # file:/var/www/owncloud/web/tests/e2e/cucumber/steps/ui/links.ts:5
       | resource    | password |
       | spaceFolder | %public% |
       Error: expect(received).toHaveLength(expected)

       Expected length: 0
       Received length: 1
       Received array:  [{"description": "Ensure [role=\"img\"] elements have alternative text", "help": "[role=\"img\"] elements must have alternative text", "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/role-img-alt?application=playwright", "id": "role-img-alt", "impact": "serious", "nodes": [{"all": [], "any": [{"data": null, "id": "aria-label", "impact": "serious", "message": "aria-label attribute does not exist or is empty", "relatedNodes": []}, {"data": null, "id": "aria-labelledby", "impact": "serious", "message": "aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty", "relatedNodes": []}, {"data": {"messageKey": "noAttr"}, "id": "non-empty-title", "impact": "serious", "message": "Element has no title attribute", "relatedNodes": []}], "failureSummary": "Fix any of the following:
         aria-label attribute does not exist or is empty
         aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
         Element has no title attribute", "html": "<span class=\"oc-icon oc-icon-m oc-icon-passive oc-files-file-link-has-password oc-mr-xs\" role=\"img\">", "impact": "serious", "none": [], "target": [".oc-files-file-link-has-password"]}], "tags": ["cat.text-alternatives", "wcag2a", "wcag111", "section508", "section508.22.a", "TTv5", "TT7.a", "EN-301-549", "EN-9.1.1.1", "ACT", …]}]
           at Proxy.<anonymous> (/var/www/owncloud/web/node_modules/.pnpm/playwright@1.56.1/node_modules/playwright/lib/matchers/expect.js:221:24)
           at Module.createLink (file:///var/www/owncloud/web/tests/e2e/support/objects/app-files/link/actions.ts:60:114)
           at async Link.create (file:///var/www/owncloud/web/tests/e2e/support/objects/app-files/link/index.ts:12:21)
           at async World.<anonymous> (file:///var/www/owncloud/web/tests/e2e/cucumber/steps/ui/links.ts:9:9)
```
```
✖ And "Alice" creates the following resources # file:/var/www/owncloud/web/tests/e2e/cucumber/steps/ui/resources.ts:8
       | resource         | type   |
       | folderPublic     | folder |
       | folder_to_shared | folder |
       Error: expect(received).toHaveLength(expected)

       Expected length: 0
       Received length: 2
       Received array:  [{"description": "Ensure every ARIA input field has an accessible name", "help": "ARIA input fields must have an accessible name", "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/aria-input-field-name?application=playwright", "id": "aria-input-field-name", "impact": "serious", "nodes": [{"all": [], "any": [{"data": null, "id": "aria-label", "impact": "serious", "message": "aria-label attribute does not exist or is empty", "relatedNodes": []}, {"data": null, "id": "aria-labelledby", "impact": "serious", "message": "aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty", "relatedNodes": []}, {"data": {"messageKey": "noAttr"}, "id": "non-empty-title", "impact": "serious", "message": "Element has no title attribute", "relatedNodes": []}], "failureSummary": "Fix any of the following:
         aria-label attribute does not exist or is empty
         aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
         Element has no title attribute", "html": "<div class=\"tippy-box\" data-state=\"hidden\" tabindex=\"-1\" data-theme=\"none\" data-animation=\"fade\" role=\"listbox\" data-placement=\"bottom-start\" style=\"max-width: 416px; transition-duration: 250ms;\">", "impact": "serious", "none": [], "target": [".tippy-box"]}], "tags": ["cat.aria", "wcag2a", "wcag412", "TTv5", "TT5.c", "EN-301-549", "EN-9.4.1.2", "ACT", "RGAAv4", "RGAA-11.1.1"]}, {"description": "Ensure elements with an ARIA role that require child roles contain them", "help": "Certain ARIA roles must contain particular children", "helpUrl": "https://dequeuniversity.com/rules/axe/4.11/aria-required-children?application=playwright", "id": "aria-required-children", "impact": "critical", "nodes": [{"all": [], "any": [{"data": {"messageKey": "unallowed", "values": "ul[tabindex]"}, "id": "aria-required-children", "impact": "critical", "message": "Element has children which are not allowed: ul[tabindex]", "relatedNodes": [{"html": "<ul class=\"oc-list oc-my-rm oc-mx-rm expanded-list\" id=\"create-list\">", "target": ["#create-list"]}, {"html": "<ul class=\"oc-list oc-my-rm oc-mx-rm\">", "target": [".oc-background-secondary > ul:nth-child(2)"]}, {"html": "<ul class=\"oc-list oc-my-rm oc-mx-rm\">", "target": ["ul:nth-child(3)"]}]}], "failureSummary": "Fix any of the following:
         Element has children which are not allowed: ul[tabindex]", "html": "<div class=\"tippy-box\" data-state=\"hidden\" tabindex=\"-1\" data-theme=\"none\" data-animation=\"fade\" role=\"listbox\" data-placement=\"bottom-start\" style=\"max-width: 416px; transition-duration: 250ms;\">", "impact": "critical", "none": [], "target": [".tippy-box"]}], "tags": ["cat.aria", "wcag2a", "wcag131", "EN-301-549", "EN-9.1.3.1", "RGAAv4", "RGAA-9.3.1"]}]
```

## Related Issue
- Fixes https://github.com/owncloud/web/issues/13348

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
