### PR TITLE
[full-ci][tests-only] test: intercept HEAD request of download action 

### DIFF
--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -764,6 +764,18 @@ export const downloadResources = async (args: downloadResourcesArgs): Promise<Do
   const { page, resources, folder, via } = args
   const downloads = []
 
+  // When tracing is enabled, the HEAD request (download action) triggers a credentials prompt
+  // which blocks next actions in the test.
+  // See https://github.com/owncloud/web/issues/11541
+  // As a workaround, we fulfill the HEAD requests with an empty response to fix the issue.
+  await page.route('*/**/*.*', async (route, req) => {
+    if (req.method() === 'HEAD') {
+      await route.fulfill({ body: '' })
+      return
+    }
+    await route.continue()
+  })
+
   switch (via) {
     case 'SIDEBAR_PANEL': {
       if (folder) {


### PR DESCRIPTION
## Description
Intercept HEAD request of download action and return empty body to fix the issue with playwright while tracing is enabled 

## Related Issue
- https://github.com/owncloud/web/issues/11541
- Fixes https://github.com/owncloud/ocis/issues/11853

## Motivation and Context

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

