### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on stable-12.2 branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=0604ec570a33abde18e77e7d194694eb913519f2
+OCIS_COMMITID=e3dae1b48a74ab0e6d4d61a3f2f0988dbe2c5957
 OCIS_BRANCH=master


### PR DESCRIPTION
## Description
Bump latest ocis `master` branch commit id.

Part of: https://github.com/owncloud/QA/issues/912