### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on stable-12.2 branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=e3dae1b48a74ab0e6d4d61a3f2f0988dbe2c5957
+OCIS_COMMITID=327141eea1c023c1729f2dba6f292427ff67b933
 OCIS_BRANCH=master


### PR DESCRIPTION
## Description
Bump latest ocis `master` branch commit id.

Part of: https://github.com/owncloud/QA/issues/913