### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on stable-12.2 branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=327141eea1c023c1729f2dba6f292427ff67b933
+OCIS_COMMITID=624b646bf3a4343d1d11f517d544067781a49131
 OCIS_BRANCH=master


### PR DESCRIPTION
## Description
Bump latest ocis `master` branch commit id.

Part of: https://github.com/owncloud/QA/issues/913