### PR TITLE
fix(web-pkg): [OCISDEV-553] filter only personal trashed spaces

### DIFF
--- a/changelog/unreleased/bugfix-filter-only-personal-trashed-spaces.md
+++ b/changelog/unreleased/bugfix-filter-only-personal-trashed-spaces.md
@@ -1,0 +1,6 @@
+Bugfix: Filter only personal trashed spaces
+
+Instead of filtering all trashed spaces, we now filter only personal trashed spaces.
+This fixes the issue where listing spaces with "Include disabled" option toggled did not show disabled spaces.
+
+https://github.com/owncloud/web/pull/13415

--- a/packages/web-pkg/src/composables/piniaStores/spaces.ts
+++ b/packages/web-pkg/src/composables/piniaStores/spaces.ts
@@ -49,7 +49,8 @@ export const getSpacesByType = async ({
   }
 
   const enabledMountpoints = mountpoints.filter(
-    (space) => space.root.deleted?.state !== SpaceDeletedState.Trashed
+    (space) =>
+      !isPersonalSpaceResource(space) || space.root.deleted?.state !== SpaceDeletedState.Trashed
   )
 
   if (driveType !== 'mountpoint' || !configStore.options.routing?.fullShareOwnerPaths) {

--- a/packages/web-pkg/tests/unit/composables/piniaStores/spaces.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/piniaStores/spaces.spec.ts
@@ -206,14 +206,23 @@ describe('spaces', () => {
         }
       })
     })
-    it('should filter out trashed spaces', async () => {
+    it('should filter out trashed personal spaces', async () => {
       await new Promise<void>((resolve, reject) => {
         try {
           getWrapper({
             setup: async (instance) => {
               const spaces = [
                 mock<SpaceResource>({ id: '1' }),
-                mock<SpaceResource>({ id: '2', root: { deleted: { state: 'trashed' } } })
+                mock<SpaceResource>({
+                  id: '2',
+                  root: { deleted: { state: 'trashed' } },
+                  driveType: 'personal'
+                }),
+                mock<SpaceResource>({
+                  id: '3',
+                  root: { deleted: { state: 'trashed' } },
+                  driveType: 'project'
+                })
               ]
               const graphClient = mockDeep<Graph>()
               graphClient.drives.listMyDrives.mockResolvedValue(spaces)
@@ -238,7 +247,7 @@ describe('spaces', () => {
                 },
                 expect.anything()
               )
-              expect(instance.spaces.length).toBe(2)
+              expect(instance.spaces.length).toBe(4)
               expect(instance.spacesLoading).toBeFalsy()
               expect(instance.spacesInitialized).toBeTruthy()
               resolve()


### PR DESCRIPTION
## Description

Instead of filtering all trashed spaces, we now filter only personal trashed spaces. This fixes the issue where listing spaces with "Include disabled" option toggled did not show disabled spaces.

## Motivation and Context

Disabled project spaces are again listable.

## How Has This Been Tested?

- test environment: macos v26.2, chrome v143.0.7499.170
- test case 1: open UI with light user
- test case 2: toggle "Include disabled" option with regular user in spaces list

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
