### PR TITLE
chore: [OCISDEV-536] enable encoded chars for collabora

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,11 +184,17 @@ services:
     command: ['-c', 'coolconfig generate-proof-key ; /start-collabora-online.sh']
     environment:
       DONT_GEN_SSL_CERT: YES
-      extra_params: --o:ssl.enable=false --o:ssl.ssl_verification=false --o:ssl.termination=true --o:welcome.enable=false --o:net.frame_ancestors=${OCIS_URL:-https://host.docker.internal:9200}
+      extra_params: |
+        --o:ssl.enable=false \
+        --o:ssl.ssl_verification=false \
+        --o:ssl.termination=true \
+        --o:welcome.enable=false \
+        --o:net.content_security_policy=frame-ancestors ${OCIS_URL:-https://host.docker.internal:9200}
       username: ${COLLABORA_ADMIN_USER:-admin}
       password: ${COLLABORA_ADMIN_PASSWORD:-admin}
     cap_add:
       - MKNOD
+      - SYS_ADMIN
     extra_hosts:
       - host.docker.internal:${DOCKER_HOST:-host-gateway}
     healthcheck:
@@ -295,6 +301,10 @@ services:
       - '--entrypoints.ocis.address=:9200'
       - '--entrypoints.ocis-federated.address=:10200'
       - '--entrypoints.collabora.address=:9980'
+      # allow encoded characters which is required for collaboration/Collabora
+      - '--entryPoints.collabora.http.encodedCharacters.allowEncodedSlash=true'
+      - '--entryPoints.collabora.http.encodedCharacters.allowEncodedQuestionMark=true'
+      - '--entryPoints.collabora.http.encodedCharacters.allowEncodedPercent=true'
       - '--entrypoints.wopi.address=:8880'
       - '--entrypoints.collaboration.address=:9300'
       - '--entrypoints.collaboration-oo.address=:9302'


### PR DESCRIPTION
## Description

In the docker compose file, we now enable encoded characters in Traefik for Collabora service. This is needed to fix proxy issues with Collabora after updated the Traefik image version to 3.5.4. We also changed the `o:net.frame_ancestors` to `--o:net.content_security_policy` because the former configuration option is deprecated.

## Motivation and Context

Working Collabora.

## How Has This Been Tested?

- test environment: macos
- test case 1: run the containers and try to edit file in Collabora

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [x] Maintenance (e.g. dependency updates or tooling)
