### PR TITLE
[tests-only] test: fix multiple playwright test suites run

### DIFF
--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -174,10 +174,21 @@ function checkSuites() {
 }
 
 function buildSuitesPattern() {
+    local delimiter=","
+    local bracket_open="{"
+    local bracket_close="}"
+
     CURRENT_SUITES_COUNT=$(echo "$1" | wc -w) # count words
-    suites=$(echo "$1" | xargs | sed -E "s/( )+/,/g")
+
+    if [[ "$TEST_TYPE" == "playwright" ]]; then
+        delimiter="|"
+        bracket_open="("
+        bracket_close=")"
+    fi
+
+    suites=$(echo "$1" | xargs | sed -E "s/( )+/$delimiter/g")
     if [[ $CURRENT_SUITES_COUNT -gt 1 ]]; then
-        suites="{$suites}"
+        suites="$bracket_open${suites}$bracket_close"
     fi
     GLOB_FEATURE_PATHS="$FEATURES_DIR/$suites"
 }


### PR DESCRIPTION
## Description
Fix multiple playwright test suites run

:x: INVALID
```
> NODE_TLS_REJECT_UNAUTHORIZED=0 npx playwright test --config=tests/e2e-playwright/ --project=chromium '/var/www/owncloud/web/tests/e2e-playwright/specs/{shares,search}'
```

:heavy_check_mark: VALID
```
> NODE_TLS_REJECT_UNAUTHORIZED=0 npx playwright test --config=tests/e2e-playwright/ --project=chromium '/var/www/owncloud/web/tests/e2e-playwright/specs/(shares|search)'
```

## Related Issue
- Fixes 

## How Has This Been Tested?
<!--- see how your change affects other areas of the code, etc. -->
- test environment:


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

