### PR TITLE
[tests-only] ci: compare with second last head for push event

### DIFF
--- a/tests/drone/filterTestSuitesToRun.js
+++ b/tests/drone/filterTestSuitesToRun.js
@@ -87,7 +87,12 @@ function mapDependentPackagesToTestSuite(testSuite, depPackages) {
 }
 
 function getChangedFiles() {
-  const changedFiles = execSync(`git diff --name-only origin/${targetBranch} HEAD`).toString()
+  const isPushEvent = process.env.DRONE_BUILD_EVENT === 'push'
+  // compare with the second last commit for push events
+  const commitHead = isPushEvent ? '~1' : ''
+  const changedFiles = execSync(
+    `git diff --name-only origin/${targetBranch} HEAD${commitHead}`
+  ).toString()
   console.log('[INFO] Changed files:\n', changedFiles)
   return [...new Set([...changedFiles.split('\n')])].filter((file) => file.trim())
 }


### PR DESCRIPTION
## Description
Compare the current head with the second head for the push event. This is required because the latest origin/master and HEAD will have same commit hash resulting no file changes and skipping the e2e pipelines.

## Related Issue
- Fixes: e2e test not running for push event CI builds - https://drone.owncloud.com/owncloud/web/56816/9/2


## How Has This Been Tested?
- test environment:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

