### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on stable-12.2 branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=624b646bf3a4343d1d11f517d544067781a49131
+OCIS_COMMITID=e2e3e9a0586bb9d58da0e9fe854fd2c67f9362b7
 OCIS_BRANCH=master


### PR DESCRIPTION
## Description
Bump latest ocis `master` branch commit id.

Part of: https://github.com/owncloud/QA/issues/923