### PR TITLE
bugfix(web-app-admin-settings): [OCISDEV-474] fix showing hint to select a user and details when user is already selected

### DIFF
--- a/packages/web-app-admin-settings/src/components/Users/SideBar/DetailsPanel.vue
+++ b/packages/web-app-admin-settings/src/components/Users/SideBar/DetailsPanel.vue
@@ -2,7 +2,7 @@
   <div class="oc-mt-xl">
     <div v-if="noUsers" class="oc-flex user-info oc-text-center">
       <oc-icon name="user" size="xxlarge" />
-      <p v-translate>Select a user to view details</p>
+      <p v-translate data-testid="no-user-selected">Select a user to view details</p>
     </div>
     <div v-if="multipleUsers" class="oc-flex group-info">
       <oc-icon name="group" size="xxlarge" />
@@ -105,7 +105,7 @@ const { $gettext } = language
 const currentLanguage = computed(() => {
   return language.current
 })
-const noUsers = computed(() => users.length)
+const noUsers = computed(() => !users.length)
 const multipleUsers = computed(() => users.length > 1)
 const multipleUsersSelectedText = computed(() => {
   return $gettext('%{count} users selected', {

--- a/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/DetailsPanel.spec.ts
+++ b/packages/web-app-admin-settings/tests/unit/components/Users/SideBar/DetailsPanel.spec.ts
@@ -1,5 +1,6 @@
 import { User } from '@ownclouders/web-client/graph/generated'
 import DetailsPanel from '../../../../../src/components/Users/SideBar/DetailsPanel.vue'
+import UserInfoBox from '../../../../../src/components/Users/SideBar/UserInfoBox.vue'
 import { PartialComponentProps, defaultPlugins, shallowMount } from '@ownclouders/web-test-helpers'
 
 const defaultUser = { displayName: 'user', memberOf: [] } as User
@@ -25,18 +26,38 @@ describe('DetailsPanel', () => {
   })
 
   describe('computed method "noUsers"', () => {
-    it('should have 0 users if no users are given', () => {
+    it('should be true if no users are given', () => {
       const { wrapper } = getWrapper({
         props: { user: null, users: [] }
       })
-      expect((wrapper.vm as any).noUsers).toEqual(0)
+      expect((wrapper.vm as any).noUsers).toBeTruthy()
     })
-    it('should have users if users are given', () => {
+    it('should be false if users are given', () => {
       const { wrapper } = getWrapper({ props: { user: defaultUser, users: [defaultUser] } })
-      expect((wrapper.vm as any).noUsers).toEqual(1)
+      expect((wrapper.vm as any).noUsers).toBeFalsy()
     })
   })
 
+  describe("should render either user's info when a user is selected or a hint to select a user when no user is selected, but not both at the same time", () => {
+    it('should not show user info when no users are selected', () => {
+      const { wrapper } = getWrapper({
+        props: { user: null, users: [] }
+      })
+
+      expect(wrapper.find('[data-testid="no-user-selected"]').text()).toEqual(
+        'Select a user to view details'
+      )
+
+      expect(wrapper.findComponent(UserInfoBox).exists()).toBeFalsy()
+    })
+
+    it('should show user info when a user is selected', () => {
+      const { wrapper } = getWrapper({ props: { user: defaultUser, users: [defaultUser] } })
+
+      expect(wrapper.findComponent(UserInfoBox).exists()).toBeTruthy()
+      expect(wrapper.find('[data-testid="no-user-selected"]').exists()).toBeFalsy()
+    })
+  })
   describe('computed method "multipleUsers"', () => {
     it('should be false if no users are given', () => {
       const { wrapper } = getWrapper({ props: { user: null, users: [] } })


### PR DESCRIPTION
We have fixed a bug in the admin-settings/users page where a hint for selecting a user and user's details were showing at the same time while a user has already been selected.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://kiteworks.atlassian.net/browse/OCISDEV-474

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
