### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on stable-12.2 branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=035d65fdcbcf485f3d42132a35e54f443f6313c0
+OCIS_COMMITID=05340b177c0484ae8c8ccd890801d2fa43a62776
 OCIS_BRANCH=master


### PR DESCRIPTION
## Description
Bump latest ocis `master` branch commit id.

Part of: https://github.com/owncloud/QA/issues/926