### PR TITLE
[full-ci] feat(web-app-files): [OCISDEV-585] drop custom share filters

### DIFF
--- a/changelog/unreleased/enhancement-drop-custom-share-filters.md
+++ b/changelog/unreleased/enhancement-drop-custom-share-filters.md
@@ -1,0 +1,8 @@
+Enhancement: Drop custom share filters
+
+In the Shares panel, we have dropped the custom filters applied to the recipients autocomplete.
+The filtering is happening already in the backend, so we don't need to apply any custom filters here.
+It also makes implementing new filters faster in the future because they need to be implemented only once in the backend.
+If this change breaks any specific use cases, it will be fixed in the backend.
+
+https://github.com/owncloud/web/pull/13485

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -514,19 +514,7 @@ function onSearch(query: string) {
 }
 
 function filterRecipients(recipients: CollaboratorAutoCompleteItem[], query: string) {
-  if (unref(recipients).length < 1) {
-    return []
-  }
-
-  // Allow advanced queries
-  query = unref(query).split(':')[1] || query
-
-  return unref(recipients).filter(
-    (recipient) =>
-      recipient.shareType === ShareTypes.remote.value ||
-      recipient.displayName.toLocaleLowerCase().indexOf(query.toLocaleLowerCase()) > -1 ||
-      recipient.mail?.toLocaleLowerCase().indexOf(query.toLocaleLowerCase()) > -1
-  )
+  return unref(recipients)
 }
 
 function collaboratorRoleChanged(role: ShareRole) {


### PR DESCRIPTION
## Description

In the Shares panel, we have dropped the custom filters applied to the recipients autocomplete. The filtering is happening already in the backend, so we don't need to apply any custom filters here. It also makes implementing new filters faster in the future because they need to be implemented only once in the backend. If this change breaks any specific use cases, it will be fixed in the backend.

## Motivation and Context

- unblock testing of multi-instance sharing
- faster iterations in the future
- no duplicate logic

## How Has This Been Tested?

- test environment: macos v26.2, chrome v143.0.7499.193
- test case 1: share a folder

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
