### PR TITLE
feat(web-runtime): [OCISDEV-459] add cross-instance reference

### DIFF
--- a/changelog/unreleased/enhancement-add-cross-instance-reference.md
+++ b/changelog/unreleased/enhancement-add-cross-instance-reference.md
@@ -1,0 +1,5 @@
+Enhancement: Add cross-instance reference
+
+Added cross-instance reference to the user account page. The cross-instance reference is a unique identifier for the user across different oCIS instances.
+
+https://github.com/owncloud/web/pull/13499

--- a/packages/web-runtime/src/pages/account.vue
+++ b/packages/web-runtime/src/pages/account.vue
@@ -40,6 +40,47 @@
             <span v-else v-text="$gettext('No email has been set up')" />
           </oc-td>
         </oc-tr>
+        <oc-tr
+          v-if="user.crossInstanceReference"
+          class="account-page-info-cross-instance-reference"
+          data-testid="account-cross-instance-reference-row"
+        >
+          <oc-td>{{
+            $pgettext(
+              'The oCIS multi-instance reference term displayed in the account page.',
+              'Cross-instance reference'
+            )
+          }}</oc-td>
+          <oc-td>
+            <span class="cross-instance-reference-wrapper">
+              {{ user.crossInstanceReference }}
+              <oc-button
+                v-oc-tooltip="
+                  $pgettext(
+                    'The tooltip text for the copy oCIS multi-instance reference button.',
+                    'Copy cross-instance reference'
+                  )
+                "
+                appearance="raw"
+                variation="passive"
+                size="small"
+                data-testid="account-cross-instance-reference-copy-btn"
+                @click="copyCrossInstanceReference"
+              >
+                <oc-icon name="file-copy" size="small" />
+                <span
+                  class="oc-invisible-sr"
+                  v-text="
+                    $pgettext(
+                      'The text of the copy oCIS multi-instance reference button visible only to screen readers.',
+                      'Copy cross-instance reference'
+                    )
+                  "
+                />
+              </oc-button>
+            </span>
+          </oc-td>
+        </oc-tr>
         <oc-tr v-if="!!quota" class="account-page-info-quota">
           <oc-td>{{ $gettext('Personal storage') }}</oc-td>
           <oc-td data-testid="quota">
@@ -298,7 +339,8 @@ import {
   useResourcesStore,
   useSpacesStore,
   useUserStore,
-  useSharesStore
+  useSharesStore,
+  useClipboard
 } from '@ownclouders/web-pkg'
 import { useTask } from 'vue-concurrency'
 import { useGettext } from 'vue3-gettext'
@@ -333,11 +375,12 @@ export default defineComponent({
     const userStore = useUserStore()
     const authStore = useAuthStore()
     const language = useGettext()
-    const { $gettext } = language
+    const { $gettext, $pgettext } = language
     const clientService = useClientService()
     const resourcesStore = useResourcesStore()
     const appsStore = useAppsStore()
     const sharesStore = useSharesStore()
+    const { copyToClipboard } = useClipboard()
 
     const valuesList = ref<SettingsValue[]>()
     const graphUser = ref<User>()
@@ -756,6 +799,27 @@ export default defineComponent({
       })
     }
 
+    function copyCrossInstanceReference() {
+      if (!unref(user).crossInstanceReference) {
+        const error = new Error('Attempted to copy cross-instance reference while it is not set')
+        console.error(error)
+        captureException(error)
+        return
+      }
+
+      copyToClipboard(unref(user).crossInstanceReference)
+      showMessage({
+        title: $pgettext(
+          'The toast title of the successful copy oCIS multi-instance reference operation.',
+          'Cross-instance reference copied'
+        ),
+        desc: $pgettext(
+          'The toast message of the successful copy oCIS multi-instance reference operation.',
+          'The cross-instance reference has been copied to your clipboard.'
+        )
+      })
+    }
+
     return {
       clientService,
       languageOptions,
@@ -791,7 +855,8 @@ export default defineComponent({
       updateMultiChoiceSettingsValue,
       emailNotificationsValues,
       updateSingleChoiceValue,
-      canConfigureSpecificNotifications
+      canConfigureSpecificNotifications,
+      copyCrossInstanceReference
     }
   }
 })
@@ -812,6 +877,15 @@ export default defineComponent({
       padding-left: var(--oc-space-medium);
       padding-right: var(--oc-space-medium);
     }
+  }
+
+  .cross-instance-reference-wrapper {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--oc-space-xsmall);
+    justify-content: flex-start;
+    position: relative;
   }
 }
 </style>

--- a/packages/web-runtime/src/services/auth/userManager.ts
+++ b/packages/web-runtime/src/services/auth/userManager.ts
@@ -201,7 +201,9 @@ export class UserManager extends OidcUserManager {
       mail: graphUser.mail,
       memberOf: graphUser.memberOf,
       appRoleAssignments: role ? [role as any] : [], // FIXME
-      preferredLanguage: graphUser.preferredLanguage || ''
+      preferredLanguage: graphUser.preferredLanguage || '',
+      crossInstanceReference: graphUser.crossInstanceReference || '',
+      instances: graphUser.instances || []
     })
 
     if (graphUser.preferredLanguage) {

--- a/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.ts.snap
+++ b/packages/web-runtime/tests/unit/pages/__snapshots__/account.spec.ts.snap
@@ -27,6 +27,7 @@ exports[`account page > account information section > displays basic user inform
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td">some-email</td>
       </tr>
       <!--v-if-->
+      <!--v-if-->
       <tr class="account-page-info-groups">
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td">Group memberships</td>
         <td class="oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-td" data-testid="group-names"><span data-testid="group-names-empty">You are not part of any group</span></td>


### PR DESCRIPTION
## Description

Added cross-instance reference to the user account page. The cross-instance reference is a unique identifier for the user across different oCIS instances.

## Motivation and Context

Users known and can copy their cross-instance reference.

## How Has This Been Tested?

- test environment: macos v26.2, chrome v143.0.7499.193
- test case 1: open account settings with the cross-reference
- test case 2: open account settings without the cross-reference

## Screenshots (if appropriate):

<img width="635" height="398" alt="image" src="https://github.com/user-attachments/assets/f4dd26c7-0d11-41c3-ae9e-63cf58d743b6" />

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:

- [x] https://github.com/owncloud/web/pull/13498 has to be merged first
