### PR TITLE
feat: add instance switcher

### DIFF
--- a/changelog/unreleased/enhancement-add-instance-switcher.md
+++ b/changelog/unreleased/enhancement-add-instance-switcher.md
@@ -1,0 +1,6 @@
+Enhancement: Add instance switcher
+
+Added a list of users' instances to the user menu. When multiple instances are enabled in oCIS, the user can switch between instances by clicking on the instance in the list.
+The list displays maximum 3 instances. If there are more instances, the user can click on a button to open the instances modal. Within the modal, the user can see all instances and switch between them by clicking on the instance or a "Switch" button.
+
+https://github.com/owncloud/web/pull/13500

--- a/packages/web-runtime/src/components/InstancesModal.vue
+++ b/packages/web-runtime/src/components/InstancesModal.vue
@@ -1,0 +1,72 @@
+<template>
+  <oc-list class="instances-list">
+    <li
+      v-for="instance in instances"
+      :key="instance.url"
+      :class="['instance', instance.active && 'active']"
+    >
+      <div class="instance-info">
+        <a :href="instance.url">{{ instance.url }}</a>
+        <div>
+          <oc-tag v-if="instance.primary" size="small">{{
+            $pgettext(
+              'The badge label for the primary instance in the instances modal available when multiple instances are enabled in oCIS',
+              'Primary'
+            )
+          }}</oc-tag>
+          <oc-tag v-if="instance.active" size="small">{{
+            $pgettext(
+              'The badge label for the active instance in the instances modal available when multiple instances are enabled in oCIS',
+              'Active'
+            )
+          }}</oc-tag>
+        </div>
+      </div>
+      <oc-button v-if="!instance.active" type="a" variation="secondary" :href="instance.url">
+        {{
+          $pgettext(
+            'The switch action label of an instance in the instances modal available when multiple instances are enabled in oCIS',
+            'Active'
+          )
+        }}
+      </oc-button>
+    </li>
+  </oc-list>
+</template>
+
+<script lang="ts" setup>
+import { Modal } from '@ownclouders/web-pkg'
+import { useInstances } from '../composables/instances'
+
+const props = defineProps<{
+  modal: Modal
+}>()
+
+const { instances } = useInstances()
+</script>
+
+<style lang="scss" scoped>
+.instances-list {
+  display: grid;
+  gap: var(--oc-space-small);
+}
+
+.instance {
+  align-items: center;
+  border: 1px solid var(--oc-color-border);
+  border-radius: 5px;
+  display: flex;
+  gap: var(--oc-space-small);
+  justify-content: space-between;
+  padding: var(--oc-space-small);
+
+  &.active {
+    border-color: var(--oc-color-swatch-primary-default);
+  }
+}
+
+.instance-info {
+  display: grid;
+  gap: var(--oc-space-small);
+}
+</style>

--- a/packages/web-runtime/src/components/Topbar/UserMenu.vue
+++ b/packages/web-runtime/src/components/Topbar/UserMenu.vue
@@ -88,6 +88,51 @@
               <span v-text="$gettext('Preferences')" />
             </oc-button>
           </li>
+          <li v-if="inlineInstances.length > 0">
+            <div class="oc-width-1-1" data-testid="instance-switcher">
+              <p class="oc-text-xs oc-text-muted">
+                {{
+                  $pgettext(
+                    'The instance switcher section title in the user menu available when multiple instances are enabled in oCIS',
+                    'Instances'
+                  )
+                }}
+              </p>
+              <oc-list>
+                <li
+                  v-for="instance in inlineInstances"
+                  :key="instance.url"
+                  data-testid="instance-switcher-item"
+                >
+                  <a :href="instance.url" class="instance-link oc-rounded">
+                    <span
+                      :class="[
+                        'instance-indicator',
+                        instance.primary && 'primary',
+                        instance.active && 'current'
+                      ]"
+                    />
+                    {{ instance.url }}
+                  </a>
+                </li>
+                <li v-if="canOpenInstancesModal">
+                  <oc-button
+                    appearance="raw"
+                    data-testid="instance-switcher-show-all-button"
+                    @click="showInstancesModal"
+                  >
+                    <span class="instance-indicator placeholder" />
+                    {{
+                      $pgettext(
+                        'The open instances modal action label in the user menu available when multiple instances are enabled in oCIS',
+                        'Show all instances'
+                      )
+                    }}
+                  </oc-button>
+                </li>
+              </oc-list>
+            </div>
+          </li>
           <li>
             <oc-button id="oc-topbar-account-logout" appearance="raw" @click="logout">
               <oc-icon name="logout-box-r" fill-type="line" class="oc-p-xs" />
@@ -122,6 +167,7 @@ import {
 import { OcDrop } from '@ownclouders/design-system/components'
 import QuotaInformation from '../Account/QuotaInformation.vue'
 import { useGettext } from 'vue3-gettext'
+import { useInstances } from '../../composables/instances'
 
 export default defineComponent({
   components: { QuotaInformation },
@@ -132,6 +178,7 @@ export default defineComponent({
     const spacesStore = useSpacesStore()
     const authService = useAuthService()
     const { $pgettext } = useGettext()
+    const { inlineInstances, canOpenInstancesModal, showInstancesModal } = useInstances()
 
     const { user } = storeToRefs(userStore)
 
@@ -192,7 +239,10 @@ export default defineComponent({
       loginLink,
       quota,
       footerLinks,
-      logout
+      inlineInstances,
+      logout,
+      showInstancesModal,
+      canOpenInstancesModal
     }
   },
   computed: {
@@ -258,6 +308,33 @@ export default defineComponent({
   a {
     font-size: var(--oc-font-size-medium) !important;
     color: var(--oc-color-text-default);
+  }
+}
+
+.instance-link {
+  align-items: center;
+  display: flex;
+  gap: var(--oc-space-medium);
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.instance-indicator {
+  background-color: var(--oc-color-swatch-passive-default);
+  border-radius: 50%;
+  height: 0.5rem;
+  width: 0.5rem;
+
+  &.primary {
+    background-color: var(--oc-color-swatch-primary-default);
+  }
+
+  &.current {
+    background-color: var(--oc-color-swatch-success-default);
+  }
+
+  &.placeholder {
+    background-color: transparent;
   }
 }
 </style>

--- a/packages/web-runtime/src/composables/instances/index.ts
+++ b/packages/web-runtime/src/composables/instances/index.ts
@@ -1,0 +1,1 @@
+export * from './useInstances'

--- a/packages/web-runtime/src/composables/instances/useInstances.ts
+++ b/packages/web-runtime/src/composables/instances/useInstances.ts
@@ -1,0 +1,72 @@
+import { useModals, useUserStore } from '@ownclouders/web-pkg'
+import { storeToRefs } from 'pinia'
+import { computed, unref } from 'vue'
+import { useGettext } from 'vue3-gettext'
+import InstancesModal from '../../components/InstancesModal.vue'
+
+/** Limits the number of instances displayed in the user menu list */
+const INLINE_INSTANCES_LIMIT = 3
+
+export function useInstances() {
+  const { dispatchModal } = useModals()
+  const { $pgettext } = useGettext()
+
+  const userStore = useUserStore()
+  const { user } = storeToRefs(userStore)
+
+  const currentInstance = computed(() => window.location.origin)
+
+  const instances = computed(() => {
+    if (unref(user).instances.length < 1) {
+      return []
+    }
+
+    return unref(user)
+      .instances.map((instance) => ({
+        ...instance,
+        active: instance.url === unref(currentInstance)
+      }))
+      .toSorted((a, b) => {
+        if (a.active !== b.active) {
+          return a.active ? -1 : 1
+        }
+
+        if (a.primary !== b.primary) {
+          return a.primary ? -1 : 1
+        }
+
+        return a.url.localeCompare(b.url)
+      })
+  })
+
+  const inlineInstances = computed(() => unref(instances).slice(0, INLINE_INSTANCES_LIMIT))
+
+  const canOpenInstancesModal = computed(() => unref(instances).length > INLINE_INSTANCES_LIMIT)
+
+  function showInstancesModal() {
+    dispatchModal({
+      title: $pgettext(
+        'The instances modal title available when multiple instances are enabled in oCIS',
+        'Instances'
+      ),
+      customComponent: InstancesModal,
+      customComponentAttrs: () => ({
+        modal: {
+          id: 'instances-modal'
+        }
+      }),
+      hideConfirmButton: true,
+      cancelText: $pgettext(
+        'The close instances modal action label in the instances modal available when multiple instances are enabled in oCIS',
+        'Close'
+      )
+    })
+  }
+
+  return {
+    instances,
+    inlineInstances,
+    canOpenInstancesModal,
+    showInstancesModal
+  }
+}

--- a/packages/web-runtime/tests/unit/components/Topbar/__snapshots__/UserMenu.spec.ts.snap
+++ b/packages/web-runtime/tests/unit/components/Topbar/__snapshots__/UserMenu.spec.ts.snap
@@ -16,6 +16,7 @@ exports[`User Menu component > when no quota and email is set > the user menu do
           <oc-icon-stub data-v-0550d31b="" name="settings-4" fill-type="line" class="oc-p-xs"></oc-icon-stub> <span data-v-0550d31b="">Preferences</span>
         </oc-button-stub>
       </li>
+      <!--v-if-->
       <li data-v-0550d31b="">
         <oc-button-stub data-v-0550d31b="" id="oc-topbar-account-logout" appearance="raw">
           <oc-icon-stub data-v-0550d31b="" name="logout-box-r" fill-type="line" class="oc-p-xs"></oc-icon-stub> <span data-v-0550d31b="">Log out</span>
@@ -44,6 +45,7 @@ exports[`User Menu component > when no quota and no email is set > the user menu
           <oc-icon-stub data-v-0550d31b="" name="settings-4" fill-type="line" class="oc-p-xs"></oc-icon-stub> <span data-v-0550d31b="">Preferences</span>
         </oc-button-stub>
       </li>
+      <!--v-if-->
       <li data-v-0550d31b="">
         <oc-button-stub data-v-0550d31b="" id="oc-topbar-account-logout" appearance="raw">
           <oc-icon-stub data-v-0550d31b="" name="logout-box-r" fill-type="line" class="oc-p-xs"></oc-icon-stub> <span data-v-0550d31b="">Log out</span>
@@ -78,6 +80,7 @@ exports[`User Menu component > when quota and no email is set > renders a naviga
           <oc-icon-stub data-v-0550d31b="" name="settings-4" fill-type="line" class="oc-p-xs"></oc-icon-stub> <span data-v-0550d31b="">Preferences</span>
         </oc-button-stub>
       </li>
+      <!--v-if-->
       <li data-v-0550d31b="">
         <oc-button-stub data-v-0550d31b="" id="oc-topbar-account-logout" appearance="raw">
           <oc-icon-stub data-v-0550d31b="" name="logout-box-r" fill-type="line" class="oc-p-xs"></oc-icon-stub> <span data-v-0550d31b="">Log out</span>
@@ -111,6 +114,7 @@ exports[`User Menu component > when quota is above 80% and below 90% > renders a
           <oc-icon-stub data-v-0550d31b="" name="settings-4" fill-type="line" class="oc-p-xs"></oc-icon-stub> <span data-v-0550d31b="">Preferences</span>
         </oc-button-stub>
       </li>
+      <!--v-if-->
       <li data-v-0550d31b="">
         <oc-button-stub data-v-0550d31b="" id="oc-topbar-account-logout" appearance="raw">
           <oc-icon-stub data-v-0550d31b="" name="logout-box-r" fill-type="line" class="oc-p-xs"></oc-icon-stub> <span data-v-0550d31b="">Log out</span>
@@ -144,6 +148,7 @@ exports[`User Menu component > when quota is above 90% > renders a danger quota 
           <oc-icon-stub data-v-0550d31b="" name="settings-4" fill-type="line" class="oc-p-xs"></oc-icon-stub> <span data-v-0550d31b="">Preferences</span>
         </oc-button-stub>
       </li>
+      <!--v-if-->
       <li data-v-0550d31b="">
         <oc-button-stub data-v-0550d31b="" id="oc-topbar-account-logout" appearance="raw">
           <oc-icon-stub data-v-0550d31b="" name="logout-box-r" fill-type="line" class="oc-p-xs"></oc-icon-stub> <span data-v-0550d31b="">Log out</span>
@@ -177,6 +182,7 @@ exports[`User Menu component > when quota is below 80% > renders a primary quota
           <oc-icon-stub data-v-0550d31b="" name="settings-4" fill-type="line" class="oc-p-xs"></oc-icon-stub> <span data-v-0550d31b="">Preferences</span>
         </oc-button-stub>
       </li>
+      <!--v-if-->
       <li data-v-0550d31b="">
         <oc-button-stub data-v-0550d31b="" id="oc-topbar-account-logout" appearance="raw">
           <oc-icon-stub data-v-0550d31b="" name="logout-box-r" fill-type="line" class="oc-p-xs"></oc-icon-stub> <span data-v-0550d31b="">Log out</span>
@@ -210,6 +216,7 @@ exports[`User Menu component > when quota is not defined > renders no percentag 
           <oc-icon-stub data-v-0550d31b="" name="settings-4" fill-type="line" class="oc-p-xs"></oc-icon-stub> <span data-v-0550d31b="">Preferences</span>
         </oc-button-stub>
       </li>
+      <!--v-if-->
       <li data-v-0550d31b="">
         <oc-button-stub data-v-0550d31b="" id="oc-topbar-account-logout" appearance="raw">
           <oc-icon-stub data-v-0550d31b="" name="logout-box-r" fill-type="line" class="oc-p-xs"></oc-icon-stub> <span data-v-0550d31b="">Log out</span>
@@ -243,6 +250,7 @@ exports[`User Menu component > when quota is unlimited > renders no percentag of
           <oc-icon-stub data-v-0550d31b="" name="settings-4" fill-type="line" class="oc-p-xs"></oc-icon-stub> <span data-v-0550d31b="">Preferences</span>
         </oc-button-stub>
       </li>
+      <!--v-if-->
       <li data-v-0550d31b="">
         <oc-button-stub data-v-0550d31b="" id="oc-topbar-account-logout" appearance="raw">
           <oc-icon-stub data-v-0550d31b="" name="logout-box-r" fill-type="line" class="oc-p-xs"></oc-icon-stub> <span data-v-0550d31b="">Log out</span>


### PR DESCRIPTION
## Description

Added a list of users' instances to the user menu. When multiple instances are enabled in oCIS, the user can switch between instances by clicking on the instance in the list. The list displays maximum 3 instances. If there are more instances, the user can click on a button to open the instances modal. Within the modal, the user can see all instances and switch between them by clicking on the instance or a "Switch" button.

## Motivation and Context

Users are able to switch between their instances.

## How Has This Been Tested?

- test environment: macos v26.2, chrome v144.0.7559.61
- test case 1: open user menu and switch instance
- test case 2: open instances modal and switch instance

## Screenshots (if appropriate):

<img width="334" height="410" alt="Snímek obrazovky 2026-01-22 v 11 58 47" src="https://github.com/user-attachments/assets/ffeaac1a-b7f5-4b5b-9c9f-87f6bc737505" />

<img width="611" height="427" alt="Snímek obrazovky 2026-01-22 v 11 57 40" src="https://github.com/user-attachments/assets/1c1693e2-baa7-4476-b2fb-7fe0cd79ba8b" />

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
