### PR TITLE
bugfix(web-pkg): [OCISDEV-601] show correct aria-label value

### DIFF
--- a/packages/web-pkg/src/components/FilesList/ResourceTable.vue
+++ b/packages/web-pkg/src/components/FilesList/ResourceTable.vue
@@ -258,6 +258,7 @@ import {
   IncomingShareResource,
   isPasswordProtectedFolderFileResource,
   isProjectSpaceResource,
+  isSpaceResource,
   Resource,
   TrashResource
 } from '@ownclouders/web-client'
@@ -526,7 +527,12 @@ const isResourceInDeleteQueue = (id: string): boolean => {
 }
 
 const getRenameButtonAriaLabel = (resource: Resource): string => {
-  if (resource.isFolder) {
+  if (isSpaceResource(resource)) {
+    return $pgettext(
+      'The label of the rename button in the resource table for spaces',
+      'Rename space'
+    )
+  } else if (resource.isFolder) {
     return $pgettext(
       'The label of the rename button in the resource table for folders',
       'Rename folder'


### PR DESCRIPTION
We have fixed a bug in which aria-label contained the wrong value for renaming a space. It was showing 'rename folder' for a space instead of 'rename space.'

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://kiteworks.atlassian.net/browse/OCISDEV-601

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
