### PR TITLE
enhancement: dynamic theme-color meta tag from theme brand color

### DIFF
--- a/changelog/unreleased/enhancement-dynamic-theme-color
+++ b/changelog/unreleased/enhancement-dynamic-theme-color
@@ -1,0 +1,8 @@
+Enhancement: Dynamic theme-color meta tag based on loaded theme
+
+The theme-color meta tag now dynamically uses the brand color from the
+currently loaded theme instead of a hardcoded value. This improves
+Safari's tab bar styling to match custom themes and provides a more
+cohesive branded experience.
+
+https://github.com/owncloud/web/issues/5847

--- a/packages/web-runtime/src/composables/head/useHead.ts
+++ b/packages/web-runtime/src/composables/head/useHead.ts
@@ -1,4 +1,4 @@
-import { computed, unref, onMounted, ref } from 'vue'
+import { computed, unref } from 'vue'
 import { useHead as _useHead } from '@vueuse/head'
 import {
   useCapabilityStore,
@@ -15,16 +15,10 @@ export const useHead = () => {
 
   const favicon = computed(() => currentTheme.value.logo.favicon)
 
-  // Get brand color from CSS variable set by theme
-  const themeColor = ref('#375f7E')
-  onMounted(() => {
-    const brandColor = getComputedStyle(document.documentElement)
-      .getPropertyValue('--oc-color-swatch-brand-default')
-      .trim()
-    if (brandColor) {
-      themeColor.value = brandColor
-    }
-  })
+  // Get brand color directly from theme store (reactive to theme changes)
+  const themeColor = computed(
+    () => currentTheme.value.designTokens.colorPalette['swatch-brand-default']
+  )
 
   _useHead(
     computed(() => {


### PR DESCRIPTION
## Description

Dynamic [theme-color](cci:7://file:///home/priyanshu/repos/Resume_Projects/owncloud-web/changelog/unreleased/enhancement-dynamic-theme-color:0:0-0:0) meta tag using the brand color from the loaded theme via `getComputedStyle()`.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/5847

## Motivation and Context

Safari uses `<meta name="theme-color">` to style the tab bar. The hardcoded value didn't match custom themes.

## How Has This Been Tested?

- test environment: Local dev server, Safari macOS
- test case 1: Verified meta tag contains resolved hex color (not CSS variable)
- test case 2: Inspected `<head>` to confirm [theme-color](cci:7://file:///home/priyanshu/repos/Resume_Projects/owncloud-web/changelog/unreleased/enhancement-dynamic-theme-color:0:0-0:0) meta tag is present

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
