### PR TITLE
fix: disable rename action in password-protected folder view

### DIFF
--- a/changelog/unreleased/bugfix-disable-rename-in-ppf
+++ b/changelog/unreleased/bugfix-disable-rename-in-ppf
@@ -1,0 +1,8 @@
+Bugfix: Disable rename action in password-protected folder view
+
+We've fixed a bug where renaming a folder from inside a password-protected
+folder view would create a duplicate folder instead of renaming the original.
+The rename action is now hidden in public link contexts, which aligns with
+the documented behavior that link files should not be manipulated from this view.
+
+https://github.com/owncloud/web/issues/12365

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsRename.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsRename.ts
@@ -1,5 +1,9 @@
 import { isSameResource } from '../../../helpers/resource'
-import { isLocationTrashActive, isLocationSharesActive } from '../../../router'
+import {
+  isLocationTrashActive,
+  isLocationSharesActive,
+  isLocationPublicActive
+} from '../../../router'
 import { Resource } from '@ownclouders/web-client'
 import { dirname, join } from 'path'
 import { WebDAV } from '@ownclouders/web-client/webdav'
@@ -216,6 +220,11 @@ export const useFileActionsRename = () => {
       handler,
       isVisible: ({ resources }) => {
         if (isLocationTrashActive(router, 'files-trash-generic')) {
+          return false
+        }
+        // Disable rename in public link context (e.g., password-protected folders)
+        // See https://github.com/owncloud/web/issues/12365
+        if (isLocationPublicActive(router, 'files-public-link')) {
           return false
         }
         if (

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsRename.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsRename.ts
@@ -222,8 +222,7 @@ export const useFileActionsRename = () => {
         if (isLocationTrashActive(router, 'files-trash-generic')) {
           return false
         }
-        // Disable rename in public link context (e.g., password-protected folders)
-        // See https://github.com/owncloud/web/issues/12365
+
         if (isLocationPublicActive(router, 'files-public-link')) {
           return false
         }


### PR DESCRIPTION
## Description
Disables the **Rename** action in the breadcrumb context menu when viewing a password-protected folder (public link context).

## Related Issue
Fixes #12365

## Motivation and Context
When renaming a folder from inside a password-protected folder view, the action operates in the public link context. This causes the rename to create a duplicate folder instead of renaming the original.

The fix aligns with:
- The existing pattern in `useFileActionsDelete.ts` which already disables delete in public links
- The README documentation stating "Moving or renaming a link file is prevented by the webUI"

## How Has This Been Tested?
- [x] Unit tests pass (17 tests)
- [x] Manual: Verified rename option is hidden inside PPF view
- [x] Manual: Verified rename still works in normal folder views

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)