### PR TITLE
[tests-only][full-ci] ci: fail ci if there are any invalid suite config

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -642,7 +642,20 @@ def e2eTestsOnPlaywright(ctx):
             steps += filterTestSuitesToRun(ctx, params["features"])
         else:
             print("Error: No suites or features defined for e2e test suite '%s'" % suite)
-            return []
+            pipelines.append({
+                "kind": "pipeline",
+                "type": "docker",
+                "name": "invalid-suite-%s" % suite,
+                "steps": [{
+                    "name": "invalid-suite",
+                    "image": OC_CI_ALPINE_IMAGE,
+                    "commands": [
+                        "echo \"Error: No suites or features defined for e2e test suite '%s'\"" % suite,
+                        "exit 1",
+                    ],
+                }],
+                "trigger": base_trigger,
+            })
 
         steps += restoreBuildArtifactCache(ctx, "pnpm", ".pnpm-store") + \
                  installPnpm() + \
@@ -657,10 +670,10 @@ def e2eTestsOnPlaywright(ctx):
         if "keycloak" in suite:
             environment["KEYCLOAK"] = "true"
             environment["KEYCLOAK_HOST"] = "keycloak:8443"
-            e2e_volumes += [{
+            e2e_volumes.append({
                 "name": "certs",
                 "temp": {},
-            }]
+            })
             steps += keycloakService()
             services += postgresService()
 
@@ -683,7 +696,7 @@ def e2eTestsOnPlaywright(ctx):
             steps += (tikaService() if params["tikaNeeded"] else []) + \
                      ocisService(params["extraServerEnvironment"])
 
-        steps += [{
+        steps.append({
             "name": "e2e-tests",
             "image": OC_CI_NODEJS_IMAGE,
             "environment": environment,
@@ -692,7 +705,7 @@ def e2eTestsOnPlaywright(ctx):
                 "cd tests/e2e",
                 "bash run-e2e.sh --type playwright",
             ],
-        }]
+        })
 
         if not "skip-a11y" in ctx.build.title.lower():
             steps += uploadA11yResult(ctx) + logA11yReport()
@@ -774,7 +787,20 @@ def e2eTests(ctx):
             steps += filterTestSuitesToRun(ctx, params["features"])
         else:
             print("Error: No suites or features defined for e2e test suite '%s'" % suite)
-            return []
+            pipelines.append({
+                "kind": "pipeline",
+                "type": "docker",
+                "name": "invalid-suite-%s" % suite,
+                "steps": [{
+                    "name": "invalid-suite",
+                    "image": OC_CI_ALPINE_IMAGE,
+                    "commands": [
+                        "echo \"Error: No suites or features defined for e2e test suite '%s'\"" % suite,
+                        "exit 1",
+                    ],
+                }],
+                "trigger": base_trigger,
+            })
 
         steps += restoreBuildArtifactCache(ctx, "pnpm", ".pnpm-store") + \
                  installPnpm() + \
@@ -789,10 +815,10 @@ def e2eTests(ctx):
         if "keycloak" in suite:
             environment["KEYCLOAK"] = "true"
             environment["KEYCLOAK_HOST"] = "keycloak:8443"
-            e2e_volumes += [{
+            e2e_volumes.append({
                 "name": "certs",
                 "temp": {},
-            }]
+            })
             steps += keycloakService()
             services += postgresService()
 

--- a/.drone.star
+++ b/.drone.star
@@ -205,7 +205,7 @@ config = {
         },
         "oidc-iframe": {
             "skip": False,
-            "feature": [
+            "features": [
                 "specs/oidc/iframeTokenRenewal.spec.ts",
             ],
             "extraServerEnvironment": {
@@ -718,6 +718,7 @@ def e2eTestsOnPlaywright(ctx):
             "type": "docker",
             "name": "e2e-pw-%s" % suite,
             "workspace": web_workspace,
+            "environment": environment,
             "steps": steps,
             "depends_on": ["cache-ocis"],
             "trigger": base_trigger,

--- a/tests/e2e-playwright/playwright.config.ts
+++ b/tests/e2e-playwright/playwright.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
   retries: config.retry,
 
   // Opt out of parallel tests on CI.
-  workers: process.env.CI ? 1 : undefined,
+  workers: 1,
 
   // Reporter to use
   reporter: [

--- a/tests/e2e-playwright/specs/navigation/personalSpacePagination.spec.ts
+++ b/tests/e2e-playwright/specs/navigation/personalSpacePagination.spec.ts
@@ -40,7 +40,7 @@ test.describe('Personal space pagination', { tag: '@predefined-users' }, () => {
     await ui.logInUser({ usersEnvironment, actorsEnvironment, stepUser: 'Alice' })
 
     // And "Alice" creates 15 folders in personal space using API
-    for (let i = 0; i < 15; i++) {
+    for (let i = 1; i <= 15; i++) {
       await api.userHasCreatedFolder({
         usersEnvironment,
         stepUser: 'Alice',
@@ -48,11 +48,12 @@ test.describe('Personal space pagination', { tag: '@predefined-users' }, () => {
       })
     }
     // And "Alice" creates 10 files in personal space using API
-    for (let i = 0; i < 15; i++) {
+    for (let i = 1; i <= 10; i++) {
       await api.userHasCreatedFile({
         usersEnvironment,
         stepUser: 'Alice',
-        filename: `file${i}`
+        filename: `file${i}`,
+        content: `This is a test file${i}`
       })
     }
     // And "Alice" creates the following files into personal space using API
@@ -91,7 +92,7 @@ test.describe('Personal space pagination', { tag: '@predefined-users' }, () => {
       expectedNumberOfResources: 6
     })
     // When "Alice" changes the items per page to "500"
-    await ui.changeItemsPerPage({ actorsEnvironment, stepUser: 'Alice', itemsPerPage: '20' })
+    await ui.changeItemsPerPage({ actorsEnvironment, stepUser: 'Alice', itemsPerPage: '500' })
 
     // Then "Alice" should not see the pagination in the personal space files view
     await ui.expectPageNumberNotToBeVisible({ actorsEnvironment, stepUser: 'Alice' })

--- a/tests/e2e-playwright/specs/oidc/iframeTokenRenewal.spec.ts
+++ b/tests/e2e-playwright/specs/oidc/iframeTokenRenewal.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 import { config } from './../../../e2e/config.js'
 import { ActorsEnvironment, UsersEnvironment } from '../../../e2e/support/environment'
 import { setAccessAndRefreshToken } from '../../helpers/setAccessAndRefreshToken'

--- a/tests/e2e-playwright/specs/oidc/refreshToken.spec.ts
+++ b/tests/e2e-playwright/specs/oidc/refreshToken.spec.ts
@@ -27,6 +27,7 @@ test.describe('details', () => {
   })
 
   test.afterEach(async () => {
+    await setAccessAndRefreshToken(usersEnvironment)
     await api.deleteUser({ usersEnvironment, stepUser: 'Admin', targetUser: 'Alice' })
   })
 

--- a/tests/e2e-playwright/specs/spaces/createSpaceFromSelection.spec.ts
+++ b/tests/e2e-playwright/specs/spaces/createSpaceFromSelection.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 import { config } from './../../../e2e/config.js'
 import {
   ActorsEnvironment,
@@ -84,7 +84,7 @@ test.describe('create Space shortcut', () => {
       actorsEnvironment,
       filesEnvironment,
       stepUser: 'Alice',
-      resource: 'lorem.zip',
+      resource: 'lorem.txt',
       to: 'spaceFolder'
     })
 
@@ -141,19 +141,19 @@ test.describe('create Space shortcut', () => {
     // And "Alice" uploads the following resources
     //   | resource          | to             |
     //   | data.zip          | resourceFolder |
-    //   | lorem.txt         | spaceFolder    |
+    //   | lorem.txt         |                |
     await ui.uploadResource({
       actorsEnvironment,
       filesEnvironment,
       stepUser: 'Alice',
       resource: 'data.zip',
-      to: 'spaceFolder'
+      to: 'resourceFolder'
     })
     await ui.uploadResource({
       actorsEnvironment,
       filesEnvironment,
       stepUser: 'Alice',
-      resource: 'lorem.zip',
+      resource: 'lorem.txt',
       to: ''
     })
 

--- a/tests/e2e-playwright/specs/spaces/denySpaceAccess.spec.ts
+++ b/tests/e2e-playwright/specs/spaces/denySpaceAccess.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 import { config } from './../../../e2e/config.js'
 import {
   ActorsEnvironment,
@@ -91,7 +91,7 @@ test.describe('deny space access', () => {
     await api.userHasAddedMembersToSpace({
       usersEnvironment,
       stepUser: 'Alice',
-      space: 'team',
+      space: 'sales',
       shareType: 'user',
       sharee: 'Brian',
       role: 'Can edit'

--- a/tests/e2e-playwright/specs/spaces/downloadSpace.spec.ts
+++ b/tests/e2e-playwright/specs/spaces/downloadSpace.spec.ts
@@ -102,7 +102,7 @@ test.describe('download space', () => {
       actorsEnvironment,
       usersEnvironment,
       stepUser: 'Alice',
-      sharee: 'team.1',
+      sharee: 'Brian',
       role: 'Can edit',
       kind: 'user'
     })

--- a/tests/e2e-playwright/specs/user-settings/notifications.spec.ts
+++ b/tests/e2e-playwright/specs/user-settings/notifications.spec.ts
@@ -271,7 +271,7 @@ test.describe('Notifications', () => {
     //   | message                         |
     //   | %user_alice_displayName% deleted Space team |
     messages = await ui.getNotificationMessages({ actorsEnvironment, stepUser: 'Brian' })
-    expect(messages).toContain(substitute('%user_alice_displayName% delete Space team'))
+    expect(messages).toContain(substitute('%user_alice_displayName% deleted Space team'))
 
     await api.userHasDeletedGroup({ usersEnvironment, stepUser: 'Admin', name: 'sales' })
   })
@@ -298,7 +298,7 @@ test.describe('Notifications', () => {
     })
 
     // And "Brian" logs in
-    await ui.logInUser({ usersEnvironment, actorsEnvironment, stepUser: 'Alice' })
+    await ui.logInUser({ usersEnvironment, actorsEnvironment, stepUser: 'Brian' })
 
     // And "Brian" opens the user menu
     await ui.userOpensAccountPage({ actorsEnvironment, stepUser: 'Brian' })
@@ -444,7 +444,7 @@ test.describe('Notifications', () => {
     })
 
     // Then "Carol" should see no notifications
-    messages = await ui.getNotificationMessages({ actorsEnvironment, stepUser: 'Coral' })
+    messages = await ui.getNotificationMessages({ actorsEnvironment, stepUser: 'Carol' })
     expect(messages).toHaveLength(0)
   })
 })

--- a/tests/e2e-playwright/steps/api/api.ts
+++ b/tests/e2e-playwright/steps/api/api.ts
@@ -9,8 +9,9 @@ import { ResourceType } from '../../../e2e/support/api/share/share'
 import { Group, Space, User } from '../../../e2e/support/types'
 import fs from 'fs'
 import { integer } from 'vscode-languageserver-types'
-import join from 'join-path'
+
 import { checkResponseStatus, request } from '../../../e2e/support/api/http'
+import { join } from 'path'
 
 export async function userHasBeenCreated({
   usersEnvironment,
@@ -360,6 +361,7 @@ export async function userHasDeletedProjectSpace({
 }) {
   const user = usersEnvironment.getUser({ key: stepUser })
   await api.graph.deleteSpace({ user, space: { id, name } as unknown as Space })
+  store.createdSpaceStore.clear()
 }
 
 export async function userHasAddedMembersToSpace({

--- a/tests/e2e-playwright/steps/ui/spaces.ts
+++ b/tests/e2e-playwright/steps/ui/spaces.ts
@@ -2,6 +2,7 @@ import { ActorsEnvironment, UsersEnvironment } from '../../../e2e/support/enviro
 import { objects } from '../../../e2e/support'
 import { Space } from '../../../e2e/support/types'
 import { getDynamicRoleIdByName, ResourceType } from '../../../e2e/support/api/share/share'
+import { expect } from '@playwright/test'
 
 export async function navigateToPersonalSpacePage({
   actorsEnvironment,

--- a/tests/e2e/config.js
+++ b/tests/e2e/config.js
@@ -42,7 +42,7 @@ export const config = {
   retry: parseInt(process.env.RETRY) || 0,
   // playwright
   slowMo: parseInt(process.env.SLOW_MO) || 0,
-  timeout: parseInt(process.env.TIMEOUT) || 60,
+  timeout: parseInt(process.env.TIMEOUT) || 120,
   minTimeout: parseInt(process.env.MIN_TIMEOUT) || 5,
   tokenTimeout: parseInt(process.env.TOKEN_TIMEOUT) || 40,
   headless: process.env.HEADLESS === 'true',


### PR DESCRIPTION
## Description
There was a typo in config for playwright tests which made all other playwright tests to not run. This pr fixes that typo and fails if it happens again. This pr also fixes other tests which were merged because the ci was green. 

## Related Issue
- playwright test suites not running in CI

## Motivation and Context

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
