### PR TITLE
[full-ci] feat(web-client): strip base path

### DIFF
--- a/changelog/unreleased/enhancement-strip-webdav-prefix.md
+++ b/changelog/unreleased/enhancement-strip-webdav-prefix.md
@@ -1,0 +1,6 @@
+Enhancement: Strip WebDAV prefix
+
+Added a new logic to the WebDAV client to strip the prefix from the path if it is present. Previously, only `/dav/` prefix would be stripped when parsing the response.
+Now, it will strip all the parts of the base remote URL. For example, if the base remote URL is `https://example.com/my/nested/path/`, it will strip the `/my/nested/path/dav/` prefix.
+
+https://github.com/owncloud/web/pull/13545

--- a/packages/web-client/src/webdav/client/parsers.ts
+++ b/packages/web-client/src/webdav/client/parsers.ts
@@ -3,6 +3,7 @@ import { XMLParser } from 'fast-xml-parser'
 import { WebDavResponseResource, WebDavResponseTusSupport } from '../../helpers'
 import { urlJoin } from '../../utils'
 import { DavErrorCode } from '../constants'
+import { join, normalize } from 'path'
 
 export const parseTusHeaders = (headers: Headers) => {
   const result: WebDavResponseTusSupport = {}
@@ -25,12 +26,13 @@ export const parseTusHeaders = (headers: Headers) => {
   return result
 }
 
-export const parseMultiStatus = async (xmlBody: string) => {
+export const parseMultiStatus = async (xmlBody: string, remoteBasePath: string) => {
   const parseFileName = (name: string) => {
     const decoded = decodeURIComponent(name)
-    if (name?.startsWith('/dav/')) {
+    const prefix = normalize(join(remoteBasePath, 'dav'))
+    if (name?.startsWith(prefix)) {
       // strip out '/dav/' from the beginning
-      return urlJoin(decoded.replace('/dav/', ''), {
+      return urlJoin(decoded.replace(prefix, ''), {
         leadingSlash: true,
         trailingSlash: false
       })


### PR DESCRIPTION
## Description

Added a new logic to the WebDAV client to strip the prefix from the path if it is present. Previously, only `/dav/` prefix would be stripped when parsing the response. Now, it will strip all the parts of the base remote URL. For example, if the base remote URL is `[https://example.com/my/nested/path/`](https://example.com/my/nested/path/%60), it will strip the `/my/nested/path/dav/` prefix.

## Motivation and Context

Support deployments where base server URL is using nested paths.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: chrome, macos
- test case 1: run oC on a subpath

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
