### PR TITLE
[tests-only][full-ci] Update role map string in test

### DIFF
--- a/tests/e2e-playwright/specs/spaces/denySpaceAccess.spec.ts
+++ b/tests/e2e-playwright/specs/spaces/denySpaceAccess.spec.ts
@@ -94,7 +94,7 @@ test.describe('deny space access', () => {
       space: 'sales',
       shareType: 'user',
       sharee: 'Brian',
-      role: 'Can edit'
+      role: 'Can edit with versions and trashbin'
     })
 
     // When "Alice" navigates to the project space "sales"

--- a/tests/e2e-playwright/specs/spaces/downloadSpace.spec.ts
+++ b/tests/e2e-playwright/specs/spaces/downloadSpace.spec.ts
@@ -103,7 +103,7 @@ test.describe('download space', () => {
       usersEnvironment,
       stepUser: 'Alice',
       sharee: 'Brian',
-      role: 'Can edit',
+      role: 'Can edit with versions and trashbin',
       kind: 'user'
     })
 

--- a/tests/e2e-playwright/specs/spaces/memberExpiry.spec.ts
+++ b/tests/e2e-playwright/specs/spaces/memberExpiry.spec.ts
@@ -85,7 +85,7 @@ test.describe('spaces member expiry', () => {
       usersEnvironment,
       stepUser: 'Alice',
       sharee: 'Brian',
-      role: 'Can edit',
+      role: 'Can edit with versions and trashbin',
       kind: 'user'
     })
 

--- a/tests/e2e-playwright/specs/user-settings/notifications.spec.ts
+++ b/tests/e2e-playwright/specs/user-settings/notifications.spec.ts
@@ -125,7 +125,7 @@ test.describe('Notifications', () => {
       resource: 'folder_to_shared',
       recipient: 'Brian',
       type: 'user',
-      role: 'Can edit without versions',
+      role: 'Can edit with trashbin',
       resourceType: 'folder'
     })
     await ui.shareResource({
@@ -136,7 +136,7 @@ test.describe('Notifications', () => {
       resource: 'share_to_group',
       recipient: 'sales',
       type: 'group',
-      role: 'Can edit without versions',
+      role: 'Can edit with trashbin',
       resourceType: 'folder'
     })
 
@@ -184,7 +184,7 @@ test.describe('Notifications', () => {
       usersEnvironment,
       stepUser: 'Alice',
       sharee: 'Brian',
-      role: 'Can edit',
+      role: 'Can edit with versions and trashbin',
       kind: 'user'
     })
 
@@ -193,7 +193,7 @@ test.describe('Notifications', () => {
       usersEnvironment,
       stepUser: 'Alice',
       sharee: 'Carol',
-      role: 'Can edit',
+      role: 'Can edit with versions and trashbin',
       kind: 'user'
     })
 
@@ -225,7 +225,7 @@ test.describe('Notifications', () => {
       usersEnvironment,
       stepUser: 'Alice',
       reciver: 'Carol',
-      role: 'Can edit without versions'
+      role: 'Can edit with trashbin'
     })
 
     // And "Carol" logs in
@@ -365,7 +365,7 @@ test.describe('Notifications', () => {
       resource: 'folder_to_shared',
       recipient: 'Brian',
       type: 'user',
-      role: 'Can edit without versions',
+      role: 'Can edit with trashbin',
       resourceType: 'folder'
     })
 
@@ -393,7 +393,7 @@ test.describe('Notifications', () => {
       stepUser: 'Alice',
       space: 'team.1',
       reciver: 'Brian',
-      role: 'Can edit',
+      role: 'Can edit with versions and trashbin',
       kind: 'user'
     })
     await ui.addUserToProjectSpace({
@@ -402,7 +402,7 @@ test.describe('Notifications', () => {
       stepUser: 'Alice',
       space: 'team.1',
       reciver: 'Carol',
-      role: 'Can edit',
+      role: 'Can edit with versions and trashbin',
       kind: 'user'
     })
 
@@ -414,7 +414,7 @@ test.describe('Notifications', () => {
       usersEnvironment,
       stepUser: 'Alice',
       reciver: 'Carol',
-      role: 'Can edit'
+      role: 'Can edit with versions and trashbin'
     })
 
     // Then "Alice" should see no notifications

--- a/tests/e2e/cucumber/features/app-provider/lock.feature
+++ b/tests/e2e/cucumber/features/app-provider/lock.feature
@@ -16,8 +16,8 @@ Feature: lock
       | resource | type         | content      |
       | test.odt | OpenDocument | some content |
     And "Alice" shares the following resource using API
-      | resource | recipient | type | role     | resourceType |
-      | test.odt | Brian     | user | Can edit | file         |
+      | resource | recipient | type | role                                | resourceType |
+      | test.odt | Brian     | user | Can edit with versions and trashbin | file         |
     And "Brian" logs in
     And "Brian" navigates to the shared with me page
     When "Brian" opens the following file in Collabora

--- a/tests/e2e/cucumber/features/app-provider/officeSuites.feature
+++ b/tests/e2e/cucumber/features/app-provider/officeSuites.feature
@@ -56,8 +56,8 @@ Feature: Integrate with online office suites like Collabora and OnlyOffice
       | OpenDocument.odt | OpenDocument | Edited OpenDocument Content |
     And "Brian" closes the file viewer
     When "Alice" updates following sharee role
-      | resource         | recipient | type | role                      | resourceType |
-      | OpenDocument.odt | Brian     | user | Can edit without versions | file         |
+      | resource         | recipient | type | role                   | resourceType |
+      | OpenDocument.odt | Brian     | user | Can edit with trashbin | file         |
     And "Alice" opens the following file in Collabora
       | resource         |
       | OpenDocument.odt |
@@ -121,8 +121,8 @@ Feature: Integrate with online office suites like Collabora and OnlyOffice
       | MicrosoftWord.docx | Microsoft Word | Edited Microsoft Word Content |
     And "Brian" closes the file viewer
     When "Alice" updates following sharee role
-      | resource           | recipient | type | role                      | resourceType |
-      | MicrosoftWord.docx | Brian     | user | Can edit without versions | file         |
+      | resource           | recipient | type | role                   | resourceType |
+      | MicrosoftWord.docx | Brian     | user | Can edit with trashbin | file         |
     And "Alice" opens the following file in OnlyOffice
       | resource           |
       | MicrosoftWord.docx |
@@ -272,5 +272,5 @@ Feature: Integrate with online office suites like Collabora and OnlyOffice
     Then following resources should not be displayed in the files list for user "Alice"
       | resource          |
       | Template (2).docx |
-    
+
     And "Alice" logs out

--- a/tests/e2e/cucumber/features/file-action/download.feature
+++ b/tests/e2e/cucumber/features/file-action/download.feature
@@ -25,10 +25,10 @@ Feature: Download
       | localFile                     | to             |
       | filesForUpload/testavatar.jpg | testavatar.jpg |
     And "Alice" shares the following resource using API
-      | resource       | recipient | type | role     | resourceType |
-      | folderPublic   | Brian     | user | Can edit | folder       |
-      | emptyFolder    | Brian     | user | Can edit | folder       |
-      | testavatar.jpg | Brian     | user | Can edit | file         |
+      | resource       | recipient | type | role                                | resourceType |
+      | folderPublic   | Brian     | user | Can edit with versions and trashbin | folder       |
+      | emptyFolder    | Brian     | user | Can edit with versions and trashbin | folder       |
+      | testavatar.jpg | Brian     | user | Can edit with versions and trashbin | file         |
 
     When "Alice" downloads the following resources using the batch action
       | resource       | type   |

--- a/tests/e2e/cucumber/features/file-action/groupActions.feature
+++ b/tests/e2e/cucumber/features/file-action/groupActions.feature
@@ -36,25 +36,25 @@ Feature: Group actions
       | folder5                |
       | parentFolder/SubFolder |
     And "Alice" shares the following resource using API
-      | resource     | recipient | type | role                      | resourceType |
-      | folder1      | Brian     | user | Can edit without versions | folder       |
-      | folder2      | Brian     | user | Can edit without versions | folder       |
-      | folder3      | Brian     | user | Can edit without versions | folder       |
-      | folder4      | Brian     | user | Can edit without versions | folder       |
-      | folder5      | Brian     | user | Can edit without versions | folder       |
-      | parentFolder | Brian     | user | Can edit without versions | folder       |
+      | resource     | recipient | type | role                   | resourceType |
+      | folder1      | Brian     | user | Can edit with trashbin | folder       |
+      | folder2      | Brian     | user | Can edit with trashbin | folder       |
+      | folder3      | Brian     | user | Can edit with trashbin | folder       |
+      | folder4      | Brian     | user | Can edit with trashbin | folder       |
+      | folder5      | Brian     | user | Can edit with trashbin | folder       |
+      | parentFolder | Brian     | user | Can edit with trashbin | folder       |
     And "Alice" logs in
 
     # multiple share
     And "Alice" shares the following resources using the sidebar panel
-      | resource     | recipient | type  | role                      | resourceType |
-      | sharedFolder | Brian     | user  | Can edit without versions | folder       |
-      | sharedFolder | Carol     | user  | Can edit without versions | folder       |
-      | sharedFolder | David     | user  | Can edit without versions | folder       |
-      | sharedFolder | Edith     | user  | Can edit without versions | folder       |
-      | sharedFolder | sales     | group | Can edit without versions | folder       |
-      | sharedFolder | finance   | group | Can edit without versions | folder       |
-      | sharedFolder | security  | group | Can edit without versions | folder       |
+      | resource     | recipient | type  | role                   | resourceType |
+      | sharedFolder | Brian     | user  | Can edit with trashbin | folder       |
+      | sharedFolder | Carol     | user  | Can edit with trashbin | folder       |
+      | sharedFolder | David     | user  | Can edit with trashbin | folder       |
+      | sharedFolder | Edith     | user  | Can edit with trashbin | folder       |
+      | sharedFolder | sales     | group | Can edit with trashbin | folder       |
+      | sharedFolder | finance   | group | Can edit with trashbin | folder       |
+      | sharedFolder | security  | group | Can edit with trashbin | folder       |
 
     And "Brian" navigates to the shared with me page
 

--- a/tests/e2e/cucumber/features/journeys/kindergarten.feature
+++ b/tests/e2e/cucumber/features/journeys/kindergarten.feature
@@ -40,26 +40,26 @@ Feature: Kindergarten can use web to organize a day
     # Implementation of sharing with different roles is currently broken
     # since we switched to bulk creating of shares with a single dropdown
     And "Alice" shares the following resources using the sidebar panel
-      | resource                                           | recipient | type  | role                      | resourceType |
-      | groups/Pre-Schools Pirates/meal plan               | Brian     | user  | Can edit without versions | folder       |
-      | groups/Pre-Schools Pirates/meal plan               | Carol     | user  | Can edit without versions | folder       |
-      | groups/Pre-Schools Pirates/meal plan/lorem-big.txt | sales     | group | Can view                  | file         |
-      | groups/Pre-Schools Pirates/meal plan/lorem-big.txt | Carol     | user  | Can view                  | file         |
-      | groups/Kindergarten Koalas/meal plan               | sales     | group | Can view                  | folder       |
-      | groups/Kindergarten Koalas/meal plan               | security  | group | Can edit without versions | folder       |
-      | groups/Kindergarten Koalas/meal plan/lorem.txt     | sales     | group | Can view                  | file         |
-      | groups/Kindergarten Koalas/meal plan/lorem.txt     | security  | group | Can view                  | file         |
-      | groups/Teddy Bear Daycare/meal plan                | Brian     | user  | Can edit without versions | folder       |
-      | groups/Teddy Bear Daycare/meal plan                | Carol     | user  | Can edit without versions | folder       |
-      | groups/Teddy Bear Daycare/meal plan/data.zip       | Brian     | user  | Can edit without versions | file         |
-      | groups/Teddy Bear Daycare/meal plan/data.zip       | Carol     | user  | Can edit without versions | file         |
+      | resource                                           | recipient | type  | role                   | resourceType |
+      | groups/Pre-Schools Pirates/meal plan               | Brian     | user  | Can edit with trashbin | folder       |
+      | groups/Pre-Schools Pirates/meal plan               | Carol     | user  | Can edit with trashbin | folder       |
+      | groups/Pre-Schools Pirates/meal plan/lorem-big.txt | sales     | group | Can view               | file         |
+      | groups/Pre-Schools Pirates/meal plan/lorem-big.txt | Carol     | user  | Can view               | file         |
+      | groups/Kindergarten Koalas/meal plan               | sales     | group | Can view               | folder       |
+      | groups/Kindergarten Koalas/meal plan               | security  | group | Can edit with trashbin | folder       |
+      | groups/Kindergarten Koalas/meal plan/lorem.txt     | sales     | group | Can view               | file         |
+      | groups/Kindergarten Koalas/meal plan/lorem.txt     | security  | group | Can view               | file         |
+      | groups/Teddy Bear Daycare/meal plan                | Brian     | user  | Can edit with trashbin | folder       |
+      | groups/Teddy Bear Daycare/meal plan                | Carol     | user  | Can edit with trashbin | folder       |
+      | groups/Teddy Bear Daycare/meal plan/data.zip       | Brian     | user  | Can edit with trashbin | file         |
+      | groups/Teddy Bear Daycare/meal plan/data.zip       | Carol     | user  | Can edit with trashbin | file         |
     # update share
     And "Alice" updates following sharee role
-      | resource                                           | recipient | type  | role                      | resourceType |
-      | groups/Pre-Schools Pirates/meal plan               | Carol     | user  | Can view                  | folder       |
-      | groups/Pre-Schools Pirates/meal plan/lorem-big.txt | sales     | group | Can edit without versions | file         |
-      | groups/Kindergarten Koalas/meal plan               | sales     | group | Can edit without versions | folder       |
-      | groups/Teddy Bear Daycare/meal plan/data.zip       | Carol     | user  | Can edit without versions | file         |
+      | resource                                           | recipient | type  | role                   | resourceType |
+      | groups/Pre-Schools Pirates/meal plan               | Carol     | user  | Can view               | folder       |
+      | groups/Pre-Schools Pirates/meal plan/lorem-big.txt | sales     | group | Can edit with trashbin | file         |
+      | groups/Kindergarten Koalas/meal plan               | sales     | group | Can edit with trashbin | folder       |
+      | groups/Teddy Bear Daycare/meal plan/data.zip       | Carol     | user  | Can edit with trashbin | file         |
     # Then what do we check for to be confident that the above things done by Alice have worked?
     When "Brian" logs in
     And "Brian" navigates to the shared with me page

--- a/tests/e2e/cucumber/features/keycloak/groups.feature
+++ b/tests/e2e/cucumber/features/keycloak/groups.feature
@@ -35,8 +35,8 @@ Feature: groups management
     And "Alice" logs in
     And "Alice" shares the following resource using the sidebar panel
       | resource            | recipient      | type  | role                      | resourceType |
-      | shareToSales.txt    | keycloak sales | group | Can edit without versions | file         |
-      | shareToSecurity.txt | security       | group | Can edit without versions | file         |
+      | shareToSales.txt    | keycloak sales | group | Can edit with trashbin | file         |
+      | shareToSecurity.txt | security       | group | Can edit with trashbin | file         |
     And "Alice" logs out
 
     And "Brian" logs in

--- a/tests/e2e/cucumber/features/ocm/ocm.feature
+++ b/tests/e2e/cucumber/features/ocm/ocm.feature
@@ -40,8 +40,8 @@ Feature: federation management
     And "Alice" opens the "files" app
     And "Alice" shares the following resource using the sidebar panel
       | resource       | recipient | type | role                      | resourceType | shareType |
-      | folderPublic   | Brian     | user | Can edit without versions | folder       | external  |
-      | sampleGif.gif  | Brian     | user | Can edit without versions | file         | external  |
+      | folderPublic   | Brian     | user | Can edit with trashbin | folder       | external  |
+      | sampleGif.gif  | Brian     | user | Can edit with trashbin | file         | external  |
       | testavatar.jpg | Brian     | user | Can view                  | file         | external  |
     And "Alice" checks the following access details of share "folderPublic" for user "Brian"
       | Name   | Brian Murphy |

--- a/tests/e2e/cucumber/features/shares/share.feature
+++ b/tests/e2e/cucumber/features/shares/share.feature
@@ -20,10 +20,10 @@ Feature: share
       | lorem.txt     | folder_to_shared   |
       | lorem-big.txt | folder_to_shared_2 |
     When "Alice" shares the following resource using the sidebar panel
-      | resource           | recipient | type | role                      | resourceType |
-      | folder_to_shared   | Brian     | user | Can edit without versions | folder       |
-      | shared_folder      | Brian     | user | Can edit without versions | folder       |
-      | folder_to_shared_2 | Brian     | user | Can edit without versions | folder       |
+      | resource           | recipient | type | role                   | resourceType |
+      | folder_to_shared   | Brian     | user | Can edit with trashbin | folder       |
+      | shared_folder      | Brian     | user | Can edit with trashbin | folder       |
+      | folder_to_shared_2 | Brian     | user | Can edit with trashbin | folder       |
 
     And "Brian" navigates to the shared with me page
     And "Brian" opens folder "folder_to_shared"
@@ -93,12 +93,12 @@ Feature: share
       | simple.pdf      |
       | testavatar.jpeg |
     When "Alice" shares the following resource using the sidebar panel
-      | resource         | recipient | type | role                      | resourceType |
-      | shareToBrian.txt | Brian     | user | Can edit without versions | file         |
-      | shareToBrian.md  | Brian     | user | Can edit without versions | file         |
-      | testavatar.jpeg  | Brian     | user | Can view                  | file         |
-      | simple.pdf       | Brian     | user | Can edit without versions | file         |
-      | sharedFile.txt   | Brian     | user | Can edit without versions | file         |
+      | resource         | recipient | type | role                   | resourceType |
+      | shareToBrian.txt | Brian     | user | Can edit with trashbin | file         |
+      | shareToBrian.md  | Brian     | user | Can edit with trashbin | file         |
+      | testavatar.jpeg  | Brian     | user | Can view               | file         |
+      | simple.pdf       | Brian     | user | Can edit with trashbin | file         |
+      | sharedFile.txt   | Brian     | user | Can edit with trashbin | file         |
     And "Alice" navigates to the shared with others page
     And "Alice" opens the following file in mediaviewer
       | resource        |
@@ -158,10 +158,10 @@ Feature: share
       | mainFolder/lorem.txt | lorem epsum  |
     And "Alice" logs in
     When "Alice" shares the following resource using the sidebar panel
-      | resource   | recipient | type  | role                      | resourceType | expirationDate |
-      | new.txt    | Brian     | user  | Can edit without versions | file         | +5 days        |
-      | myfolder   | sales     | group | Can view                  | folder       | +10 days       |
-      | mainFolder | Brian     | user  | Can edit without versions | folder       |                |
+      | resource   | recipient | type  | role                   | resourceType | expirationDate |
+      | new.txt    | Brian     | user  | Can edit with trashbin | file         | +5 days        |
+      | myfolder   | sales     | group | Can view               | folder       | +10 days       |
+      | mainFolder | Brian     | user  | Can edit with trashbin | folder       |                |
 
     # set expirationDate to existing share
     And "Alice" sets the expiration date of share "mainFolder" of user "Brian" to "+5 days"
@@ -233,9 +233,9 @@ Feature: share
       | testfile.txt             | example text |
       | test-folder/testfile.txt | some text    |
     And "Alice" shares the following resource using API
-      | resource                 | recipient | type | role                      | resourceType |
-      | testfile.txt             | Brian     | user | Can edit without versions | file         |
-      | test-folder/testfile.txt | Brian     | user | Can edit without versions | file         |
+      | resource                 | recipient | type | role                   | resourceType |
+      | testfile.txt             | Brian     | user | Can edit with trashbin | file         |
+      | test-folder/testfile.txt | Brian     | user | Can edit with trashbin | file         |
     And "Brian" logs out
     When "Alice" navigates to the shared with others page
     Then following resources should be displayed in the files list for user "Alice"
@@ -250,8 +250,8 @@ Feature: share
       | name                  |
       | shareFolder/subFolder |
     And "Alice" shares the following resource using API
-      | resource    | recipient | type | role                      | resourceType |
-      | shareFolder | Brian     | user | Can edit without versions | folder       |
+      | resource    | recipient | type | role                   | resourceType |
+      | shareFolder | Brian     | user | Can edit with trashbin | folder       |
     And "Alice" logs in
     Then "Alice" should see user-direct indicator on the folder "shareFolder"
     When "Alice" opens folder "shareFolder"

--- a/tests/e2e/cucumber/features/smoke/activity.feature
+++ b/tests/e2e/cucumber/features/smoke/activity.feature
@@ -26,11 +26,11 @@ Feature: Users can see all activities of the resources and spaces
       | localFile                   | to                        |
       | filesForUpload/textfile.txt | sharedFolder/textfile.txt |
     And "Alice" shares the following resource using API
-      | resource     | recipient | type | role                      | resourceType |
-      | sharedFolder | Brian     | user | Can edit without versions | folder       |
+      | resource     | recipient | type | role                   | resourceType |
+      | sharedFolder | Brian     | user | Can edit with trashbin | folder       |
     And "Alice" creates a public link of following resource using API
-      | resource     | role                      | password |
-      | sharedFolder | Can edit without versions | %public% |
+      | resource     | role                   | password |
+      | sharedFolder | Can edit with trashbin | %public% |
 
     When "Anonymous" opens the public link "Unnamed link"
     And "Anonymous" unlocks the public link with password "%public%"

--- a/tests/e2e/cucumber/features/smoke/sse.feature
+++ b/tests/e2e/cucumber/features/smoke/sse.feature
@@ -146,8 +146,8 @@ Feature: server sent events
 
     # share-updated
     When "Alice" updates following sharee role
-      | resource     | recipient | type | role                      | resourceType |
-      | sharedFolder | Brian     | user | Can edit without versions | folder       |
+      | resource     | recipient | type | role                   | resourceType |
+      | sharedFolder | Brian     | user | Can edit with trashbin | folder       |
     Then "Alice" should get "share-updated" SSE event
     And "Brian" should get "share-updated" SSE event
     And "Brian" opens folder "sharedFolder"
@@ -173,8 +173,8 @@ Feature: server sent events
       | name      | id        |
       | Marketing | marketing |
     And "Alice" adds the following members to the space "Marketing" using API
-      | user  | role                      | shareType |
-      | Brian | Can edit without versions | user      |
+      | user  | role                   | shareType |
+      | Brian | Can edit with trashbin | user      |
     And "Alice" creates the following folder in space "Marketing" using API
       | name         |
       | space-folder |

--- a/tests/e2e/cucumber/features/smoke/tags.feature
+++ b/tests/e2e/cucumber/features/smoke/tags.feature
@@ -81,8 +81,8 @@ Feature: Users can use web to organize tags
       | resource                   | tags         |
       | folder_to_shared/lorem.txt | tag 1, tag 2 |
     When "Alice" shares the following resource using the sidebar panel
-      | resource         | recipient | type | role                      | resourceType |
-      | folder_to_shared | Brian     | user | Can edit without versions | folder       |
+      | resource         | recipient | type | role                   | resourceType |
+      | folder_to_shared | Brian     | user | Can edit with trashbin | folder       |
     And "Alice" logs out
 
     And "Brian" navigates to the shared with me page

--- a/tests/e2e/cucumber/features/smoke/trashbinDelete.feature
+++ b/tests/e2e/cucumber/features/smoke/trashbinDelete.feature
@@ -54,8 +54,8 @@ Feature: Trashbin delete
       | folderToShare/lorem.txt | lorem ipsum |
       | sample.txt              | sample      |
     And "Alice" shares the following resource using API
-      | resource      | recipient | type | role                      | resourceType |
-      | folderToShare | Brian     | user | Can edit without versions | folder       |
+      | resource      | recipient | type | role                   | resourceType |
+      | folderToShare | Brian     | user | Can edit with trashbin | folder       |
     When "Brian" navigates to the shared with me page
     And "Brian" opens folder "folderToShare"
     And "Brian" deletes the following resources using the sidebar panel

--- a/tests/e2e/cucumber/features/spaces/participantManagement.feature
+++ b/tests/e2e/cucumber/features/spaces/participantManagement.feature
@@ -25,11 +25,11 @@ Feature: spaces participant management
       | team | team.1 |
     And "Alice" navigates to the project space "team.1"
     And "Alice" adds following users to the project space
-      | user     | role     | kind  |
-      | Brian    | Can edit | user  |
-      | Carol    | Can view | user  |
-      | sales    | Can view | group |
-      | security | Can edit | group |
+      | user     | role                                | kind  |
+      | Brian    | Can edit with versions and trashbin | user  |
+      | Carol    | Can view                            | user  |
+      | sales    | Can view                            | group |
+      | security | Can edit with versions and trashbin | group |
     When "Brian" logs in
     And "Brian" navigates to the project space "team.1"
     And "Brian" creates the following resources

--- a/tests/e2e/cucumber/features/spaces/project.feature
+++ b/tests/e2e/cucumber/features/spaces/project.feature
@@ -56,8 +56,8 @@ Feature: spaces.personal
 
     # borrowed from share.feature
     When "Alice" shares the following resource using the sidebar panel
-      | resource         | recipient | type | role                      | resourceType |
-      | folder_to_shared | Brian     | user | Can edit without versions | folder       |
+      | resource         | recipient | type | role                   | resourceType |
+      | folder_to_shared | Brian     | user | Can edit with trashbin | folder       |
 
     # team.2
     And "Alice" navigates to the project space "team.2"
@@ -145,9 +145,9 @@ Feature: spaces.personal
       | resource     | to     | option  |
       | textfile.txt | parent | replace |
     And "Alice" adds following users to the project space
-      | user  | role     | kind |
-      | Carol | Can view | user |
-      | Brian | Can edit | user |
+      | user  | role                                | kind |
+      | Carol | Can view                            | user |
+      | Brian | Can edit with versions and trashbin | user |
     And "Alice" logs out
 
     When "Carol" logs in

--- a/tests/e2e/cucumber/features/spaces/publicLink.feature
+++ b/tests/e2e/cucumber/features/spaces/publicLink.feature
@@ -22,10 +22,10 @@ Feature: spaces public link
       | spaceFolder/shareToBrian.txt          | some text |
       | spaceFolder/subFolder/shareToBrian.md | readme    |
     And "Alice" adds the following members to the space "team" using API
-      | user  | role       | shareType |
-      | Brian | Can edit   | user      |
-      | Carol | Can view   | user      |
-      | David | Can manage | user      |
+      | user  | role                                | shareType |
+      | Brian | Can edit with versions and trashbin | user      |
+      | Carol | Can view                            | user      |
+      | David | Can manage                          | user      |
     And "Alice" navigates to the project space "team.1"
     And "Alice" uploads the following resources via drag-n-drop
       | resource       |

--- a/tests/e2e/support/api/share/share.ts
+++ b/tests/e2e/support/api/share/share.ts
@@ -37,7 +37,7 @@ export const shareRoles: Readonly<{
   'Can manage': string
   'Can edit': string
   'Can edit with versions and trashbin': string
-  'Can edit without versions': string
+  'Can edit with trashbin': string
   'Can view': string
   'Secret File Drop': string
   'Cannot access': string
@@ -48,7 +48,7 @@ export const shareRoles: Readonly<{
   'Can manage': 'manager',
   'Can edit': 'editor',
   'Can edit with versions and trashbin': 'editor',
-  'Can edit without versions': 'editor',
+  'Can edit with trashbin': 'editor',
   'Can view': 'viewer',
   'Secret File Drop': 'uploader',
   'Cannot access': 'denied',
@@ -60,14 +60,14 @@ export const linkShareRoles: Readonly<{
   'Can view': string
   'Can upload': string
   'Can edit': string
-  'Can edit without versions': string
+  'Can edit with trashbin': string
   'Secret File Drop': string
 }> = {
   'Invited people': 'internal',
   'Can view': 'view',
   'Can upload': 'upload',
   'Can edit': 'edit',
-  'Can edit without versions': 'edit',
+  'Can edit with trashbin': 'edit',
   'Secret File Drop': 'createOnly'
 } as const
 
@@ -125,9 +125,9 @@ const getRecipientId = (shareType: string, shareWith: string): string => {
 const dynamicRoles = {}
 const requiredDynamicRoles = [
   'Can view',
-  'Can edit',
+  'Can edit with versions and trashbin',
   'Can edit (file)',
-  'Can edit without versions',
+  'Can edit with trashbin',
   'Can edit without versions (file)'
 ]
 
@@ -140,7 +140,10 @@ export const getDynamicRoleIdByName = async (
     return getRoleId(roleName, resourceType)
   }
 
-  if (resourceType === 'file' && ['Can edit', 'Can edit without versions'].includes(roleName)) {
+  if (
+    resourceType === 'file' &&
+    ['Can edit with versions and trashbin', 'Can edit with trashbin'].includes(roleName)
+  ) {
     roleName = `${roleName} (file)`
   } else if (resourceType === 'space' && !['Can manage'].includes(roleName)) {
     roleName = `${roleName} (space)`


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
This PR updates the role map strings:
- `Can edit` to `Can edit with versions and trashbin`
- `Can edit without versions` to `Can edit with trashbin`

For the case of folder share role `Can edit` and `Can Upload` role have same behavior mentioned in this [comment](https://github.com/owncloud/ocis/issues/11977#issuecomment-3811778366).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/web/issues/13534

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
