### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on stable-12.3 branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=2c918627b370fae0ad1e1074c3f022866dab1d4a
+OCIS_COMMITID=f73b3a524ef04ab4a852efdff29c630e1af2f275
 OCIS_BRANCH=master


### PR DESCRIPTION
## Description
Bump latest ocis `master` branch commit id.

Part of: https://github.com/owncloud/QA/issues/927