### PR TITLE
feat: [OCISDEV-617] use signature auth

### DIFF
--- a/changelog/unreleased/enhancement-use-signature-auth.md
+++ b/changelog/unreleased/enhancement-use-signature-auth.md
@@ -1,0 +1,6 @@
+Enhancement: Use signature auth
+
+When requesting resources from public links, we now request also `oc:signature-auth` property. This property is then used to sign the archiver download URL within password protected public links.
+
+https://github.com/owncloud/ocis/issues/11963
+https://github.com/owncloud/web/pull/13576

--- a/packages/web-client/src/helpers/resource/functions.ts
+++ b/packages/web-client/src/helpers/resource/functions.ts
@@ -136,7 +136,7 @@ export function buildResource(
     }
   }
 
-  const r = {
+  const r: Resource = {
     id,
     fileId: id,
     storageId: extractStorageId(id),
@@ -225,12 +225,20 @@ export function buildResource(
       return this.permissions.indexOf(DavPermission.Deny) >= 0
     },
     getDomSelector: () => extractDomSelector(id)
-  } satisfies Resource
+  }
   Object.defineProperty(r, 'nodeId', {
     get() {
       return extractNodeId(this.id)
     }
   })
+
+  if (resource.props[DavProperty.SignatureAuth]) {
+    r.signatureAuth = {
+      signature: resource.props[DavProperty.SignatureAuth].signature,
+      expiration: new Date(resource.props[DavProperty.SignatureAuth].expiration)
+    }
+  }
+
   return r
 }
 

--- a/packages/web-client/src/helpers/resource/types.ts
+++ b/packages/web-client/src/helpers/resource/types.ts
@@ -31,6 +31,14 @@ export type AbilitySubjects =
 export type Ability = MongoAbility<[AbilityActions, AbilitySubjects]>
 export type AbilityRule = SubjectRawRule<AbilityActions, AbilitySubjects, any>
 
+/**
+ * Signature authentication for public links
+ */
+export interface SignatureAuth {
+  signature: string
+  expiration: Date
+}
+
 // FIXME: almost all of the properties are non-optional, the interface should reflect that
 export interface Resource {
   id: string
@@ -69,6 +77,11 @@ export interface Resource {
   // necessary for incoming share resources and resources inside shares
   remoteItemId?: string
   remoteItemPath?: string
+
+  /**
+   * Signature authentication for public links
+   */
+  signatureAuth?: SignatureAuth
 
   canCreate?(): boolean
   canUpload?({ user }: { user?: User }): boolean

--- a/packages/web-client/src/webdav/constants/dav.ts
+++ b/packages/web-client/src/webdav/constants/dav.ts
@@ -105,7 +105,11 @@ const DavPropertyMapping = {
   PublicLinkPermission: defString('public-link-permission' as const),
   PublicLinkExpiration: defString('public-link-expiration' as const),
   PublicLinkShareDate: defString('public-link-share-datetime' as const),
-  PublicLinkShareOwner: defString('public-link-share-owner' as const)
+  PublicLinkShareOwner: defString('public-link-share-owner' as const),
+  SignatureAuth: {
+    value: 'signature-auth',
+    type: null as Record<'signature' | 'expiration', string>
+  }
 } as const satisfies Record<string, M<unknown, unknown>>
 
 type DavPropertyMappingType = typeof DavPropertyMapping
@@ -156,7 +160,8 @@ export abstract class DavProperties {
     DavProperty.PublicLinkPermission,
     DavProperty.PublicLinkExpiration,
     DavProperty.PublicLinkShareDate,
-    DavProperty.PublicLinkShareOwner
+    DavProperty.PublicLinkShareOwner,
+    DavProperty.SignatureAuth
   ])
 
   static readonly Trashbin: DavPropertyValue[] = [

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadArchive.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsDownloadArchive.ts
@@ -50,7 +50,8 @@ export const useFileActionsDownloadArchive = () => {
           isPublicSpaceResource(space) && {
             publicToken: space.id as string,
             publicLinkPassword: authStore.publicLinkPassword,
-            publicLinkShareOwner: space.publicLinkShareOwner
+            publicLinkShareOwner: space.publicLinkShareOwner,
+            signatureAuth: resources[0].signatureAuth
           })
       })
       .catch((e) => {

--- a/packages/web-pkg/tests/unit/services/archiver.spec.ts
+++ b/packages/web-pkg/tests/unit/services/archiver.spec.ts
@@ -127,7 +127,35 @@ describe('archiver', () => {
     })
   })
 
-  it('should sign the download url if a public token is provided with a password', async () => {
+  it('should use signature auth if a public token is provided with a password', async () => {
+    const archiverService = getArchiverServiceInstance(capabilities)
+    const fileId = 'asdf'
+    const signatureExpiration = new Date(Date.now() + 1000 * 60 * 60)
+
+    await archiverService.triggerDownload({
+      fileIds: [fileId],
+      publicToken: 'token',
+      publicLinkPassword: 'password',
+      publicLinkShareOwner: 'owner',
+      signatureAuth: {
+        signature: 'resource-signature-string',
+        expiration: signatureExpiration
+      }
+    })
+    expect(archiverService.clientService.ocs.signUrl).not.toHaveBeenCalled()
+    expect(window.open).toHaveBeenCalledWith(
+      archiverUrl +
+        '?public-token=token' +
+        '&signature=resource-signature-string' +
+        '&expiration=' +
+        encodeURIComponent(signatureExpiration.toISOString()) +
+        '&id=' +
+        fileId,
+      '_blank'
+    )
+  })
+
+  it('should fallback to signing the download url if a public token is provided with a password but signature auth is not provided', async () => {
     const archiverService = getArchiverServiceInstance(capabilities)
     const fileId = 'asdf'
     await archiverService.triggerDownload({


### PR DESCRIPTION
## Description

When requesting resources form public links, we now request also `oc:signature-auth` property. This property is then used to sign the archiver download URL within password protected public links.

## Related Issue

- Fixes https://github.com/owncloud/ocis/issues/11963

## Motivation and Context

Signing the download URL does not work in public links from within project spaces.

## Screenshots & videos

<img width="2560" height="1239" alt="image" src="https://github.com/user-attachments/assets/6e89832d-44aa-4469-a23e-0819f23ee0f1" />

<img width="2560" height="956" alt="image" src="https://github.com/user-attachments/assets/6c33232a-480c-4430-b9c3-7a4457f54296" />


https://github.com/user-attachments/assets/e58d8bbe-ab87-4a22-9053-47edc4c8b532



## How Has This Been Tested?

- test environment: macos v26.2, chrome v144.0.7559.133
- test case 1: share public link from within project space and download an archive

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
