### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on stable-12.3 branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=76b9843d0867d764cf021027cd18ec523cef3b99
+OCIS_COMMITID=95ba2da3fb8b95ec6480956a91a7cbf2752098da
 OCIS_BRANCH=master


### PR DESCRIPTION
## Description
Bump latest ocis `master` branch commit id.

Part of: https://github.com/owncloud/QA/issues/929