### PR TITLE
[tests-only][full-ci] bump latest ocis commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=4f4fb4a3fbd66fe4a7803c46433a8641663de224
+OCIS_COMMITID=043fa7a1293101b961c0000f12f42afe555c88c8
 OCIS_BRANCH=master


### PR DESCRIPTION
### Description
Bump latest ocis commit id.

Part of: https://github.com/owncloud/QA/issues/929