### PR TITLE
[tests-only][full-ci] bump ocis commit id on stable-12.3

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=95ba2da3fb8b95ec6480956a91a7cbf2752098da
+OCIS_COMMITID=043fa7a1293101b961c0000f12f42afe555c88c8
 OCIS_BRANCH=master


### PR DESCRIPTION
### Desctiption
Bump latest ocis commit id.

Part of: https://github.com/owncloud/QA/issues/929