### PR TITLE
bugfix(web-app-files): [OCISDEV-701] clip link name and show ellipsis when public link name is too long

### DIFF
--- a/changelog/unreleased/cannot-edit-public-link-when-name-is-too-long.md
+++ b/changelog/unreleased/cannot-edit-public-link-when-name-is-too-long.md
@@ -1,0 +1,6 @@
+Bugfix: Cannot-edit-public-link-when-name-is-too-long
+
+We've fixed an issue where users were unable to edit a public link if the name of the link was too long.
+
+https://kiteworks.atlassian.net/browse/OCISDEV-701
+https://github.com/owncloud/web/pull/13610

--- a/packages/web-app-files/src/components/SideBar/Shares/Links/ListItem.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Links/ListItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="oc-width-1-1 oc-flex oc-flex-middle oc-flex-between files-links-details">
-    <div class="oc-flex oc-flex-middle">
+    <div class="oc-flex oc-flex-middle files-links-content">
       <oc-avatar-item :width="36" icon-size="medium" icon="link" name="df" />
       <div class="files-links-name-wrapper oc-pl-s">
         <div class="oc-flex oc-flex-middle">
@@ -145,3 +145,12 @@ const currentLinkRoleLabel = computed(() => {
   return getLinkRoleByType(unref(currentLinkType))?.displayName || ''
 })
 </script>
+<style lang="scss" scoped>
+.files-links-content {
+  min-width: 0;
+}
+
+.files-links-name-wrapper {
+  min-width: 0;
+}
+</style>


### PR DESCRIPTION
We've fixed an issue where users were unable to edit a public link if the name of the link was too long.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/13593

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
