### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on stable-12.3 branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=043fa7a1293101b961c0000f12f42afe555c88c8
+OCIS_COMMITID=cfa5bb9ebce76ad5f6b25ca0e2af2d0d1e73e84c
 OCIS_BRANCH=master


### PR DESCRIPTION
## Description
Bump latest ocis `master` branch commit id.

Part of: https://github.com/owncloud/QA/issues/929