### PR TITLE
feat: add vault and drive to breadcrumbs

### DIFF
--- a/changelog/unreleased/enhancement-vault-aware-breadcrumbs.md
+++ b/changelog/unreleased/enhancement-vault-aware-breadcrumbs.md
@@ -1,0 +1,5 @@
+Enhancement: Vault-aware breadcrumbs
+
+We've introduced vault-aware breadcrumbs that show Vault or Drive as the root item depending on the active scope. Users without vault access see the original labels instead.
+
+https://github.com/owncloud/web/pull/13628

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -129,6 +129,7 @@ import {
 import {
   ResourceTransfer,
   TransferType,
+  useAbility,
   useConfigStore,
   useExtensionRegistry,
   useFileActions,
@@ -189,6 +190,7 @@ interface Props {
 const { space = null, item = null, itemId = null } = defineProps<Props>()
 
 const router = useRouter()
+const { can } = useAbility()
 const userStore = useUserStore()
 const { $gettext, $ngettext } = useGettext()
 const openWithDefaultAppQuery = useRouteQuery('openWithDefaultApp')
@@ -256,12 +258,27 @@ const titleSegments = computed(() => {
 useDocumentTitle({ titleSegments })
 
 const route = useRoute()
+const canAccessVault = computed(() => can('read-all', 'Vault'))
+
+const getSpacesBreadcrumbText = () => {
+  if (!unref(canAccessVault)) {
+    return $gettext('Spaces')
+  }
+
+  if (unref(route).params.scope === 'vault') {
+    return $gettext('Vault')
+  }
+
+  return $gettext('Drive')
+}
+
+
 const breadcrumbs = computed(() => {
   const rootBreadcrumbItems: BreadcrumbItem[] = []
   if (isProjectSpaceResource(unref(space))) {
     rootBreadcrumbItems.push({
       id: uuidV4(),
-      text: $gettext('Spaces'),
+      text: getSpacesBreadcrumbText(),
       to: createLocationSpaces('files-spaces-projects'),
       isStaticNav: true
     })
@@ -286,6 +303,16 @@ const breadcrumbs = computed(() => {
   let { params, query } = createFileRouteOptions(unref(space), { fileId: unref(space).fileId })
   query = omit({ ...unref(route).query, ...query }, 'page')
   if (isPersonalSpaceResource(unref(space))) {
+    if (unref(canAccessVault)) {
+      const vaultText = unref(route).params.scope === 'vault' ? $gettext('Vault') : $gettext('Drive')
+      rootBreadcrumbItems.push({
+        id: uuidV4(),
+        text: vaultText,
+        to: createLocationSpaces('files-spaces-projects'),
+        isStaticNav: true
+      })
+    }
+
     spaceBreadcrumbItem = {
       id: uuidV4(),
       text: unref(space).name,

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -335,6 +335,7 @@ watch(filterTerm, async () => {
 })
 
 const hasCreatePermission = computed(() => can('create-all', 'Drive'))
+const canAccessVault = computed(() => can('read-all', 'Vault'))
 
 const extensionRegistry = useExtensionRegistry()
 const viewModes = computed(() => {
@@ -459,10 +460,22 @@ const spacesHelpList = computed(() => {
     }
   ]
 })
+const getBreadcrumbText = () => {
+  if (!unref(canAccessVault)) {
+    return $gettext('Spaces')
+  }
+
+  if (unref(route).params.scope === 'vault') {
+    return $gettext('Vault')
+  }
+
+  return $gettext('Drive')
+}
+
 const breadcrumbs = computed(() => {
   return [
     {
-      text: $gettext('Spaces'),
+      text: getBreadcrumbText(),
       onClick: () => loadResourcesTask.perform(),
       isStativNav: true
     }

--- a/packages/web-app-files/tests/unit/components/Spaces/__snapshots__/SpaceHeader.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/Spaces/__snapshots__/SpaceHeader.spec.ts.snap
@@ -21,7 +21,7 @@ exports[`SpaceHeader > should add the "squashed"-class when the sidebar is opene
         </div>
       </div> <button type="button" aria-label="Open context menu and show members" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
         <!--v-if-->
-        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">21 members</span>
+        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">19 members</span>
       </button>
     </div>
     <!--v-if-->
@@ -52,7 +52,7 @@ exports[`SpaceHeader > space description > should show the description 1`] = `
         </div>
       </div> <button type="button" aria-label="Open context menu and show members" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
         <!--v-if-->
-        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">21 members</span>
+        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">19 members</span>
       </button>
     </div>
     <!--v-if-->
@@ -86,7 +86,7 @@ exports[`SpaceHeader > space image > should show the default image if no other i
         </div>
       </div> <button type="button" aria-label="Open context menu and show members" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
         <!--v-if-->
-        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">21 members</span>
+        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">19 members</span>
       </button>
     </div>
     <!--v-if-->
@@ -115,7 +115,7 @@ exports[`SpaceHeader > space image > should show the set image 1`] = `
         </div>
       </div> <button type="button" aria-label="Open context menu and show members" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
         <!--v-if-->
-        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">21 members</span>
+        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">19 members</span>
       </button>
     </div>
     <!--v-if-->

--- a/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
@@ -1,6 +1,6 @@
 import { computed, ref } from 'vue'
 import { mock, mockDeep } from 'vitest-mock-extended'
-import { Resource, SpaceResource } from '@ownclouders/web-client'
+import { AbilityRule, Resource, SpaceResource } from '@ownclouders/web-client'
 import GenericSpace from '../../../../src/views/spaces/GenericSpace.vue'
 import { useResourcesViewDefaults } from '../../../../src/composables/resourcesViewDefaults'
 import { useResourcesViewDefaultsMock } from '../../../../tests/mocks/useResourcesViewDefaultsMock'
@@ -113,6 +113,105 @@ describe('GenericSpace view', () => {
       expect(wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs.length).toBe(
         expectedItems
       )
+    })
+    describe('personal space with vault access', () => {
+      it('shows "Drive" as root breadcrumb when scope is not vault', () => {
+        const space = mock<SpaceResource>({
+          id: '1',
+          getDriveAliasAndItem: vi.fn(),
+          driveType: 'personal',
+          name: 'Personal space',
+          isOwner: () => true
+        })
+        const { wrapper } = getMountedWrapper({
+          files: [mockDeep<Resource>()],
+          props: { space },
+          abilities: [{ action: 'read-all', subject: 'Vault' }]
+        })
+        const breadcrumbs = wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs
+        expect(breadcrumbs.length).toBe(2)
+        expect(breadcrumbs[0].text).toBe('Drive')
+        expect(breadcrumbs[1].text).toBe('Personal space')
+      })
+      it('shows "Vault" as root breadcrumb when scope is vault', () => {
+        const space = mock<SpaceResource>({
+          id: '1',
+          getDriveAliasAndItem: vi.fn(),
+          driveType: 'personal',
+          name: 'Personal space',
+          isOwner: () => true
+        })
+        const { wrapper } = getMountedWrapper({
+          files: [mockDeep<Resource>()],
+          props: { space },
+          abilities: [{ action: 'read-all', subject: 'Vault' }],
+          currentRoute: { name: 'files-spaces-generic', path: '/', params: { scope: 'vault' } }
+        })
+        const breadcrumbs = wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs
+        expect(breadcrumbs.length).toBe(2)
+        expect(breadcrumbs[0].text).toBe('Vault')
+        expect(breadcrumbs[1].text).toBe('Personal space')
+      })
+      it('shows only space name when user cannot access vault', () => {
+        const space = mock<SpaceResource>({
+          id: '1',
+          getDriveAliasAndItem: vi.fn(),
+          driveType: 'personal',
+          name: 'Personal space',
+          isOwner: () => true
+        })
+        const { wrapper } = getMountedWrapper({
+          files: [mockDeep<Resource>()],
+          props: { space }
+        })
+        const breadcrumbs = wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs
+        expect(breadcrumbs.length).toBe(1)
+        expect(breadcrumbs[0].text).toBe('Personal space')
+      })
+    })
+    describe('project space breadcrumbs', () => {
+      it('shows "Spaces" when user cannot access vault', () => {
+        const space = mock<SpaceResource>({
+          id: '1',
+          getDriveAliasAndItem: vi.fn(),
+          driveType: 'project'
+        })
+        const { wrapper } = getMountedWrapper({
+          files: [mockDeep<Resource>()],
+          props: { space }
+        })
+        const breadcrumbs = wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs
+        expect(breadcrumbs[0].text).toBe('Spaces')
+      })
+      it('shows "Drive" when user can access vault and scope is not vault', () => {
+        const space = mock<SpaceResource>({
+          id: '1',
+          getDriveAliasAndItem: vi.fn(),
+          driveType: 'project'
+        })
+        const { wrapper } = getMountedWrapper({
+          files: [mockDeep<Resource>()],
+          props: { space },
+          abilities: [{ action: 'read-all', subject: 'Vault' }]
+        })
+        const breadcrumbs = wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs
+        expect(breadcrumbs[0].text).toBe('Drive')
+      })
+      it('shows "Vault" when user can access vault and scope is vault', () => {
+        const space = mock<SpaceResource>({
+          id: '1',
+          getDriveAliasAndItem: vi.fn(),
+          driveType: 'project'
+        })
+        const { wrapper } = getMountedWrapper({
+          files: [mockDeep<Resource>()],
+          props: { space },
+          abilities: [{ action: 'read-all', subject: 'Vault' }],
+          currentRoute: { name: 'files-spaces-generic', path: '/', params: { scope: 'vault' } }
+        })
+        const breadcrumbs = wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs
+        expect(breadcrumbs[0].text).toBe('Vault')
+      })
     })
     it('include the root item and the current folder', () => {
       const folderName = 'someFolder'
@@ -258,20 +357,23 @@ function getMountedWrapper({
     driveType: ''
   }),
   breadcrumbsFromPath = [],
-  stubs = {}
+  stubs = {},
+  abilities = []
 }: {
   mocks?: Record<string, unknown>
   props?: PartialComponentProps<typeof GenericSpace>
   files?: Resource[]
   loading?: boolean
-  currentRoute?: { name?: string; path?: string }
+  currentRoute?: { name?: string; path?: string; params?: Record<string, string> }
   currentFolder?: Resource
   runningOnEos?: boolean
   space?: SpaceResource
   breadcrumbsFromPath?: BreadcrumbItem[]
   stubs?: any
+  abilities?: AbilityRule[]
 } = {}) {
   const plugins = defaultPlugins({
+    abilities,
     piniaOptions: {
       configState: { options: { runningOnEos } },
       resourcesStore: { currentFolder }

--- a/packages/web-app-files/tests/unit/views/spaces/Projects.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/Projects.spec.ts
@@ -123,6 +123,39 @@ describe('Projects view', () => {
     })
     expect(wrapper.find('create-space-stub').exists()).toBeTruthy()
   })
+  describe('breadcrumbs', () => {
+    it('shows "Spaces" when user cannot access vault', async () => {
+      const { wrapper } = getMountedWrapper({ spaces: spacesResources })
+      await (wrapper.vm as any).loadResourcesTask.last
+      expect(wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs[0].text).toBe(
+        'Spaces'
+      )
+    })
+    it('shows "Drive" when user can access vault and scope is not vault', async () => {
+      const { wrapper } = getMountedWrapper({
+        spaces: spacesResources,
+        abilities: [{ action: 'read-all', subject: 'Vault' }]
+      })
+      await (wrapper.vm as any).loadResourcesTask.last
+      expect(wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs[0].text).toBe(
+        'Drive'
+      )
+    })
+    it('shows "Vault" when user can access vault and scope is vault', async () => {
+      const { wrapper } = getMountedWrapper({
+        spaces: spacesResources,
+        abilities: [{ action: 'read-all', subject: 'Vault' }],
+        currentRoute: mock<RouteLocation>({
+          name: 'files-spaces-projects',
+          params: { scope: 'vault' }
+        })
+      })
+      await (wrapper.vm as any).loadResourcesTask.last
+      expect(wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs[0].text).toBe(
+        'Vault'
+      )
+    })
+  })
   it('should not pass selected resource as space to sidebar when driveType is not "project"', () => {
     const resource = mock<SpaceResource>({ id: 'selected-resource', driveType: 'personal' })
     const { wrapper } = getMountedWrapper({
@@ -147,7 +180,8 @@ function getMountedWrapper({
   abilities = [],
   stubAppBar = true,
   includeDisabled = false,
-  store = {}
+  store = {},
+  currentRoute = mock<RouteLocation>({ name: 'files-spaces-projects' })
 }: {
   mocks?: Record<string, unknown>
   spaces?: SpaceResource[]
@@ -155,6 +189,7 @@ function getMountedWrapper({
   stubAppBar?: boolean
   includeDisabled?: boolean
   store?: PiniaMockOptions
+  currentRoute?: RouteLocation
 } = {}) {
   const plugins = defaultPlugins({ abilities, piniaOptions: { spacesState: { spaces }, ...store } })
 
@@ -184,9 +219,7 @@ function getMountedWrapper({
   vi.mocked(requestExtensions).mockReturnValue(extensions)
 
   const defaultMocks = {
-    ...defaultComponentMocks({
-      currentRoute: mock<RouteLocation>({ name: 'files-spaces-projects' })
-    }),
+    ...defaultComponentMocks({ currentRoute }),
     ...(mocks && mocks)
   }
 


### PR DESCRIPTION
## Description

  Breadcrumbs in the Projects and GenericSpace views now reflect the current vault/drive context. When the user has vault access, the
  root breadcrumb shows "Vault" or "Drive" depending on the active scope. For the personal space, a parent breadcrumb is prepended.
  Users without vault access see the original labels unchanged.

  ## Related Issue

  - Fixes https://kiteworks.atlassian.net/browse/OCISDEV-711

  ## Motivation and Context

  With the introduction of vault mode, users need visual feedback in the breadcrumb navigation to understand whether they are browsing
  within the vault or drive scope. Without this, the navigation context is unclear when switching between modes.

  ## How Has This Been Tested?

  - test environment: local dev server with oCIS backend, vault permissions enabled
  - test case 1: User with vault access sees "Drive" breadcrumb on default scope
  - test case 2: User with vault access sees "Vault" breadcrumb on vault scope
  - test case 3: User without vault access sees "Spaces" in Projects view
  - test case 4: User without vault access sees only space name in personal space
  - test case 5: Personal space with vault access shows "Drive > {space name}" or "Vault > {space name}"
  - test case 6: Unit tests pass for all breadcrumb combinations in both Projects.spec.ts and GenericSpace.spec.ts

  ## Screenshots (if appropriate):

  ## Types of changes

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Technical debt
  - [ ] Tests
  - [ ] Documentation
  - [ ] Maintenance (e.g. dependency updates or tooling)