### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id on stable-12.3 branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=cfa5bb9ebce76ad5f6b25ca0e2af2d0d1e73e84c
+OCIS_COMMITID=90655c56a301a03ca1fbf455a84123809003961b
 OCIS_BRANCH=master


### PR DESCRIPTION
## Description
Bump latest ocis `master` branch commit id.

Part of: https://github.com/owncloud/QA/issues/929