### PR TITLE
feat: [OCISDEV-710] add theme mode

### DIFF
--- a/changelog/unreleased/enhancement-add-theme-mode.md
+++ b/changelog/unreleased/enhancement-add-theme-mode.md
@@ -1,0 +1,6 @@
+Enhancement: Add theme mode
+
+We've added a new property to the theme called `mode`. This property specifies whether the theme is suitable for regular mode or vault mode.
+Valid values are `regular` and `vault`.
+
+https://github.com/owncloud/web/pull/13631

--- a/packages/web-pkg/src/composables/piniaStores/theme.ts
+++ b/packages/web-pkg/src/composables/piniaStores/theme.ts
@@ -5,6 +5,7 @@ import { useLocalStorage, usePreferredDark } from '@vueuse/core'
 import { z } from 'zod'
 import { applyCustomProp } from '@ownclouders/design-system/helpers'
 import { ShareRole } from '@ownclouders/web-client'
+import { useVault } from '../vault'
 
 const AppBanner = z.object({
   title: z.string().optional(),
@@ -76,6 +77,11 @@ const WebTheme = z.object({
   common: CommonSection.optional(),
   designTokens: DesignTokens.optional(),
   isDark: z.boolean(),
+  /**
+   * Specifies whether the theme is suitable for regular mode or vault mode.
+   * If not specified, the theme is suitable for regular mode.
+   */
+  mode: z.optional(z.enum(['regular', 'vault']).default('regular')),
   name: z.string(),
   loginPage: LoginPage.optional(),
   logo: Logo.optional(),
@@ -103,13 +109,24 @@ export const useThemeStore = defineStore('theme', () => {
   const currentLocalStorageThemeName = useLocalStorage(themeStorageKey, null)
 
   const isDark = usePreferredDark()
+  const { isInVault } = useVault()
 
   const currentTheme = ref<WebThemeType | undefined>()
 
-  const availableThemes = ref<WebThemeType[]>([])
+  const themes = ref<WebThemeType[]>([])
+
+  const availableThemes = computed(() => {
+    return unref(themes).filter((theme) => {
+      if (unref(isInVault)) {
+        return theme.mode === 'vault'
+      }
+
+      return theme.mode === 'regular' || theme.mode === undefined
+    })
+  })
 
   const initializeThemes = (themeConfig: WebThemeConfigType) => {
-    availableThemes.value = themeConfig.themes.map((theme) =>
+    themes.value = themeConfig.themes.map((theme) =>
       merge<WebThemeType>(themeConfig.defaults, theme)
     )
     setThemeFromStorageOrSystem()
@@ -168,6 +185,7 @@ export const useThemeStore = defineStore('theme', () => {
   return {
     availableThemes,
     currentTheme,
+    themes,
     initializeThemes,
     setAndApplyTheme,
     setAutoSystemTheme,

--- a/packages/web-pkg/src/composables/vault/index.ts
+++ b/packages/web-pkg/src/composables/vault/index.ts
@@ -1,0 +1,31 @@
+/**
+ * This composable is used for various vault-related functionality.
+ */
+interface VaultComposable {
+  /**
+   * Checks whether the user is currently in the vault.
+   * This is not reactive value because a full page reload is required to switch between regular and vault mode.
+   */
+  isInVault: boolean
+}
+
+export function useVault(): VaultComposable {
+  const isInVault = (() => {
+    const { pathname, hash } = window.location
+
+    if (pathname.startsWith('/vault')) {
+      return true
+    }
+
+    if (hash) {
+      const vaultHashPattern = /^#\/vault(?:\/|$)/
+      return vaultHashPattern.test(hash)
+    }
+
+    return false
+  })()
+
+  return {
+    isInVault
+  }
+}

--- a/packages/web-pkg/tests/unit/composables/piniaStores/theme.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/piniaStores/theme.spec.ts
@@ -3,9 +3,14 @@ import { useThemeStore, WebThemeConfigType } from '../../../../src/composables/p
 import { mockDeep } from 'vitest-mock-extended'
 import { createPinia, setActivePinia } from 'pinia'
 import { ref, computed } from 'vue'
+import { useVault } from '../../../../src/composables/vault'
 
 vi.mock('@vueuse/core', () => {
   return { useLocalStorage: vi.fn(() => ref('')), usePreferredDark: vi.fn(() => ref(false)) }
+})
+
+vi.mock('../../../../src/composables/vault', () => {
+  return { useVault: vi.fn(() => ({ isInVault: false })) }
 })
 
 describe('useThemeStore', () => {
@@ -67,6 +72,63 @@ describe('useThemeStore', () => {
         store.initializeThemes(themeConfig)
 
         expect(store.currentTheme.name).toEqual('light')
+      })
+    })
+
+    describe('availableThemes', () => {
+      it('returns regular themes if not in vault', () => {
+        vi.mocked(useVault).mockReturnValue({ isInVault: false })
+
+        const themeConfig = mockDeep<WebThemeConfigType>()
+        themeConfig.themes = [
+          { name: 'light', designTokens: {}, isDark: false, mode: 'regular' },
+          { name: 'dark', designTokens: {}, isDark: true, mode: 'regular' },
+          { name: 'light', designTokens: {}, isDark: false, mode: 'vault' },
+          { name: 'dark', designTokens: {}, isDark: true, mode: 'vault' }
+        ]
+
+        const store = useThemeStore()
+        store.initializeThemes(themeConfig)
+
+        for (const theme of store.availableThemes) {
+          expect(theme.mode).toBe('regular')
+        }
+      })
+      it('returns vault themes if in vault', () => {
+        vi.mocked(useVault).mockReturnValue({ isInVault: true })
+
+        const themeConfig = mockDeep<WebThemeConfigType>()
+        themeConfig.themes = [
+          { name: 'light', designTokens: {}, isDark: false, mode: 'regular' },
+          { name: 'dark', designTokens: {}, isDark: true, mode: 'regular' },
+          { name: 'light', designTokens: {}, isDark: false, mode: 'vault' },
+          { name: 'dark', designTokens: {}, isDark: true, mode: 'vault' }
+        ]
+
+        const store = useThemeStore()
+        store.initializeThemes(themeConfig)
+
+        for (const theme of store.availableThemes) {
+          expect(theme.mode).toBe('vault')
+        }
+      })
+      it('treats themes without mode as regular themes', () => {
+        vi.mocked(useVault).mockReturnValue({ isInVault: false })
+
+        const themeConfig = mockDeep<WebThemeConfigType>()
+        themeConfig.themes = [
+          { name: 'light', designTokens: {}, isDark: false, mode: 'regular' },
+          { name: 'dark', designTokens: {}, isDark: true },
+          { name: 'light', designTokens: {}, isDark: false, mode: 'vault' },
+          { name: 'dark', designTokens: {}, isDark: true, mode: 'vault' }
+        ]
+
+        const store = useThemeStore()
+        store.initializeThemes(themeConfig)
+        expect(store.availableThemes.length).toBe(2)
+        for (const theme of store.availableThemes) {
+          expect(theme.mode).not.toBe('vault')
+        }
       })
     })
   })

--- a/packages/web-runtime/src/components/Account/ThemeSwitcher.vue
+++ b/packages/web-runtime/src/components/Account/ThemeSwitcher.vue
@@ -47,9 +47,11 @@ export default defineComponent({
       return unref(currentTheme)
     })
 
-    const translatedThemeNames = unref(availableThemes).map((theme) => {
-      return { ...theme, name: $gettext(theme.name) }
-    })
+    const translatedThemeNames = computed(() =>
+      unref(availableThemes).map((theme) => {
+        return { ...theme, name: $gettext(theme.name) }
+      })
+    )
 
     const availableThemesAndAuto = computed(() => [
       unref(autoTheme),

--- a/packages/web-runtime/src/components/Topbar/UserMenu.vue
+++ b/packages/web-runtime/src/components/Topbar/UserMenu.vue
@@ -184,7 +184,10 @@ export default defineComponent({
 
     const accountPageRoute = computed(() => ({
       name: 'account',
-      query: routeToContextQuery(unref(route))
+      query: routeToContextQuery(unref(route)),
+      params: {
+        scope: unref(route).params.scope
+      }
     }))
 
     const loginLink = computed(() => {

--- a/packages/web-runtime/src/router/index.ts
+++ b/packages/web-runtime/src/router/index.ts
@@ -84,7 +84,7 @@ const routes = [
     meta: { title: $gettext('Access denied'), authContext: 'anonymous' }
   },
   {
-    path: '/account',
+    path: '/:scope(vault)?/account',
     name: 'account',
     component: Account,
     meta: { title: $gettext('Account'), authContext: 'hybrid' }

--- a/packages/web-runtime/tests/unit/components/Account/ThemeSwitcher.spec.ts
+++ b/packages/web-runtime/tests/unit/components/Account/ThemeSwitcher.spec.ts
@@ -34,7 +34,7 @@ describe('ThemeSwitcher component', () => {
 })
 
 function getWrapper({ hasOnlyOneTheme = false } = {}) {
-  const availableThemes = hasOnlyOneTheme
+  const themes = hasOnlyOneTheme
     ? [defaultTheme.clients.web.themes[0]]
     : defaultTheme.clients.web.themes
 
@@ -46,7 +46,7 @@ function getWrapper({ hasOnlyOneTheme = false } = {}) {
             piniaOptions: {
               stubActions: false,
               themeState: {
-                availableThemes,
+                themes,
                 currentTheme: mock<WebThemeType>({
                   ...defaultOwnCloudTheme.defaults,
                   ...defaultOwnCloudTheme.themes[0]

--- a/packages/web-test-helpers/src/mocks/pinia.ts
+++ b/packages/web-test-helpers/src/mocks/pinia.ts
@@ -37,7 +37,7 @@ export type PiniaMockOptions = {
     userContextReady?: boolean
     publicLinkContextReady?: boolean
   }
-  themeState?: { availableThemes?: WebThemeType[]; currentTheme?: WebThemeType }
+  themeState?: { themes?: WebThemeType[]; currentTheme?: WebThemeType }
   clipboardState?: { action?: ClipboardActions; resources?: Resource[] }
   configState?: {
     server?: string
@@ -135,7 +135,7 @@ export function createMockStore({
           ...defaultOwnCloudTheme.defaults,
           ...defaultOwnCloudTheme.themes[0]
         },
-        availableThemes: defaultOwnCloudTheme.themes,
+        themes: defaultOwnCloudTheme.themes,
         ...themeState
       },
       resources: { resources: [], ...resourcesStore },


### PR DESCRIPTION
## Description

Added a new property to the theme called `mode`. This property specifies whether the theme is suitable for regular mode or vault mode. Valid values are `regular` and `vault`.

## Motivation and Context

A clearly separate theme can be used in vault mode to hint to the users that they are within such mode.

## How Has This Been Tested?

- test environment: macos 26.3.1, chrome 145.0.7632.160
- test case 1: load custom vault theme

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)
