### PR TITLE
[tests-only][full-ci] update url for testing shortcut to website

### DIFF
--- a/tests/e2e/cucumber/features/navigation/shortcut.feature
+++ b/tests/e2e/cucumber/features/navigation/shortcut.feature
@@ -33,7 +33,7 @@ Feature: Users can create shortcuts for resources and sites
       | resource                   | name           | type    |
       | notice.txt                 | important file | file    |
       | docs                       |                | folder  |
-      | https://owncloud.com/news/ | companyNews    | website |
+      | https://owncloud.com/blogs/ | companyNews    | website |
 
     And "Alice" downloads the following resources using the sidebar panel
       | resource           | type |
@@ -43,7 +43,7 @@ Feature: Users can create shortcuts for resources and sites
     Then "Alice" is in a text-editor
     And "Alice" closes the file viewer
     And "Alice" opens the "files" app
-    Then "Alice" can open a shortcut "companyNews.url" with external url "https://owncloud.com/news/"
+    Then "Alice" can open a shortcut "companyNews.url" with external url "https://owncloud.com/blogs/"
     And "Alice" logs out
 
     # create a shortcut to the shared file


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
We have used `https://owncloud.com/news/` as a test URL in a shortcut-related test to create and open a shortcut for the website. Currently, this redirects to `https://owncloud.com/blogs/`. So, this PR updates this url in the feature file.

This should fix the issue https://github.com/owncloud/ocis/issues/12215