### PR TITLE
[tests-only][full-ci] update url for testing shortcut to website

### DIFF
--- a/tests/e2e-playwright/specs/navigation/shortcut.spec.ts
+++ b/tests/e2e-playwright/specs/navigation/shortcut.spec.ts
@@ -93,7 +93,7 @@ test.describe(
         resources: [
           { resource: 'notice.txt', name: 'important file', type: 'file' },
           { resource: 'docs', name: '', type: 'folder' },
-          { resource: 'https://owncloud.com/news/', name: 'companyNews', type: 'website' }
+          { resource: 'https://owncloud.com/blogs/', name: 'companyNews', type: 'website' }
         ]
       })
 
@@ -129,7 +129,7 @@ test.describe(
         world,
         stepUser: 'Alice',
         name: 'companyNews.url',
-        url: 'https://owncloud.com/news/'
+        url: 'https://owncloud.com/blogs/'
       })
       // And "Alice" logs out
       await ui.userLogsOut({ world, stepUser: 'Alice' })


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
We have used `https://owncloud.com/news/` as a test URL in a shortcut-related test to create and open a shortcut for the website. Currently, this redirects to `https://owncloud.com/blogs/` and fails. So, this PR updates this url in the test file.

Part of: https://github.com/owncloud/ocis/issues/12215
