### PR TITLE
ci: add reviewers to GH translation-sync Action

### DIFF
--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -12,6 +12,8 @@ jobs:
     uses: owncloud/reusable-workflows/.github/workflows/translation-sync.yml@main
     with:
       mode: make
+      reviewers: kobergj,mmattel          # individual users
+      # team_reviewers: owncloud/ocis-team  # and/or a GitHub team slug if exists
       sub_path: .
       package_manager: pnpm
     secrets:


### PR DESCRIPTION
As discussed with @kobergj, this adds automatically added reviewers for PRs created by the translation-sync Gh Action