### PR TITLE
Revert "fix(ci): grant contents:read permission for translation-sync caller"

### DIFF
--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -5,8 +5,7 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   sync:


### PR DESCRIPTION
Reverts owncloud/web#13683

This was wrong as this repo does not rely on reusable workflows