### PR TITLE
docs: add basic readme to actions support files

### DIFF
--- a/tests/actions/README.md
+++ b/tests/actions/README.md
@@ -1,0 +1,9 @@
+# Actions
+
+This directory contains files (scrips, environment, etc.) for testing the application using GitHub Actions.
+
+## How to use
+
+### Specify oCIS commit
+
+To test the application against a specific oCIS commit, you can specify the commit SHA in the `setup-services.sh` script using the `OCIS_COMMIT` variable. The default value is `latest` which will always use the latest commit from the `master` branch.


### PR DESCRIPTION
## Description

Add readme to the actions support directory. So far only specifying oCIS commit is documented there.

## Motivation and Context

Spread knowledge.
