### PR TITLE
[full-ci][tests-only]: stabilize full text search test by polling files list assertion

### DIFF
--- a/tests/e2e-playwright/steps/ui/resources.ts
+++ b/tests/e2e-playwright/steps/ui/resources.ts
@@ -184,32 +184,26 @@ export async function userShouldSeeResources({
 }): Promise<void> {
   const { page } = world.actorsEnvironment.getActor({ key: stepUser })
   const resourceObject = new objects.applicationFiles.Resource({ page })
-  // For search results, use polling to wait for tika indexing in CI
-  if (listType === 'search list') {
-    for (const resource of resources) {
-      await expect
-        .poll(
-          async () => {
-            const actualList = await resourceObject.getDisplayedResources({
-              keyword: listType
-            })
-            return actualList.includes(resource)
-          },
-          {
-            message: `Waiting for resource "${resource}" to appear in search results`,
-            timeout: 30000, // 30 seconds for tika indexing
-            intervals: [500, 1000, 2000] // Retry with increasing delays
-          }
-        )
-        .toBe(true)
-    }
-  } else {
-    const actualList = await resourceObject.getDisplayedResources({
-      keyword: listType
-    })
-    for (const resource of resources) {
-      expect(actualList).toContain(resource)
-    }
+
+  // search list waits longer for tika full-text indexing; other lists only need UI render time
+  const timeout = listType === 'search list' ? 30000 : 10000
+
+  for (const resource of resources) {
+    await expect
+      .poll(
+        async () => {
+          const actualList = await resourceObject.getDisplayedResources({
+            keyword: listType
+          })
+          return actualList.includes(resource)
+        },
+        {
+          message: `Waiting for resource "${resource}" to appear in ${listType}`,
+          timeout,
+          intervals: [500, 1000, 2000]
+        }
+      )
+      .toBe(true)
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
### Problem
`Search for content of file` was failing intermittently with an empty files list assertion after filtering search results by tag. The files list hadn't fully rendered by the time the assertion fired.

### Root Cause
`userShouldSeeResources` only used `expect.poll` for `search list` type (to handle tika indexing delays). The `else` branch for `files list` used a single snapshot assertion with no retry, making it vulnerable to UI 
rendering timing.

### Fix
Unified the polling logic across all list types, removing the `if/else` split. All list types now use `expect.poll` with type-specific timeouts:
- `search list` → 30s (tika indexing)
- everything else → 10s (UI rendering)

## Fixes
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes: https://github.com/owncloud/web/issues/13694

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To fix flakiness

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test passed 40 consecutive runs (2 × 20) after the fix while running locally

## Screenshots (if appropriate):

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->

