### PR TITLE
ci: run release makefile directly

### DIFF
--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -41,6 +41,12 @@ jobs:
         env:
           NO_INSTALL: 'true'
 
+      - name: Generate checksums
+        run: |
+          cd ${{ github.workspace }}/release
+          md5sum * > md5sum.txt
+          sha256sum * > sha256sum.txt
+
       - name: Get release version
         id: version
         run: echo "version=$(echo '${{ github.ref_name }}' | sed 's/^v//' | cut -d- -f1)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -37,7 +37,7 @@ jobs:
         run: pnpm install
 
       - name: Build release
-        run: make release
+        run: make -f Makefile.release
         env:
           NO_INSTALL: 'true'
 


### PR DESCRIPTION
## Description

The default makefile first runs clean which combined with the `NO_INSTALL` env var leads to missing node_modules. Running the release makefile skips the clean and also aligns the workflow with how we were doing it in drone.

## Motivation and Context

Working release workflow.

## How Has This Been Tested?

Will be tested after merge via tag.
