### PR TITLE
fix: the translation-sync action needs a permission fix

### DIFF
--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -5,7 +5,8 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   sync:


### PR DESCRIPTION
The `translation-sync` action does currently not run due to a permission error (fixed in ocis already)

**Error:** `The workflow is requesting 'contents: read', but is only allowed 'contents: none'.`

This PR fixes the issue.