### PR TITLE
feat: show correct modal when user clicks on 3 dots menu to trigger saveAs/open

### DIFF
--- a/changelog/unreleased/enhancement-show-correct-modal-for-save-as-and-open.md
+++ b/changelog/unreleased/enhancement-show-correct-modal-for-save-as-and-open.md
@@ -1,0 +1,5 @@
+Enhancement: Show correct modal when user clicks on 3 dots menu to trigger saveAs/open
+
+We've added logic to show the correct modal when the user clicks on "Save As" or "Open" from the 3 dots context menu.
+
+https://github.com/owncloud/web/pull/13759

--- a/packages/web-pkg/src/composables/actions/files/useFileActions.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActions.ts
@@ -4,7 +4,7 @@ import { isShareSpaceResource } from '@ownclouders/web-client'
 import { routeToContextQuery } from '../../appDefaults'
 import { isLocationTrashActive } from '../../../router'
 import { computed, unref } from 'vue'
-import { useRouter } from '../../router'
+import { useRouter, useRoute } from '../../router'
 import { useGettext } from 'vue3-gettext'
 import {
   Action,
@@ -53,6 +53,7 @@ export interface GetFileActionsOptions extends FileActionOptions {
 export const useFileActions = () => {
   const appsStore = useAppsStore()
   const router = useRouter()
+  const route = useRoute()
   const { $gettext } = useGettext()
   const isSearchActive = useIsSearchActive()
   const { isEnabled: isEmbedModeEnabled } = useEmbedMode()
@@ -221,6 +222,7 @@ export const useFileActions = () => {
         driveAliasAndItem: space?.getDriveAliasAndItem(resource),
         filePath: resource.path,
         fileId: resource.fileId,
+        scope: route.value.params.scope,
         mode
       },
       query: {


### PR DESCRIPTION
We've added logic to show the correct modal when the user clicks on "Save As" or "Open" from the 3 dots context menu.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
