### PR TITLE
fix(sse): use spaceid instead of itemid when refreshing drive on space membership SSE events

### DIFF
--- a/packages/web-runtime/src/container/sse/shares.ts
+++ b/packages/web-runtime/src/container/sse/shares.ts
@@ -21,7 +21,7 @@ export const onSSESpaceMemberAddedEvent = async ({
   }
 
   const space = await clientService.graphAuthenticated.drives.getDrive(
-    sseData.itemid,
+    sseData.spaceid,
     sharesStore.graphRoles
   )
   spacesStore.upsertSpace(space)
@@ -51,7 +51,7 @@ export const onSSESpaceMemberRemovedEvent = async ({
 
   if (!sseData.affecteduserids?.includes(userStore.user.id)) {
     const space = await clientService.graphAuthenticated.drives.getDrive(
-      sseData.itemid,
+      sseData.spaceid,
       sharesStore.graphRoles
     )
     return spacesStore.upsertSpace(space)
@@ -98,7 +98,7 @@ export const onSSESpaceShareUpdatedEvent = async ({
   }
 
   const space = await clientService.graphAuthenticated.drives.getDrive(
-    sseData.itemid,
+    sseData.spaceid,
     sharesStore.graphRoles
   )
   spacesStore.upsertSpace(space)


### PR DESCRIPTION
## Summary

- In the three SSE handlers for space membership changes (`space-member-added`, `space-member-removed`, `space-share-updated`), `getDrive` was called with `sseData.itemid` instead of `sseData.spaceid`
- `itemid` carries the item-ID format (`storageId$spaceId!nodeId`), but `getDriveBeta` expects the drive-ID format (`storageId$spaceId`)
- For entitlement-managed spaces using `OCIS_CLAIM_MANAGED_SPACES_REGEXP` with a `gp-` prefix, `nodeId === spaceId`, making the malformed suffix visible and causing an immediate 404

## Root cause

`packages/web-runtime/src/container/sse/shares.ts` lines 24, 54, 101:

```ts
// before (wrong — itemid = storageId$spaceId!nodeId)
getDrive(sseData.itemid, sharesStore.graphRoles)

// after (correct — spaceid = storageId$spaceId)
getDrive(sseData.spaceid, sharesStore.graphRoles)
```

## Call stack (de-minified)

```
SSEAdapter.onmessage          (web-client/src/sse/index.ts:69)
  → registered listener
    → onSSESpaceMember*Event  (web-runtime/src/container/sse/shares.ts)
      → getDrive              (web-client/src/graph/drives/drives.ts:15)
        → getDriveBeta        → GET /graph/v1beta1/drives/{wrongId} → 404
```

## Test plan

- [ ] In an oCIS deployment with `OCIS_CLAIM_MANAGED_SPACES_REGEXP` configured, open a project space with a `gp-` prefix as one browser tab
- [ ] In another tab/session, add or remove a space member
- [ ] Verify no 404 appears in the network tab for `/graph/v1beta1/drives/…` in the first tab
- [ ] Verify the space membership change is reflected in the first tab's UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)