### PR TITLE
feat(web-pkg, web-app-files, web-app-search): [OCISDEV-853] add vault:true token to search payload in vault context

### DIFF
--- a/changelog/unreleased/enhancement-add-vault-to-search.md
+++ b/changelog/unreleased/enhancement-add-vault-to-search.md
@@ -1,0 +1,5 @@
+Enhancement: Add vault search separation
+
+We've implemented vault search separation by adding the `vault:true` query token to the `<oc:pattern>` search payload. The token is now included in both "All files" and "Current folder" search requests, ensuring vault content is correctly scoped in all search scenarios.
+
+https://github.com/owncloud/web/pull/13769

--- a/packages/web-app-files/src/components/Search/List.vue
+++ b/packages/web-app-files/src/components/Search/List.vue
@@ -342,7 +342,8 @@ const doSearch = (manuallyUpdateFilterChip = false) => {
     lastModified,
     mediaType,
     scope: queryItemAsString(unref(scopeQuery)),
-    useScope: unref(doUseScope) === 'true'
+    useScope: unref(doUseScope) === 'true',
+    isVault: unref(route).params?.scope === 'vault'
   })
 
   const updateFilter = (v: Ref<InstanceType<typeof ItemFilter>>) => {

--- a/packages/web-app-search/src/portals/SearchBar.vue
+++ b/packages/web-app-search/src/portals/SearchBar.vue
@@ -498,6 +498,10 @@ const search = async () => {
     terms.push(`scope:${unref(scope)}`)
   }
 
+  if (unref(route).params?.scope === 'vault') {
+    terms.push('vault:true')
+  }
+
   loading.value = true
 
   for (const availableProvider of unref(availableProviders)) {

--- a/packages/web-app-search/tests/unit/portals/SearchBar.spec.ts
+++ b/packages/web-app-search/tests/unit/portals/SearchBar.spec.ts
@@ -269,6 +269,22 @@ describe('Search Bar portal component', () => {
     const spyRouterPushStub = wrapper.vm.$router.push
     expect(spyRouterPushStub).not.toHaveBeenCalled()
   })
+  test('includes vault:true in search term when route scope is vault', async () => {
+    wrapper = getMountedWrapper({ routeParams: { scope: 'vault' } }).wrapper
+    wrapper.find(selectors.searchInput).setValue('albert')
+    await flushPromises()
+    expect(providerFiles.previewSearch.search).toHaveBeenCalledWith(
+      expect.stringContaining('vault:true')
+    )
+  })
+  test('does not include vault:true in search term when route scope is not vault', async () => {
+    wrapper = getMountedWrapper().wrapper
+    wrapper.find(selectors.searchInput).setValue('albert')
+    await flushPromises()
+    expect(providerFiles.previewSearch.search).not.toHaveBeenCalledWith(
+      expect.stringContaining('vault:true')
+    )
+  })
 })
 
 type Mocks = {
@@ -284,7 +300,8 @@ function getMountedWrapper({
   userContextReady = true,
   providers = [providerFiles, providerContacts],
   route = 'files-spaces-generic',
-  store = {}
+  store = {},
+  routeParams = {} as Record<string, string>
 } = {}) {
   vi.mocked(useAvailableProviders).mockReturnValue(ref(providers))
 
@@ -293,7 +310,8 @@ function getMountedWrapper({
     query: {
       term: mocks?.$route?.query?.term || '',
       provider: ''
-    }
+    },
+    params: routeParams
   })
   const localMocks = {
     ...defaultComponentMocks({ currentRoute }),

--- a/packages/web-pkg/src/composables/search/useSearch.ts
+++ b/packages/web-pkg/src/composables/search/useSearch.ts
@@ -78,7 +78,8 @@ export const useSearch = () => {
     lastModified,
     mediaType,
     scope,
-    useScope
+    useScope,
+    isVault
   }: {
     term: string
     isTitleOnlySearch?: boolean
@@ -87,6 +88,7 @@ export const useSearch = () => {
     mediaType?: string
     scope?: string
     useScope?: boolean
+    isVault?: boolean
   }) => {
     const query: string[] = []
 
@@ -120,6 +122,11 @@ export const useSearch = () => {
       const mediatypes = mediaType.split('+').map((t) => `"${t}"`)
       query.push(`mediatype:(${mediatypes.join(' OR ')})`)
     }
+
+    if (isVault) {
+      query.push('vault:true')
+    }
+
     return query
       .sort((a, b) => Number(a.startsWith('scope:')) - Number(b.startsWith('scope:')))
       .join(' AND ')

--- a/packages/web-pkg/tests/unit/composables/search/useSearch.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/search/useSearch.spec.ts
@@ -3,6 +3,44 @@ import { CapabilityStore, useSearch } from '../../../../src/composables'
 import { SearchResource, SpaceResource } from '@ownclouders/web-client'
 
 describe('useSearch', () => {
+  describe('method "buildSearchTerm"', () => {
+    it('appends vault:true when isVault is true', () => {
+      const wrapper = createWrapper()
+      const result = wrapper.vm.buildSearchTerm({ term: 'test', isVault: true })
+      expect(result).toContain('vault:true')
+    })
+    it('does not append vault:true when isVault is false', () => {
+      const wrapper = createWrapper()
+      const result = wrapper.vm.buildSearchTerm({ term: 'test', isVault: false })
+      expect(result).not.toContain('vault:true')
+    })
+    it('does not append vault:true when isVault is undefined', () => {
+      const wrapper = createWrapper()
+      const result = wrapper.vm.buildSearchTerm({ term: 'test' })
+      expect(result).not.toContain('vault:true')
+    })
+    it('combines vault:true with other query parts', () => {
+      const wrapper = createWrapper()
+      const result = wrapper.vm.buildSearchTerm({
+        term: 'test',
+        tags: 'lorem',
+        isVault: true
+      })
+      expect(result).toContain('vault:true')
+      expect(result).toContain('tag:("lorem")')
+      expect(result).toContain('name:"*test*"')
+    })
+    it('places scope: at the end of the query', () => {
+      const wrapper = createWrapper()
+      const result = wrapper.vm.buildSearchTerm({
+        term: 'test',
+        scope: 'lorem',
+        useScope: true,
+        isVault: true
+      })
+      expect(result).toMatch(/scope:lorem$/)
+    })
+  })
   describe('method "search"', () => {
     it('can search', async () => {
       const files = [
@@ -58,10 +96,11 @@ const createWrapper = ({ resources = [] }: { resources?: SearchResource[] } = {}
 
   return getComposableWrapper(
     () => {
-      const { search } = useSearch()
+      const { search, buildSearchTerm } = useSearch()
 
       return {
-        search
+        search,
+        buildSearchTerm
       }
     },
     {


### PR DESCRIPTION
## Description
Implements vault search separation by appending the `vault:true` query token to the `<oc:pattern>` search payload when the user is in the vault context.

The token is injected in both **All files** and **Current folder** search scenarios:

```xml
<!-- All files -->
<oc:pattern>(name:"*foo*" OR content:"foo") vault:true</oc:pattern>

<!-- Current folder -->
<oc:pattern>(name:"*foo*" OR content:"foo") vault:true scope:&lt;space-id&gt;</oc:pattern>
```

## Related Issue
- Fixes https://jira.owncloud.com/browse/OCISDEV-853

## Motivation and Context
Without this token, searching in the vault context would return results from all spaces. The `vault:true` token ensures the backend scopes the search correctly to vault content only.

## How Has This Been Tested?
- test environment: oCIS local + Docker
- test case 1: Search in vault context — verify `vault:true` appears in the request payload and results are scoped to vault
- test case 2: Search outside vault context — verify `vault:true` is NOT included in the request payload

