### PR TITLE
[OCISDEV-843] Flaky search test

### DIFF
--- a/tests/e2e/specs/search/search.spec.ts
+++ b/tests/e2e/specs/search/search.spec.ts
@@ -265,6 +265,9 @@ test.describe('Search', { tag: '@predefined-users' }, () => {
     })
 
     // # search difficult names
+    // allow extra time for search indexing of Unicode folder name after rename operations
+    const { page } = world.actorsEnvironment.getActor({ key: 'Alice' })
+    await page.waitForTimeout(2000)
     // When "Alice" searches "strängéनेपालीName" using the global search and the "all files" filter and presses enter
     await ui.userSearchesGloballyWithFilter({
       world,


### PR DESCRIPTION
## Summary
- Adds extra wait time (2s) before the Unicode search for `strängéनेपालीName` to allow the search index to catch up after preceding rename operations
- Fixes intermittent timeout failure where the search index hadn't processed the Unicode folder name in time

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes [#OCISDEV-843](https://kiteworks.atlassian.net/browse/OCISDEV-843)


## Test plan
- [x] Verify the "Search in personal spaces" test passes consistently in CI
- [x] Check that no new test regressions are introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)