### PR TITLE
bugfix(web-app-files): [OCISDEV-862] Fix share invite button being pushed down in space sharing

### DIFF
--- a/changelog/unreleased/bugfix-share-invite-button-pushed-down.md
+++ b/changelog/unreleased/bugfix-share-invite-button-pushed-down.md
@@ -1,0 +1,5 @@
+Bugfix: Fix share invite button being pushed down in space sharing
+
+We have fixed a bug where the "Share" button in the invite collaborator form was being pushed down when sharing a space. The layout now properly aligns items vertically and prevents the button from wrapping to a new line.
+
+https://github.com/owncloud/web/pull/13793

--- a/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/Collaborators/InviteCollaborator/InviteCollaboratorForm.vue
@@ -82,7 +82,7 @@
         </template>
       </oc-select>
     </div>
-    <div class="oc-flex oc-flex-between oc-flex-wrap oc-mb-l oc-mt-s">
+    <div class="oc-flex oc-flex-between oc-flex-middle oc-mb-l oc-mt-s">
       <role-dropdown
         mode="create"
         :show-icon="isRunningOnEos"
@@ -90,7 +90,7 @@
         :is-external="isExternalShareRoleType"
         @option-change="collaboratorRoleChanged"
       />
-      <div class="oc-flex oc-flex-middle">
+      <div class="oc-flex oc-flex-middle oc-flex-nowrap">
         <expiration-date-indicator
           v-if="expirationDate"
           :expiration-date="DateTime.fromISO(expirationDate)"
@@ -135,14 +135,9 @@
           <span v-text="$gettext(saveButtonText)" />
         </oc-button>
       </div>
-      <div class="oc-width-1-1 oc-mt-s">
-        <oc-checkbox
-          v-if="isRunningOnEos"
-          v-model="notifyEnabled"
-          :value="false"
-          :label="$gettext('Notify via mail')"
-        />
-      </div>
+    </div>
+    <div v-if="isRunningOnEos" class="oc-mb-l">
+      <oc-checkbox v-model="notifyEnabled" :value="false" :label="$gettext('Notify via mail')" />
     </div>
     <oc-hidden-announcer level="assertive" :announcement="announcement" />
   </div>
@@ -577,6 +572,7 @@ function resetFocusOnInvite(event: CollaboratorAutoCompleteItem[]) {
 #new-collaborators-form-create-button {
   padding-left: 30px;
   padding-right: 30px;
+  white-space: nowrap;
 
   .oc-spinner {
     margin-left: -0.5rem;


### PR DESCRIPTION
## Description
Fixes the layout of the invite collaborator form where the "Share" button was being pushed down to a new line when sharing a space. The changes include:

- Replaced `oc-flex-wrap` with `oc-flex-middle` on the main action row to vertically center items and prevent wrapping
- Added `oc-flex-nowrap` to the button container to keep the expiration indicator and share button on the same line
- Moved the "Notify via mail" checkbox out of the flex row into its own block-level container, so it no longer affects the
  button positioning
- Added `white-space: nowrap` to the share button to prevent its text from breaking across lines

## Related Issue
- Fixes https://kiteworks.atlassian.net/browse/OCISDEV-862

## Motivation and Context
When sharing a space, the additional UI elements (role dropdown, expiration indicator) caused the "Share" button to be pushed below the action row. This made the form look broken and was confusing to users.

## How Has This Been Tested?
- test environment: local dev server with oCIS backend
- test case 1: Open sidebar → share a space with a user → verify the Share button stays inline with the role dropdown
- test case 2: Set an expiration date → verify the expiration indicator, share button, and role dropdown all remain on the same row
- test case 3: Regular file/folder sharing still renders correctly