### PR TITLE
fix(files-drop): Fix upload confirmation not visible at small viewports

### DIFF
--- a/changelog/unreleased/bugfix-files-drop-upload-info-not-visible.md
+++ b/changelog/unreleased/bugfix-files-drop-upload-info-not-visible.md
@@ -1,0 +1,5 @@
+Bugfix: Fix upload confirmation not visible on file drop page
+
+We've fixed a responsive layout issue where the upload confirmation message was not visible at small browser window sizes on the file drop page. The `UploadInfo` panel was being clipped due to broken CSS. The layout now uses natural document flow so the confirmation is always visible regardless of viewport size.
+
+https://github.com/owncloud/web/pull/13796

--- a/packages/web-app-files/src/views/FilesDrop.vue
+++ b/packages/web-app-files/src/views/FilesDrop.vue
@@ -35,10 +35,10 @@
             </div>
           </div>
 
-          <div class="oc-overflow-hidden">
+          <div>
             <upload-info
               id="files-drop-upload-info"
-              class="oc-width-1-1 oc-height-1-1 oc-overflow-hidden oc-display-grid"
+              class="oc-width-1-1 oc-height-1-1"
               :info-expanded-initial="true"
               :headless="true"
               :show-expand-details-button="false"
@@ -331,6 +331,7 @@ defineExpose({ loading })
     padding: var(--oc-space-medium);
     border: none;
     position: relative;
+    overflow-y: auto;
 
     @media (min-width: $oc-breakpoint-small-default) {
       border: 3px dashed var(--oc-color-input-border);
@@ -392,9 +393,5 @@ defineExpose({ loading })
   bottom: 0;
   position: absolute;
   z-index: 9;
-}
-
-#files-drop-upload-info {
-  grid-template-columns: max-content;
 }
 </style>


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Fix a responsive design issue where the upload confirmation message was not visible on the file drop page.

Refactor the layout to use natural document flow instead of fragile height-dependent CSS

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes [OCISDEV-703](https://kiteworks.atlassian.net/browse/OCISDEV-703)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The upload confirmation message was invisible at small browser window sizes when using file drop links. The UploadInfo panel was placed in a 1fr grid row whose height depended on a broken height: 100% chain from the root element. The oc-overflow hidden wrapper then silently clipped the collapsed panel. This caused users to be unable to confirm their upload succeeded

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: Chrome on macOS,
- test case 1: Open a file drop link at small viewport, upload a file. confirmation message is now visible immediately
- test case 2: Resize from large to small viewport after upload. confirmation remains visible
- ...

## Screenshots (if appropriate):

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
