### PR TITLE
[OCISDEV-843] Flaky search test - 2nd fix

### DIFF
--- a/tests/e2e/specs/search/search.spec.ts
+++ b/tests/e2e/specs/search/search.spec.ts
@@ -282,7 +282,7 @@ test.describe('Search', { tag: '@predefined-users' }, () => {
     //   | strängéनेपालीName |
     await ui.userShouldSeeResources({
       world,
-      listType: resourcePage.searchList,
+      listType: resourcePage.filesList,
       stepUser: 'Alice',
       resources: ['strängéनेपालीName']
     })

--- a/tests/e2e/specs/search/search.spec.ts
+++ b/tests/e2e/specs/search/search.spec.ts
@@ -265,6 +265,9 @@ test.describe('Search', { tag: '@predefined-users' }, () => {
     })
 
     // # search difficult names
+    // allow extra time for search indexing of Unicode folder name after rename operations
+    const { page } = world.actorsEnvironment.getActor({ key: 'Alice' })
+    await page.waitForTimeout(5000)
     // When "Alice" searches "strängéनेपालीName" using the global search and the "all files" filter and presses enter
     await ui.userSearchesGloballyWithFilter({
       world,
@@ -279,7 +282,7 @@ test.describe('Search', { tag: '@predefined-users' }, () => {
     //   | strängéनेपालीName |
     await ui.userShouldSeeResources({
       world,
-      listType: resourcePage.filesList,
+      listType: resourcePage.searchList,
       stepUser: 'Alice',
       resources: ['strängéनेपालीName']
     })

--- a/tests/e2e/specs/search/search.spec.ts
+++ b/tests/e2e/specs/search/search.spec.ts
@@ -265,9 +265,6 @@ test.describe('Search', { tag: '@predefined-users' }, () => {
     })
 
     // # search difficult names
-    // allow extra time for search indexing of Unicode folder name after rename operations
-    const { page } = world.actorsEnvironment.getActor({ key: 'Alice' })
-    await page.waitForTimeout(2000)
     // When "Alice" searches "strängéनेपालीName" using the global search and the "all files" filter and presses enter
     await ui.userSearchesGloballyWithFilter({
       world,
@@ -282,7 +279,7 @@ test.describe('Search', { tag: '@predefined-users' }, () => {
     //   | strängéनेपालीName |
     await ui.userShouldSeeResources({
       world,
-      listType: resourcePage.searchList,
+      listType: resourcePage.filesList,
       stepUser: 'Alice',
       resources: ['strängéनेपालीName']
     })


### PR DESCRIPTION
## Summary
- Uses `resourcePage.filesList` instead of `resourcePage.searchList` for asserting search results after pressing Enter
- After pressing Enter, the test navigates to the full search results page which renders via `ResourceTable` with `[data-test-resource-path]` selectors — NOT the dropdown (`#files-global-search-options`)
- Removes the unnecessary 2000ms `waitForTimeout` workaround from the first fix attempt


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes [#OCISDEV-843](https://kiteworks.atlassian.net/browse/OCISDEV-843)


## Test plan
- [x] Verify the "Search in personal spaces" test passes consistently in CI
- [x] Confirm no regressions in other search tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)