### PR TITLE
feat: [OCISDEV-527] check vault permission

### DIFF
--- a/changelog/unreleased/enhancement-check-vault-permission.md
+++ b/changelog/unreleased/enhancement-check-vault-permission.md
@@ -1,0 +1,5 @@
+Enhancement: Check vault permission
+
+When the user has the `VaultMode.ReadWriteEnabled.own` permission, the mode switch will be shown in the topbar.
+
+https://github.com/owncloud/web/pull/13802

--- a/packages/web-client/src/helpers/resource/types.ts
+++ b/packages/web-client/src/helpers/resource/types.ts
@@ -27,6 +27,7 @@ export type AbilitySubjects =
   | 'Role'
   | 'Setting'
   | 'Share'
+  | 'Vault'
 
 export type Ability = MongoAbility<[AbilityActions, AbilitySubjects]>
 export type AbilityRule = SubjectRawRule<AbilityActions, AbilitySubjects, any>

--- a/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -19,7 +19,7 @@
           class="oc-logo-image"
         />
       </router-link>
-      <div v-if="!isEmbedModeEnabled" class="oc-flex oc-flex-middle">
+      <div v-if="!isEmbedModeEnabled && canAccessVault" class="oc-flex oc-flex-middle">
         <oc-button
           id="oc-topbar-mode-switch-btn"
           class="oc-topbar-mode-switch"
@@ -95,7 +95,8 @@ import {
   useOpenEmptyEditor,
   useRouter,
   useThemeStore,
-  useClipboardStore
+  useClipboardStore,
+  useAbility
 } from '@ownclouders/web-pkg'
 import { useGettext } from 'vue3-gettext'
 import { isRuntimeRoute } from '../../router'
@@ -128,6 +129,7 @@ export default {
     const extensionRegistry = useExtensionRegistry()
     const { openEmptyEditor } = useOpenEmptyEditor()
     const { clearClipboard } = useClipboardStore()
+    const ability = useAbility()
 
     const authStore = useAuthStore()
     const router = useRouter()
@@ -212,6 +214,8 @@ export default {
       }
     })
 
+    const canAccessVault = computed(() => ability.can('read-all', 'Vault'))
+
     return {
       configOptions,
       contentOnLeftPortal,
@@ -229,7 +233,8 @@ export default {
       hideAccountMenu,
       isUniversalAccessEnabled,
       modeOptions,
-      selectedMode
+      selectedMode,
+      canAccessVault
     }
   },
   computed: {

--- a/packages/web-runtime/src/services/auth/abilities.ts
+++ b/packages/web-runtime/src/services/auth/abilities.ts
@@ -51,7 +51,8 @@ export const getAbilities = (
       { action: 'update-all', subject: 'Drive' }
     ],
     'Drives.List.all': [{ action: 'read-all', subject: 'Drive' }],
-    'Drives.ReadWriteProjectQuota.all': [{ action: 'set-quota-all', subject: 'Drive' }]
+    'Drives.ReadWriteProjectQuota.all': [{ action: 'set-quota-all', subject: 'Drive' }],
+    'VaultMode.ReadWriteEnabled.own': [{ action: 'read-all', subject: 'Vault' }]
   }
 
   return Object.keys(abilities).reduce((acc, permission) => {


### PR DESCRIPTION
## Description

When the user has the `VaultMode.ReadWriteEnabled.own` permission, the mode switch will be shown in the topbar.

## Related Issue

- https://kiteworks.atlassian.net/browse/OCISDEV-527

## Motivation and Context

Users who hasn't got permissions to access vault should not see the mode switcher so that they do not try to access it.

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: open web with admin user
- test case 2: open web with regular user
- test case 3: open web with light user
