### PR TITLE
feat(web-runtime, web-pkg, web-client, web-app-files): [OCISDEV-534] add MFA session expiry warning and session extension

### DIFF
--- a/changelog/unreleased/enhancement-mfa-session-expiry-warning.md
+++ b/changelog/unreleased/enhancement-mfa-session-expiry-warning.md
@@ -1,0 +1,5 @@
+Enhancement: MFA session expiry warning
+
+We've added a warning modal that notifies users before their multi-factor authentication session expires. Users can extend the session via silent OIDC renewal or dismiss the warning. The modal state is synchronized across multiple browser tabs using a BroadcastChannel.
+
+https://github.com/owncloud/web/pull/13803

--- a/packages/web-app-files/tests/unit/components/Spaces/__snapshots__/SpaceHeader.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/Spaces/__snapshots__/SpaceHeader.spec.ts.snap
@@ -21,7 +21,7 @@ exports[`SpaceHeader > should add the "squashed"-class when the sidebar is opene
         </div>
       </div> <button type="button" aria-label="Open context menu and show members" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
         <!--v-if-->
-        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">19 members</span>
+        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">21 members</span>
       </button>
     </div>
     <!--v-if-->
@@ -52,7 +52,7 @@ exports[`SpaceHeader > space description > should show the description 1`] = `
         </div>
       </div> <button type="button" aria-label="Open context menu and show members" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
         <!--v-if-->
-        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">19 members</span>
+        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">21 members</span>
       </button>
     </div>
     <!--v-if-->
@@ -86,7 +86,7 @@ exports[`SpaceHeader > space image > should show the default image if no other i
         </div>
       </div> <button type="button" aria-label="Open context menu and show members" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
         <!--v-if-->
-        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">19 members</span>
+        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">21 members</span>
       </button>
     </div>
     <!--v-if-->
@@ -115,7 +115,7 @@ exports[`SpaceHeader > space image > should show the set image 1`] = `
         </div>
       </div> <button type="button" aria-label="Open context menu and show members" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
         <!--v-if-->
-        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">19 members</span>
+        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">21 members</span>
       </button>
     </div>
     <!--v-if-->

--- a/packages/web-client/src/ocs/capabilities.ts
+++ b/packages/web-client/src/ocs/capabilities.ts
@@ -54,6 +54,7 @@ interface AuthCapability {
   mfa: {
     enabled?: boolean
     levelnames?: string[]
+    session_duration?: number
   }
 }
 

--- a/packages/web-pkg/src/composables/piniaStores/capabilities.ts
+++ b/packages/web-pkg/src/composables/piniaStores/capabilities.ts
@@ -153,6 +153,7 @@ export const useCapabilityStore = defineStore('capabilities', () => {
 
   const authMfaEnabled = computed(() => unref(capabilities).auth.mfa.enabled)
   const authMfaRequiredLevelname = computed(() => unref(capabilities).auth.mfa.levelnames.at(0))
+  const authMfaSessionDuration = computed(() => unref(capabilities).auth.mfa.session_duration)
 
   return {
     isInitialized,
@@ -202,7 +203,8 @@ export const useCapabilityStore = defineStore('capabilities', () => {
     searchMediaType,
     searchContent,
     authMfaEnabled,
-    authMfaRequiredLevelname
+    authMfaRequiredLevelname,
+    authMfaSessionDuration
   }
 })
 

--- a/packages/web-pkg/src/composables/webWorkers/index.ts
+++ b/packages/web-pkg/src/composables/webWorkers/index.ts
@@ -1,4 +1,5 @@
 export * from './deleteWorker'
+export * from './mfaExpiryWorker'
 export * from './pasteWorker'
 export * from './restoreWorker'
 export * from './tokenTimerWorker'

--- a/packages/web-pkg/src/composables/webWorkers/mfaExpiryWorker/index.ts
+++ b/packages/web-pkg/src/composables/webWorkers/mfaExpiryWorker/index.ts
@@ -1,0 +1,1 @@
+export * from './useMfaExpiryWorker'

--- a/packages/web-pkg/src/composables/webWorkers/mfaExpiryWorker/useMfaExpiryWorker.ts
+++ b/packages/web-pkg/src/composables/webWorkers/mfaExpiryWorker/useMfaExpiryWorker.ts
@@ -1,0 +1,49 @@
+import { ref, unref } from 'vue'
+import { WebWorker, useWebWorkersStore } from '../../piniaStores/webWorkers'
+import MfaWorker from './worker?worker'
+
+export type MfaExpiryWorkerTopic = 'set' | 'reset'
+
+const MFA_WARNING_THRESHOLD_SECONDS = 300 // 5 minutes before expiry
+
+export const useMfaExpiryWorker = ({ onExpiring }: { onExpiring: () => void }) => {
+  const { createWorker } = useWebWorkersStore()
+
+  const worker = ref<WebWorker>()
+
+  const startWorker = () => {
+    worker.value = createWorker(MfaWorker as unknown as string)
+
+    unref(unref(worker).worker).onmessage = () => {
+      onExpiring()
+    }
+  }
+
+  const setMfaTimer = ({ authTime, sessionDuration }: { authTime: number; sessionDuration: number }) => {
+    if (!unref(worker)) {
+      console.error('mfa expiry worker is not running')
+      return
+    }
+
+    const expiresAt = authTime + sessionDuration
+
+    unref(worker).post(
+      JSON.stringify({
+        topic: 'set',
+        expiresAt,
+        warningThreshold: MFA_WARNING_THRESHOLD_SECONDS
+      })
+    )
+  }
+
+  const resetMfaTimer = () => {
+    if (!unref(worker)) {
+      console.error('mfa expiry worker is not running')
+      return
+    }
+
+    unref(worker).post(JSON.stringify({ topic: 'reset' }))
+  }
+
+  return { startWorker, setMfaTimer, resetMfaTimer }
+}

--- a/packages/web-pkg/src/composables/webWorkers/mfaExpiryWorker/worker.ts
+++ b/packages/web-pkg/src/composables/webWorkers/mfaExpiryWorker/worker.ts
@@ -1,0 +1,35 @@
+import { MfaExpiryWorkerTopic } from './useMfaExpiryWorker'
+
+type Message = {
+  topic: MfaExpiryWorkerTopic
+  expiresAt: number
+  warningThreshold: number
+}
+
+let timerId: ReturnType<typeof setTimeout>
+
+const resetTimer = () => {
+  clearTimeout(timerId)
+  timerId = undefined
+}
+
+self.onmessage = (e: MessageEvent) => {
+  const { topic, expiresAt, warningThreshold } = JSON.parse(e.data) as Message
+
+  if (topic === 'reset') {
+    resetTimer()
+    return
+  }
+
+  const now = Math.floor(Date.now() / 1000)
+  let timerInSeconds = expiresAt - warningThreshold - now
+  if (timerInSeconds <= 0) {
+    timerInSeconds = 1
+  }
+
+  resetTimer()
+
+  timerId = setTimeout(() => {
+    postMessage(true)
+  }, timerInSeconds * 1000)
+}

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -7,6 +7,8 @@ import {
   CapabilityStore,
   ConfigStore,
   useTokenTimerWorker,
+  useMfaExpiryWorker,
+  useModals,
   AuthServiceInterface
 } from '@ownclouders/web-pkg'
 import { RouteLocation, Router } from 'vue-router'
@@ -39,6 +41,11 @@ export class AuthService implements AuthServiceInterface {
 
   private tokenTimerWorker: ReturnType<typeof useTokenTimerWorker>
   private tokenTimerInitialized = false
+
+  private mfaExpiryWorker: ReturnType<typeof useMfaExpiryWorker>
+  private mfaExpiryModalDismissed = false
+  private mfaExpiryModalId: string | null = null
+  private mfaExpiryBroadcastChannel: BroadcastChannel
 
   // number of seconds before an access token is to expire to raise the accessTokenExpiring event
   private accessTokenExpiryThreshold = 10
@@ -119,6 +126,12 @@ export class AuthService implements AuthServiceInterface {
         if (!options.embed?.enabled || !options.embed?.delegateAuthentication) {
           this.tokenTimerWorker = useTokenTimerWorker({ authService: this })
           this.tokenTimerWorker.startWorker()
+
+          this.mfaExpiryWorker = useMfaExpiryWorker({
+            onExpiring: () => this.showMfaExpiryWarning()
+          })
+          this.mfaExpiryWorker.startWorker()
+          this.initMfaExpiryBroadcastChannel()
         }
       }
     }
@@ -168,6 +181,7 @@ export class AuthService implements AuthServiceInterface {
           )
           try {
             await this.userManager.updateContext(user.access_token, fetchUserData)
+            this.updateMfaExpiryTimer(user.profile?.auth_time as number | undefined)
           } catch (e) {
             console.error(e)
             await this.handleAuthError(unref(this.router.currentRoute))
@@ -177,6 +191,7 @@ export class AuthService implements AuthServiceInterface {
         this.userManager.events.addUserUnloaded(() => {
           console.log('user unloaded…')
           this.tokenTimerWorker?.resetTokenTimer()
+          this.mfaExpiryWorker?.resetMfaTimer()
           this.resetStateAfterUserLogout()
 
           if (this.userManager.unloadReason === 'authError') {
@@ -228,6 +243,8 @@ export class AuthService implements AuthServiceInterface {
               expiryThreshold: this.accessTokenExpiryThreshold
             })
 
+            this.updateMfaExpiryTimer(user.profile?.auth_time as number | undefined)
+
             this.tokenTimerInitialized = true
           }
         } catch (e) {
@@ -265,6 +282,11 @@ export class AuthService implements AuthServiceInterface {
         window.addEventListener('message', this.handleDelegatedTokenUpdate)
       } else {
         await this.userManager.signinRedirectCallback(this.buildSignInCallbackUrl())
+      }
+
+      const user = await this.userManager.getUser()
+      if (user) {
+        this.updateMfaExpiryTimer(user.profile?.auth_time as number | undefined)
       }
 
       const redirectRoute = this.router.resolve(this.userManager.getAndClearPostLoginRedirectUrl())
@@ -411,6 +433,79 @@ export class AuthService implements AuthServiceInterface {
 
     this.userManager.setPostLoginRedirectUrl(redirectUrl)
     return this.userManager.signinRedirect({ acr_values: acrValue })
+  }
+
+  private updateMfaExpiryTimer(authTime: number | undefined) {
+    if (!this.mfaExpiryWorker) {
+      return
+    }
+
+    const sessionDuration = this.capabilityStore.authMfaSessionDuration
+    if (!authTime || !sessionDuration) {
+      return
+    }
+
+    this.mfaExpiryModalDismissed = false
+    this.mfaExpiryWorker.setMfaTimer({ authTime, sessionDuration })
+  }
+
+  private showMfaExpiryWarning() {
+    if (this.mfaExpiryModalDismissed) {
+      return
+    }
+
+    this.mfaExpiryModalDismissed = true
+    const { $gettext } = this.language
+
+    const modalStore = useModals()
+    const modal = modalStore.dispatchModal({
+      title: $gettext('Session expiring'),
+      message: $gettext(
+        'Your multi-factor authentication session is about to expire. Would you like to extend it?'
+      ),
+      confirmText: $gettext('Extend session'),
+      cancelText: $gettext('Dismiss'),
+      onConfirm: async () => {
+        this.mfaExpiryModalId = null
+        this.mfaExpiryBroadcastChannel?.postMessage({ action: 'prolonged' })
+        await this.prolongMfaSession()
+      },
+      onCancel: () => {
+        this.mfaExpiryModalId = null
+        this.mfaExpiryBroadcastChannel?.postMessage({ action: 'dismissed' })
+      }
+    })
+    this.mfaExpiryModalId = modal.id
+  }
+
+  private async prolongMfaSession() {
+    const acrValue = this.capabilityStore.authMfaRequiredLevelname
+    if (!acrValue) {
+      return
+    }
+
+    try {
+      await this.userManager.signinSilent({ acr_values: acrValue })
+    } catch {
+      const redirectUrl = unref(this.router.currentRoute)?.fullPath
+      this.userManager.setPostLoginRedirectUrl(redirectUrl)
+      await this.userManager.signinRedirect({ acr_values: acrValue })
+    }
+  }
+
+  private initMfaExpiryBroadcastChannel() {
+    this.mfaExpiryBroadcastChannel = new BroadcastChannel('oc-mfa-expiry')
+    this.mfaExpiryBroadcastChannel.onmessage = (event: MessageEvent) => {
+      const { action } = event.data
+      if (action === 'prolonged' || action === 'dismissed') {
+        this.mfaExpiryModalDismissed = true
+        if (this.mfaExpiryModalId) {
+          const modalStore = useModals()
+          modalStore.removeModal(this.mfaExpiryModalId)
+          this.mfaExpiryModalId = null
+        }
+      }
+    }
   }
 }
 

--- a/packages/web-runtime/src/services/auth/userManager.ts
+++ b/packages/web-runtime/src/services/auth/userManager.ts
@@ -75,8 +75,8 @@ export class UserManager extends OidcUserManager {
       // we trigger the token renewal manually via a timer running in a web worker
       automaticSilentRenew: false,
 
-      // do not filter acr
-      filterProtocolClaims: ['nbf', 'jti', 'auth_time', 'nonce', 'amr', 'azp', 'at_hash']
+      // do not filter acr and auth_time (needed for MFA session expiry detection)
+      filterProtocolClaims: ['nbf', 'jti', 'nonce', 'amr', 'azp', 'at_hash']
     }
 
     if (options.configStore.isOIDC) {

--- a/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
+++ b/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
@@ -48,6 +48,7 @@ describe('AuthService', () => {
         Object.defineProperty(authService, 'userManager', {
           value: {
             signinRedirectCallback: vi.fn(),
+            getUser: vi.fn().mockResolvedValue(null),
             getAndClearPostLoginRedirectUrl: () => url
           }
         })
@@ -73,6 +74,7 @@ describe('AuthService', () => {
       Object.defineProperty(authService, 'userManager', {
         value: mock<UserManager>({
           getAccessToken: vi.fn().mockResolvedValue('access-token'),
+          getUser: vi.fn().mockResolvedValue(mock<User>({ expires_in: 3600 })),
           updateContext: mockUpdateContext
         })
       })
@@ -107,6 +109,7 @@ describe('AuthService', () => {
       Object.defineProperty(authService, 'userManager', {
         value: mock<UserManager>({
           getAccessToken: vi.fn().mockResolvedValue('access-token'),
+          getUser: vi.fn().mockResolvedValue(mock<User>({ expires_in: 3600 })),
           updateContext: mockUpdateContext
         })
       })
@@ -143,6 +146,7 @@ describe('AuthService', () => {
       Object.defineProperty(authService, 'userManager', {
         value: mock<UserManager>({
           getAccessToken: vi.fn().mockResolvedValue('access-token'),
+          getUser: vi.fn().mockResolvedValue(mock<User>({ expires_in: 3600 })),
           updateContext: mockUpdateContext
         })
       })


### PR DESCRIPTION
## Description

Add a warning modal that notifies users before their MFA session expires. The modal appears 5 minutes before expiry and offers the option to extend the session via silent OIDC renewal (with redirect fallback) or dismiss. A web worker timer handles the countdown to avoid main-thread drift, and a BroadcastChannel synchronizes the modal state across browser tabs.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/OCISDEV-534

## Motivation and Context

Users with MFA-protected sessions had no warning before their session expired, leading to abrupt logouts. This change gives users advance notice and the ability to seamlessly extend their session without losing context.

## How Has This Been Tested?

- test environment: local dev server with oCIS backend, MFA enabled with short session duration for testing
- test case 1: Modal appears ~5 minutes before MFA session expiry
- test case 2: "Extend session" triggers silent OIDC renewal with correct `acr_values`
- test case 3: Fallback to redirect if silent renewal fails
- test case 4: Open multiple tabs, dismiss/extend in one — all tabs update
- test case 5: Non-MFA sessions are unaffected (no modal when `session_duration` is absent)
- test case 6: Embedded mode with delegated auth does not initialize the worker

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Documentation
- [ ] Maintenance (e.g. dependency updates or tooling)