### PR TITLE
Feat/ocisdev 524/mode switch

### DIFF
--- a/changelog/unreleased/enhancement-add-new-theme-colors.md
+++ b/changelog/unreleased/enhancement-add-new-theme-colors.md
@@ -1,0 +1,11 @@
+Enhancement: Add new theme colors
+
+We've added new theme colors. These new colors are:
+
+- background-sidebar
+- search-input-text-default
+- search-input-text-muted
+- search-input-border
+- search-input-bg
+
+https://github.com/owncloud/web/pull/13795

--- a/changelog/unreleased/enhancement-add-vault-to-search.md
+++ b/changelog/unreleased/enhancement-add-vault-to-search.md
@@ -1,0 +1,5 @@
+Enhancement: Add vault search separation
+
+We've implemented vault search separation by adding the `vault:true` query token to the `<oc:pattern>` search payload. The token is now included in both "All files" and "Current folder" search requests, ensuring vault content is correctly scoped in all search scenarios.
+
+https://github.com/owncloud/web/pull/13769

--- a/changelog/unreleased/enhancement-check-vault-permission.md
+++ b/changelog/unreleased/enhancement-check-vault-permission.md
@@ -1,0 +1,5 @@
+Enhancement: Check vault permission
+
+When the user has the `VaultMode.ReadWriteEnabled.own` permission, the mode switch will be shown in the topbar.
+
+https://github.com/owncloud/web/pull/13802

--- a/changelog/unreleased/enhancement-mfa-session-expiry-warning.md
+++ b/changelog/unreleased/enhancement-mfa-session-expiry-warning.md
@@ -1,0 +1,5 @@
+Enhancement: MFA session expiry warning
+
+We've added a warning modal that notifies users before their multi-factor authentication session expires. Users can extend the session via silent OIDC renewal or dismiss the warning. The modal state is synchronized across multiple browser tabs using a BroadcastChannel.
+
+https://github.com/owncloud/web/pull/13803

--- a/changelog/unreleased/enhancement-show-correct-modal-for-save-as-and-open.md
+++ b/changelog/unreleased/enhancement-show-correct-modal-for-save-as-and-open.md
@@ -1,0 +1,5 @@
+Enhancement: Show correct modal when user clicks on 3 dots menu to trigger saveAs/open
+
+We've added logic to show the correct modal when the user clicks on "Save As" or "Open" from the 3 dots context menu.
+
+https://github.com/owncloud/web/pull/13759

--- a/changelog/unreleased/enhancement-show-correct-modal-for-save-as-and-open.md
+++ b/changelog/unreleased/enhancement-show-correct-modal-for-save-as-and-open.md
@@ -1,4 +1,4 @@
-Enhancement: Show correct modal when user clicks on 3 dots menu to trigger saveAs/open
+Enhancement: Show correct modal for saveAs and open actions
 
 We've added logic to show the correct modal when the user clicks on "Save As" or "Open" from the 3 dots context menu.
 

--- a/changelog/unreleased/enhancement-vault-aware-breadcrumbs.md
+++ b/changelog/unreleased/enhancement-vault-aware-breadcrumbs.md
@@ -1,0 +1,5 @@
+Enhancement: Vault-aware breadcrumbs
+
+We've introduced vault-aware breadcrumbs that show Vault or Drive as the root item depending on the active scope. Users without vault access see the original labels instead.
+
+https://github.com/owncloud/web/pull/13803

--- a/packages/design-system/src/components/OcButton/OcButton.vue
+++ b/packages/design-system/src/components/OcButton/OcButton.vue
@@ -187,12 +187,30 @@ const handlers = computed(() => {
     .oc-icon > svg {
       fill: $color;
     }
+
+    &:focus:not([disabled]),
+    &:hover:not([disabled]) {
+      color: $hover-color;
+
+      .oc-icon > svg {
+        fill: $hover-color;
+      }
+    }
   }
   &-raw-inverse {
     color: $contrast-color;
 
     .oc-icon > svg {
       fill: $contrast-color;
+    }
+
+    &:focus:not([disabled]),
+    &:hover:not([disabled]) {
+      color: $contrast-color;
+
+      .oc-icon > svg {
+        fill: $contrast-color;
+      }
     }
   }
 
@@ -340,12 +358,12 @@ const handlers = computed(() => {
     &-outline {
       &:focus:not([disabled]),
       &:hover:not([disabled]) {
-        color: var(--oc-color-swatch-passive-default);
+        color: var(--oc-color-swatch-passive-contrast);
         background-color: var(--oc-color-swatch-passive-hover-outline);
         border-color: var(--oc-color-swatch-passive-hover-outline);
 
         .oc-icon > svg {
-          fill: var(--oc-color-swatch-passive-default);
+          fill: var(--oc-color-swatch-passive-contrast);
         }
       }
     }

--- a/packages/web-app-admin-settings/src/views/Spaces.vue
+++ b/packages/web-app-admin-settings/src/views/Spaces.vue
@@ -126,7 +126,7 @@ const loadResourcesTask = useTask(function* (signal) {
       sharesStore.graphRoles,
       {
         orderBy: 'name asc',
-        filter: 'driveType eq project'
+        filter: "driveType eq 'protected-project'"
       },
       { signal }
     )

--- a/packages/web-app-admin-settings/src/views/Spaces.vue
+++ b/packages/web-app-admin-settings/src/views/Spaces.vue
@@ -126,7 +126,7 @@ const loadResourcesTask = useTask(function* (signal) {
       sharesStore.graphRoles,
       {
         orderBy: 'name asc',
-        filter: "driveType eq 'protected-project'"
+        filter: 'driveType'
       },
       { signal }
     )

--- a/packages/web-app-admin-settings/src/views/Spaces.vue
+++ b/packages/web-app-admin-settings/src/views/Spaces.vue
@@ -126,7 +126,7 @@ const loadResourcesTask = useTask(function* (signal) {
       sharesStore.graphRoles,
       {
         orderBy: 'name asc',
-        filter: 'driveType'
+        filter: 'driveType eq project'
       },
       { signal }
     )

--- a/packages/web-app-files/src/components/AppBar/SharesNavigation.vue
+++ b/packages/web-app-files/src/components/AppBar/SharesNavigation.vue
@@ -1,7 +1,7 @@
 <template>
   <nav id="shares-navigation" class="oc-py-s" :aria-label="$gettext('Shares pages navigation')">
     <oc-list class="oc-flex oc-visible@s">
-      <li v-for="navItem in navItems" :key="`shares-navigation-desktop-${navItem.to}`">
+      <li v-for="navItem in navItems" :key="`shares-navigation-desktop-${navItem.id}`">
         <oc-button
           type="router-link"
           class="oc-mr-m oc-py-s shares-nav-desktop"
@@ -20,7 +20,7 @@
       </oc-button>
       <oc-drop toggle="#shares_navigation_mobile" mode="click" close-on-click padding-size="small">
         <oc-list>
-          <li v-for="navItem in navItems" :key="`shares-navigation-mobile-${navItem.to}`">
+          <li v-for="navItem in navItems" :key="`shares-navigation-mobile-${navItem.id}`">
             <oc-button
               type="router-link"
               class="oc-my-xs shares-nav-mobile"
@@ -53,16 +53,45 @@ import { computed, unref } from 'vue'
 import { useRouter } from '@ownclouders/web-pkg'
 import { useActiveLocation } from '@ownclouders/web-pkg'
 import { useGettext } from 'vue3-gettext'
-import { RouteRecordNormalized } from 'vue-router'
+import { RouteLocationRaw } from 'vue-router'
 
 const { $gettext } = useGettext()
 const router = useRouter()
-const sharesRoutes = [locationSharesWithMe, locationSharesWithOthers, locationSharesViaLink].reduce<
-  Record<string, RouteRecordNormalized>
->((routes, route) => {
-  routes[route.name as string] = router.getRoutes().find((r) => r.name === route.name)
-  return routes
-}, {})
+
+const resolveScopeTemplatePath = (path: string, scopePrefix: string) =>
+  path.replace(/^\/:scope\(vault\)\?/, scopePrefix)
+
+const locationToPath = (location: RouteLocationRaw) => {
+  const scope = unref(router.currentRoute).params?.scope
+  const scopePrefix = scope === 'vault' ? '/vault' : ''
+
+  if (typeof location === 'string') {
+    return location
+  }
+
+  const locationWithScope: RouteLocationRaw = {
+    ...location,
+    ...(scope && {
+      params: {
+        ...((location as { params?: Record<string, unknown> }).params || {}),
+        scope
+      }
+    })
+  }
+
+  const resolvedPath = router.resolve(locationWithScope).path
+  if (resolvedPath) {
+    return resolvedPath
+  }
+
+  const routeName = (location as { name?: string }).name
+  const route = routeName ? router.getRoutes().find((r) => r.name === routeName) : undefined
+  if (route?.path) {
+    return resolveScopeTemplatePath(route.path, scopePrefix)
+  }
+
+  return ''
+}
 const sharesWithMeActive = useActiveLocation(
   isLocationSharesActive,
   locationSharesWithMe.name as RouteShareTypes
@@ -77,20 +106,23 @@ const sharesViaLinkActive = useActiveLocation(
 )
 const navItems = computed(() => [
   {
+    id: locationSharesWithMe.name as string,
     icon: 'share-forward',
-    to: sharesRoutes[locationSharesWithMe.name as string].path,
+    to: locationToPath(locationSharesWithMe),
     text: $gettext('Shared with me'),
     active: unref(sharesWithMeActive)
   },
   {
+    id: locationSharesWithOthers.name as string,
     icon: 'reply',
-    to: sharesRoutes[locationSharesWithOthers.name as string].path,
+    to: locationToPath(locationSharesWithOthers),
     text: $gettext('Shared with others'),
     active: unref(sharesWithOthersActive)
   },
   {
+    id: locationSharesViaLink.name as string,
     icon: 'link',
-    to: sharesRoutes[locationSharesViaLink.name as string].path,
+    to: locationToPath(locationSharesViaLink),
     text: $gettext('Shared via link'),
     active: unref(sharesViaLinkActive)
   }

--- a/packages/web-app-files/src/components/Search/List.vue
+++ b/packages/web-app-files/src/components/Search/List.vue
@@ -346,7 +346,8 @@ const doSearch = (manuallyUpdateFilterChip = false) => {
     lastModified,
     mediaType,
     scope: queryItemAsString(unref(scopeQuery)),
-    useScope: unref(doUseScope) === 'true'
+    useScope: unref(doUseScope) === 'true',
+    isVault: unref(route).params?.scope === 'vault'
   })
 
   const updateFilter = (v: Ref<InstanceType<typeof ItemFilter>>) => {

--- a/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
+++ b/packages/web-app-files/src/components/SideBar/Details/FileDetails.vue
@@ -398,8 +398,8 @@ watch(
 
 .details-preview,
 .details-icon-wrapper {
-  background-color: var(--oc-color-background-muted);
-  border: 10px solid var(--oc-color-background-muted);
+  background-color: var(--oc-color-background-highlight);
+  border: 10px solid var(--oc-color-background-highlight);
   height: 230px;
 
   background-size: contain;

--- a/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
+++ b/packages/web-app-files/src/components/SideBar/Shares/SharesPanel.vue
@@ -8,9 +8,9 @@
       </p>
     </div>
     <template v-else>
-      <space-members v-if="showSpaceMembers" class="oc-background-highlight oc-p-m oc-mb-s" />
-      <file-shares v-else class="oc-background-highlight oc-p-m oc-mb-s" />
-      <file-links v-if="showLinks" class="oc-background-highlight oc-p-m" />
+      <space-members v-if="showSpaceMembers" class="oc-background-muted oc-p-m oc-mb-s" />
+      <file-shares v-else class="oc-background-muted oc-p-m oc-mb-s" />
+      <file-links v-if="showLinks" class="oc-background-muted oc-p-m" />
     </template>
   </div>
 </template>

--- a/packages/web-app-files/src/index.ts
+++ b/packages/web-app-files/src/index.ts
@@ -61,6 +61,7 @@ export const navItems = (context: ComponentCustomProperties): AppNavigationItem[
       isActive: () => {
         return !spacesStores.currentSpace || spacesStores.currentSpace?.isOwner(userStore.user)
       },
+      activeFor: [{ path: `/${appInfo.id}/spaces/protected-personal` }],
       isVisible() {
         if (!spacesStores.spacesInitialized) {
           return true
@@ -112,7 +113,10 @@ export const navItems = (context: ComponentCustomProperties): AppNavigationItem[
       route: {
         path: `/${appInfo.id}/spaces/projects`
       },
-      activeFor: [{ path: `/${appInfo.id}/spaces/project` }],
+      activeFor: [
+        { path: `/${appInfo.id}/spaces/project` },
+        { path: `/${appInfo.id}/spaces/protected-project` }
+      ],
       isVisible() {
         return capabilityStore.spacesProjects
       },

--- a/packages/web-app-files/src/index.ts
+++ b/packages/web-app-files/src/index.ts
@@ -22,11 +22,7 @@ import { AppNavigationItem } from '@ownclouders/web-pkg'
 
 // dirty: importing view from other extension within project
 import SearchResults from '../../web-app-search/src/views/List.vue'
-import {
-  isPersonalSpaceResource,
-  isProtectedPersonalSpaceResource,
-  isShareSpaceResource
-} from '@ownclouders/web-client'
+import { isPersonalSpaceResource, isShareSpaceResource } from '@ownclouders/web-client'
 import { ComponentCustomProperties, unref } from 'vue'
 import { extensionPoints } from './extensionPoints'
 
@@ -61,16 +57,13 @@ export const navItems = (context: ComponentCustomProperties): AppNavigationItem[
       isActive: () => {
         return !spacesStores.currentSpace || spacesStores.currentSpace?.isOwner(userStore.user)
       },
-      activeFor: [{ path: `/${appInfo.id}/spaces/protected-personal` }],
       isVisible() {
         if (!spacesStores.spacesInitialized) {
           return true
         }
 
         return !!spacesStores.spaces.find(
-          (drive) =>
-            (isPersonalSpaceResource(drive) || isProtectedPersonalSpaceResource(drive)) &&
-            drive.isOwner(userStore.user)
+          (drive) => isPersonalSpaceResource(drive) && drive.isOwner(userStore.user)
         )
       },
       priority: 10
@@ -113,10 +106,7 @@ export const navItems = (context: ComponentCustomProperties): AppNavigationItem[
       route: {
         path: `/${appInfo.id}/spaces/projects`
       },
-      activeFor: [
-        { path: `/${appInfo.id}/spaces/project` },
-        { path: `/${appInfo.id}/spaces/protected-project` }
-      ],
+      activeFor: [{ path: `/${appInfo.id}/spaces/project` }],
       isVisible() {
         return capabilityStore.spacesProjects
       },

--- a/packages/web-app-files/src/index.ts
+++ b/packages/web-app-files/src/index.ts
@@ -40,6 +40,8 @@ const appInfo: ApplicationInformation = {
 }
 
 export const navItems = (context: ComponentCustomProperties): AppNavigationItem[] => {
+  const currentPath = window.location.pathname
+  const isVault = currentPath.startsWith('/vault')
   const spacesStores = useSpacesStore()
   const userStore = useUserStore()
   const capabilityStore = useCapabilityStore()
@@ -48,7 +50,7 @@ export const navItems = (context: ComponentCustomProperties): AppNavigationItem[
   return [
     {
       name() {
-        return $gettext('Personal')
+        return isVault ? $gettext('Safe-Personal') : $gettext('Personal')
       },
       icon: appInfo.icon,
       route: {
@@ -101,7 +103,7 @@ export const navItems = (context: ComponentCustomProperties): AppNavigationItem[
       priority: 30
     },
     {
-      name: $gettext('Spaces'),
+      name: isVault ? $gettext('Safe-Spaces') : $gettext('Spaces'),
       icon: 'layout-grid',
       route: {
         path: `/${appInfo.id}/spaces/projects`

--- a/packages/web-app-files/src/index.ts
+++ b/packages/web-app-files/src/index.ts
@@ -22,7 +22,11 @@ import { AppNavigationItem } from '@ownclouders/web-pkg'
 
 // dirty: importing view from other extension within project
 import SearchResults from '../../web-app-search/src/views/List.vue'
-import { isPersonalSpaceResource, isShareSpaceResource } from '@ownclouders/web-client'
+import {
+  isPersonalSpaceResource,
+  isProtectedPersonalSpaceResource,
+  isShareSpaceResource
+} from '@ownclouders/web-client'
 import { ComponentCustomProperties, unref } from 'vue'
 import { extensionPoints } from './extensionPoints'
 
@@ -63,7 +67,9 @@ export const navItems = (context: ComponentCustomProperties): AppNavigationItem[
         }
 
         return !!spacesStores.spaces.find(
-          (drive) => isPersonalSpaceResource(drive) && drive.isOwner(userStore.user)
+          (drive) =>
+            (isPersonalSpaceResource(drive) || isProtectedPersonalSpaceResource(drive)) &&
+            drive.isOwner(userStore.user)
         )
       },
       priority: 10

--- a/packages/web-app-files/src/views/spaces/DriveRedirect.vue
+++ b/packages/web-app-files/src/views/spaces/DriveRedirect.vue
@@ -49,7 +49,9 @@ const route = useRoute()
 const spacesStore = useSpacesStore()
 
 const personalSpace = computed(() => {
-  return spacesStore.spaces.find((space) => space.driveType === 'personal')
+  return spacesStore.spaces.find(
+    (space) => space.driveType === 'personal' || space.driveType === 'protected-personal'
+  )
 })
 
 const spacesRoute = computed(() => createLocationSpaces('files-spaces-projects'))

--- a/packages/web-app-files/src/views/spaces/DriveRedirect.vue
+++ b/packages/web-app-files/src/views/spaces/DriveRedirect.vue
@@ -49,9 +49,7 @@ const route = useRoute()
 const spacesStore = useSpacesStore()
 
 const personalSpace = computed(() => {
-  return spacesStore.spaces.find(
-    (space) => space.driveType === 'personal' || space.driveType === 'protected-personal'
-  )
+  return spacesStore.spaces.find((space) => space.driveType === 'personal')
 })
 
 const spacesRoute = computed(() => createLocationSpaces('files-spaces-projects'))

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -159,7 +159,8 @@ import {
   useKeyboardActions,
   useRoute,
   useRouteQuery,
-  FolderLoaderOptions
+  FolderLoaderOptions,
+  useCapabilityStore
 } from '@ownclouders/web-pkg'
 import CreateAndUpload from '../../components/AppBar/CreateAndUpload.vue'
 import FilesViewWrapper from '../../components/FilesViewWrapper.vue'
@@ -191,6 +192,7 @@ const { space = null, item = null, itemId = null } = defineProps<Props>()
 
 const router = useRouter()
 const { can } = useAbility()
+const capabilityStore = useCapabilityStore()
 const userStore = useUserStore()
 const { $gettext, $ngettext } = useGettext()
 const openWithDefaultAppQuery = useRouteQuery('openWithDefaultApp')
@@ -258,7 +260,7 @@ const titleSegments = computed(() => {
 useDocumentTitle({ titleSegments })
 
 const route = useRoute()
-const canAccessVault = computed(() => can('read-all', 'Vault'))
+const canAccessVault = computed(() => capabilityStore.vaultEnabled && can('read-all', 'Vault'))
 
 const getSpacesBreadcrumbText = () => {
   if (!unref(canAccessVault)) {

--- a/packages/web-app-files/src/views/spaces/GenericSpace.vue
+++ b/packages/web-app-files/src/views/spaces/GenericSpace.vue
@@ -129,6 +129,7 @@ import {
 import {
   ResourceTransfer,
   TransferType,
+  useAbility,
   useConfigStore,
   useExtensionRegistry,
   useFileActions,
@@ -189,6 +190,7 @@ interface Props {
 const { space = null, item = null, itemId = null } = defineProps<Props>()
 
 const router = useRouter()
+const { can } = useAbility()
 const userStore = useUserStore()
 const { $gettext, $ngettext } = useGettext()
 const openWithDefaultAppQuery = useRouteQuery('openWithDefaultApp')
@@ -256,12 +258,26 @@ const titleSegments = computed(() => {
 useDocumentTitle({ titleSegments })
 
 const route = useRoute()
+const canAccessVault = computed(() => can('read-all', 'Vault'))
+
+const getSpacesBreadcrumbText = () => {
+  if (!unref(canAccessVault)) {
+    return $gettext('Spaces')
+  }
+
+  if (unref(route).params.scope === 'vault') {
+    return $gettext('Vault')
+  }
+
+  return $gettext('Drive')
+}
+
 const breadcrumbs = computed(() => {
   const rootBreadcrumbItems: BreadcrumbItem[] = []
   if (isProjectSpaceResource(unref(space))) {
     rootBreadcrumbItems.push({
       id: uuidV4(),
-      text: $gettext('Spaces'),
+      text: getSpacesBreadcrumbText(),
       to: createLocationSpaces('files-spaces-projects'),
       isStaticNav: true
     })
@@ -286,6 +302,17 @@ const breadcrumbs = computed(() => {
   let { params, query } = createFileRouteOptions(unref(space), { fileId: unref(space).fileId })
   query = omit({ ...unref(route).query, ...query }, 'page')
   if (isPersonalSpaceResource(unref(space))) {
+    if (unref(canAccessVault)) {
+      const vaultText =
+        unref(route).params.scope === 'vault' ? $gettext('Vault') : $gettext('Drive')
+      rootBreadcrumbItems.push({
+        id: uuidV4(),
+        text: vaultText,
+        to: createLocationSpaces('files-spaces-projects'),
+        isStaticNav: true
+      })
+    }
+
     spaceBreadcrumbItem = {
       id: uuidV4(),
       text: unref(space).name,

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -232,7 +232,7 @@ const loadResourcesTask = useTask(function* (signal) {
   yield spacesStore.reloadProjectSpaces({
     graphClient: clientService.graphAuthenticated,
     signal,
-    isInVault: unref(route).params.scope === 'vault'
+    isInVault: unref(route)?.params?.scope === 'vault'
   })
   initResourceList({ currentFolder: null, resources: unref(spaces) })
 })

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -192,6 +192,7 @@ import SpaceContextActions from '../../components/Spaces/SpaceContextActions.vue
 import {
   getSpaceManagers,
   isProjectSpaceResource,
+  isProtectedProjectSpaceResource,
   ProjectSpaceResource,
   SpaceResource
 } from '@ownclouders/web-client'
@@ -249,7 +250,11 @@ let loadPreviewToken: string = null
 const { isSideBarOpen, sideBarActivePanel } = useSideBar()
 
 const runtimeSpaces = computed(() => {
-  return spacesStore.spaces.filter(isProjectSpaceResource) || []
+  return (
+    spacesStore.spaces.filter(
+      (space) => isProjectSpaceResource(space) || isProtectedProjectSpaceResource(space)
+    ) || []
+  )
 })
 const selectedSpace = computed(() => {
   if (

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -230,7 +230,8 @@ const loadResourcesTask = useTask(function* (signal) {
   setAncestorMetaData({})
   yield spacesStore.reloadProjectSpaces({
     graphClient: clientService.graphAuthenticated,
-    signal
+    signal,
+    isInVault: unref(route).params.scope === 'vault'
   })
   initResourceList({ currentFolder: null, resources: unref(spaces) })
 })

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -192,7 +192,6 @@ import SpaceContextActions from '../../components/Spaces/SpaceContextActions.vue
 import {
   getSpaceManagers,
   isProjectSpaceResource,
-  isProtectedProjectSpaceResource,
   ProjectSpaceResource,
   SpaceResource
 } from '@ownclouders/web-client'
@@ -250,11 +249,7 @@ let loadPreviewToken: string = null
 const { isSideBarOpen, sideBarActivePanel } = useSideBar()
 
 const runtimeSpaces = computed(() => {
-  return (
-    spacesStore.spaces.filter(
-      (space) => isProjectSpaceResource(space) || isProtectedProjectSpaceResource(space)
-    ) || []
-  )
+  return spacesStore.spaces.filter((space) => isProjectSpaceResource(space)) || []
 })
 const selectedSpace = computed(() => {
   if (

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -335,6 +335,7 @@ watch(filterTerm, async () => {
 })
 
 const hasCreatePermission = computed(() => can('create-all', 'Drive'))
+const canAccessVault = computed(() => can('read-all', 'Vault'))
 
 const extensionRegistry = useExtensionRegistry()
 const viewModes = computed(() => {
@@ -459,10 +460,22 @@ const spacesHelpList = computed(() => {
     }
   ]
 })
+const getBreadcrumbText = () => {
+  if (!unref(canAccessVault)) {
+    return $gettext('Spaces')
+  }
+
+  if (unref(route).params.scope === 'vault') {
+    return $gettext('Vault')
+  }
+
+  return $gettext('Drive')
+}
+
 const breadcrumbs = computed(() => {
   return [
     {
-      text: $gettext('Spaces'),
+      text: getBreadcrumbText(),
       onClick: () => loadResourcesTask.perform(),
       isStativNav: true
     }

--- a/packages/web-app-files/src/views/spaces/Projects.vue
+++ b/packages/web-app-files/src/views/spaces/Projects.vue
@@ -186,7 +186,8 @@ import {
   useRoute,
   Pagination,
   FileSideBar,
-  NoContentMessage
+  NoContentMessage,
+  useCapabilityStore
 } from '@ownclouders/web-pkg'
 import SpaceContextActions from '../../components/Spaces/SpaceContextActions.vue'
 import {
@@ -221,6 +222,7 @@ const { $gettext } = language
 const filterTerm = ref('')
 const markInstance = ref(undefined)
 const includeDisabledParam = useRouteQuery('q_includeDisabled')
+const capabilityStore = useCapabilityStore()
 
 const { setSelection, initResourceList, clearResourceList, setAncestorMetaData } =
   useResourcesStore()
@@ -335,7 +337,7 @@ watch(filterTerm, async () => {
 })
 
 const hasCreatePermission = computed(() => can('create-all', 'Drive'))
-const canAccessVault = computed(() => can('read-all', 'Vault'))
+const canAccessVault = computed(() => capabilityStore.vaultEnabled && can('read-all', 'Vault'))
 
 const extensionRegistry = useExtensionRegistry()
 const viewModes = computed(() => {

--- a/packages/web-app-files/src/views/trash/Overview.vue
+++ b/packages/web-app-files/src/views/trash/Overview.vue
@@ -97,6 +97,7 @@ import { AppLoadingSpinner } from '@ownclouders/web-pkg'
 import { NoContentMessage } from '@ownclouders/web-pkg'
 import { FieldType } from '@ownclouders/design-system/helpers'
 import { useFileListHeaderPosition } from '@ownclouders/web-pkg'
+import { useRoute } from 'vue-router'
 
 const userStore = useUserStore()
 const spacesStore = useSpacesStore()
@@ -107,6 +108,7 @@ const { y: fileListHeaderY } = useFileListHeaderPosition()
 const resourcesStore = useResourcesStore()
 const { isSideBarOpen, sideBarActivePanel } = useSideBar()
 const { isSticky } = useIsTopBarSticky()
+const route = useRoute()
 
 const sortBy = ref<keyof SpaceResource>('name')
 const sortDir = ref<SortDir>(SortDir.Asc)
@@ -125,7 +127,8 @@ const loadResourcesTask = useTask(function* (signal) {
   resourcesStore.clearResourceList()
   yield spacesStore.reloadProjectSpaces({
     graphClient: clientService.graphAuthenticated,
-    signal
+    signal,
+    isInVault: unref(route).params.scope === 'vault'
   })
   resourcesStore.initResourceList({ currentFolder: null, resources: unref(spaces) })
 })

--- a/packages/web-app-files/src/views/trash/Overview.vue
+++ b/packages/web-app-files/src/views/trash/Overview.vue
@@ -128,7 +128,7 @@ const loadResourcesTask = useTask(function* (signal) {
   yield spacesStore.reloadProjectSpaces({
     graphClient: clientService.graphAuthenticated,
     signal,
-    isInVault: unref(route).params.scope === 'vault'
+    isInVault: unref(route)?.params?.scope === 'vault'
   })
   resourcesStore.initResourceList({ currentFolder: null, resources: unref(spaces) })
 })

--- a/packages/web-app-files/tests/unit/components/Spaces/__snapshots__/SpaceHeader.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/Spaces/__snapshots__/SpaceHeader.spec.ts.snap
@@ -21,7 +21,7 @@ exports[`SpaceHeader > should add the "squashed"-class when the sidebar is opene
         </div>
       </div> <button type="button" aria-label="Open context menu and show members" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
         <!--v-if-->
-        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">19 members</span>
+        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">21 members</span>
       </button>
     </div>
     <!--v-if-->
@@ -52,7 +52,7 @@ exports[`SpaceHeader > space description > should show the description 1`] = `
         </div>
       </div> <button type="button" aria-label="Open context menu and show members" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
         <!--v-if-->
-        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">19 members</span>
+        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">21 members</span>
       </button>
     </div>
     <!--v-if-->
@@ -86,7 +86,7 @@ exports[`SpaceHeader > space image > should show the default image if no other i
         </div>
       </div> <button type="button" aria-label="Open context menu and show members" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
         <!--v-if-->
-        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">19 members</span>
+        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">21 members</span>
       </button>
     </div>
     <!--v-if-->
@@ -115,7 +115,7 @@ exports[`SpaceHeader > space image > should show the set image 1`] = `
         </div>
       </div> <button type="button" aria-label="Open context menu and show members" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
         <!--v-if-->
-        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">19 members</span>
+        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">21 members</span>
       </button>
     </div>
     <!--v-if-->

--- a/packages/web-app-files/tests/unit/components/Spaces/__snapshots__/SpaceHeader.spec.ts.snap
+++ b/packages/web-app-files/tests/unit/components/Spaces/__snapshots__/SpaceHeader.spec.ts.snap
@@ -21,7 +21,7 @@ exports[`SpaceHeader > should add the "squashed"-class when the sidebar is opene
         </div>
       </div> <button type="button" aria-label="Open context menu and show members" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
         <!--v-if-->
-        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">21 members</span>
+        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">19 members</span>
       </button>
     </div>
     <!--v-if-->
@@ -52,7 +52,7 @@ exports[`SpaceHeader > space description > should show the description 1`] = `
         </div>
       </div> <button type="button" aria-label="Open context menu and show members" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
         <!--v-if-->
-        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">21 members</span>
+        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">19 members</span>
       </button>
     </div>
     <!--v-if-->
@@ -86,7 +86,7 @@ exports[`SpaceHeader > space image > should show the default image if no other i
         </div>
       </div> <button type="button" aria-label="Open context menu and show members" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
         <!--v-if-->
-        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">21 members</span>
+        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">19 members</span>
       </button>
     </div>
     <!--v-if-->
@@ -115,7 +115,7 @@ exports[`SpaceHeader > space image > should show the set image 1`] = `
         </div>
       </div> <button type="button" aria-label="Open context menu and show members" class="oc-button oc-rounded oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw">
         <!--v-if-->
-        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">21 members</span>
+        <!-- @slot Content of the button --> <span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="space-header-people-count oc-text-small">19 members</span>
       </button>
     </div>
     <!--v-if-->

--- a/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
@@ -1,6 +1,6 @@
 import { computed, ref } from 'vue'
 import { mock, mockDeep } from 'vitest-mock-extended'
-import { Resource, SpaceResource } from '@ownclouders/web-client'
+import { AbilityRule, Resource, SpaceResource } from '@ownclouders/web-client'
 import GenericSpace from '../../../../src/views/spaces/GenericSpace.vue'
 import { useResourcesViewDefaults } from '../../../../src/composables/resourcesViewDefaults'
 import { useResourcesViewDefaultsMock } from '../../../../tests/mocks/useResourcesViewDefaultsMock'
@@ -113,6 +113,105 @@ describe('GenericSpace view', () => {
       expect(wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs.length).toBe(
         expectedItems
       )
+    })
+    describe('personal space with vault access', () => {
+      it('shows "Drive" as root breadcrumb when scope is not vault', () => {
+        const space = mock<SpaceResource>({
+          id: '1',
+          getDriveAliasAndItem: vi.fn(),
+          driveType: 'personal',
+          name: 'Personal space',
+          isOwner: () => true
+        })
+        const { wrapper } = getMountedWrapper({
+          files: [mockDeep<Resource>()],
+          props: { space },
+          abilities: [{ action: 'read-all', subject: 'Vault' }]
+        })
+        const breadcrumbs = wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs
+        expect(breadcrumbs.length).toBe(2)
+        expect(breadcrumbs[0].text).toBe('Drive')
+        expect(breadcrumbs[1].text).toBe('Personal space')
+      })
+      it('shows "Vault" as root breadcrumb when scope is vault', () => {
+        const space = mock<SpaceResource>({
+          id: '1',
+          getDriveAliasAndItem: vi.fn(),
+          driveType: 'personal',
+          name: 'Personal space',
+          isOwner: () => true
+        })
+        const { wrapper } = getMountedWrapper({
+          files: [mockDeep<Resource>()],
+          props: { space },
+          abilities: [{ action: 'read-all', subject: 'Vault' }],
+          currentRoute: { name: 'files-spaces-generic', path: '/', params: { scope: 'vault' } }
+        })
+        const breadcrumbs = wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs
+        expect(breadcrumbs.length).toBe(2)
+        expect(breadcrumbs[0].text).toBe('Vault')
+        expect(breadcrumbs[1].text).toBe('Personal space')
+      })
+      it('shows only space name when user cannot access vault', () => {
+        const space = mock<SpaceResource>({
+          id: '1',
+          getDriveAliasAndItem: vi.fn(),
+          driveType: 'personal',
+          name: 'Personal space',
+          isOwner: () => true
+        })
+        const { wrapper } = getMountedWrapper({
+          files: [mockDeep<Resource>()],
+          props: { space }
+        })
+        const breadcrumbs = wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs
+        expect(breadcrumbs.length).toBe(1)
+        expect(breadcrumbs[0].text).toBe('Personal space')
+      })
+    })
+    describe('project space breadcrumbs', () => {
+      it('shows "Spaces" when user cannot access vault', () => {
+        const space = mock<SpaceResource>({
+          id: '1',
+          getDriveAliasAndItem: vi.fn(),
+          driveType: 'project'
+        })
+        const { wrapper } = getMountedWrapper({
+          files: [mockDeep<Resource>()],
+          props: { space }
+        })
+        const breadcrumbs = wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs
+        expect(breadcrumbs[0].text).toBe('Spaces')
+      })
+      it('shows "Drive" when user can access vault and scope is not vault', () => {
+        const space = mock<SpaceResource>({
+          id: '1',
+          getDriveAliasAndItem: vi.fn(),
+          driveType: 'project'
+        })
+        const { wrapper } = getMountedWrapper({
+          files: [mockDeep<Resource>()],
+          props: { space },
+          abilities: [{ action: 'read-all', subject: 'Vault' }]
+        })
+        const breadcrumbs = wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs
+        expect(breadcrumbs[0].text).toBe('Drive')
+      })
+      it('shows "Vault" when user can access vault and scope is vault', () => {
+        const space = mock<SpaceResource>({
+          id: '1',
+          getDriveAliasAndItem: vi.fn(),
+          driveType: 'project'
+        })
+        const { wrapper } = getMountedWrapper({
+          files: [mockDeep<Resource>()],
+          props: { space },
+          abilities: [{ action: 'read-all', subject: 'Vault' }],
+          currentRoute: { name: 'files-spaces-generic', path: '/', params: { scope: 'vault' } }
+        })
+        const breadcrumbs = wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs
+        expect(breadcrumbs[0].text).toBe('Vault')
+      })
     })
     it('include the root item and the current folder', () => {
       const folderName = 'someFolder'
@@ -258,20 +357,23 @@ function getMountedWrapper({
     driveType: ''
   }),
   breadcrumbsFromPath = [],
-  stubs = {}
+  stubs = {},
+  abilities = []
 }: {
   mocks?: Record<string, unknown>
   props?: PartialComponentProps<typeof GenericSpace>
   files?: Resource[]
   loading?: boolean
-  currentRoute?: { name?: string; path?: string }
+  currentRoute?: { name?: string; path?: string; params?: Record<string, string> }
   currentFolder?: Resource
   runningOnEos?: boolean
   space?: SpaceResource
   breadcrumbsFromPath?: BreadcrumbItem[]
   stubs?: any
+  abilities?: AbilityRule[]
 } = {}) {
   const plugins = defaultPlugins({
+    abilities,
     piniaOptions: {
       configState: { options: { runningOnEos } },
       resourcesStore: { currentFolder }

--- a/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/GenericSpace.spec.ts
@@ -11,7 +11,8 @@ import {
   defaultStubs,
   RouteLocation,
   ComponentProps,
-  PartialComponentProps
+  PartialComponentProps,
+  PiniaMockOptions
 } from '@ownclouders/web-test-helpers'
 import {
   AppBar,
@@ -126,7 +127,8 @@ describe('GenericSpace view', () => {
         const { wrapper } = getMountedWrapper({
           files: [mockDeep<Resource>()],
           props: { space },
-          abilities: [{ action: 'read-all', subject: 'Vault' }]
+          abilities: [{ action: 'read-all', subject: 'Vault' }],
+          capabilityState: { capabilities: { vault: { enabled: true } } }
         })
         const breadcrumbs = wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs
         expect(breadcrumbs.length).toBe(2)
@@ -145,6 +147,7 @@ describe('GenericSpace view', () => {
           files: [mockDeep<Resource>()],
           props: { space },
           abilities: [{ action: 'read-all', subject: 'Vault' }],
+          capabilityState: { capabilities: { vault: { enabled: true } } },
           currentRoute: { name: 'files-spaces-generic', path: '/', params: { scope: 'vault' } }
         })
         const breadcrumbs = wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs
@@ -192,7 +195,8 @@ describe('GenericSpace view', () => {
         const { wrapper } = getMountedWrapper({
           files: [mockDeep<Resource>()],
           props: { space },
-          abilities: [{ action: 'read-all', subject: 'Vault' }]
+          abilities: [{ action: 'read-all', subject: 'Vault' }],
+          capabilityState: { capabilities: { vault: { enabled: true } } }
         })
         const breadcrumbs = wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs
         expect(breadcrumbs[0].text).toBe('Drive')
@@ -207,6 +211,7 @@ describe('GenericSpace view', () => {
           files: [mockDeep<Resource>()],
           props: { space },
           abilities: [{ action: 'read-all', subject: 'Vault' }],
+          capabilityState: { capabilities: { vault: { enabled: true } } },
           currentRoute: { name: 'files-spaces-generic', path: '/', params: { scope: 'vault' } }
         })
         const breadcrumbs = wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs
@@ -358,7 +363,8 @@ function getMountedWrapper({
   }),
   breadcrumbsFromPath = [],
   stubs = {},
-  abilities = []
+  abilities = [],
+  capabilityState = {}
 }: {
   mocks?: Record<string, unknown>
   props?: PartialComponentProps<typeof GenericSpace>
@@ -371,12 +377,14 @@ function getMountedWrapper({
   breadcrumbsFromPath?: BreadcrumbItem[]
   stubs?: any
   abilities?: AbilityRule[]
+  capabilityState?: PiniaMockOptions['capabilityState']
 } = {}) {
   const plugins = defaultPlugins({
     abilities,
     piniaOptions: {
       configState: { options: { runningOnEos } },
-      resourcesStore: { currentFolder }
+      resourcesStore: { currentFolder },
+      capabilityState
     }
   })
 

--- a/packages/web-app-files/tests/unit/views/spaces/Projects.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/Projects.spec.ts
@@ -123,6 +123,39 @@ describe('Projects view', () => {
     })
     expect(wrapper.find('create-space-stub').exists()).toBeTruthy()
   })
+  describe('breadcrumbs', () => {
+    it('shows "Spaces" when user cannot access vault', async () => {
+      const { wrapper } = getMountedWrapper({ spaces: spacesResources })
+      await (wrapper.vm as any).loadResourcesTask.last
+      expect(wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs[0].text).toBe(
+        'Spaces'
+      )
+    })
+    it('shows "Drive" when user can access vault and scope is not vault', async () => {
+      const { wrapper } = getMountedWrapper({
+        spaces: spacesResources,
+        abilities: [{ action: 'read-all', subject: 'Vault' }]
+      })
+      await (wrapper.vm as any).loadResourcesTask.last
+      expect(wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs[0].text).toBe(
+        'Drive'
+      )
+    })
+    it('shows "Vault" when user can access vault and scope is vault', async () => {
+      const { wrapper } = getMountedWrapper({
+        spaces: spacesResources,
+        abilities: [{ action: 'read-all', subject: 'Vault' }],
+        currentRoute: mock<RouteLocation>({
+          name: 'files-spaces-projects',
+          params: { scope: 'vault' }
+        })
+      })
+      await (wrapper.vm as any).loadResourcesTask.last
+      expect(wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs[0].text).toBe(
+        'Vault'
+      )
+    })
+  })
   it('should not pass selected resource as space to sidebar when driveType is not "project"', () => {
     const resource = mock<SpaceResource>({ id: 'selected-resource', driveType: 'personal' })
     const { wrapper } = getMountedWrapper({
@@ -147,7 +180,8 @@ function getMountedWrapper({
   abilities = [],
   stubAppBar = true,
   includeDisabled = false,
-  store = {}
+  store = {},
+  currentRoute = mock<RouteLocation>({ name: 'files-spaces-projects' })
 }: {
   mocks?: Record<string, unknown>
   spaces?: SpaceResource[]
@@ -155,6 +189,7 @@ function getMountedWrapper({
   stubAppBar?: boolean
   includeDisabled?: boolean
   store?: PiniaMockOptions
+  currentRoute?: RouteLocation
 } = {}) {
   const plugins = defaultPlugins({ abilities, piniaOptions: { spacesState: { spaces }, ...store } })
 
@@ -184,9 +219,7 @@ function getMountedWrapper({
   vi.mocked(requestExtensions).mockReturnValue(extensions)
 
   const defaultMocks = {
-    ...defaultComponentMocks({
-      currentRoute: mock<RouteLocation>({ name: 'files-spaces-projects' })
-    }),
+    ...defaultComponentMocks({ currentRoute }),
     ...(mocks && mocks)
   }
 

--- a/packages/web-app-files/tests/unit/views/spaces/Projects.spec.ts
+++ b/packages/web-app-files/tests/unit/views/spaces/Projects.spec.ts
@@ -134,7 +134,8 @@ describe('Projects view', () => {
     it('shows "Drive" when user can access vault and scope is not vault', async () => {
       const { wrapper } = getMountedWrapper({
         spaces: spacesResources,
-        abilities: [{ action: 'read-all', subject: 'Vault' }]
+        abilities: [{ action: 'read-all', subject: 'Vault' }],
+        store: { capabilityState: { capabilities: { vault: { enabled: true } } } }
       })
       await (wrapper.vm as any).loadResourcesTask.last
       expect(wrapper.findComponent<typeof AppBar>('app-bar-stub').props().breadcrumbs[0].text).toBe(
@@ -145,6 +146,7 @@ describe('Projects view', () => {
       const { wrapper } = getMountedWrapper({
         spaces: spacesResources,
         abilities: [{ action: 'read-all', subject: 'Vault' }],
+        store: { capabilityState: { capabilities: { vault: { enabled: true } } } },
         currentRoute: mock<RouteLocation>({
           name: 'files-spaces-projects',
           params: { scope: 'vault' }

--- a/packages/web-app-search/src/portals/SearchBar.vue
+++ b/packages/web-app-search/src/portals/SearchBar.vue
@@ -498,6 +498,10 @@ const search = async () => {
     terms.push(`scope:${unref(scope)}`)
   }
 
+  if (unref(route).params?.scope === 'vault') {
+    terms.push('vault:true')
+  }
+
   loading.value = true
 
   for (const availableProvider of unref(availableProviders)) {

--- a/packages/web-app-search/src/portals/SearchBar.vue
+++ b/packages/web-app-search/src/portals/SearchBar.vue
@@ -713,9 +713,15 @@ onBeforeUnmount(() => {
   }
 
   .oc-search-input {
-    background-color: var(--oc-color-input-bg);
+    background-color: var(--oc-color-search-input-bg, var(--oc-color-input-bg));
+    border: 1px solid var(--oc-color-search-input-border, var(--oc-color-input-border));
+    color: var(--oc-color-search-input-text-default, var(--oc-color-input-text-default));
     transition: 0s;
     height: 2.3rem;
+
+    &::placeholder {
+      color: var(--oc-color-search-input-text-muted, --oc-color-text-muted);
+    }
 
     @media (max-width: 639px) {
       border: none;
@@ -750,11 +756,16 @@ onBeforeUnmount(() => {
 
       input,
       input:not(:placeholder-shown) {
-        background-color: var(--oc-color-input-bg);
-        border: 1px solid var(--oc-color-input-border);
+        background-color: var(--oc-color-search-input-bg, var(--oc-color-input-bg));
+        border: 1px solid var(--oc-color-search-input-border, var(--oc-color-input-border));
+        color: var(--oc-color-search-input-text-default, var(--oc-color-input-text-default));
         z-index: var(--oc-z-index-modal);
         margin: 0 auto;
         padding-right: 5.875rem;
+
+        &::placeholder {
+          color: var(--oc-color-search-input-text-muted, --oc-color-text-muted);
+        }
       }
     }
   }
@@ -831,6 +842,14 @@ onBeforeUnmount(() => {
         }
       }
     }
+  }
+
+  .oc-filter-chip-button.oc-pill {
+    color: var(--oc-color-search-input-text-default, var(--oc-color-text-muted)) !important;
+  }
+
+  .oc-button-passive-raw .oc-icon > svg {
+    fill: var(--oc-color-search-input-text-default, var(--oc-color-text-muted));
   }
 }
 </style>

--- a/packages/web-app-search/tests/unit/portals/SearchBar.spec.ts
+++ b/packages/web-app-search/tests/unit/portals/SearchBar.spec.ts
@@ -269,6 +269,22 @@ describe('Search Bar portal component', () => {
     const spyRouterPushStub = wrapper.vm.$router.push
     expect(spyRouterPushStub).not.toHaveBeenCalled()
   })
+  test('includes vault:true in search term when route scope is vault', async () => {
+    wrapper = getMountedWrapper({ routeParams: { scope: 'vault' } }).wrapper
+    wrapper.find(selectors.searchInput).setValue('albert')
+    await flushPromises()
+    expect(providerFiles.previewSearch.search).toHaveBeenCalledWith(
+      expect.stringContaining('vault:true')
+    )
+  })
+  test('does not include vault:true in search term when route scope is not vault', async () => {
+    wrapper = getMountedWrapper().wrapper
+    wrapper.find(selectors.searchInput).setValue('albert')
+    await flushPromises()
+    expect(providerFiles.previewSearch.search).not.toHaveBeenCalledWith(
+      expect.stringContaining('vault:true')
+    )
+  })
 })
 
 type Mocks = {
@@ -284,7 +300,8 @@ function getMountedWrapper({
   userContextReady = true,
   providers = [providerFiles, providerContacts],
   route = 'files-spaces-generic',
-  store = {}
+  store = {},
+  routeParams = {} as Record<string, string>
 } = {}) {
   vi.mocked(useAvailableProviders).mockReturnValue(ref(providers))
 
@@ -293,7 +310,8 @@ function getMountedWrapper({
     query: {
       term: mocks?.$route?.query?.term || '',
       provider: ''
-    }
+    },
+    params: routeParams
   })
   const localMocks = {
     ...defaultComponentMocks({ currentRoute }),

--- a/packages/web-client/src/helpers/resource/types.ts
+++ b/packages/web-client/src/helpers/resource/types.ts
@@ -27,6 +27,7 @@ export type AbilitySubjects =
   | 'Role'
   | 'Setting'
   | 'Share'
+  | 'Vault'
 
 export type Ability = MongoAbility<[AbilityActions, AbilitySubjects]>
 export type AbilityRule = SubjectRawRule<AbilityActions, AbilitySubjects, any>

--- a/packages/web-client/src/helpers/space/types.ts
+++ b/packages/web-client/src/helpers/space/types.ts
@@ -91,6 +91,14 @@ export const isMountPointSpaceResource = (
   return (resource as SpaceResource)?.driveType === 'mountpoint'
 }
 
+export interface ProtectedPersonalSpaceResource extends SpaceResource {}
+
+export function isProtectedPersonalSpaceResource(
+  resource: Resource
+): resource is ProtectedPersonalSpaceResource {
+  return (resource as SpaceResource)?.driveType === 'protected-personal'
+}
+
 export interface PublicSpaceResource extends SpaceResource {
   publicLinkPassword?: string
   publicLinkItemType?: string

--- a/packages/web-client/src/helpers/space/types.ts
+++ b/packages/web-client/src/helpers/space/types.ts
@@ -31,7 +31,15 @@ export interface SpaceResource extends Resource {
   description: string
   disabled: boolean
   driveAlias: string
-  driveType: 'mountpoint' | 'personal' | 'project' | 'share' | 'public' | (string & unknown)
+  driveType:
+    | 'mountpoint'
+    | 'personal'
+    | 'project'
+    | 'share'
+    | 'public'
+    | 'protected-project'
+    | 'protected-personal'
+    | (string & unknown)
   root: DriveItem
   members: Record<string, SpaceMember>
   spaceQuota: Quota
@@ -97,6 +105,14 @@ export function isProtectedPersonalSpaceResource(
   resource: Resource
 ): resource is ProtectedPersonalSpaceResource {
   return (resource as SpaceResource)?.driveType === 'protected-personal'
+}
+
+export interface ProtectedProjectSpaceResource extends SpaceResource {}
+
+export function isProtectedProjectSpaceResource(
+  resource: Resource
+): resource is ProtectedPersonalSpaceResource {
+  return (resource as SpaceResource)?.driveType === 'protected-project'
 }
 
 export interface PublicSpaceResource extends SpaceResource {

--- a/packages/web-client/src/helpers/space/types.ts
+++ b/packages/web-client/src/helpers/space/types.ts
@@ -31,15 +31,7 @@ export interface SpaceResource extends Resource {
   description: string
   disabled: boolean
   driveAlias: string
-  driveType:
-    | 'mountpoint'
-    | 'personal'
-    | 'project'
-    | 'share'
-    | 'public'
-    | 'protected-project'
-    | 'protected-personal'
-    | (string & unknown)
+  driveType: 'mountpoint' | 'personal' | 'project' | 'share' | 'public' | (string & unknown)
   root: DriveItem
   members: Record<string, SpaceMember>
   spaceQuota: Quota
@@ -101,19 +93,7 @@ export const isMountPointSpaceResource = (
 
 export interface ProtectedPersonalSpaceResource extends SpaceResource {}
 
-export function isProtectedPersonalSpaceResource(
-  resource: Resource
-): resource is ProtectedPersonalSpaceResource {
-  return (resource as SpaceResource)?.driveType === 'protected-personal'
-}
-
 export interface ProtectedProjectSpaceResource extends SpaceResource {}
-
-export function isProtectedProjectSpaceResource(
-  resource: Resource
-): resource is ProtectedPersonalSpaceResource {
-  return (resource as SpaceResource)?.driveType === 'protected-project'
-}
 
 export interface PublicSpaceResource extends SpaceResource {
   publicLinkPassword?: string

--- a/packages/web-client/src/helpers/space/types.ts
+++ b/packages/web-client/src/helpers/space/types.ts
@@ -91,10 +91,6 @@ export const isMountPointSpaceResource = (
   return (resource as SpaceResource)?.driveType === 'mountpoint'
 }
 
-export interface ProtectedPersonalSpaceResource extends SpaceResource {}
-
-export interface ProtectedProjectSpaceResource extends SpaceResource {}
-
 export interface PublicSpaceResource extends SpaceResource {
   publicLinkPassword?: string
   publicLinkItemType?: string

--- a/packages/web-client/src/ocs/capabilities.ts
+++ b/packages/web-client/src/ocs/capabilities.ts
@@ -54,6 +54,7 @@ interface AuthCapability {
   mfa: {
     enabled?: boolean
     levelnames?: string[]
+    session_duration?: number
   }
 }
 

--- a/packages/web-client/src/ocs/capabilities.ts
+++ b/packages/web-client/src/ocs/capabilities.ts
@@ -175,6 +175,9 @@ export interface Capabilities {
       version?: string
       server_managed?: boolean
     }
+    vault?: {
+      enabled?: boolean
+    }
     graph?: {
       'personal-data-export'?: boolean
       users: {

--- a/packages/web-pkg/src/components/AppBar/CreateSpace.vue
+++ b/packages/web-pkg/src/components/AppBar/CreateSpace.vue
@@ -23,6 +23,7 @@ import {
   useSpacesStore,
   useResourcesStore
 } from '../../composables'
+import { useRoute } from 'vue-router'
 import { SpaceResource } from '@ownclouders/web-client'
 
 interface Props {
@@ -40,10 +41,16 @@ const { checkSpaceNameModalInput } = useSpaceHelpers()
 const { dispatchModal } = useModals()
 const spacesStore = useSpacesStore()
 const { upsertResource } = useResourcesStore()
+const route = useRoute()
 
 const addNewSpace = async (name: string) => {
+  let driveType = 'project'
   try {
-    const createdSpace = await createSpace(name)
+    if (route.params.scope === 'vault') {
+      driveType = 'protected-project'
+    }
+
+    const createdSpace = await createSpace(name, driveType)
     upsertResource(createdSpace)
     spacesStore.upsertSpace(createdSpace)
     emit('spaceCreated', createdSpace)

--- a/packages/web-pkg/src/components/AppBar/CreateSpace.vue
+++ b/packages/web-pkg/src/components/AppBar/CreateSpace.vue
@@ -41,16 +41,10 @@ const { checkSpaceNameModalInput } = useSpaceHelpers()
 const { dispatchModal } = useModals()
 const spacesStore = useSpacesStore()
 const { upsertResource } = useResourcesStore()
-const route = useRoute()
 
 const addNewSpace = async (name: string) => {
-  let driveType = 'project'
   try {
-    if (route?.params?.scope === 'vault') {
-      driveType = 'protected-project'
-    }
-
-    const createdSpace = await createSpace(name, driveType)
+    const createdSpace = await createSpace(name, 'project')
     upsertResource(createdSpace)
     spacesStore.upsertSpace(createdSpace)
     emit('spaceCreated', createdSpace)

--- a/packages/web-pkg/src/components/AppBar/CreateSpace.vue
+++ b/packages/web-pkg/src/components/AppBar/CreateSpace.vue
@@ -46,7 +46,7 @@ const route = useRoute()
 const addNewSpace = async (name: string) => {
   let driveType = 'project'
   try {
-    if (route.params.scope === 'vault') {
+    if (route?.params?.scope === 'vault') {
       driveType = 'protected-project'
     }
 

--- a/packages/web-pkg/src/components/AppBar/CreateSpace.vue
+++ b/packages/web-pkg/src/components/AppBar/CreateSpace.vue
@@ -23,7 +23,6 @@ import {
   useSpacesStore,
   useResourcesStore
 } from '../../composables'
-import { useRoute } from 'vue-router'
 import { SpaceResource } from '@ownclouders/web-client'
 
 interface Props {

--- a/packages/web-pkg/src/components/SideBar/SideBar.vue
+++ b/packages/web-pkg/src/components/SideBar/SideBar.vue
@@ -284,7 +284,7 @@ onBeforeUnmount(() => {
   max-height: 100%;
   display: grid;
   grid-template-rows: auto auto 1fr;
-  background-color: var(--oc-color-background-default);
+  background-color: var(--oc-color-background-sidebar, var(--oc-color-background-default));
   top: 0;
   position: absolute;
   transform: translateX(100%);

--- a/packages/web-pkg/src/components/ViewOptions.vue
+++ b/packages/web-pkg/src/components/ViewOptions.vue
@@ -12,6 +12,7 @@
         :class="viewMode.name"
         :appearance="viewModeCurrent === viewMode.name ? 'filled' : 'outline'"
         :aria-label="$gettext(viewMode.label)"
+        variation="primary"
         @click="setViewMode(viewMode)"
       >
         <oc-icon
@@ -29,6 +30,7 @@
       data-testid="files-view-options-btn"
       :aria-label="viewOptionsButtonLabel"
       appearance="raw"
+      variation="primary"
       class="oc-my-s oc-p-xs"
     >
       <oc-icon name="settings-3" fill-type="line" />
@@ -257,6 +259,10 @@ const fileExtensionsShownModel = computed(() => unref(areFileExtensionsShown))
 <style lang="scss" scoped>
 .viewmode-switch-buttons {
   flex-flow: initial;
+}
+
+.viewmode-switch-buttons.oc-button-group {
+  outline: 1px solid var(--oc-color-swatch-primary-default);
 }
 
 #files-view-options-btn {

--- a/packages/web-pkg/src/composables/actions/files/useFileActions.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActions.ts
@@ -4,7 +4,7 @@ import { isShareSpaceResource } from '@ownclouders/web-client'
 import { routeToContextQuery } from '../../appDefaults'
 import { isLocationTrashActive } from '../../../router'
 import { computed, unref } from 'vue'
-import { useRouter } from '../../router'
+import { useRouter, useRoute } from '../../router'
 import { useGettext } from 'vue3-gettext'
 import {
   Action,
@@ -53,6 +53,7 @@ export interface GetFileActionsOptions extends FileActionOptions {
 export const useFileActions = () => {
   const appsStore = useAppsStore()
   const router = useRouter()
+  const route = useRoute()
   const { $gettext } = useGettext()
   const isSearchActive = useIsSearchActive()
   const { isEnabled: isEmbedModeEnabled } = useEmbedMode()
@@ -221,6 +222,7 @@ export const useFileActions = () => {
         driveAliasAndItem: space?.getDriveAliasAndItem(resource),
         filePath: resource.path,
         fileId: resource.fileId,
+        scope: route.value.params.scope,
         mode
       },
       query: {

--- a/packages/web-pkg/src/composables/actions/files/useFileActionsPaste.ts
+++ b/packages/web-pkg/src/composables/actions/files/useFileActionsPaste.ts
@@ -10,7 +10,13 @@ import { useClientService } from '../../clientService'
 import { useRouter } from '../../router'
 import { FileAction, FileActionOptions } from '../types'
 import { Resource, SpaceResource, isShareSpaceResource } from '@ownclouders/web-client'
-import { useClipboardStore, useResourcesStore } from '../../piniaStores'
+import {
+  ClipboardMode,
+  useClipboardStore,
+  useConfigStore,
+  useMessages,
+  useResourcesStore
+} from '../../piniaStores'
 import { ClipboardActions, ResourceTransfer, TransferType } from '../../../helpers'
 import { storeToRefs } from 'pinia'
 import { usePasteWorker } from '../../webWorkers/pasteWorker'
@@ -20,12 +26,29 @@ export const useFileActionsPaste = () => {
   const clientService = useClientService()
   const { getMatchingSpace } = useGetMatchingSpace()
   const { $gettext, $ngettext } = useGettext()
+  const { showErrorMessage } = useMessages()
   const clipboardStore = useClipboardStore()
+  const configStore = useConfigStore()
   const { startWorker } = usePasteWorker()
 
   const resourcesStore = useResourcesStore()
   const { currentFolder } = storeToRefs(resourcesStore)
   const { resources: clipboardResources } = storeToRefs(clipboardStore)
+
+  const isCrossModePasteAllowed = computed(() => {
+    return (
+      !clipboardStore.sourceMode ||
+      clipboardStore.sourceMode !== ClipboardMode.Vault ||
+      configStore.isInVault
+    )
+  })
+
+  const getSourceSpace = (resource: Resource): SpaceResource => {
+    const sourceBucketId = clipboardStore.getClipboardSourceSpaceKey(resource)
+    const persistedSpace = clipboardStore.sourceSpaces[sourceBucketId]
+
+    return (persistedSpace as SpaceResource) || getMatchingSpace(resource)
+  }
 
   const isMacOs = computed(() => {
     return window.navigator.platform.match('Mac')
@@ -135,6 +158,13 @@ export const useFileActionsPaste = () => {
   })
 
   const handler = async ({ space: targetSpace }: FileActionOptions) => {
+    if (!unref(isCrossModePasteAllowed)) {
+      showErrorMessage({
+        title: $gettext('Pasting from Vault into the default mode is not supported.')
+      })
+      return
+    }
+
     if (unref(isCuttingAndPastingIntoSameFolder)) {
       return
     }
@@ -142,18 +172,19 @@ export const useFileActionsPaste = () => {
     const resourceSpaceMapping = clipboardStore.resources.reduce<
       Record<string, { space: SpaceResource; resources: Resource[] }>
     >((acc, resource) => {
-      if (resource.storageId in acc) {
-        acc[resource.storageId].resources.push(resource)
+      const sourceBucketId = clipboardStore.getClipboardSourceSpaceKey(resource)
+      const sourceSpace = getSourceSpace(resource)
+
+      if (sourceBucketId in acc) {
+        acc[sourceBucketId].resources.push(resource)
         return acc
       }
 
-      const matchingSpace = getMatchingSpace(resource)
-
-      if (!(matchingSpace.id in acc)) {
-        acc[matchingSpace.id] = { space: matchingSpace, resources: [] }
+      if (!(sourceSpace.id in acc)) {
+        acc[sourceSpace.id] = { space: sourceSpace, resources: [] }
       }
 
-      acc[matchingSpace.id].resources.push(resource)
+      acc[sourceSpace.id].resources.push(resource)
       return acc
     }, {})
 
@@ -175,6 +206,9 @@ export const useFileActionsPaste = () => {
       shortcut: unref(pasteShortcutString),
       isVisible: ({ resources }) => {
         if (clipboardStore.resources.length === 0) {
+          return false
+        }
+        if (!unref(isCrossModePasteAllowed)) {
           return false
         }
         if (

--- a/packages/web-pkg/src/composables/appDefaults/useAppDefaults.ts
+++ b/packages/web-pkg/src/composables/appDefaults/useAppDefaults.ts
@@ -63,7 +63,7 @@ export function useAppDefaults(options: AppDefaultsOptions): AppDefaultsResult {
       path = urlJoin(unref(space).webDavPath, unref(item))
     } else {
       // deprecated.
-      path = urlJoin(queryItemAsString(unref(currentRoute).params.filePath))
+      path = urlJoin(queryItemAsString(unref(currentRoute)?.params?.filePath))
     }
 
     return {

--- a/packages/web-pkg/src/composables/piniaStores/capabilities.ts
+++ b/packages/web-pkg/src/composables/piniaStores/capabilities.ts
@@ -71,6 +71,9 @@ const defaultValues = {
     max_quota: 0,
     projects: false,
     server_managed: false
+  },
+  vault: {
+    enabled: false
   }
 } satisfies Partial<Capabilities['capabilities']>
 
@@ -155,6 +158,8 @@ export const useCapabilityStore = defineStore('capabilities', () => {
   const authMfaRequiredLevelname = computed(() => unref(capabilities).auth.mfa.levelnames.at(0))
   const authMfaSessionDuration = computed(() => unref(capabilities).auth.mfa.session_duration)
 
+  const vaultEnabled = computed(() => unref(capabilities).vault?.enabled)
+
   return {
     isInitialized,
     capabilities,
@@ -204,7 +209,8 @@ export const useCapabilityStore = defineStore('capabilities', () => {
     searchContent,
     authMfaEnabled,
     authMfaRequiredLevelname,
-    authMfaSessionDuration
+    authMfaSessionDuration,
+    vaultEnabled
   }
 })
 

--- a/packages/web-pkg/src/composables/piniaStores/capabilities.ts
+++ b/packages/web-pkg/src/composables/piniaStores/capabilities.ts
@@ -153,6 +153,7 @@ export const useCapabilityStore = defineStore('capabilities', () => {
 
   const authMfaEnabled = computed(() => unref(capabilities).auth.mfa.enabled)
   const authMfaRequiredLevelname = computed(() => unref(capabilities).auth.mfa.levelnames.at(0))
+  const authMfaSessionDuration = computed(() => unref(capabilities).auth.mfa.session_duration)
 
   return {
     isInitialized,
@@ -202,7 +203,8 @@ export const useCapabilityStore = defineStore('capabilities', () => {
     searchMediaType,
     searchContent,
     authMfaEnabled,
-    authMfaRequiredLevelname
+    authMfaRequiredLevelname,
+    authMfaSessionDuration
   }
 })
 

--- a/packages/web-pkg/src/composables/piniaStores/clipboard.ts
+++ b/packages/web-pkg/src/composables/piniaStores/clipboard.ts
@@ -1,35 +1,167 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
-import { Resource } from '@ownclouders/web-client'
+import { computed, ref, unref, watch } from 'vue'
+import { Resource, SpaceResource } from '@ownclouders/web-client'
 import { ClipboardActions } from '../../helpers'
 import { useGettext } from 'vue3-gettext'
 import { useMessages } from './messages'
+import { useConfigStore } from './config'
+import { useGetMatchingSpace } from '../spaces'
+
+const clipboardStorageKey = 'oc-clipboard'
+
+export enum ClipboardMode {
+  Default = 'default',
+  Vault = 'vault'
+}
+
+type ClipboardResourceSnapshot = Pick<
+  Resource,
+  | 'id'
+  | 'fileId'
+  | 'extension'
+  | 'isFolder'
+  | 'name'
+  | 'mimeType'
+  | 'parentFolderId'
+  | 'path'
+  | 'remoteItemId'
+  | 'remoteItemPath'
+  | 'shareTypes'
+  | 'spaceId'
+  | 'storageId'
+  | 'type'
+  | 'webDavPath'
+>
+
+type ClipboardSpaceSnapshot = Pick<SpaceResource, 'driveType' | 'id' | 'storageId' | 'webDavPath'>
+
+type PersistedClipboardPayload = {
+  action: ClipboardActions
+  resources: ClipboardResourceSnapshot[]
+  sourceMode: ClipboardMode
+  sourceSpaces: Record<string, ClipboardSpaceSnapshot>
+}
 
 export const useClipboardStore = defineStore('clipboard', () => {
   const { $gettext } = useGettext()
   const { showMessage } = useMessages()
+  const configStore = useConfigStore()
+  const { getMatchingSpace } = useGetMatchingSpace()
 
   const action = ref<ClipboardActions>()
   const resources = ref<Resource[]>([])
+  const sourceMode = ref<ClipboardMode>()
+  const sourceSpaces = ref<Record<string, ClipboardSpaceSnapshot>>({})
+
+  const currentMode = computed(() =>
+    unref(configStore.isInVault) ? ClipboardMode.Vault : ClipboardMode.Default
+  )
+
+  const toClipboardSnapshot = (resource: Resource): ClipboardResourceSnapshot => ({
+    id: resource.id,
+    fileId: resource.fileId,
+    extension: resource.extension,
+    isFolder: resource.isFolder,
+    name: resource.name,
+    mimeType: resource.mimeType,
+    parentFolderId: resource.parentFolderId,
+    path: resource.path,
+    remoteItemId: resource.remoteItemId,
+    remoteItemPath: resource.remoteItemPath,
+    shareTypes: resource.shareTypes,
+    spaceId: resource.spaceId,
+    storageId: resource.storageId,
+    type: resource.type,
+    webDavPath: resource.webDavPath
+  })
+
+  const getClipboardSourceSpaceKey = (resource: Pick<Resource, 'spaceId' | 'storageId'>) => {
+    return resource.storageId || resource.spaceId
+  }
+
+  const buildSourceSpaces = (spaces: SpaceResource[] = []) =>
+    spaces.reduce<Record<string, ClipboardSpaceSnapshot>>((acc, space) => {
+      const key = space && getClipboardSourceSpaceKey(space)
+      if (key)
+        acc[key] = {
+          driveType: space.driveType,
+          id: space.id,
+          storageId: space.storageId,
+          webDavPath: space.webDavPath
+        }
+      return acc
+    }, {})
+
+  const removePersistedClipboard = () => {
+    try {
+      sessionStorage.removeItem(clipboardStorageKey)
+    } catch (e) {
+      console.log('error removing session item: ', e)
+    }
+  }
+
+  const persistClipboard = () => {
+    if (!action.value || resources.value.length === 0) {
+      removePersistedClipboard()
+      return
+    }
+
+    const payload: PersistedClipboardPayload = {
+      action: action.value,
+      resources: resources.value.map(toClipboardSnapshot),
+      sourceMode: sourceMode.value,
+      sourceSpaces: sourceSpaces.value
+    }
+
+    try {
+      sessionStorage.setItem(clipboardStorageKey, JSON.stringify(payload))
+    } catch (e) {
+      console.log('error setting session item: ', e)
+    }
+  }
+
+  const hydrateClipboard = () => {
+    try {
+      const stored = sessionStorage.getItem(clipboardStorageKey)
+      if (!stored) return
+      const payload = JSON.parse(stored) as PersistedClipboardPayload
+      if (!payload.action || !Array.isArray(payload.resources)) {
+        removePersistedClipboard()
+        return
+      }
+      action.value = payload.action
+      resources.value = payload.resources as Resource[]
+      sourceMode.value = payload.sourceMode
+      sourceSpaces.value = payload.sourceSpaces || {}
+    } catch {
+      removePersistedClipboard()
+    }
+  }
 
   const copyResources = (r: Resource[]) => {
-    if (!r[0].canDownload()) {
+    if (!r.length || !r[0].canDownload?.()) {
       return
     }
 
     action.value = ClipboardActions.Copy
     resources.value = r
+    sourceMode.value = unref(currentMode)
+    sourceSpaces.value = buildSourceSpaces(r.map(getMatchingSpace))
+    persistClipboard()
 
     showMessage({ title: $gettext('Copied to clipboard!'), status: 'success' })
   }
 
   const cutResources = (r: Resource[]) => {
-    if (!r[0].canDownload()) {
+    if (!r.length || !r[0].canDownload?.()) {
       return
     }
 
     action.value = ClipboardActions.Cut
     resources.value = r
+    sourceMode.value = unref(currentMode)
+    sourceSpaces.value = buildSourceSpaces(r.map(getMatchingSpace))
+    persistClipboard()
 
     showMessage({ title: $gettext('Cut to clipboard!'), status: 'success' })
   }
@@ -37,11 +169,19 @@ export const useClipboardStore = defineStore('clipboard', () => {
   const clearClipboard = () => {
     action.value = undefined
     resources.value = []
+    sourceMode.value = undefined
+    sourceSpaces.value = {}
+    removePersistedClipboard()
   }
+
+  hydrateClipboard()
 
   return {
     action,
     resources,
+    sourceMode,
+    sourceSpaces,
+    getClipboardSourceSpaceKey,
 
     copyResources,
     cutResources,

--- a/packages/web-pkg/src/composables/piniaStores/clipboard.ts
+++ b/packages/web-pkg/src/composables/piniaStores/clipboard.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { computed, ref, unref, watch } from 'vue'
+import { computed, ref, unref } from 'vue'
 import { Resource, SpaceResource } from '@ownclouders/web-client'
 import { ClipboardActions } from '../../helpers'
 import { useGettext } from 'vue3-gettext'

--- a/packages/web-pkg/src/composables/piniaStores/config/config.ts
+++ b/packages/web-pkg/src/composables/piniaStores/config/config.ts
@@ -58,6 +58,8 @@ export const useConfigStore = defineStore('config', () => {
 
   const maintenanceMode = ref(false)
 
+  const isInVault = ref(false)
+
   const serverUrl = computed(() =>
     urlJoin(unref(server) || window.location.origin, { trailingSlash: true })
   )
@@ -100,6 +102,10 @@ export const useConfigStore = defineStore('config', () => {
     maintenanceMode.value = value
   }
 
+  const setIsInVault = (value: boolean) => {
+    isInVault.value = value
+  }
+
   return {
     options,
     oAuth2,
@@ -115,6 +121,8 @@ export const useConfigStore = defineStore('config', () => {
     styles,
     serverUrl,
     maintenanceMode,
+    setIsInVault,
+    isInVault,
     loadConfig,
     setMaintenanceMode
   }

--- a/packages/web-pkg/src/composables/piniaStores/extensionRegistry/extensionRegistry.ts
+++ b/packages/web-pkg/src/composables/piniaStores/extensionRegistry/extensionRegistry.ts
@@ -15,7 +15,6 @@ export const useExtensionRegistry = defineStore('extensionRegistry', () => {
           const e = ext as SidebarNavExtension
           const routeType =
             typeof e.navItem.route === 'string' ? e.navItem.route : e.navItem.route.path
-          console.log('params: ', unref(route).params)
 
           return {
             ...e,

--- a/packages/web-pkg/src/composables/piniaStores/extensionRegistry/extensionRegistry.ts
+++ b/packages/web-pkg/src/composables/piniaStores/extensionRegistry/extensionRegistry.ts
@@ -1,12 +1,38 @@
 import { defineStore } from 'pinia'
 import { ref, Ref, unref } from 'vue'
 import { useConfigStore } from '../config'
-import { Extension, ExtensionPoint, ExtensionType } from './types'
+import path from 'path'
+import { Extension, ExtensionPoint, ExtensionType, SidebarNavExtension } from './types'
 
 export const useExtensionRegistry = defineStore('extensionRegistry', () => {
   const configStore = useConfigStore()
 
   const extensions = ref<Ref<Extension[]>[]>([])
+  const rebuild = ({ route }) => {
+    extensions.value = unref(extensions).map((extension) =>
+      unref(extension).map((ext) => {
+        if (ext.type === 'sidebarNav') {
+          const e = ext as SidebarNavExtension
+          const routeType =
+            typeof e.navItem.route === 'string' ? e.navItem.route : e.navItem.route.path
+          console.log('params: ', unref(route).params)
+
+          return {
+            ...e,
+            navItem: {
+              ...e.navItem,
+              route:
+                unref(route).params?.scope === 'vault'
+                  ? path.join('/vault', routeType)
+                  : e.navItem.route
+            }
+          }
+        }
+
+        return ext
+      })
+    )
+  }
 
   const registerExtensions = (e: Ref<Extension[]>) => {
     extensions.value.push(e)
@@ -67,7 +93,8 @@ export const useExtensionRegistry = defineStore('extensionRegistry', () => {
     extensionPoints,
     registerExtensionPoints,
     unregisterExtensionPoints,
-    getExtensionPoints
+    getExtensionPoints,
+    rebuild
   }
 })
 

--- a/packages/web-pkg/src/composables/piniaStores/extensionRegistry/extensionRegistry.ts
+++ b/packages/web-pkg/src/composables/piniaStores/extensionRegistry/extensionRegistry.ts
@@ -1,35 +1,62 @@
 import { defineStore } from 'pinia'
 import { ref, Ref, unref } from 'vue'
 import { useConfigStore } from '../config'
-import path from 'path'
 import { Extension, ExtensionPoint, ExtensionType, SidebarNavExtension } from './types'
+
+const withScopePrefix = (routePath: string, isVaultScope: boolean) => {
+  const normalizedPath = routePath.replace(/^\/vault(?=\/|$)/, '')
+  const basePath = normalizedPath.startsWith('/') ? normalizedPath : `/${normalizedPath}`
+
+  if (!isVaultScope) {
+    return basePath
+  }
+
+  return basePath === '/' ? '/vault' : `/vault${basePath}`
+}
+
+const mapNavRoute = (navRoute: SidebarNavExtension['navItem']['route'], isVaultScope: boolean) => {
+  if (typeof navRoute === 'string') {
+    return withScopePrefix(navRoute, isVaultScope)
+  }
+
+  if (!navRoute || typeof navRoute !== 'object' || !('path' in navRoute)) {
+    return navRoute
+  }
+
+  if (typeof navRoute.path !== 'string') {
+    return navRoute
+  }
+
+  return {
+    ...navRoute,
+    path: withScopePrefix(navRoute.path, isVaultScope)
+  }
+}
 
 export const useExtensionRegistry = defineStore('extensionRegistry', () => {
   const configStore = useConfigStore()
 
   const extensions = ref<Ref<Extension[]>[]>([])
   const rebuild = ({ route }) => {
-    extensions.value = unref(extensions).map((extension) =>
-      unref(extension).map((ext) => {
-        if (ext.type === 'sidebarNav') {
-          const e = ext as SidebarNavExtension
-          const routeType =
-            typeof e.navItem.route === 'string' ? e.navItem.route : e.navItem.route.path
+    const isVaultScope = unref(route).params?.scope === 'vault'
 
+    extensions.value = unref(extensions).map((extension) =>
+      ref(
+        unref(extension).map((ext) => {
+          if (ext.type !== 'sidebarNav') {
+            return ext
+          }
+
+          const sidebarExtension = ext as SidebarNavExtension
           return {
-            ...e,
+            ...sidebarExtension,
             navItem: {
-              ...e.navItem,
-              route:
-                unref(route).params?.scope === 'vault'
-                  ? path.join('/vault', routeType)
-                  : e.navItem.route
+              ...sidebarExtension.navItem,
+              route: mapNavRoute(sidebarExtension.navItem.route, isVaultScope)
             }
           }
-        }
-
-        return ext
-      })
+        })
+      )
     )
   }
 

--- a/packages/web-pkg/src/composables/piniaStores/spaces.ts
+++ b/packages/web-pkg/src/composables/piniaStores/spaces.ts
@@ -11,8 +11,7 @@ import {
   buildSpace,
   extractStorageId,
   isPersonalSpaceResource,
-  isProjectSpaceResource,
-  isProtectedProjectSpaceResource
+  isProjectSpaceResource
 } from '@ownclouders/web-client'
 import type { CollaboratorShare, MountPointSpaceResource, ShareRole } from '@ownclouders/web-client'
 import { useUserStore } from './user'
@@ -215,13 +214,13 @@ export const useSpacesStore = defineStore('spaces', () => {
       const [personalSpaces, projectSpaces] = await Promise.all([
         getSpacesByType({
           graphClient,
-          driveType: isInVault ? "'protected-personal'" : 'personal',
+          driveType: 'personal',
           configStore,
           graphRoles: sharesStore.graphRoles
         }),
         getSpacesByType({
           graphClient,
-          driveType: isInVault ? "'protected-project'" : 'project',
+          driveType: 'project',
           configStore,
           graphRoles: sharesStore.graphRoles
         })
@@ -270,14 +269,12 @@ export const useSpacesStore = defineStore('spaces', () => {
   }) => {
     const projectSpaces = await getSpacesByType({
       graphClient,
-      driveType: isInVault ? "'protected-project'" : 'project',
+      driveType: 'project',
       configStore,
       graphRoles: sharesStore.graphRoles,
       signal
     })
-    spaces.value = unref(spaces).filter(
-      (s) => !isProjectSpaceResource(s) && !isProtectedProjectSpaceResource(s)
-    )
+    spaces.value = unref(spaces).filter((s) => !isProjectSpaceResource(s))
     addSpaces(projectSpaces)
   }
 

--- a/packages/web-pkg/src/composables/piniaStores/spaces.ts
+++ b/packages/web-pkg/src/composables/piniaStores/spaces.ts
@@ -194,7 +194,13 @@ export const useSpacesStore = defineStore('spaces', () => {
     }
   }
 
-  const loadSpaces = async ({ graphClient }: { graphClient: Graph }) => {
+  const loadSpaces = async ({
+    graphClient,
+    isInVault
+  }: {
+    graphClient: Graph
+    isInVault: boolean
+  }) => {
     spacesLoading.value = true
     try {
       /**
@@ -208,13 +214,13 @@ export const useSpacesStore = defineStore('spaces', () => {
       const [personalSpaces, projectSpaces] = await Promise.all([
         getSpacesByType({
           graphClient,
-          driveType: 'personal',
+          driveType: isInVault ? "'protected-personal'" : 'personal',
           configStore,
           graphRoles: sharesStore.graphRoles
         }),
         getSpacesByType({
           graphClient,
-          driveType: 'project',
+          driveType: isInVault ? "'protected-project'" : 'project',
           configStore,
           graphRoles: sharesStore.graphRoles
         })
@@ -254,14 +260,16 @@ export const useSpacesStore = defineStore('spaces', () => {
 
   const reloadProjectSpaces = async ({
     graphClient,
+    isInVault,
     signal
   }: {
     graphClient: Graph
+    isInVault: boolean
     signal?: AbortSignal
   }) => {
     const projectSpaces = await getSpacesByType({
       graphClient,
-      driveType: 'project',
+      driveType: isInVault ? "'protected-project'" : 'project',
       configStore,
       graphRoles: sharesStore.graphRoles,
       signal

--- a/packages/web-pkg/src/composables/piniaStores/spaces.ts
+++ b/packages/web-pkg/src/composables/piniaStores/spaces.ts
@@ -11,7 +11,8 @@ import {
   buildSpace,
   extractStorageId,
   isPersonalSpaceResource,
-  isProjectSpaceResource
+  isProjectSpaceResource,
+  isProtectedProjectSpaceResource
 } from '@ownclouders/web-client'
 import type { CollaboratorShare, MountPointSpaceResource, ShareRole } from '@ownclouders/web-client'
 import { useUserStore } from './user'
@@ -274,7 +275,9 @@ export const useSpacesStore = defineStore('spaces', () => {
       graphRoles: sharesStore.graphRoles,
       signal
     })
-    spaces.value = unref(spaces).filter((s) => !isProjectSpaceResource(s))
+    spaces.value = unref(spaces).filter(
+      (s) => !isProjectSpaceResource(s) && !isProtectedProjectSpaceResource(s)
+    )
     addSpaces(projectSpaces)
   }
 

--- a/packages/web-pkg/src/composables/router/useActiveApp.ts
+++ b/packages/web-pkg/src/composables/router/useActiveApp.ts
@@ -3,7 +3,8 @@ import { useRoute } from './useRoute'
 import { RouteLocationNormalizedLoaded } from 'vue-router'
 
 export const activeApp = (route: RouteLocationNormalizedLoaded): string => {
-  return route.path.split('/')[1]
+  const removeVaultPrefix = route.path.replace(/^\/vault/, '')
+  return removeVaultPrefix.split('/')[1]
 }
 
 export const useActiveApp = (): ComputedRef<string> => {

--- a/packages/web-pkg/src/composables/search/useSearch.ts
+++ b/packages/web-pkg/src/composables/search/useSearch.ts
@@ -78,7 +78,8 @@ export const useSearch = () => {
     lastModified,
     mediaType,
     scope,
-    useScope
+    useScope,
+    isVault
   }: {
     term: string
     isTitleOnlySearch?: boolean
@@ -87,6 +88,7 @@ export const useSearch = () => {
     mediaType?: string
     scope?: string
     useScope?: boolean
+    isVault?: boolean
   }) => {
     const query: string[] = []
 
@@ -120,6 +122,11 @@ export const useSearch = () => {
       const mediatypes = mediaType.split('+').map((t) => `"${t}"`)
       query.push(`mediatype:(${mediatypes.join(' OR ')})`)
     }
+
+    if (isVault) {
+      query.push('vault:true')
+    }
+
     return query
       .sort((a, b) => Number(a.startsWith('scope:')) - Number(b.startsWith('scope:')))
       .join(' AND ')

--- a/packages/web-pkg/src/composables/spaces/useCreateSpace.ts
+++ b/packages/web-pkg/src/composables/spaces/useCreateSpace.ts
@@ -7,9 +7,9 @@ export const useCreateSpace = () => {
   const resourcesStore = useResourcesStore()
   const sharesStore = useSharesStore()
 
-  const createSpace = (name: string) => {
+  const createSpace = (name: string, driveType: string = 'project') => {
     const { graphAuthenticated } = clientService
-    return graphAuthenticated.drives.createDrive({ name }, sharesStore.graphRoles, {
+    return graphAuthenticated.drives.createDrive({ name, driveType }, sharesStore.graphRoles, {
       params: { template: 'default' }
     })
   }

--- a/packages/web-pkg/src/composables/webWorkers/index.ts
+++ b/packages/web-pkg/src/composables/webWorkers/index.ts
@@ -1,4 +1,5 @@
 export * from './deleteWorker'
+export * from './mfaExpiryWorker'
 export * from './pasteWorker'
 export * from './restoreWorker'
 export * from './tokenTimerWorker'

--- a/packages/web-pkg/src/composables/webWorkers/mfaExpiryWorker/index.ts
+++ b/packages/web-pkg/src/composables/webWorkers/mfaExpiryWorker/index.ts
@@ -1,0 +1,1 @@
+export * from './useMfaExpiryWorker'

--- a/packages/web-pkg/src/composables/webWorkers/mfaExpiryWorker/useMfaExpiryWorker.ts
+++ b/packages/web-pkg/src/composables/webWorkers/mfaExpiryWorker/useMfaExpiryWorker.ts
@@ -19,19 +19,11 @@ export const useMfaExpiryWorker = ({ onExpiring }: { onExpiring: () => void }) =
     }
   }
 
-  const setMfaTimer = ({
-    authTime,
-    sessionDuration
-  }: {
-    authTime: number
-    sessionDuration: number
-  }) => {
+  const setMfaTimer = ({ expiresAt }: { expiresAt: number }) => {
     if (!unref(worker)) {
       console.error('mfa expiry worker is not running')
       return
     }
-
-    const expiresAt = authTime + sessionDuration
 
     unref(worker).post(
       JSON.stringify({

--- a/packages/web-pkg/src/composables/webWorkers/mfaExpiryWorker/useMfaExpiryWorker.ts
+++ b/packages/web-pkg/src/composables/webWorkers/mfaExpiryWorker/useMfaExpiryWorker.ts
@@ -1,0 +1,49 @@
+import { ref, unref } from 'vue'
+import { WebWorker, useWebWorkersStore } from '../../piniaStores/webWorkers'
+import MfaWorker from './worker?worker'
+
+export type MfaExpiryWorkerTopic = 'set' | 'reset'
+
+const MFA_WARNING_THRESHOLD_SECONDS = 300 // 5 minutes before expiry
+
+export const useMfaExpiryWorker = ({ onExpiring }: { onExpiring: () => void }) => {
+  const { createWorker } = useWebWorkersStore()
+
+  const worker = ref<WebWorker>()
+
+  const startWorker = () => {
+    worker.value = createWorker(MfaWorker as unknown as string)
+
+    unref(unref(worker).worker).onmessage = () => {
+      onExpiring()
+    }
+  }
+
+  const setMfaTimer = ({ authTime, sessionDuration }: { authTime: number; sessionDuration: number }) => {
+    if (!unref(worker)) {
+      console.error('mfa expiry worker is not running')
+      return
+    }
+
+    const expiresAt = authTime + sessionDuration
+
+    unref(worker).post(
+      JSON.stringify({
+        topic: 'set',
+        expiresAt,
+        warningThreshold: MFA_WARNING_THRESHOLD_SECONDS
+      })
+    )
+  }
+
+  const resetMfaTimer = () => {
+    if (!unref(worker)) {
+      console.error('mfa expiry worker is not running')
+      return
+    }
+
+    unref(worker).post(JSON.stringify({ topic: 'reset' }))
+  }
+
+  return { startWorker, setMfaTimer, resetMfaTimer }
+}

--- a/packages/web-pkg/src/composables/webWorkers/mfaExpiryWorker/useMfaExpiryWorker.ts
+++ b/packages/web-pkg/src/composables/webWorkers/mfaExpiryWorker/useMfaExpiryWorker.ts
@@ -19,7 +19,13 @@ export const useMfaExpiryWorker = ({ onExpiring }: { onExpiring: () => void }) =
     }
   }
 
-  const setMfaTimer = ({ authTime, sessionDuration }: { authTime: number; sessionDuration: number }) => {
+  const setMfaTimer = ({
+    authTime,
+    sessionDuration
+  }: {
+    authTime: number
+    sessionDuration: number
+  }) => {
     if (!unref(worker)) {
       console.error('mfa expiry worker is not running')
       return

--- a/packages/web-pkg/src/composables/webWorkers/mfaExpiryWorker/worker.ts
+++ b/packages/web-pkg/src/composables/webWorkers/mfaExpiryWorker/worker.ts
@@ -1,0 +1,35 @@
+import { MfaExpiryWorkerTopic } from './useMfaExpiryWorker'
+
+type Message = {
+  topic: MfaExpiryWorkerTopic
+  expiresAt: number
+  warningThreshold: number
+}
+
+let timerId: ReturnType<typeof setTimeout>
+
+const resetTimer = () => {
+  clearTimeout(timerId)
+  timerId = undefined
+}
+
+self.onmessage = (e: MessageEvent) => {
+  const { topic, expiresAt, warningThreshold } = JSON.parse(e.data) as Message
+
+  if (topic === 'reset') {
+    resetTimer()
+    return
+  }
+
+  const now = Math.floor(Date.now() / 1000)
+  let timerInSeconds = expiresAt - warningThreshold - now
+  if (timerInSeconds <= 0) {
+    timerInSeconds = 1
+  }
+
+  resetTimer()
+
+  timerId = setTimeout(() => {
+    postMessage(true)
+  }, timerInSeconds * 1000)
+}

--- a/packages/web-pkg/src/services/client/client.ts
+++ b/packages/web-pkg/src/services/client/client.ts
@@ -3,7 +3,7 @@ import { graph, ocs, webdav } from '@ownclouders/web-client'
 import { Graph } from '@ownclouders/web-client/graph'
 import { OCS } from '@ownclouders/web-client/ocs'
 import { AuthParameters } from './auth'
-import axios, { AxiosResponse } from 'axios'
+import axios, { AxiosInstance, AxiosResponse } from 'axios'
 import { v4 as uuidV4 } from 'uuid'
 import { WebDAV } from '@ownclouders/web-client/webdav'
 import { Language } from 'vue3-gettext'
@@ -38,6 +38,7 @@ export class ClientService {
   private httpUnAuthenticatedClient: HttpClient
 
   private graphClient: Graph
+  private graphAxiosClient: AxiosInstance
   private ocsClient: OCS
   private webDavClient: WebDAV
 
@@ -53,7 +54,7 @@ export class ClientService {
     this.language = options.language
     this.authStore = options.authStore
 
-    this.initGraphClient()
+    this.initGraphClient(this.configStore.isInVault)
     this.initOcsClient()
     this.initWebDavClient()
 
@@ -86,6 +87,10 @@ export class ClientService {
     return this.graphClient
   }
 
+  public reinitializeGraphClient(isInVault: boolean) {
+    this.initGraphClient(isInVault)
+  }
+
   public get sseAuthenticated(): EventSource {
     return sse(
       this.configStore.serverUrl,
@@ -105,19 +110,24 @@ export class ClientService {
     return this.language.current
   }
 
-  private initGraphClient() {
-    const axiosClient = axios.create({ headers: this.staticHeaders })
-    axiosClient.interceptors.request.use((config) => {
-      Object.assign(config.headers, this.getDynamicHeaders())
-      return config
-    })
+  private initGraphClient(isInVault: boolean) {
+    if (!this.graphAxiosClient) {
+      const axiosClient = axios.create({ headers: this.staticHeaders })
+      axiosClient.interceptors.request.use((config) => {
+        Object.assign(config.headers, this.getDynamicHeaders())
+        return config
+      })
+      axiosClient.interceptors.response.use(
+        this.#handleAxiosResponse.bind(this),
+        this.#handleAxiosError.bind(this)
+      )
+      this.graphAxiosClient = axiosClient
+    }
 
-    axiosClient.interceptors.response.use(
-      this.#handleAxiosResponse.bind(this),
-      this.#handleAxiosError.bind(this)
+    this.graphClient = graph(
+      isInVault ? `${this.configStore.serverUrl}vault` : this.configStore.serverUrl,
+      this.graphAxiosClient
     )
-
-    this.graphClient = graph(this.configStore.serverUrl, axiosClient)
   }
 
   private initOcsClient() {

--- a/packages/web-pkg/src/services/client/client.ts
+++ b/packages/web-pkg/src/services/client/client.ts
@@ -43,6 +43,7 @@ export class ClientService {
   private webDavClient: WebDAV
 
   public initiatorId = uuidV4()
+  public lastSuccessfulRequestTime: number | null = null
 
   private staticHeaders: Record<string, string> = {
     'Initiator-ID': this.initiatorId,
@@ -187,6 +188,8 @@ export class ClientService {
     if (response.status !== 503) {
       this.configStore.setMaintenanceMode(false)
     }
+
+    this.lastSuccessfulRequestTime = Math.floor(Date.now() / 1000)
 
     return response
   }

--- a/packages/web-pkg/src/services/folder/loaders/loaderSpace.ts
+++ b/packages/web-pkg/src/services/folder/loaders/loaderSpace.ts
@@ -8,7 +8,6 @@ import {
   isPersonalSpaceResource,
   isPublicSpaceResource,
   isShareSpaceResource,
-  isProtectedPersonalSpaceResource,
   SpaceMember,
   SpaceResource
 } from '@ownclouders/web-client'
@@ -85,11 +84,7 @@ export class FolderLoaderSpace implements FolderLoader {
                 serverUrl: configStore.serverUrl
               })
             }
-          } else if (
-            !isPersonalSpaceResource(space) &&
-            !isPublicSpaceResource(space) &&
-            !isProtectedPersonalSpaceResource(space)
-          ) {
+          } else if (!isPersonalSpaceResource(space) && !isPublicSpaceResource(space)) {
             // note: in the future we might want to show the space as root for personal spaces as well (to show quota and the like). Currently not needed.
             currentFolder = space
           }

--- a/packages/web-pkg/src/services/folder/loaders/loaderSpace.ts
+++ b/packages/web-pkg/src/services/folder/loaders/loaderSpace.ts
@@ -8,6 +8,7 @@ import {
   isPersonalSpaceResource,
   isPublicSpaceResource,
   isShareSpaceResource,
+  isProtectedPersonalSpaceResource,
   SpaceMember,
   SpaceResource
 } from '@ownclouders/web-client'
@@ -84,7 +85,11 @@ export class FolderLoaderSpace implements FolderLoader {
                 serverUrl: configStore.serverUrl
               })
             }
-          } else if (!isPersonalSpaceResource(space) && !isPublicSpaceResource(space)) {
+          } else if (
+            !isPersonalSpaceResource(space) &&
+            !isPublicSpaceResource(space) &&
+            !isProtectedPersonalSpaceResource(space)
+          ) {
             // note: in the future we might want to show the space as root for personal spaces as well (to show quota and the like). Currently not needed.
             currentFolder = space
           }

--- a/packages/web-pkg/tests/unit/composables/piniaStores/extensionRegistry/extensionRegistry.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/piniaStores/extensionRegistry/extensionRegistry.spec.ts
@@ -3,12 +3,13 @@ import {
   CustomComponentExtension,
   Extension,
   ExtensionPoint,
+  SidebarNavExtension,
   SidebarPanelExtension,
   useExtensionRegistry
 } from '../../../../../src'
 import { getComposableWrapper } from '@ownclouders/web-test-helpers'
 import { createPinia, setActivePinia } from 'pinia'
-import { computed, unref } from 'vue'
+import { computed, ref, unref } from 'vue'
 import { mock } from 'vitest-mock-extended'
 
 describe('useExtensionRegistry', () => {
@@ -246,6 +247,52 @@ describe('useExtensionRegistry', () => {
 
           const result2 = instance.getExtensionPoints({ extensionType: 'customComponent' })
           expect(result2.length).toBe(0)
+        }
+      })
+    })
+  })
+
+  describe('rebuild', () => {
+    it('returns a non-vault route when scope is not vault', () => {
+      const sidebarExtension = mock<SidebarNavExtension>({
+        id: 'sidebar-non-vault',
+        type: 'sidebarNav',
+        navItem: {
+          name: 'Files',
+          route: 'files'
+        }
+      })
+
+      getWrapper({
+        setup: (instance) => {
+          instance.registerExtensions(ref<Extension[]>([sidebarExtension]))
+
+          instance.rebuild({ route: ref({ params: { scope: 'projects' } }) })
+
+          const rebuiltExtension = unref(unref(instance.extensions)[0])[0] as SidebarNavExtension
+          expect(rebuiltExtension.navItem.route).toBe('/files')
+        }
+      })
+    })
+
+    it('returns a vault-prefixed route when scope is vault', () => {
+      const sidebarExtension = mock<SidebarNavExtension>({
+        id: 'sidebar-vault',
+        type: 'sidebarNav',
+        navItem: {
+          name: 'Files',
+          route: 'files'
+        }
+      })
+
+      getWrapper({
+        setup: (instance) => {
+          instance.registerExtensions(ref<Extension[]>([sidebarExtension]))
+
+          instance.rebuild({ route: ref({ params: { scope: 'vault' } }) })
+
+          const rebuiltExtension = unref(unref(instance.extensions)[0])[0] as SidebarNavExtension
+          expect(rebuiltExtension.navItem.route).toBe('/vault/files')
         }
       })
     })

--- a/packages/web-pkg/tests/unit/composables/piniaStores/spaces.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/piniaStores/spaces.spec.ts
@@ -179,7 +179,7 @@ describe('spaces', () => {
           const spaces = [mock<SpaceResource>({ id: '1' })]
           const graphClient = mockDeep<Graph>()
           graphClient.drives.listMyDrives.mockResolvedValue(spaces)
-          await instance.loadSpaces({ graphClient })
+          await instance.loadSpaces({ graphClient, isInVault: false })
 
           expect(graphClient.drives.listMyDrives).toHaveBeenCalledTimes(2)
           expect(graphClient.drives.listMyDrives).toHaveBeenNthCalledWith(
@@ -226,7 +226,7 @@ describe('spaces', () => {
               ]
               const graphClient = mockDeep<Graph>()
               graphClient.drives.listMyDrives.mockResolvedValue(spaces)
-              await instance.loadSpaces({ graphClient })
+              await instance.loadSpaces({ graphClient, isInVault: false })
 
               expect(graphClient.drives.listMyDrives).toHaveBeenCalledTimes(2)
               expect(graphClient.drives.listMyDrives).toHaveBeenNthCalledWith(
@@ -290,7 +290,7 @@ describe('spaces', () => {
           const spaces = [mock<SpaceResource>({ id: '1' })]
           const graphClient = mockDeep<Graph>()
           graphClient.drives.listMyDrives.mockResolvedValue(spaces)
-          await instance.reloadProjectSpaces({ graphClient })
+          await instance.reloadProjectSpaces({ graphClient, isInVault: false })
 
           expect(graphClient.drives.listMyDrives).toHaveBeenCalledTimes(1)
           expect(graphClient.drives.listMyDrives).toHaveBeenCalledWith(

--- a/packages/web-pkg/tests/unit/composables/search/useSearch.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/search/useSearch.spec.ts
@@ -3,6 +3,44 @@ import { CapabilityStore, useSearch } from '../../../../src/composables'
 import { SearchResource, SpaceResource } from '@ownclouders/web-client'
 
 describe('useSearch', () => {
+  describe('method "buildSearchTerm"', () => {
+    it('appends vault:true when isVault is true', () => {
+      const wrapper = createWrapper()
+      const result = wrapper.vm.buildSearchTerm({ term: 'test', isVault: true })
+      expect(result).toContain('vault:true')
+    })
+    it('does not append vault:true when isVault is false', () => {
+      const wrapper = createWrapper()
+      const result = wrapper.vm.buildSearchTerm({ term: 'test', isVault: false })
+      expect(result).not.toContain('vault:true')
+    })
+    it('does not append vault:true when isVault is undefined', () => {
+      const wrapper = createWrapper()
+      const result = wrapper.vm.buildSearchTerm({ term: 'test' })
+      expect(result).not.toContain('vault:true')
+    })
+    it('combines vault:true with other query parts', () => {
+      const wrapper = createWrapper()
+      const result = wrapper.vm.buildSearchTerm({
+        term: 'test',
+        tags: 'lorem',
+        isVault: true
+      })
+      expect(result).toContain('vault:true')
+      expect(result).toContain('tag:("lorem")')
+      expect(result).toContain('name:"*test*"')
+    })
+    it('places scope: at the end of the query', () => {
+      const wrapper = createWrapper()
+      const result = wrapper.vm.buildSearchTerm({
+        term: 'test',
+        scope: 'lorem',
+        useScope: true,
+        isVault: true
+      })
+      expect(result).toMatch(/scope:lorem$/)
+    })
+  })
   describe('method "search"', () => {
     it('can search', async () => {
       const files = [
@@ -58,10 +96,11 @@ const createWrapper = ({ resources = [] }: { resources?: SearchResource[] } = {}
 
   return getComposableWrapper(
     () => {
-      const { search } = useSearch()
+      const { search, buildSearchTerm } = useSearch()
 
       return {
-        search
+        search,
+        buildSearchTerm
       }
     },
     {

--- a/packages/web-runtime/src/components/SidebarNav/SidebarNav.vue
+++ b/packages/web-runtime/src/components/SidebarNav/SidebarNav.vue
@@ -172,7 +172,7 @@ export default defineComponent({
 }
 
 #web-nav-sidebar {
-  background-color: var(--oc-color-background-default);
+  background-color: var(--oc-color-background-sidebar, var(--oc-color-background-default));
   border-radius: 15px 0 0 15px;
   box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.2);
   display: flex;

--- a/packages/web-runtime/src/components/SidebarNav/SidebarNavItem.vue
+++ b/packages/web-runtime/src/components/SidebarNav/SidebarNavItem.vue
@@ -111,7 +111,6 @@ export default defineComponent({
   }
   .text {
     opacity: 1;
-    transition: all 0.3s;
   }
   .text-invisible {
     opacity: 0 !important;
@@ -119,7 +118,12 @@ export default defineComponent({
   }
 
   &:hover:not(.active) {
-    color: var(--oc-color-swatch-brand-hover) !important;
+    background-color: var(--oc-color-swatch-primary-hover) !important;
+    color: var(--oc-color-swatch-primary-contrast) !important;
+
+    .oc-icon > svg {
+      fill: var(--oc-color-swatch-primary-contrast);
+    }
   }
 
   &:hover,
@@ -128,10 +132,10 @@ export default defineComponent({
   }
   &.active {
     overflow: hidden;
-  }
 
-  .oc-icon svg {
-    transition: all 0.3s;
+    &:hover .oc-icon > svg {
+      fill: var(--oc-color-swatch-primary-contrast);
+    }
   }
 }
 </style>

--- a/packages/web-runtime/src/components/Topbar/ApplicationsMenu.vue
+++ b/packages/web-runtime/src/components/Topbar/ApplicationsMenu.vue
@@ -91,6 +91,19 @@ export default defineComponent({
     const getAdditionalEventBindings = (item: AppMenuItemExtension) => {
       return item.handler ? { click: item.handler } : {}
     }
+
+    const getScopeAwarePath = (rawPath?: string) => {
+      if (!rawPath) {
+        return rawPath
+      }
+
+      const normalizedPath = rawPath.startsWith('/') ? rawPath : `/${rawPath}`
+      const pathWithoutVault = normalizedPath.replace(/^\/vault(?=\/|$)/, '')
+      const isVaultScope = unref(router.currentRoute).params?.scope === 'vault'
+
+      return isVaultScope ? `/vault${pathWithoutVault}` : pathWithoutVault
+    }
+
     const getAdditionalAttributes = (item: AppMenuItemExtension) => {
       let type: string
       if (item.handler) {
@@ -103,12 +116,13 @@ export default defineComponent({
 
       return {
         type,
-        ...(type === 'router-link' && { to: item.path }),
+        ...(type === 'router-link' && { to: getScopeAwarePath(item.path) }),
         ...(type === 'a' && { href: item.url, target: '_blank' })
       }
     }
     const isMenuItemActive = (item: AppMenuItemExtension) => {
-      return unref(activeRoutePath)?.startsWith(item.path)
+      const routePath = getScopeAwarePath(item.path)
+      return !!routePath && unref(activeRoutePath)?.startsWith(routePath)
     }
 
     return {

--- a/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -175,12 +175,12 @@ export default {
 
     const selectedMode = computed({
       get() {
-        const currentPath = unref(router.currentRoute).path
+        const currentPath = window.location.pathname
         return currentPath.startsWith('/vault') ? unref(modeOptions)[1] : unref(modeOptions)[0]
       },
       set(mode) {
-        if (mode?.route && mode.route !== unref(router.currentRoute).path) {
-          router.push(mode.route)
+        if (mode?.route && mode.route !== window.location.pathname) {
+          window.location.href = mode.route
         }
       }
     })

--- a/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -19,12 +19,25 @@
           class="oc-logo-image"
         />
       </router-link>
+      <div class="oc-flex oc-flex-middle">
+        <oc-select
+          v-if="!isEmbedModeEnabled"
+          v-model="selectedMode"
+          class="oc-topbar-mode-switch"
+          :label="$gettext('Mode')"
+          :label-hidden="true"
+          :clearable="false"
+          :searchable="false"
+          :options="modeOptions"
+          option-label="label"
+        />
+      </div>
     </div>
     <div v-if="!contentOnLeftPortal" class="oc-topbar-center oc-width-1-1">
       <custom-component-target :extension-point="topBarCenterExtensionPoint" />
     </div>
     <div class="oc-topbar-right oc-flex oc-flex-middle">
-      <oc-select
+      <!-- <oc-select
         v-if="!isEmbedModeEnabled"
         v-model="selectedMode"
         class="oc-topbar-mode-switch"
@@ -33,7 +46,7 @@
         :clearable="false"
         :options="modeOptions"
         option-label="label"
-      />
+      /> -->
       <portal-target name="app.runtime.header.right" multiple />
     </div>
     <template v-if="!isEmbedModeEnabled">
@@ -304,6 +317,11 @@ export default {
     .oc-topbar-mode-switch {
       min-width: 12rem;
     }
+  }
+
+  .oc-topbar-mode-switch {
+    flex-shrink: 0;
+    min-width: 12rem;
   }
 }
 </style>

--- a/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -24,6 +24,16 @@
       <custom-component-target :extension-point="topBarCenterExtensionPoint" />
     </div>
     <div class="oc-topbar-right oc-flex oc-flex-middle">
+      <oc-select
+        v-if="!isEmbedModeEnabled"
+        v-model="selectedMode"
+        class="oc-topbar-mode-switch"
+        :label="$gettext('Mode')"
+        :label-hidden="true"
+        :clearable="false"
+        :options="modeOptions"
+        option-label="label"
+      />
       <portal-target name="app.runtime.header.right" multiple />
     </div>
     <template v-if="!isEmbedModeEnabled">
@@ -65,6 +75,7 @@ import {
   useRouter,
   useThemeStore
 } from '@ownclouders/web-pkg'
+import { useGettext } from 'vue3-gettext'
 import { isRuntimeRoute } from '../../router'
 import { appMenuExtensionPoint, topBarCenterExtensionPoint } from '../../extensionPoints'
 
@@ -86,6 +97,7 @@ export default {
     }
   },
   setup() {
+    const { $gettext } = useGettext()
     const capabilityStore = useCapabilityStore()
     const themeStore = useThemeStore()
     const { currentTheme } = storeToRefs(themeStore)
@@ -146,6 +158,33 @@ export default {
       )
     })
 
+    const modeOptions = computed(() => {
+      return [
+        {
+          id: 'default-mode',
+          label: $gettext('Default mode'),
+          route: '/'
+        },
+        {
+          id: 'account-mode',
+          label: $gettext('Vault'),
+          route: '/vault/files'
+        }
+      ]
+    })
+
+    const selectedMode = computed({
+      get() {
+        const currentPath = unref(router.currentRoute).path
+        return currentPath.startsWith('/vault') ? unref(modeOptions)[1] : unref(modeOptions)[0]
+      },
+      set(mode) {
+        if (mode?.route && mode.route !== unref(router.currentRoute).path) {
+          router.push(mode.route)
+        }
+      }
+    })
+
     return {
       configOptions,
       contentOnLeftPortal,
@@ -161,7 +200,9 @@ export default {
       appMenuExtensions,
       hideAppSwitcher,
       hideAccountMenu,
-      isUniversalAccessEnabled
+      isUniversalAccessEnabled,
+      modeOptions,
+      selectedMode
     }
   },
   computed: {
@@ -257,6 +298,10 @@ export default {
     @media (min-width: $oc-breakpoint-small-default) {
       gap: 20px;
       justify-content: flex-end;
+    }
+
+    .oc-topbar-mode-switch {
+      min-width: 12rem;
     }
   }
 }

--- a/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -132,7 +132,8 @@ export default {
         }
       }
 
-      return '/'
+      const isVaultScope = unref(router.currentRoute).params?.scope === 'vault'
+      return isVaultScope ? '/vault/files' : '/'
     })
 
     const isFilesPublicUpoad = computed(() => {

--- a/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -37,16 +37,6 @@
       <custom-component-target :extension-point="topBarCenterExtensionPoint" />
     </div>
     <div class="oc-topbar-right oc-flex oc-flex-middle">
-      <!-- <oc-select
-        v-if="!isEmbedModeEnabled"
-        v-model="selectedMode"
-        class="oc-topbar-mode-switch"
-        :label="$gettext('Mode')"
-        :label-hidden="true"
-        :clearable="false"
-        :options="modeOptions"
-        option-label="label"
-      /> -->
       <portal-target name="app.runtime.header.right" multiple />
     </div>
     <template v-if="!isEmbedModeEnabled">
@@ -86,7 +76,8 @@ import {
   useExtensionRegistry,
   useOpenEmptyEditor,
   useRouter,
-  useThemeStore
+  useThemeStore,
+  useClipboardStore
 } from '@ownclouders/web-pkg'
 import { useGettext } from 'vue3-gettext'
 import { isRuntimeRoute } from '../../router'
@@ -118,6 +109,7 @@ export default {
     const { options: configOptions } = storeToRefs(configStore)
     const extensionRegistry = useExtensionRegistry()
     const { openEmptyEditor } = useOpenEmptyEditor()
+    const { clearClipboard } = useClipboardStore()
 
     const authStore = useAuthStore()
     const router = useRouter()
@@ -176,11 +168,11 @@ export default {
       return [
         {
           id: 'default-mode',
-          label: $gettext('Default mode'),
+          label: $gettext('Drive'),
           route: '/'
         },
         {
-          id: 'account-mode',
+          id: 'vault-mode',
           label: $gettext('Vault'),
           route: '/vault/files'
         }
@@ -193,6 +185,9 @@ export default {
         return currentPath.startsWith('/vault') ? unref(modeOptions)[1] : unref(modeOptions)[0]
       },
       set(mode) {
+        if (mode.id === 'default-mode') {
+          clearClipboard()
+        }
         if (mode?.route && mode.route !== window.location.pathname) {
           window.location.href = mode.route
         }

--- a/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -334,9 +334,14 @@ export default {
   }
 
   .oc-topbar-mode-switch {
+    color: var(--oc-color-swatch-brand-contrast);
     flex-shrink: 0;
     text-transform: uppercase;
     font-weight: bold;
+
+    .oc-icon > svg {
+      fill: var(--oc-color-swatch-brand-contrast);
+    }
   }
 
   .oc-topbar-mode-switch-list li {

--- a/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -19,18 +19,36 @@
           class="oc-logo-image"
         />
       </router-link>
-      <div class="oc-flex oc-flex-middle">
-        <oc-select
-          v-if="!isEmbedModeEnabled"
-          v-model="selectedMode"
+      <div v-if="!isEmbedModeEnabled" class="oc-flex oc-flex-middle">
+        <oc-button
+          id="oc-topbar-mode-switch-btn"
           class="oc-topbar-mode-switch"
-          :label="$gettext('Mode')"
-          :label-hidden="true"
-          :clearable="false"
-          :searchable="false"
-          :options="modeOptions"
-          option-label="label"
-        />
+          appearance="raw"
+          gap-size="none"
+        >
+          <span class="oc-mr-xs" v-text="selectedMode.label" />
+          <oc-icon name="arrow-down-s" />
+        </oc-button>
+        <oc-drop
+          toggle="#oc-topbar-mode-switch-btn"
+          mode="click"
+          padding-size="small"
+          close-on-click
+        >
+          <oc-list class="oc-topbar-mode-switch-list">
+            <li v-for="option in modeOptions" :key="option.id">
+              <oc-button
+                appearance="raw"
+                justify-content="space-between"
+                class="oc-topbar-mode-switch-option oc-p-s oc-width-1-1"
+                @click="selectedMode = option"
+              >
+                <span>{{ option.label }}</span>
+                <oc-icon v-if="selectedMode.id === option.id" name="check" />
+              </oc-button>
+            </li>
+          </oc-list>
+        </oc-drop>
       </div>
     </div>
     <div v-if="!contentOnLeftPortal" class="oc-topbar-center oc-width-1-1">
@@ -308,15 +326,32 @@ export default {
       gap: 20px;
       justify-content: flex-end;
     }
-
-    .oc-topbar-mode-switch {
-      min-width: 12rem;
-    }
   }
 
   .oc-topbar-mode-switch {
     flex-shrink: 0;
-    min-width: 12rem;
+    text-transform: uppercase;
+    font-weight: bold;
+  }
+
+  .oc-topbar-mode-switch-list li {
+    margin: var(--oc-space-xsmall) 0;
+
+    &:first-child {
+      margin-top: 0;
+    }
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  .oc-topbar-mode-switch-option {
+    &:hover,
+    &:focus {
+      background-color: var(--oc-color-background-hover);
+      text-decoration: none;
+    }
   }
 }
 </style>

--- a/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -19,7 +19,7 @@
           class="oc-logo-image"
         />
       </router-link>
-      <div v-if="!isEmbedModeEnabled" class="oc-flex oc-flex-middle">
+      <div v-if="!isEmbedModeEnabled && canAccessVault" class="oc-flex oc-flex-middle">
         <oc-button
           id="oc-topbar-mode-switch-btn"
           class="oc-topbar-mode-switch"
@@ -95,7 +95,8 @@ import {
   useOpenEmptyEditor,
   useRouter,
   useThemeStore,
-  useClipboardStore
+  useClipboardStore,
+  useAbility
 } from '@ownclouders/web-pkg'
 import { useGettext } from 'vue3-gettext'
 import { isRuntimeRoute } from '../../router'
@@ -128,6 +129,7 @@ export default {
     const extensionRegistry = useExtensionRegistry()
     const { openEmptyEditor } = useOpenEmptyEditor()
     const { clearClipboard } = useClipboardStore()
+    const ability = useAbility()
 
     const authStore = useAuthStore()
     const router = useRouter()
@@ -212,6 +214,8 @@ export default {
       }
     })
 
+    const canAccessVault = computed(() => ability.can('read-all', 'Vault'))
+
     return {
       configOptions,
       contentOnLeftPortal,
@@ -229,7 +233,8 @@ export default {
       hideAccountMenu,
       isUniversalAccessEnabled,
       modeOptions,
-      selectedMode
+      selectedMode,
+      canAccessVault
     }
   },
   computed: {

--- a/packages/web-runtime/src/components/Topbar/TopBar.vue
+++ b/packages/web-runtime/src/components/Topbar/TopBar.vue
@@ -214,7 +214,9 @@ export default {
       }
     })
 
-    const canAccessVault = computed(() => ability.can('read-all', 'Vault'))
+    const canAccessVault = computed(
+      () => capabilityStore.vaultEnabled && ability.can('read-all', 'Vault')
+    )
 
     return {
       configOptions,

--- a/packages/web-runtime/src/container/api.ts
+++ b/packages/web-runtime/src/container/api.ts
@@ -38,7 +38,7 @@ const announceRoutes = (applicationId: string, router: Router, routes: RouteReco
           applicationId === route.name ? route.name : namespaceRouteName(String(route.name))
       }
 
-      route.path = `/${encodeURI(applicationId)}${route.path}`
+      route.path = `/:scope(vault)?/${encodeURI(applicationId)}${route.path}`
 
       if (route.children) {
         route.children = route.children.map((childRoute) => {

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -235,6 +235,9 @@ export const bootstrapApp = async (configurationPath: string, appsReadyCallback:
 
       const isInVault = window.location.pathname.startsWith('/vault')
 
+      configStore.setIsInVault(isInVault)
+      clientService.reinitializeGraphClient(isInVault)
+
       // Load spaces to make them available across the application
       try {
         await spacesStore.loadSpaces({ graphClient: clientService.graphAuthenticated, isInVault })

--- a/packages/web-runtime/src/index.ts
+++ b/packages/web-runtime/src/index.ts
@@ -233,9 +233,11 @@ export const bootstrapApp = async (configurationPath: string, appsReadyCallback:
         await clientService.graphAuthenticated.permissions.listRoleDefinitions()
       sharesStore.setGraphRoles(graphRoleDefinitions)
 
+      const isInVault = window.location.pathname.startsWith('/vault')
+
       // Load spaces to make them available across the application
       try {
-        await spacesStore.loadSpaces({ graphClient: clientService.graphAuthenticated })
+        await spacesStore.loadSpaces({ graphClient: clientService.graphAuthenticated, isInVault })
         const personalSpace = spacesStore.spaces.find(isPersonalSpaceResource)
 
         if (personalSpace) {

--- a/packages/web-runtime/src/layouts/Application.vue
+++ b/packages/web-runtime/src/layouts/Application.vue
@@ -198,7 +198,6 @@ export default defineComponent({
       return orderBy(
         unref(extensionNavItems).map((item) => {
           let active = typeof item.isActive !== 'function' || item.isActive()
-          console.log('active item: ', active)
 
           if (active) {
             active = [item.route, ...(item.activeFor || [])].filter(Boolean).some((currentItem) => {

--- a/packages/web-runtime/src/layouts/Application.vue
+++ b/packages/web-runtime/src/layouts/Application.vue
@@ -114,6 +114,16 @@ export default defineComponent({
     const allMessages = ref<{ id: string; title: string; desc?: string }[]>([])
 
     watch(
+      () => route.value.params?.scope,
+      () => {
+        extensionRegistry.rebuild({ route })
+      },
+      {
+        immediate: true
+      }
+    )
+
+    watch(
       () => messageStore.messages,
       (messages) => {
         if (messages && messages.length > 0) {
@@ -183,17 +193,21 @@ export default defineComponent({
       }
 
       const { href: currentHref } = router.resolve(unref(route))
+      const newRef = currentHref.replace(/^\/vault/, '')
+
       return orderBy(
         unref(extensionNavItems).map((item) => {
           let active = typeof item.isActive !== 'function' || item.isActive()
+          console.log('active item: ', active)
 
           if (active) {
             active = [item.route, ...(item.activeFor || [])].filter(Boolean).some((currentItem) => {
               try {
-                const comparativeHref = router.resolve(
-                  currentItem as RouteLocationAsRelativeTyped
-                ).href
-                return currentHref.startsWith(comparativeHref)
+                const comparativeHref = router
+                  .resolve(currentItem as RouteLocationAsRelativeTyped)
+                  .href.replace(/^\/vault/, '')
+
+                return newRef.startsWith(comparativeHref)
               } catch (e) {
                 console.error(e)
                 return false

--- a/packages/web-runtime/src/pages/resolvePublicLink.vue
+++ b/packages/web-runtime/src/pages/resolvePublicLink.vue
@@ -118,7 +118,7 @@ const publicLinkSpace = computed(() =>
   })
 )
 
-const item = computed(() => queryItemAsString(unref(route).params.driveAliasAndItem))
+const item = computed(() => queryItemAsString(unref(route)?.params?.driveAliasAndItem))
 
 const detailsQuery = useRouteQuery('details')
 const details = computed(() => queryItemAsString(unref(detailsQuery)))

--- a/packages/web-runtime/src/services/auth/abilities.ts
+++ b/packages/web-runtime/src/services/auth/abilities.ts
@@ -51,7 +51,8 @@ export const getAbilities = (
       { action: 'update-all', subject: 'Drive' }
     ],
     'Drives.List.all': [{ action: 'read-all', subject: 'Drive' }],
-    'Drives.ReadWriteProjectQuota.all': [{ action: 'set-quota-all', subject: 'Drive' }]
+    'Drives.ReadWriteProjectQuota.all': [{ action: 'set-quota-all', subject: 'Drive' }],
+    'VaultMode.ReadWriteEnabled.own': [{ action: 'read-all', subject: 'Vault' }]
   }
 
   return Object.keys(abilities).reduce((acc, permission) => {

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -123,6 +123,10 @@ export class AuthService implements AuthServiceInterface {
       }
     }
 
+    if (to.params.scope === 'vault') {
+      this.requireAcr('advanced', to.fullPath)
+    }
+
     if (isPublicLinkContextRequired(this.router, to)) {
       const user = await this.userManager.getUser()
 

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -7,6 +7,8 @@ import {
   CapabilityStore,
   ConfigStore,
   useTokenTimerWorker,
+  useMfaExpiryWorker,
+  useModals,
   AuthServiceInterface
 } from '@ownclouders/web-pkg'
 import { RouteLocation, Router } from 'vue-router'
@@ -39,6 +41,11 @@ export class AuthService implements AuthServiceInterface {
 
   private tokenTimerWorker: ReturnType<typeof useTokenTimerWorker>
   private tokenTimerInitialized = false
+
+  private mfaExpiryWorker: ReturnType<typeof useMfaExpiryWorker>
+  private mfaExpiryModalDismissed = false
+  private mfaExpiryModalId: string | null = null
+  private mfaExpiryBroadcastChannel: BroadcastChannel
 
   // number of seconds before an access token is to expire to raise the accessTokenExpiring event
   private accessTokenExpiryThreshold = 10
@@ -119,6 +126,12 @@ export class AuthService implements AuthServiceInterface {
         if (!options.embed?.enabled || !options.embed?.delegateAuthentication) {
           this.tokenTimerWorker = useTokenTimerWorker({ authService: this })
           this.tokenTimerWorker.startWorker()
+
+          this.mfaExpiryWorker = useMfaExpiryWorker({
+            onExpiring: () => this.showMfaExpiryWarning()
+          })
+          this.mfaExpiryWorker.startWorker()
+          this.initMfaExpiryBroadcastChannel()
         }
       }
     }
@@ -168,6 +181,7 @@ export class AuthService implements AuthServiceInterface {
           )
           try {
             await this.userManager.updateContext(user.access_token, fetchUserData)
+            this.updateMfaExpiryTimer(user.profile?.auth_time as number | undefined)
           } catch (e) {
             console.error(e)
             await this.handleAuthError(unref(this.router.currentRoute))
@@ -177,6 +191,7 @@ export class AuthService implements AuthServiceInterface {
         this.userManager.events.addUserUnloaded(() => {
           console.log('user unloaded…')
           this.tokenTimerWorker?.resetTokenTimer()
+          this.mfaExpiryWorker?.resetMfaTimer()
           this.resetStateAfterUserLogout()
 
           if (this.userManager.unloadReason === 'authError') {
@@ -228,6 +243,8 @@ export class AuthService implements AuthServiceInterface {
               expiryThreshold: this.accessTokenExpiryThreshold
             })
 
+            this.updateMfaExpiryTimer(user.profile?.auth_time as number | undefined)
+
             this.tokenTimerInitialized = true
           }
         } catch (e) {
@@ -265,6 +282,11 @@ export class AuthService implements AuthServiceInterface {
         window.addEventListener('message', this.handleDelegatedTokenUpdate)
       } else {
         await this.userManager.signinRedirectCallback(this.buildSignInCallbackUrl())
+      }
+
+      const user = await this.userManager.getUser()
+      if (user) {
+        this.updateMfaExpiryTimer(user.profile?.auth_time as number | undefined)
       }
 
       const redirectRoute = this.router.resolve(this.userManager.getAndClearPostLoginRedirectUrl())
@@ -411,6 +433,79 @@ export class AuthService implements AuthServiceInterface {
 
     this.userManager.setPostLoginRedirectUrl(redirectUrl)
     return this.userManager.signinRedirect({ acr_values: acrValue })
+  }
+
+  private updateMfaExpiryTimer(authTime: number | undefined) {
+    if (!this.mfaExpiryWorker) {
+      return
+    }
+
+    const sessionDuration = this.capabilityStore.authMfaSessionDuration
+    if (!authTime || !sessionDuration) {
+      return
+    }
+
+    this.mfaExpiryModalDismissed = false
+    this.mfaExpiryWorker.setMfaTimer({ authTime, sessionDuration })
+  }
+
+  private showMfaExpiryWarning() {
+    if (this.mfaExpiryModalDismissed) {
+      return
+    }
+
+    this.mfaExpiryModalDismissed = true
+    const { $gettext } = this.language
+
+    const modalStore = useModals()
+    const modal = modalStore.dispatchModal({
+      title: $gettext('Session expiring'),
+      message: $gettext(
+        'Your multi-factor authentication session is about to expire. Would you like to extend it?'
+      ),
+      confirmText: $gettext('Extend session'),
+      cancelText: $gettext('Dismiss'),
+      onConfirm: async () => {
+        this.mfaExpiryModalId = null
+        this.mfaExpiryBroadcastChannel?.postMessage({ action: 'prolonged' })
+        await this.prolongMfaSession()
+      },
+      onCancel: () => {
+        this.mfaExpiryModalId = null
+        this.mfaExpiryBroadcastChannel?.postMessage({ action: 'dismissed' })
+      }
+    })
+    this.mfaExpiryModalId = modal.id
+  }
+
+  private async prolongMfaSession() {
+    const acrValue = this.capabilityStore.authMfaRequiredLevelname
+    if (!acrValue) {
+      return
+    }
+
+    try {
+      await this.userManager.signinSilent({ acr_values: acrValue })
+    } catch {
+      const redirectUrl = unref(this.router.currentRoute)?.fullPath
+      this.userManager.setPostLoginRedirectUrl(redirectUrl)
+      await this.userManager.signinRedirect({ acr_values: acrValue })
+    }
+  }
+
+  private initMfaExpiryBroadcastChannel() {
+    this.mfaExpiryBroadcastChannel = new BroadcastChannel('oc-mfa-expiry')
+    this.mfaExpiryBroadcastChannel.onmessage = (event: MessageEvent) => {
+      const { action } = event.data
+      if (action === 'prolonged' || action === 'dismissed') {
+        this.mfaExpiryModalDismissed = true
+        if (this.mfaExpiryModalId) {
+          const modalStore = useModals()
+          modalStore.removeModal(this.mfaExpiryModalId)
+          this.mfaExpiryModalId = null
+        }
+      }
+    }
   }
 }
 

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -181,7 +181,7 @@ export class AuthService implements AuthServiceInterface {
           )
           try {
             await this.userManager.updateContext(user.access_token, fetchUserData)
-            this.updateMfaExpiryTimer(user.profile?.auth_time as number | undefined)
+            this.updateMfaExpiryTimer()
           } catch (e) {
             console.error(e)
             await this.handleAuthError(unref(this.router.currentRoute))
@@ -243,7 +243,7 @@ export class AuthService implements AuthServiceInterface {
               expiryThreshold: this.accessTokenExpiryThreshold
             })
 
-            this.updateMfaExpiryTimer(user.profile?.auth_time as number | undefined)
+            this.updateMfaExpiryTimer()
 
             this.tokenTimerInitialized = true
           }
@@ -286,7 +286,7 @@ export class AuthService implements AuthServiceInterface {
 
       const user = await this.userManager.getUser()
       if (user) {
-        this.updateMfaExpiryTimer(user.profile?.auth_time as number | undefined)
+        this.updateMfaExpiryTimer()
       }
 
       const redirectRoute = this.router.resolve(this.userManager.getAndClearPostLoginRedirectUrl())
@@ -435,18 +435,20 @@ export class AuthService implements AuthServiceInterface {
     return this.userManager.signinRedirect({ acr_values: acrValue })
   }
 
-  private updateMfaExpiryTimer(authTime: number | undefined) {
+  private updateMfaExpiryTimer() {
     if (!this.mfaExpiryWorker) {
       return
     }
 
     const sessionDuration = this.capabilityStore.authMfaSessionDuration
-    if (!authTime || !sessionDuration) {
+    if (!sessionDuration) {
       return
     }
 
-    this.mfaExpiryModalDismissed = false
-    this.mfaExpiryWorker.setMfaTimer({ authTime, sessionDuration })
+    const baseTime = this.clientService.lastSuccessfulRequestTime ?? Math.floor(Date.now() / 1000)
+    const expiresAt = baseTime + sessionDuration
+
+    this.mfaExpiryWorker.setMfaTimer({ expiresAt })
   }
 
   private showMfaExpiryWarning() {
@@ -465,10 +467,10 @@ export class AuthService implements AuthServiceInterface {
       ),
       confirmText: $gettext('Extend session'),
       cancelText: $gettext('Dismiss'),
-      onConfirm: async () => {
+      onConfirm: () => {
         this.mfaExpiryModalId = null
         this.mfaExpiryBroadcastChannel?.postMessage({ action: 'prolonged' })
-        await this.prolongMfaSession()
+        this.prolongMfaSession()
       },
       onCancel: () => {
         this.mfaExpiryModalId = null
@@ -478,26 +480,30 @@ export class AuthService implements AuthServiceInterface {
     this.mfaExpiryModalId = modal.id
   }
 
-  private async prolongMfaSession() {
-    const acrValue = this.capabilityStore.authMfaRequiredLevelname
-    if (!acrValue) {
+  private prolongMfaSession() {
+    const sessionDuration = this.capabilityStore.authMfaSessionDuration
+    if (!sessionDuration) {
       return
     }
 
-    try {
-      await this.userManager.signinSilent({ acr_values: acrValue })
-    } catch {
-      const redirectUrl = unref(this.router.currentRoute)?.fullPath
-      this.userManager.setPostLoginRedirectUrl(redirectUrl)
-      await this.userManager.signinRedirect({ acr_values: acrValue })
-    }
+    this.mfaExpiryModalDismissed = false
+    const expiresAt = Math.floor(Date.now() / 1000) + sessionDuration
+    this.mfaExpiryWorker?.setMfaTimer({ expiresAt })
   }
 
   private initMfaExpiryBroadcastChannel() {
     this.mfaExpiryBroadcastChannel = new BroadcastChannel('oc-mfa-expiry')
     this.mfaExpiryBroadcastChannel.onmessage = (event: MessageEvent) => {
       const { action } = event.data
-      if (action === 'prolonged' || action === 'dismissed') {
+      if (action === 'prolonged') {
+        this.mfaExpiryModalDismissed = true
+        if (this.mfaExpiryModalId) {
+          const modalStore = useModals()
+          modalStore.removeModal(this.mfaExpiryModalId)
+          this.mfaExpiryModalId = null
+        }
+        this.prolongMfaSession()
+      } else if (action === 'dismissed') {
         this.mfaExpiryModalDismissed = true
         if (this.mfaExpiryModalId) {
           const modalStore = useModals()

--- a/packages/web-runtime/src/services/auth/userManager.ts
+++ b/packages/web-runtime/src/services/auth/userManager.ts
@@ -75,8 +75,8 @@ export class UserManager extends OidcUserManager {
       // we trigger the token renewal manually via a timer running in a web worker
       automaticSilentRenew: false,
 
-      // do not filter acr
-      filterProtocolClaims: ['nbf', 'jti', 'auth_time', 'nonce', 'amr', 'azp', 'at_hash']
+      // do not filter acr and auth_time (needed for MFA session expiry detection)
+      filterProtocolClaims: ['nbf', 'jti', 'nonce', 'amr', 'azp', 'at_hash']
     }
 
     if (options.configStore.isOIDC) {

--- a/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
+++ b/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
@@ -48,6 +48,7 @@ describe('AuthService', () => {
         Object.defineProperty(authService, 'userManager', {
           value: {
             signinRedirectCallback: vi.fn(),
+            getUser: vi.fn().mockResolvedValue(null),
             getAndClearPostLoginRedirectUrl: () => url
           }
         })
@@ -73,6 +74,7 @@ describe('AuthService', () => {
       Object.defineProperty(authService, 'userManager', {
         value: mock<UserManager>({
           getAccessToken: vi.fn().mockResolvedValue('access-token'),
+          getUser: vi.fn().mockResolvedValue(mock<User>({ expires_in: 3600 })),
           updateContext: mockUpdateContext
         })
       })
@@ -107,6 +109,7 @@ describe('AuthService', () => {
       Object.defineProperty(authService, 'userManager', {
         value: mock<UserManager>({
           getAccessToken: vi.fn().mockResolvedValue('access-token'),
+          getUser: vi.fn().mockResolvedValue(mock<User>({ expires_in: 3600 })),
           updateContext: mockUpdateContext
         })
       })
@@ -143,6 +146,7 @@ describe('AuthService', () => {
       Object.defineProperty(authService, 'userManager', {
         value: mock<UserManager>({
           getAccessToken: vi.fn().mockResolvedValue('access-token'),
+          getUser: vi.fn().mockResolvedValue(mock<User>({ expires_in: 3600 })),
           updateContext: mockUpdateContext
         })
       })


### PR DESCRIPTION
Introduces the vault mode switch feature. Users with the appropriate permission can switch between "Drive" (default) and "Vault" (MFA-protected) modes via a dropdown in the topbar. Switching to vault mode triggers MFA authentication, after which the user can access vault-protected spaces and personal files. The feature includes session expiry warnings, cross-tab synchronization, vault-aware breadcrumbs, search integration, and clipboard handling between modes.