### PR TITLE
fix(web-app-pdf-viewer): [OCISDEV-878] display open button on iOS/iPadOS

### DIFF
--- a/changelog/unreleased/bugfix-add-open-button-to-pdf-viewer-on-ios.md
+++ b/changelog/unreleased/bugfix-add-open-button-to-pdf-viewer-on-ios.md
@@ -1,0 +1,6 @@
+Bugfix: Add open button to PDF viewer on iOS/iPadOS
+
+On iOS/iPadOS, we now display a button to open the PDF file in the browser instead of the native PDF viewer. This is a workaround to avoid issues with the native PDF viewer on iOS/iPadOS.
+
+https://github.com/owncloud/web/issues/13797
+https://github.com/owncloud/web/pull/13816

--- a/packages/web-app-pdf-viewer/src/App.vue
+++ b/packages/web-app-pdf-viewer/src/App.vue
@@ -1,5 +1,6 @@
 <template>
   <object
+    v-if="!isIos"
     class="pdf-viewer oc-width-1-1 oc-height-1-1"
     :data="url"
     :type="objectType"
@@ -7,6 +8,14 @@
       $pgettext('Accessible label for the object holding the PDF file content', 'PDF document')
     "
   />
+  <div
+    v-else
+    class="oc-flex oc-flex-column oc-flex-center oc-flex-middle oc-width-1-1 oc-height-1-1 oc-gap-s"
+  >
+    <oc-button type="a" :href="url" target="_blank" appearance="filled" variation="primary">
+      {{ $pgettext('Button to open a PDF file in the browser on iOS/iPadOS', 'Open PDF') }}
+    </oc-button>
+  </div>
 </template>
 
 <script lang="ts" setup>
@@ -14,8 +23,12 @@ interface Props {
   url: string
 }
 const { url } = defineProps<Props>()
+
 const isSafari = navigator.userAgent?.includes('Safari') && !navigator.userAgent?.includes('Chrome')
 const objectType = isSafari ? undefined : 'application/pdf'
+
+// iOS/iPadOS does not support scrollable multi-page PDFs inside iframes.
+const isIos = /iPad|iPhone|iPod/.test(navigator.userAgent)
 </script>
 
 <style scoped>

--- a/packages/web-app-pdf-viewer/tests/unit/app.spec.ts
+++ b/packages/web-app-pdf-viewer/tests/unit/app.spec.ts
@@ -1,0 +1,94 @@
+import App from '../../src/App.vue'
+import { defaultPlugins, shallowMount } from '@ownclouders/web-test-helpers'
+
+const selectors = {
+  object: 'object',
+  openButton: 'oc-button-stub'
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('PDF Viewer App', () => {
+  describe('on non-iOS', () => {
+    it('renders the object element with the PDF URL', () => {
+      const { wrapper } = getWrapper()
+      expect(wrapper.find(selectors.object).exists()).toBe(true)
+      expect(wrapper.find(selectors.object).attributes('data')).toBe('blob:test-url')
+    })
+
+    it('does not render the Open PDF button', () => {
+      const { wrapper } = getWrapper()
+      expect(wrapper.find(selectors.openButton).exists()).toBe(false)
+    })
+  })
+
+  describe('on iOS', () => {
+    beforeEach(() => {
+      vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15'
+      )
+    })
+
+    it('does not render the object element', () => {
+      const { wrapper } = getWrapper()
+      expect(wrapper.find(selectors.object).exists()).toBe(false)
+    })
+
+    it('renders the Open PDF button linking to the PDF URL', () => {
+      const { wrapper } = getWrapper()
+      expect(wrapper.find(selectors.openButton).attributes('href')).toBe('blob:test-url')
+    })
+
+    it('opens the PDF in a new tab', () => {
+      const { wrapper } = getWrapper()
+      expect(wrapper.find(selectors.openButton).attributes('target')).toBe('_blank')
+    })
+  })
+
+  describe('on iPadOS', () => {
+    beforeEach(() => {
+      vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(
+        'Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15'
+      )
+    })
+
+    it('does not render the object element', () => {
+      const { wrapper } = getWrapper()
+      expect(wrapper.find(selectors.object).exists()).toBe(false)
+    })
+
+    it('renders the Open PDF button linking to the PDF URL', () => {
+      const { wrapper } = getWrapper()
+      expect(wrapper.find(selectors.openButton).attributes('href')).toBe('blob:test-url')
+    })
+  })
+
+  describe('on iPadOS in desktop mode', () => {
+    beforeEach(() => {
+      vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15'
+      )
+    })
+
+    it('renders the object element', () => {
+      const { wrapper } = getWrapper()
+      expect(wrapper.find(selectors.object).exists()).toBe(true)
+    })
+
+    it('does not render the Open PDF button', () => {
+      const { wrapper } = getWrapper()
+      expect(wrapper.find(selectors.openButton).exists()).toBe(false)
+    })
+  })
+})
+
+function getWrapper() {
+  return {
+    wrapper: shallowMount(App, {
+      props: { url: 'blob:test-url' },
+      global: { plugins: [...defaultPlugins()] }
+    })
+  }
+}

--- a/packages/web-app-pdf-viewer/vitest.config.ts
+++ b/packages/web-app-pdf-viewer/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineProject, mergeConfig } from 'vitest/config'
+import configShared from '../../tests/unit/config/vitest.config'
+
+export default mergeConfig(
+  configShared,
+  defineProject({
+    test: {
+      name: 'web-app-pdf-viewer'
+    }
+  })
+)


### PR DESCRIPTION
## Description

On iOS/iPadOS, we now display a button to open the PDF file in the browser instead of the native PDF viewer. This is a workaround to avoid issues with the native PDF viewer on iOS/iPadOS.

## Related Issue

- Fixes https://github.com/owncloud/web/issues/13797

## Motivation and Context

On iOS/iPadOS, the object/iframe approach does not fully work because it always renders only the first page. This makes the viewer unusable. To work around this, an open button allows user to simply open the PDF in a new tab where it works as expected.

## How Has This Been Tested?

- test environment: iPad Pro 11 inch 4th generation v26.1 & iPhone 16 v26.5 and macos
- test case 1: open pdf via the button
- test case 2: open pdf on desktop via object

## Screenshots (if appropriate):

<img width="359" height="780" alt="B46EEC04-912F-407F-B555-B4FEDDDB02E4_4_5005_c" src="https://github.com/user-attachments/assets/2066fb0f-757a-4a97-a4c6-92930a65132d" />
