### PR TITLE
fix: [OCISDEV-916] apply vault theme on oidc callback

### DIFF
--- a/changelog/unreleased/bugfix-vault-theme-on-oidc-callback.md
+++ b/changelog/unreleased/bugfix-vault-theme-on-oidc-callback.md
@@ -1,0 +1,7 @@
+Bugfix: Apply vault theme after OIDC callback
+
+When opening the vault for the first time, the user is redirected to an external IdP for 2FA.
+Upon returning, the OIDC callback URL contains no vault context, causing the regular theme to be applied instead of the vault theme.
+We now also check the stored post-login redirect URL during the OIDC callback to correctly detect vault mode.
+
+https://github.com/owncloud/web/pull/13826

--- a/packages/web-pkg/src/composables/vault/index.ts
+++ b/packages/web-pkg/src/composables/vault/index.ts
@@ -9,17 +9,45 @@ interface VaultComposable {
   isInVault: boolean
 }
 
+/**
+ * Checks whether the given URL is a vault URL.
+ * @param url - The URL to check.
+ * @returns Whether the URL is a vault URL.
+ */
+function getIsVaultUrl(url: string): boolean {
+  if (url.startsWith('/vault')) {
+    return true
+  }
+
+  const hashIndex = url.indexOf('#')
+  if (hashIndex !== -1) {
+    const hash = url.slice(hashIndex)
+    return /^#\/vault(?:\/|$)/.test(hash)
+  }
+
+  return false
+}
+
 export function useVault(): VaultComposable {
   const isInVault = (() => {
     const { pathname, hash } = window.location
 
-    if (pathname.startsWith('/vault')) {
+    if (getIsVaultUrl(pathname + hash)) {
       return true
     }
 
-    if (hash) {
-      const vaultHashPattern = /^#\/vault(?:\/|$)/
-      return vaultHashPattern.test(hash)
+    // During OIDC callback the current URL is /web-oidc-callback, not the vault path.
+    // The intended post-login destination is stored in sessionStorage/localStorage under
+    // this key by the auth service (web-runtime/src/services/auth/userManager.ts).
+    if (pathname === '/web-oidc-callback') {
+      const postLoginRedirectUrlKey = 'oc.postLoginRedirectUrl'
+      const postLoginRedirectUrl =
+        sessionStorage.getItem(postLoginRedirectUrlKey) ||
+        localStorage.getItem(postLoginRedirectUrlKey)
+
+      if (postLoginRedirectUrl) {
+        return getIsVaultUrl(postLoginRedirectUrl)
+      }
     }
 
     return false


### PR DESCRIPTION
## Description

When opening the vault for the first time, the user is redirected to an external IdP for 2FA. Upon returning, the OIDC callback URL contains no vault context, causing the regular theme to be applied instead of the vault theme. We now also check the stored post-login redirect URL during the OIDC callback to correctly detect vault mode.

### Fixed issue

- JIRA -> [OCISDEV-916](https://kiteworks.atlassian.net/browse/OCISDEV-916)
- resolves https://github.com/owncloud/web/issues/13818

## Motivation and Context

Correct theme is loaded.

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: open regular drive and then vault for the first time
- test case 2: open regular drive and then vault repeatedly

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/84405148-221d-4ff9-80c7-d2a78bdeb799
