### PR TITLE
fix: gate MFA expiry dialog on vault capability

### DIFF
--- a/changelog/unreleased/bugfix-gate-mfa-expiry-on-vault-capability.md
+++ b/changelog/unreleased/bugfix-gate-mfa-expiry-on-vault-capability.md
@@ -1,0 +1,5 @@
+Bugfix: Gate MFA expiry dialog on vault capability
+
+We've fixed the MFA session expiry warning to only appear when the vault capability is enabled. Previously, the expiry worker and broadcast channel were initialized unconditionally, causing the dialog to fire even when vault mode was off. They are now lazily created only when vault is enabled and a session duration is configured.
+
+https://github.com/owncloud/web/pull/13827

--- a/packages/web-pkg/src/composables/webWorkers/mfaExpiryWorker/worker.ts
+++ b/packages/web-pkg/src/composables/webWorkers/mfaExpiryWorker/worker.ts
@@ -13,7 +13,7 @@ const resetTimer = () => {
   timerId = undefined
 }
 
-self.onmessage = (e: MessageEvent) => {
+globalThis.onmessage = (e: MessageEvent) => {
   const { topic, expiresAt, warningThreshold } = JSON.parse(e.data) as Message
 
   if (topic === 'reset') {

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -126,12 +126,6 @@ export class AuthService implements AuthServiceInterface {
         if (!options.embed?.enabled || !options.embed?.delegateAuthentication) {
           this.tokenTimerWorker = useTokenTimerWorker({ authService: this })
           this.tokenTimerWorker.startWorker()
-
-          this.mfaExpiryWorker = useMfaExpiryWorker({
-            onExpiring: () => this.showMfaExpiryWarning()
-          })
-          this.mfaExpiryWorker.startWorker()
-          this.initMfaExpiryBroadcastChannel()
         }
       }
     }
@@ -436,13 +430,21 @@ export class AuthService implements AuthServiceInterface {
   }
 
   private updateMfaExpiryTimer() {
-    if (!this.mfaExpiryWorker) {
+    if (!this.capabilityStore?.vaultEnabled) {
       return
     }
 
     const sessionDuration = this.capabilityStore.authMfaSessionDuration
     if (!sessionDuration) {
       return
+    }
+
+    if (!this.mfaExpiryWorker) {
+      this.mfaExpiryWorker = useMfaExpiryWorker({
+        onExpiring: () => this.showMfaExpiryWarning()
+      })
+      this.mfaExpiryWorker.startWorker()
+      this.initMfaExpiryBroadcastChannel()
     }
 
     const baseTime = this.clientService.lastSuccessfulRequestTime ?? Math.floor(Date.now() / 1000)


### PR DESCRIPTION
## Description

  Gate the MFA session expiry dialog behind the vault capability. The expiry worker and broadcast channel are now
  lazily initialized only when `vaultEnabled` is true and `authMfaSessionDuration` is configured, preventing the
  warning modal from appearing when vault mode is disabled.

  Also replaced `self` with `globalThis` in the web worker to resolve a SonarQube warning.

  ## Related Issue

  - Fixes [OCISDEV-919](https://kiteworks.atlassian.net/browse/OCISDEV-919)

  ## Motivation and Context

  The MFA session expiry warning was firing whenever `auth.mfa.session_duration` was present in capabilities,
  regardless of whether vault mode was enabled. Since the MFA session is only relevant for vault access, the dialog
   should not appear when vault is off. Additionally, the worker and broadcast channel were being allocated
  unconditionally at startup, wasting resources in non-vault deployments.

  ## How Has This Been Tested?

  - test environment: local oCIS + web dev server
  - test case 1: vault disabled (`OCIS_ENABLE_VAULT_MODE=false`), MFA enabled with session duration set → no expiry
   dialog appears
  - test case 2: vault enabled (`OCIS_ENABLE_VAULT_MODE=true`), MFA enabled with session duration set → expiry
  dialog appears 5 minutes before session end
  - test case 3: extend session from dialog → timer resets correctly
  - test case 4: dismiss dialog in one tab → broadcast channel syncs to other tabs