### PR TITLE
fix(web-app-files): [OCISDEV-915] add explicit size to space image

### DIFF
--- a/changelog/unreleased/bugfix-add-explicit-size-to-space-header-image.md
+++ b/changelog/unreleased/bugfix-add-explicit-size-to-space-header-image.md
@@ -1,0 +1,7 @@
+Bugfix: Add explicit size to space header image
+
+The space header image did not have explicit width and height causing the image to overflow its container.
+Adding explicit width and height with values of 100% makes sure that the image stays within the boundaries of the container.
+
+https://github.com/owncloud/web/issues/13822
+https://github.com/owncloud/web/pull/13835

--- a/packages/web-app-files/src/components/Spaces/SpaceHeader.vue
+++ b/packages/web-app-files/src/components/Spaces/SpaceHeader.vue
@@ -300,6 +300,8 @@ const isMobileWidth = inject<Ref<boolean>>('isMobileWidth')
       border: none;
       cursor: pointer;
       outline: none;
+      height: 100%;
+      width: 100%;
     }
   }
 


### PR DESCRIPTION
## Description

The space header image did not have explicit width and height causing the image to overflow its container. Adding explicit width and height with values of 100% makes sure that the image stays within the boundaries of the container.

## Related Issue

- fixes [OCISDEV-915](https://kiteworks.atlassian.net/browse/OCISDEV-915)
- resolves https://github.com/owncloud/web/issues/13822

## Motivation and Context

Image is not overlapping the content.

## How Has This Been Tested?

- test environment: macos, chrome
- test case 1: upload a vertical image

## Screenshots (if appropriate):

<img width="853" height="491" alt="image" src="https://github.com/user-attachments/assets/d357b28a-d726-4fbb-ae75-5deeaeab2454" />
