### PR TITLE
fix: gate MFA expiry dialog on vault capability

### DIFF
--- a/changelog/unreleased/bugfix-gate-mfa-expiry-on-vault-capability.md
+++ b/changelog/unreleased/bugfix-gate-mfa-expiry-on-vault-capability.md
@@ -1,0 +1,5 @@
+Bugfix: Gate MFA expiry dialog on vault capability
+
+We've fixed the MFA session expiry warning to only appear when the vault capability is enabled. Previously, the expiry worker and broadcast channel were initialized unconditionally, causing the dialog to fire even when vault mode was off. They are now lazily created only when vault is enabled and a session duration is configured.
+
+https://github.com/owncloud/web/pull/13827

--- a/packages/web-pkg/src/composables/webWorkers/mfaExpiryWorker/worker.ts
+++ b/packages/web-pkg/src/composables/webWorkers/mfaExpiryWorker/worker.ts
@@ -13,7 +13,7 @@ const resetTimer = () => {
   timerId = undefined
 }
 
-self.onmessage = (e: MessageEvent) => {
+globalThis.onmessage = (e: MessageEvent) => {
   const { topic, expiresAt, warningThreshold } = JSON.parse(e.data) as Message
 
   if (topic === 'reset') {

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -126,12 +126,6 @@ export class AuthService implements AuthServiceInterface {
         if (!options.embed?.enabled || !options.embed?.delegateAuthentication) {
           this.tokenTimerWorker = useTokenTimerWorker({ authService: this })
           this.tokenTimerWorker.startWorker()
-
-          this.mfaExpiryWorker = useMfaExpiryWorker({
-            onExpiring: () => this.showMfaExpiryWarning()
-          })
-          this.mfaExpiryWorker.startWorker()
-          this.initMfaExpiryBroadcastChannel()
         }
       }
     }
@@ -436,13 +430,21 @@ export class AuthService implements AuthServiceInterface {
   }
 
   private updateMfaExpiryTimer() {
-    if (!this.mfaExpiryWorker) {
+    if (!this.capabilityStore?.vaultEnabled) {
       return
     }
 
     const sessionDuration = this.capabilityStore.authMfaSessionDuration
     if (!sessionDuration) {
       return
+    }
+
+    if (!this.mfaExpiryWorker) {
+      this.mfaExpiryWorker = useMfaExpiryWorker({
+        onExpiring: () => this.showMfaExpiryWarning()
+      })
+      this.mfaExpiryWorker.startWorker()
+      this.initMfaExpiryBroadcastChannel()
     }
 
     const baseTime = this.clientService.lastSuccessfulRequestTime ?? Math.floor(Date.now() / 1000)


### PR DESCRIPTION
The MFA expiry worker and broadcast channel were initialized unconditionally at startup. Now they are lazily created only when the vault capability is enabled and a session duration is configured, preventing the expiry warning from firing when vault mode is off.

Also replaced `self` with `globalThis` in the worker as SonarQube was flagging the deprecated `self` reference.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
