### PR TITLE
fix(web-app-password-protected-folders): [OCISDEV-917] fix theme switching and cancel button visibility

### DIFF
--- a/changelog/unreleased/bugfix-theme-switching.md
+++ b/changelog/unreleased/bugfix-theme-switching.md
@@ -1,0 +1,9 @@
+Bugfix: Fix theme switching issues
+
+When switching between themes, colors could get stuck or become unreadable until a page refresh.
+Empty string values in theme tokens were overriding stylesheet defaults with nothing, making elements invisible.
+Additionally, tokens from the previous theme were not cleared before applying the new theme, causing stale values to persist.
+We now remove previous theme properties before applying the new theme and treat empty token values as unset.
+We also fixed the cancel button in the password protected folder modal being invisible because its color matched the dark action bar background.
+
+https://github.com/owncloud/web/pull/13843

--- a/packages/design-system/src/helpers/applyCustomProp.ts
+++ b/packages/design-system/src/helpers/applyCustomProp.ts
@@ -2,5 +2,15 @@ export const applyCustomProp = (key: string, value: string | undefined) => {
   if (value === undefined) {
     return
   }
-  ;(document.querySelector(':root') as HTMLElement).style.setProperty('--oc-' + key, value)
+  const root = document.querySelector(':root') as HTMLElement
+  const prop = '--oc-' + key
+  if (value === '') {
+    root.style.removeProperty(prop)
+  } else {
+    root.style.setProperty(prop, value)
+  }
+}
+
+export const removeCustomProp = (key: string) => {
+  ;(document.querySelector(':root') as HTMLElement).style.removeProperty('--oc-' + key)
 }

--- a/packages/web-app-password-protected-folders/src/components/FolderViewModal.vue
+++ b/packages/web-app-password-protected-folders/src/components/FolderViewModal.vue
@@ -66,6 +66,18 @@ const onLoad = () => {
 
   .oc-modal-body-actions {
     background-color: var(--oc-color-swatch-brand-default);
+
+    .oc-modal-body-actions-cancel {
+      color: var(--oc-color-swatch-brand-contrast);
+      outline-color: var(--oc-color-swatch-brand-contrast);
+
+      &:hover:not([disabled]),
+      &:focus:not([disabled]) {
+        background-color: var(--oc-color-swatch-brand-contrast);
+        color: var(--oc-color-swatch-brand-default);
+        border-color: var(--oc-color-swatch-brand-contrast);
+      }
+    }
   }
 }
 </style>

--- a/packages/web-pkg/src/composables/piniaStores/theme.ts
+++ b/packages/web-pkg/src/composables/piniaStores/theme.ts
@@ -3,7 +3,7 @@ import { defineStore } from 'pinia'
 import { computed, ref, unref } from 'vue'
 import { useLocalStorage, usePreferredDark } from '@vueuse/core'
 import { z } from 'zod'
-import { applyCustomProp } from '@ownclouders/design-system/helpers'
+import { applyCustomProp, removeCustomProp } from '@ownclouders/design-system/helpers'
 import { ShareRole } from '@ownclouders/web-client'
 import { useVault } from '../vault'
 
@@ -153,6 +153,7 @@ export const useThemeStore = defineStore('theme', () => {
   })
 
   const setAndApplyTheme = (theme: WebThemeType, updateStorage = true) => {
+    const previousTheme = unref(currentTheme)
     currentTheme.value = theme
     if (updateStorage) {
       currentLocalStorageThemeName.value = unref(currentTheme).name
@@ -165,6 +166,14 @@ export const useThemeStore = defineStore('theme', () => {
       { name: 'sizes', prefix: 'size' },
       { name: 'spacing', prefix: 'spacing' }
     ] as const
+
+    if (previousTheme) {
+      customizableDesignTokens.forEach((token) => {
+        for (const param in previousTheme.designTokens[token.name]) {
+          removeCustomProp(`${token.prefix}-${param}`)
+        }
+      })
+    }
 
     applyCustomProp('font-family', unref(currentTheme).designTokens.fontFamily)
 


### PR DESCRIPTION
## Description

Fix theme switching issues where colors could get stuck or become unreadable until a page refresh. Additionally fix the cancel button in the password protected folder modal being invisible against the dark action bar background.

Changes:
- Clear previous theme's custom properties before applying the new theme so stale values don't persist
- Treat empty token strings as unset by removing the CSS property instead of setting it to blank
- Style the cancel button in FolderViewModal to use brand contrast colors for visibility

## Related Issue

- Fixes [OCISDEV-917](https://kiteworks.atlassian.net/browse/OCISDEV-917)
- Fixes [OCISDEV-910](https://kiteworks.atlassian.net/browse/OCISDEV-910)
- Fixes https://github.com/owncloud/web/issues/13817

## Motivation and Context

When switching between themes, tokens from the previous theme were not cleared before applying the new theme, causing stale values to persist. Empty string values in theme tokens were overriding stylesheet defaults with nothing, making elements invisible. The cancel button in the password protected folder modal was invisible because its color matched the dark action bar background.

## How Has This Been Tested?

- test environment: local dev server with oCIS backend
- test case 1: Switch between light and dark themes — verify no stale color values persist
- test case 2: Open password protected folder modal — verify cancel button is visible and has proper hover/focus states