### PR TITLE
chore(ci): remove SonarCloud CI-based analysis to enable Automatic Analysis

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -2,9 +2,6 @@ name: Build
 
 on:
   workflow_call:
-    secrets:
-      SONAR_TOKEN:
-        required: false
 
 jobs:
   build:
@@ -44,15 +41,6 @@ jobs:
 
       - name: Run unit tests
         run: pnpm test:unit --coverage
-
-      - name: SonarCloud Scan
-        if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/')
-        uses: SonarSource/sonarqube-scan-action@c7ee0f9df90b7aa20e8dcf9695dcfe2e7da5b4f2 # v7.2.1
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_PULL_REQUEST_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || '' }}
-          SONAR_PULL_REQUEST_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
-          SONAR_PULL_REQUEST_KEY: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
 
       - name: Build
         run: make dist

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,8 +12,6 @@ permissions:
 jobs:
   build:
     uses: ./.github/workflows/_build.yml
-    secrets:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   e2e:
     needs: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,8 +99,6 @@ jobs:
       needs.check-flags.outputs.workflows == 'true' ||
       needs.check-flags.outputs.affected-suites != ''
     uses: ./.github/workflows/_build.yml
-    secrets:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   e2e:
     needs: [build, check-flags]


### PR DESCRIPTION
## Description

Remove CI-based SonarCloud analysis from GitHub Actions workflows to enable SonarCloud's Automatic Analysis mode via the GitHub App integration. This eliminates the need for a `SONAR_TOKEN` secret in CI runners.

## Related Issue

- N/A

## Motivation and Context

SonarCloud's Automatic Analysis mode provides static analysis without requiring a token in CI. This reduces secret exposure surface in GitHub Actions and simplifies the workflow. Coverage data is no longer uploaded automatically, but static analysis (bugs, code smells, security hotspots) continues via SonarCloud's own infrastructure.

## How Has This Been Tested?

- test environment: GitHub Actions workflow syntax validation
- test case 1: Verified `_build.yml` and `test.yml` are valid YAML after changes
- test case 2: Automatic Analysis toggle becomes available on SonarCloud after merge