### PR TITLE
fix(web-pkg): [OCISDEV-777] validate postMessage origin in embed mode…

### DIFF
--- a/changelog/unreleased/security-embed-mode-postmessage-origin-validation.md
+++ b/changelog/unreleased/security-embed-mode-postmessage-origin-validation.md
@@ -1,0 +1,9 @@
+Security: Validate postMessage origin in embed mode modals
+
+We've fixed a cross-site request forgery (CSRF) vulnerability where the embed mode modals (Save As, Export As PDF and the file
+picker) processed incoming `postMessage` events without verifying the sender's origin. A malicious page holding a reference to an
+authenticated ownCloud window could forge `owncloud-embed:select`, `owncloud-embed:file-pick` or `owncloud-embed:cancel` messages
+and trigger authenticated file writes in the victim's space. Incoming messages are now validated against an allowlist consisting of
+the application's own origin and the optionally configured `embed.messagesOrigin`.
+
+https://github.com/owncloud/web/issues/13844

--- a/packages/web-pkg/src/components/Modals/ExportAsPdfModal.vue
+++ b/packages/web-pkg/src/components/Modals/ExportAsPdfModal.vue
@@ -18,6 +18,7 @@ import { onBeforeUnmount, onMounted, ref } from 'vue'
 import {
   embedModeLocationPickMessageData,
   Modal,
+  useEmbedMode,
   useGetMatchingSpace,
   useMessages,
   useModals,
@@ -45,6 +46,7 @@ const { removeModal } = useModals()
 const { showMessage, showErrorMessage } = useMessages()
 const { getMatchingSpace } = useGetMatchingSpace()
 const { startWorker } = useExportAsPdfWorker()
+const { verifyMessageOrigin } = useEmbedMode()
 
 const parentFolderRoute = router.resolve(parentFolderLink)
 const iframeTitle = themeStore.currentTheme.common?.name
@@ -101,6 +103,10 @@ function onLocationPick({ data }: MessageEvent) {
 }
 
 function handleMessage(event: MessageEvent) {
+  if (!verifyMessageOrigin(event.origin)) {
+    return
+  }
+
   if (event.data.name === 'owncloud-embed:select') {
     onLocationPick(event)
     return

--- a/packages/web-pkg/src/components/Modals/FilePickerModal.vue
+++ b/packages/web-pkg/src/components/Modals/FilePickerModal.vue
@@ -18,6 +18,7 @@ import { onBeforeUnmount, onMounted, ref } from 'vue'
 import {
   EDITOR_MODE_EDIT,
   Modal,
+  useEmbedMode,
   useGetMatchingSpace,
   useModals,
   useRouter,
@@ -44,6 +45,7 @@ const { removeModal } = useModals()
 const { getMatchingSpace } = useGetMatchingSpace()
 const themeStore = useThemeStore()
 const { getEditorRouteOpts } = useFileActions()
+const { verifyMessageOrigin } = useEmbedMode()
 const parentFolderRoute = router.resolve(parentFolderLink)
 
 const availableFileTypes = (app as ApplicationInformation).extensions.map((e) =>
@@ -65,7 +67,11 @@ const onLoad = () => {
   unref(iframeRef).contentWindow.focus()
 }
 
-const onFilePick = ({ data }: MessageEvent) => {
+const onFilePick = ({ data, origin }: MessageEvent) => {
+  if (!verifyMessageOrigin(origin)) {
+    return
+  }
+
   if (data.name !== 'owncloud-embed:file-pick') {
     return
   }
@@ -91,7 +97,11 @@ const onFilePick = ({ data }: MessageEvent) => {
   window.open(editorRouteUrl.href, '_blank')
 }
 
-const onCancel = ({ data }: MessageEvent) => {
+const onCancel = ({ data, origin }: MessageEvent) => {
+  if (!verifyMessageOrigin(origin)) {
+    return
+  }
+
   if (data.name !== 'owncloud-embed:cancel') {
     return
   }

--- a/packages/web-pkg/src/components/Modals/SaveAsModal.vue
+++ b/packages/web-pkg/src/components/Modals/SaveAsModal.vue
@@ -25,7 +25,8 @@ import {
   useMessages,
   useModals,
   useRouter,
-  useThemeStore
+  useThemeStore,
+  useEmbedMode
 } from '../../composables'
 import { LocationQuery, RouteLocationRaw } from 'vue-router'
 import AppLoadingSpinner from '../AppLoadingSpinner.vue'
@@ -52,6 +53,7 @@ const { removeModal } = useModals()
 const { showMessage, showErrorMessage } = useMessages()
 const { getMatchingSpace } = useGetMatchingSpace()
 const { getEditorRouteOpts } = useFileActions()
+const { verifyMessageOrigin } = useEmbedMode()
 
 const parentFolderRoute = router.resolve(parentFolderLink)
 const iframeTitle = themeStore.currentTheme.common?.name
@@ -70,7 +72,11 @@ const onLoad = () => {
   unref(iframeRef).contentWindow.focus()
 }
 
-const onLocationPick = async ({ data }: MessageEvent) => {
+const onLocationPick = async ({ data, origin }: MessageEvent) => {
+  if (!verifyMessageOrigin(origin)) {
+    return
+  }
+
   if (data.name !== 'owncloud-embed:select') {
     return
   }
@@ -153,7 +159,11 @@ const openFile = ({
   window.open(editorRouteUrl.href, '_blank')
 }
 
-const onCancel = ({ data }: MessageEvent) => {
+const onCancel = ({ data, origin }: MessageEvent) => {
+  if (!verifyMessageOrigin(origin)) {
+    return
+  }
+
   if (data.name !== 'owncloud-embed:cancel') {
     return
   }

--- a/packages/web-pkg/src/composables/embedMode/useEmbedMode.ts
+++ b/packages/web-pkg/src/composables/embedMode/useEmbedMode.ts
@@ -67,6 +67,16 @@ export const useEmbedMode = () => {
     return unref(delegateAuthenticationOrigin) === eventOrigin
   }
 
+  const verifyMessageOrigin = (eventOrigin: string): boolean => {
+    const allowedOrigins = [window.location.origin]
+
+    if (unref(messagesTargetOrigin)) {
+      allowedOrigins.push(unref(messagesTargetOrigin))
+    }
+
+    return allowedOrigins.includes(eventOrigin)
+  }
+
   return {
     isEnabled,
     isLocationPicker,
@@ -77,6 +87,7 @@ export const useEmbedMode = () => {
     isDelegatingAuthentication,
     fileTypes,
     postMessage,
-    verifyDelegatedAuthenticationOrigin
+    verifyDelegatedAuthenticationOrigin,
+    verifyMessageOrigin
   }
 }

--- a/packages/web-pkg/tests/unit/components/Modals/ExportAsPdfModal.spec.ts
+++ b/packages/web-pkg/tests/unit/components/Modals/ExportAsPdfModal.spec.ts
@@ -1,0 +1,152 @@
+import ExportAsPdfModal from '../../../../src/components/Modals/ExportAsPdfModal.vue'
+import { defaultComponentMocks, defaultPlugins, shallowMount } from '@ownclouders/web-test-helpers'
+import { mock } from 'vitest-mock-extended'
+import { Resource, SpaceResource } from '@ownclouders/web-client'
+import { Modal, useMessages, useModals } from '../../../../src/composables/piniaStores'
+import {
+  ExportAsPdfWorkerReturnData,
+  useExportAsPdfWorker
+} from '../../../../src/composables/webWorkers/exportAsPdfWorker'
+
+vi.mock('../../../../src/composables/webWorkers/exportAsPdfWorker')
+
+// The worker runs PDF generation off-thread (and its import can't be resolved in tests),
+// so we stub it: capture the callback the modal passes in to drive the result handling.
+let workerCallback: (result: ExportAsPdfWorkerReturnData) => void
+const startWorker = vi.fn((_folder, _space, _fileName, _content, callback) => {
+  workerCallback = callback
+  return Promise.resolve()
+})
+
+beforeEach(() => {
+  startWorker.mockClear()
+  vi.mocked(useExportAsPdfWorker).mockReturnValue({ startWorker })
+})
+
+const messageEvent = (name: string, origin = window.location.origin) =>
+  mock<MessageEvent>({
+    origin,
+    data: {
+      name,
+      data: {
+        resources: [mock<Resource>({ storageId: '1', spaceId: '1' })],
+        fileName: 'test.pdf'
+      }
+    }
+  })
+
+describe('ExportAsPdfModal', () => {
+  describe('iframe', () => {
+    it('sets the iframe src correctly', () => {
+      const { wrapper } = getWrapper()
+      expect((wrapper.vm as any).iframeUrl.href).toEqual(
+        'http://localhost:3000/files-spaces-generic?hide-logo=true&embed=true&embed-target=location&embed-choose-file-name=true&embed-delegate-authentication=false&embed-choose-file-name-suggestion=test.pdf'
+      )
+    })
+    it('sets the iframe title correctly', () => {
+      const { wrapper } = getWrapper()
+      expect((wrapper.vm as any).iframeTitle).toEqual('ownCloud')
+    })
+  })
+
+  describe('method "handleMessage"', () => {
+    it('does nothing if the event message is neither "owncloud-embed:select" nor "owncloud-embed:cancel"', () => {
+      const { wrapper } = getWrapper()
+      const modalStore = useModals()
+      ;(wrapper.vm as any).handleMessage(messageEvent('some-other-event'))
+      expect(startWorker).not.toHaveBeenCalled()
+      expect(modalStore.removeModal).not.toHaveBeenCalled()
+    })
+
+    it('starts the export worker when message does equal "owncloud-embed:select"', () => {
+      const { wrapper } = getWrapper()
+      const modalStore = useModals()
+      ;(wrapper.vm as any).handleMessage(messageEvent('owncloud-embed:select'))
+      expect(startWorker).toHaveBeenCalled()
+      expect(modalStore.removeModal).toHaveBeenCalled()
+    })
+
+    it('closes the modal when message does equal "owncloud-embed:cancel"', () => {
+      const { wrapper } = getWrapper()
+      const modalStore = useModals()
+      ;(wrapper.vm as any).handleMessage(messageEvent('owncloud-embed:cancel'))
+      expect(startWorker).not.toHaveBeenCalled()
+      expect(modalStore.removeModal).toHaveBeenCalled()
+    })
+
+    it('does nothing when the message originates from an untrusted origin', () => {
+      const { wrapper } = getWrapper()
+      const modalStore = useModals()
+      ;(wrapper.vm as any).handleMessage(
+        messageEvent('owncloud-embed:select', 'https://attacker.example.com')
+      )
+      expect(startWorker).not.toHaveBeenCalled()
+      expect(modalStore.removeModal).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('export result handling', () => {
+    it('shows a success message when the export succeeds', () => {
+      const { wrapper } = getWrapper()
+      const messageStore = useMessages()
+      ;(wrapper.vm as any).handleMessage(messageEvent('owncloud-embed:select'))
+
+      workerCallback({ successful: [mock<Resource>()], failed: [] })
+
+      expect(messageStore.showMessage).toHaveBeenCalled()
+      expect(messageStore.showErrorMessage).not.toHaveBeenCalled()
+    })
+
+    it('shows an error message when the export fails', () => {
+      console.error = vi.fn()
+      const { wrapper } = getWrapper()
+      const messageStore = useMessages()
+      ;(wrapper.vm as any).handleMessage(messageEvent('owncloud-embed:select'))
+
+      workerCallback({ successful: [], failed: [{ resourceName: 'test.pdf', error: mock() }] })
+
+      expect(messageStore.showErrorMessage).toHaveBeenCalled()
+      expect(messageStore.showMessage).not.toHaveBeenCalled()
+    })
+  })
+})
+
+function getWrapper() {
+  const mocks = defaultComponentMocks()
+
+  return {
+    mocks,
+    wrapper: shallowMount(ExportAsPdfModal, {
+      props: {
+        modal: mock<Modal>(),
+        content: 'some text',
+        originalResource: {
+          id: '1',
+          path: '/test.md',
+          name: 'test.md',
+          extension: 'md',
+          spaceId: '1'
+        },
+        parentFolderLink: {
+          name: 'files-spaces-generic',
+          params: {
+            driveAliasAndItem: 'personal/admin'
+          },
+          query: {
+            fileId:
+              '61dcd768-0bc4-4dd5-975a-2fe2bc9bc664$f1e4f3ec-1f24-460d-9f9a-4416ab6ddb6b!36cce768-8c9d-45e4-9c7d-4c9611962a75'
+          }
+        }
+      },
+      global: {
+        plugins: [
+          ...defaultPlugins({
+            piniaOptions: { spacesState: { spaces: [mock<SpaceResource>({ id: '1' })] } }
+          })
+        ],
+        mocks,
+        provide: mocks
+      }
+    })
+  }
+}

--- a/packages/web-pkg/tests/unit/components/Modals/FilePickerModal.spec.ts
+++ b/packages/web-pkg/tests/unit/components/Modals/FilePickerModal.spec.ts
@@ -31,6 +31,7 @@ describe('FilePickerModal', () => {
       const modalStore = useModals()
       ;(wrapper.vm as any).onFilePick(
         mock<MessageEvent>({
+          origin: window.location.origin,
           data: {
             name: 'owncloud-embed:file-pick',
             data: {
@@ -42,6 +43,22 @@ describe('FilePickerModal', () => {
       )
       expect(modalStore.removeModal).toHaveBeenCalled()
       expect(window.open).toHaveBeenCalled()
+    })
+    it('does nothing when the message originates from an untrusted origin', () => {
+      const { wrapper } = getWrapper()
+      ;(wrapper.vm as any).onFilePick(
+        mock<MessageEvent>({
+          origin: 'https://attacker.example.com',
+          data: {
+            name: 'owncloud-embed:file-pick',
+            data: {
+              resource: mock<Resource>({ spaceId: '1' }),
+              originRoute: mock<RouteLocation>()
+            }
+          }
+        })
+      )
+      expect(window.open).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/web-pkg/tests/unit/components/Modals/SaveAsModal.spec.ts
+++ b/packages/web-pkg/tests/unit/components/Modals/SaveAsModal.spec.ts
@@ -42,6 +42,7 @@ describe('SaveAsModal', () => {
       mocks.$clientService.webdav.putFileContents.mockResolvedValue(mock<Resource>())
       ;(wrapper.vm as any).onLocationPick(
         mock<MessageEvent>({
+          origin: window.location.origin,
           data: {
             name: 'owncloud-embed:select',
             data: {
@@ -57,6 +58,26 @@ describe('SaveAsModal', () => {
       expect(modalStore.removeModal).toHaveBeenCalled()
       expect(window.open).toHaveBeenCalled()
     })
+    it('does nothing when the message originates from an untrusted origin', async () => {
+      const { wrapper, mocks } = getWrapper()
+
+      ;(wrapper.vm as any).onLocationPick(
+        mock<MessageEvent>({
+          origin: 'https://attacker.example.com',
+          data: {
+            name: 'owncloud-embed:select',
+            data: {
+              resources: [mock<Resource>({ storageId: '1', spaceId: '1' })],
+              fileName: 'test with new name.txt'
+            }
+          }
+        })
+      )
+
+      await nextTicks(4)
+      expect(mocks.$clientService.webdav.putFileContents).not.toHaveBeenCalled()
+      expect(window.open).not.toHaveBeenCalled()
+    })
     it('shows an error message when the file when message does equal "owncloud-embed:select and request fails"', async () => {
       console.error = vi.fn()
       const { wrapper, mocks } = getWrapper()
@@ -66,6 +87,7 @@ describe('SaveAsModal', () => {
       mocks.$clientService.webdav.putFileContents.mockRejectedValue(new Error(''))
       ;(wrapper.vm as any).onLocationPick(
         mock<MessageEvent>({
+          origin: window.location.origin,
           data: {
             name: 'owncloud-embed:select',
             data: {

--- a/packages/web-pkg/tests/unit/composables/embedMode/useEmbedMode.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/embedMode/useEmbedMode.spec.ts
@@ -201,6 +201,52 @@ describe('useEmbedMode', () => {
       )
     })
   })
+
+  describe('verifyMessageOrigin', () => {
+    it('returns true for the application origin', () => {
+      getComposableWrapper(
+        () => {
+          const { verifyMessageOrigin } = useEmbedMode()
+
+          expect(verifyMessageOrigin(window.location.origin)).toStrictEqual(true)
+        },
+        { mocks: defaultComponentMocks() }
+      )
+    })
+
+    it('returns false for a foreign origin when messagesOrigin is not set', () => {
+      getComposableWrapper(
+        () => {
+          const { verifyMessageOrigin } = useEmbedMode()
+
+          expect(verifyMessageOrigin('https://attacker.example.com')).toStrictEqual(false)
+        },
+        { mocks: defaultComponentMocks() }
+      )
+    })
+
+    it('returns true for the configured messagesOrigin', () => {
+      getComposableWrapper(
+        () => {
+          const { verifyMessageOrigin } = useEmbedMode()
+
+          expect(verifyMessageOrigin('https://trusted.example.com')).toStrictEqual(true)
+        },
+        getWrapperOptions({ messagesOrigin: 'https://trusted.example.com' })
+      )
+    })
+
+    it('returns false for a foreign origin even when messagesOrigin is set', () => {
+      getComposableWrapper(
+        () => {
+          const { verifyMessageOrigin } = useEmbedMode()
+
+          expect(verifyMessageOrigin('https://attacker.example.com')).toStrictEqual(false)
+        },
+        getWrapperOptions({ messagesOrigin: 'https://trusted.example.com' })
+      )
+    })
+  })
 })
 
 const getWrapperOptions = (embed = {}) => ({


### PR DESCRIPTION
… modals

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
The embed mode modals (`SaveAsModal`, `ExportAsPdfModal`, `FilePickerModal`) registered global `window` `message` listeners and acted on incoming `owncloud-embed:*` messages without validating `event.origin`. Any page holding a reference to an authenticated ownCloud window (e.g. via `window.open`) could forge an `owncloud-embed:select`, `owncloud-embed:file-pick` or `owncloud-embed:cancel` message and trigger an authenticated file write in the victim's space (CSRF).



## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes [OCISDEV-777](https://kiteworks.atlassian.net/browse/OCISDEV-777)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: local oCIS, chrome browser
- test case 1: manual - reproduced the report's PoC from a foreign origin via `window.open` + `postMessage(payload, '*')`; no file is created and the modal stays open (before the fix a file was written)
- ...

## Screenshots (if appropriate):

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
