### PR TITLE
fix(notifications): [OCISDEV-967] filter notifications by vault mode

### DIFF
--- a/changelog/unreleased/bugfix-filter-notifications-by-vault-mode.md
+++ b/changelog/unreleased/bugfix-filter-notifications-by-vault-mode.md
@@ -1,0 +1,5 @@
+Bugfix: Filter notifications by vault mode
+
+We've fixed the notifications panel to only show notifications relevant to the current mode. Previously, all notifications were shown regardless of whether the user was in vault or drive mode. Notifications are now filtered so that vault notifications appear only in vault mode and drive notifications appear only in drive mode.
+
+https://github.com/owncloud/web/pull/13877

--- a/packages/web-client/src/ocs/capabilities.ts
+++ b/packages/web-client/src/ocs/capabilities.ts
@@ -177,6 +177,7 @@ export interface Capabilities {
     }
     vault?: {
       enabled?: boolean
+      vault_storage_provider?: string
     }
     graph?: {
       'personal-data-export'?: boolean

--- a/packages/web-pkg/src/composables/piniaStores/capabilities.ts
+++ b/packages/web-pkg/src/composables/piniaStores/capabilities.ts
@@ -159,6 +159,7 @@ export const useCapabilityStore = defineStore('capabilities', () => {
   const authMfaSessionDuration = computed(() => unref(capabilities).auth.mfa.session_duration)
 
   const vaultEnabled = computed(() => unref(capabilities).vault?.enabled)
+  const vaultStorageProvider = computed(() => unref(capabilities).vault?.vault_storage_provider)
 
   return {
     isInitialized,
@@ -210,7 +211,8 @@ export const useCapabilityStore = defineStore('capabilities', () => {
     authMfaEnabled,
     authMfaRequiredLevelname,
     authMfaSessionDuration,
-    vaultEnabled
+    vaultEnabled,
+    vaultStorageProvider
   }
 })
 

--- a/packages/web-runtime/src/components/Topbar/Notifications.vue
+++ b/packages/web-runtime/src/components/Topbar/Notifications.vue
@@ -84,7 +84,8 @@ import {
   createFileRouteOptions,
   formatDateFromISO,
   formatRelativeDateFromISO,
-  useClientService
+  useClientService,
+  useVault
 } from '@ownclouders/web-pkg'
 import NotificationBell from './NotificationBell.vue'
 import { Notification } from '../../helpers/notifications'
@@ -106,8 +107,24 @@ export default {
     const clientService = useClientService()
     const language = useGettext()
 
-    const notifications = ref<Notification[]>([])
+    const rawNotifications = ref<Notification[]>([])
     const notificationsInterval = ref()
+    const { isInVault } = useVault()
+
+    const isVaultNotification = (notification: Notification) =>
+      notification.object_id?.split('$')[0] === capabilityStore.vaultStorageProvider
+
+    const notifications = computed(() => {
+      if (!capabilityStore.vaultEnabled) {
+        return unref(rawNotifications)
+      }
+      if (isInVault) {
+        return unref(rawNotifications).filter(isVaultNotification)
+      }
+      return unref(rawNotifications).filter(
+        (notification: Notification) => !isVaultNotification(notification)
+      )
+    })
 
     const loading = computed(() => {
       return fetchNotificationsTask.isRunning || deleteNotificationsTask.isRunning
@@ -193,8 +210,9 @@ export default {
         const {
           ocs: { data = [] }
         } = response.data
-        notifications.value = data?.sort((a, b) => b.datetime.localeCompare(a.datetime)) || []
-        unref(notifications).forEach((notification) => setAdditionalNotificationData(notification))
+        const sorted = data?.sort((a, b) => b.datetime.localeCompare(a.datetime)) || []
+        sorted.forEach((notification) => setAdditionalNotificationData(notification))
+        rawNotifications.value = sorted
       } catch (e) {
         console.error(e)
       }
@@ -210,7 +228,9 @@ export default {
       } catch (e) {
         console.error(e)
       } finally {
-        notifications.value = unref(notifications).filter((n) => !ids.includes(n.notification_id))
+        rawNotifications.value = unref(rawNotifications).filter(
+          (n) => !ids.includes(n.notification_id)
+        )
       }
     }).restartable()
 
@@ -226,7 +246,7 @@ export default {
           return
         }
         setAdditionalNotificationData(notification)
-        notifications.value = [notification, ...unref(notifications)]
+        rawNotifications.value = [notification, ...unref(rawNotifications)]
       } catch {
         console.error('Unable to parse sse notification data')
       }

--- a/packages/web-runtime/tests/unit/components/Topbar/Notifications.spec.ts
+++ b/packages/web-runtime/tests/unit/components/Topbar/Notifications.spec.ts
@@ -18,12 +18,16 @@ const selectors = {
   notificationMessage: '.oc-notifications-message',
   notificationLink: '.oc-notifications-link'
 }
+const object_id = 'normal-provider$resource-1'
 
 vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
   ...(await importOriginal<any>()),
   queryItemAsString: vi.fn(),
-  useAppDefaults: vi.fn()
+  useAppDefaults: vi.fn(),
+  useVault: vi.fn(() => ({ isInVault: false }))
 }))
+
+const { useVault } = vi.mocked(await import('@ownclouders/web-pkg'))
 
 describe('Notification component', () => {
   it('renders the notification bell and no notifications if there are none', () => {
@@ -37,7 +41,8 @@ describe('Notification component', () => {
       mock<Notification>({
         messageRich: undefined,
         computedMessage: undefined,
-        computedLink: undefined
+        computedLink: undefined,
+        object_id
       })
     ]
     const { wrapper } = getWrapper({ notifications })
@@ -46,13 +51,13 @@ describe('Notification component', () => {
     expect(wrapper.findAll(selectors.notificationItem).length).toBe(notifications.length)
   })
   it('renders the loading state', async () => {
-    const notifications = [mock<Notification>({ messageRich: undefined })]
+    const notifications = [mock<Notification>({ messageRich: undefined, object_id })]
     const { wrapper } = getWrapper({ notifications })
     await wrapper.vm.$nextTick()
     expect(wrapper.find(selectors.notificationsLoading).exists()).toBeTruthy()
   })
   it('marks all notifications as read', async () => {
-    const notifications = [mock<Notification>({ messageRich: undefined })]
+    const notifications = [mock<Notification>({ messageRich: undefined, object_id })]
     const { wrapper, mocks } = getWrapper({ notifications })
     await wrapper.vm.fetchNotificationsTask.last
     await wrapper.find(selectors.markAll).trigger('click')
@@ -64,7 +69,8 @@ describe('Notification component', () => {
     it('loads based on the username', async () => {
       const notification = mock<Notification>({
         messageRich: undefined,
-        user: 'einstein'
+        user: 'einstein',
+        object_id
       })
       const { wrapper } = getWrapper({ notifications: [notification] })
       await wrapper.vm.fetchNotificationsTask.last
@@ -77,7 +83,8 @@ describe('Notification component', () => {
       const name = 'einstein'
       const notification = mock<Notification>({
         messageRich: undefined,
-        messageRichParameters: { user: { displayname, name } }
+        messageRichParameters: { user: { displayname, name } },
+        object_id
       })
       const { wrapper } = getWrapper({ notifications: [notification] })
       await wrapper.vm.fetchNotificationsTask.last
@@ -92,7 +99,8 @@ describe('Notification component', () => {
         messageRich: undefined,
         message: undefined,
         computedMessage: undefined,
-        computedLink: undefined
+        computedLink: undefined,
+        object_id
       })
       const { wrapper } = getWrapper({ notifications: [notification] })
       await wrapper.vm.fetchNotificationsTask.last
@@ -105,7 +113,8 @@ describe('Notification component', () => {
         messageRich: undefined,
         message: 'some message',
         computedMessage: undefined,
-        computedLink: undefined
+        computedLink: undefined,
+        object_id
       })
       const { wrapper } = getWrapper({ notifications: [notification] })
       await wrapper.vm.fetchNotificationsTask.last
@@ -120,7 +129,8 @@ describe('Notification component', () => {
           resource: { name: 'someFile.txt' }
         },
         computedMessage: undefined,
-        computedLink: undefined
+        computedLink: undefined,
+        object_id
       })
       const { wrapper } = getWrapper({ notifications: [notification] })
       await wrapper.vm.fetchNotificationsTask.last
@@ -130,38 +140,29 @@ describe('Notification component', () => {
       )
     })
     describe('escape server response', () => {
-      it('strips script tags from plain message', async () => {
+      it.each([
+        ['script tags', '<script>alert("lorem")</script>hello', 'script'],
+        ['img onerror (OCM share name vector)', '<img src=x onerror="alert(1)">', 'img']
+      ])('strips %s from plain message', async (_label, message, selector) => {
         const notification = mock<Notification>({
           messageRich: undefined,
-          message: '<script>alert("lorem")</script>hello',
+          message,
           computedMessage: undefined,
-          computedLink: undefined
+          computedLink: undefined,
+          object_id
         })
         const { wrapper } = getWrapper({ notifications: [notification] })
         await wrapper.vm.fetchNotificationsTask.last
         await wrapper.vm.$nextTick()
-        expect(wrapper.find('script').exists()).toBe(false)
-      })
-      it('strips img onerror payload from plain message (OCM share name vector)', async () => {
-        const notification = mock<Notification>({
-          messageRich: undefined,
-          message: '<img src=x onerror="alert(1)">',
-          computedMessage: undefined,
-          computedLink: undefined
-        })
-        const { wrapper } = getWrapper({ notifications: [notification] })
-        await wrapper.vm.fetchNotificationsTask.last
-        await wrapper.vm.$nextTick()
-        expect(wrapper.find('img').exists()).toBe(false)
+        expect(wrapper.find(selector).exists()).toBe(false)
       })
       it('strips XSS from messageRich template itself', async () => {
         const notification = mock<Notification>({
           messageRich: '<img src=x onerror="alert(1)"> {user} shared with you',
-          messageRichParameters: {
-            user: { displayname: 'lorem' }
-          },
+          messageRichParameters: { user: { displayname: 'lorem' } },
           computedMessage: undefined,
-          computedLink: undefined
+          computedLink: undefined,
+          object_id
         })
         const { wrapper } = getWrapper({ notifications: [notification] })
         await wrapper.vm.fetchNotificationsTask.last
@@ -177,7 +178,8 @@ describe('Notification component', () => {
             resource: { name: 'file.txt' }
           },
           computedMessage: undefined,
-          computedLink: undefined
+          computedLink: undefined,
+          object_id
         })
         const { wrapper } = getWrapper({ notifications: [notification] })
         await wrapper.vm.fetchNotificationsTask.last
@@ -193,7 +195,8 @@ describe('Notification component', () => {
         messageRich: undefined,
         computedMessage: undefined,
         computedLink: undefined,
-        link: 'http://some-link.com'
+        link: 'https://some-link.com',
+        object_id
       })
       const { wrapper } = getWrapper({ notifications: [notification] })
       await wrapper.vm.fetchNotificationsTask.last
@@ -210,7 +213,8 @@ describe('Notification component', () => {
             share: { id: '1' }
           },
           computedMessage: undefined,
-          computedLink: undefined
+          computedLink: undefined,
+          object_id
         })
         const { wrapper } = getWrapper({ notifications: [notification] })
         await wrapper.vm.fetchNotificationsTask.last
@@ -240,7 +244,8 @@ describe('Notification component', () => {
             space: { name: 'someFile.txt', id: `${spaceMock.fileId}!2` }
           },
           computedMessage: undefined,
-          computedLink: undefined
+          computedLink: undefined,
+          object_id
         })
         const { wrapper } = getWrapper({ notifications: [notification], spaces: [spaceMock] })
         await wrapper.vm.fetchNotificationsTask.last
@@ -254,16 +259,65 @@ describe('Notification component', () => {
       })
     })
   })
+  describe('vault filtering', () => {
+    const vaultNotification = mock<Notification>({
+      messageRich: undefined,
+      computedMessage: undefined,
+      computedLink: undefined,
+      object_id: 'vault-provider$resource-20',
+      datetime: '2024-01-01T00:00:00Z'
+    })
+    const driveNotification = mock<Notification>({
+      messageRich: undefined,
+      computedMessage: undefined,
+      computedLink: undefined,
+      object_id: 'other-provider$resource-22',
+      datetime: '2024-01-01T00:00:01Z'
+    })
+    const vaultCapabilityState = {
+      capabilities: { vault: { enabled: true, vault_storage_provider: 'vault-provider' } }
+    }
+
+    it('shows only vault notifications when in vault mode', async () => {
+      vi.mocked(useVault).mockReturnValue({ isInVault: true })
+      const { wrapper } = getWrapper({
+        notifications: [vaultNotification, driveNotification],
+        capabilityState: vaultCapabilityState
+      })
+      await wrapper.vm.fetchNotificationsTask.last
+      expect(wrapper.findAll(selectors.notificationItem).length).toBe(1)
+    })
+    it('shows only non-vault notifications when in drive mode', async () => {
+      vi.mocked(useVault).mockReturnValue({ isInVault: false })
+      const { wrapper } = getWrapper({
+        notifications: [vaultNotification, driveNotification],
+        capabilityState: vaultCapabilityState
+      })
+      await wrapper.vm.fetchNotificationsTask.last
+      expect(wrapper.findAll(selectors.notificationItem).length).toBe(1)
+    })
+    it('shows all notifications when vault is not enabled', async () => {
+      vi.mocked(useVault).mockReturnValue({ isInVault: false })
+      const { wrapper } = getWrapper({
+        notifications: [driveNotification, driveNotification],
+        capabilityState: { capabilities: { vault: { enabled: false } } }
+      })
+      await wrapper.vm.fetchNotificationsTask.last
+      expect(wrapper.findAll(selectors.notificationItem).length).toBe(2)
+    })
+  })
 })
 
 function getWrapper({
   mocks = {},
   notifications = [],
-  spaces = []
+  spaces = [],
+  capabilityState = {}
 }: {
   mocks?: Record<string, unknown>
   notifications?: Notification[]
   spaces?: SpaceResource[]
+  capabilityState?: Record<string, unknown>
 } = {}) {
   const localMocks = { ...defaultComponentMocks(), ...mocks }
   localMocks.$clientService.httpAuthenticated.get.mockResolvedValue(
@@ -275,7 +329,14 @@ function getWrapper({
     wrapper: shallowMount(Notifications, {
       global: {
         renderStubDefaultSlot: true,
-        plugins: [...defaultPlugins({ piniaOptions: { spacesState: { spaces } } })],
+        plugins: [
+          ...defaultPlugins({
+            piniaOptions: {
+              spacesState: { spaces },
+              capabilityState
+            }
+          })
+        ],
         mocks: localMocks,
         provide: localMocks,
         stubs: { 'avatar-image': true, OcButton: false }


### PR DESCRIPTION
## Description
Filter notifications in the topbar by the current mode (vault vs. drive). Previously the backend returned all notifications and the frontend showed them all regardless of context. Now notifications are stored raw and filtered reactively via a computed — vault notifications are shown only in vault mode, drive notifications only in drive mode.

## Related Issue
- Fixes https://kiteworks.atlassian.net/browse/OCISDEV-967

## Motivation and Context
Users in vault mode were seeing drive notifications (and vice versa), causing confusion. The fix uses a single fetch and a computed filter keyed on `isInVault` and the `vault_storage_provider` capability, so no duplicate fetches or SSE handlers are needed.

## How Has This Been Tested?
- test environment: local oCIS with vault capability enabled
- test case 1: in vault mode, only vault notifications appear in the topbar
- test case 2: in drive mode, only non-vault notifications appear in the topbar
- test case 3: SSE notifications are also filtered correctly without additional logic
- test case 4: unit tests added covering vault mode, drive mode, and vault-disabled scenarios