### PR TITLE
[OCISDEV-843][full-ci][tests-only] fix flaky search by re-querying the global search dropdown

### DIFF
--- a/tests/e2e/steps/ui/resources.ts
+++ b/tests/e2e/steps/ui/resources.ts
@@ -196,15 +196,19 @@ export async function userShouldSeeResources({
   const resourceObject = new objects.applicationFiles.Resource({ page })
 
   // search list waits longer for tika full-text indexing; other lists only need UI render time
-  const timeout = listType === resourcePage.searchList ? 30000 : 10000
+  const isSearchList = listType === resourcePage.searchList
+  const timeout = isSearchList ? 30000 : 10000
 
   for (const resource of resources) {
     await expect
       .poll(
         async () => {
-          const actualList = await resourceObject.getDisplayedResources({
-            keyword: listType
-          })
+          // the global search dropdown is a one-shot query, so for the search list we
+          // re-issue the search each poll to pick up resources that finish indexing after
+          // the initial query instead of repeatedly reading a stale result list
+          const actualList = isSearchList
+            ? await resourceObject.reSearchAndGetDisplayedResources()
+            : await resourceObject.getDisplayedResources({ keyword: listType })
           return actualList.includes(resource)
         },
         {

--- a/tests/e2e/support/objects/app-files/resource/actions.ts
+++ b/tests/e2e/support/objects/app-files/resource/actions.ts
@@ -1899,6 +1899,26 @@ export const getDisplayedResourcesFromSearch = async (page: Page): Promise<strin
   return result.map((result) => result.replace('\n', ''))
 }
 
+// The global search dropdown only queries the backend when the search term changes
+// (see the debounced `watch(term)` in SearchBar.vue). A single query issued right after
+// an upload can miss resources that tika is still indexing, and re-reading that one-shot
+// dropdown will never surface them. Re-issue the query by clearing and re-filling the
+// existing keyword: clearing forces a term change so the watcher re-runs the search even
+// for the same keyword, and avoiding a page reload preserves the active location filter.
+export const reSearchAndGetDisplayedResourcesFromSearch = async (page: Page): Promise<string[]> => {
+  const searchInput = page.locator(globalSearchInput)
+  const keyword = await searchInput.inputValue()
+  if (keyword) {
+    await searchInput.clear()
+    await Promise.all([
+      page.waitForResponse((resp) => resp.status() === 207 && resp.request().method() === 'REPORT'),
+      searchInput.fill(keyword)
+    ])
+    await expect(page.locator(loadingSpinner)).not.toBeVisible()
+  }
+  return getDisplayedResourcesFromSearch(page)
+}
+
 export const getDisplayedResourcesFromFilesList = async (page: Page): Promise<string[]> => {
   // wait for tika indexing
   await new Promise((resolve) => setTimeout(resolve, 1000))

--- a/tests/e2e/support/objects/app-files/resource/index.ts
+++ b/tests/e2e/support/objects/app-files/resource/index.ts
@@ -189,6 +189,12 @@ export class Resource {
     await po.searchResourceGlobalSearch({ ...args, page: this.#page })
   }
 
+  // re-issues the global search before reading, so resources still being indexed when the
+  // initial query ran are picked up instead of polling a stale one-shot result list
+  reSearchAndGetDisplayedResources(): Promise<string[]> {
+    return po.reSearchAndGetDisplayedResourcesFromSearch(this.#page)
+  }
+
   getDisplayedResources(args: Omit<po.getDisplayedResourcesArgs, 'page'>): Promise<string[]> {
     switch (args.keyword) {
       case resourcePage.filesList:


### PR DESCRIPTION
## Summary

`userShouldSeeResources` asserts on the global search **dropdown** (`resourcePage.searchList`) by polling `getDisplayedResourcesFromSearch`, which only re-reads the dropdown DOM. The dropdown is filled by a **single, debounced query** issued once when the search step runs (`watch(term)` → `debouncedSearch` in `SearchBar.vue`). If a resource is still being indexed by tika at that moment, it never lands in that one-shot result list — and re-reading the same DOM can never surface it. The 30s poll therefore just dead-waits and times out.

This is the underlying cause of OCISDEV-843. The earlier fixes addressed only the single Unicode `strängéनेपालीName` case (extra `waitForTimeout`s, then moving that one assertion off the dropdown to the full results page / files list). The mechanism itself was never fixed, so the **~18 other `searchList` assertions** in `search.spec.ts` / `searchProjectSpace.spec.ts` still poll the one-shot dropdown and stay latently flaky.

The failure is deterministic when indexing is slow — e.g. on the oCIS-side e2e job it failed on all four attempts:

```
✘ search.spec.ts › Search › Search in personal spaces  (+ retry #1, #2, #3)
Error: Waiting for resource "strängéनेपालीName" to appear in search list
- Timeout 30000ms exceeded while waiting on the predicate   (resources.ts:205)
```

## Changes

- Add `reSearchAndGetDisplayedResourcesFromSearch`: re-issues the global search by clearing and re-filling the existing keyword, then reads the dropdown. Clearing forces a term change so the debounced `watch(term)` re-runs the query even for the same keyword; not reloading the page preserves the active location filter.
- `userShouldSeeResources` now uses it for the `searchList` poll, so every poll iteration reflects the *current* index state and resources that finish indexing after the initial query are picked up. Other list types are unchanged.

This is a generic root-cause fix for all dropdown-based search assertions, not another per-test workaround.

## Related Issue

- Fixes [#OCISDEV-843](https://kiteworks.atlassian.net/browse/OCISDEV-843)

## Test plan

- [x] `pnpm lint` — passes (no new warnings/errors in the changed files)
- [x] `pnpm check:types` (`vue-tsc --noEmit`) — passes
- [ ] CI runs the e2e search suite against a live backend — note: the full e2e suite requires a running oCIS + tika deployment and was not run locally; this PR relies on CI as the e2e gate. `[full-ci]` is set so the search suite runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
