### PR TITLE
fix(design-system): [OCISDEV-926] fix danger filled button text color on focus

### DIFF
--- a/changelog/unreleased/bugfix-danger-button-focus-text-color.md
+++ b/changelog/unreleased/bugfix-danger-button-focus-text-color.md
@@ -1,0 +1,5 @@
+Bugfix: Fix danger filled button text color on focus
+
+We've fixed the `OcButton` danger filled variant not applying the correct text color when focused via keyboard.
+
+https://github.com/owncloud/web/pull/13887

--- a/packages/design-system/src/components/OcButton/OcButton.vue
+++ b/packages/design-system/src/components/OcButton/OcButton.vue
@@ -422,7 +422,8 @@ const handlers = computed(() => {
       var(--oc-color-swatch-danger-contrast)
     );
 
-    &-filled:hover {
+    &-filled:hover,
+    &-filled:focus {
       color: var(--oc-color-swatch-danger-default) !important;
       span > svg {
         fill: var(--oc-color-swatch-danger-default) !important;


### PR DESCRIPTION
## Description
Fix `OcButton` danger filled variant not applying the correct text color when focused via keyboard. Added missing `:focus` and `:focus-visible` CSS rules to the `&-danger` block so the text turns red on focus, consistent with hover behavior.
 
## Related Issue
- Fixes https://kiteworks.atlassian.net/browse/OCISDEV-926

## Motivation and Context
The danger filled button showed dark text when focused with the keyboard, making it inconsistent with the hover state (red text). The focus CSS rules were missing from the `&-danger-filled` block in `OcButton.vue`.

## How Has This Been Tested?
- test environment: local dev server
- test case 1: Tab to a danger filled button → text color is red
- test case 2: Click a danger filled button (hover) → text color is red, consistent with focus