### PR TITLE
fix(web-app-external): resolve external app by file mime type

### DIFF
--- a/changelog/unreleased/bugfix-external-redirect-mimetype.md
+++ b/changelog/unreleased/bugfix-external-redirect-mimetype.md
@@ -1,0 +1,12 @@
+Bugfix: Open external apps based on the file mime type
+
+We've fixed the external app redirect (`/external`) picking an arbitrary app when no `app`
+query parameter was present. It fell back to the first registered app provider, which might
+not support the file's mime type, so the following request to open the file failed with an
+"app not found" error that surfaced as a generic error to the user.
+
+The redirect now resolves the app from the file's mime type, preferring the configured
+default application, and shows an explicit error when no suitable app is available instead of
+silently redirecting to the wrong one.
+
+https://github.com/owncloud/web/pull/13888

--- a/packages/web-app-external/src/Redirect.vue
+++ b/packages/web-app-external/src/Redirect.vue
@@ -4,22 +4,34 @@
   >
     <h1 class="oc-invisible-sr" v-text="pageTitle" />
     <div class="oc-card oc-card-body oc-text-center oc-width-large">
-      <h2 key="external-redirect-loading">
-        <span v-text="$gettext('One moment please…')" />
-      </h2>
-      <p v-text="$gettext('You are being redirected.')" />
+      <template v-if="hasError">
+        <h2 key="external-redirect-error">
+          <span v-text="$gettext('We could not open this file')" />
+        </h2>
+        <p v-text="errorMessage" />
+      </template>
+      <template v-else>
+        <h2 key="external-redirect-loading">
+          <span v-text="$gettext('One moment please…')" />
+        </h2>
+        <p v-text="$gettext('You are being redirected.')" />
+      </template>
     </div>
   </main>
 </template>
 
 <script lang="ts" setup>
-import { computed, unref, watch } from 'vue'
+import { computed, ref, unref, watch } from 'vue'
 import {
   queryItemAsString,
   useAppProviderService,
+  useClientService,
   useRouteMeta,
-  useRouteQuery
+  useRouteQuery,
+  useSharesStore
 } from '@ownclouders/web-pkg'
+import { buildSpace } from '@ownclouders/web-client'
+import { DavProperty } from '@ownclouders/web-client/webdav'
 import { useRouter } from 'vue-router'
 import { omit } from 'lodash-es'
 import { useGettext } from 'vue3-gettext'
@@ -28,23 +40,94 @@ import { storeToRefs } from 'pinia'
 
 const { $gettext } = useGettext()
 const appProviderService = useAppProviderService()
+const clientService = useClientService()
+const sharesStore = useSharesStore()
 const router = useRouter()
 const { isReady } = storeToRefs(useApplicationReadyStore())
 
 const appQuery = useRouteQuery('app')
 const appNameQuery = useRouteQuery('appName')
-const appName = computed(() => {
+const fileIdQuery = useRouteQuery('fileId')
+
+const hasError = ref(false)
+const errorMessage = ref('')
+
+// An explicit app/appName query parameter always wins. It is set by callers that
+// already know which app to open the file with.
+const explicitAppName = computed(() => {
   if (unref(appQuery)) {
     return queryItemAsString(unref(appQuery))
   }
   if (unref(appNameQuery)) {
     return queryItemAsString(unref(appNameQuery))
   }
-  if (unref(isReady)) {
-    return appProviderService.appNames?.[0]
-  }
   return ''
 })
+
+const fail = (message: string) => {
+  errorMessage.value = message
+  hasError.value = true
+}
+
+const redirectToApp = (appName: string) => {
+  hasError.value = false
+  router.replace({
+    name: `external-${appName.toLowerCase()}-apps`,
+    query: omit(unref(router.currentRoute).query, ['app', 'appName'])
+  })
+}
+
+// Resolve the target app from the file's mime type. A single PROPFIND by file id
+// is enough and is safe on a cold deep link (no space from the store required),
+// mirroring useGetResourceContext's loadFileInfoById.
+const resolveAppNameByFileId = async (fileId: string): Promise<string | undefined> => {
+  const space = buildSpace({ id: fileId, name: '' }, sharesStore.graphRoles)
+  const resource = await clientService.webdav.getFileInfo(
+    space,
+    { fileId },
+    { davProperties: [DavProperty.MimeType, DavProperty.FileId, DavProperty.Name] }
+  )
+
+  if (!resource?.mimeType) {
+    return undefined
+  }
+
+  return appProviderService.getDefaultAppNameForMimeType(resource.mimeType)
+}
+
+const redirect = async () => {
+  const explicit = unref(explicitAppName)
+  if (explicit) {
+    redirectToApp(explicit)
+    return
+  }
+
+  const fileId = queryItemAsString(unref(fileIdQuery))
+  if (!fileId) {
+    fail($gettext('No file was specified to open.'))
+    return
+  }
+
+  let appName: string | undefined
+  try {
+    appName = await resolveAppNameByFileId(fileId)
+  } catch (e) {
+    console.error(e)
+    fail(
+      $gettext(
+        'The file could not be loaded. It may have been deleted or you might not have access to it.'
+      )
+    )
+    return
+  }
+
+  if (!appName) {
+    fail($gettext('No application is available to open this file type.'))
+    return
+  }
+
+  redirectToApp(appName)
+}
 
 watch(
   isReady,
@@ -52,11 +135,7 @@ watch(
     if (!ready) {
       return
     }
-
-    router.replace({
-      name: `external-${unref(appName).toLowerCase()}-apps`,
-      query: omit(unref(router.currentRoute).query, ['app', 'appName'])
-    })
+    void redirect()
   },
   { immediate: true }
 )

--- a/packages/web-app-external/tests/unit/Redirect.spec.ts
+++ b/packages/web-app-external/tests/unit/Redirect.spec.ts
@@ -1,0 +1,151 @@
+import { mock } from 'vitest-mock-extended'
+import { ref } from 'vue'
+import {
+  defaultComponentMocks,
+  defaultPlugins,
+  flushPromises,
+  shallowMount
+} from '@ownclouders/web-test-helpers'
+import {
+  AppProviderService,
+  queryItemAsString,
+  useRouteMeta,
+  useRouteQuery
+} from '@ownclouders/web-pkg'
+import { Resource } from '@ownclouders/web-client'
+import Redirect from '../../src/Redirect.vue'
+import { useApplicationReadyStore } from '../../src/piniaStores'
+
+vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
+  ...(await importOriginal<any>()),
+  useRouteQuery: vi.fn(),
+  useRouteMeta: vi.fn(),
+  queryItemAsString: vi.fn()
+}))
+
+const { mockRouterReplace } = vi.hoisted(() => ({ mockRouterReplace: vi.fn() }))
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<any>()
+  const { ref } = await import('vue')
+  return {
+    ...actual,
+    useRouter: () => ({ replace: mockRouterReplace, currentRoute: ref({ query: {} }) })
+  }
+})
+
+const docxMimeType = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+
+describe('Redirect.vue', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    mockRouterReplace.mockClear()
+  })
+
+  it('does not redirect while the application is not ready', async () => {
+    const { wrapper } = getWrapper({ query: { app: 'Collabora' }, ready: false })
+    await flushPromises()
+    expect(mockRouterReplace).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('You are being redirected.')
+  })
+
+  it('redirects to the app given via the "app" query', async () => {
+    getWrapper({ query: { app: 'Collabora' } })
+    await flushPromises()
+    expect(mockRouterReplace).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'external-collabora-apps' })
+    )
+  })
+
+  it('redirects to the app given via the "appName" query', async () => {
+    getWrapper({ query: { appName: 'OnlyOffice' } })
+    await flushPromises()
+    expect(mockRouterReplace).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'external-onlyoffice-apps' })
+    )
+  })
+
+  it('resolves the app from the file mime type when no app query is given', async () => {
+    const { appProviderService } = getWrapper({
+      query: { fileId: 'file-id' },
+      mimeType: docxMimeType,
+      resolvedApp: 'ByCS-Office'
+    })
+    await flushPromises()
+    expect(appProviderService.getDefaultAppNameForMimeType).toHaveBeenCalledWith(docxMimeType)
+    expect(mockRouterReplace).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'external-bycs-office-apps' })
+    )
+  })
+
+  it('shows an error and does not redirect when no app is configured for the mime type', async () => {
+    const { wrapper } = getWrapper({
+      query: { fileId: 'file-id' },
+      mimeType: 'application/x-unknown',
+      resolvedApp: undefined
+    })
+    await flushPromises()
+    expect(mockRouterReplace).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('We could not open this file')
+  })
+
+  it('shows an error and does not redirect when the file cannot be statted', async () => {
+    const { wrapper } = getWrapper({ query: { fileId: 'file-id' }, statThrows: true })
+    await flushPromises()
+    expect(mockRouterReplace).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('We could not open this file')
+  })
+
+  it('shows an error and does not redirect when neither app nor fileId is given', async () => {
+    const { wrapper } = getWrapper({ query: {} })
+    await flushPromises()
+    expect(mockRouterReplace).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('We could not open this file')
+  })
+})
+
+function getWrapper({
+  query = {},
+  mimeType = '',
+  resolvedApp = undefined,
+  statThrows = false,
+  ready = true
+}: {
+  query?: { app?: string; appName?: string; fileId?: string }
+  mimeType?: string
+  resolvedApp?: string
+  statThrows?: boolean
+  ready?: boolean
+} = {}) {
+  vi.mocked(useRouteQuery).mockImplementation(
+    (name: string) => ref((query as Record<string, string>)[name] ?? '') as never
+  )
+  vi.mocked(useRouteMeta).mockReturnValue(ref('Redirecting to external app') as never)
+  vi.mocked(queryItemAsString).mockImplementation((value) => (value ?? '').toString())
+
+  const appProviderService = mock<AppProviderService>()
+  appProviderService.getDefaultAppNameForMimeType.mockReturnValue(resolvedApp)
+
+  const mocks = {
+    ...defaultComponentMocks(),
+    $appProviderService: appProviderService
+  }
+
+  if (statThrows) {
+    mocks.$clientService.webdav.getFileInfo.mockRejectedValue(new Error('stat failed'))
+  } else {
+    mocks.$clientService.webdav.getFileInfo.mockResolvedValue(mock<Resource>({ mimeType }))
+  }
+
+  const wrapper = shallowMount(Redirect, {
+    global: {
+      plugins: [...defaultPlugins()],
+      provide: mocks,
+      mocks
+    }
+  })
+
+  useApplicationReadyStore().isReady = ready
+
+  return { wrapper, mocks, appProviderService }
+}

--- a/packages/web-pkg/src/services/appProvider/service.ts
+++ b/packages/web-pkg/src/services/appProvider/service.ts
@@ -52,4 +52,23 @@ export class AppProviderService {
       mimeType.app_providers.some((appProvider) => appProvider.name === appName)
     )
   }
+
+  /**
+   * Resolves the app that should open a given mime type. Prefers the configured
+   * default_application (but only if it is actually offered for that mime type),
+   * otherwise the first registered provider. Returns undefined when the mime type
+   * is not handled by any app provider, so callers can surface an error instead of
+   * silently falling back to an arbitrary app.
+   */
+  public getDefaultAppNameForMimeType(mimeType: string): string | undefined {
+    const entry = unref(this._mimeTypes).find((m) => m.mime_type === mimeType)
+    if (!entry) {
+      return undefined
+    }
+    const providerNames = entry.app_providers.map((appProvider) => appProvider.name)
+    if (entry.default_application && providerNames.includes(entry.default_application)) {
+      return entry.default_application
+    }
+    return providerNames[0]
+  }
 }

--- a/packages/web-pkg/tests/unit/services/appProvider.spec.ts
+++ b/packages/web-pkg/tests/unit/services/appProvider.spec.ts
@@ -1,0 +1,65 @@
+import { mockDeep } from 'vitest-mock-extended'
+import { AppProviderService, ClientService } from '../../../src/services'
+import { MimeType } from '../../../src/services/appProvider/schemas'
+
+const docx = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+
+const buildService = (mimeTypes: MimeType[]) => {
+  const service = new AppProviderService('https://example.test', mockDeep<ClientService>())
+  service.mimeTypes = mimeTypes
+  return service
+}
+
+describe('AppProviderService', () => {
+  describe('getDefaultAppNameForMimeType', () => {
+    it('returns the configured default_application when it is offered for the mime type', () => {
+      const service = buildService([
+        {
+          mime_type: docx,
+          default_application: 'ByCS-Office',
+          app_providers: [
+            { name: 'Webeditor', icon: '', secure_view: false },
+            { name: 'ByCS-Office', icon: '', secure_view: false }
+          ]
+        }
+      ])
+      expect(service.getDefaultAppNameForMimeType(docx)).toEqual('ByCS-Office')
+    })
+
+    it('falls back to the first provider when no default_application is configured', () => {
+      const service = buildService([
+        {
+          mime_type: docx,
+          app_providers: [
+            { name: 'ByCS-Office', icon: '', secure_view: false },
+            { name: 'Webeditor', icon: '', secure_view: false }
+          ]
+        }
+      ])
+      expect(service.getDefaultAppNameForMimeType(docx)).toEqual('ByCS-Office')
+    })
+
+    it('ignores a default_application that is not among the registered providers', () => {
+      const service = buildService([
+        {
+          mime_type: docx,
+          default_application: 'GoneApp',
+          app_providers: [{ name: 'ByCS-Office', icon: '', secure_view: false }]
+        }
+      ])
+      expect(service.getDefaultAppNameForMimeType(docx)).toEqual('ByCS-Office')
+    })
+
+    it('returns undefined for a mime type that no provider handles', () => {
+      const service = buildService([
+        { mime_type: docx, app_providers: [{ name: 'ByCS-Office', icon: '', secure_view: false }] }
+      ])
+      expect(service.getDefaultAppNameForMimeType('application/x-unknown')).toBeUndefined()
+    })
+
+    it('returns undefined when the mime type entry has no providers', () => {
+      const service = buildService([{ mime_type: docx, app_providers: [] }])
+      expect(service.getDefaultAppNameForMimeType(docx)).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
## Problem

The external app redirect route (`/external`) picks the wrong app when it is opened without
an explicit `app` (or `appName`) query parameter. `Redirect.vue` falls back to the first
registered app provider (`appProviderService.appNames[0]`), which is just the first provider
across all configured mime types in insertion order.

In a deployment with multiple WOPI providers serving disjoint mime types (e.g. one office
suite for OOXML/ODF and a separate editor for its own formats), that first provider often
does not support the file being opened. The subsequent `POST /app/open` then carries a wrong
`app_name`, the gateway rejects it with `app '<name>' not found`, and the user sees a generic
"could not open" error. Which app is picked depends only on mime-type config order, so the
failure is deployment-wide for any file type not served by the first-listed provider.

## Fix

Resolve the target app from the **file's mime type** instead of guessing:

- `Redirect.vue` now reads the `fileId` query parameter and performs a single, cold-load-safe
  `PROPFIND` by file id (mirroring `useGetResourceContext`'s `loadFileInfoById`) to obtain the
  resource's mime type.
- A new `AppProviderService.getDefaultAppNameForMimeType(mimeType)` maps the mime type to an
  app: it prefers the configured `default_application` (only when that app is actually offered
  for the mime type) and otherwise returns the first registered provider. It returns
  `undefined` when no provider handles the mime type.
- When no `fileId` is present, the stat fails, or no app handles the mime type, the page now
  shows an **explicit error** instead of silently redirecting to an arbitrary (wrong) app.
- The explicit `app` / `appName` query parameters still take precedence, so callers that
  already know the app are unaffected.

## Testing

- New `packages/web-app-external/tests/unit/Redirect.spec.ts`: explicit `app`/`appName` query
  redirects; mime-type resolution redirects to the configured app; and the no-fileId /
  stat-failure / unknown-mime-type cases render an error and do **not** redirect.
- New `packages/web-pkg/tests/unit/services/appProvider.spec.ts` covers
  `getDefaultAppNameForMimeType` (configured default, first-provider fallback, dangling
  default ignored, unknown mime type, empty providers).
- `pnpm check:types`, `pnpm check:format`, `eslint`, and the unit suites for both touched
  packages pass locally.

## Notes

This only changes the previously-broken no-`app` path. A successful resolution produces the
same `external-<app>-apps` redirect as before; the explicit-query path is unchanged.
