### PR TITLE
docs(e2e): add documentation screenshot capture tool

### DIFF
--- a/changelog/unreleased/enhancement-documentation-screenshot-capture.md
+++ b/changelog/unreleased/enhancement-documentation-screenshot-capture.md
@@ -1,0 +1,10 @@
+Enhancement: Add a documentation screenshot capture tool
+
+We added a Playwright-based tool under `tests/e2e/docs` that automatically captures end-user
+documentation screenshots from a live ownCloud Web instance. Each "tour" drives the UI through a
+documented flow and saves a captioned screenshot per step plus a `manifest.json`, so the
+screenshots used in the user documentation can be regenerated on demand and never drift from the
+product. The initial tours mirror the "Web for users" documentation: the top navigation, the file
+sidebars, sharing roles and contextual help.
+
+https://github.com/owncloud/web/pull/13894

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint vite.config.ts '{packages,tests}/**/*.{js,ts,vue}' --color",
     "serve": "SERVER=true pnpm build:w",
     "test:e2e:playwright": "NODE_TLS_REJECT_UNAUTHORIZED=0 npx playwright test --config=tests/e2e/",
+    "docs:screenshots": "NODE_TLS_REJECT_UNAUTHORIZED=0 npx playwright test --config=tests/e2e/docs/playwright.config.ts",
     "test:unit": "NODE_OPTIONS=--unhandled-rejections=throw vitest",
     "licenses:check": "license-checker-rseidelsohn --summary --relativeLicensePath --onlyAllow 'Python-2.0;Apache*;Apache License, Version 2.0;Apache-2.0;Apache 2.0;Artistic-2.0;BSD;BSD-3-Clause;CC-BY-3.0;CC-BY-4.0;CC0-1.0;ISC;MIT;MPL-2.0;Public Domain;Unicode-TOU;Unlicense;WTFPL;BlueOak-1.0.0' --excludePackages '@ownclouders/babel-preset;@ownclouders/eslint-config;@ownclouders/prettier-config;@ownclouders/tsconfig;@ownclouders/web-client;@ownclouders/web-pkg;external;web-app-files;text-editor;preview;web-app-ocm;@ownclouders/design-system;pdf-viewer;web-app-search;admin-settings;webfinger;web-runtime;@ownclouders/web-test-helpers'",
     "licenses:csv": "license-checker-rseidelsohn --relativeLicensePath --csv --out ./third-party-licenses/third-party-licenses.csv",

--- a/tests/e2e/docs/.gitignore
+++ b/tests/e2e/docs/.gitignore
@@ -1,0 +1,3 @@
+output/
+test-results/
+playwright-report/

--- a/tests/e2e/docs/README.md
+++ b/tests/e2e/docs/README.md
@@ -1,0 +1,37 @@
+# Documentation screenshot capture
+
+A small Playwright tool that automatically captures **end-user documentation screenshots** from a
+live ownCloud Web instance, so the screenshots in the user documentation never drift from the
+product.
+
+Each "tour" in [`tours.ts`](./tours.ts) is one documented flow: an ordered list of steps with a
+title, a caption and a `run` action that drives the UI into the state to capture. Running the tool
+logs in, performs every step, saves a screenshot per step under `output/<tour-id>/NN-<shot>.png`,
+and writes an `output/manifest.json` that pairs every screenshot with its caption.
+
+The initial tours mirror the
+[Web for users](https://doc.owncloud.com/webui/latest/owncloud_web/web_for_users.html)
+documentation: the top navigation, the left and right sidebars, sharing roles, and contextual help.
+
+## Run
+
+This reuses the repository's Playwright install — no extra dependencies. Point it at a running
+instance (defaults shown):
+
+```bash
+# from the repository root
+OCIS_URL=https://localhost:9200 OCIS_USER=admin OCIS_PASSWORD=admin pnpm docs:screenshots
+```
+
+The tool seeds a little best-effort demo data first (a versioned file, a trashed item, a project
+space and one incoming share) so the tours have something to show. Seeding is idempotent and
+tolerant of failures, so it is safe to run repeatedly and against an instance where some of that
+data already exists.
+
+Generated screenshots and the manifest land in `tests/e2e/docs/output/` (git-ignored) — they are
+build artefacts, regenerated on demand.
+
+## Add a tour
+
+Append an entry to `tours.ts` with `id`, `category`, `title`, `summary` and `steps`
+(each `{ shot, title, caption, run }`), then run the capture again. No other changes are needed.

--- a/tests/e2e/docs/README.md
+++ b/tests/e2e/docs/README.md
@@ -15,12 +15,14 @@ documentation: the top navigation, the left and right sidebars, sharing roles, a
 
 ## Run
 
-This reuses the repository's Playwright install — no extra dependencies. Point it at a running
-instance (defaults shown):
+This reuses the repository's Playwright install — no extra dependencies — and the shared e2e
+config in [`tests/e2e/config.js`](../config.js), so the instance URL and admin credentials are the
+same `BASE_URL_OCIS` / `ADMIN_USERNAME` / `ADMIN_PASSWORD` variables used by the rest of the e2e
+suite (all defaulting to a local instance with `admin` / `admin`):
 
 ```bash
 # from the repository root
-OCIS_URL=https://localhost:9200 OCIS_USER=admin OCIS_PASSWORD=admin pnpm docs:screenshots
+BASE_URL_OCIS=https://localhost:9200 pnpm docs:screenshots
 ```
 
 The tool seeds a little best-effort demo data first (a versioned file, a trashed item, a project

--- a/tests/e2e/docs/capture.spec.ts
+++ b/tests/e2e/docs/capture.spec.ts
@@ -5,10 +5,11 @@ import { fileURLToPath } from 'url'
 import { login } from './support/oc'
 import { seed } from './support/seed'
 import { tours } from './tours'
+import { config } from '../config'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const outputRoot = path.join(__dirname, 'output')
-const baseURL = process.env.OCIS_URL ?? 'https://localhost:9200'
+const baseURL = config.baseUrl
 
 const shotName = (index: number, shot: string) =>
   `${String(index + 1).padStart(2, '0')}-${shot}.png`

--- a/tests/e2e/docs/capture.spec.ts
+++ b/tests/e2e/docs/capture.spec.ts
@@ -1,0 +1,65 @@
+import { test, request } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { login } from './support/oc'
+import { seed } from './support/seed'
+import { tours } from './tours'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const outputRoot = path.join(__dirname, 'output')
+const baseURL = process.env.OCIS_URL ?? 'https://localhost:9200'
+
+const shotName = (index: number, shot: string) => `${String(index + 1).padStart(2, '0')}-${shot}.png`
+
+// Seed best-effort demo data once before capturing.
+test.beforeAll(async () => {
+  const api = await request.newContext({ baseURL, ignoreHTTPSErrors: true })
+  try {
+    await seed(api)
+  } finally {
+    await api.dispose()
+  }
+})
+
+// Capture each tour: drive the UI step by step and screenshot the resulting state.
+for (const tour of tours) {
+  test(`capture: ${tour.id}`, async ({ page }) => {
+    await login(page)
+    const dir = path.join(outputRoot, tour.id)
+    fs.mkdirSync(dir, { recursive: true })
+    for (let i = 0; i < tour.steps.length; i++) {
+      const step = tour.steps[i]
+      await step.run(page)
+      await page.waitForTimeout(300)
+      await page.screenshot({ path: path.join(dir, shotName(i, step.shot)) })
+    }
+  })
+}
+
+// Write a manifest describing the fully-captured tours and their captions, so a
+// documentation site (or any consumer) can pick up the screenshots and text.
+test.afterAll(() => {
+  const captured = tours.filter((tour) =>
+    tour.steps.every((_, i) => fs.existsSync(path.join(outputRoot, tour.id, shotName(i, tour.steps[i].shot))))
+  )
+  const manifest = {
+    source: 'doc.owncloud.com/webui/latest/owncloud_web/web_for_users.html',
+    tours: captured.map((tour) => ({
+      id: tour.id,
+      category: tour.category,
+      title: tour.title,
+      summary: tour.summary,
+      steps: tour.steps.map((step, i) => ({
+        title: step.title,
+        caption: step.caption,
+        screenshot: `${tour.id}/${shotName(i, step.shot)}`
+      }))
+    }))
+  }
+  fs.mkdirSync(outputRoot, { recursive: true })
+  fs.writeFileSync(path.join(outputRoot, 'manifest.json'), JSON.stringify(manifest, null, 2) + '\n')
+  console.log(
+    `[docs-capture] captured ${captured.length}/${tours.length} tour(s) -> ${outputRoot} (+ manifest.json)`
+  )
+})

--- a/tests/e2e/docs/capture.spec.ts
+++ b/tests/e2e/docs/capture.spec.ts
@@ -10,7 +10,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const outputRoot = path.join(__dirname, 'output')
 const baseURL = process.env.OCIS_URL ?? 'https://localhost:9200'
 
-const shotName = (index: number, shot: string) => `${String(index + 1).padStart(2, '0')}-${shot}.png`
+const shotName = (index: number, shot: string) =>
+  `${String(index + 1).padStart(2, '0')}-${shot}.png`
 
 // Seed best-effort demo data once before capturing.
 test.beforeAll(async () => {
@@ -41,7 +42,9 @@ for (const tour of tours) {
 // documentation site (or any consumer) can pick up the screenshots and text.
 test.afterAll(() => {
   const captured = tours.filter((tour) =>
-    tour.steps.every((_, i) => fs.existsSync(path.join(outputRoot, tour.id, shotName(i, tour.steps[i].shot))))
+    tour.steps.every((_, i) =>
+      fs.existsSync(path.join(outputRoot, tour.id, shotName(i, tour.steps[i].shot)))
+    )
   )
   const manifest = {
     source: 'doc.owncloud.com/webui/latest/owncloud_web/web_for_users.html',

--- a/tests/e2e/docs/playwright.config.ts
+++ b/tests/e2e/docs/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from '@playwright/test'
+
+// Standalone Playwright config for the documentation screenshot capture tool.
+// It reuses the repository's Playwright install. Point OCIS_URL at a running
+// ownCloud Web / oCIS instance (defaults to https://localhost:9200, admin/admin);
+// override credentials with OCIS_USER / OCIS_PASSWORD.
+export default defineConfig({
+  testDir: '.',
+  testMatch: 'capture.spec.ts',
+  outputDir: './test-results',
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 1 : 0,
+  reporter: 'list',
+  timeout: 120_000,
+  use: {
+    baseURL: process.env.OCIS_URL ?? 'https://localhost:9200',
+    ignoreHTTPSErrors: true,
+    headless: true,
+    viewport: { width: 1440, height: 900 }
+  }
+})

--- a/tests/e2e/docs/playwright.config.ts
+++ b/tests/e2e/docs/playwright.config.ts
@@ -1,9 +1,11 @@
 import { defineConfig } from '@playwright/test'
+import { config } from '../config'
 
 // Standalone Playwright config for the documentation screenshot capture tool.
-// It reuses the repository's Playwright install. Point OCIS_URL at a running
-// ownCloud Web / oCIS instance (defaults to https://localhost:9200, admin/admin);
-// override credentials with OCIS_USER / OCIS_PASSWORD.
+// It reuses the repository's Playwright install and the shared e2e config
+// (tests/e2e/config.js): point BASE_URL_OCIS at a running ownCloud Web / oCIS
+// instance and set ADMIN_USERNAME / ADMIN_PASSWORD (all default to the same
+// values as the rest of the e2e suite).
 export default defineConfig({
   testDir: '.',
   testMatch: 'capture.spec.ts',
@@ -14,7 +16,7 @@ export default defineConfig({
   reporter: 'list',
   timeout: 120_000,
   use: {
-    baseURL: process.env.OCIS_URL ?? 'https://localhost:9200',
+    baseURL: config.baseUrl,
     ignoreHTTPSErrors: true,
     headless: true,
     viewport: { width: 1440, height: 900 }

--- a/tests/e2e/docs/support/oc.ts
+++ b/tests/e2e/docs/support/oc.ts
@@ -1,0 +1,25 @@
+import { Page } from '@playwright/test'
+
+const USER = process.env.OCIS_USER ?? 'admin'
+const PASS = process.env.OCIS_PASSWORD ?? 'admin'
+
+/**
+ * Log in to ownCloud Web through the built-in IdP and wait until the Files
+ * view is ready (the account menu is present in the top bar).
+ */
+export async function login(page: Page): Promise<void> {
+  await page.goto('/')
+  const username = page.locator('input[placeholder="Username"]')
+  await username.waitFor({ state: 'visible', timeout: 30_000 })
+  await username.fill(USER)
+  await page.locator('input[placeholder="Password"]').fill(PASS)
+  await page.locator('input[placeholder="Password"]').press('Enter')
+  await page.getByRole('button', { name: 'My Account' }).waitFor({ state: 'visible', timeout: 30_000 })
+  await page.waitForTimeout(600)
+}
+
+/** Dismiss any open popover/menu so the next step starts from a clean top bar. */
+export async function dismissOverlays(page: Page): Promise<void> {
+  await page.keyboard.press('Escape').catch(() => {})
+  await page.waitForTimeout(200)
+}

--- a/tests/e2e/docs/support/oc.ts
+++ b/tests/e2e/docs/support/oc.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test'
+import { Page, expect } from '@playwright/test'
 
 const USER = process.env.OCIS_USER ?? 'admin'
 const PASS = process.env.OCIS_PASSWORD ?? 'admin'
@@ -14,7 +14,9 @@ export async function login(page: Page): Promise<void> {
   await username.fill(USER)
   await page.locator('input[placeholder="Password"]').fill(PASS)
   await page.locator('input[placeholder="Password"]').press('Enter')
-  await page.getByRole('button', { name: 'My Account' }).waitFor({ state: 'visible', timeout: 30_000 })
+  await page
+    .getByRole('button', { name: 'My Account' })
+    .waitFor({ state: 'visible', timeout: 30_000 })
   await page.waitForTimeout(600)
 }
 
@@ -22,4 +24,36 @@ export async function login(page: Page): Promise<void> {
 export async function dismissOverlays(page: Page): Promise<void> {
   await page.keyboard.press('Escape').catch(() => {})
   await page.waitForTimeout(200)
+}
+
+/**
+ * Open Personal, select the seeded `report.md`, and reveal the right sidebar
+ * (it is collapsed in a fresh session). Shared by the tours that start from a
+ * selected file.
+ */
+export async function selectReportAndOpenSidebar(page: Page): Promise<void> {
+  await page.goto('/files/spaces/personal')
+  await page.waitForURL(/files\/spaces\/personal/, { timeout: 30_000 })
+  const checkbox = page.getByRole('row', { name: /report\.md/ }).getByLabel('Select file')
+  await checkbox.waitFor({ state: 'visible', timeout: 30_000 })
+  await checkbox.click()
+  const openSidebar = page.getByRole('button', { name: 'Open sidebar to view details' })
+  if (await openSidebar.isVisible().catch(() => false)) {
+    await openSidebar.click()
+  }
+}
+
+/** Open the right sidebar's Shares panel and wait for it to render. */
+export async function openSharingPanel(page: Page): Promise<void> {
+  await page.locator('[data-testid="sidebar-panel-sharing-select"]').click()
+  await expect(page.getByRole('heading', { name: 'Share with people' })).toBeVisible({
+    timeout: 15_000
+  })
+}
+
+/** Click a left-sidebar navigation entry and wait for its route to load. */
+export async function openSection(page: Page, name: string, url: RegExp): Promise<void> {
+  await page.getByRole('link', { name }).click()
+  await page.waitForURL(url, { timeout: 30_000 })
+  await page.waitForTimeout(900)
 }

--- a/tests/e2e/docs/support/oc.ts
+++ b/tests/e2e/docs/support/oc.ts
@@ -1,7 +1,5 @@
 import { Page, expect } from '@playwright/test'
-
-const USER = process.env.OCIS_USER ?? 'admin'
-const PASS = process.env.OCIS_PASSWORD ?? 'admin'
+import { config } from '../../config'
 
 /**
  * Log in to ownCloud Web through the built-in IdP and wait until the Files
@@ -11,8 +9,8 @@ export async function login(page: Page): Promise<void> {
   await page.goto('/')
   const username = page.locator('input[placeholder="Username"]')
   await username.waitFor({ state: 'visible', timeout: 30_000 })
-  await username.fill(USER)
-  await page.locator('input[placeholder="Password"]').fill(PASS)
+  await username.fill(config.adminUsername)
+  await page.locator('input[placeholder="Password"]').fill(config.adminPassword)
   await page.locator('input[placeholder="Password"]').press('Enter')
   await page
     .getByRole('button', { name: 'My Account' })

--- a/tests/e2e/docs/support/seed.ts
+++ b/tests/e2e/docs/support/seed.ts
@@ -1,0 +1,83 @@
+import { APIRequestContext } from '@playwright/test'
+
+const USER = process.env.OCIS_USER ?? 'admin'
+const PASS = process.env.OCIS_PASSWORD ?? 'admin'
+
+const basic = (user: string, pass: string) =>
+  'Basic ' + Buffer.from(`${user}:${pass}`).toString('base64')
+
+/**
+ * Best-effort, idempotent demo data so the tours have something to show:
+ * a versioned file, a trashed item, a project space, and one incoming share.
+ * Every step is independent and tolerates "already exists" responses, so the
+ * tool is safe to run repeatedly. Failures are logged, never fatal — the tours
+ * simply capture whatever state the instance is in.
+ */
+export async function seed(api: APIRequestContext): Promise<void> {
+  const admin = basic(USER, PASS)
+
+  // A versioned text file (details / versions / sharing / contextual-help tours).
+  try {
+    const versions = [
+      '# Project report\n\nInitial draft of the quarterly report.\n',
+      '# Project report\n\nQuarterly report with the Q3 budget and an updated timeline.\n'
+    ]
+    for (const data of versions) {
+      await api.put(`/remote.php/dav/files/${USER}/report.md`, {
+        headers: { Authorization: admin, 'Content-Type': 'text/markdown' },
+        data
+      })
+      await new Promise((resolve) => setTimeout(resolve, 1100))
+    }
+  } catch (error) {
+    console.warn('[seed] report.md:', error)
+  }
+
+  // A trashed item (deleted-files tour).
+  try {
+    await api.put(`/remote.php/dav/files/${USER}/old-draft.txt`, {
+      headers: { Authorization: admin },
+      data: 'An old draft, later deleted.'
+    })
+    await api.delete(`/remote.php/dav/files/${USER}/old-draft.txt`, { headers: { Authorization: admin } })
+  } catch (error) {
+    console.warn('[seed] trash:', error)
+  }
+
+  // A project space (spaces tour).
+  try {
+    await api.post('/graph/v1.0/drives', {
+      headers: { Authorization: admin, 'Content-Type': 'application/json' },
+      data: { name: 'Demo project', driveType: 'project' }
+    })
+  } catch (error) {
+    console.warn('[seed] project space:', error)
+  }
+
+  // An incoming share (shared-with-you tour): a helper user shares a file with the admin.
+  try {
+    const helper = 'doc-demo'
+    const helperPass = 'Secret123!'
+    await api.post('/graph/v1.0/users', {
+      headers: { Authorization: admin, 'Content-Type': 'application/json' },
+      data: {
+        displayName: 'Documentation Demo',
+        onPremisesSamAccountName: helper,
+        mail: 'doc-demo@example.org',
+        accountEnabled: true,
+        passwordProfile: { password: helperPass }
+      }
+    })
+    const helperAuth = basic(helper, helperPass)
+    await api.put(`/remote.php/dav/files/${helper}/shared-notes.txt`, {
+      headers: { Authorization: helperAuth },
+      data: 'A file shared with you.'
+    })
+    await api.post('/ocs/v2.php/apps/files_sharing/api/v1/shares?format=json', {
+      headers: { Authorization: helperAuth, 'OCS-APIRequest': 'true' },
+      form: { path: '/shared-notes.txt', shareType: '0', shareWith: USER, permissions: '1' }
+    })
+  } catch (error) {
+    console.warn('[seed] incoming share:', error)
+  }
+}

--- a/tests/e2e/docs/support/seed.ts
+++ b/tests/e2e/docs/support/seed.ts
@@ -1,7 +1,8 @@
 import { APIRequestContext } from '@playwright/test'
+import { config } from '../../config'
 
-const USER = process.env.OCIS_USER ?? 'admin'
-const PASS = process.env.OCIS_PASSWORD ?? 'admin'
+const USER = config.adminUsername
+const PASS = config.adminPassword
 
 const basic = (user: string, pass: string) =>
   'Basic ' + Buffer.from(`${user}:${pass}`).toString('base64')

--- a/tests/e2e/docs/support/seed.ts
+++ b/tests/e2e/docs/support/seed.ts
@@ -39,7 +39,9 @@ export async function seed(api: APIRequestContext): Promise<void> {
       headers: { Authorization: admin },
       data: 'An old draft, later deleted.'
     })
-    await api.delete(`/remote.php/dav/files/${USER}/old-draft.txt`, { headers: { Authorization: admin } })
+    await api.delete(`/remote.php/dav/files/${USER}/old-draft.txt`, {
+      headers: { Authorization: admin }
+    })
   } catch (error) {
     console.warn('[seed] trash:', error)
   }

--- a/tests/e2e/docs/tours.ts
+++ b/tests/e2e/docs/tours.ts
@@ -1,5 +1,10 @@
 import { Page, expect } from '@playwright/test'
-import { dismissOverlays } from './support/oc'
+import {
+  dismissOverlays,
+  openSection,
+  openSharingPanel,
+  selectReportAndOpenSidebar
+} from './support/oc'
 
 /**
  * A single captured step. `run` drives the UI into the state to capture; the
@@ -125,9 +130,7 @@ export const tours: Tour[] = [
         caption:
           '<strong>Shares</strong> collects everything other people have shared with you. Depending on the instance you may need to accept a share before it appears, and you can decline ones you do not want.',
         run: async (page) => {
-          await page.getByRole('link', { name: 'Shares' }).click()
-          await page.waitForURL(/files\/shares/, { timeout: 30_000 })
-          await page.waitForTimeout(900)
+          await openSection(page, 'Shares', /files\/shares/)
         }
       },
       {
@@ -136,9 +139,7 @@ export const tours: Tour[] = [
         caption:
           '<strong>Spaces</strong> are shared project areas with their own members and storage. Use them to collaborate with a team in a dedicated location, separate from your personal files.',
         run: async (page) => {
-          await page.getByRole('link', { name: 'Spaces' }).click()
-          await page.waitForURL(/files\/spaces\/projects/, { timeout: 30_000 })
-          await page.waitForTimeout(900)
+          await openSection(page, 'Spaces', /files\/spaces\/projects/)
         }
       },
       {
@@ -147,9 +148,7 @@ export const tours: Tour[] = [
         caption:
           '<strong>Deleted files</strong> is your trash bin. Restore something you removed by mistake, or permanently delete it to free up space.',
         run: async (page) => {
-          await page.getByRole('link', { name: 'Deleted files' }).click()
-          await page.waitForURL(/files\/trash/, { timeout: 30_000 })
-          await page.waitForTimeout(900)
+          await openSection(page, 'Deleted files', /files\/trash/)
         }
       }
     ]
@@ -168,16 +167,7 @@ export const tours: Tour[] = [
         caption:
           'Select a file to open the right sidebar. <strong>Details</strong> shows its size, when it was last modified, the owner, sharing status, tags and how many versions it has.',
         run: async (page) => {
-          await page.goto('/files/spaces/personal')
-          await page.waitForURL(/files\/spaces\/personal/, { timeout: 30_000 })
-          const checkbox = page.getByRole('row', { name: /report\.md/ }).getByLabel('Select file')
-          await checkbox.waitFor({ state: 'visible', timeout: 30_000 })
-          await checkbox.click()
-          // The right sidebar is collapsed in a fresh session; open it to reveal details.
-          const openSidebar = page.getByRole('button', { name: 'Open sidebar to view details' })
-          if (await openSidebar.isVisible().catch(() => false)) {
-            await openSidebar.click()
-          }
+          await selectReportAndOpenSidebar(page)
           await expect(page.getByRole('heading', { level: 3, name: 'report.md' })).toBeVisible({
             timeout: 15_000
           })
@@ -189,10 +179,7 @@ export const tours: Tour[] = [
         caption:
           'The <strong>Shares</strong> panel lets you invite registered users by name, or create a <strong>public link</strong> that anyone can open, optionally protected with a password and an expiry date.',
         run: async (page) => {
-          await page.locator('[data-testid="sidebar-panel-sharing-select"]').click()
-          await expect(page.getByRole('heading', { name: 'Share with people' })).toBeVisible({
-            timeout: 15_000
-          })
+          await openSharingPanel(page)
           await page.waitForTimeout(400)
         }
       },
@@ -241,19 +228,8 @@ export const tours: Tour[] = [
         caption:
           "Throughout the interface a small <strong>?</strong> icon sits next to features that need a little explanation, such as beside <strong>Share with people</strong> and <strong>Public links</strong> in a file's sharing panel.",
         run: async (page) => {
-          await page.goto('/files/spaces/personal')
-          await page.waitForURL(/files\/spaces\/personal/, { timeout: 30_000 })
-          const checkbox = page.getByRole('row', { name: /report\.md/ }).getByLabel('Select file')
-          await checkbox.waitFor({ state: 'visible', timeout: 30_000 })
-          await checkbox.click()
-          const openSidebar = page.getByRole('button', { name: 'Open sidebar to view details' })
-          if (await openSidebar.isVisible().catch(() => false)) {
-            await openSidebar.click()
-          }
-          await page.locator('[data-testid="sidebar-panel-sharing-select"]').click()
-          await expect(page.getByRole('heading', { name: 'Share with people' })).toBeVisible({
-            timeout: 15_000
-          })
+          await selectReportAndOpenSidebar(page)
+          await openSharingPanel(page)
           await page.waitForTimeout(300)
         }
       },

--- a/tests/e2e/docs/tours.ts
+++ b/tests/e2e/docs/tours.ts
@@ -1,0 +1,276 @@
+import { Page, expect } from '@playwright/test'
+import { dismissOverlays } from './support/oc'
+
+/**
+ * A single captured step. `run` drives the UI into the state to capture; the
+ * runner then screenshots it as `output/<tour.id>/NN-<shot>.png`. `title` and
+ * `caption` describe the step in the generated `manifest.json`.
+ */
+export interface Step {
+  shot: string
+  title: string
+  caption: string
+  run: (page: Page) => Promise<void>
+}
+
+export interface Tour {
+  id: string
+  source: string
+  category: string
+  title: string
+  summary: string
+  steps: Step[]
+}
+
+/**
+ * Documentation tours derived from the ownCloud Web end-user documentation
+ * (doc.owncloud.com/webui/latest/owncloud_web/web_for_users.html).
+ *
+ * Each tour produces one set of captioned screenshots. Add a tour here, run the
+ * capture, and the screenshots plus their captions are produced from the live
+ * UI, so the documentation never drifts from the product. New tours need only
+ * data plus the `run` actions below.
+ */
+export const tours: Tour[] = [
+  {
+    id: 'webtour',
+    source: 'doc.owncloud.com · ownCloud Web for users',
+    category: 'Getting started',
+    title: 'Getting around ownCloud Web',
+    summary:
+      'A tour of the ownCloud Web interface for everyday use: where your files live, how to switch apps, search everything, and find your account, storage and appearance settings.',
+    steps: [
+      {
+        shot: 'files',
+        title: 'Your files',
+        caption:
+          'After signing in you land in <strong>Personal</strong>, your private space. The left sidebar switches between <strong>Personal</strong>, <strong>Shares</strong>, <strong>Spaces</strong> and <strong>Deleted files</strong>; the main area lists whatever is in the current location.',
+        run: async (page) => {
+          await expect(page.getByRole('heading', { level: 1, name: 'Personal' })).toBeVisible()
+        }
+      },
+      {
+        shot: 'app-switcher',
+        title: 'Switch applications',
+        caption:
+          'The <strong>application switcher</strong> in the top-left corner jumps between Files and the other apps enabled for you, such as the text editor, admin settings or installed extensions.',
+        run: async (page) => {
+          await page.getByRole('button', { name: 'Application Switcher' }).click()
+          await page.waitForTimeout(400)
+        }
+      },
+      {
+        shot: 'search',
+        title: 'Search everything',
+        caption:
+          'The <strong>search bar</strong> at the top finds files by name across everything you can access, and by their content when full-text search is enabled. Filters let you narrow a search to a space or file type.',
+        run: async (page) => {
+          await dismissOverlays(page)
+          const search = page.getByRole('combobox', { name: 'Enter search term' })
+          await search.click()
+          await search.fill('report')
+          await page.waitForTimeout(600)
+        }
+      },
+      {
+        shot: 'account',
+        title: 'Your account and storage',
+        caption:
+          'The <strong>account menu</strong> in the top-right shows how much storage you have used, opens your <strong>Preferences</strong>, and lets you log out.',
+        run: async (page) => {
+          const search = page.getByRole('combobox', { name: 'Enter search term' })
+          await search.fill('')
+          await dismissOverlays(page)
+          await page.getByRole('button', { name: 'My Account' }).click()
+          await expect(page.getByRole('link', { name: 'Preferences' })).toBeVisible()
+        }
+      },
+      {
+        shot: 'preferences',
+        title: 'Preferences and appearance',
+        caption:
+          'Open <strong>Preferences</strong> to set your language, switch between light and dark mode, and review your account details.',
+        run: async (page) => {
+          await page.goto('/account')
+          await expect(page.getByRole('heading', { name: 'Account', level: 1 })).toBeVisible({
+            timeout: 30_000
+          })
+          await page.waitForTimeout(500)
+        }
+      }
+    ]
+  },
+  {
+    id: 'storagetour',
+    source: 'doc.owncloud.com · ownCloud Web for users',
+    category: 'Getting started',
+    title: 'Your files, shares and spaces',
+    summary:
+      'The left sidebar is your map to everything you can reach: your private files, what others have shared with you, collaborative spaces, and a trash bin for recovering deleted items.',
+    steps: [
+      {
+        shot: 'personal',
+        title: 'Personal',
+        caption:
+          '<strong>Personal</strong> is your private space. Only you can see what is here until you choose to share it. Upload files, create folders and organise your own documents.',
+        run: async (page) => {
+          await page.goto('/files/spaces/personal')
+          await page.waitForURL(/files\/spaces\/personal/, { timeout: 30_000 })
+          await expect(page.getByRole('heading', { level: 1, name: 'Personal' })).toBeVisible()
+        }
+      },
+      {
+        shot: 'shares',
+        title: 'Shared with you',
+        caption:
+          '<strong>Shares</strong> collects everything other people have shared with you. Depending on the instance you may need to accept a share before it appears, and you can decline ones you do not want.',
+        run: async (page) => {
+          await page.getByRole('link', { name: 'Shares' }).click()
+          await page.waitForURL(/files\/shares/, { timeout: 30_000 })
+          await page.waitForTimeout(900)
+        }
+      },
+      {
+        shot: 'spaces',
+        title: 'Spaces',
+        caption:
+          '<strong>Spaces</strong> are shared project areas with their own members and storage. Use them to collaborate with a team in a dedicated location, separate from your personal files.',
+        run: async (page) => {
+          await page.getByRole('link', { name: 'Spaces' }).click()
+          await page.waitForURL(/files\/spaces\/projects/, { timeout: 30_000 })
+          await page.waitForTimeout(900)
+        }
+      },
+      {
+        shot: 'deleted',
+        title: 'Deleted files',
+        caption:
+          '<strong>Deleted files</strong> is your trash bin. Restore something you removed by mistake, or permanently delete it to free up space.',
+        run: async (page) => {
+          await page.getByRole('link', { name: 'Deleted files' }).click()
+          await page.waitForURL(/files\/trash/, { timeout: 30_000 })
+          await page.waitForTimeout(900)
+        }
+      }
+    ]
+  },
+  {
+    id: 'filesidebar',
+    source: 'doc.owncloud.com · ownCloud Web for users',
+    category: 'Getting started',
+    title: 'File details, sharing and versions',
+    summary:
+      'Select any file and the right sidebar shows everything about it: its details, who it is shared with, and its previous versions. This is where most day-to-day file actions happen.',
+    steps: [
+      {
+        shot: 'details',
+        title: 'See the details',
+        caption:
+          'Select a file to open the right sidebar. <strong>Details</strong> shows its size, when it was last modified, the owner, sharing status, tags and how many versions it has.',
+        run: async (page) => {
+          await page.goto('/files/spaces/personal')
+          await page.waitForURL(/files\/spaces\/personal/, { timeout: 30_000 })
+          const checkbox = page.getByRole('row', { name: /report\.md/ }).getByLabel('Select file')
+          await checkbox.waitFor({ state: 'visible', timeout: 30_000 })
+          await checkbox.click()
+          // The right sidebar is collapsed in a fresh session; open it to reveal details.
+          const openSidebar = page.getByRole('button', { name: 'Open sidebar to view details' })
+          if (await openSidebar.isVisible().catch(() => false)) {
+            await openSidebar.click()
+          }
+          await expect(page.getByRole('heading', { level: 3, name: 'report.md' })).toBeVisible({
+            timeout: 15_000
+          })
+        }
+      },
+      {
+        shot: 'share',
+        title: 'Share with people',
+        caption:
+          'The <strong>Shares</strong> panel lets you invite registered users by name, or create a <strong>public link</strong> that anyone can open, optionally protected with a password and an expiry date.',
+        run: async (page) => {
+          await page.locator('[data-testid="sidebar-panel-sharing-select"]').click()
+          await expect(page.getByRole('heading', { name: 'Share with people' })).toBeVisible({
+            timeout: 15_000
+          })
+          await page.waitForTimeout(400)
+        }
+      },
+      {
+        shot: 'roles',
+        title: 'Choose what they can do',
+        caption:
+          'Pick a role for each person you share with. <strong>Can view</strong> lets them view and download; <strong>Can edit</strong> also lets them upload and change the file. Folders and spaces offer further roles such as Uploader and Manager.',
+        run: async (page) => {
+          await page.locator('#files-collaborators-role-button-new').click()
+          await page.waitForTimeout(500)
+        }
+      },
+      {
+        shot: 'versions',
+        title: 'Restore an earlier version',
+        caption:
+          'The <strong>Versions</strong> panel keeps previous copies of a file. Open it to download or restore an older version, which is handy when several people edit the same document.',
+        run: async (page) => {
+          await page.keyboard.press('Escape')
+          await page.waitForTimeout(200)
+          // The Shares sub-panel is active; return to the Details panel where the
+          // Versions tab lives before opening it.
+          const back = page.getByRole('button', { name: 'Back to Details panel' })
+          if (await back.isVisible().catch(() => false)) {
+            await back.click()
+            await page.waitForTimeout(300)
+          }
+          await page.locator('[data-testid="sidebar-panel-versions-select"]').click()
+          await page.waitForTimeout(700)
+        }
+      }
+    ]
+  },
+  {
+    id: 'contextualhelp',
+    source: 'doc.owncloud.com · ownCloud Web for users',
+    category: 'Getting started',
+    title: 'Help where you need it',
+    summary:
+      'ownCloud Web keeps help close at hand: small question-mark icons sit next to features that benefit from a little explanation, and clicking one shows guidance specific to what you are doing without leaving the page.',
+    steps: [
+      {
+        shot: 'icons',
+        title: 'Spot the help icons',
+        caption:
+          "Throughout the interface a small <strong>?</strong> icon sits next to features that need a little explanation, such as beside <strong>Share with people</strong> and <strong>Public links</strong> in a file's sharing panel.",
+        run: async (page) => {
+          await page.goto('/files/spaces/personal')
+          await page.waitForURL(/files\/spaces\/personal/, { timeout: 30_000 })
+          const checkbox = page.getByRole('row', { name: /report\.md/ }).getByLabel('Select file')
+          await checkbox.waitFor({ state: 'visible', timeout: 30_000 })
+          await checkbox.click()
+          const openSidebar = page.getByRole('button', { name: 'Open sidebar to view details' })
+          if (await openSidebar.isVisible().catch(() => false)) {
+            await openSidebar.click()
+          }
+          await page.locator('[data-testid="sidebar-panel-sharing-select"]').click()
+          await expect(page.getByRole('heading', { name: 'Share with people' })).toBeVisible({
+            timeout: 15_000
+          })
+          await page.waitForTimeout(300)
+        }
+      },
+      {
+        shot: 'popover',
+        title: 'Open contextual help',
+        caption:
+          'Click a help icon to read short, context-specific guidance right where you are, here explaining how sharing with people works, with a <strong>Read more</strong> link to the full documentation.',
+        run: async (page) => {
+          await page
+            .locator('#sidebar-panel-sharing')
+            .getByRole('button', { name: 'Show more information' })
+            .first()
+            .click()
+          await page.waitForTimeout(500)
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Description

Adds a small Playwright tool under `tests/e2e/docs` that automatically captures **end-user documentation screenshots** from a live ownCloud Web instance, so the screenshots used in the user documentation never drift from the product.

Each "tour" in `tours.ts` is a documented flow: an ordered list of steps with a title, a caption and a `run` action that drives the UI. Running the tool logs in, performs each step, saves a screenshot per step under `output/<tour-id>/NN-<shot>.png`, and writes an `output/manifest.json` that pairs every screenshot with its caption.

The initial tours mirror the [Web for users](https://doc.owncloud.com/webui/latest/owncloud_web/web_for_users.html) documentation (whose screenshots are currently outdated):

- **webtour** — top navigation: app switcher, global search, account + storage, preferences/appearance
- **storagetour** — left sidebar: Personal, Shares, Spaces, Deleted files
- **filesidebar** — right sidebar: details, sharing, sharing roles, versions
- **contextualhelp** — the `?` help icons and the guidance popovers they open

## How to run

It reuses the repository's Playwright install — no new dependencies:

```bash
OCIS_URL=https://localhost:9200 OCIS_USER=admin OCIS_PASSWORD=admin pnpm docs:screenshots
```

It first seeds best-effort, idempotent demo data (a versioned file, a trashed item, a project space and one incoming share) so the tours have something to show. Generated screenshots and the manifest land in `tests/e2e/docs/output/` (git-ignored — they are build artefacts, regenerated on demand). Adding a new tour is just another entry in `tours.ts`.

## Notes

- Purely additive: a new `tests/e2e/docs/` directory, one root `package.json` script (`docs:screenshots`), and a changelog item. No existing code or the existing e2e suite is touched.
- Not wired into CI; it is a tool to run on demand when refreshing documentation screenshots.

## Testing

- `eslint` is clean on the new files; the code is ESM and matches the repo (`"type": "module"`).
- The tour/login logic and the seeding API calls (WebDAV upload + versions, OCS share, Graph user/space) were validated against a live oCIS instance, with all four tours capturing successfully.