### PR TITLE
test(web-pkg): raise timeout for flaky real web worker unit tests

### DIFF
--- a/packages/web-pkg/tests/unit/composables/webWorkers/deleteWorker/worker.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/webWorkers/deleteWorker/worker.spec.ts
@@ -21,6 +21,10 @@ const dataMock = {
   baseUrl: 'https://example.com'
 }
 
+// Real web workers can be slow to spin up and reply under heavy CI parallelism;
+// give these tests more headroom than the 5s default to avoid flaky timeouts.
+vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
+
 describe('delete worker', () => {
   let worker: ReturnType<typeof useWebWorker>
   let webDavMock: ReturnType<typeof mock<WebDAV>>

--- a/packages/web-pkg/tests/unit/composables/webWorkers/exportAsPdfWorker/worker.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/webWorkers/exportAsPdfWorker/worker.spec.ts
@@ -42,6 +42,10 @@ vi.mock('../../../../../src/composables/webWorkers/exportAsPdfWorker/renderer', 
   })
 }))
 
+// Real web workers can be slow to spin up and reply under heavy CI parallelism;
+// give these tests more headroom than the 5s default to avoid flaky timeouts.
+vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
+
 describe('export as PDF worker', () => {
   let worker: ReturnType<typeof useWebWorker>
   let webDavMock: ReturnType<typeof mock<WebDAV>>

--- a/packages/web-pkg/tests/unit/composables/webWorkers/pasteWorker/worker.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/webWorkers/pasteWorker/worker.spec.ts
@@ -33,6 +33,10 @@ const transferDataMock = {
   baseUrl: 'https://example.com'
 }
 
+// Real web workers can be slow to spin up and reply under heavy CI parallelism;
+// give these tests more headroom than the 5s default to avoid flaky timeouts.
+vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
+
 describe('paste worker', () => {
   let worker: ReturnType<typeof useWebWorker>
   let webDavMock: ReturnType<typeof mock<WebDAV>>

--- a/packages/web-pkg/tests/unit/composables/webWorkers/restoreWorker/worker.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/webWorkers/restoreWorker/worker.spec.ts
@@ -25,7 +25,7 @@ const dataMock = {
 // give these tests more headroom than the 5s default to avoid flaky timeouts.
 vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
 
-describe('delete worker', () => {
+describe('restore worker', () => {
   let worker: ReturnType<typeof useWebWorker>
   let webDavMock: ReturnType<typeof mock<WebDAV>>
 

--- a/packages/web-pkg/tests/unit/composables/webWorkers/restoreWorker/worker.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/webWorkers/restoreWorker/worker.spec.ts
@@ -21,6 +21,10 @@ const dataMock = {
   baseUrl: 'https://example.com'
 }
 
+// Real web workers can be slow to spin up and reply under heavy CI parallelism;
+// give these tests more headroom than the 5s default to avoid flaky timeouts.
+vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
+
 describe('delete worker', () => {
   let worker: ReturnType<typeof useWebWorker>
   let webDavMock: ReturnType<typeof mock<WebDAV>>

--- a/packages/web-pkg/tests/unit/composables/webWorkers/tokenTimerWorker/worker.spec.ts
+++ b/packages/web-pkg/tests/unit/composables/webWorkers/tokenTimerWorker/worker.spec.ts
@@ -2,6 +2,10 @@ import { unref } from 'vue'
 import { useWebWorker } from '@vueuse/core'
 import TokenWorker from '../../../../../src/composables/webWorkers/tokenTimerWorker/worker?worker'
 
+// Real web workers can be slow to spin up and reply under heavy CI parallelism;
+// give these tests more headroom than the 5s default to avoid flaky timeouts.
+vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 })
+
 describe('token timer worker', () => {
   let worker: ReturnType<typeof useWebWorker>
 


### PR DESCRIPTION
## Problem

The `packages/web-pkg/tests/unit/composables/webWorkers/*/worker.spec.ts` suites
spin up **real** web workers (`useWebWorker(... ?worker)`) and `await` the worker's
`postMessage` reply. Under heavy CI fork-parallelism (e.g. when the full
`vitest` projects run with many concurrent forks) the worker thread is starved and
does not reply within vitest's 5s default `testTimeout`. The result is flaky
failures like:

```
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
Error: Test timed out in 5000ms.
```

across `deleteWorker`, `pasteWorker`, `restoreWorker` and `exportAsPdfWorker`. The
tests pass locally and in lighter runs, so this is a timing/contention flake, not a
product bug.

## Fix

Raise `testTimeout` (and `hookTimeout`) to 20s for the five real-worker specs via a
per-file `vi.setConfig`. The timeout only affects tests that would otherwise exceed
5s, so fast runs are unchanged; it simply gives the real workers enough headroom to
reply under CI load. The change is scoped to exactly the affected spec files.

## Testing

- `pnpm --filter @ownclouders/web-pkg exec vitest run tests/unit/composables/webWorkers` -> 15 files / 129 tests pass.
- prettier and eslint clean on the changed files.
