### PR TITLE
docs: normalize legacy server product name to "ownCloud Classic"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ownCloud Web is a single page, standalone frontend, based on modern web technolo
 
 ## Compatibility
 
-Usage of Web UI and [ownCloud 10](https://github.com/owncloud/core) as backend is **not** recommended starting with version `7.1.0` of the Web UI, meaning newer versions only support [ownCloud Infinite Scale](https://github.com/owncloud/ocis). If you want to use the Web UI with ownCloud 10, please use App version `7.0.2`. Critical bugs can be fixed upon request.
+Usage of Web UI and [ownCloud Classic 10](https://github.com/owncloud/core) as backend is **not** recommended starting with version `7.1.0` of the Web UI, meaning newer versions only support [ownCloud Infinite Scale](https://github.com/owncloud/ocis). If you want to use the Web UI with ownCloud Classic 10, please use App version `7.0.2`. Critical bugs can be fixed upon request.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ownCloud Web is a single page, standalone frontend, based on modern web technolo
 
 ## Compatibility
 
-Usage of Web UI and [ownCloud Classic 10](https://github.com/owncloud/core) as backend is **not** recommended starting with version `7.1.0` of the Web UI, meaning newer versions only support [ownCloud Infinite Scale](https://github.com/owncloud/ocis). If you want to use the Web UI with ownCloud Classic 10, please use App version `7.0.2`. Critical bugs can be fixed upon request.
+Usage of Web UI and [ownCloud Classic](https://github.com/owncloud/core) as backend is **not** recommended starting with version `7.1.0` of the Web UI, meaning newer versions only support [ownCloud Infinite Scale](https://github.com/owncloud/ocis). If you want to use the Web UI with ownCloud Classic, please use App version `7.0.2`. Critical bugs can be fixed upon request.
 
 ## Examples
 

--- a/docs/backend-oc10.md
+++ b/docs/backend-oc10.md
@@ -1,5 +1,5 @@
 ---
-title: "Setup With ownCloud 10"
+title: "Setup With ownCloud Classic 10"
 date: 2020-04-15T00:00:00+00:00
 weight: 40
 geekdocRepo: https://github.com/owncloud/web
@@ -11,7 +11,7 @@ geekdocFilePath: backend-oc10.md
 
 ## Compatibility
 
-Please note that the usage of Web UI and ownCloud 10 as backend is not recommended starting with version 7.1.0 of the Web UI. Therefore, this section only applies to versions < 7.1.0.
+Please note that the usage of Web UI and ownCloud Classic 10 as backend is not recommended starting with version 7.1.0 of the Web UI. Therefore, this section only applies to versions < 7.1.0.
 
 ## Prerequisites
 
@@ -20,9 +20,9 @@ In this document, we will refer to the following:
 - `<web-url>` as the full URL, for example `https://web-host:9100/web-path/`
 - `<web-domain>` as the protocol, domain and port, for example: `https://web-host:9100`
 
-## Setting up the ownCloud Server
+## Setting up ownCloud Classic
 
-Make sure you have an [ownCloud Server](https://owncloud.org/download/#owncloud-server) already installed.
+Make sure you have [ownCloud Classic](https://owncloud.org/download/#owncloud-server) already installed.
 
 ### Adjusting config.php
 
@@ -48,7 +48,7 @@ Install and enable the [oauth2 app](https://marketplace.owncloud.com/apps/oauth2
 % occ app:enable oauth2
 ```
 
-Login as administrator in the ownCloud Server web interface and go to the "User Authentication" section in the admin settings and add an entry for Web as follows:
+Login as administrator in the ownCloud Classic web interface and go to the "User Authentication" section in the admin settings and add an entry for Web as follows:
 
 - pick an arbitrary name for the client
 - set the redirection URI to `<web-url>/oidc-callback.html`

--- a/docs/backend-oc10.md
+++ b/docs/backend-oc10.md
@@ -1,5 +1,5 @@
 ---
-title: "Setup With ownCloud Classic 10"
+title: "Setup With ownCloud Classic"
 date: 2020-04-15T00:00:00+00:00
 weight: 40
 geekdocRepo: https://github.com/owncloud/web
@@ -11,7 +11,7 @@ geekdocFilePath: backend-oc10.md
 
 ## Compatibility
 
-Please note that the usage of Web UI and ownCloud Classic 10 as backend is not recommended starting with version 7.1.0 of the Web UI. Therefore, this section only applies to versions < 7.1.0.
+Please note that the usage of Web UI and ownCloud Classic as backend is not recommended starting with version 7.1.0 of the Web UI. Therefore, this section only applies to versions < 7.1.0.
 
 ## Prerequisites
 

--- a/docs/deployments/oc10-app.md
+++ b/docs/deployments/oc10-app.md
@@ -1,5 +1,5 @@
 ---
-title: "Deploy as an app in ownCloud 10"
+title: "Deploy as an app in ownCloud Classic 10"
 date: 2018-05-02T00:00:00+00:00
 weight: 1
 geekdocRepo: https://github.com/owncloud/web
@@ -12,15 +12,15 @@ geekdocFilePath: oc10-app.md
 
 ## Compatibility
 
-Please note that the usage of Web UI and ownCloud 10 as backend is not recommended starting with version 7.1.0 of the Web UI. Therefore, this section only applies to versions < 7.1.0.
+Please note that the usage of Web UI and ownCloud Classic 10 as backend is not recommended starting with version 7.1.0 of the Web UI. Therefore, this section only applies to versions < 7.1.0.
 
 ## Introduction
 
-ownCloud Web is being deployed as an app to [ownCloud marketplace](https://marketplace.owncloud.com/) to enable easy integration into existing ownCloud 10 instances.
+ownCloud Web is being deployed as an app to [ownCloud marketplace](https://marketplace.owncloud.com/) to enable easy integration into existing ownCloud Classic 10 instances.
 After completing this setup, ownCloud Web will be available on `https://<your-owncloud-server>/index.php/apps/web`.
 
 ## Prerequisites
-- Running [ownCloud 10 server](https://owncloud.com/download-server/) with version 10.8
+- Running [ownCloud Classic 10 server](https://owncloud.com/download-server/) with version 10.8
 - Installed [oauth2 app](https://marketplace.owncloud.com/apps/oauth2)
 - Command line access to your server
 
@@ -31,7 +31,7 @@ occ market:install web
 ```
 
 ## Configure oauth2
-Within the `Admin` page of ownCloud 10, head into `User Authentication` and add a new client with arbitrary name (e.g. `ownCloud Web`) and redirection URL `https://<your-owncloud-server>/index.php/apps/web/oidc-callback.html`.
+Within the `Admin` page of ownCloud Classic 10, head into `User Authentication` and add a new client with arbitrary name (e.g. `ownCloud Web`) and redirection URL `https://<your-owncloud-server>/index.php/apps/web/oidc-callback.html`.
 
 {{< figure src="/clients/web/static/oauth2.png" alt="Example OAuth2 entry" >}}
 
@@ -43,7 +43,7 @@ You can mark the ownCloud web client as `trusted` by clicking the respective che
 If you use OpenID Connect you need to add a new client for ownCloud Web to your identity provider instead.
 {{< /hint >}}
 
-## Configure ownCloud 10
+## Configure ownCloud Classic 10
 ### Set ownCloud Web address
 To set the ownCloud Web address and to display ownCloud Web in the app switcher, add the following line into `config/config.php`:
 
@@ -118,7 +118,7 @@ If any issues arise when trying to access the new design, a good start for debug
 
 |config parameter|explanation|
 |---|---|
-|server|ownCloud 10 server address|
+|server|ownCloud Classic 10 server address|
 |theme|Theme to be used in ownCloud Web pointing to a json file inside of `themes` folder|
 |auth.clientId|Client ID received when adding ownCloud Web in the `User Authentication` section in `Admin`|
 |apps|List of internal extensions to be loaded|
@@ -166,7 +166,7 @@ To add new elements in the app switcher, paste the following into the `applicati
 ```
 
 {{< hint info >}}
-The URL in the example might need adaptations depending on the configuration of your ownCloud Server. App switcher elements added this way will open the respective page in a new tab. This method can also be used to link external sites like Help pages or similar.
+The URL in the example might need adaptations depending on the configuration of your ownCloud Classic. App switcher elements added this way will open the respective page in a new tab. This method can also be used to link external sites like Help pages or similar.
 {{< /hint >}}
 
 ### Add links to the user menu
@@ -188,10 +188,10 @@ Just like adding links to the app switcher, you can also add links to the user m
 This will add a link to the specified URL in the user menu. This way, the link will open in the same tab. If you instead want to open it in a new tab, just remove the line `"target": "_self",`.
 
 ### ONLYOFFICE
-For ONLYOFFICE there is a [native integration](https://github.com/ONLYOFFICE/onlyoffice-owncloud-web) available for ownCloud Web when it is used with ownCloud Classic Server. It fully integrates the ONLYOFFICE Document Editors and allows users to create and open documents right from ownCloud Web.
+For ONLYOFFICE there is a [native integration](https://github.com/ONLYOFFICE/onlyoffice-owncloud-web) available for ownCloud Web when it is used with ownCloud Classic. It fully integrates the ONLYOFFICE Document Editors and allows users to create and open documents right from ownCloud Web.
 
 To be able to use ONLYOFFICE in ownCloud Web, it is required to run
-- ownCloud Server >= 10.8
+- ownCloud Classic >= 10.8
 - ownCloud Web >= 4.0.0
 - [ONLYOFFICE Connector for ownCloud Classic](https://marketplace.owncloud.com/apps/onlyoffice) >= 7.1.1
 
@@ -207,14 +207,14 @@ Make sure that ONLYOFFICE works as expected in the Classic UI and add the follow
 ```
 
 {{< hint info >}}
-The URL in the example might need adaptations depending on the configuration of your ownCloud Server.
+The URL in the example might need adaptations depending on the configuration of your ownCloud Classic.
 {{< /hint >}}
 
 ### Collabora Online
-For Collabora Online there is a native integration available for ownCloud Web when it is used with ownCloud Classic Server. It fully integrates the Collabora Online Document Editors and allows users to create and open documents right from ownCloud Web.
+For Collabora Online there is a native integration available for ownCloud Web when it is used with ownCloud Classic. It fully integrates the Collabora Online Document Editors and allows users to create and open documents right from ownCloud Web.
 
 To be able to use Collabora Online in ownCloud Web, it is required to run
-- ownCloud Server >= 10.8
+- ownCloud Classic >= 10.8
 - ownCloud Web >= 4.0.0
 - [Collabora Online Connector for ownCloud Classic](https://marketplace.owncloud.com/apps/richdocuments) >= 2.7.0
 
@@ -230,7 +230,7 @@ Make sure that Collabora Online works as expected in the Classic UI and add the 
 ```
 
 {{< hint info >}}
-The URL in the example might need adaptations depending on the configuration of your ownCloud Server.
+The URL in the example might need adaptations depending on the configuration of your ownCloud Classic.
 {{< /hint >}}
 
 ## Additional configuration for certain core apps
@@ -285,4 +285,4 @@ The reason why the app needs to be ported from the `apps` section to the `extern
 ## Accessing ownCloud Web
 After following all the steps, you should see a new entry in the application switcher called `New Design` which points to the ownCloud web.
 
-{{< figure src="/clients/web/static/application-switcher-oc10.jpg" alt="ownCloud 10 application switcher" >}}
+{{< figure src="/clients/web/static/application-switcher-oc10.jpg" alt="ownCloud Classic 10 application switcher" >}}

--- a/docs/deployments/oc10-app.md
+++ b/docs/deployments/oc10-app.md
@@ -1,5 +1,5 @@
 ---
-title: "Deploy as an app in ownCloud Classic 10"
+title: "Deploy as an app in ownCloud Classic"
 date: 2018-05-02T00:00:00+00:00
 weight: 1
 geekdocRepo: https://github.com/owncloud/web
@@ -12,15 +12,15 @@ geekdocFilePath: oc10-app.md
 
 ## Compatibility
 
-Please note that the usage of Web UI and ownCloud Classic 10 as backend is not recommended starting with version 7.1.0 of the Web UI. Therefore, this section only applies to versions < 7.1.0.
+Please note that the usage of Web UI and ownCloud Classic as backend is not recommended starting with version 7.1.0 of the Web UI. Therefore, this section only applies to versions < 7.1.0.
 
 ## Introduction
 
-ownCloud Web is being deployed as an app to [ownCloud marketplace](https://marketplace.owncloud.com/) to enable easy integration into existing ownCloud Classic 10 instances.
+ownCloud Web is being deployed as an app to [ownCloud marketplace](https://marketplace.owncloud.com/) to enable easy integration into existing ownCloud Classic instances.
 After completing this setup, ownCloud Web will be available on `https://<your-owncloud-server>/index.php/apps/web`.
 
 ## Prerequisites
-- Running [ownCloud Classic 10 server](https://owncloud.com/download-server/) with version 10.8
+- Running [ownCloud Classic server](https://owncloud.com/download-server/) with version 10.8
 - Installed [oauth2 app](https://marketplace.owncloud.com/apps/oauth2)
 - Command line access to your server
 
@@ -31,7 +31,7 @@ occ market:install web
 ```
 
 ## Configure oauth2
-Within the `Admin` page of ownCloud Classic 10, head into `User Authentication` and add a new client with arbitrary name (e.g. `ownCloud Web`) and redirection URL `https://<your-owncloud-server>/index.php/apps/web/oidc-callback.html`.
+Within the `Admin` page of ownCloud Classic, head into `User Authentication` and add a new client with arbitrary name (e.g. `ownCloud Web`) and redirection URL `https://<your-owncloud-server>/index.php/apps/web/oidc-callback.html`.
 
 {{< figure src="/clients/web/static/oauth2.png" alt="Example OAuth2 entry" >}}
 
@@ -43,7 +43,7 @@ You can mark the ownCloud web client as `trusted` by clicking the respective che
 If you use OpenID Connect you need to add a new client for ownCloud Web to your identity provider instead.
 {{< /hint >}}
 
-## Configure ownCloud Classic 10
+## Configure ownCloud Classic
 ### Set ownCloud Web address
 To set the ownCloud Web address and to display ownCloud Web in the app switcher, add the following line into `config/config.php`:
 
@@ -118,7 +118,7 @@ If any issues arise when trying to access the new design, a good start for debug
 
 |config parameter|explanation|
 |---|---|
-|server|ownCloud Classic 10 server address|
+|server|ownCloud Classic server address|
 |theme|Theme to be used in ownCloud Web pointing to a json file inside of `themes` folder|
 |auth.clientId|Client ID received when adding ownCloud Web in the `User Authentication` section in `Admin`|
 |apps|List of internal extensions to be loaded|
@@ -285,4 +285,4 @@ The reason why the app needs to be ported from the `apps` section to the `extern
 ## Accessing ownCloud Web
 After following all the steps, you should see a new entry in the application switcher called `New Design` which points to the ownCloud web.
 
-{{< figure src="/clients/web/static/application-switcher-oc10.jpg" alt="ownCloud Classic 10 application switcher" >}}
+{{< figure src="/clients/web/static/application-switcher-oc10.jpg" alt="ownCloud Classic application switcher" >}}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,7 +98,7 @@ integration libraries.
 
 ## Setting up backend and running
 
-Newer versions of Web (> 7.0.2) can only run against [oCIS](https://github.com/owncloud/ocis), whereas older versions (< 7.1.0) can run against [ownCloud 10](https://github.com/owncloud/core/) as well.
+Newer versions of Web (> 7.0.2) can only run against [oCIS](https://github.com/owncloud/ocis), whereas older versions (< 7.1.0) can run against [ownCloud Classic 10](https://github.com/owncloud/core/) as well.
 Depending which one you chose, please check the matching section:
 
 - [Setting up with oCIS as backend]({{< ref "backend-ocis.md" >}})

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,7 +98,7 @@ integration libraries.
 
 ## Setting up backend and running
 
-Newer versions of Web (> 7.0.2) can only run against [oCIS](https://github.com/owncloud/ocis), whereas older versions (< 7.1.0) can run against [ownCloud Classic 10](https://github.com/owncloud/core/) as well.
+Newer versions of Web (> 7.0.2) can only run against [oCIS](https://github.com/owncloud/ocis), whereas older versions (< 7.1.0) can run against [ownCloud Classic](https://github.com/owncloud/core/) as well.
 Depending which one you chose, please check the matching section:
 
 - [Setting up with oCIS as backend]({{< ref "backend-ocis.md" >}})

--- a/docs/theming/_index.md
+++ b/docs/theming/_index.md
@@ -23,7 +23,7 @@ Generally, your theming configuration lives inside a `.json` file, e.g. `theme.j
 To reference your theme, you have two options:
 
 - Using a URL, e.g. `"theme": "https://externalurl.example.com/theme-name/theme.json",`. To avoid CORS issues, please make sure that you host the URL on the same URL as your ownCloud web hosting.
-- For development and testing purposes, you can store your `theme.json` inside `packages/web-runtime/themes/{theme-name}/` and reference it in the `config.json`. However, this isn't recommended for production use since your changes may get lost when updating oCIS or the `web` app in OC10.
+- For development and testing purposes, you can store your `theme.json` inside `packages/web-runtime/themes/{theme-name}/` and reference it in the `config.json`. However, this isn't recommended for production use since your changes may get lost when updating oCIS or the `web` app in ownCloud Classic.
 
 **Hint:** If no theme is provided, the loading of your custom theme fails or the theme can't be parsed correctly, the standard ownCloud theme will be loaded as a fallback and an error with further information will be logged on the browser console.
 


### PR DESCRIPTION
Renames the legacy server product to **ownCloud Classic** across the repository’s own documentation (`README.md` and `docs/`), applying the version only as additional information where relevant ("ownCloud Classic 10").

**Scope:** documentation prose only. Left untouched:
- URLs and image/asset paths (e.g. `application-switcher-oc10.jpg`)
- geekdoc cross-references (`{{< ref "backend-oc10.md" >}}`)
- `oc10` config/command identifiers (compose service `oc10`, `config.json.sample-oc10`, file names `backend-oc10.md` / `oc10-app.md`, `pnpm vite:oc10`)
- oCIS / Infinite Scale references
- historical `CHANGELOG.md` files (frozen release history)

A couple of determiners were adjusted where "ownCloud Server" → "ownCloud Classic" left dangling grammar (e.g. "Setting up ownCloud Classic").

Part of the cross-repo rebrand campaign tracked in owncloud/docs#5111 (Tier B — code-repo docs).