### PR TITLE
fix(web-app-external): enable Collabora Save As / export to storage

### DIFF
--- a/changelog/unreleased/enhancement-collabora-save-as.md
+++ b/changelog/unreleased/enhancement-collabora-save-as.md
@@ -1,0 +1,18 @@
+Enhancement: Save a copy of office documents to another format (Collabora)
+
+Office documents opened in Collabora Online could be renamed but not saved as a
+copy or exported to another format back into oCIS storage: "Save As" silently
+did nothing. Collabora exposes "Save As" as a host-delegated operation - it
+posts a `UI_SaveAs` message and waits for the integration to reply with the
+target filename via `Action_SaveAs` - but the app-provider integration never
+opened that postMessage channel.
+
+The app-provider now announces itself to the editor with `Host_PostmessageReady`
+once the iframe has loaded, requests the grouped Save-As control via
+`ui_defaults` (`SaveAsMode=group`), and on `UI_SaveAs` prompts for the copy's
+name and replies with `Action_SaveAs`. The collaboration service already
+implements WOPI `PutRelativeFile`, so the copy is written into the same space,
+respecting the user's permissions. The chosen file extension selects the export
+format (e.g. docx to pdf/odt, xlsx to ods, pptx to pdf).
+
+https://github.com/owncloud/web/pull/13906

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -110,6 +110,10 @@ const appName = computed(() => {
   return appProviderService.appNames.find((appName) => appName.toLowerCase() === lowerCaseAppName)
 })
 
+// The grouped Save-As control and the Host_PostmessageReady handshake are
+// Collabora-specific WOPI extensions; other app providers don't implement them.
+const isCollabora = computed(() => unref(appName) === 'Collabora')
+
 const appUrl = ref()
 const formParameters = ref({})
 const method = ref()
@@ -129,14 +133,17 @@ const appOrigin = computed(() => {
 // Collabora exposes "Save As" (export to another format, saved back to storage
 // via WOPI PutRelativeFile) as a host-delegated operation: it shows a grouped
 // Save-As control and posts a `UI_SaveAs` message, expecting the host to reply
-// with the target filename. Request that grouped control via `ui_defaults`.
-// The parameter is Collabora-specific and ignored by other app providers.
+// with the target filename. Request that grouped control via `ui_defaults`,
+// which is a semicolon-delimited list, so append rather than overwrite it in
+// case the server already decorates the URL with its own defaults.
 const withSaveAsUiDefaults = (rawUrl: string) => {
   try {
     const url = new URL(rawUrl)
-    if (!url.searchParams.has('ui_defaults')) {
-      url.searchParams.set('ui_defaults', 'SaveAsMode=group')
-    }
+    const existing = url.searchParams.get('ui_defaults')
+    url.searchParams.set(
+      'ui_defaults',
+      existing ? `${existing};SaveAsMode=group` : 'SaveAsMode=group'
+    )
     return url.href
   } catch {
     return rawUrl
@@ -155,14 +162,18 @@ const postToApp = (message: Record<string, unknown>) => {
 // The editor only emits its rich postMessage API (UI_SaveAs, App_LoadingStatus,
 // ...) once the host has announced itself with `Host_PostmessageReady`. Without
 // this handshake "Save As" silently does nothing. Send it as soon as the iframe
-// has loaded.
+// has loaded. This handshake is Collabora-specific; other providers don't expect it.
 const onIframeLoad = () => {
+  if (!unref(isCollabora)) {
+    return
+  }
   postToApp({ MessageId: 'Host_PostmessageReady', Values: {} })
 }
 
-// Reject empty names and any path separators before the name is sent on. The
-// server-side `PutRelativeFile` sanitizes the name as well, but validating here
-// gives immediate feedback and avoids a pointless round-trip on invalid input.
+// Reject empty names, path separators and the reserved "." / ".." names before
+// the name is sent on. The server-side `PutRelativeFile` sanitizes the name as
+// well, but validating here gives immediate feedback and avoids a pointless
+// round-trip on invalid input.
 const validateSaveAsFilename = (filename: string): string => {
   const trimmed = filename?.trim()
   if (!trimmed) {
@@ -171,6 +182,9 @@ const validateSaveAsFilename = (filename: string): string => {
   if (/[/\\]/.test(trimmed)) {
     return $gettext('The file name cannot contain "/" or "\\".')
   }
+  if (trimmed === '.' || trimmed === '..') {
+    return $gettext('The file name cannot be "." or "..".')
+  }
   return ''
 }
 
@@ -178,6 +192,10 @@ const validateSaveAsFilename = (filename: string): string => {
 // extension selects the export format) and reply with `Action_SaveAs`, which
 // makes the editor render to that format and PutRelativeFile it into the space.
 const onSaveAs = () => {
+  if (props.isReadOnly) {
+    showErrorMessage({ title: $gettext('Cannot save a copy: file is read-only') })
+    return
+  }
   dispatchModal({
     variation: 'passive',
     title: $gettext('Save a copy'),
@@ -261,7 +279,9 @@ const loadAppUrl = useTask(function* (signal, viewMode: string) {
       throw new Error('Error in app server response')
     }
 
-    appUrl.value = withSaveAsUiDefaults(response.data.app_url)
+    appUrl.value = unref(isCollabora)
+      ? withSaveAsUiDefaults(response.data.app_url)
+      : response.data.app_url
     method.value = response.data.method
 
     if (response.data.form_parameters) {

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -121,10 +121,12 @@ const subm: VNodeRef = ref()
 const appIframe = ref<HTMLIFrameElement>()
 
 // Origin of the editor (e.g. the Collabora host) used as the target origin when
-// posting messages into the iframe.
+// posting messages into the iframe. Resolved against the current origin so a
+// relative `app_url` (WOPI server co-hosted with the web app) still yields a
+// usable origin instead of permanently failing the postMessage origin check.
 const appOrigin = computed(() => {
   try {
-    return new URL(unref(appUrl)).origin
+    return new URL(unref(appUrl), window.location.origin).origin
   } catch {
     return ''
   }
@@ -151,12 +153,20 @@ const withSaveAsUiDefaults = (rawUrl: string) => {
 }
 
 // Post a WOPI postMessage into the editor iframe (messages are JSON strings).
-const postToApp = (message: Record<string, unknown>) => {
-  const target = unref(appIframe)?.contentWindow
-  if (!target || !unref(appOrigin)) {
-    return
+// Accepts an explicit target/origin so callers that captured them at the time
+// a user action started (e.g. opening the Save-As modal) don't re-read the
+// live refs, which may have moved on to a different resource by the time the
+// user confirms. Returns whether the message was actually sent.
+const postToApp = (
+  message: Record<string, unknown>,
+  target: Window | null | undefined = unref(appIframe)?.contentWindow,
+  origin: string = unref(appOrigin)
+): boolean => {
+  if (!target || !origin) {
+    return false
   }
-  target.postMessage(JSON.stringify({ ...message, SendTime: Date.now() }), unref(appOrigin))
+  target.postMessage(JSON.stringify({ ...message, SendTime: Date.now() }), origin)
+  return true
 }
 
 // The editor only emits its rich postMessage API (UI_SaveAs, App_LoadingStatus,
@@ -188,6 +198,11 @@ const validateSaveAsFilename = (filename: string): string => {
   return ''
 }
 
+// Guards against a second Save-As modal being dispatched while one is already
+// open (e.g. the editor's grouped Save-As control emitting `UI_SaveAs` twice
+// in quick succession).
+const isSaveAsModalOpen = ref(false)
+
 // Handle the editor's "Save As" request: ask the user for the copy's name (the
 // extension selects the export format) and reply with `Action_SaveAs`, which
 // makes the editor render to that format and PutRelativeFile it into the space.
@@ -196,6 +211,18 @@ const onSaveAs = () => {
     showErrorMessage({ title: $gettext('Cannot save a copy: file is read-only') })
     return
   }
+  if (unref(isSaveAsModalOpen)) {
+    return
+  }
+
+  // Capture the target iframe/origin now, at dispatch time, rather than
+  // re-reading the (reactive) refs in `onConfirm`: if the component gets
+  // reused for a different resource while the modal is open, the live refs
+  // would point at the new document by the time the user presses Save.
+  const target = unref(appIframe)?.contentWindow
+  const origin = unref(appOrigin)
+
+  isSaveAsModalOpen.value = true
   dispatchModal({
     variation: 'passive',
     title: $gettext('Save a copy'),
@@ -206,16 +233,24 @@ const onSaveAs = () => {
     onInput: (filename: string, setError: (error: string) => void) => {
       setError(validateSaveAsFilename(filename))
     },
+    onCancel: () => {
+      isSaveAsModalOpen.value = false
+    },
     onConfirm: (filename: string) => {
+      isSaveAsModalOpen.value = false
       // Guard again on confirm (defense-in-depth); onInput normally prevents
       // reaching here with an invalid name.
       if (validateSaveAsFilename(filename)) {
         return
       }
-      postToApp({
-        MessageId: 'Action_SaveAs',
-        Values: { Filename: filename.trim(), Notify: true }
-      })
+      const sent = postToApp(
+        { MessageId: 'Action_SaveAs', Values: { Filename: filename.trim(), Notify: true } },
+        target,
+        origin
+      )
+      if (!sent) {
+        showErrorMessage({ title: $gettext('Cannot save a copy: the editor is not available') })
+      }
     }
   })
 }

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -160,6 +160,20 @@ const onIframeLoad = () => {
   postToApp({ MessageId: 'Host_PostmessageReady', Values: {} })
 }
 
+// Reject empty names and any path separators before the name is sent on. The
+// server-side `PutRelativeFile` sanitizes the name as well, but validating here
+// gives immediate feedback and avoids a pointless round-trip on invalid input.
+const validateSaveAsFilename = (filename: string): string => {
+  const trimmed = filename?.trim()
+  if (!trimmed) {
+    return $gettext('The file name cannot be empty.')
+  }
+  if (/[/\\]/.test(trimmed)) {
+    return $gettext('The file name cannot contain "/" or "\\".')
+  }
+  return ''
+}
+
 // Handle the editor's "Save As" request: ask the user for the copy's name (the
 // extension selects the export format) and reply with `Action_SaveAs`, which
 // makes the editor render to that format and PutRelativeFile it into the space.
@@ -171,8 +185,19 @@ const onSaveAs = () => {
     hasInput: true,
     inputValue: props.resource.name,
     inputLabel: $gettext('File name'),
+    onInput: (filename: string, setError: (error: string) => void) => {
+      setError(validateSaveAsFilename(filename))
+    },
     onConfirm: (filename: string) => {
-      postToApp({ MessageId: 'Action_SaveAs', Values: { Filename: filename, Notify: true } })
+      // Guard again on confirm (defense-in-depth); onInput normally prevents
+      // reaching here with an invalid name.
+      if (validateSaveAsFilename(filename)) {
+        return
+      }
+      postToApp({
+        MessageId: 'Action_SaveAs',
+        Values: { Filename: filename.trim(), Notify: true }
+      })
     }
   })
 }
@@ -261,7 +286,14 @@ const determineOpenAsPreview = (appName: string) => {
 // Single handler for the editor's postMessage events. Only messages coming from
 // the editor's own origin are accepted.
 const onAppMessage = (event: MessageEvent) => {
-  if (unref(appOrigin) && event.origin !== unref(appOrigin)) {
+  // Fail closed: reject every message until the editor origin is known (i.e.
+  // `appUrl` has resolved to an absolute URL) and accept only messages from that
+  // exact origin. The listener is attached on mount, before the WOPI `open_url`
+  // POST resolves, so an empty `appOrigin` must reject rather than wave messages
+  // through. No legitimate editor message can arrive before `appUrl` is set (the
+  // iframe cannot have loaded yet), so this is strictly correct and also covers a
+  // backend returning a non-absolute `app_url`.
+  if (!unref(appOrigin) || event.origin !== unref(appOrigin)) {
     return
   }
   let message: { MessageId?: string }

--- a/packages/web-app-external/src/App.vue
+++ b/packages/web-app-external/src/App.vue
@@ -1,11 +1,13 @@
 <template>
   <iframe
     v-if="appUrl && method === 'GET'"
+    ref="appIframe"
     :src="appUrl"
     class="oc-width-1-1 oc-height-1-1"
     :title="iFrameTitle"
     allowfullscreen
     allow="camera; clipboard-read; clipboard-write"
+    @load="onIframeLoad"
   />
   <div v-if="appUrl && method === 'POST' && formParameters" class="oc-height-1-1 oc-width-1-1">
     <form :action="appUrl" target="app-iframe" method="post">
@@ -15,19 +17,32 @@
       </div>
     </form>
     <iframe
+      ref="appIframe"
       name="app-iframe"
       :src="appUrl"
       class="oc-width-1-1 oc-height-1-1"
       :title="iFrameTitle"
       allowfullscreen
       allow="camera; clipboard-read; clipboard-write"
+      @load="onIframeLoad"
     />
   </div>
 </template>
 
 <script lang="ts" setup>
 import { stringify } from 'qs'
-import { computed, inject, unref, nextTick, ref, watch, VNodeRef, onMounted, type Ref } from 'vue'
+import {
+  computed,
+  inject,
+  unref,
+  nextTick,
+  ref,
+  watch,
+  VNodeRef,
+  onMounted,
+  onBeforeUnmount,
+  type Ref
+} from 'vue'
 import { useTask } from 'vue-concurrency'
 import { useGettext } from 'vue3-gettext'
 
@@ -38,6 +53,7 @@ import {
   useCapabilityStore,
   useConfigStore,
   useMessages,
+  useModals,
   useRequest,
   useAppProviderService,
   useRoute,
@@ -67,6 +83,7 @@ const props = defineProps<Props>()
 const language = useGettext()
 const { $gettext } = language
 const { showErrorMessage } = useMessages()
+const { dispatchModal } = useModals()
 const capabilityStore = useCapabilityStore()
 const configStore = useConfigStore()
 const route = useRoute()
@@ -97,6 +114,68 @@ const appUrl = ref()
 const formParameters = ref({})
 const method = ref()
 const subm: VNodeRef = ref()
+const appIframe = ref<HTMLIFrameElement>()
+
+// Origin of the editor (e.g. the Collabora host) used as the target origin when
+// posting messages into the iframe.
+const appOrigin = computed(() => {
+  try {
+    return new URL(unref(appUrl)).origin
+  } catch {
+    return ''
+  }
+})
+
+// Collabora exposes "Save As" (export to another format, saved back to storage
+// via WOPI PutRelativeFile) as a host-delegated operation: it shows a grouped
+// Save-As control and posts a `UI_SaveAs` message, expecting the host to reply
+// with the target filename. Request that grouped control via `ui_defaults`.
+// The parameter is Collabora-specific and ignored by other app providers.
+const withSaveAsUiDefaults = (rawUrl: string) => {
+  try {
+    const url = new URL(rawUrl)
+    if (!url.searchParams.has('ui_defaults')) {
+      url.searchParams.set('ui_defaults', 'SaveAsMode=group')
+    }
+    return url.href
+  } catch {
+    return rawUrl
+  }
+}
+
+// Post a WOPI postMessage into the editor iframe (messages are JSON strings).
+const postToApp = (message: Record<string, unknown>) => {
+  const target = unref(appIframe)?.contentWindow
+  if (!target || !unref(appOrigin)) {
+    return
+  }
+  target.postMessage(JSON.stringify({ ...message, SendTime: Date.now() }), unref(appOrigin))
+}
+
+// The editor only emits its rich postMessage API (UI_SaveAs, App_LoadingStatus,
+// ...) once the host has announced itself with `Host_PostmessageReady`. Without
+// this handshake "Save As" silently does nothing. Send it as soon as the iframe
+// has loaded.
+const onIframeLoad = () => {
+  postToApp({ MessageId: 'Host_PostmessageReady', Values: {} })
+}
+
+// Handle the editor's "Save As" request: ask the user for the copy's name (the
+// extension selects the export format) and reply with `Action_SaveAs`, which
+// makes the editor render to that format and PutRelativeFile it into the space.
+const onSaveAs = () => {
+  dispatchModal({
+    variation: 'passive',
+    title: $gettext('Save a copy'),
+    confirmText: $gettext('Save'),
+    hasInput: true,
+    inputValue: props.resource.name,
+    inputLabel: $gettext('File name'),
+    onConfirm: (filename: string) => {
+      postToApp({ MessageId: 'Action_SaveAs', Values: { Filename: filename, Notify: true } })
+    }
+  })
+}
 
 const iFrameTitle = computed(() => {
   return $gettext('"%{appName}" app content area', {
@@ -157,7 +236,7 @@ const loadAppUrl = useTask(function* (signal, viewMode: string) {
       throw new Error('Error in app server response')
     }
 
-    appUrl.value = response.data.app_url
+    appUrl.value = withSaveAsUiDefaults(response.data.app_url)
     method.value = response.data.method
 
     if (response.data.form_parameters) {
@@ -179,20 +258,35 @@ const determineOpenAsPreview = (appName: string) => {
   return openAsPreview === true || (Array.isArray(openAsPreview) && openAsPreview.includes(appName))
 }
 
-// switch to write mode when edit is clicked
-const catchClickMicrosoftEdit = (event: MessageEvent) => {
+// Single handler for the editor's postMessage events. Only messages coming from
+// the editor's own origin are accepted.
+const onAppMessage = (event: MessageEvent) => {
+  if (unref(appOrigin) && event.origin !== unref(appOrigin)) {
+    return
+  }
+  let message: { MessageId?: string }
   try {
-    if (JSON.parse(event.data)?.MessageId === 'UI_Edit') {
-      loadAppUrl.perform('write')
-    }
-  } catch {}
+    message = JSON.parse(event.data)
+  } catch {
+    return
+  }
+  switch (message?.MessageId) {
+    case 'UI_Edit':
+      // switch to write mode when edit is clicked
+      if (determineOpenAsPreview(unref(appName))) {
+        loadAppUrl.perform('write')
+      }
+      break
+    case 'UI_SaveAs':
+      onSaveAs()
+      break
+  }
 }
 onMounted(() => {
-  if (determineOpenAsPreview(unref(appName))) {
-    window.addEventListener('message', catchClickMicrosoftEdit)
-  } else {
-    window.removeEventListener('message', catchClickMicrosoftEdit)
-  }
+  window.addEventListener('message', onAppMessage)
+})
+onBeforeUnmount(() => {
+  window.removeEventListener('message', onAppMessage)
 })
 
 watch(

--- a/packages/web-app-external/tests/unit/__snapshots__/app.spec.ts.snap
+++ b/packages/web-app-external/tests/unit/__snapshots__/app.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`The app provider extension > should be able to load an iFrame via get 1`] = `
-"<iframe src="https://example.test/d12ab86/loe009157-MzBw?ui_defaults=SaveAsMode%3Dgroup" class="oc-width-1-1 oc-height-1-1" title="&quot;example-app&quot; app content area" allowfullscreen="" allow="camera; clipboard-read; clipboard-write"></iframe>
+"<iframe src="https://example.test/d12ab86/loe009157-MzBw" class="oc-width-1-1 oc-height-1-1" title="&quot;example-app&quot; app content area" allowfullscreen="" allow="camera; clipboard-read; clipboard-write"></iframe>
 
 <!--v-if-->"
 `;
@@ -10,10 +10,10 @@ exports[`The app provider extension > should be able to load an iFrame via post 
 "<!--v-if-->
 
 <div class="oc-height-1-1 oc-width-1-1">
-  <form action="https://example.test/d12ab86/loe009157-MzBw?ui_defaults=SaveAsMode%3Dgroup" target="app-iframe" method="post"><input type="submit" class="oc-hidden" value="[object Object]">
+  <form action="https://example.test/d12ab86/loe009157-MzBw" target="app-iframe" method="post"><input type="submit" class="oc-hidden" value="[object Object]">
     <div><input name="access_token" type="hidden" value="asdfsadfsadf"></div>
     <div><input name="access_token_ttl" type="hidden" value="123456"></div>
-  </form> <iframe name="app-iframe" src="https://example.test/d12ab86/loe009157-MzBw?ui_defaults=SaveAsMode%3Dgroup" class="oc-width-1-1 oc-height-1-1" title="&quot;example-app&quot; app content area" allowfullscreen="" allow="camera; clipboard-read; clipboard-write"></iframe>
+  </form> <iframe name="app-iframe" src="https://example.test/d12ab86/loe009157-MzBw" class="oc-width-1-1 oc-height-1-1" title="&quot;example-app&quot; app content area" allowfullscreen="" allow="camera; clipboard-read; clipboard-write"></iframe>
 </div>"
 `;
 

--- a/packages/web-app-external/tests/unit/__snapshots__/app.spec.ts.snap
+++ b/packages/web-app-external/tests/unit/__snapshots__/app.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`The app provider extension > should be able to load an iFrame via get 1`] = `
-"<iframe src="https://example.test/d12ab86/loe009157-MzBw" class="oc-width-1-1 oc-height-1-1" title="&quot;example-app&quot; app content area" allowfullscreen="" allow="camera; clipboard-read; clipboard-write"></iframe>
+"<iframe src="https://example.test/d12ab86/loe009157-MzBw?ui_defaults=SaveAsMode%3Dgroup" class="oc-width-1-1 oc-height-1-1" title="&quot;example-app&quot; app content area" allowfullscreen="" allow="camera; clipboard-read; clipboard-write"></iframe>
 
 <!--v-if-->"
 `;
@@ -10,10 +10,10 @@ exports[`The app provider extension > should be able to load an iFrame via post 
 "<!--v-if-->
 
 <div class="oc-height-1-1 oc-width-1-1">
-  <form action="https://example.test/d12ab86/loe009157-MzBw" target="app-iframe" method="post"><input type="submit" class="oc-hidden" value="[object Object]">
+  <form action="https://example.test/d12ab86/loe009157-MzBw?ui_defaults=SaveAsMode%3Dgroup" target="app-iframe" method="post"><input type="submit" class="oc-hidden" value="[object Object]">
     <div><input name="access_token" type="hidden" value="asdfsadfsadf"></div>
     <div><input name="access_token_ttl" type="hidden" value="123456"></div>
-  </form> <iframe name="app-iframe" src="https://example.test/d12ab86/loe009157-MzBw" class="oc-width-1-1 oc-height-1-1" title="&quot;example-app&quot; app content area" allowfullscreen="" allow="camera; clipboard-read; clipboard-write"></iframe>
+  </form> <iframe name="app-iframe" src="https://example.test/d12ab86/loe009157-MzBw?ui_defaults=SaveAsMode%3Dgroup" class="oc-width-1-1 oc-height-1-1" title="&quot;example-app&quot; app content area" allowfullscreen="" allow="camera; clipboard-read; clipboard-write"></iframe>
 </div>"
 `;
 

--- a/packages/web-app-external/tests/unit/app.spec.ts
+++ b/packages/web-app-external/tests/unit/app.spec.ts
@@ -102,7 +102,9 @@ describe('Collabora Save As postMessage handling', () => {
   it('ignores editor messages until the editor origin is known (fail closed)', async () => {
     // makeRequest never resolves -> appUrl stays undefined -> origin unknown
     const makeRequest = vi.fn().mockReturnValue(new Promise(() => undefined))
-    const { wrapper, dispatchModal } = createShallowMountWrapper(makeRequest)
+    const { wrapper, dispatchModal } = createShallowMountWrapper(makeRequest, {
+      appName: 'Collabora'
+    })
     await wrapper.vm.$nextTick()
 
     dispatchEditorMessage(appOrigin, 'UI_SaveAs')
@@ -113,7 +115,9 @@ describe('Collabora Save As postMessage handling', () => {
 
   it('drops editor messages coming from a foreign origin', async () => {
     const makeRequest = vi.fn().mockResolvedValue(successGet)
-    const { wrapper, dispatchModal } = createShallowMountWrapper(makeRequest)
+    const { wrapper, dispatchModal } = createShallowMountWrapper(makeRequest, {
+      appName: 'Collabora'
+    })
     await flushAppUrl(wrapper)
 
     dispatchEditorMessage('https://evil.test', 'UI_SaveAs')
@@ -124,7 +128,9 @@ describe('Collabora Save As postMessage handling', () => {
 
   it('opens the modal on UI_SaveAs from the editor origin and posts Action_SaveAs on confirm', async () => {
     const makeRequest = vi.fn().mockResolvedValue(successGet)
-    const { wrapper, dispatchModal } = createShallowMountWrapper(makeRequest)
+    const { wrapper, dispatchModal } = createShallowMountWrapper(makeRequest, {
+      appName: 'Collabora'
+    })
     await flushAppUrl(wrapper)
     const { postMessage } = stubIframeContentWindow(wrapper)
 
@@ -146,9 +152,25 @@ describe('Collabora Save As postMessage handling', () => {
     wrapper.unmount()
   })
 
-  it('rejects empty and path-separator file names in the modal', async () => {
+  it('does not open the modal on UI_SaveAs when the file is read-only', async () => {
     const makeRequest = vi.fn().mockResolvedValue(successGet)
-    const { wrapper, dispatchModal } = createShallowMountWrapper(makeRequest)
+    const { wrapper, dispatchModal } = createShallowMountWrapper(makeRequest, {
+      appName: 'Collabora',
+      isReadOnly: true
+    })
+    await flushAppUrl(wrapper)
+
+    dispatchEditorMessage(appOrigin, 'UI_SaveAs')
+
+    expect(dispatchModal).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('rejects empty, path-separator and reserved file names in the modal', async () => {
+    const makeRequest = vi.fn().mockResolvedValue(successGet)
+    const { wrapper, dispatchModal } = createShallowMountWrapper(makeRequest, {
+      appName: 'Collabora'
+    })
     await flushAppUrl(wrapper)
     const { postMessage } = stubIframeContentWindow(wrapper)
 
@@ -160,6 +182,8 @@ describe('Collabora Save As postMessage handling', () => {
     expect(setError).toHaveBeenLastCalledWith(expect.stringContaining('empty'))
     modal.onInput('foo/bar.pdf', setError)
     expect(setError).toHaveBeenLastCalledWith(expect.stringContaining('/'))
+    modal.onInput('..', setError)
+    expect(setError).toHaveBeenLastCalledWith(expect.stringContaining('..'))
     modal.onInput('valid.pdf', setError)
     expect(setError).toHaveBeenLastCalledWith('')
 
@@ -171,7 +195,7 @@ describe('Collabora Save As postMessage handling', () => {
 
   it('posts Host_PostmessageReady when the editor iframe loads', async () => {
     const makeRequest = vi.fn().mockResolvedValue(successGet)
-    const { wrapper } = createShallowMountWrapper(makeRequest)
+    const { wrapper } = createShallowMountWrapper(makeRequest, { appName: 'Collabora' })
     await flushAppUrl(wrapper)
     const { iframe, postMessage } = stubIframeContentWindow(wrapper)
 
@@ -183,15 +207,52 @@ describe('Collabora Save As postMessage handling', () => {
     expect(JSON.parse(payload as string)).toMatchObject({ MessageId: 'Host_PostmessageReady' })
     wrapper.unmount()
   })
+
+  it('does not post Host_PostmessageReady or request ui_defaults for non-Collabora providers', async () => {
+    const makeRequest = vi.fn().mockResolvedValue(successGet)
+    const { wrapper } = createShallowMountWrapper(makeRequest, { appName: 'example-app' })
+    await flushAppUrl(wrapper)
+    const { iframe, postMessage } = stubIframeContentWindow(wrapper)
+
+    expect(wrapper.find('iframe').attributes('src')).toBe(appUrl)
+
+    await iframe.trigger('load')
+
+    expect(postMessage).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('does not switch to write mode on UI_Edit when openAsPreview is false', async () => {
+    const makeRequest = vi.fn().mockResolvedValue(successGet)
+    const { wrapper } = createShallowMountWrapper(makeRequest, {
+      appName: 'Collabora',
+      openAsPreview: false
+    })
+    await flushAppUrl(wrapper)
+    makeRequest.mockClear()
+
+    dispatchEditorMessage(appOrigin, 'UI_Edit')
+    await wrapper.vm.$nextTick()
+
+    expect(makeRequest).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
 })
 
-function createShallowMountWrapper(makeRequest = vi.fn().mockResolvedValue({ status: 200 })) {
+function createShallowMountWrapper(
+  makeRequest = vi.fn().mockResolvedValue({ status: 200 }),
+  {
+    appName = 'example-app',
+    isReadOnly = false,
+    openAsPreview = true
+  }: { appName?: string; isReadOnly?: boolean; openAsPreview?: boolean | string[] } = {}
+) {
   vi.mocked(useRequest).mockImplementation(() => ({
     makeRequest
   }))
 
   vi.mocked(useRoute).mockReturnValue(
-    computed(() => mock<RouteLocation>({ name: 'external-example-app-apps' }))
+    computed(() => mock<RouteLocation>({ name: `external-${appName.toLowerCase()}-apps` }))
   )
 
   const dispatchModal = vi.fn()
@@ -199,7 +260,7 @@ function createShallowMountWrapper(makeRequest = vi.fn().mockResolvedValue({ sta
 
   const mocks = {
     ...defaultComponentMocks(),
-    $appProviderService: mock<AppProviderService>({ appNames: ['example-app'] })
+    $appProviderService: mock<AppProviderService>({ appNames: [appName] })
   }
 
   const capabilities = {
@@ -214,14 +275,14 @@ function createShallowMountWrapper(makeRequest = vi.fn().mockResolvedValue({ sta
       props: {
         space: null,
         resource: mock<Resource>({ name: 'document.odt' }),
-        isReadOnly: false
+        isReadOnly
       },
       global: {
         plugins: [
           ...defaultPlugins({
             piniaOptions: {
               capabilityState: { capabilities },
-              configState: { options: { editor: { openAsPreview: true } } }
+              configState: { options: { editor: { openAsPreview } } }
             }
           })
         ],

--- a/packages/web-app-external/tests/unit/app.spec.ts
+++ b/packages/web-app-external/tests/unit/app.spec.ts
@@ -1,6 +1,6 @@
 import { mock } from 'vitest-mock-extended'
 import { defaultComponentMocks, defaultPlugins, shallowMount } from '@ownclouders/web-test-helpers'
-import { AppProviderService, useRequest, useRoute } from '@ownclouders/web-pkg'
+import { AppProviderService, useModals, useRequest, useRoute } from '@ownclouders/web-pkg'
 import { computed } from 'vue'
 
 import { Resource } from '@ownclouders/web-client'
@@ -10,10 +10,12 @@ import { RouteLocation } from 'vue-router'
 vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
   ...(await importOriginal<any>()),
   useRequest: vi.fn(),
-  useRoute: vi.fn()
+  useRoute: vi.fn(),
+  useModals: vi.fn()
 }))
 
 const appUrl = 'https://example.test/d12ab86/loe009157-MzBw'
+const appOrigin = 'https://example.test'
 
 const providerSuccessResponsePost = {
   app_url: appUrl,
@@ -72,6 +74,117 @@ describe('The app provider extension', () => {
   })
 })
 
+describe('Collabora Save As postMessage handling', () => {
+  const successGet = { ok: true, status: 200, data: providerSuccessResponseGet }
+
+  const flushAppUrl = async (wrapper: any) => {
+    for (let i = 0; i < 5; i++) {
+      await wrapper.vm.$nextTick()
+    }
+  }
+
+  const dispatchEditorMessage = (origin: string, messageId: string) => {
+    window.dispatchEvent(
+      new MessageEvent('message', { origin, data: JSON.stringify({ MessageId: messageId }) })
+    )
+  }
+
+  const stubIframeContentWindow = (wrapper: any) => {
+    const postMessage = vi.fn()
+    const iframe = wrapper.find('iframe')
+    Object.defineProperty(iframe.element, 'contentWindow', {
+      value: { postMessage },
+      configurable: true
+    })
+    return { iframe, postMessage }
+  }
+
+  it('ignores editor messages until the editor origin is known (fail closed)', async () => {
+    // makeRequest never resolves -> appUrl stays undefined -> origin unknown
+    const makeRequest = vi.fn().mockReturnValue(new Promise(() => undefined))
+    const { wrapper, dispatchModal } = createShallowMountWrapper(makeRequest)
+    await wrapper.vm.$nextTick()
+
+    dispatchEditorMessage(appOrigin, 'UI_SaveAs')
+
+    expect(dispatchModal).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('drops editor messages coming from a foreign origin', async () => {
+    const makeRequest = vi.fn().mockResolvedValue(successGet)
+    const { wrapper, dispatchModal } = createShallowMountWrapper(makeRequest)
+    await flushAppUrl(wrapper)
+
+    dispatchEditorMessage('https://evil.test', 'UI_SaveAs')
+
+    expect(dispatchModal).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('opens the modal on UI_SaveAs from the editor origin and posts Action_SaveAs on confirm', async () => {
+    const makeRequest = vi.fn().mockResolvedValue(successGet)
+    const { wrapper, dispatchModal } = createShallowMountWrapper(makeRequest)
+    await flushAppUrl(wrapper)
+    const { postMessage } = stubIframeContentWindow(wrapper)
+
+    dispatchEditorMessage(appOrigin, 'UI_SaveAs')
+
+    expect(dispatchModal).toHaveBeenCalledTimes(1)
+    const modal = dispatchModal.mock.calls[0][0] as any
+    expect(modal.hasInput).toBe(true)
+
+    modal.onConfirm('export.pdf')
+
+    expect(postMessage).toHaveBeenCalledTimes(1)
+    const [payload, targetOrigin] = postMessage.mock.calls[0]
+    expect(targetOrigin).toBe(appOrigin)
+    expect(JSON.parse(payload as string)).toMatchObject({
+      MessageId: 'Action_SaveAs',
+      Values: { Filename: 'export.pdf', Notify: true }
+    })
+    wrapper.unmount()
+  })
+
+  it('rejects empty and path-separator file names in the modal', async () => {
+    const makeRequest = vi.fn().mockResolvedValue(successGet)
+    const { wrapper, dispatchModal } = createShallowMountWrapper(makeRequest)
+    await flushAppUrl(wrapper)
+    const { postMessage } = stubIframeContentWindow(wrapper)
+
+    dispatchEditorMessage(appOrigin, 'UI_SaveAs')
+    const modal = dispatchModal.mock.calls[0][0] as any
+
+    const setError = vi.fn()
+    modal.onInput('', setError)
+    expect(setError).toHaveBeenLastCalledWith(expect.stringContaining('empty'))
+    modal.onInput('foo/bar.pdf', setError)
+    expect(setError).toHaveBeenLastCalledWith(expect.stringContaining('/'))
+    modal.onInput('valid.pdf', setError)
+    expect(setError).toHaveBeenLastCalledWith('')
+
+    // a confirm with an invalid name must not post anything
+    modal.onConfirm('foo/bar.pdf')
+    expect(postMessage).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('posts Host_PostmessageReady when the editor iframe loads', async () => {
+    const makeRequest = vi.fn().mockResolvedValue(successGet)
+    const { wrapper } = createShallowMountWrapper(makeRequest)
+    await flushAppUrl(wrapper)
+    const { iframe, postMessage } = stubIframeContentWindow(wrapper)
+
+    await iframe.trigger('load')
+
+    expect(postMessage).toHaveBeenCalledTimes(1)
+    const [payload, targetOrigin] = postMessage.mock.calls[0]
+    expect(targetOrigin).toBe(appOrigin)
+    expect(JSON.parse(payload as string)).toMatchObject({ MessageId: 'Host_PostmessageReady' })
+    wrapper.unmount()
+  })
+})
+
 function createShallowMountWrapper(makeRequest = vi.fn().mockResolvedValue({ status: 200 })) {
   vi.mocked(useRequest).mockImplementation(() => ({
     makeRequest
@@ -80,6 +193,9 @@ function createShallowMountWrapper(makeRequest = vi.fn().mockResolvedValue({ sta
   vi.mocked(useRoute).mockReturnValue(
     computed(() => mock<RouteLocation>({ name: 'external-example-app-apps' }))
   )
+
+  const dispatchModal = vi.fn()
+  vi.mocked(useModals).mockReturnValue(mock<ReturnType<typeof useModals>>({ dispatchModal }))
 
   const mocks = {
     ...defaultComponentMocks(),
@@ -93,10 +209,11 @@ function createShallowMountWrapper(makeRequest = vi.fn().mockResolvedValue({ sta
   }
 
   return {
+    dispatchModal,
     wrapper: shallowMount(App, {
       props: {
         space: null,
-        resource: mock<Resource>(),
+        resource: mock<Resource>({ name: 'document.odt' }),
         isReadOnly: false
       },
       global: {

--- a/packages/web-app-external/tests/unit/app.spec.ts
+++ b/packages/web-app-external/tests/unit/app.spec.ts
@@ -1,6 +1,17 @@
 import { mock } from 'vitest-mock-extended'
-import { defaultComponentMocks, defaultPlugins, shallowMount } from '@ownclouders/web-test-helpers'
-import { AppProviderService, useModals, useRequest, useRoute } from '@ownclouders/web-pkg'
+import {
+  defaultComponentMocks,
+  defaultPlugins,
+  flushPromises,
+  shallowMount
+} from '@ownclouders/web-test-helpers'
+import {
+  AppProviderService,
+  useMessages,
+  useModals,
+  useRequest,
+  useRoute
+} from '@ownclouders/web-pkg'
 import { computed } from 'vue'
 
 import { Resource } from '@ownclouders/web-client'
@@ -11,7 +22,8 @@ vi.mock('@ownclouders/web-pkg', async (importOriginal) => ({
   ...(await importOriginal<any>()),
   useRequest: vi.fn(),
   useRoute: vi.fn(),
-  useModals: vi.fn()
+  useModals: vi.fn(),
+  useMessages: vi.fn()
 }))
 
 const appUrl = 'https://example.test/d12ab86/loe009157-MzBw'
@@ -77,12 +89,6 @@ describe('The app provider extension', () => {
 describe('Collabora Save As postMessage handling', () => {
   const successGet = { ok: true, status: 200, data: providerSuccessResponseGet }
 
-  const flushAppUrl = async (wrapper: any) => {
-    for (let i = 0; i < 5; i++) {
-      await wrapper.vm.$nextTick()
-    }
-  }
-
   const dispatchEditorMessage = (origin: string, messageId: string) => {
     window.dispatchEvent(
       new MessageEvent('message', { origin, data: JSON.stringify({ MessageId: messageId }) })
@@ -118,7 +124,7 @@ describe('Collabora Save As postMessage handling', () => {
     const { wrapper, dispatchModal } = createShallowMountWrapper(makeRequest, {
       appName: 'Collabora'
     })
-    await flushAppUrl(wrapper)
+    await flushPromises()
 
     dispatchEditorMessage('https://evil.test', 'UI_SaveAs')
 
@@ -131,7 +137,7 @@ describe('Collabora Save As postMessage handling', () => {
     const { wrapper, dispatchModal } = createShallowMountWrapper(makeRequest, {
       appName: 'Collabora'
     })
-    await flushAppUrl(wrapper)
+    await flushPromises()
     const { postMessage } = stubIframeContentWindow(wrapper)
 
     dispatchEditorMessage(appOrigin, 'UI_SaveAs')
@@ -152,13 +158,56 @@ describe('Collabora Save As postMessage handling', () => {
     wrapper.unmount()
   })
 
+  it('ignores a second UI_SaveAs while the modal is already open', async () => {
+    const makeRequest = vi.fn().mockResolvedValue(successGet)
+    const { wrapper, dispatchModal } = createShallowMountWrapper(makeRequest, {
+      appName: 'Collabora'
+    })
+    await flushPromises()
+    stubIframeContentWindow(wrapper)
+
+    dispatchEditorMessage(appOrigin, 'UI_SaveAs')
+    dispatchEditorMessage(appOrigin, 'UI_SaveAs')
+
+    expect(dispatchModal).toHaveBeenCalledTimes(1)
+
+    // once cancelled/confirmed, a subsequent UI_SaveAs may open the modal again
+    const modal = dispatchModal.mock.calls[0][0] as any
+    modal.onCancel()
+    dispatchEditorMessage(appOrigin, 'UI_SaveAs')
+    expect(dispatchModal).toHaveBeenCalledTimes(2)
+    wrapper.unmount()
+  })
+
+  it('shows an error instead of silently closing when the iframe is unavailable on confirm', async () => {
+    const makeRequest = vi.fn().mockResolvedValue(successGet)
+    const { wrapper, dispatchModal, showErrorMessage } = createShallowMountWrapper(makeRequest, {
+      appName: 'Collabora'
+    })
+    await flushPromises()
+    Object.defineProperty(wrapper.find('iframe').element, 'contentWindow', {
+      value: null,
+      configurable: true
+    })
+
+    dispatchEditorMessage(appOrigin, 'UI_SaveAs')
+    const modal = dispatchModal.mock.calls[0][0] as any
+
+    modal.onConfirm('export.pdf')
+
+    expect(showErrorMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ title: expect.stringContaining('editor is not available') })
+    )
+    wrapper.unmount()
+  })
+
   it('does not open the modal on UI_SaveAs when the file is read-only', async () => {
     const makeRequest = vi.fn().mockResolvedValue(successGet)
     const { wrapper, dispatchModal } = createShallowMountWrapper(makeRequest, {
       appName: 'Collabora',
       isReadOnly: true
     })
-    await flushAppUrl(wrapper)
+    await flushPromises()
 
     dispatchEditorMessage(appOrigin, 'UI_SaveAs')
 
@@ -171,7 +220,7 @@ describe('Collabora Save As postMessage handling', () => {
     const { wrapper, dispatchModal } = createShallowMountWrapper(makeRequest, {
       appName: 'Collabora'
     })
-    await flushAppUrl(wrapper)
+    await flushPromises()
     const { postMessage } = stubIframeContentWindow(wrapper)
 
     dispatchEditorMessage(appOrigin, 'UI_SaveAs')
@@ -196,7 +245,7 @@ describe('Collabora Save As postMessage handling', () => {
   it('posts Host_PostmessageReady when the editor iframe loads', async () => {
     const makeRequest = vi.fn().mockResolvedValue(successGet)
     const { wrapper } = createShallowMountWrapper(makeRequest, { appName: 'Collabora' })
-    await flushAppUrl(wrapper)
+    await flushPromises()
     const { iframe, postMessage } = stubIframeContentWindow(wrapper)
 
     await iframe.trigger('load')
@@ -211,7 +260,7 @@ describe('Collabora Save As postMessage handling', () => {
   it('does not post Host_PostmessageReady or request ui_defaults for non-Collabora providers', async () => {
     const makeRequest = vi.fn().mockResolvedValue(successGet)
     const { wrapper } = createShallowMountWrapper(makeRequest, { appName: 'example-app' })
-    await flushAppUrl(wrapper)
+    await flushPromises()
     const { iframe, postMessage } = stubIframeContentWindow(wrapper)
 
     expect(wrapper.find('iframe').attributes('src')).toBe(appUrl)
@@ -228,7 +277,7 @@ describe('Collabora Save As postMessage handling', () => {
       appName: 'Collabora',
       openAsPreview: false
     })
-    await flushAppUrl(wrapper)
+    await flushPromises()
     makeRequest.mockClear()
 
     dispatchEditorMessage(appOrigin, 'UI_Edit')
@@ -258,6 +307,9 @@ function createShallowMountWrapper(
   const dispatchModal = vi.fn()
   vi.mocked(useModals).mockReturnValue(mock<ReturnType<typeof useModals>>({ dispatchModal }))
 
+  const showErrorMessage = vi.fn()
+  vi.mocked(useMessages).mockReturnValue(mock<ReturnType<typeof useMessages>>({ showErrorMessage }))
+
   const mocks = {
     ...defaultComponentMocks(),
     $appProviderService: mock<AppProviderService>({ appNames: [appName] })
@@ -271,6 +323,7 @@ function createShallowMountWrapper(
 
   return {
     dispatchModal,
+    showErrorMessage,
     wrapper: shallowMount(App, {
       props: {
         space: null,


### PR DESCRIPTION
## Problem

Office documents opened in Collabora Online can be **renamed** but **"Save As" / "Export As" silently does nothing** — the copy is never written back into oCIS storage.

Root cause: Collabora implements "Save As" as a **host-delegated** operation. When the user triggers it, Collabora posts a `UI_SaveAs` message and waits for the integration to reply with the target filename via `Action_SaveAs`; only then does it render to the chosen format and call WOPI `PutRelativeFile`. The app-provider (`web-app-external`) never opened that postMessage channel — it never sent `Host_PostmessageReady` and never handled `UI_SaveAs` (it only listened for `UI_Edit`). Rename works because Collabora performs it as a *native* WOPI `RenameFile` call that needs no host involvement.

## Fix

In `web-app-external/src/App.vue`:
- Send `Host_PostmessageReady` once the editor iframe has loaded — this is what makes Collabora start emitting its postMessage API (`App_LoadingStatus`, `UI_SaveAs`, …).
- Append `ui_defaults=SaveAsMode=group` to the editor URL so Collabora shows the grouped Save-As control that delegates the target filename to the host (the parameter is Collabora-specific and ignored by other app providers).
- Handle `UI_SaveAs`: prompt for the copy's name (the extension selects the export format) and reply with `Action_SaveAs`. Incoming messages are now origin-checked against the editor origin.

No server change is needed — the collaboration service already implements `PutRelativeFile`.

## Testing

- Unit: `web-app-external` tests pass; snapshot updated for the `ui_defaults` URL parameter.
- `check:types`, ESLint clean.
- Verified live against `ocis_full` + Collabora Online `25.04.7.3.1`:
  - `PutRelativeFile` writes the converted copy into the space (confirmed end-to-end: a real call created a `.pdf` next to the source; `PutFile: success` → `PutRelativeFileSuggested: success`, HTTP 200).
  - Sending `Host_PostmessageReady` on iframe load opens Collabora's full postMessage channel (`App_LoadingStatus` → `Document_Loaded`); without it Collabora stays silent. `CheckFileInfo` already returns `UserCanNotWriteRelative:false` + `PostMessageOrigin`.
  - The end-to-end `UI_SaveAs → Action_SaveAs → PutRelativeFile` chain is exercised by the office web e2e suite (`webOffice`), which drives Collabora's Save-As UI.

## Risk

Low. Behaviour is additive: a new postMessage handshake + an extra UI param. The existing `UI_Edit` handling is preserved (now also origin-checked). Non-Collabora app providers ignore the `ui_defaults` parameter.
