### PR TITLE
fix(web-runtime): use authMfaRequiredLevelname from capability store instead of hardcoded value

### DIFF
--- a/changelog/unreleased/bugfix-use-auth-mfa-required-level-from-capability.md
+++ b/changelog/unreleased/bugfix-use-auth-mfa-required-level-from-capability.md
@@ -1,0 +1,5 @@
+Bugfix: Use authMfaRequiredLevelname from capabilities instead of hardcoded value
+
+The MFA required ACR level for vault routes is now read from the capabilities store (`authMfaRequiredLevelname`) instead of being hardcoded to `"advanced"`. This ensures the correct level is always used as configured by the server.
+
+https://github.com/owncloud/web/pull/13907

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -131,7 +131,23 @@ export class AuthService implements AuthServiceInterface {
     }
 
     if (to.params.scope === 'vault') {
-      this.requireAcr('advanced', to.fullPath)
+      // Capabilities carry the required MFA level name. Fetch them directly (without
+      // establishing the user context) so we can enforce the ACR before any vault data
+      // is loaded. Establishing the user context here would flip `userContextReady`,
+      // triggering the bootstrap watcher to load spaces against the vault endpoint with
+      // a non-MFA token, which fails and crashes the app.
+      if (!this.capabilityStore.isInitialized) {
+        this.capabilityStore.setCapabilities(await this.clientService.ocs.getCapabilities())
+      }
+
+      const requiredAcr = this.capabilityStore.authMfaRequiredLevelname
+      const user = await this.userManager.getUser()
+      if (!user || user.expired || user.profile.acr !== requiredAcr) {
+        this.userManager.setPostLoginRedirectUrl(to.fullPath)
+        await this.userManager.signinRedirect({ acr_values: requiredAcr })
+        // redirecting to the IdP, don't establish the user context below
+        return
+      }
     }
 
     if (isPublicLinkContextRequired(this.router, to)) {


### PR DESCRIPTION
## Description

Replace the hardcoded `"advanced"` ACR level string with `this.capabilityStore.authMfaRequiredLevelname` when requiring MFA for vault routes. This ensures the correct level is always driven by the server's capabilities response.

## Related Issue
- Fixes https://kiteworks.atlassian.net/browse/OCISDEV-1003

## Motivation and Context
The hardcoded value `"advanced"` could diverge from what the server actually requires. Reading `authMfaRequiredLevelname` from the capability store makes this dynamic and correct regardless of server configuration.
