### PR TITLE
fix(web-runtime): use authMfaRequiredLevelname from capability store instead of hardcoded value

### DIFF
--- a/changelog/unreleased/bugfix-use-auth-mfa-required-level-from-capability.md
+++ b/changelog/unreleased/bugfix-use-auth-mfa-required-level-from-capability.md
@@ -1,0 +1,5 @@
+Bugfix: Use authMfaRequiredLevelname from capabilities instead of hardcoded value
+
+The MFA required ACR level for vault routes is now read from the capabilities store (`authMfaRequiredLevelname`) instead of being hardcoded to `"advanced"`. This ensures the correct level is always used as configured by the server.
+
+https://github.com/owncloud/web/pull/13907

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -131,7 +131,23 @@ export class AuthService implements AuthServiceInterface {
     }
 
     if (to.params.scope === 'vault') {
-      this.requireAcr('advanced', to.fullPath)
+      // Capabilities carry the required MFA level name. Fetch them directly (without
+      // establishing the user context) so we can enforce the ACR before any vault data
+      // is loaded. Establishing the user context here would flip `userContextReady`,
+      // triggering the bootstrap watcher to load spaces against the vault endpoint with
+      // a non-MFA token, which fails and crashes the app.
+      if (!this.capabilityStore.isInitialized) {
+        this.capabilityStore.setCapabilities(await this.clientService.ocs.getCapabilities())
+      }
+
+      const requiredAcr = this.capabilityStore.authMfaRequiredLevelname
+      const user = await this.userManager.getUser()
+      if (!user || user.expired || user.profile.acr !== requiredAcr) {
+        this.userManager.setPostLoginRedirectUrl(to.fullPath)
+        await this.userManager.signinRedirect({ acr_values: requiredAcr })
+        // redirecting to the IdP, don't establish the user context below
+        return
+      }
     }
 
     if (isPublicLinkContextRequired(this.router, to)) {


### PR DESCRIPTION
backport fix/use-authMfaRequiredLevelname-instead-of-hardcoded

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for Web. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" or save as draft PR in case the PR still has open tasks
- Set label "Category:*" where it fits best
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
<!-- Please make sure to keep your PR in draft mode until it's ready for review -->
- [ ] ...
