### PR TITLE
chore: add missing 12.4.2 changelog entry

### DIFF
--- a/changelog/12.4.2_2026-06-26/bugfix-use-auth-mfa-required-level-from-capability.md
+++ b/changelog/12.4.2_2026-06-26/bugfix-use-auth-mfa-required-level-from-capability.md
@@ -1,0 +1,5 @@
+Bugfix: Use authMfaRequiredLevelname from capabilities instead of hardcoded value
+
+The MFA required ACR level for vault routes is now read from the capabilities store (`authMfaRequiredLevelname`) instead of being hardcoded to `"advanced"`. This ensures the correct level is always used as configured by the server.
+
+https://github.com/owncloud/web/pull/13907


### PR DESCRIPTION
The version bump PR #13912 deleted the changelog entry from `unreleased/` but missed moving it to `changelog/12.4.2_2026-06-26/`. As a result, calens had nothing to render and the GitHub release body is empty.

After this merges, the tag `v12.4.2` needs to be deleted and recreated on the new HEAD so the release workflow reruns.