### PR TITLE
fix(web-runtime): keep session on transient network errors during context init

### DIFF
--- a/changelog/unreleased/bugfix-preserve-session-on-network-error
+++ b/changelog/unreleased/bugfix-preserve-session-on-network-error
@@ -1,0 +1,11 @@
+Bugfix: Keep the session on transient network errors during context init
+
+We've fixed a bug where a temporary connectivity failure (e.g. a fast page reload
+cancelling in-flight requests, or a short offline period) while re-establishing the
+authenticated context on page load would be treated like an expired or invalid token.
+This forced a full logout and redirected the user to the "trouble connecting to the
+login service" page. Network/connectivity errors now preserve the existing session,
+while genuine authentication rejections (e.g. a 401) still trigger the regular logout
+flow as before.
+
+https://github.com/owncloud/web/issues/12980

--- a/packages/web-runtime/src/services/auth/authService.ts
+++ b/packages/web-runtime/src/services/auth/authService.ts
@@ -26,6 +26,40 @@ import { PublicLinkType } from '@ownclouders/web-client'
 import { WebWorkersStore } from '@ownclouders/web-pkg'
 import { isSilentRedirectRoute } from '../../helpers/silentRedirect'
 
+/**
+ * Distinguishes a transient network/connectivity failure from a genuine
+ * authentication rejection.
+ *
+ * When the context is (re-)established on page reload, user data is fetched over
+ * HTTP. If that request fails because of a temporary connectivity issue (offline,
+ * DNS, a page refresh cancelling in-flight requests, ...) we must NOT treat it like
+ * an expired/invalid token and tear down the session. Only errors that carry an HTTP
+ * response (e.g. a `401`) are real auth rejections.
+ *
+ * Recognised connectivity failures:
+ * - Axios errors without an HTTP `response`, with code `ERR_NETWORK` (connection
+ *   refused / DNS / CORS / offline) or `ECONNABORTED` (timeout).
+ * - Browser `fetch` failures, which surface as a `TypeError` (Safari: "Load failed",
+ *   Chromium: "Failed to fetch", Firefox: "NetworkError when attempting to fetch ...").
+ */
+export const isNetworkError = (e: unknown): boolean => {
+  if (e instanceof TypeError) {
+    return /load failed|failed to fetch|networkerror/i.test(e.message)
+  }
+
+  if (e && typeof e === 'object') {
+    const err = e as { response?: unknown; code?: string }
+    // An error that carries an HTTP response is an answered request, not a
+    // connectivity failure - let the regular auth-error handling deal with it.
+    if (err.response) {
+      return false
+    }
+    return err.code === 'ERR_NETWORK' || err.code === 'ECONNABORTED'
+  }
+
+  return false
+}
+
 export class AuthService implements AuthServiceInterface {
   private clientService: ClientService
   private configStore: ConfigStore
@@ -194,7 +228,11 @@ export class AuthService implements AuthServiceInterface {
             this.updateMfaExpiryTimer()
           } catch (e) {
             console.error(e)
-            await this.handleAuthError(unref(this.router.currentRoute))
+            // A transient connectivity failure must not force a logout - keep the
+            // session and let the regular auth flow recover once back online.
+            if (!isNetworkError(e)) {
+              await this.handleAuthError(unref(this.router.currentRoute))
+            }
           }
         })
 
@@ -259,7 +297,11 @@ export class AuthService implements AuthServiceInterface {
           }
         } catch (e) {
           console.error(e)
-          await this.handleAuthError(unref(this.router.currentRoute))
+          // A transient connectivity failure must not force a logout - keep the
+          // session and let the regular auth flow recover once back online.
+          if (!isNetworkError(e)) {
+            await this.handleAuthError(unref(this.router.currentRoute))
+          }
         }
       }
     }

--- a/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
+++ b/packages/web-runtime/tests/unit/services/auth/authService.spec.ts
@@ -1,7 +1,7 @@
 import { ConfigStore, useAuthStore, useConfigStore } from '@ownclouders/web-pkg'
 import { mock } from 'vitest-mock-extended'
 import { Router } from 'vue-router'
-import { AuthService } from '../../../../src/services/auth/authService'
+import { AuthService, isNetworkError } from '../../../../src/services/auth/authService'
 import { UserManager } from '../../../../src/services/auth/userManager'
 import { RouteLocation, createRouter, createTestingPinia } from '@ownclouders/web-test-helpers'
 import { User } from 'oidc-client-ts'
@@ -222,6 +222,108 @@ describe('AuthService', () => {
 
       await authService.requireAcr('advanced', '/')
       expect(mockSignInRedirect).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('isNetworkError', () => {
+    it.each([
+      ['axios ERR_NETWORK (offline / connection refused)', { code: 'ERR_NETWORK' }, true],
+      ['axios ECONNABORTED (timeout)', { code: 'ECONNABORTED' }, true],
+      ['fetch TypeError - Safari "Load failed"', new TypeError('Load failed'), true],
+      ['fetch TypeError - Chromium "Failed to fetch"', new TypeError('Failed to fetch'), true],
+      [
+        'fetch TypeError - Firefox "NetworkError ..."',
+        new TypeError('NetworkError when attempting to fetch resource.'),
+        true
+      ],
+      ['an answered request carrying an HTTP response (401)', { response: { status: 401 } }, false],
+      [
+        'an ERR_NETWORK code that nonetheless carries a response',
+        { code: 'ERR_NETWORK', response: { status: 500 } },
+        false
+      ],
+      ['an unrelated TypeError (real bug)', new TypeError('foo is not a function'), false],
+      ['an error with an unknown code', { code: 'ERR_BAD_REQUEST' }, false],
+      ['a null error', null, false],
+      ['a plain string error', 'boom', false]
+    ])('returns %s => %s', (_desc, error, expected) => {
+      expect(isNetworkError(error)).toBe(expected)
+    })
+  })
+
+  describe('initializeContext auth-error classification', () => {
+    const buildAuthService = (rejection: unknown) => {
+      const authService = new AuthService()
+      Object.defineProperty(authService, 'userManager', {
+        value: mock<UserManager>({
+          getAccessToken: vi.fn().mockResolvedValue('access-token'),
+          getUser: vi.fn().mockResolvedValue(mock<User>({ expires_in: 3600 })),
+          updateContext: vi.fn().mockRejectedValue(rejection)
+        })
+      })
+      const router = createRouter()
+      initAuthService({ authService, router })
+      const handleAuthErrorSpy = vi
+        .spyOn(authService, 'handleAuthError')
+        .mockResolvedValue(undefined)
+      return { authService, handleAuthErrorSpy }
+    }
+
+    it('preserves the session (no handleAuthError) when updateContext fails with a network error on reload', async () => {
+      const { authService, handleAuthErrorSpy } = buildAuthService({ code: 'ERR_NETWORK' })
+
+      await authService.initializeContext(mock<RouteLocation>({}))
+
+      expect(handleAuthErrorSpy).not.toHaveBeenCalled()
+    })
+
+    it('triggers handleAuthError when updateContext fails with a 401 on reload', async () => {
+      const { authService, handleAuthErrorSpy } = buildAuthService({ response: { status: 401 } })
+
+      await authService.initializeContext(mock<RouteLocation>({}))
+
+      expect(handleAuthErrorSpy).toHaveBeenCalled()
+    })
+
+    it('addUserLoaded handler preserves the session on a network error but logs out on an auth rejection', async () => {
+      const authService = new AuthService()
+      let userLoadedCb: (user: User) => Promise<void>
+      const updateContext = vi.fn()
+      Object.defineProperty(authService, 'userManager', {
+        value: mock<UserManager>({
+          // skip the reload branch, we drive the addUserLoaded handler directly
+          getAccessToken: vi.fn().mockResolvedValue(null),
+          // force event-handler registration (mock<> would otherwise make this truthy)
+          areEventHandlersRegistered: false,
+          updateContext,
+          events: {
+            addAccessTokenExpired: vi.fn(),
+            addAccessTokenExpiring: vi.fn(),
+            addUserLoaded: vi.fn().mockImplementation((cb) => {
+              userLoadedCb = cb
+            }),
+            addUserUnloaded: vi.fn(),
+            addSilentRenewError: vi.fn()
+          } as unknown as UserManager['events']
+        })
+      })
+      const router = createRouter()
+      initAuthService({ authService, router })
+      const handleAuthErrorSpy = vi
+        .spyOn(authService, 'handleAuthError')
+        .mockResolvedValue(undefined)
+
+      await authService.initializeContext(mock<RouteLocation>({}))
+
+      // network error -> session preserved
+      updateContext.mockRejectedValueOnce({ code: 'ERR_NETWORK' })
+      await userLoadedCb(mock<User>({ access_token: 'tok', expires_in: 3600 }))
+      expect(handleAuthErrorSpy).not.toHaveBeenCalled()
+
+      // auth rejection -> existing logout flow
+      updateContext.mockRejectedValueOnce({ response: { status: 401 } })
+      await userLoadedCb(mock<User>({ access_token: 'tok', expires_in: 3600 }))
+      expect(handleAuthErrorSpy).toHaveBeenCalledTimes(1)
     })
   })
 })


### PR DESCRIPTION
## Description
On page reload the authenticated context is re-established in `AuthService.initializeContext()` by calling `userManager.updateContext()`, which fetches user data over HTTP (`graph.users.getMe()`, capabilities, roles). Both the page-reload token-restore path and the `addUserLoaded` event handler wrapped that call in a blanket `catch` that treated **any** thrown error identically to a genuine authentication rejection: it called `handleAuthError()` → `removeUser('authError')` → redirect to `accessDenied`.

**Root cause:** the `catch` blocks did not distinguish a transient network/connectivity failure (e.g. a fast page refresh cancelling in-flight requests, a short offline period, a timeout) from a real auth rejection (401 / invalid or expired token). A temporary connectivity blip therefore forced a full logout and showed the "trouble connecting to the login service" page.

**Fix:** a small `isNetworkError()` classifier is introduced. Connectivity failures (axios `ERR_NETWORK` / `ECONNABORTED` with no HTTP `response`, or a fetch `TypeError` such as Safari's "Load failed") now preserve the existing session and let the regular auth flow recover on the next navigation / token refresh. Errors that carry an HTTP `response` (e.g. `401`) still go through the unchanged `handleAuthError()` logout flow. The change is applied to the two `catch` blocks named in the issue analysis (reload path + `addUserLoaded`).

## Related Issue
- Fixes #12980

## Motivation and Context
Users were being logged out on transient connectivity issues and bounced to the access-denied page, losing their active session — reported as a real, reproducible problem (e.g. quick reloads in Safari). Only genuine auth rejections should end the session.

## How Has This Been Tested?
- test environment: repository unit test suite (Vitest) + `vue-tsc --noEmit` type check + ESLint/Prettier, run locally in this branch.
- `packages/web-runtime/tests/unit/services/auth/authService.spec.ts` — **26/26 passing**. New coverage:
  - `isNetworkError` table test across all branches (axios `ERR_NETWORK`/`ECONNABORTED`, fetch `TypeError` variants, an error carrying an HTTP response, an `ERR_NETWORK` that nonetheless carries a response, an unrelated `TypeError`, unknown code, `null`, string).
  - reload path: network error → `handleAuthError` **not** called; `401` → `handleAuthError` called.
  - `addUserLoaded` handler: network error preserves the session; `401` triggers logout.
- `pnpm check:types` → passes. `eslint` + `prettier --check` on the changed files → clean.
- New-code coverage: the classifier and both modified `catch` branches are exercised by the added tests (well above the 85% target). Not run: Playwright e2e (needs a full running oCIS stack, not available in this environment).

## Screenshots (if appropriate):
n/a — no UI change.

## Open tasks:
- [ ] Maintainer review. Scoping notes below.

---

### Notes for reviewers
- **Scope kept minimal (by design):** on a network error the session is preserved but the context is left for the regular flow to re-establish on the next navigation/token-refresh; no new user-facing "offline/retry" UI state was added. The issue analysis mentioned surfacing a retryable offline state — that is intentionally left out here to keep the diff small and focused on the acceptance criteria (do not force logout on a network error). Happy to add an explicit offline indicator in a follow-up if wanted.
- **Classifier is conservative:** anything not positively recognised as a connectivity failure falls through to the existing `handleAuthError` behaviour, so unknown/real errors are no worse off than today.
- **Repo consolidation:** `owncloud/web`'s README notes development is moving into `owncloud/ocis`. This fix is filed here because the issue and the affected code live here; a maintainer may want to port it to `ocis` as well.
- **Documentation:** changelog entry added (`changelog/unreleased/bugfix-preserve-session-on-network-error`). No admin/end-user docs change (behaviour is strictly less disruptive than before). REUSE per-file headers are not used on TS sources in this repo, so none were added. No OTel tooling in this package.
- **Risk:** low — logic is additive and gated behind the new classifier; existing logout paths for auth rejections are unchanged.

🤖 Automated by Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nf5p9hdg4kGRaVjjgVX5vz)_