### PR TITLE
test(app-store): add unit tests for stores and app list view

### DIFF
--- a/changelog/unreleased/change-add-app-store-unit-tests
+++ b/changelog/unreleased/change-add-app-store-unit-tests
@@ -1,0 +1,8 @@
+Change: Add unit tests for the app store views and stores
+
+We've added unit test coverage for the app store, covering the apps and
+repositories pinia stores and the app list overview (no-content state, tile
+rendering, search filtering and reflecting the search term into the route query).
+
+https://github.com/owncloud/web/issues/11634
+https://github.com/owncloud/web/pull/13943

--- a/packages/web-app-app-store/tests/unit/piniaStores/apps.spec.ts
+++ b/packages/web-app-app-store/tests/unit/piniaStores/apps.spec.ts
@@ -1,0 +1,102 @@
+import { setActivePinia } from 'pinia'
+import { createTestingPinia } from '@ownclouders/web-test-helpers'
+import { useAppsStore } from '../../../src/piniaStores/apps'
+import { useRepositoriesStore } from '../../../src/piniaStores/repositories'
+import { AppStoreRepository } from '../../../src/types'
+
+const repo1: AppStoreRepository = { name: 'repo1', url: 'https://example.test/repo1.json' }
+const repo2: AppStoreRepository = { name: 'repo2', url: 'https://example.test/repo2.json' }
+
+const makeRawApp = (id: string, name: string) => ({
+  id,
+  name,
+  subtitle: `${name} subtitle`,
+  license: 'MIT',
+  versions: [{ version: '1.0.0', url: `https://example.test/${id}.zip` }],
+  authors: [{ name: 'ownCloud' }],
+  tags: ['productivity']
+})
+
+const stubFetch = (responsesByUrl: Record<string, unknown | 'reject'>) => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url: string) => {
+      const entry = responsesByUrl[url]
+      if (entry === 'reject') {
+        return Promise.reject(new Error('network error'))
+      }
+      return Promise.resolve({ json: () => Promise.resolve(entry) })
+    })
+  )
+}
+
+describe('useAppsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('method "loadApps"', () => {
+    it('loads and maps apps from the configured repositories', async () => {
+      useRepositoriesStore().setRepositories([repo1])
+      stubFetch({ [repo1.url]: { apps: [makeRawApp('alpha', 'Alpha')] } })
+
+      const store = useAppsStore()
+      await store.loadApps()
+
+      expect(store.apps).toHaveLength(1)
+      expect(store.apps[0].id).toBe('alpha')
+      expect(store.apps[0].repository).toEqual(repo1)
+      expect(store.apps[0].mostRecentVersion).toEqual({
+        version: '1.0.0',
+        url: 'https://example.test/alpha.zip'
+      })
+    })
+
+    it('catches and logs a per-repository failure and returns no apps for that repository', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+      useRepositoriesStore().setRepositories([repo1, repo2])
+      stubFetch({
+        [repo1.url]: { apps: [makeRawApp('alpha', 'Alpha')] },
+        [repo2.url]: 'reject'
+      })
+
+      const store = useAppsStore()
+      await store.loadApps()
+
+      expect(errorSpy).toHaveBeenCalled()
+      expect(store.apps).toHaveLength(1)
+      expect(store.apps[0].id).toBe('alpha')
+    })
+
+    it('sorts the apps of a repository by name (case-insensitive)', async () => {
+      useRepositoriesStore().setRepositories([repo1])
+      stubFetch({
+        [repo1.url]: {
+          apps: [makeRawApp('c', 'Charlie'), makeRawApp('a', 'alpha'), makeRawApp('b', 'Bravo')]
+        }
+      })
+
+      const store = useAppsStore()
+      await store.loadApps()
+
+      expect(store.apps.map((app) => app.name)).toEqual(['alpha', 'Bravo', 'Charlie'])
+    })
+  })
+
+  describe('method "getById"', () => {
+    it('returns the matching app or undefined', async () => {
+      useRepositoriesStore().setRepositories([repo1])
+      stubFetch({ [repo1.url]: { apps: [makeRawApp('alpha', 'Alpha')] } })
+
+      const store = useAppsStore()
+      await store.loadApps()
+
+      expect(store.getById('alpha')?.name).toBe('Alpha')
+      expect(store.getById('does-not-exist')).toBeUndefined()
+    })
+  })
+})

--- a/packages/web-app-app-store/tests/unit/piniaStores/repositories.spec.ts
+++ b/packages/web-app-app-store/tests/unit/piniaStores/repositories.spec.ts
@@ -1,0 +1,25 @@
+import { setActivePinia } from 'pinia'
+import { createTestingPinia } from '@ownclouders/web-test-helpers'
+import { useRepositoriesStore } from '../../../src/piniaStores/repositories'
+import { AppStoreRepository } from '../../../src/types'
+
+describe('useRepositoriesStore', () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }))
+  })
+
+  describe('method "setRepositories"', () => {
+    it('updates the repositories state', () => {
+      const store = useRepositoriesStore()
+      expect(store.repositories).toEqual([])
+
+      const repositories: AppStoreRepository[] = [
+        { name: 'repo1', url: 'https://example.test/repo1.json' },
+        { name: 'repo2', url: 'https://example.test/repo2.json' }
+      ]
+      store.setRepositories(repositories)
+
+      expect(store.repositories).toEqual(repositories)
+    })
+  })
+})

--- a/packages/web-app-app-store/tests/unit/views/AppList.spec.ts
+++ b/packages/web-app-app-store/tests/unit/views/AppList.spec.ts
@@ -1,0 +1,100 @@
+import { RouteLocationNormalizedLoaded } from 'vue-router'
+import { setActivePinia } from 'pinia'
+import {
+  createTestingPinia,
+  defaultComponentMocks,
+  defaultPlugins,
+  flushPromises,
+  shallowMount,
+  VueWrapper
+} from '@ownclouders/web-test-helpers'
+import AppList from '../../../src/views/AppList.vue'
+import { useAppsStore } from '../../../src/piniaStores'
+import { App } from '../../../src/types'
+
+const selectors = {
+  noContentMessage: 'no-content-message-stub',
+  appTile: 'app-tile-stub',
+  filterInput: '#apps-filter'
+}
+
+const makeApp = (id: string, name: string): App => ({
+  id,
+  name,
+  subtitle: `${name} subtitle`,
+  license: 'MIT',
+  versions: [{ version: '1.0.0', url: 'https://example.test/app.zip' }],
+  authors: [{ name: 'ownCloud' }],
+  tags: ['productivity'],
+  screenshots: [],
+  resources: [],
+  repository: { name: 'repo', url: 'https://example.test/repo.json' },
+  mostRecentVersion: { version: '1.0.0', url: 'https://example.test/app.zip' }
+})
+
+describe('AppList', () => {
+  it('shows the no-content message when no apps match', () => {
+    const { wrapper } = getWrapper({ apps: [] })
+    expect(wrapper.find(selectors.noContentMessage).exists()).toBe(true)
+    expect(wrapper.findAll(selectors.appTile)).toHaveLength(0)
+  })
+
+  it('renders a tile for each app', () => {
+    const { wrapper } = getWrapper({ apps: [makeApp('alpha', 'Alpha'), makeApp('bravo', 'Bravo')] })
+    expect(wrapper.findAll(selectors.appTile)).toHaveLength(2)
+    expect(wrapper.find(selectors.noContentMessage).exists()).toBe(false)
+  })
+
+  it('reflects the search term into the filter route query on input', async () => {
+    const { wrapper, mocks } = getWrapper({ apps: [makeApp('alpha', 'Alpha')] })
+    await (wrapper.findComponent(selectors.filterInput) as VueWrapper).vm.$emit(
+      'update:modelValue',
+      'foo'
+    )
+    expect(mocks.$router.replace).toHaveBeenCalledWith({ query: { filter: 'foo' } })
+  })
+
+  it('narrows the rendered tiles to the ones matching the active filter query', async () => {
+    const { wrapper } = getWrapper({
+      apps: [makeApp('alpha', 'Alpha'), makeApp('bravo', 'Bravo')],
+      filter: 'Alpha'
+    })
+    await flushPromises()
+    const filteredApps = (wrapper.vm as unknown as { filteredApps: App[] }).filteredApps
+    expect(filteredApps.map((app) => app.name)).toEqual(['Alpha'])
+    expect(wrapper.findAll(selectors.appTile)).toHaveLength(1)
+  })
+})
+
+function getWrapper({ apps, filter = '' }: { apps: App[]; filter?: string }) {
+  const pinia = createTestingPinia({ stubActions: false })
+  setActivePinia(pinia)
+  const appsStore = useAppsStore()
+  appsStore.apps = apps
+  const plugins = [...defaultPlugins({ pinia: false }), pinia]
+
+  const mocks = {
+    ...defaultComponentMocks({
+      currentRoute: {
+        name: 'app-store',
+        path: '/',
+        params: {},
+        query: { ...(filter && { filter }) },
+        meta: {}
+      } as unknown as RouteLocationNormalizedLoaded
+    })
+  }
+
+  return {
+    mocks,
+    wrapper: shallowMount(AppList, {
+      global: {
+        plugins,
+        mocks,
+        provide: mocks,
+        // render oc-list's default slot so the app tiles inside become visible stubs
+        stubs: { 'oc-list': { template: '<ul><slot /></ul>' } }
+      }
+    })
+  }
+}


### PR DESCRIPTION
## Description

Adds unit test coverage for the app store, which had merged e2e journeys and a
first batch of component tests but no coverage for its pinia stores or the
`AppList` overview view.

New files:
- `packages/web-app-app-store/tests/unit/piniaStores/apps.spec.ts`
- `packages/web-app-app-store/tests/unit/piniaStores/repositories.spec.ts`
- `packages/web-app-app-store/tests/unit/views/AppList.spec.ts`

**`useAppsStore` covered:**
- `loadApps`: successful load and mapping (`repository`/`mostRecentVersion`), a
  per-repository fetch failure being caught + logged and yielding no apps for
  that repository, and case-insensitive name sorting
- `getById`: match and no-match

**`useRepositoriesStore` covered:**
- `setRepositories` state update

**`AppList.vue` covered:**
- no-content message shown when there are no matching apps
- a tile rendered per app
- search input reflected into the `filter` route query
- tiles narrowed to apps matching the active `filter` query

## Related Issue

- Fixes #11634

## Motivation and Context

Locks down the store data flow (fetch/parse/sort/merge, failure isolation) and
the list view's rendering/search behaviour so future changes are guarded.

## How Has This Been Tested?

- test environment: `pnpm --filter web-app-app-store test:unit` (vitest 4.1.6, node 22)
- result: `Test Files 3 passed`, `Tests 9 passed (9)`
- coverage on the three touched source files: **98.27% lines, 100% branches**
  (`apps.ts` and `repositories.ts` at 100%; `AppList.vue` 96.77% lines / 100%
  branches) — above the 85% target
- `eslint`: clean · `prettier --check`: clean · full-repo `vue-tsc --noEmit`: no
  type errors

This is a **test-only** change — no product code is modified.

**Documentation checklist**
- Changelog: added `changelog/unreleased/change-add-app-store-unit-tests`.
- REUSE/SPDX headers: not applicable — this repo uses a single root `LICENSE`
  and carries no per-file SPDX headers on existing source/test files, so none
  were added, to stay consistent with the codebase.
- Admin/end-user docs, WCAG note, OTEL metrics: not applicable (no behaviour or
  UI change).

**Phase 4 pre-flight review (non-blocking findings):** none — specs use a real
testing pinia for the stores and fully stubbed dependencies for the view (global
`fetch` stubbed, no network), deterministic.

**Risk level:** minimal (adds tests only).

## Open tasks:
- [ ] none

---

🤖 Automated by Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01XmrWqs7jyAQQyauBnoKRsb)_