### PR TITLE
docs: mark repository as archived and unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> **⚠️ This repository is archived and no longer maintained.**
+> It is read-only and will not receive further updates or contributions.
+
 > [!IMPORTANT]
 > The [owncloud/web](https://github.com/owncloud/web) repository has been merged into [owncloud/ocis](https://github.com/owncloud/ocis) as part of our ongoing consolidation into a single oCIS monorepo. All future development, issues, and pull requests for the web frontend now happen there.
 


### PR DESCRIPTION
The repository is being archived and will no longer be maintained. This adds a deprecation notice to the top of the README before archiving.